### PR TITLE
Fixed issue with /\ca/ and doesn't match to string "\u0001"

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -376,6 +376,11 @@ if (regexp.anchorCh >= 0) {
         return Character.isLetter(c) || isDigit(c) || c == '_';
     }
 
+    private static boolean isControlLetter(char c)
+    {
+        return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
+    }
+
     private static boolean isLineTerm(char c)
     {
         return ScriptRuntime.isJSLineTerminator(c);
@@ -554,9 +559,10 @@ if (regexp.anchorCh >= 0) {
                     localMax = 0xB;
                     break;
                 case 'c':
-                    if (((index + 1) < end) && Character.isLetter(src[index + 1]))
+                    if ((index < end) && isControlLetter(src[index]))
                         localMax = (char)(src[index++] & 0x1F);
                     else
+                        --index;
                         localMax = '\\';
                     break;
                 case 'u':
@@ -884,8 +890,8 @@ if (regexp.anchorCh >= 0) {
                     break;
                 /* Control letter */
                 case 'c':
-                    if (((state.cp + 1) < state.cpend) &&
-                                        Character.isLetter(src[state.cp + 1]))
+                    if ((state.cp < state.cpend) &&
+                                        isControlLetter(src[state.cp]))
                         c = (char)(src[state.cp++] & 0x1F);
                     else {
                         /* back off to accepting the original '\' as a literal */
@@ -1516,7 +1522,7 @@ if (regexp.anchorCh >= 0) {
                     thisCh = 0xB;
                     break;
                 case 'c':
-                    if (((src + 1) < end) && isWord(gData.regexp.source[src + 1]))
+                    if ((src < end) && isControlLetter(gData.regexp.source[src]))
                         thisCh = (char)(gData.regexp.source[src++] & 0x1F);
                     else {
                         --src;

--- a/testsrc/base.skip
+++ b/testsrc/base.skip
@@ -469,7 +469,6 @@ ecma_3/RegExp/regress-307456.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-311414.js
 ecma_3/RegExp/regress-330684.js
-ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-367888.js
 ecma_3/Statements/regress-121744.js
 ecma_3/String/15.5.4.14.js

--- a/testsrc/opt-1.tests
+++ b/testsrc/opt-1.tests
@@ -963,6 +963,7 @@ ecma_3/RegExp/regress-28686.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
+ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-346090.js
 ecma_3/RegExp/regress-375715-02.js
 ecma_3/RegExp/regress-375715-03.js

--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -964,6 +964,7 @@ ecma_3/RegExp/regress-28686.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
+ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-346090.js
 ecma_3/RegExp/regress-375715-02.js
 ecma_3/RegExp/regress-375715-03.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -964,6 +964,7 @@ ecma_3/RegExp/regress-28686.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
+ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-346090.js
 ecma_3/RegExp/regress-375715-02.js
 ecma_3/RegExp/regress-375715-03.js


### PR DESCRIPTION
The regex /\ca/ and /[\ca]/ should match to string "\u0001" , but it does not match.
I believe this patch can fix this issue.

without this patch:

<pre>js> escape("\u0001".match(/\ca/))
null
js> escape("\u0001".match(/[\ca]/))
Exception in thread "main" java.lang.RuntimeException
    at org.mozilla.javascript.regexp.NativeRegExp.addCharacterToCharSet(NativeRegExp.java:1423)
    at org.mozilla.javascript.regexp.NativeRegExp.processCharSetImpl(NativeRegExp.java:1636)
    at org.mozilla.javascript.regexp.NativeRegExp.processCharSet(NativeRegExp.java:1460)
    at org.mozilla.javascript.regexp.NativeRegExp.classMatcher(NativeRegExp.java:1658)
    at org.mozilla.javascript.regexp.NativeRegExp.executeREBytecode(NativeRegExp.java:1901)
    at org.mozilla.javascript.regexp.NativeRegExp.matchRegExp(NativeRegExp.java:2250)
    at org.mozilla.javascript.regexp.NativeRegExp.executeRegExp(NativeRegExp.java:2277)
    at org.mozilla.javascript.regexp.RegExpImpl.matchOrReplace(RegExpImpl.java:190)
    at org.mozilla.javascript.regexp.RegExpImpl.action(RegExpImpl.java:74)
    at org.mozilla.javascript.NativeString.execIdCall(NativeString.java:389)
    at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:129)
    at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:66)
    at org.mozilla.javascript.gen._stdin__2._c_script_0(Unknown Source)
    at org.mozilla.javascript.gen._stdin__2.call(Unknown Source)
    at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:426)
    at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3156)
    at org.mozilla.javascript.gen._stdin__2.call(Unknown Source)
    at org.mozilla.javascript.gen._stdin__2.exec(Unknown Source)
    at org.mozilla.javascript.tools.shell.Main.evaluateScript(Main.java:650)
    at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:464)
    at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:214)
    at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:133)
    at org.mozilla.javascript.Context.call(Context.java:521)
    at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:536)
    at org.mozilla.javascript.tools.shell.Main.exec(Main.java:197)
    at org.mozilla.javascript.tools.shell.Main.main(Main.java:173)

js> "\\c_".match(/[\c_]/g)
Exception in thread "main" java.lang.RuntimeException
    at org.mozilla.javascript.regexp.NativeRegExp.addCharacterToCharSet(NativeRegExp.java:1423)
    at org.mozilla.javascript.regexp.NativeRegExp.processCharSetImpl(NativeRegExp.java:1636)
    at org.mozilla.javascript.regexp.NativeRegExp.processCharSet(NativeRegExp.java:1460)
    at org.mozilla.javascript.regexp.NativeRegExp.classMatcher(NativeRegExp.java:1658)
    at org.mozilla.javascript.regexp.NativeRegExp.executeREBytecode(NativeRegExp.java:1901)
    at org.mozilla.javascript.regexp.NativeRegExp.matchRegExp(NativeRegExp.java:2250)
    at org.mozilla.javascript.regexp.NativeRegExp.executeRegExp(NativeRegExp.java:2277)
    at org.mozilla.javascript.regexp.RegExpImpl.matchOrReplace(RegExpImpl.java:169)
    at org.mozilla.javascript.regexp.RegExpImpl.action(RegExpImpl.java:74)
    at org.mozilla.javascript.NativeString.execIdCall(NativeString.java:389)
    at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:129)
    at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:66)
    at org.mozilla.javascript.gen._stdin__1._c_script_0(Unknown Source)
    at org.mozilla.javascript.gen._stdin__1.call(Unknown Source)
    at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:426)
    at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3156)
    at org.mozilla.javascript.gen._stdin__1.call(Unknown Source)
    at org.mozilla.javascript.gen._stdin__1.exec(Unknown Source)
    at org.mozilla.javascript.tools.shell.Main.evaluateScript(Main.java:650)
    at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:464)
    at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:214)
    at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:133)
    at org.mozilla.javascript.Context.call(Context.java:521)
    at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:536)
    at org.mozilla.javascript.tools.shell.Main.exec(Main.java:197)
    at org.mozilla.javascript.tools.shell.Main.main(Main.java:173)
</pre>

with this patch:

<pre>js> escape("\u0001".match(/\ca/))
%01
js> escape("\u0001".match(/[\ca]/))
%01
js> "\\c_".match(/[\c_]/g)
\,c,_
js> 
</pre>
