### PR TITLE
Missing entries in Messages_fr.properties

### DIFF
--- a/src/org/mozilla/javascript/resources/Messages_fr.properties
+++ b/src/org/mozilla/javascript/resources/Messages_fr.properties
@@ -155,6 +155,12 @@ msg.no.function.interface.conversion =\
     Impossible de convertir la fonction {0} en interface puisqu'elle contient des m\u00e9thodes avec \
     des noms diff\u00e9rentes
 
+msg.undefined.function.interface =\
+    La propri\u00E9t\u00E9 "{0}" n''est pas d\u00E9finie dans l''adaptateur d''interface
+
+msg.not.function.interface =\
+    La propri\u00E9t\u00E9 "{0}" n''est pas une fonction dans l''adaptateur d''interface
+
 # NativeJavaPackage
 msg.not.classloader =\
     Le constructeur de "Packages" attend un argument de type java.lang.Classloader
@@ -580,6 +586,9 @@ msg.instanceof.not.object =\
 
 msg.instanceof.bad.prototype =\
     La propri\u00E9t\u00E9 ''prototype'' de {0} n''est pas un objet
+
+msg.in.not.object = \
+    Il est impossible d''utiliser une instance d''un \u00E9l\u00E9ment autre qu''un objet
 
 msg.bad.radix =\
     la base {0} n''est pas autoris\u00E9e


### PR DESCRIPTION
Messages_fr.properties does not contain localized entries for:
- msg.undefined.function.interface
- msg.not.function.interface
- msg.in.not.object

I reused the existing `msg.instanceof.not.object` entry for `msg.in.not.object` since the translation actually applies to both cases. And I also removed the (UTF-8 encoded) unicode replacement characters (no idea how those got into the document..).
