### PR TITLE
Parsing error with EOL + comment in place of semicolon

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -333,7 +333,6 @@ public class Parser
                 lineno++;
                 sawEOL = true;
             } else {
-                sawEOL = false;
                 if (compilerEnv.isRecordingComments()) {
                     recordComment(lineno);
                 }

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -28,6 +28,16 @@ public class ParserTest extends TestCase {
         assertEquals("z", third.getString());
     }
 
+    public void testParseAutoSemiColonBeforeNewlineAndComments() throws IOException {
+        AstRoot root = parseAsReader(
+        		"var s = 3\n"
+        		+ "/* */var t = 1;");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+
+        assertEquals("var s = 3;\nvar t = 1;\n", root.toSource());
+    }
+
     public void testLinenoAssign() {
         AstRoot root = parse("\n\na = b");
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();


### PR DESCRIPTION
code like this
var s = 3
/\* */var t = 1;
can't be parsed. Exception below is thrown. Pull request contains unit test + fix.

junit.framework.AssertionFailedError: extra error: missing ; before statement
    at junit.framework.Assert.fail(Assert.java:47)
    at org.mozilla.javascript.testing.TestErrorReporter.error(TestErrorReporter.java:38)
    at org.mozilla.javascript.Parser.addError(Parser.java:230)
    at org.mozilla.javascript.Parser.addError(Parser.java:208)
    at org.mozilla.javascript.Parser.reportError(Parser.java:265)
    at org.mozilla.javascript.Parser.reportError(Parser.java:252)
    at org.mozilla.javascript.Parser.reportError(Parser.java:245)
    at org.mozilla.javascript.Parser.autoInsertSemicolon(Parser.java:1109)
    at org.mozilla.javascript.Parser.statementHelper(Parser.java:1086)
    at org.mozilla.javascript.Parser.statement(Parser.java:943)
    at org.mozilla.javascript.Parser.parse(Parser.java:568)
    at org.mozilla.javascript.Parser.parse(Parser.java:530)
    at org.mozilla.javascript.tests.ParserTest.parseAsReader(ParserTest.java:977)
    at org.mozilla.javascript.tests.ParserTest.testParseAutoSemiColonBeforeNewlineAndComments(ParserTest.java:34)
