### PR TITLE
Patch for Bug 782363 ("Increment/Decrement alters const variables")

### DIFF
--- a/src/org/mozilla/javascript/optimizer/Block.java
+++ b/src/org/mozilla/javascript/optimizer/Block.java
@@ -379,6 +379,7 @@ class Block
             }
             break;
             case Token.SETVAR :
+            case Token.SETCONSTVAR :
             {
                 Node lhs = n.getFirstChild();
                 Node rhs = lhs.getNext();
@@ -548,6 +549,7 @@ class Block
 
             case Token.COMMA:
             case Token.SETVAR:
+            case Token.SETCONSTVAR:
             case Token.SETNAME:
             case Token.SETPROP:
             case Token.SETELEM:
@@ -579,14 +581,20 @@ class Block
                 if (first.getType() == Token.GETVAR) {
                     // theVar is a Number now
                     int i = fn.getVarIndex(first);
-                    result |= assignType(varTypes, i, Optimizer.NumberType);
+                    if (!fn.fnode.getParamAndVarConst()[i]) {
+                        result |= assignType(varTypes, i, Optimizer.NumberType);
+                    }
                 }
                 break;
-            case Token.SETVAR : {
+            case Token.SETVAR :
+            case Token.SETCONSTVAR : {
                 Node rValue = first.getNext();
                 int theType = findExpressionType(fn, rValue, varTypes);
                 int i = fn.getVarIndex(n);
-                result |= assignType(varTypes, i, theType);
+                if (!(n.getType() == Token.SETVAR
+                        && fn.fnode.getParamAndVarConst()[i])) {
+                    result |= assignType(varTypes, i, theType);
+                }
                 break;
             }
         }

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -4314,6 +4314,42 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
             boolean post = ((incrDecrMask & Node.POST_FLAG) != 0);
             int varIndex = fnCurrent.getVarIndex(child);
             short reg = varRegisters[varIndex];
+            boolean[] constDeclarations = fnCurrent.fnode.getParamAndVarConst();
+            if (constDeclarations[varIndex]) {
+                if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1) {
+                    int offset = varIsDirectCallParameter(varIndex) ? 1 : 0;
+                    cfw.addDLoad(reg + offset);
+                    if (!post) {
+                        cfw.addPush(1.0);
+                        if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                            cfw.add(ByteCode.DADD);
+                        } else {
+                            cfw.add(ByteCode.DSUB);
+                        }
+                    }
+                } else {
+                    if (varIsDirectCallParameter(varIndex)) {
+                        dcpLoadAsObject(reg);
+                    } else {
+                        cfw.addALoad(reg);
+                    }
+                    if (post) {
+                        cfw.add(ByteCode.DUP);
+                        addObjectToDouble();
+                        cfw.add(ByteCode.POP2);
+                    } else {
+                        addObjectToDouble();
+                        cfw.addPush(1.0);
+                        if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                            cfw.add(ByteCode.DADD);
+                        } else {
+                            cfw.add(ByteCode.DSUB);
+                        }
+                        addDoubleWrap();
+                    }
+                }
+                break;
+            }
             if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1) {
                 int offset = varIsDirectCallParameter(varIndex) ? 1 : 0;
                 cfw.addDLoad(reg + offset);
@@ -4351,7 +4387,6 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                     cfw.add(ByteCode.DUP);
                 }
                 cfw.addAStore(reg);
-                break;
             }
             break;
           case Token.NAME:
@@ -5241,87 +5276,63 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
      */
     private short getNewWordPairLocal(boolean isConst)
     {
-        short result = getConsecutiveSlots(2, isConst);
-        if (result < (MAX_LOCALS - 1)) {
-            locals[result] = 1;
-            locals[result + 1] = 1;
-            if (isConst)
-                locals[result + 2] = 1;
-            if (result == firstFreeLocal) {
-                for (int i = firstFreeLocal + 2; i < MAX_LOCALS; i++) {
-                    if (locals[i] == 0) {
-                        firstFreeLocal = (short) i;
-                        if (localsMax < firstFreeLocal)
-                            localsMax = firstFreeLocal;
-                        return result;
-                    }
-                }
-            }
-            else {
-                return result;
-            }
-        }
-        throw Context.reportRuntimeError("Program too complex " +
-                                         "(out of locals)");
+        return getNewWordIntern(isConst ? 3 : 2);
     }
 
     private short getNewWordLocal(boolean isConst)
     {
-        short result = getConsecutiveSlots(1, isConst);
-        if (result < (MAX_LOCALS - 1)) {
-            locals[result] = 1;
-            if (isConst)
-                locals[result + 1] = 1;
-            if (result == firstFreeLocal) {
-                for (int i = firstFreeLocal + 2; i < MAX_LOCALS; i++) {
-                    if (locals[i] == 0) {
-                        firstFreeLocal = (short) i;
-                        if (localsMax < firstFreeLocal)
-                            localsMax = firstFreeLocal;
-                        return result;
-                    }
-                }
-            }
-            else {
-                return result;
-            }
-        }
-        throw Context.reportRuntimeError("Program too complex " +
-                                         "(out of locals)");
+        return getNewWordIntern(isConst ? 2 : 1);
     }
 
     private short getNewWordLocal()
     {
-        short result = firstFreeLocal;
-        locals[result] = 1;
-        for (int i = firstFreeLocal + 1; i < MAX_LOCALS; i++) {
-            if (locals[i] == 0) {
-                firstFreeLocal = (short) i;
-                if (localsMax < firstFreeLocal)
-                    localsMax = firstFreeLocal;
-                return result;
-            }
-        }
-        throw Context.reportRuntimeError("Program too complex " +
-                                         "(out of locals)");
+        return getNewWordIntern(1);
     }
 
