### PR TITLE
Patch for Bug 780147

### DIFF
--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -3586,10 +3586,9 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                     +"Lorg/mozilla/javascript/Scriptable;"
                     +")Lorg/mozilla/javascript/Callable;");
             } else {
-                // Optimizer do not optimize this case for now
-                if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1)
-                    throw Codegen.badTree();
                 generateExpression(id, node);  // id
+                if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1)
+                    addDoubleWrap();
                 cfw.addALoad(contextLocal);
                 addScriptRuntimeInvoke(
                     "getElemFunctionAndThis",

--- a/src/org/mozilla/javascript/optimizer/Optimizer.java
+++ b/src/org/mozilla/javascript/optimizer/Optimizer.java
@@ -147,10 +147,9 @@ class Optimizer
             case Token.INC :
             case Token.DEC : {
                     Node child = n.getFirstChild();
-                    // "child" will be GETVAR or GETPROP or GETELEM
+                    int type = rewriteForNumberVariables(child, NumberType);
                     if (child.getType() == Token.GETVAR) {
-                        if (rewriteForNumberVariables(child, NumberType) == NumberType
-                                && !convertParameter(child))
+                        if (type == NumberType && !convertParameter(child))
                         {
                             n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                             markDCPNumberContext(child);
@@ -160,7 +159,7 @@ class Optimizer
                     }
                     else if (child.getType() == Token.GETELEM
                             || child.getType() == Token.GETPROP) {
-                        return rewriteForNumberVariables(child, NumberType);
+                        return type;
                     }
                     return NoType;
                 }

--- a/testsrc/jstests/780147.jstest
+++ b/testsrc/jstests/780147.jstest
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=780147
+
+function F () { var i=0, a=[]; --a[i]() }
+function G () { var i=0, a=[]; --a(i) }
+
+
+"success";


### PR DESCRIPTION
The "child" of INC/DEC is not restricted to GETVAR/GETPROP/GETELEM, for example in case of reference calls. Therefore simply omitting the call to rewriteForNumberVariables() is not valid, b/c that may lead to not emitting ToObject instructions.
