### PR TITLE
Fix to support QName(null, 'foo')

### DIFF
--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlNode.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlNode.java
@@ -619,7 +619,7 @@ class XmlNode implements Serializable {
             rv.uri = uri;
 
             // Avoid null prefix for "" namespace
-            if (uri.length() == 0) {
+            if (uri == null || uri.length() == 0) {
                 rv.prefix = "";
             }
 


### PR DESCRIPTION
The current Rhino master will throw a NullpointerException when executing the following:

```
$ java -jar build/rhino1_7R3/js.jar 
Rhino 1.7 release 3 2011 11 30
js> var x = <foo><bar>baz</bar></foo>
js> x.bar
baz
js> x.elements(QName(null, 'bar'))

Exception in thread "main" java.lang.NullPointerException
    at org.mozilla.javascript.xmlimpl.XmlNode$Namespace.create(XmlNode.java:622)
    at org.mozilla.javascript.xmlimpl.XMLName.formProperty(XMLName.java:150)
    at org.mozilla.javascript.xmlimpl.XMLLibImpl.toXMLName(XMLLibImpl.java:214)
    at org.mozilla.javascript.xmlimpl.XMLObjectImpl.execIdCall(XMLObjectImpl.java:797)
    at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:129)
    at org.mozilla.javascript.xmlimpl.XMLList.call(XMLList.java:821)
    at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:66)
    at org.mozilla.javascript.gen._stdin__3._c_script_0(Unknown Source)
    at org.mozilla.javascript.gen._stdin__3.call(Unknown Source)
    at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:426)
    at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3276)
    at org.mozilla.javascript.gen._stdin__3.call(Unknown Source)
    at org.mozilla.javascript.gen._stdin__3.exec(Unknown Source)
    at org.mozilla.javascript.tools.shell.Main.evaluateScript(Main.java:650)
    at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:464)
    at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:214)
    at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:133)
    at org.mozilla.javascript.Context.call(Context.java:521)
    at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:536)
    at org.mozilla.javascript.tools.shell.Main.exec(Main.java:197)
    at org.mozilla.javascript.tools.shell.Main.main(Main.java:173)
```

This is valid a valid E4X expression and is equivalent to using a \* namespace but commonly used when the element name is dynamic (help in a var). This used to work in 1.7RC2.

The fix is a simple null check in XmlNode.Namespace.create(String) as the uri can be null.