-    private short getConsecutiveSlots(int count, boolean isConst) {
-        if (isConst)
-            count++;
-        short result = firstFreeLocal;
-        while (true) {
-            if (result >= (MAX_LOCALS - 1))
+    private short getNewWordIntern(int count)
+    {
+        assert count >= 1 && count <= 3;
+
+        int[] locals = this.locals;
+        int result = -1;
+        if (count > 1) {
+            // we need 'count' consecutive free slots
+            OUTER: for (int i = firstFreeLocal; i + count <= MAX_LOCALS;) {
+                for (int j = 0; j < count; ++j) {
+                    if (locals[i + j] != 0) {
+                        i += j + 1;
+                        continue OUTER;
+                    }
+                }
+                result = i;
                 break;
-            int i;
-            for (i = 0; i < count; i++)
-                if (locals[result + i] != 0)
-                    break;
-            if (i >= count)
-                break;
-            result++;
+            }
+        } else {
+            result = firstFreeLocal;
         }
-        return result;
+
+        if (result != -1) {
+            locals[result] = 1;
+            if (count > 1)
+                locals[result + 1] = 1;
+            if (count > 2)
+                locals[result + 2] = 1;
+
+            if (result == firstFreeLocal) {
+                for (int i = result + count; i < MAX_LOCALS; i++) {
+                    if (locals[i] == 0) {
+                        firstFreeLocal = (short) i;
+                        if (localsMax < firstFreeLocal)
+                            localsMax = firstFreeLocal;
+                        return (short) result;
+                    }
+                }
+            } else {
+                return (short) result;
+            }
+        }
+
+        throw Context.reportRuntimeError("Program too complex (out of locals)");
     }
 
     // This is a valid call only for a local that is allocated by default.

--- a/src/org/mozilla/javascript/optimizer/Optimizer.java
+++ b/src/org/mozilla/javascript/optimizer/Optimizer.java
@@ -163,7 +163,8 @@ class Optimizer
                     }
                     return NoType;
                 }
