### PR TITLE
Patch for bug reported in "Infinite loop with rhino1.7R4" thread

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1671,7 +1671,7 @@ public class NativeRegExp extends IdScriptableObject implements Function
             if (inRange) {
                 if ((gData.regexp.flags & JSREG_FOLD) != 0) {
                     assert(rangeStart <= thisCh);
-                    for (c = rangeStart; c <= thisCh; c++) {
+                    for (c = rangeStart; c <= thisCh;) {
                         addCharacterToCharSet(charSet, c);
                         char uch = upcase(c);
                         char dch = downcase(c);
@@ -1679,6 +1679,8 @@ public class NativeRegExp extends IdScriptableObject implements Function
                             addCharacterToCharSet(charSet, uch);
                         if (c != dch)
                             addCharacterToCharSet(charSet, dch);
+                        if (++c == 0)
+                            break; // overflow
                     }
                 } else {
                     addCharacterRangeToCharSet(charSet, rangeStart, thisCh);

--- a/testsrc/doctests/regexp.class-overflow.doctest
+++ b/testsrc/doctests/regexp.class-overflow.doctest
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+js> /[\u0000-\uFFFF]/i.test(0)
+true


### PR DESCRIPTION
Add missing overflow detection when processing RegExp character class pattern

Reported at:
https://groups.google.com/group/mozilla-rhino/browse_thread/thread/366e76d7ee7bd3f7?hl=de
