### PR TITLE
Patch for bug 637811:

### DIFF
--- a/src/org/mozilla/javascript/ast/LabeledStatement.java
+++ b/src/org/mozilla/javascript/ast/LabeledStatement.java
@@ -105,6 +105,12 @@ public class LabeledStatement extends AstNode {
     }
 
     @Override
+    public boolean hasSideEffects() {
+        // just to avoid the default case for EXPR_VOID in AstNode
+        return true;
+    }
+
+    @Override
     public String toSource(int depth) {
         StringBuilder sb = new StringBuilder();
         for (Label label : labels) {

--- a/testsrc/org/mozilla/javascript/tests/Bug637811Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug637811Test.java
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+
+/**
+ *
+ * @author André Bargull
+ */
+public class Bug637811Test {
+    private Context cx;
+
+    @Before
+    public void setUp() throws Exception {
+        cx = new ContextFactory() {
+            @Override
+            protected boolean hasFeature(Context cx, int featureIndex) {
+                switch (featureIndex) {
+                case Context.FEATURE_STRICT_MODE:
+                case Context.FEATURE_WARNING_AS_ERROR:
+                    return true;
+                }
+                return super.hasFeature(cx, featureIndex);
+            }
+        }.enterContext();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Context.exit();
+    }
+
+    @Test
+    public void test() {
+        String source = "";
+        source += "var x = 0;";
+        source += "bar: while (x < 0) { x = x + 1; }";
+        cx.compileString(source, "", 1, null);
+    }
+}


### PR DESCRIPTION
LabeledStatement uses EXPR_VOID as its type, that means AstNode#hasSideEffects() uses the default case (=> it returns false). So every labelled statement gets the "code has no side effects" warning, which is clearly wrong.
