### PR TITLE
Patch for Bug 608235 ("Incorrect error message for undefined[undefined]")

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -1709,8 +1709,7 @@ public class ScriptRuntime {
             if (isName) {
                 return Boolean.TRUE;
             }
-            String idStr = (id == null) ? "null" : id.toString();
-            throw typeError2("msg.undef.prop.delete", toString(obj), idStr);
+            throw undefDeleteError(obj, id);
         }
         boolean result = deleteObjectElem(sobj, id, cx);
         return wrapBoolean(result);
@@ -3725,25 +3724,25 @@ public class ScriptRuntime {
 
     public static RuntimeException undefReadError(Object object, Object id)
     {
-        String idStr = (id == null) ? "null" : id.toString();
-        return typeError2("msg.undef.prop.read", toString(object), idStr);
+        return typeError2("msg.undef.prop.read", toString(object), toString(id));
     }
 
     public static RuntimeException undefCallError(Object object, Object id)
     {
-        String idStr = (id == null) ? "null" : id.toString();
-        return typeError2("msg.undef.method.call", toString(object), idStr);
+        return typeError2("msg.undef.method.call", toString(object), toString(id));
     }
 
     public static RuntimeException undefWriteError(Object object,
                                                    Object id,
                                                    Object value)
     {
-        String idStr = (id == null) ? "null" : id.toString();
-        String valueStr = (value instanceof Scriptable)
-                          ? value.toString() : toString(value);
-        return typeError3("msg.undef.prop.write", toString(object), idStr,
-                          valueStr);
+        return typeError3("msg.undef.prop.write", toString(object), toString(id),
+                          toString(value));
+    }
+
+    private static RuntimeException undefDeleteError(Object object, Object id)
+    {
+        throw typeError2("msg.undef.prop.delete", toString(object), toString(id));
     }
 
     public static RuntimeException notFoundError(Scriptable object,

--- a/testsrc/jstests/608235.jstest
+++ b/testsrc/jstests/608235.jstest
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=608235
+
+function Try(f, expected) {
+  try {
+    f();
+    throw "Expected error: " + expected;
+  } catch (e) {
+    if (e != expected) {
+      throw "Expected error: " + expected;
+    }
+  }
+}
+
+Try(
+  function(){ undefined[undefined] },
+  'TypeError: Cannot read property "undefined" from undefined'
+);
+
+Try(
+  function(){ undefined[undefined] = 1 },
+  'TypeError: Cannot set property "undefined" of undefined to "1"'
+);
+
+Try(
+  function(){ undefined[undefined] = {} },
+  'TypeError: Cannot set property "undefined" of undefined to "[object Object]"'
+);
+
+Try(
+  function(){ undefined[undefined] = [1,2,3] },
+  'TypeError: Cannot set property "undefined" of undefined to "1,2,3"'
+);
+
+Try(
+  function(){ delete undefined[undefined] },
+  'TypeError: Cannot delete property "undefined" of undefined'
+);
+
+Try(
+  function(){ undefined[undefined]() },
+  'TypeError: Cannot call method "undefined" of undefined'
+);
+
+"success";


### PR DESCRIPTION
To ensure a user-friendly representation is being used, ScriptRuntime.toString() is now called for each argument. Also added undefDeleteError() to get all undefXError() code at a single location in the ScriptRuntime class.
