### PR TITLE
Bug489326 builtin objects (from 'ES5-Test262 progress' pull request)

### DIFF
--- a/src/org/mozilla/javascript/Arguments.java
+++ b/src/org/mozilla/javascript/Arguments.java
@@ -67,9 +67,6 @@ final class Arguments extends IdScriptableObject
         NativeFunction f = activation.function;
         calleeObj = f;
 
-        Scriptable topLevel = getTopLevelScope(parent);
-        constructor = getProperty(topLevel, "Object");
-
         int version = f.getLanguageVersion();
         if (version <= Context.VERSION_1_3
             && version != Context.VERSION_DEFAULT)
@@ -197,9 +194,8 @@ final class Arguments extends IdScriptableObject
         Id_callee           = 1,
         Id_length           = 2,
         Id_caller           = 3,
-        Id_constructor      = 4,
 
-        MAX_INSTANCE_ID     = Id_constructor;
+        MAX_INSTANCE_ID     = Id_caller;
 
     @Override
     protected int getMaxInstanceId()
@@ -220,7 +216,6 @@ final class Arguments extends IdScriptableObject
                 else if (c=='h') { X="length";id=Id_length; }
                 else if (c=='r') { X="caller";id=Id_caller; }
             }
-            else if (s_length==11) { X="constructor";id=Id_constructor; }
             if (X!=null && X!=s && !X.equals(s)) id = 0;
             break L0;
         }
@@ -233,7 +228,6 @@ final class Arguments extends IdScriptableObject
           case Id_callee:
           case Id_caller:
           case Id_length:
-          case Id_constructor:
             attr = DONTENUM;
             break;
           default: throw new IllegalStateException();
@@ -250,7 +244,6 @@ final class Arguments extends IdScriptableObject
             case Id_callee: return "callee";
             case Id_length: return "length";
             case Id_caller: return "caller";
-            case Id_constructor: return "constructor";
         }
         return null;
     }
@@ -272,8 +265,6 @@ final class Arguments extends IdScriptableObject
                 }
                 return value;
             }
-            case Id_constructor:
-                return constructor;
         }
         return super.getInstanceIdValue(id);
     }
@@ -287,7 +278,6 @@ final class Arguments extends IdScriptableObject
             case Id_caller:
                 callerObj = (value != null) ? value : UniqueTag.NULL_VALUE;
                 return;
-            case Id_constructor: constructor = value; return;
         }
         super.setInstanceIdValue(id, value);
     }
@@ -397,7 +387,6 @@ final class Arguments extends IdScriptableObject
     private Object callerObj;
     private Object calleeObj;
     private Object lengthObj;
-    private Object constructor;
 
     private NativeCall activation;
 

--- a/src/org/mozilla/javascript/Arguments.java
+++ b/src/org/mozilla/javascript/Arguments.java
@@ -226,9 +226,13 @@ final class Arguments extends IdScriptableObject
         int attr;
         switch (id) {
           case Id_callee:
+            attr = calleeAttr;
+            break;
           case Id_caller:
+            attr = callerAttr;
+            break;
           case Id_length:
-            attr = DONTENUM;
+            attr = lengthAttr;
             break;
           default: throw new IllegalStateException();
         }
@@ -280,6 +284,17 @@ final class Arguments extends IdScriptableObject
                 return;
         }
         super.setInstanceIdValue(id, value);
+    }
+
+    @Override
+    protected void setInstanceIdAttributes(int id, int attr)
+    {
+        switch (id) {
+            case Id_callee: calleeAttr = attr; return;
+            case Id_length: lengthAttr = attr; return;
+            case Id_caller: callerAttr = attr; return;
+        }
+        super.setInstanceIdAttributes(id, attr);
     }
 
     @Override
@@ -387,6 +402,10 @@ final class Arguments extends IdScriptableObject
     private Object callerObj;
     private Object calleeObj;
     private Object lengthObj;
+
+    private int callerAttr = DONTENUM;
+    private int calleeAttr = DONTENUM;
+    private int lengthAttr = DONTENUM;
 
     private NativeCall activation;
 

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -166,7 +166,7 @@ public class BaseFunction extends IdScriptableObject implements Function
             attr = prototypePropertyAttributes;
             break;
           case Id_arguments:
-            attr = DONTENUM | PERMANENT;
+            attr = argumentsAttributes;
             break;
           default: throw new IllegalStateException();
         }
@@ -214,7 +214,11 @@ public class BaseFunction extends IdScriptableObject implements Function
                     // This should not be called since "arguments" is PERMANENT
                     Kit.codeBug();
                 }
-                defaultPut("arguments", value);
+                if (defaultHas("arguments")) {
+                    defaultPut("arguments", value);
+                } else if ((argumentsAttributes & READONLY) == 0) {
+                    argumentsObj = value;
+                }
                 return;
             case Id_name:
             case Id_arity:
@@ -230,6 +234,9 @@ public class BaseFunction extends IdScriptableObject implements Function
         switch (id) {
             case Id_prototype:
                 prototypePropertyAttributes = attr;
+                return;
+            case Id_arguments:
+                argumentsAttributes = attr;
                 return;
         }
         super.setInstanceIdAttributes(id, attr);
@@ -504,7 +511,7 @@ public class BaseFunction extends IdScriptableObject implements Function
       // <Function name>.arguments is deprecated, so we use a slow
       // way of getting it that doesn't add to the invocation cost.
       // TODO: add warning, error based on version
-      Object value = defaultGet("arguments");
+      Object value = defaultHas("arguments") ? defaultGet("arguments") : argumentsObj;
       if (value != NOT_FOUND) {
           // Should after changing <Function name>.arguments its
           // activation still be available during Function call?
@@ -620,9 +627,12 @@ public class BaseFunction extends IdScriptableObject implements Function
 // #/string_id_map#
 
     private Object prototypeProperty;
+    private Object argumentsObj = NOT_FOUND;
+
     // For function object instances, attributes are
     //  {configurable:false, enumerable:false};
     // see ECMA 15.3.5.2
     private int prototypePropertyAttributes = PERMANENT|DONTENUM;
+    private int argumentsAttributes = PERMANENT|DONTENUM;
 }
 

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -241,7 +241,7 @@ public class BaseFunction extends IdScriptableObject implements Function
         int arity;
         switch (id) {
           case Id_constructor: arity=1; s="constructor"; break;
-          case Id_toString:    arity=1; s="toString";    break;
+          case Id_toString:    arity=0; s="toString";    break;
           case Id_toSource:    arity=1; s="toSource";    break;
           case Id_apply:       arity=2; s="apply";       break;
           case Id_call:        arity=1; s="call";        break;

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -225,6 +225,17 @@ public class BaseFunction extends IdScriptableObject implements Function
     }
 
     @Override
