### PR TITLE
Fixed issue with repeated empty match causes infinite loop

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2027,6 +2027,11 @@ System.out.println("Testing at " + gData.cp + ", op = " + op);
                 continue;
 
             case REOP_ENDCHILD:
+                //
+                // If we have not gotten a result here, it is because of an
+                // empty match.  Do the same thing REOP_EMPTY would do.
+                //
+                result = true;
                 // Use the current continuation.
                 pc = currentContinuation_pc;
                 op = currentContinuation_op;

--- a/testsrc/base.skip
+++ b/testsrc/base.skip
@@ -469,7 +469,6 @@ ecma_3/RegExp/regress-307456.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-311414.js
 ecma_3/RegExp/regress-330684.js
-ecma_3/RegExp/regress-367888.js
 ecma_3/Statements/regress-121744.js
 ecma_3/String/15.5.4.14.js
 ecma_3/String/regress-304376.js
@@ -625,7 +624,6 @@ e4x/Expressions/regress-366123.js
 e4x/decompilation/regress-352459.js
 ecma/Date/15.9.5.31-1.js
 ecma/Date/15.9.5.35-1.js
-ecma_3/RegExp/regress-375642.js
 js1_5/Regress/regress-306727.js
 js1_5/Regress/regress-308566.js
 js1_5/Regress/regress-312260.js

--- a/testsrc/opt-1.tests
+++ b/testsrc/opt-1.tests
@@ -965,6 +965,8 @@ ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
 ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-346090.js
+ecma_3/RegExp/regress-367888.js:
+ecma_3/RegExp/regress-375642.js:
 ecma_3/RegExp/regress-375715-02.js
 ecma_3/RegExp/regress-375715-03.js
 ecma_3/RegExp/regress-57572.js

--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -966,6 +966,8 @@ ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
 ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-346090.js
+ecma_3/RegExp/regress-367888.js:
+ecma_3/RegExp/regress-375642.js:
 ecma_3/RegExp/regress-375715-02.js
 ecma_3/RegExp/regress-375715-03.js
 ecma_3/RegExp/regress-57572.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -966,6 +966,8 @@ ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
 ecma_3/RegExp/regress-334158.js
 ecma_3/RegExp/regress-346090.js
+ecma_3/RegExp/regress-367888.js:
+ecma_3/RegExp/regress-375642.js:
 ecma_3/RegExp/regress-375715-02.js
 ecma_3/RegExp/regress-375715-03.js
 ecma_3/RegExp/regress-57572.js


### PR DESCRIPTION
This patch will pass the following mozilla JS tests.
ecma_3/RegExp/regress-367888.js
ecma_3/RegExp/regress-375642.js

with this patch:

<pre>js&gt; /(|)??x/g.exec(&quot;y&quot;)
null
js&gt;</pre>


without this patch:

<pre>js&gt; /(|)??x/g.exec(&quot;y&quot;)
java.lang.OutOfMemoryError: Java heap space
    at org.mozilla.javascript.regexp.NativeRegExp.pushProgState(NativeRegExp.java:1307)
    at org.mozilla.javascript.regexp.NativeRegExp.executeREBytecode(NativeRegExp.java:1842)
    at org.mozilla.javascript.regexp.NativeRegExp.matchRegExp(NativeRegExp.java:2249)
    at org.mozilla.javascript.regexp.NativeRegExp.executeRegExp(NativeRegExp.java:2276)
    at org.mozilla.javascript.regexp.NativeRegExp.execSub(NativeRegExp.java:279)
    at org.mozilla.javascript.regexp.NativeRegExp.execIdCall(NativeRegExp.java:2549)
    at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:129)
    at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:66)
    at org.mozilla.javascript.gen._stdin__1._c_script_0(Unknown Source)
    at org.mozilla.javascript.gen._stdin__1.call(Unknown Source)
    at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:426)
    at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3112)
    at org.mozilla.javascript.gen._stdin__1.call(Unknown Source)
    at org.mozilla.javascript.gen._stdin__1.exec(Unknown Source)
    at org.mozilla.javascript.tools.shell.Main.evaluateScript(Main.java:650)
    at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:464)
    at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:214)
    at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:133)
    at org.mozilla.javascript.Context.call(Context.java:521)
    at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:536)
    at org.mozilla.javascript.tools.shell.Main.exec(Main.java:197)
    at org.mozilla.javascript.tools.shell.Main.main(Main.java:173)
js: exception from uncaught JavaScript throw: java.lang.OutOfMemoryError: Java heap space
js&gt;</pre>
