### PR TITLE
Test262 - chapter11

### DIFF
--- a/examples/Matrix.java
+++ b/examples/Matrix.java
@@ -260,8 +260,11 @@ public class Matrix implements Scriptable {
      * true if <code>this</code> appears in <code>value</code>'s prototype
      * chain.
      */
-    public boolean hasInstance(Scriptable value) {
-        Scriptable proto = value.getPrototype();
+    public boolean hasInstance(Object value) {
+        if (! (value instanceof Scriptable)) {
+            return false;
+        }
+        Scriptable proto = ((Scriptable) value).getPrototype();
         while (proto != null) {
             if (proto.equals(this))
                 return true;

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -101,7 +101,7 @@ public class BaseFunction extends IdScriptableObject implements Function
      *
      */
     @Override
-    public boolean hasInstance(Scriptable instance)
+    public boolean hasInstance(Object instance)
     {
         Object protoProp = ScriptableObject.getProperty(this, "prototype");
         if (protoProp instanceof Scriptable) {

--- a/src/org/mozilla/javascript/BoundFunction.java
+++ b/src/org/mozilla/javascript/BoundFunction.java
@@ -95,7 +95,7 @@ public class BoundFunction extends BaseFunction {
   }
 
   @Override
-  public boolean hasInstance(Scriptable instance) {
+  public boolean hasInstance(Object instance) {
     if (targetFunction instanceof Function) {
       return ((Function) targetFunction).hasInstance(instance);
     }

--- a/src/org/mozilla/javascript/Delegator.java
+++ b/src/org/mozilla/javascript/Delegator.java
@@ -217,7 +217,7 @@ public class Delegator implements Function {
     /**
      * @see org.mozilla.javascript.Scriptable#hasInstance
      */
-    public boolean hasInstance(Scriptable instance) {
+    public boolean hasInstance(Object instance) {
         return obj.hasInstance(instance);
     }
     /**

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -1105,16 +1105,16 @@ switch (op) {
             }
             switch (op) {
               case Token.GE:
-                valBln = ScriptRuntime.cmp_LE(rhs, lhs);
+                valBln = !ScriptRuntime.cmp_LT(lhs, rhs, true, true);
                 break;
               case Token.LE:
-                valBln = ScriptRuntime.cmp_LE(lhs, rhs);
+                valBln = !ScriptRuntime.cmp_LT(rhs, lhs, false, true);
                 break;
               case Token.GT:
-                valBln = ScriptRuntime.cmp_LT(rhs, lhs);
+                valBln = ScriptRuntime.cmp_LT(rhs, lhs, false, false);
                 break;
               case Token.LT:
-                valBln = ScriptRuntime.cmp_LT(lhs, rhs);
+                valBln = ScriptRuntime.cmp_LT(lhs, rhs, true, false);
                 break;
               default:
                 throw Kit.codeBug();
@@ -1328,10 +1328,9 @@ switch (op) {
     case Token.MUL :
     case Token.DIV :
     case Token.MOD : {
+        double lDbl = stack_double(frame, stackTop-1);
         double rDbl = stack_double(frame, stackTop);
-        --stackTop;
-        double lDbl = stack_double(frame, stackTop);
-        stack[stackTop] = DBL_MRK;
+        stack[--stackTop] = DBL_MRK;
         switch (op) {
           case Token.SUB:
             lDbl -= rDbl;

--- a/src/org/mozilla/javascript/NativeIterator.java
+++ b/src/org/mozilla/javascript/NativeIterator.java
@@ -101,7 +101,7 @@ public final class NativeIterator extends IdScriptableObject {
          * doesn't have a constructor.
          */
         @Override
-        public boolean hasInstance(Scriptable instance) {
+        public boolean hasInstance(Object instance) {
             return instance instanceof StopIteration;
         }
     }

--- a/src/org/mozilla/javascript/NativeJavaArray.java
+++ b/src/org/mozilla/javascript/NativeJavaArray.java
@@ -157,7 +157,7 @@ public class NativeJavaArray extends NativeJavaObject
     }
 
     @Override
-    public boolean hasInstance(Scriptable value) {
+    public boolean hasInstance(Object value) {
         if (!(value instanceof Wrapper))
             return false;
         Object instance = ((Wrapper)value).unwrap();

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -315,7 +315,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
      * static methods exposed by a JavaNativeClass.
      */
     @Override
-    public boolean hasInstance(Scriptable value) {
+    public boolean hasInstance(Object value) {
 
         if (value instanceof Wrapper &&
             !(value instanceof NativeJavaClass)) {

--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -131,7 +131,7 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
         throw members.reportMemberNotFound(Integer.toString(index));
     }
 
-    public boolean hasInstance(Scriptable value) {
+    public boolean hasInstance(Object value) {
         // This is an instance of a Java class, so always return false
         return false;
     }

--- a/src/org/mozilla/javascript/NativeWith.java
+++ b/src/org/mozilla/javascript/NativeWith.java
@@ -151,7 +151,7 @@ public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
         return prototype.getDefaultValue(typeHint);
     }
 
-    public boolean hasInstance(Scriptable value) {
+    public boolean hasInstance(Object value) {
         return prototype.hasInstance(value);
     }
 

--- a/src/org/mozilla/javascript/Scriptable.java
+++ b/src/org/mozilla/javascript/Scriptable.java
@@ -330,13 +330,13 @@ public interface Scriptable {
      * return an appropriate value.  See the JS 1.3 language documentation for more
      * detail.
      *
-     * <p>This operator corresponds to the proposed EMCA [[HasInstance]] operator.
+     * <p>This operator corresponds to the EMCA [[HasInstance]] operator.
      *
      * @param instance The value that appeared on the LHS of the instanceof
      *              operator
      *
      * @return an implementation dependent value
      */
-    public boolean hasInstance(Scriptable instance);
+    public boolean hasInstance(Object instance);
 }
 

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -1016,21 +1016,21 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
     }
 
     /**
-     * Implements the instanceof operator.
+     * <p>Implements the instanceof operator.</p>
      *
-     * <p>This operator has been proposed to ECMA.
+     * <p>Sub-classes should override this method to provide custom 'instanceof'
+     * functionality. {@link ScriptRuntime#jsDelegatesTo(Scriptable, Scriptable)}
+     * provides a useful default implementation. The implementation in this
+     * class just throws a 'TypeError' exception.</p>
      *
      * @param instance The value that appeared on the LHS of the instanceof
      *              operator
      * @return true if "this" appears in value's prototype chain
-     *
+     * @see ScriptRuntime#jsDelegatesTo(Scriptable, Scriptable)
      */
-    public boolean hasInstance(Scriptable instance) {
-        // Default for JS objects (other than Function) is to do prototype
-        // chasing.  This will be overridden in NativeFunction and non-JS
-        // objects.
-
-        return ScriptRuntime.jsDelegatesTo(instance, this);
+    public boolean hasInstance(Object instance) {
+        // Default for JS objects (other than Function) is to throw a TypeError
+        throw ScriptRuntime.typeError0("msg.instanceof.not.object");
     }
 
     /**

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLCtor.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLCtor.java
@@ -283,7 +283,7 @@ class XMLCtor extends IdFunctionObject
         hasInstance for XML objects works differently than other objects; see ECMA357 13.4.3.10.
      */
     @Override
-    public boolean hasInstance(Scriptable instance) {
+    public boolean hasInstance(Object instance) {
         return (instance instanceof XML || instance instanceof XMLList);
     }
 }

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
@@ -146,7 +146,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     @Override
-    public final boolean hasInstance(Scriptable scriptable) {
+    public final boolean hasInstance(Object scriptable) {
         return super.hasInstance(scriptable);
     }
 


### PR DESCRIPTION
One single commit to resolve test case failures when running test262-chapter11 tests (only covered non-strict tests!). If you need smaller commits to ease reviewing, let me know!

-- André

Scriptable:
- hasInstance(): change argument from Scriptable to Object to comply with specification, which defines [[HasInstance]] as SpecOp(any) -> Boolean
- this is a public API change!
- update the following classes to conform to the new interface:
  -- Matrix, BaseFunction, BoundFunction, Delegator, NativeIterator, NativeJavaArray, NativeJavaClass, NativeJavaObject, NativeWith, XMLCtor, XMLObjectImpl

ScriptableObject:
- default implementation of hasInstance() now throws a 'TypeError' to conform to the spec

ScriptRuntime:
- move primitive check from instanceOf() to jsDelegatesTo()
- add updated version of the "Abstract Relational Comparison Algorithm" with flags to control evaluation order
- deprecate old cmp_LT() and cmp_LE() methods

Interpreter:
- ensure proper left-to-right evaluation order for SUB, MUL, DIV, MOD
- ensure proper evaluation order for GE, LE, GT, LT

Parser:
- track property-type in addition to property-name to detect duplicate properties (code adapted from SpiderMonkey parser)
- always warn for duplicate getter/setter independent of strict-mode (SpiderMonkey behaviour)
- add check for parameter count in case of getter/setter functions
