### PR TITLE
Bug 772011: Decompiler does not add curly brackets for labelled statements

### DIFF
--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -627,7 +627,7 @@ public class Decompiler
                 // This needs to be distinct from COLON in the general case
                 // to distinguish from the colon in a ternary... which needs
                 // different spacing.
-                result.append(':');
+                result.append(": ");
                 break;
 
             case Token.COLON:

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -745,12 +745,27 @@ public final class IRFactory extends Parser
     }
 
     private Node transformLabeledStatement(LabeledStatement ls) {
-        for (Label lb : ls.getLabels()) {
-            decompiler.addName(lb.getName());
+        Label label = ls.getFirstLabel();
+        List<Label> labels = ls.getLabels();
+        decompiler.addName(label.getName());
+        if (labels.size() > 1) {
+            // more than one label
+            for (Label lb : labels.subList(1, labels.size())) {
+                decompiler.addEOL(Token.COLON);
+                decompiler.addName(lb.getName());
+            }
+        }
+        if (ls.getStatement().getType() == Token.BLOCK) {
+            // reuse OBJECTLIT for ':' workaround, cf. transformObjectLiteral()
+            decompiler.addToken(Token.OBJECTLIT);
+            decompiler.addEOL(Token.LC);
+        } else {
             decompiler.addEOL(Token.COLON);
         }
-        Label label = ls.getFirstLabel();
         Node statement = transform(ls.getStatement());
+        if (ls.getStatement().getType() == Token.BLOCK) {
+            decompiler.addEOL(Token.RC);
+        }
 
         // Make a target and put it _after_ the statement node.  Add in the
         // LABEL node, so breaks get the right target.

--- a/testsrc/jstests/772011.jstest
+++ b/testsrc/jstests/772011.jstest
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=772011
+
+function assertEquals(expected, actual) {
+  if (expected != actual) {
+    throw "Expected '" + expected + "' but was '" + actual + "'";
+  }
+}
+
+function label_no_block() {
+  foo:
+    break foo;
+  return "pass";
+}
+
+function label_block() {
+  foo: {
+    break foo;
+    return "fail";
+  }
+  return "pass";
+}
+
+function multi_label_no_block() {
+  foo: bar: baz:
+    break foo;
+  return "pass";
+}
+
+function multi_label_block() {
+  foo: bar: baz: {
+    break foo;
+    return "fail";
+  }
+  return "pass";
+}
+
+assertEquals("pass", label_no_block());
+assertEquals("pass", label_block());
+assertEquals("pass", multi_label_no_block());
+assertEquals("pass", multi_label_block());
+
+assertEquals("pass", eval(label_no_block.toString())());
+assertEquals("pass", eval(label_block.toString())());
+assertEquals("pass", eval(multi_label_no_block.toString())());
+assertEquals("pass", eval(multi_label_block.toString())());
+
+"success";


### PR DESCRIPTION
Curly brackets weren't added when decompiling labelled statements, see bug report https://bugzilla.mozilla.org/show_bug.cgi?id=772011. Two changes are necessary:

`IRFactory#transformLabeledStatement(...)`:
- handle the case when the statement is a block
- change decompiled output in case of multiple labels for parity with Spidermonkey

`Decompiler#decompile(...)`:
- change output for OBJECTLIT from `":"` to `": "` for parity with Spidermonkey
