### PR TITLE
Test262 - chapter 15

### DIFF
--- a/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/Namespace.java
+++ b/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/Namespace.java
@@ -269,10 +269,11 @@ class Namespace extends IdScriptableObject
         initPrototypeMethod(NAMESPACE_TAG, id, s, arity);
     }
 
+    @Override
     public Object execIdCall(IdFunctionObject f,
                              Context cx,
                              Scriptable scope,
-                             Scriptable thisObj,
+                             Object thisObj,
                              Object[] args)
     {
         if (!f.hasTag(NAMESPACE_TAG)) {
@@ -290,7 +291,7 @@ class Namespace extends IdScriptableObject
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private Namespace realThis(Scriptable thisObj, IdFunctionObject f)
+    private Namespace realThis(Object thisObj, IdFunctionObject f)
     {
         if(!(thisObj instanceof Namespace))
             throw incompatibleCallError(f);

--- a/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/QName.java
+++ b/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/QName.java
@@ -255,10 +255,11 @@ final class QName extends IdScriptableObject
         initPrototypeMethod(QNAME_TAG, id, s, arity);
     }
 
+    @Override
     public Object execIdCall(IdFunctionObject f,
                              Context cx,
                              Scriptable scope,
-                             Scriptable thisObj,
+                             Object thisObj,
                              Object[] args)
     {
         if (!f.hasTag(QNAME_TAG)) {
@@ -276,7 +277,7 @@ final class QName extends IdScriptableObject
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private QName realThis(Scriptable thisObj, IdFunctionObject f)
+    private QName realThis(Object thisObj, IdFunctionObject f)
     {
         if(!(thisObj instanceof QName))
             throw incompatibleCallError(f);

--- a/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/XMLCtor.java
+++ b/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/XMLCtor.java
@@ -233,8 +233,9 @@ class XMLCtor extends IdFunctionObject
         initPrototypeMethod(XMLCTOR_TAG, id, s, arity);
     }
 
+    @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(XMLCTOR_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/XMLList.java
+++ b/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/XMLList.java
@@ -1528,7 +1528,7 @@ class XMLList extends XMLObjectImpl implements Function
 
     private Object applyOrCall(boolean isApply,
                                Context cx, Scriptable scope,
-                               Scriptable thisObj, Object[] args)
+                               Object thisObj, Object[] args)
     {
         String methodName = isApply ? "apply" : "call";
         if(!(thisObj instanceof XMLList) ||
@@ -1574,7 +1574,7 @@ class XMLList extends XMLObjectImpl implements Function
         return null;
     }
 
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         // This XMLList is being called as a Function.
@@ -1592,7 +1592,7 @@ class XMLList extends XMLObjectImpl implements Function
             throw ScriptRuntime.typeError1("msg.incompat.call", methodName);
         }
         Object func = null;
-        Scriptable sobj = thisObj;
+        Scriptable sobj = (XMLObject) thisObj;
 
         while (sobj instanceof XMLObject) {
             XMLObject xmlObject = (XMLObject) sobj;

--- a/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/XMLObjectImpl.java
+++ b/deprecatedsrc/org/mozilla/javascript/xml/impl/xmlbeans/XMLObjectImpl.java
@@ -579,8 +579,9 @@ abstract class XMLObjectImpl extends XMLObject
      * @param args
      * @return
      */
+    @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(XMLOBJECT_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/BoundFunction.java
+++ b/src/org/mozilla/javascript/BoundFunction.java
@@ -80,7 +80,7 @@ public class BoundFunction extends BaseFunction {
   }
 
   @Override
-  public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] extraArgs)
+  public Object call(Context cx, Scriptable scope, Object thisObj, Object[] extraArgs)
   {
     Scriptable callThis = boundThis != null ? boundThis : ScriptRuntime.getTopCallScope(cx);
     return targetFunction.call(cx, scope, callThis, concat(boundArgs, extraArgs));

--- a/src/org/mozilla/javascript/Callable.java
+++ b/src/org/mozilla/javascript/Callable.java
@@ -53,7 +53,7 @@ public interface Callable
      * @param args the array of arguments
      * @return the result of the call
      */
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args);
 }
 

--- a/src/org/mozilla/javascript/Delegator.java
+++ b/src/org/mozilla/javascript/Delegator.java
@@ -223,7 +223,7 @@ public class Delegator implements Function {
     /**
      * @see org.mozilla.javascript.Function#call
      */
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         return ((Function)obj).call(cx,scope,thisObj,args);

--- a/src/org/mozilla/javascript/Function.java
+++ b/src/org/mozilla/javascript/Function.java
@@ -64,7 +64,7 @@ public interface Function extends Scriptable, Callable
      * @param args the array of arguments
      * @return the result of the call
      */
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args);
 
     /**

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -401,7 +401,7 @@ public class FunctionObject extends BaseFunction
      *          Context, Scriptable, Scriptable, Object[])
      */
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         Object result;

--- a/src/org/mozilla/javascript/IdFunctionCall.java
+++ b/src/org/mozilla/javascript/IdFunctionCall.java
@@ -49,7 +49,7 @@ public interface IdFunctionCall
      * instance of Scriptable should be returned
      */
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args);
+                             Object thisObj, Object[] args);
 
 }
 