-            case Token.SETVAR : {
+            case Token.SETVAR :
+            case Token.SETCONSTVAR : {
                     Node lChild = n.getFirstChild();
                     Node rChild = lChild.getNext();
                     int rType = rewriteForNumberVariables(rChild, NumberType);

--- a/testsrc/jstests/782363.jstest
+++ b/testsrc/jstests/782363.jstest
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=782363
+
+function assertSame(expected, actual) {
+  if (expected !== actual) {
+    throw "Expected '" + expected + "' but was '" + actual + "'";
+  }
+}
+
+function f1() { const a = 0; a++; return a; }
+function f2() { const a = 0; ++a; return a; }
+function f3() { const a = 0; return a++; }
+function f4() { const a = 0; return ++a; }
+function f5() { const a = 0; a--; return a; }
+function f6() { const a = 0; --a; return a; }
+function f7() { const a = 0; return a--; }
+function f8() { const a = 0; return --a; }
+
+var called = 0;
+var obj = {valueOf: function(){ called += 1; return 0 }};
+function g1() { const a = obj; a++; return a; }
+function g2() { const a = obj; ++a; return a; }
+function g3() { const a = obj; return a++; }
+function g4() { const a = obj; return ++a; }
+function g5() { const a = obj; a--; return a; }
+function g6() { const a = obj; --a; return a; }
+function g7() { const a = obj; return a--; }
+function g8() { const a = obj; return --a; }
+
+assertSame(0, f1());
+assertSame(0, f2());
+assertSame(0, f3());
+assertSame(1, f4());
+assertSame(0, f5());
+assertSame(0, f6());
+assertSame(0, f7());
+assertSame(-1, f8());
+
+assertSame(obj, g1());
+assertSame(obj, g2());
+assertSame(obj, g3());
+assertSame(1, g4());
+assertSame(obj, g5());
+assertSame(obj, g6());
+assertSame(obj, g7());
+assertSame(-1, g8());
+
+assertSame(8, called);
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/Bug782363Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug782363Test.java
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.IRFactory;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.ast.ScriptNode;
+import org.mozilla.javascript.optimizer.Codegen;
+import org.mozilla.javascript.optimizer.OptFunctionNode;
+
+/**
+ * @author André Bargull
+ *
+ */
+public class Bug782363Test {
+    private Context cx;
+
+    @Before
+    public void setUp() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_1_8);
+        cx.setOptimizationLevel(9);
+    }
+
+    @After
+    public void tearDown() {
+        Context.exit();
+    }
+
+    /**
+     * Compiles {@code source} and returns the transformed and optimized
+     * {@link ScriptNode}
+     */
+    protected ScriptNode compile(CharSequence source) {
+        final String mainMethodClassName = "Main";
+        final String scriptClassName = "Main";
+
+        CompilerEnvirons compilerEnv = new CompilerEnvirons();
+        compilerEnv.initFromContext(cx);
+        Parser p = new Parser(compilerEnv);
+        AstRoot ast = p.parse(source.toString(), "<eval>", 1);
+        IRFactory irf = new IRFactory(compilerEnv);
+        ScriptNode tree = irf.transformTree(ast);
+
+        Codegen codegen = new Codegen();
+        codegen.setMainMethodClass(mainMethodClassName);
+        codegen.compileToClassFile(compilerEnv, scriptClassName, tree, tree.getEncodedSource(),
+                false);
+
+        return tree;
+    }
+
+    /**
+     * Checks every variable {@code v} in {@code source} is marked as a
+     * number-variable iff {@code numbers} contains {@code v}
+     */
+    protected void assertNumberVars(CharSequence source, String... numbers) {
+        // wrap source in function
+        ScriptNode tree = compile("function f(){" + source + "}");
+
+        FunctionNode fnode = tree.getFunctionNode(0);
+        assertNotNull(fnode);
+        OptFunctionNode opt = OptFunctionNode.get(fnode);
+        assertNotNull(opt);
+        assertSame(fnode, opt.fnode);
+
+        for (int i = 0, c = fnode.getParamCount(); i < c; ++i) {
+            assertTrue(opt.isParameter(i));
+            assertFalse(opt.isNumberVar(i));
+        }
+
+        Set<String> set = new HashSet<String>(asList(numbers));
+        for (int i = fnode.getParamCount(), c = fnode.getParamAndVarCount(); i < c; ++i) {
+            assertFalse(opt.isParameter(i));
+            String name = fnode.getParamOrVarName(i);
+            String msg = format("{%s -> number? = %b}", name, opt.isNumberVar(i));
+            assertEquals(msg, set.contains(name), opt.isNumberVar(i));
+        }
+    }
+
+    @Test
+    public void testConst() {
+        assertNumberVars("const a");
+        assertNumberVars("const a=0", "a");
+        assertNumberVars("const a; a=0");
+        // inc/dec
+        assertNumberVars("const a; a++");
+        assertNumberVars("const a=0; a++", "a");
+        assertNumberVars("const a; a=0; a++");
+        // used before defined
+        assertNumberVars("a; const a");
+        assertNumberVars("a; const a=0");
+        assertNumberVars("a; const a; a=0");
+        // re-assignment
+        assertNumberVars("const a=0; a=1", "a");
+        assertNumberVars("const a=0; a='z'", "a");
+        assertNumberVars("const a='z'; a=1");
+    }
+
+    @Test
+    public void testMaxLocals() throws IOException {
+        test(339);
+        try {
+            test(340);
+        } catch (EvaluatorException e) {
+            // may fail with 'out of locals' exception
+        }
+    }
+
+    private void test(int variables) {
+        double expected = (variables * (variables - 1)) / 2d;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("function F (){\n");
+        for (int i = 0; i < variables; ++i) {
+            sb.append("const x_").append(i).append("=").append(i).append(";");
+        }
+        sb.append("return 0");
+        for (int i = 0; i < variables; ++i) {
+            sb.append("+").append("x_").append(i);
+        }
+        sb.append("}; F()");
+
+        ScriptableObject scope = cx.initStandardObjects();
+        Object ret = cx.evaluateString(scope, sb.toString(), "<eval>", 1, null);
+        assertTrue(ret instanceof Number);
+        assertEquals(expected, ((Number) ret).doubleValue(), 0);
+    }
+}


### PR DESCRIPTION
- Update Interpreter#doVarIncDec() and BodyCodegen#visitIncDec() in a similar way to handle constants
- Update optimizer/Block and optimizer/Optimizer to process the Token.SETCONSTVAR opcode, also make sure not to re-assign the type of constants
- Replace the various getNewWordLocal() implementations with a single shared implementation to reduce duplicated code
- While I was at it, I also fixed two bugs in that code:
  - getNewWordLocal() wasted variable space because it started to search for free entries at `firstFreeLocal + 2` even if `isConst=false`
  - getConsecutiveSlots() could throw ArrayIndexOutOfBounds exceptions when `count=2 & isConst=true`
