### PR TITLE
Fixed issue with the word boundary assertion

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -373,7 +373,7 @@ if (regexp.anchorCh >= 0) {
 
     private static boolean isWord(char c)
     {
-        return Character.isLetter(c) || isDigit(c) || c == '_';
+        return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || isDigit(c) || c == '_';
     }
 
     private static boolean isControlLetter(char c)

--- a/testsrc/base.skip
+++ b/testsrc/base.skip
@@ -512,7 +512,6 @@ js1_5/Regress/regress-139316.js
 js1_5/Regress/regress-173067.js
 js1_5/Regress/regress-203278-1.js
 js1_5/Regress/regress-213482.js
-js1_5/Regress/regress-247179.js
 js1_5/Regress/regress-248444.js
 js1_5/Regress/regress-252892.js
 js1_5/Regress/regress-261886.js

--- a/testsrc/opt-1.tests
+++ b/testsrc/opt-1.tests
@@ -1232,6 +1232,7 @@ js1_5/Regress/regress-245113.js
 js1_5/Regress/regress-245308.js
 js1_5/Regress/regress-246911.js
 js1_5/Regress/regress-246964.js
+js1_5/Regress/regress-247179.js
 js1_5/Regress/regress-253150.js
 js1_5/Regress/regress-254296.js
 js1_5/Regress/regress-254974.js

--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -1229,6 +1229,7 @@ js1_5/Regress/regress-245113.js
 js1_5/Regress/regress-245308.js
 js1_5/Regress/regress-246911.js
 js1_5/Regress/regress-246964.js
+js1_5/Regress/regress-247179.js
 js1_5/Regress/regress-253150.js
 js1_5/Regress/regress-254296.js
 js1_5/Regress/regress-254974.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -1229,6 +1229,7 @@ js1_5/Regress/regress-245113.js
 js1_5/Regress/regress-245308.js
 js1_5/Regress/regress-246911.js
 js1_5/Regress/regress-246964.js
+js1_5/Regress/regress-247179.js
 js1_5/Regress/regress-253150.js
 js1_5/Regress/regress-254296.js
 js1_5/Regress/regress-254974.js


### PR DESCRIPTION
This patch will pass the following mozilla JS test
js1_5/Regress/regress-247179.js
and the following test262 tests.
ch15/15.10/15.10.2/15.10.2.12/S15.10.2.12_A3_T4
ch15/15.10/15.10.2/15.10.2.12/S15.10.2.12_A4_T1
ch15/15.10/15.10.2/15.10.2.12/S15.10.2.12_A4_T4

with this patch:

<pre>js&gt; "m\ucc44nd".split(/\b/).length
3
js&gt;</pre>


without this patch:

<pre>js&gt; "m\ucc44nd".split(/\b/).length
1
js&gt;</pre>
