### PR TITLE
FIX: resolve uri relative to loading module

### DIFF
--- a/src/org/mozilla/javascript/commonjs/module/Require.java
+++ b/src/org/mozilla/javascript/commonjs/module/Require.java
@@ -194,7 +194,6 @@ public class Require extends BaseFunction
             if (base == null) {
                 // calling module is absolute, resolve to absolute URI
                 // (but without file extension)
-                uri = current.resolve(id);
                 id = uri.toString();
             } else {
                 // try to convert to a relative URI rooted on base
@@ -206,7 +205,6 @@ public class Require extends BaseFunction
                         throw ScriptRuntime.throwError(cx, scope,
                             "Module \"" + id + "\" is not contained in sandbox.");
                     } else {
-                        uri = current.resolve(id);
                         id = uri.toString();
                     }
                 }


### PR DESCRIPTION
As discussed, set the uri of the module to be loaded relative to the currently loading one.
