### PR TITLE
Patch for Bug 757410

### DIFF
--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -3080,7 +3080,7 @@ class BodyCodegen
         // load array to store array literal objects
         if (isGenerator) {
             // TODO: this is actually only necessary if the yield operation is
-            // a child of this array or its children (bug xxxxxx)
+            // a child of this array or its children (bug 757410)
             for (int i = 0; i != count; ++i) {
                 generateExpression(child, node);
                 child = child.getNext();
@@ -3142,7 +3142,7 @@ class BodyCodegen
     /** load array with property values */
     private void addLoadPropertyValues(Node node, Node child, int count) {
         if (isGenerator) {
-            // see bug xxxxxx for explanation why we need to split this
+            // see bug 757410 for an explanation why we need to split this
             for (int i = 0; i != count; ++i) {
                 int childType = child.getType();
                 if (childType == Token.GET || childType == Token.SET) {
@@ -3207,7 +3207,7 @@ class BodyCodegen
 
         if (isGenerator) {
             // TODO: this is actually only necessary if the yield operation is
-            // a child of this object or its children (bug xxxxxx)
+            // a child of this object or its children (bug 757410)
             addLoadPropertyValues(node, child, count);
             addLoadPropertyIds(properties, count);
             // swap property-values and property-ids arrays

--- a/testsrc/doctests/757410.doctest
+++ b/testsrc/doctests/757410.doctest
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=757410
+
+js> version(180)
+0
+js> function gen() {
+  > [yield 1];
+  > ({x: yield 2});
+  > }
+js> var g = gen()
+js> g.next() == 1 && g.next() == 2
+true
+js> try {g.next()} catch(e) {e instanceof StopIteration}
+true


### PR DESCRIPTION
 Generators save and later restore the current stack when processing the 'yield' operation. Our current implementation for restoring the stack unfortunately confuses the Java classfile verifier, so at class load time a VerifierError is thrown. This happens because the verifier can no longer ensure that the proper types are placed on the stack, since the stack-state is saved in a simple Object[]. Re-ordering a few operations is necessary so the verifier will accept the generated class again. But this is only done for generators because it creates slightly less efficient code compared to the standard case.
