### PR TITLE
Patch for Bug 778549

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1018,14 +1018,14 @@ public class NativeArray extends IdScriptableObject implements List
         // sorted cheaply.
         final Object[] working = new Object[length];
         for (int i = 0; i != length; ++i) {
-            working[i] = getElem(cx, thisObj, i);
+            working[i] = getRawElem(thisObj, i);
         }
 
         Arrays.sort(working, comparator);
 
         // copy the working array back into thisObj
         for (int i = 0; i < length; ++i) {
-            setElem(cx, thisObj, i, working[i]);
+            setRawElem(cx, thisObj, i, working[i]);
         }
 
         return thisObj;

--- a/testsrc/jstests/778549.jstest
+++ b/testsrc/jstests/778549.jstest
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=778549
+
+function assertSame(expected, actual) {
+  if (expected !== actual) {
+    throw "Expected '" + expected + "' but was '" + actual + "'";
+  }
+}
+
+function assertTrue(actual) {
+  assertSame(true, actual);
+}
+
+function assertFalse(actual) {
+  assertSame(false, actual);
+}
+
+
+var array = ['a',,void 0];
+
+assertSame(3, array.length);
+assertTrue(array.hasOwnProperty('0'));
+assertFalse(array.hasOwnProperty('1'));
+assertTrue(array.hasOwnProperty('2'));
+
+array.sort();
+
+assertSame(3, array.length);
+assertTrue(array.hasOwnProperty('0'));
+assertTrue(array.hasOwnProperty('1'));
+assertFalse(array.hasOwnProperty('2'));
+
+"success";


### PR DESCRIPTION
Use [gs]etRawElem() instead of [gs]etElem() in js_sort() to avoid changing non-existent elements to undefined elements.
