### PR TITLE
Add missing license header to DefineClassMapInheritance.java

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/DefineClassMapInheritance.java
+++ b/testsrc/org/mozilla/javascript/tests/DefineClassMapInheritance.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
The file testsrc/org/mozilla/javascript/tests/DefineClassMapInheritance.java does not contain the MPL2 license header.