+    protected void setInstanceIdAttributes(int id, int attr)
+    {
+        switch (id) {
+            case Id_prototype:
+                prototypePropertyAttributes = attr;
+                return;
+        }
+        super.setInstanceIdAttributes(id, attr);
+    }
+
+    @Override
     protected void fillConstructorProperties(IdFunctionObject ctor)
     {
         // Fix up bootstrapping problem: getPrototype of the IdFunctionObject

--- a/src/org/mozilla/javascript/BoundFunction.java
+++ b/src/org/mozilla/javascript/BoundFunction.java
@@ -67,7 +67,7 @@ public class BoundFunction extends BaseFunction {
 
     ScriptRuntime.setFunctionProtoAndParent(this, scope);
 
-    Function thrower = ScriptRuntime.typeErrorThrower();
+    Function thrower = ScriptRuntime.typeErrorThrower(cx);
     NativeObject throwing = new NativeObject();
     throwing.put("get", throwing, thrower);
     throwing.put("set", throwing, thrower);

--- a/src/org/mozilla/javascript/ConsString.java
+++ b/src/org/mozilla/javascript/ConsString.java
@@ -85,7 +85,7 @@ public class ConsString implements CharSequence, Serializable {
     private Object writeReplace() {
         return this.toString();
     }
-    
+
     public String toString() {
         return depth == 0 ? (String)s1 : flatten();
     }

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -2595,6 +2595,7 @@ public class Context
     boolean isContinuationsTopCall;
     NativeCall currentActivationCall;
     XMLLib cachedXMLLib;
+    BaseFunction typeErrorThrower;
 
     // for Objects, Arrays to tag themselves as being printed out,
     // so they don't print themselves out recursively.

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -1529,11 +1529,7 @@ public class Context
     public Scriptable newObject(Scriptable scope, String constructorName,
                                 Object[] args)
     {
-        scope = ScriptableObject.getTopLevelScope(scope);
-        Function ctor = ScriptRuntime.getExistingCtor(this, scope,
-                                                      constructorName);
-        if (args == null) { args = ScriptRuntime.emptyArgs; }
-        return ctor.construct(this, scope, args);
+        return ScriptRuntime.newObject(this, scope, constructorName, args);
     }
 
     /**

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -42,7 +42,6 @@ package org.mozilla.javascript;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Reader;
@@ -2470,39 +2469,15 @@ public class Context
          * A bit of a hack, but the only way to get filename and line
          * number from an enclosing frame.
          */
-        CharArrayWriter writer = new CharArrayWriter();
-        RuntimeException re = new RuntimeException();
-        re.printStackTrace(new PrintWriter(writer));
-        String s = writer.toString();
-        int open = -1;
-        int close = -1;
-        int colon = -1;
-        for (int i=0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (c == ':')
-                colon = i;
-            else if (c == '(')
-                open = i;
-            else if (c == ')')
-                close = i;
-            else if (c == '\n' && open != -1 && close != -1 && colon != -1 &&
-                     open < colon && colon < close)
-            {
-                String fileStr = s.substring(open + 1, colon);
-                if (!fileStr.endsWith(".java")) {
-                    String lineStr = s.substring(colon + 1, close);
-                    try {
-                        linep[0] = Integer.parseInt(lineStr);
-                        if (linep[0] < 0) {
-                            linep[0] = 0;
-                        }
-                        return fileStr;
-                    }
-                    catch (NumberFormatException e) {
-                        // fall through
-                    }
+        StackTraceElement[] stackTrace = new Throwable().getStackTrace();
+        for (StackTraceElement st : stackTrace) {
+            String file = st.getFileName();
+            if (!(file == null || file.endsWith(".java"))) {
+                int line = st.getLineNumber();
+                if (line >= 0) {
+                    linep[0] = line;
+                    return file;
                 }
-                open = close = colon = -1;
             }
         }
 

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -322,6 +322,11 @@ public abstract class IdScriptableObject extends ScriptableObject
         super(scope, prototype);
     }
 
+    protected final boolean defaultHas(String name)
+    {
+        return super.has(name, this);
+    }
+
     protected final Object defaultGet(String name)
     {
         return super.get(name, this);

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1589,7 +1589,7 @@ public class NativeArray extends IdScriptableObject implements List
                         val = ScriptableObject.getProperty(proto, i);
                     }
                     if (val != NOT_FOUND &&
-                        ScriptRuntime.shallowEq(na.dense[i], compareTo))
+                        ScriptRuntime.shallowEq(val, compareTo))
                     {
                         return Long.valueOf(i);
                     }

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1006,14 +1006,14 @@ public class NativeArray extends IdScriptableObject implements List
             comparator = new Comparator<Object>() {
                 public int compare(final Object x, final Object y) {
                     // sort undefined to end
-                    if (x == y) {
-                        return 0;
-                    } else if (y == Undefined.instance
-                            || y == Scriptable.NOT_FOUND) {
+                    if (x == NOT_FOUND) {
+                        return y == NOT_FOUND ? 0 : 1;
+                    } else if (y == NOT_FOUND) {
                         return -1;
-                    } else if (x == Undefined.instance
-                            || x == Scriptable.NOT_FOUND) {
-                        return 1;
+                    } else if (x == Undefined.instance) {
+                        return y == Undefined.instance ? 0 : 1;
+                    } else if (y == Undefined.instance) {
+                        return -1;
                     }
 
                     cmpBuf[0] = x;
@@ -1033,14 +1033,14 @@ public class NativeArray extends IdScriptableObject implements List
             comparator = new Comparator<Object>() {
                 public int compare(final Object x, final Object y) {
                     // sort undefined to end
-                    if (x == y)
-                        return 0;
-                    else if (y == Undefined.instance
-                            || y == Scriptable.NOT_FOUND) {
+                    if (x == NOT_FOUND) {
+                        return y == NOT_FOUND ? 0 : 1;
+                    } else if (y == NOT_FOUND) {
                         return -1;
-                    } else if (x == Undefined.instance
-                            || x == Scriptable.NOT_FOUND) {
-                        return 1;
+                    } else if (x == Undefined.instance) {
+                        return y == Undefined.instance ? 0 : 1;
+                    } else if (y == Undefined.instance) {
+                        return -1;
                     }
 
                     final String a = ScriptRuntime.toString(x);
@@ -1067,10 +1067,6 @@ public class NativeArray extends IdScriptableObject implements List
 
         return thisObj;
     }
-
-    /**
-     * Non-ECMA methods.
-     */
 
     private static Object js_push(Context cx, Scriptable thisObj,
                                   Object[] args)

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -452,7 +452,9 @@ public class NativeArray extends IdScriptableObject implements List
         if (start == this && !isSealed() && dense != null && 0 <= index &&
             (denseOnly || !isGetterOrSetter(null, index, true)))
         {
-            if (index < dense.length) {
+            if (!isExtensible() && this.length <= index) {
+                return;
+            } else if (index < dense.length) {
                 dense[index] = value;
                 if (this.length <= index)
                     this.length = (long)index + 1;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -287,7 +287,7 @@ public class NativeArray extends IdScriptableObject implements List
               }
 
               case ConstructorId_isArray:
-                return args.length > 0 && (args[0] instanceof NativeArray);
+                return args.length > 0 && js_isArray(args[0]);
 
               case Id_constructor: {
                 boolean inNewExpr = (thisObj == null);
@@ -1356,8 +1356,7 @@ public class NativeArray extends IdScriptableObject implements List
     {
         // create an empty Array to return.
         scope = getTopLevelScope(scope);
-        Function ctor = ScriptRuntime.getExistingCtor(cx, scope, "Array");
-        Scriptable result = ctor.construct(cx, scope, ScriptRuntime.emptyArgs);
+        Scriptable result = cx.newArray(scope, 0);
         if (thisObj instanceof NativeArray && result instanceof NativeArray) {
             NativeArray denseThis = (NativeArray) thisObj;
             NativeArray denseResult = (NativeArray) result;
@@ -1403,7 +1402,7 @@ public class NativeArray extends IdScriptableObject implements List
         /* Put the target in the result array; only add it as an array
          * if it looks like one.
          */
-        if (ScriptRuntime.instanceOf(thisObj, ctor, cx)) {
+        if (js_isArray(thisObj)) {
             length = getLengthProperty(cx, thisObj);
 
             // Copy from the target object into the result
@@ -1422,8 +1421,8 @@ public class NativeArray extends IdScriptableObject implements List
          * elements separately; otherwise, just copy the argument.
          */
         for (int i = 0; i < args.length; i++) {
-            if (ScriptRuntime.instanceOf(args[i], ctor, cx)) {
-                // ScriptRuntime.instanceOf => instanceof Scriptable
+            if (js_isArray(args[i])) {
+                // js_isArray => instanceof Scriptable
                 Scriptable arg = (Scriptable)args[i];
                 length = getLengthProperty(cx, arg);
                 for (long j = 0; j < length; j++, slot++) {
@@ -1688,6 +1687,13 @@ public class NativeArray extends IdScriptableObject implements List
             throw ScriptRuntime.typeError0("msg.empty.array.reduce");
         }
         return value;
+    }
+
+    private static boolean js_isArray(Object o) {
+        if (!(o instanceof Scriptable)) {
+            return false;
+        }
+        return "Array".equals(((Scriptable)o).getClassName());
     }
 
     // methods to implement java.util.List

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -405,11 +405,11 @@ final class NativeDate extends IdScriptableObject
             return ScriptRuntime.wrapNumber(t);
 
           case Id_toISOString:
-              if (t == t) {
-                  return js_toISOString(t);
-              }
-              String msg = ScriptRuntime.getMessage0("msg.invalid.date");
-              throw ScriptRuntime.constructError("RangeError", msg);
+            if (t == t) {
+                return js_toISOString(t);
+            }
+            String msg = ScriptRuntime.getMessage0("msg.invalid.date");
+            throw ScriptRuntime.constructError("RangeError", msg);
 
           default: throw new IllegalArgumentException(String.valueOf(id));
         }
@@ -812,13 +812,13 @@ final class NativeDate extends IdScriptableObject
     }
 
     /**
-    * 15.9.1.15 Date Time String Format<br>
-    * Parse input string according to simplified ISO-8601 Extended Format:
-    * <ul>
-    * <li><code>YYYY-MM-DD'T'HH:mm:ss.sss'Z'</code></li>
-    * <li>or <code>YYYY-MM-DD'T'HH:mm:ss.sss[+-]hh:mm</code></li>
-    * </ul>
-    */
+     * 15.9.1.15 Date Time String Format<br>
+     * Parse input string according to simplified ISO-8601 Extended Format:
+     * <ul>
+     * <li><code>YYYY-MM-DD'T'HH:mm:ss.sss'Z'</code></li>
+     * <li>or <code>YYYY-MM-DD'T'HH:mm:ss.sss[+-]hh:mm</code></li>
+     * </ul>
+     */
     private static double parseISOString(String s) {
         // we use a simple state machine to parse the input string
         final int ERROR = -1;

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -208,10 +208,6 @@ final class NativeDate extends IdScriptableObject
 
           case Id_toJSON:
             {
-                if (thisObj instanceof NativeDate) {
-                    return ((NativeDate) thisObj).toISOString();
-                }
-
                 final String toISOString = "toISOString";
 
                 Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
@@ -222,7 +218,7 @@ final class NativeDate extends IdScriptableObject
                         return null;
                     }
                 }
-                Object toISO = o.get(toISOString, o);
+                Object toISO = ScriptableObject.getProperty(o, toISOString);
                 if (toISO == NOT_FOUND) {
                     throw ScriptRuntime.typeError2("msg.function.not.found.in",
                             toISOString,

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -114,7 +114,7 @@ final class NativeDate extends IdScriptableObject
         addIdFunctionProperty(ctor, DATE_TAG, ConstructorId_parse,
                               "parse", 1);
         addIdFunctionProperty(ctor, DATE_TAG, ConstructorId_UTC,
-                              "UTC", 1);
+                              "UTC", 7);
         super.fillConstructorProperties(ctor);
     }
 
@@ -124,7 +124,7 @@ final class NativeDate extends IdScriptableObject
         String s;
         int arity;
         switch (id) {
-          case Id_constructor:        arity=1; s="constructor";        break;
+          case Id_constructor:        arity=7; s="constructor";        break;
           case Id_toString:           arity=0; s="toString";           break;
           case Id_toTimeString:       arity=0; s="toTimeString";       break;
           case Id_toDateString:       arity=0; s="toDateString";       break;

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -413,21 +413,15 @@ final class NativeDate extends IdScriptableObject
             return ScriptRuntime.wrapNumber(t);
 
           case Id_toISOString:
-            return realThis.toISOString();
+              if (t == t) {
+                  return js_toISOString(t);
+              }
+              String msg = ScriptRuntime.getMessage0("msg.invalid.date");
+              throw ScriptRuntime.constructError("RangeError", msg);
 
           default: throw new IllegalArgumentException(String.valueOf(id));
         }
 
-    }
-
-    private String toISOString() {
-        if (date == date) {
-            synchronized (isoFormat) {
-                return isoFormat.format(new Date((long) date));
-            }
-        }
-        String msg = ScriptRuntime.getMessage0("msg.invalid.date");
-        throw ScriptRuntime.constructError("RangeError", msg);
     }
 
     /* ECMA helper functions */
@@ -1035,7 +1029,7 @@ final class NativeDate extends IdScriptableObject
 
     private static String date_format(double t, int methodId)
     {
-        StringBuffer result = new StringBuffer(60);
+        StringBuilder result = new StringBuilder(60);
         double local = LocalTime(t);
 
         /* Tue Oct 31 09:41:40 GMT-0800 (PST) 2000 */
@@ -1175,7 +1169,7 @@ final class NativeDate extends IdScriptableObject
 
     private static String js_toUTCString(double date)
     {
-        StringBuffer result = new StringBuffer(60);
+        StringBuilder result = new StringBuilder(60);
 
         appendWeekDayName(result, WeekDay(date));
         result.append(", ");
@@ -1198,7 +1192,35 @@ final class NativeDate extends IdScriptableObject
         return result.toString();
     }
 
-    private static void append0PaddedUint(StringBuffer sb, int i, int minWidth)
+    private static String js_toISOString(double t) {
+        StringBuilder result = new StringBuilder(27);
+
+        int year = YearFromTime(t);
+        if (year < 0) {
+            result.append('-');
+            append0PaddedUint(result, -year, 6);
+        } else if (year > 9999) {
+            append0PaddedUint(result, year, 6);
+        } else {
+            append0PaddedUint(result, year, 4);
+        }
+        result.append('-');
+        append0PaddedUint(result, MonthFromTime(t) + 1, 2);
+        result.append('-');
+        append0PaddedUint(result, DateFromTime(t), 2);
+        result.append('T');
+        append0PaddedUint(result, HourFromTime(t), 2);
+        result.append(':');
+        append0PaddedUint(result, MinFromTime(t), 2);
+        result.append(':');
+        append0PaddedUint(result, SecFromTime(t), 2);
+        result.append('.');
+        append0PaddedUint(result, msFromTime(t), 3);
+        result.append('Z');
+        return result.toString();
+    }
+
+    private static void append0PaddedUint(StringBuilder sb, int i, int minWidth)
     {
         if (i < 0) Kit.codeBug();
         int scale = 1;
@@ -1229,7 +1251,7 @@ final class NativeDate extends IdScriptableObject
         sb.append((char)('0' + i));
     }
 
-    private static void appendMonthName(StringBuffer sb, int index)
+    private static void appendMonthName(StringBuilder sb, int index)
     {
         // Take advantage of the fact that all month abbreviations
         // have the same length to minimize amount of strings runtime has
@@ -1242,7 +1264,7 @@ final class NativeDate extends IdScriptableObject
         }
     }
 
-    private static void appendWeekDayName(StringBuffer sb, int index)
+    private static void appendWeekDayName(StringBuilder sb, int index)
     {
         String days = "Sun"+"Mon"+"Tue"+"Wed"+"Thu"+"Fri"+"Sat";
         index *= 3;

--- a/src/org/mozilla/javascript/NativeError.java
+++ b/src/org/mozilla/javascript/NativeError.java
@@ -61,6 +61,8 @@ final class NativeError extends IdScriptableObject
         ScriptableObject.putProperty(obj, "message", "");
         ScriptableObject.putProperty(obj, "fileName", "");
         ScriptableObject.putProperty(obj, "lineNumber", Integer.valueOf(0));
+        obj.setAttributes("name", ScriptableObject.DONTENUM);
+        obj.setAttributes("message", ScriptableObject.DONTENUM);
         obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
     }
 

--- a/src/org/mozilla/javascript/NativeError.java
+++ b/src/org/mozilla/javascript/NativeError.java
@@ -77,8 +77,10 @@ final class NativeError extends IdScriptableObject
 
         int arglen = args.length;
         if (arglen >= 1) {
-            ScriptableObject.putProperty(obj, "message",
-                    ScriptRuntime.toString(args[0]));
+            if (args[0] != Undefined.instance) {
+                ScriptableObject.putProperty(obj, "message",
+                        ScriptRuntime.toString(args[0]));
+            }
             if (arglen >= 2) {
                 ScriptableObject.putProperty(obj, "fileName", args[1]);
                 if (arglen >= 3) {
@@ -101,7 +103,7 @@ final class NativeError extends IdScriptableObject
     public String toString()
     {
         // According to spec, Error.prototype.toString() may return undefined.
-        Object toString =  js_toString(this);
+        Object toString = js_toString(this);
         return toString instanceof String ? (String) toString : super.toString();
     }
 
@@ -183,13 +185,18 @@ final class NativeError extends IdScriptableObject
             name = ScriptRuntime.toString(name);
         }
         Object msg = ScriptableObject.getProperty(thisObj, "message");
-        final Object result;
         if (msg == NOT_FOUND || msg == Undefined.instance) {
-            result = Undefined.instance;
+            msg = "";
         } else {
-            result = ((String) name) + ": " + ScriptRuntime.toString(msg);
+            msg = ScriptRuntime.toString(msg);
         }
-        return result;
+        if (name.toString().length() == 0) {
+            return msg;
+        } else if (msg.toString().length() == 0) {
+            return name;
+        } else {
+            return ((String) name) + ": " + ((String) msg);
+        }
     }
 
     private static String js_toSource(Context cx, Scriptable scope,

--- a/src/org/mozilla/javascript/NativeGlobal.java
+++ b/src/org/mozilla/javascript/NativeGlobal.java
@@ -129,26 +129,15 @@ public class NativeGlobal implements Serializable, IdFunctionCall
             scope, "undefined", Undefined.instance,
             READONLY|DONTENUM|PERMANENT);
 
-        String[] errorMethods = {
-                "ConversionError",
-                "EvalError",
-                "RangeError",
-                "ReferenceError",
-                "SyntaxError",
-                "TypeError",
-                "URIError",
-                "InternalError",
-                "JavaException"
-        };
-
         /*
             Each error constructor gets its own Error object as a prototype,
             with the 'name' property set to the name of the error.
         */
-        for (int i = 0; i < errorMethods.length; i++) {
-            String name = errorMethods[i];
+        for (TopLevel.NativeErrors error : TopLevel.NativeErrors.values()) {
+            String name = error.name();
             ScriptableObject errorProto =
-              (ScriptableObject) ScriptRuntime.newObject(cx, scope, "Error",
+              (ScriptableObject) ScriptRuntime.newBuiltinObject(cx, scope,
+                                                  TopLevel.Builtins.Error,
                                                   ScriptRuntime.emptyArgs);
             errorProto.put("name", errorProto, name);
             errorProto.put("message", errorProto, "");

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -221,12 +221,13 @@ final class NativeNumber extends IdScriptableObject
         } else {
             /* We allow a larger range of precision than
                ECMA requires; this is permitted by ECMA. */
-            precision = ScriptRuntime.toInt32(args[0]);
-            if (precision < precisionMin || precision > MAX_PRECISION) {
+            double p = ScriptRuntime.toInteger(args[0]);
+            if (p < precisionMin || p > MAX_PRECISION) {
                 String msg = ScriptRuntime.getMessage1(
                     "msg.bad.precision", ScriptRuntime.toString(args[0]));
                 throw ScriptRuntime.constructError("RangeError", msg);
             }
+            precision = ScriptRuntime.toInt32(p);
         }
         StringBuilder sb = new StringBuilder();
         DToA.JS_dtostr(sb, oneArgMode, precision + precisionOffset, val);

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -160,7 +160,15 @@ public class NativeObject extends IdScriptableObject implements Map
             return ScriptRuntime.toObject(cx, scope, args[0]);
           }
 
-          case Id_toLocaleString: // For now just alias toString
+          case Id_toLocaleString: {
+            Object toString = ScriptableObject.getProperty(thisObj, "toString");
+            if(!(toString instanceof Callable)) {
+                throw ScriptRuntime.notFunctionError(toString);
+            }
+            Callable fun = (Callable)toString;
+            return fun.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
+          }
+
           case Id_toString: {
             if (cx.hasFeature(Context.FEATURE_TO_STRING_AS_SOURCE)) {
                 String s = ScriptRuntime.defaultObjectToSource(cx, scope,

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -188,41 +188,35 @@ public class NativeObject extends IdScriptableObject implements Map
 
           case Id_hasOwnProperty: {
             boolean result;
-            if (args.length == 0) {
-                result = false;
+            Object arg = args.length < 1 ? Undefined.instance : args[0];
+            String s = ScriptRuntime.toStringIdOrIndex(cx, arg);
+            if (s == null) {
+                int index = ScriptRuntime.lastIndexResult(cx);
+                result = thisObj.has(index, thisObj);
             } else {
-                String s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
-                if (s == null) {
-                    int index = ScriptRuntime.lastIndexResult(cx);
-                    result = thisObj.has(index, thisObj);
-                } else {
-                    result = thisObj.has(s, thisObj);
-                }
+                result = thisObj.has(s, thisObj);
             }
             return ScriptRuntime.wrapBoolean(result);
           }
 
           case Id_propertyIsEnumerable: {
             boolean result;
-            if (args.length == 0) {
-                result = false;
+            Object arg = args.length < 1 ? Undefined.instance : args[0];
+            String s = ScriptRuntime.toStringIdOrIndex(cx, arg);
+            if (s == null) {
+                int index = ScriptRuntime.lastIndexResult(cx);
+                result = thisObj.has(index, thisObj);
+                if (result && thisObj instanceof ScriptableObject) {
+                    ScriptableObject so = (ScriptableObject)thisObj;
+                    int attrs = so.getAttributes(index);
+                    result = ((attrs & ScriptableObject.DONTENUM) == 0);
+                }
             } else {
-                String s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
-                if (s == null) {
-                    int index = ScriptRuntime.lastIndexResult(cx);
-                    result = thisObj.has(index, thisObj);
-                    if (result && thisObj instanceof ScriptableObject) {
-                        ScriptableObject so = (ScriptableObject)thisObj;
-                        int attrs = so.getAttributes(index);
-                        result = ((attrs & ScriptableObject.DONTENUM) == 0);
-                    }
-                } else {
-                    result = thisObj.has(s, thisObj);
-                    if (result && thisObj instanceof ScriptableObject) {
-                        ScriptableObject so = (ScriptableObject)thisObj;
-                        int attrs = so.getAttributes(s);
-                        result = ((attrs & ScriptableObject.DONTENUM) == 0);
-                    }
+                result = thisObj.has(s, thisObj);
+                if (result && thisObj instanceof ScriptableObject) {
+                    ScriptableObject so = (ScriptableObject)thisObj;
+                    int attrs = so.getAttributes(s);
+                    result = ((attrs & ScriptableObject.DONTENUM) == 0);
                 }
             }
             return ScriptRuntime.wrapBoolean(result);
@@ -373,14 +367,14 @@ public class NativeObject extends IdScriptableObject implements Map
                 Scriptable props = Context.toObject(propsObj, getParentScope());
                 obj.defineOwnProperties(cx, ensureScriptableObject(props));
                 return obj;
-        }
+              }
           case ConstructorId_create:
               {
                 Object arg = args.length < 1 ? Undefined.instance : args[0];
                 Scriptable obj = (arg == null) ? null : ensureScriptable(arg);
 
                 ScriptableObject newObject = new NativeObject();
-                newObject.setParentScope(this.getParentScope());
+                newObject.setParentScope(getParentScope());
                 newObject.setPrototype(obj);
 
                 if (args.length > 1 && args[1] != Undefined.instance) {
@@ -390,7 +384,6 @@ public class NativeObject extends IdScriptableObject implements Map
 
                 return newObject;
               }
-
           case ConstructorId_isSealed:
               {
                 Object arg = args.length < 1 ? Undefined.instance : args[0];

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -191,7 +191,7 @@ final class NativeString extends IdScriptableObject
           case Id_equalsIgnoreCase:  arity=1; s="equalsIgnoreCase";  break;
           case Id_match:             arity=1; s="match";             break;
           case Id_search:            arity=1; s="search";            break;
-          case Id_replace:           arity=1; s="replace";           break;
+          case Id_replace:           arity=2; s="replace";           break;
           case Id_localeCompare:     arity=1; s="localeCompare";     break;
           case Id_toLocaleLowerCase: arity=0; s="toLocaleLowerCase"; break;
           case Id_toLocaleUpperCase: arity=0; s="toLocaleUpperCase"; break;

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -636,35 +636,32 @@ final class NativeString extends IdScriptableObject
     }
 
     private static CharSequence js_slice(CharSequence target, Object[] args) {
-        if (args.length != 0) {
-            double begin = ScriptRuntime.toInteger(args[0]);
-            double end;
-            int length = target.length();
-            if (begin < 0) {
-                begin += length;
-                if (begin < 0)
-                    begin = 0;
-            } else if (begin > length) {
-                begin = length;
-            }
-
-            if (args.length == 1) {
-                end = length;
-            } else {
-                end = ScriptRuntime.toInteger(args[1]);
-                if (end < 0) {
-                    end += length;
-                    if (end < 0)
-                        end = 0;
-                } else if (end > length) {
-                    end = length;
-                }
-                if (end < begin)
-                    end = begin;
-            }
-            return target.subSequence((int) begin, (int) end);
+        double begin = args.length < 1 ? 0 : ScriptRuntime.toInteger(args[0]);
+        double end;
+        int length = target.length();
+        if (begin < 0) {
+            begin += length;
+            if (begin < 0)
+                begin = 0;
+        } else if (begin > length) {
+            begin = length;
         }
-        return target;
+
+        if (args.length < 2 || args[1] == Undefined.instance) {
+            end = length;
+        } else {
+            end = ScriptRuntime.toInteger(args[1]);
+            if (end < 0) {
+                end += length;
+                if (end < 0)
+                    end = 0;
+            } else if (end > length) {
+                end = length;
+            }
+            if (end < begin)
+                end = begin;
+        }
+        return target.subSequence((int) begin, (int) end);
     }
 
 // #string_id_map#

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -829,6 +829,11 @@ public class ScriptRuntime {
     }
 
     public static String numberToString(double d, int base) {
+        if ((base < 2) || (base > 36)) {
+            throw Context.reportRuntimeError1(
+                "msg.bad.radix", Integer.toString(base));
+        }
+
         if (d != d)
             return "NaN";
         if (d == Double.POSITIVE_INFINITY)
@@ -837,11 +842,6 @@ public class ScriptRuntime {
             return "-Infinity";
         if (d == 0.0)
             return "0";
-
-        if ((base < 2) || (base > 36)) {
-            throw Context.reportRuntimeError1(
-                "msg.bad.radix", Integer.toString(base));
-        }
 
         if (base != 10) {
             return DToA.JS_dtobasestr(base, d);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -78,9 +78,20 @@ public class ScriptRuntime {
     /**
      * Returns representation of the [[ThrowTypeError]] object.
      * See ECMA 5 spec, 13.2.3
+     *
+     * @deprecated {@link #typeErrorThrower(Context)}
      */
+    @Deprecated
     public static BaseFunction typeErrorThrower() {
-      if (THROW_TYPE_ERROR == null) {
+      return typeErrorThrower(Context.getCurrentContext());
+    }
+
+    /**
+     * Returns representation of the [[ThrowTypeError]] object.
+     * See ECMA 5 spec, 13.2.3
+     */
+    public static BaseFunction typeErrorThrower(Context cx) {
+      if (cx.typeErrorThrower == null) {
         BaseFunction thrower = new BaseFunction() {
           static final long serialVersionUID = -5891740962154902286L;
 
@@ -93,12 +104,12 @@ public class ScriptRuntime {
             return 0;
           }
         };
+        ScriptRuntime.setFunctionProtoAndParent(thrower, cx.topCallScope);
         thrower.preventExtensions();
-        THROW_TYPE_ERROR = thrower;
+        cx.typeErrorThrower = thrower;
       }
-      return THROW_TYPE_ERROR;
+      return cx.typeErrorThrower;
     }
-    private static BaseFunction THROW_TYPE_ERROR = null;
 
     static class NoSuchMethodShim implements Callable {
         String methodName;

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -1777,14 +1777,15 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
      */
     public void defineOwnProperties(Context cx, ScriptableObject props) {
         Object[] ids = props.getIds();
-        for (Object id : ids) {
-            Object descObj = props.get(id);
+        ScriptableObject[] descs = new ScriptableObject[ids.length];
+        for (int i = 0, len = ids.length; i < len; ++i) {
+            Object descObj = ScriptRuntime.getObjectElem(props, ids[i], cx);
             ScriptableObject desc = ensureScriptableObject(descObj);
             checkPropertyDefinition(desc);
+            descs[i] = desc;
         }
-        for (Object id : ids) {
-            ScriptableObject desc = (ScriptableObject)props.get(id);
-            defineOwnProperty(cx, id, desc);
+        for (int i = 0, len = ids.length; i < len; ++i) {
+            defineOwnProperty(cx, ids[i], descs[i]);
         }
     }
 

--- a/src/org/mozilla/javascript/TopLevel.java
+++ b/src/org/mozilla/javascript/TopLevel.java
@@ -93,7 +93,30 @@ public class TopLevel extends IdScriptableObject {
         Error
     }
 
+    /**
+     * An enumeration of built-in native errors. [ECMAScript 5 - 15.11.6]
+     */
+    enum NativeErrors {
+        /** The native EvalError. */
+        EvalError,
+        /** The native RangeError. */
+        RangeError,
+        /** The native ReferenceError. */
+        ReferenceError,
+        /** The native SyntaxError. */
+        SyntaxError,
+        /** The native TypeError. */
+        TypeError,
+        /** The native URIError. */
+        URIError,
+        /** The native InternalError (non-standard). */
+        InternalError,
+        /** The native JavaException (non-standard). */
+        JavaException
+    }
+
     private EnumMap<Builtins, BaseFunction> ctors;
+    private EnumMap<NativeErrors, BaseFunction> errors;
 
     @Override
     public String getClassName() {
@@ -116,6 +139,13 @@ public class TopLevel extends IdScriptableObject {
                 ctors.put(builtin, (BaseFunction)value);
             }
         }
+        errors = new EnumMap<NativeErrors, BaseFunction>(NativeErrors.class);
+        for (NativeErrors error : NativeErrors.values()) {
+            Object value = ScriptableObject.getProperty(this, error.name());
+            if (value instanceof BaseFunction) {
+                errors.put(error, (BaseFunction)value);
+            }
+        }
     }
 
     /**
@@ -136,6 +166,31 @@ public class TopLevel extends IdScriptableObject {
         assert scope.getParentScope() == null;
         if (scope instanceof TopLevel) {
             Function result = ((TopLevel)scope).getBuiltinCtor(type);
+            if (result != null) {
+                return result;
+            }
+        }
+        // fall back to normal constructor lookup
+        return ScriptRuntime.getExistingCtor(cx, scope, type.name());
+    }
+
+    /**
+     * Static helper method to get a native error constructor with the given
+     * <code>type</code> from the given <code>scope</code>. If the scope is not
+     * an instance of this class or does have a cache of native errors,
+     * the constructor is looked up via normal property lookup.
+     *
+     * @param cx the current Context
+     * @param scope the top-level scope
+     * @param type the native error type
+     * @return the native error constructor
+     */
+    static Function getNativeErrorCtor(Context cx, Scriptable scope,
+                                       NativeErrors type) {
+        // must be called with top level scope
+        assert scope.getParentScope() == null;
+        if (scope instanceof TopLevel) {
+            Function result = ((TopLevel)scope).getNativeErrorCtor(type);
             if (result != null) {
                 return result;
             }
@@ -178,6 +233,17 @@ public class TopLevel extends IdScriptableObject {
      */
     public BaseFunction getBuiltinCtor(Builtins type) {
         return ctors != null ? ctors.get(type) : null;
+    }
+
+    /**
+     * Get the cached native error constructor from this scope with the
+     * given <code>type</code>. Returns null if {@link #cacheBuiltins()} has not
+     * been called on this object.
+     * @param type the native error type
+     * @return the native error constructor
+     */
+    BaseFunction getNativeErrorCtor(NativeErrors type) {
+        return errors != null ? errors.get(type) : null;
     }
 
     /**

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -877,11 +877,11 @@ public class NativeRegExp extends IdScriptableObject implements Function
                 /* Decimal escape */
                 case '0':
 /*
-* We're deliberately violating the ECMA 5.1 specification and allow octal
-* escapes to follow spidermonkey and general 'web reality':
-* http://wiki.ecmascript.org/doku.php?id=harmony:regexp_match_web_reality
-* http://wiki.ecmascript.org/doku.php?id=strawman:match_web_reality_spec
-*/
+ * We're deliberately violating the ECMA 5.1 specification and allow octal
+ * escapes to follow spidermonkey and general 'web reality':
+ * http://wiki.ecmascript.org/doku.php?id=harmony:regexp_match_web_reality
+ * http://wiki.ecmascript.org/doku.php?id=strawman:match_web_reality_spec
+ */
                     reportWarning(state.cx, "msg.bad.backref", "");
                     /* octal escape */
                     num = 0;
@@ -1786,11 +1786,11 @@ public class NativeRegExp extends IdScriptableObject implements Function
     }
 
     /*
-    *   Apply the current op against the given input to see if
-    *   it's going to match or fail. Return false if we don't
-    *   get a match, true if we do and update the state of the
-    *   input and pc if the update flag is true.
-    */
+     *   Apply the current op against the given input to see if
+     *   it's going to match or fail. Return false if we don't
+     *   get a match, true if we do and update the state of the
+     *   input and pc if the update flag is true.
+     */
     private static int simpleMatch(REGlobalData gData, String input, int op,
                                    byte[] program, int pc, int end, boolean updatecp)
     {

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2695,7 +2695,7 @@ public class NativeRegExp extends IdScriptableObject implements Function
         String s;
         int arity;
         switch (id) {
-          case Id_compile:  arity=1; s="compile";  break;
+          case Id_compile:  arity=2; s="compile";  break;
           case Id_toString: arity=0; s="toString"; break;
           case Id_toSource: arity=0; s="toSource"; break;
           case Id_exec:     arity=1; s="exec";     break;

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -320,15 +320,20 @@ public class NativeRegExp extends IdScriptableObject implements Function
         if (global != null) {
             for (int i = 0; i < global.length(); i++) {
                 char c = global.charAt(i);
+                int f = 0;
                 if (c == 'g') {
-                    flags |= JSREG_GLOB;
+                    f = JSREG_GLOB;
                 } else if (c == 'i') {
-                    flags |= JSREG_FOLD;
+                    f = JSREG_FOLD;
                 } else if (c == 'm') {
-                    flags |= JSREG_MULTILINE;
+                    f = JSREG_MULTILINE;
                 } else {
                     reportError("msg.invalid.re.flag", String.valueOf(c));
                 }
+                if ((flags & f) != 0) {
+                    reportError("msg.invalid.re.flag", String.valueOf(c));
+                }
+                flags |= f;
             }
         }
         regexp.flags = flags;

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -218,7 +218,9 @@ public class NativeRegExp extends IdScriptableObject implements Function
             this.lastIndex = thatObj.lastIndex;
             return this;
         }
-        String s = args.length == 0 ? "" : escapeRegExp(args[0]);
+        String s = args.length == 0 || args[0] == Undefined.instance
+            ? ""
+            : escapeRegExp(args[0]);
         String global = args.length > 1 && args[1] != Undefined.instance
             ? ScriptRuntime.toString(args[1])
             : null;
@@ -287,7 +289,7 @@ public class NativeRegExp extends IdScriptableObject implements Function
         if (args.length == 0) {
             str = reImpl.input;
             if (str == null) {
-                reportError("msg.no.re.input.for", toString());
+                str = ScriptRuntime.toString(Undefined.instance);
             }
         } else {
             str = ScriptRuntime.toString(args[0]);

--- a/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
@@ -189,10 +189,16 @@ class NativeRegExpCtor extends BaseFunction
         int attr;
         switch (id) {
           case Id_multiline:
+            attr = multilineAttr;
+            break;
           case Id_STAR:
+            attr = starAttr;
+            break;
           case Id_input:
+            attr = inputAttr;
+            break;
           case Id_UNDERSCORE:
-            attr = PERMANENT;
+            attr = underscoreAttr;
             break;
           default:
             attr = PERMANENT | READONLY;
@@ -319,4 +325,45 @@ class NativeRegExpCtor extends BaseFunction
         super.setInstanceIdValue(id, value);
     }
 
+    @Override
+    protected void setInstanceIdAttributes(int id, int attr) {
+        int shifted = id - super.getMaxInstanceId();
+        switch (shifted) {
+            case Id_multiline:
+                multilineAttr = attr;
+                return;
+            case Id_STAR:
+                starAttr = attr;
+                return;
+            case Id_input:
+                inputAttr = attr;
+                return;
+            case Id_UNDERSCORE:
+                underscoreAttr = attr;
+                return;
+
+            case Id_lastMatch:
+            case Id_AMPERSAND:
+            case Id_lastParen:
+            case Id_PLUS:
+            case Id_leftContext:
+            case Id_BACK_QUOTE:
+            case Id_rightContext:
+            case Id_QUOTE:
+                // non-configurable + non-writable
+                return;
+            default:
+                int substring_number = shifted - DOLLAR_ID_BASE - 1;
+                if (0 <= substring_number && substring_number <= 8) {
+                  // non-configurable + non-writable
+                  return;
+                }
+        }
+        super.setInstanceIdAttributes(id, attr);
+    }
+
+    private int multilineAttr = PERMANENT;
+    private int starAttr = PERMANENT;
+    private int inputAttr = PERMANENT;
+    private int underscoreAttr = PERMANENT;
 }

--- a/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
@@ -70,6 +70,16 @@ class NativeRegExpCtor extends BaseFunction
     }
 
     @Override
+    public int getLength() {
+        return 2;
+    }
+
+    @Override
+    public int getArity() {
+        return 2;
+    }
+
+    @Override
     public Object call(Context cx, Scriptable scope, Scriptable thisObj,
                        Object[] args)
     {

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -65,24 +65,37 @@ public class RegExpImpl implements RegExpProxy {
     {
         GlobData data = new GlobData();
         data.mode = actionType;
+        data.str = ScriptRuntime.toString(thisObj);
 
         switch (actionType) {
           case RA_MATCH:
             {
-                Object rval;
-                data.optarg = 1;
-                rval = matchOrReplace(cx, scope, thisObj, args,
-                                      this, data, false);
+                NativeRegExp re = createRegExp(cx, scope, args, 1, false);
+                Object rval = matchOrReplace(cx, scope, thisObj, args,
+                                             this, data, re);
                 return data.arrayobj == null ? rval : data.arrayobj;
             }
 
           case RA_SEARCH:
-            data.optarg = 1;
-            return matchOrReplace(cx, scope, thisObj, args,
-                                  this, data, false);
+            {
+                NativeRegExp re = createRegExp(cx, scope, args, 1, false);
+                return matchOrReplace(cx, scope, thisObj, args,
+                                      this, data, re);
+            }
 
           case RA_REPLACE:
             {
+                boolean useRE = (args.length > 0 && args[0] instanceof NativeRegExp)
+                                || args.length > 2;
+                NativeRegExp re = null;
+                String search = null;
+                if (useRE) {
+                    re = createRegExp(cx, scope, args, 2, true);
+                } else {
+                    Object arg0 = args.length < 1 ? Undefined.instance : args[0];
+                    search = ScriptRuntime.toString(arg0);
+                }
+
                 Object arg1 = args.length < 2 ? Undefined.instance : args[1];
                 String repstr = null;
                 Function lambda = null;
@@ -92,14 +105,30 @@ public class RegExpImpl implements RegExpProxy {
                     repstr = ScriptRuntime.toString(arg1);
                 }
 
-                data.optarg = 2;
                 data.lambda = lambda;
                 data.repstr = repstr;
                 data.dollar = repstr == null ? -1 : repstr.indexOf('$');
                 data.charBuf = null;
                 data.leftIndex = 0;
-                Object val = matchOrReplace(cx, scope, thisObj, args,
-                                            this, data, true);
+
+                Object val;
+                if (useRE) {
+                    val = matchOrReplace(cx, scope, thisObj, args,
+                                         this, data, re);
+                } else {
+                    String str = data.str;
+                    int index = str.indexOf(search);
+                    if (index >= 0) {
+                        int slen = search.length();
+                        this.lastParen = null;
+                        this.leftContext = new SubString(str, 0, index);
+                        this.lastMatch = new SubString(str, index, slen);
+                        this.rightContext = new SubString(str, index + slen, str.length() - index - slen);
+                        val = Boolean.TRUE;
+                    } else {
+                        val = Boolean.FALSE;
+                    }
+                }
 
                 if (data.charBuf == null) {
                     if (data.global || val == null
@@ -121,21 +150,13 @@ public class RegExpImpl implements RegExpProxy {
         }
     }
 
-    /**
-     * Analog of C match_or_replace.
-     */
-    private static Object matchOrReplace(Context cx, Scriptable scope,
-                                         Scriptable thisObj, Object[] args,
-                                         RegExpImpl reImpl,
-                                         GlobData data, boolean forceFlat)
+    private static NativeRegExp createRegExp(Context cx, Scriptable scope,
+                                             Object[] args, int optarg,
+                                             boolean forceFlat)
     {
         NativeRegExp re;
-
-        String str = ScriptRuntime.toString(thisObj);
-        data.str = str;
         Scriptable topScope = ScriptableObject.getTopLevelScope(scope);
-
-        if (args.length == 0) {
+        if (args.length == 0 || args[0] == Undefined.instance) {
             RECompiled compiled = NativeRegExp.compileRE(cx, "", "", false);
             re = new NativeRegExp(topScope, compiled);
         } else if (args[0] instanceof NativeRegExp) {
@@ -143,16 +164,27 @@ public class RegExpImpl implements RegExpProxy {
         } else {
             String src = ScriptRuntime.toString(args[0]);
             String opt;
-            if (data.optarg < args.length) {
+            if (optarg < args.length) {
                 args[0] = src;
-                opt = ScriptRuntime.toString(args[data.optarg]);
+                opt = ScriptRuntime.toString(args[optarg]);
             } else {
                 opt = null;
             }
             RECompiled compiled = NativeRegExp.compileRE(cx, src, opt, forceFlat);
             re = new NativeRegExp(topScope, compiled);
         }
+        return re;
+    }
 
+    /**
+     * Analog of C match_or_replace.
+     */
+    private static Object matchOrReplace(Context cx, Scriptable scope,
+                                         Scriptable thisObj, Object[] args,
+                                         RegExpImpl reImpl,
+                                         GlobData data, NativeRegExp re)
+    {
+        String str = data.str;
         data.global = (re.getFlags() & NativeRegExp.JSREG_GLOB) != 0;
         int[] indexp = { 0 };
         Object result = null;
@@ -517,14 +549,6 @@ public class RegExpImpl implements RegExpProxy {
         // create an empty Array to return;
         Scriptable result = cx.newArray(scope, 0);
 
-        // return an array consisting of the target if no separator given
-        // don't check against undefined, because we want
-        // 'fooundefinedbar'.split(void 0) to split to ['foo', 'bar']
-        if (args.length < 1) {
-            result.put(0, result, target);
-            return result;
-        }
-
         // Use the second argument as the split limit, if given.
         boolean limited = (args.length > 1) && (args[1] != Undefined.instance);
         long limit = 0;  // Initialize to avoid warning.
@@ -533,6 +557,14 @@ public class RegExpImpl implements RegExpProxy {
             limit = ScriptRuntime.toUint32(args[1]);
             if (limit > target.length())
                 limit = 1 + target.length();
+        }
+
+        // return an array consisting of the target if no separator given
+        // don't check against undefined, because we want
+        // 'fooundefinedbar'.split(void 0) to split to ['foo', 'bar']
+        if (args.length < 1) {
+            result.put(0, result, target);
+            return result;
         }
 
         String separator = null;
@@ -739,7 +771,6 @@ public class RegExpImpl implements RegExpProxy {
 final class GlobData
 {
     int      mode;      /* input: return index, match object, or void */
-    int      optarg;    /* input: index of optional flags argument */
     boolean  global;    /* output: whether regexp was global */
     String   str;       /* output: 'this' parameter object as string */
 

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -560,9 +560,7 @@ public class RegExpImpl implements RegExpProxy {
         }
 
         // return an array consisting of the target if no separator given
-        // don't check against undefined, because we want
-        // 'fooundefinedbar'.split(void 0) to split to ['foo', 'bar']
-        if (args.length < 1) {
+        if (args.length < 1 || args[0] == Undefined.instance) {
             result.put(0, result, target);
             return result;
         }

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -164,7 +164,7 @@ public class RegExpImpl implements RegExpProxy {
             else
                 result = Integer.valueOf(-1);
         } else if (data.global) {
-            re.lastIndex = 0;
+            re.lastIndex = 0d;
             for (int count = 0; indexp[0] <= str.length(); count++) {
                 result = re.executeRegExp(cx, scope, reImpl,
                                           str, indexp, NativeRegExp.TEST);

--- a/testsrc/doctests/arguments.doctest
+++ b/testsrc/doctests/arguments.doctest
@@ -3,10 +3,8 @@ js> Object.getPrototypeOf(args) === Object.prototype
 true
 js> args.constructor === Object.prototype.constructor
 true
-js> Object.getOwnPropertyDescriptor(args, 'constructor').toSource();
-({value:function Object() { [native code for Object.Object, arity=1] }
-, writable:true, enumerable:false, configurable:true})
-
+js> Object.getOwnPropertyDescriptor(args, "constructor") === void 0
+true
 js> args.toString()
 [object Arguments]
 

--- a/testsrc/doctests/error.tostring.doctest
+++ b/testsrc/doctests/error.tostring.doctest
@@ -3,19 +3,19 @@ js> var str = Error.prototype.toString
 js> str.call(new TypeError("msg"))
 TypeError: msg
 js> str.call(new TypeError()) // message is initialised to ''
-TypeError: 
+TypeError
 js> str.call(new Error("msg"))
 Error: msg
 js> str.call(new Error()) // message is initialised to ''
-Error: 
+Error
 js> str.call({name:"my error", message:"my message"})
 my error: my message
-js> str.call({}) === undefined
-true
-js> str.call({name:"no message defined"}) === undefined
-true
-js> str.call({name:"message is undefined", message:undefined}) === undefined
-true
+js> str.call({})
+Error
+js> str.call({name:"no message defined"})
+no message defined
+js> str.call({name:"message is undefined", message:undefined})
+message is undefined
 js> str.call({name:"null message", message:null})
 null message: null
 js> str.call({message:"no name defined"})

--- a/testsrc/opt-1.tests
+++ b/testsrc/opt-1.tests
@@ -1029,7 +1029,6 @@ js1_2/function/definition-1.js
 js1_2/function/length.js
 js1_2/function/nesting-1.js
 js1_2/function/nesting.js
-js1_2/function/regexparg-2-n.js
 js1_2/jsref.js
 js1_2/operator/strictEquality.js
 js1_2/regexp/RegExp_dollar_number.js

--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -1026,7 +1026,6 @@ js1_2/function/definition-1.js
 js1_2/function/length.js
 js1_2/function/nesting-1.js
 js1_2/function/nesting.js
-js1_2/function/regexparg-2-n.js
 js1_2/jsref.js
 js1_2/operator/strictEquality.js
 js1_2/regexp/RegExp_dollar_number.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -1026,7 +1026,6 @@ js1_2/function/definition-1.js
 js1_2/function/length.js
 js1_2/function/nesting-1.js
 js1_2/function/nesting.js
-js1_2/function/regexparg-2-n.js
 js1_2/jsref.js
 js1_2/operator/strictEquality.js
 js1_2/regexp/RegExp_dollar_number.js


### PR DESCRIPTION
This part of mozilla/rhino#39 does not involve any public API changes but merely updates the built-in objects to work in a more spec-compliant way. For the most part this affects handling of undefined arguments, missing methods to change attributes in IdScriptableObjects instances (i.e. missing setInstanceIdAttributes() overrides) and wrong execution order of spec algorithm steps. 