### PR TITLE
Add function name getter to StackFrame in Debugger Implementation

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/debugger/Dim.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/Dim.java
@@ -1307,6 +1307,13 @@ interruptedCheck:
         public int getLineNumber() {
             return lineNumber;
         }
+        
+        /**
+         * Returns the current function name.
+         */
+        public String getFunctionName() {
+            return fsource.name();
+        }
     }
 
     /**


### PR DESCRIPTION
Function name information can be useful in call stack view.
We use it in our javascript debugger, please look at screenshot: 
![screencap](http://i52.tinypic.com/eansjl.png)