--- a/src/org/mozilla/javascript/IdFunctionObject.java
+++ b/src/org/mozilla/javascript/IdFunctionObject.java
@@ -123,7 +123,7 @@ public class IdFunctionObject extends BaseFunction
     }
 
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         return idcall.execIdCall(this, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -595,9 +595,19 @@ public abstract class IdScriptableObject extends ScriptableObject
     /** 'thisObj' will be null if invoked as constructor, in which case
      ** instance of Scriptable should be returned. */
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         throw f.unknown();
+    }
+
+    /**
+     * @deprecated {@link #execIdCall(IdFunctionObject, Context, Scriptable, Object, Object[])}
+     */
+    @Deprecated
+    public final Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
+            Scriptable thisObj, Object[] args)
+    {
+        return execIdCall(f, cx, scope, (Object) thisObj, args);
     }
 
     public final IdFunctionObject exportAsJSClass(int maxPrototypeId,

--- a/src/org/mozilla/javascript/ImporterTopLevel.java
+++ b/src/org/mozilla/javascript/ImporterTopLevel.java
@@ -257,7 +257,7 @@ public class ImporterTopLevel extends TopLevel {
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(IMPORTER_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
@@ -276,7 +276,7 @@ public class ImporterTopLevel extends TopLevel {
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private ImporterTopLevel realThis(Scriptable thisObj, IdFunctionObject f)
+    private ImporterTopLevel realThis(Object thisObj, IdFunctionObject f)
     {
         if (topScopeFlag) {
             // when used as top scope importPackage and importClass are global

--- a/src/org/mozilla/javascript/InterpretedFunction.java
+++ b/src/org/mozilla/javascript/InterpretedFunction.java
@@ -155,9 +155,13 @@ final class InterpretedFunction extends NativeFunction implements Script
      * @return the result of the function call.
      */
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObject,
                        Object[] args)
     {
+        Scriptable thisObj = ScriptRuntime.toObjectOrNull(cx, thisObject, scope);
+        if (thisObj == null) {
+            thisObj = ScriptRuntime.getTopCallScope(cx);
+        }
         if (!ScriptRuntime.hasTopCall(cx)) {
             return ScriptRuntime.doTopCall(this, cx, scope, thisObj, args);
         }

--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -118,7 +118,7 @@ public final class JavaAdapter implements IdFunctionCall
     }
 
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (f.hasTag(FTAG)) {
             if (f.methodId() == Id_JavaAdapter) {

--- a/src/org/mozilla/javascript/JavaMembers.java
+++ b/src/org/mozilla/javascript/JavaMembers.java
@@ -167,7 +167,7 @@ class JavaMembers
                 Object[] args = { value };
                 bp.setters.call(Context.getContext(),
                                 ScriptableObject.getTopLevelScope(scope),
-                                scope, args);
+                                (Object) scope, args);
             }
         }
         else {

--- a/src/org/mozilla/javascript/NativeBoolean.java
+++ b/src/org/mozilla/javascript/NativeBoolean.java
@@ -94,7 +94,7 @@ final class NativeBoolean extends IdScriptableObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(BOOLEAN_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/NativeCall.java
+++ b/src/org/mozilla/javascript/NativeCall.java
@@ -128,7 +128,7 @@ public final class NativeCall extends IdScriptableObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(CALL_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/NativeContinuation.java
+++ b/src/org/mozilla/javascript/NativeContinuation.java
@@ -74,7 +74,7 @@ public final class NativeContinuation extends IdScriptableObject
         throw Context.reportRuntimeError("Direct call is not supported");
     }
 
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         return Interpreter.restartContinuation(this, cx, scope, args);
@@ -102,7 +102,7 @@ public final class NativeContinuation extends IdScriptableObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(FTAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/NativeGenerator.java
+++ b/src/org/mozilla/javascript/NativeGenerator.java
@@ -107,7 +107,7 @@ public final class NativeGenerator extends IdScriptableObject {
             Scriptable scope = ScriptableObject.getTopLevelScope(generator);
             Callable closeGenerator = new Callable() {
                 public Object call(Context cx, Scriptable scope,
-                                   Scriptable thisObj, Object[] args) {
+                                   Object thisObj, Object[] args) {
                      return ((NativeGenerator)thisObj).resume(cx, scope,
                              GENERATOR_CLOSE, new GeneratorClosedException());
                 }
@@ -134,7 +134,7 @@ public final class NativeGenerator extends IdScriptableObject {
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(GENERATOR_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/NativeGlobal.java
+++ b/src/org/mozilla/javascript/NativeGlobal.java
@@ -130,7 +130,6 @@ public class NativeGlobal implements Serializable, IdFunctionCall
             READONLY|DONTENUM|PERMANENT);
 
         String[] errorMethods = {
-                "ConversionError",
                 "EvalError",
                 "RangeError",
                 "ReferenceError",
@@ -167,7 +166,7 @@ public class NativeGlobal implements Serializable, IdFunctionCall
     }
 
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (f.hasTag(FTAG)) {
             int methodId = f.methodId();
@@ -719,8 +718,6 @@ public class NativeGlobal implements Serializable, IdFunctionCall
                     if (ucs4Char < minUcs4Char
                             || (ucs4Char >= 0xD800 && ucs4Char <= 0xDFFF)) {
                         ucs4Char = INVALID_UTF8;
-                    } else if (ucs4Char == 0xFFFE || ucs4Char == 0xFFFF) {
-                        ucs4Char = 0xFFFD;
                     }
                     if (ucs4Char >= 0x10000) {
                         ucs4Char -= 0x10000;

--- a/src/org/mozilla/javascript/NativeIterator.java
+++ b/src/org/mozilla/javascript/NativeIterator.java
@@ -126,7 +126,7 @@ public final class NativeIterator extends IdScriptableObject {
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(ITERATOR_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
@@ -158,7 +158,7 @@ public final class NativeIterator extends IdScriptableObject {
 
     /* The JavaScript constructor */
     private static Object jsConstructor(Context cx, Scriptable scope,
-                                        Scriptable thisObj, Object[] args)
+                                        Object thisObj, Object[] args)
     {
         if (args.length == 0 || args[0] == null ||
             args[0] == Undefined.instance)

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -100,7 +100,7 @@ final class NativeJSON extends IdScriptableObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(JSON_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -161,7 +161,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
         return this;
     }
 
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         // If it looks like a "cast" of an object to this class type,

--- a/src/org/mozilla/javascript/NativeJavaConstructor.java
+++ b/src/org/mozilla/javascript/NativeJavaConstructor.java
@@ -66,7 +66,7 @@ public class NativeJavaConstructor extends BaseFunction
     }
 
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         return NativeJavaClass.constructSpecific(cx, scope, args, ctor);

--- a/src/org/mozilla/javascript/NativeJavaMethod.java
+++ b/src/org/mozilla/javascript/NativeJavaMethod.java
@@ -163,7 +163,7 @@ public class NativeJavaMethod extends BaseFunction
     }
 
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         // Find a method that matches the types given.
@@ -236,7 +236,7 @@ public class NativeJavaMethod extends BaseFunction
         if (meth.isStatic()) {
             javaObject = null;  // don't need an object
         } else {
-            Scriptable o = thisObj;
+            Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
             Class<?> c = meth.getDeclaringClass();
             for (;;) {
                 if (o == null) {

--- a/src/org/mozilla/javascript/NativeJavaTopPackage.java
+++ b/src/org/mozilla/javascript/NativeJavaTopPackage.java
@@ -76,7 +76,7 @@ public class NativeJavaTopPackage
         super(true, "", loader);
     }
 
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         return construct(cx, scope, args);
@@ -146,7 +146,7 @@ public class NativeJavaTopPackage
     }
 
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (f.hasTag(FTAG)) {
             if (f.methodId() == Id_getClass) {

--- a/src/org/mozilla/javascript/NativeMath.java
+++ b/src/org/mozilla/javascript/NativeMath.java
@@ -119,7 +119,7 @@ final class NativeMath extends IdScriptableObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(MATH_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -53,8 +53,6 @@ final class NativeNumber extends IdScriptableObject
 
     private static final Object NUMBER_TAG = "Number";
 
-    private static final int MAX_PRECISION = 100;
-
     static void init(Scriptable scope, boolean sealed)
     {
         NativeNumber obj = new NativeNumber(0.0);
@@ -117,7 +115,7 @@ final class NativeNumber extends IdScriptableObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(NUMBER_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
@@ -159,7 +157,7 @@ final class NativeNumber extends IdScriptableObject
 
           case Id_toFixed:
             return num_to(value, args, DToA.DTOSTR_FIXED,
-                          DToA.DTOSTR_FIXED, -20, 0);
+                          DToA.DTOSTR_FIXED, 0, 20, 0);
 
           case Id_toExponential: {
               // Handle special values before range check
@@ -176,7 +174,7 @@ final class NativeNumber extends IdScriptableObject
               }
               // General case
               return num_to(value, args, DToA.DTOSTR_STANDARD_EXPONENTIAL,
-                      DToA.DTOSTR_EXPONENTIAL, 0, 1);
+                      DToA.DTOSTR_EXPONENTIAL, 0, 20, 1);
           }
 
           case Id_toPrecision: {
@@ -197,7 +195,7 @@ final class NativeNumber extends IdScriptableObject
                   }
               }
               return num_to(value, args, DToA.DTOSTR_STANDARD,
-                      DToA.DTOSTR_PRECISION, 1, 0);
+                      DToA.DTOSTR_PRECISION, 1, 21, 0);
           }
 
           default: throw new IllegalArgumentException(String.valueOf(id));
@@ -212,21 +210,21 @@ final class NativeNumber extends IdScriptableObject
     private static String num_to(double val,
                                  Object[] args,
                                  int zeroArgMode, int oneArgMode,
-                                 int precisionMin, int precisionOffset)
+                                 int precisionMin, int precisionMax,
+                                 int precisionOffset)
     {
         int precision;
         if (args.length == 0) {
             precision = 0;
             oneArgMode = zeroArgMode;
         } else {
-            /* We allow a larger range of precision than
-               ECMA requires; this is permitted by ECMA. */
-            precision = ScriptRuntime.toInt32(args[0]);
-            if (precision < precisionMin || precision > MAX_PRECISION) {
+            double p = ScriptRuntime.toInteger(args[0]);
+            if (p < precisionMin || p > precisionMax) {
                 String msg = ScriptRuntime.getMessage1(
                     "msg.bad.precision", ScriptRuntime.toString(args[0]));
                 throw ScriptRuntime.constructError("RangeError", msg);
             }
+            precision = ScriptRuntime.toInt32(p);
         }
         StringBuilder sb = new StringBuilder();
         DToA.JS_dtostr(sb, oneArgMode, precision + precisionOffset, val);

--- a/src/org/mozilla/javascript/NativeScript.java
+++ b/src/org/mozilla/javascript/NativeScript.java
@@ -82,7 +82,7 @@ class NativeScript extends BaseFunction
     }
 
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         if (script != null) {
@@ -135,7 +135,7 @@ class NativeScript extends BaseFunction
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(SCRIPT_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
@@ -174,7 +174,7 @@ class NativeScript extends BaseFunction
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private static NativeScript realThis(Scriptable thisObj, IdFunctionObject f)
+    private static NativeScript realThis(Object thisObj, IdFunctionObject f)
     {
         if (!(thisObj instanceof NativeScript))
             throw incompatibleCallError(f);

--- a/src/org/mozilla/javascript/NativeWith.java
+++ b/src/org/mozilla/javascript/NativeWith.java
@@ -165,7 +165,7 @@ public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
     }
 
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (f.hasTag(FTAG)) {
             if (f.methodId() == Id_constructor) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -85,7 +85,7 @@ public class ScriptRuntime {
           static final long serialVersionUID = -5891740962154902286L;
 
           @Override
-          public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+          public Object call(Context cx, Scriptable scope, Object thisObj, Object[] args) {
             throw typeError0("msg.op.not.allowed");
           }
           @Override
@@ -118,7 +118,7 @@ public class ScriptRuntime {
          * @param args the array of arguments
          * @return the result of the call
          */
-        public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+        public Object call(Context cx, Scriptable scope, Object thisObj,
                            Object[] args)
         {
             Object[] nestedArgs = new Object[2];
@@ -811,6 +811,17 @@ public class ScriptRuntime {
         }
     }
 
+    static String defaultObjectToString(Context cx, Scriptable scope, Object obj)
+    {
+        if (obj == null) {
+            return "[object Null]";
+        } else if (obj == Undefined.instance) {
+            return "[object Undefined]";
+        }
+        Scriptable val = toObject(cx, scope, obj);
+        return "[object " + val.getClassName() + ']';
+    }
+
     static String defaultObjectToString(Scriptable obj)
     {
         return "[object " + obj.getClassName() + ']';
@@ -829,6 +840,11 @@ public class ScriptRuntime {
     }
 
     public static String numberToString(double d, int base) {
+        if ((base < 2) || (base > 36)) {
+            throw Context.reportRuntimeError1(
+                "msg.bad.radix", Integer.toString(base));
+        }
+
         if (d != d)
             return "NaN";
         if (d == Double.POSITIVE_INFINITY)
@@ -837,11 +853,6 @@ public class ScriptRuntime {
             return "-Infinity";
         if (d == 0.0)
             return "0";
-
-        if ((base < 2) || (base > 36)) {
-            throw Context.reportRuntimeError1(
-                "msg.bad.radix", Integer.toString(base));
-        }
 
         if (base != 10) {
             return DToA.JS_dtobasestr(base, d);
@@ -903,8 +914,9 @@ public class ScriptRuntime {
     }
 
     static String defaultObjectToSource(Context cx, Scriptable scope,
-                                        Scriptable thisObj, Object[] args)
+                                        Object thisObject, Object[] args)
     {
+        Scriptable thisObj = toObject(cx, scope, thisObject);
         boolean toplevel, iterating;
         if (cx.iterating == null) {
             toplevel = true;
@@ -1065,6 +1077,21 @@ public class ScriptRuntime {
                                       Class<?> staticClass)
     {
         return toObject(cx, scope, val);
+    }
+
+    /**
+     * <h1>[<i>ECMA 5.1</i>] 9.10 CheckObjectCoercible</h1>
+     * <p>Checks whether {@code val} is convertible by ToObject.</p>
+     * 
+     * @see #toObject(Context, Scriptable, Object)
+     */
+    public static void checkObjectCoercible(Object val) {
+        if (val == null) {
+            throw typeError0("msg.null.to.object");
+        }
+        if (val == Undefined.instance) {
+            throw typeError0("msg.undef.to.object");
+        }
     }
 
     /**
@@ -2328,7 +2355,6 @@ public class ScriptRuntime {
         if (!(value instanceof Callable)) {
             throw notFunctionError(value);
         }
-
         Callable f = (Callable)value;
         Scriptable thisObj = null;
         if (f instanceof Scriptable) {
@@ -2441,20 +2467,12 @@ public class ScriptRuntime {
      */
     public static Object applyOrCall(boolean isApply,
                                      Context cx, Scriptable scope,
-                                     Scriptable thisObj, Object[] args)
+                                     Object thisObj, Object[] args)
     {
         int L = args.length;
         Callable function = getCallable(thisObj);
 
-        Scriptable callThis = null;
-        if (L != 0) {
-            callThis = toObjectOrNull(cx, args[0]);
-        }
-        if (callThis == null) {
-            // This covers the case of args[0] == (null|undefined) as well.
-            callThis = getTopCallScope(cx);
-        }
-
+        Object callThis = (L != 0 ? args[0] : null);
         Object[] callArgs;
         if (isApply) {
             // Follow Ecma 15.3.4.3
@@ -2484,17 +2502,19 @@ public class ScriptRuntime {
         }
     }
 
-    static Callable getCallable(Scriptable thisObj)
+    static Callable getCallable(Object thisObj)
     {
         Callable function;
         if (thisObj instanceof Callable) {
             function = (Callable)thisObj;
-        } else {
-            Object value = thisObj.getDefaultValue(ScriptRuntime.FunctionClass);
+        } else if (thisObj instanceof Scriptable) {
+            Object value = ((ScriptableObject) thisObj).getDefaultValue(ScriptRuntime.FunctionClass);
             if (!(value instanceof Callable)) {
                 throw ScriptRuntime.notFunctionError(value, thisObj);
             }
             function = (Callable)value;
+        } else {
+            throw ScriptRuntime.notFunctionError(thisObj);
         }
         return function;
     }
@@ -3521,7 +3541,7 @@ public class ScriptRuntime {
                 ++skip;
                 continue;
             }
-            ScriptableObject.putProperty(array, i, objects[j]);
+            ScriptableObject.defineProperty(array, i, objects[j], ScriptableObject.EMPTY);
             ++j;
         }
         return array;

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -1552,6 +1552,42 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
      * @param attributes the attributes of the JavaScript property
      * @see org.mozilla.javascript.Scriptable#put(String, Scriptable, Object)
      */
+    public void defineProperty(int index, Object value,
+                               int attributes)
+    {
+        checkNotSealed(null, index);
+        put(index, this, value);
+        setAttributes(index, attributes);
+    }
+
+    /**
+     * Utility method to add properties to arbitrary Scriptable object.
+     * If destination is instance of ScriptableObject, calls
+     * defineProperty there, otherwise calls put in destination
+     * ignoring attributes
+     */
+    public static void defineProperty(Scriptable destination,
+                                      int index, Object value,
+                                      int attributes)
+    {
+        if (!(destination instanceof ScriptableObject)) {
+            destination.put(index, destination, value);
+            return;
+        }
+        ScriptableObject so = (ScriptableObject)destination;
+        so.defineProperty(index, value, attributes);
+    }
+
+    /**
+     * Define a JavaScript property.
+     *
+     * Creates the property with an initial value and sets its attributes.
+     *
+     * @param propertyName the name of the property to define.
+     * @param value the initial value of the property
+     * @param attributes the attributes of the JavaScript property
+     * @see org.mozilla.javascript.Scriptable#put(String, Scriptable, Object)
+     */
     public void defineProperty(String propertyName, Object value,
                                int attributes)
     {
@@ -1845,10 +1881,14 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
             Object getter = getProperty(desc, "get");
             if (getter != NOT_FOUND) {
                 gslot.getter = getter;
+            } else if (isNew) {
+                gslot.getter = Undefined.instance;
             }
             Object setter = getProperty(desc, "set");
             if (setter != NOT_FOUND) {
                 gslot.setter = setter;
+            } else if (isNew) {
+                gslot.setter = Undefined.instance;
             }
 
             gslot.value = Undefined.instance;
@@ -1893,9 +1933,12 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
                 if (isTrue(getProperty(desc, "configurable")))
                     throw ScriptRuntime.typeError1(
                         "msg.change.configurable.false.to.true", id);
-                if (isTrue(current.get("enumerable", current)) != isTrue(getProperty(desc, "enumerable")))
-                    throw ScriptRuntime.typeError1(
-                        "msg.change.enumerable.with.configurable.false", id);
+                if (hasProperty(desc, "enumerable")) {
+                    // only reject if 'enumerable' is present in desc
+                    if (isTrue(current.get("enumerable", current)) != isTrue(getProperty(desc, "enumerable")))
+                        throw ScriptRuntime.typeError1(
+                            "msg.change.enumerable.with.configurable.false", id);
+                }
                 boolean isData = isDataDescriptor(desc);
                 boolean isAccessor = isAccessorDescriptor(desc);
                 if (!isData && !isAccessor) {

--- a/src/org/mozilla/javascript/SpecialRef.java
+++ b/src/org/mozilla/javascript/SpecialRef.java
@@ -88,6 +88,10 @@ class SpecialRef extends Ref
           case SPECIAL_NONE:
             return ScriptRuntime.getObjectProp(target, name, cx);
           case SPECIAL_PROTO:
+            Object proto = target.get("__proto__", target);
+            if (proto != ScriptableObject.NOT_FOUND) {
+                return proto;
+            }
             return target.getPrototype();
           case SPECIAL_PARENT:
             return target.getParentScope();

--- a/src/org/mozilla/javascript/Synchronizer.java
+++ b/src/org/mozilla/javascript/Synchronizer.java
@@ -86,7 +86,7 @@ public class Synchronizer extends Delegator {
      * @see org.mozilla.javascript.Function#call
      */
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         Object sync = syncObject != null ? syncObject : thisObj;

--- a/src/org/mozilla/javascript/commonjs/module/Require.java
+++ b/src/org/mozilla/javascript/commonjs/module/Require.java
@@ -169,7 +169,8 @@ public class Require extends BaseFunction
         ScriptableObject.putProperty(scope, "require", this);
     }
 
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    @Override
+    public Object call(Context cx, Scriptable scope, Object thisObj,
             Object[] args)
     {
         if(args == null || args.length < 1) {
@@ -213,6 +214,7 @@ public class Require extends BaseFunction
         return getExportedModuleInterface(cx, id, uri, false);
     }
 
+    @Override
     public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
         throw ScriptRuntime.throwError(cx, scope,
                 "require() can not be invoked as a constructor");

--- a/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
@@ -70,7 +70,17 @@ class NativeRegExpCtor extends BaseFunction
     }
 
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public int getLength() {
+        return 2;
+    }
+
+    @Override
+    public int getArity() {
+        return 2;
+    }
+
+    @Override
+    public Object call(Context cx, Scriptable scope, Object thisObj,
                        Object[] args)
     {
         if (args.length > 0 && args[0] instanceof NativeRegExp &&

--- a/testsrc/doctests/error.tostring.doctest
+++ b/testsrc/doctests/error.tostring.doctest
@@ -3,19 +3,19 @@ js> var str = Error.prototype.toString
 js> str.call(new TypeError("msg"))
 TypeError: msg
 js> str.call(new TypeError()) // message is initialised to ''
-TypeError: 
+TypeError
 js> str.call(new Error("msg"))
 Error: msg
 js> str.call(new Error()) // message is initialised to ''
-Error: 
+Error
 js> str.call({name:"my error", message:"my message"})
 my error: my message
-js> str.call({}) === undefined
-true
-js> str.call({name:"no message defined"}) === undefined
-true
-js> str.call({name:"message is undefined", message:undefined}) === undefined
-true
+js> str.call({})
+Error
+js> str.call({name:"no message defined"})
+no message defined
+js> str.call({name:"message is undefined", message:undefined})
+message is undefined
 js> str.call({name:"null message", message:null})
 null message: null
 js> str.call({message:"no name defined"})

--- a/testsrc/org/mozilla/javascript/tests/TypeOfTest.java
+++ b/testsrc/org/mozilla/javascript/tests/TypeOfTest.java
@@ -57,7 +57,7 @@ public class TypeOfTest extends TestCase
         final Function f = new BaseFunction()
         {
         	@Override
-        	public Object call(Context _cx, Scriptable _scope, Scriptable _thisObj,
+        	public Object call(Context _cx, Scriptable _scope, Object _thisObj,
         			Object[] _args)
         	{
         		return _args[0].getClass().getName();

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
@@ -88,7 +88,7 @@ public class ComplianceTest extends TestCase
             setPrototype(ScriptableObject.getFunctionPrototype(scope));
         }
 
-        public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+        public Object call(Context cx, Scriptable scope, Object thisObj,
                 Object[] args)
         {
             if(args.length > 1 && "fail".equals(args[1])) {

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/Namespace.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/Namespace.java
@@ -234,7 +234,7 @@ class Namespace extends IdScriptableObject
     public Object execIdCall(IdFunctionObject f,
                              Context cx,
                              Scriptable scope,
-                             Scriptable thisObj,
+                             Object thisObj,
                              Object[] args)
     {
         if (!f.hasTag(NAMESPACE_TAG)) {
@@ -252,7 +252,7 @@ class Namespace extends IdScriptableObject
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private Namespace realThis(Scriptable thisObj, IdFunctionObject f) {
+    private Namespace realThis(Object thisObj, IdFunctionObject f) {
         if(!(thisObj instanceof Namespace))
             throw incompatibleCallError(f);
         return (Namespace)thisObj;

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/QName.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/QName.java
@@ -260,7 +260,7 @@ final class QName extends IdScriptableObject
     public Object execIdCall(IdFunctionObject f,
                              Context cx,
                              Scriptable scope,
-                             Scriptable thisObj,
+                             Object thisObj,
                              Object[] args)
     {
         if (!f.hasTag(QNAME_TAG)) {
@@ -278,7 +278,7 @@ final class QName extends IdScriptableObject
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    private QName realThis(Scriptable thisObj, IdFunctionObject f)
+    private QName realThis(Object thisObj, IdFunctionObject f)
     {
         if(!(thisObj instanceof QName))
             throw incompatibleCallError(f);

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLCtor.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLCtor.java
@@ -246,7 +246,7 @@ class XMLCtor extends IdFunctionObject
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(XMLCTOR_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -744,7 +744,7 @@ class XMLList extends XMLObjectImpl implements Function {
 
     private Object applyOrCall(boolean isApply,
         Context cx, Scriptable scope,
-        Scriptable thisObj, Object[] args) {
+        Object thisObj, Object[] args) {
         String methodName = isApply ? "apply" : "call";
         if(!(thisObj instanceof XMLList) ||
             ((XMLList)thisObj).targetProperty == null)
@@ -781,7 +781,7 @@ class XMLList extends XMLObjectImpl implements Function {
         return null;
     }
 
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
+    public Object call(Context cx, Scriptable scope, Object thisObj,
         Object[] args) {
         // This XMLList is being called as a Function.
         // Let's find the real Function object.
@@ -798,7 +798,7 @@ class XMLList extends XMLObjectImpl implements Function {
             throw ScriptRuntime.typeError1("msg.incompat.call", methodName);
         }
         Object func = null;
-        Scriptable sobj = thisObj;
+        Scriptable sobj = (XMLObject) thisObj;
 
         while (sobj instanceof XMLObject) {
             XMLObject xmlObject = (XMLObject) sobj;

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
@@ -636,7 +636,7 @@ abstract class XMLObjectImpl extends XMLObject {
 
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
+                             Object thisObj, Object[] args)
     {
         if (!f.hasTag(XMLOBJECT_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);


### PR DESCRIPTION
One single commit to resolve test case failures when running test262-chapter15 tests (only covered non-strict tests!). If you need smaller commits to ease reviewing, let me know!

-- André

ECMAScript5 has changed "15.3.4.4  Function.prototype.call" to longer coerce the `thisObject` by means of ToObject.
That requires a few API changes in Rhino, notably for Callable#call() and IdFunctionCall#execIdCall(). As both
methods are fundamental aspects of any host object in Rhino, the API change triggered changes all over the place.
In the rest of this commit message, file changes are not separately listed below if the changes are only updates
for either call() or execIdCall().

Callable:
- changed `thisObject` type from "Scriptable" to "Object" to conform to ES5
  IdFunctionCall:
- changed `thisObject` type from "Scriptable" to "Object" to conform to ES5

xmlbeans/XMLList:
- add cast to XMLObject [short-cut instead of calling ScriptRuntime.toObject()]

Arguments:
- add initial default data-descriptor with {enumerable: true, writable: true, configurable: true} per 10.6 Arguments Object, step 11.b
- required at this point otherwise ScriptableObject#defineOwnProperty() sets the attributes to {enumerable: false, writable: false, configurable: false}
- handle case when only 'writable' is set
- replace isFalse() call with additional check whether 'writable' is actually present in descriptor
- also see [[DefineOwnProperty]] for Arguments step 5.b.i and 5.b.ii

BaseFunction:
- arity of toString() is 1
- realFunction() should default to use `thisObject` as function if valueOf() returns non-function object [valueOf() redefining the function seems to a rhino-specific implementation choice?]
- left backward compatible call() method definition to help users move to new call() interface

IdScriptableObject:
- left backward compatible execIdCall() method definition to help users move to new execIdCall() interface

InterprectedFunction:
- user functions still coerce 'null' and 'undefined' to the global object

Codegen:
- update generated code to match InterprectedFunction

NativeArray:
- [[Put]] cannot add new entries if [[Extensible]] is false, cf. 8.12.4 [[CanPut]]
- added 15.4.5.1 [[DefineOwnProperty]] for the 'length' property on Array
- added 15.4.5.1 [[DefineOwnProperty]] for the index properties on Array
- intercept 'length' and index properties and redirect to the methods listed above
- 'length' must be intercepted for both defineOwnProperty() methods, see defineOwnProperty() in super-class
- copied more or less from setLength(), but includes additional checks and always deletes index properties in descending order as specified in 15.4.5.1 [[DefineOwnProperty]]
- helper method just like setElem(), but uses [[DefineOwnProperty]] instead of [[Put]]
- follow spec for 15.4.4.11  Array.prototype.sort more closely in respect to undefined and not-defined properties
- explicitely call deleteElem() because `thisObject` may not be an Array instance
- always call setLengthProperty() to ensure update to 'length' property b/c it may be implicitely updated due to call to ToUint32 in step 3 of 15.4.4.13  Array.prototype.unshift
- add missing calls to [[Delete]], see step 12.d of 15.4.4.12  Array.prototype.splice
- 15.4.4.4  Array.prototype.concat uses [[DefineOwnProperty]] instead of [[Put]]
- handle case when first argument is `undefined`
- 15.4.4.10  Array.prototype.slice uses [[DefineOwnProperty]] instead of [[Put]]
- removed method, indexOf and lastIndexOf now use seperate methods since the amount of shared lines was negliglible to justify the added non-uniformness compared to the other js_\* methods
- 15.4.4.14  Array.prototype.indexOf uses [[Get]], therefore add search for prototype values in the dense-array case
- 15.4.4.15  Array.prototype.lastIndexOf uses [[Get]], therefore add search for prototype values in the dense-array case
- use caution to follow algorithm steps more closely
- 'filter' and 'map' use [[DefineOwnProperty]] instead of [[Put]]
- use caution to follow algorithm steps more closely

NativeDate:
- length of 'constructor' and 'UTC' is 7
- handle case when Date.prototype.toISOString is redefined for Date objects
- Date.prototype.toJSON uses [[GET]] to obtain the "toISOString" property
- don't use Java's DateFormat to parse/format dates from/into ISO-8601 Extended Format strings since DateFormat doesn't follow the syntax from 15.9.1.15  Date Time String Format
- add DaysInMonth method with same contract as DaysInMonth from jsdate.cpp
- add parseISOString method with same contract as in jsdate.cpp, but use a simple state machine since Java doesn't support macros
- parseISOString supports the following two deviations from the spec:
  1) time-only format, e.g. "08:00:00Z"
  2) timezone descriptor without ':' as separator, e.g. "08:00:00+0100" instead of "08:00:00+01:00"
- parseISOString also supports the same input validation as in jsdata.cpp, the spec isn't really clear what to do with invalid input data
- add js_toISOString method to format date values in ISO-8601 Extended Format with expanded year representation if necessary

NativeError:
- properly set default attributes for "name" and "message"
- handle `undefined` value for message in constructor
- follow spec for 15.11.4.4  Error.prototype.toString more closely

NativeGlobal:
- remove IE-support shim for "ConversionError"
- no longer replace 0xFFFE and 0xFFFF with 0xFFFD when decoding URI's

NativeNumber:
- stick with the spec and don't allow non-standard precisions

NativeObject:
- Object.prototype.toLocaleString no longer alias for toString instead follow spec and retrieve current "toString" with [[Get]]
- Object.prototype.valueOf calls ToObject on `thisObject` per spec
- handle `undefined` arguments for Object.prototype.hasOwnProperty and Object.prototype.propertyIsEnumerable
- Object.prototype.isPrototypeOf calls ToObject after argument validation per spec algorithm

NativeString:
- arity of String.prototype.replace is 2
- call CheckObjectCoercible on `thisObject` if required by spec for String.prototype methods
- add more overriden methods to be compliant to 15.5.5.2 [[GetOwnProperty]]
- handle `undefined` arguments in 15.5.4.13  String.prototype.slice

ScriptRuntime:
- add additional defaultObjectToString() method to support 15.2.4.2  Object.prototype.toString
- #numberToString(): first check radix, then process other special values like Infinity etc.
- add #checkObjectCoercible() per 9.10 CheckObjectCoercible
  -- don't map `null` or `undefined` to the global object if specified as `thisObject`, cf. 15.3.4.4  Function.prototype.call
  -- don't call ToObject for the `thisObject`, cf. 15.3.4.4  Function.prototype.call
- use [[DefineOwnProperty]] rather than [[Put]] in #newArrayLiteral() when creating new Array objects

ScriptableObject:
- add helper methods for defineProperty() which work on integer indices instead of strings
- default getter resp. setter to `undefined` when creating a new accessor property
- 'enumerable' must be present before attempting to reject property change in #checkPropertyChange()

SpecialRef:
- handle the case when an object actually has an own property named "**proto**"

NativeRegExp:
- RegExp is no longer callable, also see https://bugzilla.mozilla.org/show_bug.cgi?id=582717
- change 'lastIndex' property from double to Object to allow lazy evaluation of the property
- handle `undefined` argument when compiling a new RegExp
- make RegExp.prototype.exec work with `undefined` argument
- add lazy evaluation of 'lastIndex' in RegExp.prototype.exec
- additional check to report an error if a RegExp flag appears more than once
- don't allow unqualified '{', cf. `/a{1}{1}/`
- arity of RegExp.prototype.compile is 2

NativeRegExpCtor:
- arity of RegExp constructor is 2

RegExpImpl:
- String.prototype.replace erroneously created a RegExp if the first argument was not already an instanceof RegExp
- move NativeRegExp creation out of matchOrReplace into a new method
- handle `undefined` arguments for String.prototype.{match, search, replace}
- follow String.prototype.split algorithm steps more closely

error.tostring.doctest:
- update expected values, double-checked with SM shell
