### PR TITLE
Patch for Bug 778421

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1014,7 +1014,7 @@ public class NativeArray extends IdScriptableObject implements List
         }
 
         long llength = getLengthProperty(cx, thisObj);
-        final int length = (int)llength;
+        final int length = (int) llength;
         if (llength != length) {
             throw Context.reportRuntimeError1(
                 "msg.arraylength.too.big", String.valueOf(llength));

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -405,7 +405,7 @@ public final class NativeJSON extends IdScriptableObject
             if (index > Integer.MAX_VALUE) {
                 strP = str(Long.toString(index), value, state);
             } else {
-                strP = str(index, value, state);
+                strP = str((int) index, value, state);
             }
             if (strP == Undefined.instance) {
                 partial.add("null");


### PR DESCRIPTION
`Array.prototype.sort` performed an unchecked cast from long to int without any overflow checks, this may result in a negative length which then throws a NegativeArraySizeException in Java, cf. js1_5/Array/regress-157652.js . A similar problem was found in NativeJSON, so I've handled that as well
