### PR TITLE
Fixed issue with the regex /(?:<<)xy/ match to string "<xy" (Bug 369860)

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -489,20 +489,13 @@ if (regexp.anchorCh >= 0) {
             }
             if (!parseTerm(state))
                 return false;
-            if (headTerm == null)
+            if (headTerm == null) {
                 headTerm = state.result;
-            else {
-                if (tailTerm == null) {
-                    headTerm.next = state.result;
-                    tailTerm = state.result;
-                    while (tailTerm.next != null) tailTerm = tailTerm.next;
-                }
-                else {
-                    tailTerm.next = state.result;
-                    tailTerm = tailTerm.next;
-                    while (tailTerm.next != null) tailTerm = tailTerm.next;
-                }
+                tailTerm = headTerm;
             }
+            else
+                tailTerm.next = state.result;
+            while (tailTerm.next != null) tailTerm = tailTerm.next;
         }
     }
 

--- a/testsrc/doctests/369860.doctest
+++ b/testsrc/doctests/369860.doctest
@@ -1,0 +1,13 @@
+js> var re = new RegExp("(?:<script.*?>)(.*)<\/script>")
+js> var t = 'foo <script>boo();</script>bar'
+js> var r = re.exec(t)
+js> if (r[1] != "boo();") {
+  > 	throw "Bad result: " + r[1]
+  > } else {
+  > 	print("ok")
+  > }
+ok
+js> var str = "<<xy";
+js> var matches = str.match(/(?:<<)xy/);
+js> print(matches.join(", "));
+<<xy


### PR DESCRIPTION
The regex /(?:<<)xy/ should match to string "<<xy" , but it does not match.
I believe this patch can fix Bug 369860 ( https://bugzilla.mozilla.org/show_bug.cgi?id=369860 ).

without this patch:

<pre>js> 'foo &lt;script>boo();&lt;/script>bar'.match(/(?:&lt;script.*?>)(.*)&lt;\/script>/)[1]
script>boo();
js> '&lt;&lt;xy'.match(/(?:&lt;&lt;)xy/)
&lt;xy
js> 
</pre>


with this patch:

<pre>js> 'foo &lt;script>boo();&lt;/script>bar'.match(/(?:&lt;script.*?>)(.*)&lt;\/script>/)[1]
boo();
js> '&lt;&lt;xy'.match(/(?:&lt;&lt;)xy/)
&lt;&lt;xy
js> 
</pre>
