### PR TITLE
Patch for Bug 783507 ("Implement ES.next quasi-literals (Rhino)")

### DIFF
--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -127,6 +127,12 @@ public class Decompiler
         appendString(str);
     }
 
+    void addQuasi(String str)
+    {
+        addToken(Token.QUASI_CHARS);
+        appendString(str);
+    }
+
     void addRegexp(String regexp, String flags)
     {
         addToken(Token.REGEXP);
@@ -766,6 +772,18 @@ public class Decompiler
             case Token.MOD:
                 result.append(" % ");
                 break;
+
+            case Token.QUASI:
+                result.append("`");
+                break;
+
+            case Token.QUASI_SUBST:
+                result.append("${");
+                break;
+
+            case Token.QUASI_CHARS:
+                i = printSourceString(source, i + 1, false, result);
+                continue;
 
             case Token.COLONCOLON:
                 result.append("::");

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -124,6 +124,10 @@ public final class IRFactory extends Parser
               return transformNewExpr((NewExpression)node);
           case Token.OBJECTLIT:
               return transformObjectLiteral((ObjectLiteral)node);
+          case Token.QUASI:
+              return transformQuasi((QuasiLiteral)node);
+          case Token.QUASI_CALL:
+              return transformQuasiCall((QuasiCall)node);
           case Token.REGEXP:
               return transformRegExp((RegExpLiteral)node);
           case Token.RETURN:
@@ -929,6 +933,57 @@ public final class IRFactory extends Parser
         decompiler.addToken(Token.DOT);
         decompiler.addName(name);
         return createPropertyGet(target, null, name, 0);
+    }
+
+    private Node transformQuasi(QuasiLiteral node) {
+        decompiler.addToken(Token.QUASI);
+        List<AstNode> elems = node.getElements();
+        // start with an empty string to ensure ToString() for each substitution
+        Node pn = Node.newString("");
+        for (int i = 0; i < elems.size(); ++i) {
+            AstNode elem = elems.get(i);
+            if (elem.getType() != Token.QUASI_CHARS) {
+                decompiler.addToken(Token.QUASI_SUBST);
+                pn = createBinary(Token.ADD, pn, transform(elem));
+                decompiler.addToken(Token.RC);
+            } else {
+                QuasiCharacters chars = (QuasiCharacters) elem;
+                decompiler.addQuasi(chars.getRawValue());
+                // skip empty parts, e.g. `ε${expr}ε` where ε denotes the empty string
+                String value = chars.getValue();
+                if (value.length() > 0) {
+                    pn = createBinary(Token.ADD, pn, Node.newString(value));
+                }
+            }
+        }
+        decompiler.addToken(Token.QUASI);
+        return pn;
+    }
+
+    private Node transformQuasiCall(QuasiCall node) {
+        Node call = createCallOrNew(Token.CALL, transform(node.getTarget()));
+        call.setLineno(node.getLineno());
+        decompiler.addToken(Token.QUASI);
+        QuasiLiteral quasi = (QuasiLiteral) node.getQuasi();
+        List<AstNode> elems = quasi.getElements();
+        // Node callSite = new Node(Token.QUASI_CALL);
+        // call.addChildToBack(callSite);
+        call.addChildToBack(quasi);
+        for (int i = 0; i < elems.size(); ++i) {
+            AstNode elem = elems.get(i);
+            if (elem.getType() != Token.QUASI_CHARS) {
+                decompiler.addToken(Token.QUASI_SUBST);
+                call.addChildToBack(transform(elem));
+                decompiler.addToken(Token.RC);
+            } else {
+                QuasiCharacters chars = (QuasiCharacters) elem;
+                decompiler.addQuasi(chars.getRawValue());
+                // callSite.addChildToBack(elem);
+            }
+        }
+        currentScriptOrFn.addQuasi(quasi);
+        decompiler.addToken(Token.QUASI);
+        return call;
     }
 
     private Node transformRegExp(RegExpLiteral node) {

--- a/src/org/mozilla/javascript/Icode.java
+++ b/src/org/mozilla/javascript/Icode.java
@@ -135,8 +135,11 @@ abstract class Icode {
 
        Icode_DEBUGGER                   = -64,
 
+    // Call to GetQuasiCallSite
+       Icode_QUASI_CALLSITE             = -65,
+
        // Last icode
-        MIN_ICODE                       = -64;
+        MIN_ICODE                       = -65;
 
     static String bytecodeName(int bytecode)
     {
@@ -217,6 +220,7 @@ abstract class Icode {
           case Icode_GENERATOR:        return "GENERATOR";
           case Icode_GENERATOR_END:    return "GENERATOR_END";
           case Icode_DEBUGGER:         return "DEBUGGER";
+          case Icode_QUASI_CALLSITE:   return "QUASI_CALLSITE";
         }
 
         // icode without name

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -1715,6 +1715,11 @@ switch (op) {
         Object re = frame.idata.itsRegExpLiterals[indexReg];
         stack[++stackTop] = ScriptRuntime.wrapRegExp(cx, frame.scope, re);
         continue Loop;
+    case Icode_QUASI_CALLSITE:
+        Object[] quasis = frame.idata.itsQuasiLiterals;
+        stack[++stackTop] = ScriptRuntime.getQuasiCallSite(cx, frame.scope,
+                                                           quasis, indexReg);
+        continue Loop;
     case Icode_LITERAL_NEW :
         // indexReg: number of values in the literal
         ++stackTop;

--- a/src/org/mozilla/javascript/InterpreterData.java
+++ b/src/org/mozilla/javascript/InterpreterData.java
@@ -53,6 +53,7 @@ final class InterpreterData implements Serializable, DebuggableScript
     double[] itsDoubleTable;
     InterpreterData[] itsNestedFunctions;
     Object[] itsRegExpLiterals;
+    Object[] itsQuasiLiterals;
 
     byte[] itsICode;
 

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -344,6 +344,26 @@ public class NativeArray extends IdScriptableObject implements List
         return super.has(index, start);
     }
 
+    @Override
+    public void setAttributes(int index, int attributes) {
+        if (attributes != EMPTY && dense != null) {
+            toSparse();
+        }
+        super.setAttributes(index, attributes);
+    }
+
+    private void toSparse() {
+        assert dense != null;
+        Object[] values = dense;
+        dense = null;
+        denseOnly = false;
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] != NOT_FOUND) {
+                put(i, this, values[i]);
+            }
+        }
+    }
+
     private static long toArrayIndex(Object id) {
         if (id instanceof String) {
             return toArrayIndex((String)id);
@@ -557,14 +577,7 @@ public class NativeArray extends IdScriptableObject implements List
                                      ScriptableObject desc,
                                      boolean checkValid) {
       if (dense != null) {
-        Object[] values = dense;
-        dense = null;
-        denseOnly = false;
-        for (int i = 0; i < values.length; i++) {
-          if (values[i] != NOT_FOUND) {
-            put(i, this, values[i]);
-          }
-        }
+        toSparse();
       }
       long index = toArrayIndex(id);
       if (index >= length) {

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -82,6 +82,8 @@ final class NativeString extends IdScriptableObject
         addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_fromCharCode,
                 "fromCharCode", 1);
         addIdFunctionProperty(ctor, STRING_TAG,
+                ConstructorId_raw, "raw", 1);
+        addIdFunctionProperty(ctor, STRING_TAG,
                 ConstructorId_charAt, "charAt", 2);
         addIdFunctionProperty(ctor, STRING_TAG,
                 ConstructorId_charCodeAt, "charCodeAt", 2);
@@ -219,6 +221,9 @@ final class NativeString extends IdScriptableObject
                 }
                 return sb.toString();
               }
+
+              case ConstructorId_raw:
+                return js_raw(cx, scope, args);
 
               case Id_constructor: {
                 CharSequence s = (args.length >= 1)
@@ -632,6 +637,50 @@ final class NativeString extends IdScriptableObject
         return target;
     }
 
+    /**
+     * <h1>String.raw (callSite, ...substitutions)</h1>
+     * <p>15.5.3.4 String.raw [ECMA 6 - draft]</p>
+     */
+    private static CharSequence js_raw(Context cx, Scriptable scope, Object[] args) {
+        final Object undefined = Undefined.instance;
+        /* step 1-3 */
+        Object arg0 = args.length > 0 ? args[0] : undefined;
+        Scriptable cooked = ScriptRuntime.toObject(cx, scope, arg0);
+        /* step 4-6 */
+        Object rawValue = cooked.get("raw", cooked);
+        if (rawValue == NOT_FOUND) rawValue = undefined;
+        Scriptable raw = ScriptRuntime.toObject(cx, scope, rawValue);
+        /* step 7-9 */
+        Object len = raw.get("length", raw);
+        if (len == NOT_FOUND) len = undefined;
+        long literalSegments = ScriptRuntime.toUint32(len);
+        /* step 10 */
+        if (literalSegments == 0) return "";
+        /* step 11-13 */
+        StringBuilder elements = new StringBuilder();
+        long nextIndex = 0;
+        for (;;) {
+            /* step 13 a-e */
+            Object next;
+            if (nextIndex > Integer.MAX_VALUE) {
+                next = raw.get(Long.toString(nextIndex), raw);
+            } else {
+                next = raw.get((int) nextIndex, raw);
+            }
+            if (next == NOT_FOUND) next = undefined;
+            String nextSeg = ScriptRuntime.toString(next);
+            elements.append(nextSeg);
+            nextIndex += 1;
+            if (nextIndex == literalSegments) {
+                break;
+            }
+            next = args.length > nextIndex ? args[(int) nextIndex] : undefined;
+            String nextSub = ScriptRuntime.toString(next);
+            elements.append(nextSub);
+        }
+        return elements.toString();
+    }
+
 // #string_id_map#
 
     @Override
@@ -706,6 +755,7 @@ final class NativeString extends IdScriptableObject
 
     private static final int
         ConstructorId_fromCharCode   = -1,
+        ConstructorId_raw            = -2,
 
         Id_constructor               = 1,
         Id_toString                  = 2,

--- a/src/org/mozilla/javascript/Node.java
+++ b/src/org/mozilla/javascript/Node.java
@@ -63,7 +63,8 @@ public class Node implements Iterable<Node>
         JSDOC_PROP           = 24,
         EXPRESSION_CLOSURE_PROP = 25, // JS 1.8 expression closure pseudo-return
         DESTRUCTURING_SHORTHAND = 26, // JS 1.8 destructuring shorthand
-        LAST_PROP            = 26;
+        QUASI_PROP           = 27,
+        LAST_PROP            = 27;
 
     // values of ISNUMBER_PROP to specify
     // which of the children are Number types
@@ -427,6 +428,7 @@ public class Node implements Iterable<Node>
                                            return "destructuring_array_length";
                 case DESTRUCTURING_NAMES:  return "destructuring_names";
                 case DESTRUCTURING_PARAMS: return "destructuring_params";
+                case QUASI_PROP:           return "quasi";
 
                 default: Kit.codeBug();
             }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3836,6 +3836,47 @@ public class ScriptRuntime {
         return cx.getRegExpProxy().wrapRegExp(cx, scope, compiled);
     }
 
+    /**
+     * <h1>Abstract Operation GetQuasiCallSite</h1>
+     * <p>11.1.9 Quasi Literals [ECMA 6 - draft]</p>
+     */
+    public static Scriptable getQuasiCallSite(Context cx, Scriptable scope,
+                                              Object[] strings, int index) {
+        /* step 1 */
+        Object callsite = strings[index];
+        if (callsite instanceof Scriptable)
+            return (Scriptable) callsite;
+        assert callsite instanceof String[];
+        String[] vals = (String[]) callsite;
+        assert (vals.length & 1) == 0;
+        final int FROZEN = ScriptableObject.PERMANENT | ScriptableObject.READONLY;
+        /* step 2-7 */
+        ScriptableObject siteObj = (ScriptableObject) cx.newArray(scope, vals.length >>> 1);
+        ScriptableObject rawObj = (ScriptableObject) cx.newArray(scope, vals.length >>> 1);
+        for (int i = 0, n = vals.length; i < n; i += 2) {
+            /* step 8 a-f */
+            int idx = i >>> 1;
+            siteObj.put(idx, siteObj, vals[i]);
+            siteObj.setAttributes(idx, FROZEN);
+            rawObj.put(idx, rawObj, vals[i + 1]);
+            rawObj.setAttributes(idx, FROZEN);
+        }
+        /* step 9 */
+        // TODO: call abstract operation FreezeObject
+        rawObj.setAttributes("length", FROZEN);
+        rawObj.preventExtensions();
+        /* step 10 */
+        siteObj.put("raw", siteObj, rawObj);
+        siteObj.setAttributes("raw", FROZEN | ScriptableObject.DONTENUM);
+        /* step 11 */
+        // TODO: call abstract operation FreezeObject
+        siteObj.setAttributes("length", FROZEN);
+        siteObj.preventExtensions();
+        /* step 12 */
+        strings[index] = siteObj;
+        return siteObj;
+    }
+
     private static XMLLib currentXMLLib(Context cx)
     {
         // Scripts should be running to access this

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2586,10 +2586,14 @@ public class ScriptRuntime {
     }
 
     public static CharSequence add(CharSequence val1, Object val2) {
+        if (val2 instanceof Scriptable)
+            val2 = ((Scriptable) val2).getDefaultValue(null);
         return new ConsString(val1, toCharSequence(val2));
     }
 
     public static CharSequence add(Object val1, CharSequence val2) {
+        if (val1 instanceof Scriptable)
+            val1 = ((Scriptable) val1).getDefaultValue(null);
         return new ConsString(toCharSequence(val1), val2);
     }
 

--- a/src/org/mozilla/javascript/Token.java
+++ b/src/org/mozilla/javascript/Token.java
@@ -228,7 +228,11 @@ public class Token
         DEBUGGER       = 160,
         COMMENT        = 161,
         GENEXPR        = 162,
-        LAST_TOKEN     = 163;
+        QUASI          = 163,  // quasi literal
+        QUASI_CHARS    = 164,  // quasi - literal section
+        QUASI_SUBST    = 165,  // quasi - substitution
+        QUASI_CALL     = 166,  // quasi - tagged/handler
+        LAST_TOKEN     = 167;
 
     /**
      * Returns a name for the token.  If Rhino is compiled with certain
@@ -413,6 +417,10 @@ public class Token
           case DEBUGGER:        return "DEBUGGER";
           case COMMENT:         return "COMMENT";
           case GENEXPR:         return "GENEXPR";
+          case QUASI:           return "QUASI";
+          case QUASI_CHARS:     return "QUASI_CHARS";
+          case QUASI_SUBST:     return "QUASI_SUBST";
+          case QUASI_CALL:      return "QUASI_CALL";
         }
 
         // Token without name

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -825,6 +825,9 @@ class TokenStream
                 dirtyLine = true;
                 return c;
 
+            case '`':
+                return Token.QUASI;
+
             default:
                 parser.addError("msg.illegal.character");
                 return Token.ERROR;
@@ -930,6 +933,209 @@ class TokenStream
         String flags = this.regExpFlags;
         this.regExpFlags = null;
         return flags;
+    }
+
+    private StringBuilder rawString = new StringBuilder();
+
+    String getRawString() {
+        if (rawString.length() == 0) {
+            return "";
+        }
+        return rawString.toString();
+    }
+
+    private int getQuasiChar() throws IOException {
+        boolean unget = ungetCursor != 0;
+        int oldLineEnd = lineEndChar;
+        // getChar() skips past '\r\n' sequences, but we need a faithful
+        // representation of the complete input for quasis
+        int c = getCharIgnoreLineEnd(false);
+        if (c == '\n') {
+            c = lineEndChar;
+        }
+        // update lineno after passing line boundaries (cf. getChar())
+        // - unless this is a 'unget' character
+        // - unless this is a '\r\n' sequence
+        if (oldLineEnd >= 0 && !unget && !(oldLineEnd == '\r' && c == '\n')) {
+            lineEndChar = -1;
+            lineStart = sourceCursor - 1;
+            lineno++;
+        }
+        rawString.append((char) c);
+        return c;
+    }
+
+    private void ungetQuasiChar(int c) {
+        ungetCharIgnoreLineEnd(c);
+        rawString.setLength(rawString.length() - 1);
+    }
+
+    private boolean matchQuasiChar(int test) throws IOException {
+        int c = getQuasiChar();
+        if (c == test) {
+            return true;
+        }
+        ungetQuasiChar(c);
+        return false;
+    }
+
+    private int peekQuasiChar() throws IOException {
+        int c = getQuasiChar();
+        ungetQuasiChar(c);
+        return c;
+    }
+
+    int readQuasi() throws IOException {
+        rawString.setLength(0);
+        stringBufferTop = 0;
+        while (true) {
+            int c = getQuasiChar();
+            switch (c) {
+            case EOF_CHAR:
+                this.string = getStringFromBuffer();
+                tokenEnd = cursor - 1; // restore tokenEnd
+                parser.reportError("msg.unexpected.eof");
+                return Token.ERROR;
+            case '`':
+                rawString.setLength(rawString.length() - 1); // don't include "`"
+                this.string = getStringFromBuffer();
+                return Token.QUASI;
+            case '$':
+                if (matchQuasiChar('{')) {
+                    rawString.setLength(rawString.length() - 2); // don't include "${"
+                    this.string = getStringFromBuffer();
+                    this.tokenEnd = cursor - 1; // don't include "{"
+                    return Token.QUASI_SUBST;
+                } else {
+                    addToString(c);
+                    break;
+                }
+            case '\\':
+                // LineContinuation ::
+                //   \ LineTerminatorSequence
+                // EscapeSequence ::
+                //   CharacterEscapeSequence
+                //   0 [LA not DecimalDigit]
+                //   HexEscapeSequence
+                //   UnicodeEscapeSequence
+                // CharacterEscapeSequence ::
+                //   SingleEscapeCharacter
+                //   NonEscapeCharacter
+                // SingleEscapeCharacter ::
+                //   ' "  \  b f n r t v
+                // NonEscapeCharacter ::
+                //   SourceCharacter but not one of EscapeCharacter or LineTerminator
+                // EscapeCharacter ::
+                //   SingleEscapeCharacter
+                //   DecimalDigit
+                //   x
+                //   u
+                c = getQuasiChar();
+                switch (c) {
+                case '\r':
+                    // skip past \r\n sequence
+                    matchQuasiChar('\n');
+                    continue;
+                case '\n':
+                case '\u2028':
+                case '\u2029':
+                    continue;
+                case '\'':
+                case '"':
+                case '\\':
+                    // use as-is
+                    break;
+                case 'b':
+                    c = '\b';
+                    break;
+                case 'f':
+                    c = '\f';
+                    break;
+                case 'n':
+                    c = '\n';
+                    break;
+                case 'r':
+                    c = '\r';
+                    break;
+                case 't':
+                    c = '\t';
+                    break;
+                case 'v':
+                    c = 0xb;
+                    break;
+                case 'x': {
+                    int escapeVal = 0;
+                    escapeVal = Kit.xDigitToInt(getQuasiChar(), escapeVal);
+                    escapeVal = Kit.xDigitToInt(getQuasiChar(), escapeVal);
+                    if (escapeVal < 0) {
+                        parser.reportError("msg.syntax");
+                        return Token.ERROR;
+                    }
+                    c = escapeVal;
+                    break;
+                }
+                case 'u': {
+                    int escapeVal = 0;
+                    c = getQuasiChar();
+                    if (c == '{') {
+                        c = getQuasiChar();
+                        do {
+                            escapeVal = Kit.xDigitToInt(c, escapeVal);
+                            if (escapeVal < 0 || escapeVal > 0x10FFFF) {
+                                parser.reportError("msg.syntax");
+                                return Token.ERROR;
+                            }
+                        } while ((c = getQuasiChar()) != '}');
+                        if (escapeVal > 0xFFFF) {
+                            addToString(Character.highSurrogate(escapeVal));
+                            addToString(Character.lowSurrogate(escapeVal));
+                            continue;
+                        }
+                        c = escapeVal;
+                        break;
+                    }
+                    escapeVal = Kit.xDigitToInt(c, escapeVal);
+                    escapeVal = Kit.xDigitToInt(getQuasiChar(), escapeVal);
+                    escapeVal = Kit.xDigitToInt(getQuasiChar(), escapeVal);
+                    escapeVal = Kit.xDigitToInt(getQuasiChar(), escapeVal);
+                    if (escapeVal < 0) {
+                        parser.reportError("msg.syntax");
+                        return Token.ERROR;
+                    }
+                    c = escapeVal;
+                    break;
+                }
+                case '0': {
+                    int d = peekQuasiChar();
+                    if (d >= '0' && d <= '9') {
+                        parser.reportError("msg.syntax");
+                        return Token.ERROR;
+                    }
+                    c = 0x00;
+                    break;
+                }
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    parser.reportError("msg.syntax");
+                    return Token.ERROR;
+                default:
+                    // use as-is
+                    break;
+                }
+                addToString(c);
+                break;
+            default:
+                addToString(c);
+                break;
+            }
+        }
     }
 
     boolean isXMLAttribute()
@@ -1328,6 +1534,11 @@ class TokenStream
 
     private int getCharIgnoreLineEnd() throws IOException
     {
+        return getCharIgnoreLineEnd(true);
+    }
+
+    private int getCharIgnoreLineEnd(boolean skipFormattingChars) throws IOException
+    {
         if (ungetCursor != 0) {
             cursor++;
             return ungetBuffer[--ungetCursor];
@@ -1360,7 +1571,7 @@ class TokenStream
                 }
             } else {
                 if (c == BYTE_ORDER_MARK) return c; // BOM is considered whitespace
-                if (isJSFormatChar(c)) {
+                if (skipFormattingChars && isJSFormatChar(c)) {
                     continue;
                 }
                 if (ScriptRuntime.isJSLineTerminator(c)) {

--- a/src/org/mozilla/javascript/ast/QuasiCall.java
+++ b/src/org/mozilla/javascript/ast/QuasiCall.java
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import org.mozilla.javascript.Token;
+
+/**
+ * AST node for a Tagged Quasi.
+ * <p>Node type is {@link Token#QUASI_CALL}.</p>
+ */
+public class QuasiCall extends AstNode {
+
+    private AstNode target;
+    private AstNode quasi;
+
+    {
+        type = Token.QUASI_CALL;
+    }
+
+    public QuasiCall() {
+    }
+
+    public QuasiCall(int pos) {
+        super(pos);
+    }
+
+    public QuasiCall(int pos, int len) {
+        super(pos, len);
+    }
+
+    public AstNode getTarget() {
+        return target;
+    }
+
+    public void setTarget(AstNode target) {
+        this.target = target;
+    }
+
+    public AstNode getQuasi() {
+        return quasi;
+    }
+
+    public void setQuasi(AstNode quasi) {
+        this.quasi = quasi;
+    }
+
+    @Override
+    public String toSource(int depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(makeIndent(depth));
+        sb.append(target.toSource(0));
+        sb.append(quasi.toSource(0));
+        return sb.toString();
+    }
+
+    /**
+     * Visits this node.
+     */
+    @Override
+    public void visit(NodeVisitor v) {
+        if (v.visit(this)) {
+            target.visit(v);
+            quasi.visit(v);
+        }
+    }
+}

--- a/src/org/mozilla/javascript/ast/QuasiCharacters.java
+++ b/src/org/mozilla/javascript/ast/QuasiCharacters.java
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import org.mozilla.javascript.Token;
+
+/**
+ * AST node for Quasi Characters.
+ * <p>Node type is {@link Token#QUASI_CHARS}.</p>
+ */
+public class QuasiCharacters extends AstNode {
+
+    private String value;
+    private String rawValue;
+
+    {
+        type = Token.QUASI_CHARS;
+    }
+
+    public QuasiCharacters() {
+    }
+
+    public QuasiCharacters(int pos) {
+        super(pos);
+    }
+
+    public QuasiCharacters(int pos, int len) {
+        super(pos, len);
+    }
+
+    /**
+     * Returns the node's value: the parsed quasi-value (QV)
+     * @return the node's value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the node's value.
+     * @param value the node's value
+     * @throws IllegalArgumentException} if value is {@code null}
+     */
+    public void setValue(String value) {
+        assertNotNull(value);
+        this.value = value;
+    }
+
+    /**
+     * Returns the node's raw-value: the parsed quasi-raw-value (QRV)
+     * @return the node's raw-value
+     */
+    public String getRawValue() {
+        return rawValue;
+    }
+
+    /**
+     * Sets the node's raw-value.
+     * @param rawValue the node's raw-value
+     * @throws IllegalArgumentException} if rawValue is {@code null}
+     */
+    public void setRawValue(String rawValue) {
+        assertNotNull(rawValue);
+        this.rawValue = rawValue;
+    }
+
+    @Override
+    public String toSource(int depth) {
+        return new StringBuilder(makeIndent(depth))
+                .append(rawValue)
+                .toString();
+    }
+
+    /**
+     * Visits this node.  There are no children to visit.
+     */
+    @Override
+    public void visit(NodeVisitor v) {
+        v.visit(this);
+    }
+}

--- a/src/org/mozilla/javascript/ast/QuasiLiteral.java
+++ b/src/org/mozilla/javascript/ast/QuasiLiteral.java
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mozilla.javascript.Token;
+
+/**
+ * AST node for a Quasi literal.
+ * <p>Node type is {@link Token#QUASI}.</p>
+ */
+public class QuasiLiteral extends AstNode {
+
+    private List<AstNode> elements;
+
+    {
+        type = Token.QUASI;
+    }
+
+    public QuasiLiteral() {
+    }
+
+    public QuasiLiteral(int pos) {
+        super(pos);
+    }
+
+    public QuasiLiteral(int pos, int len) {
+        super(pos, len);
+    }
+
+    /**
+     * Returns a list of all literal sections of this quasi
+     */
+    public List<QuasiCharacters> getQuasiStrings() {
+        if (elements == null) return emptyList();
+        List<QuasiCharacters> strings = new ArrayList<QuasiCharacters>();
+        for (AstNode e : elements) {
+            if (e.getType() == Token.QUASI_CHARS) {
+                strings.add((QuasiCharacters) e);
+            }
+        }
+        return unmodifiableList(strings);
+    }
+
+    /**
+     * Returns a list of all substitutions of this quasi
+     */
+    public List<AstNode> getSubstitutions() {
+        if (elements == null) return emptyList();
+        List<AstNode> subs = new ArrayList<AstNode>();
+        for (AstNode e : elements) {
+            if (e.getType() != Token.QUASI_CHARS) {
+                subs.add(e);
+            }
+        }
+        return unmodifiableList(subs);
+    }
+
+    /**
+     * Returns the element list
+     * @return the element list.  If there are no elements, returns an immutable
+     *         empty list.
+     */
+    public List<AstNode> getElements() {
+        if (elements == null) return emptyList();
+        return elements;
+    }
+
+    /**
+     * Sets the element list, and sets each element's parent to this node.
+     * @param elements the element list.  Can be {@code null}.
+     */
+    public void setElements(List<AstNode> elements) {
+        if (elements == null) {
+            this.elements = null;
+        } else {
+            if (this.elements != null)
+                this.elements.clear();
+            for (AstNode e : elements)
+                addElement(e);
+        }
+    }
+
+    /**
+     * Adds an element to the list, and sets its parent to this node.
+     * @param element the element to add
+     * @throws IllegalArgumentException if element is {@code null}.
+     */
+    public void addElement(AstNode element) {
+        assertNotNull(element);
+        if (elements == null)
+            elements = new ArrayList<AstNode>();
+        elements.add(element);
+        element.setParent(this);
+    }
+
+    /**
+     * Returns the number of elements in this {@code Quasi} literal.
+     */
+    public int getSize() {
+        return elements == null ? 0 : elements.size();
+    }
+
+    /**
+     * Returns element at specified index.
+     * @param index the index of the element to retrieve
+     * @return the element
+     * @throws IndexOutOfBoundsException if the index is invalid
+     */
+    public AstNode getElement(int index) {
+        if (elements == null)
+            throw new IndexOutOfBoundsException("no elements");
+        return elements.get(index);
+    }
+
+    @Override
+    public String toSource(int depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(makeIndent(depth));
+        sb.append("`");
+        for (AstNode e : getElements()) {
+            if (e.getType() == Token.QUASI_CHARS) {
+                sb.append(e.toSource(0));
+            } else {
+                sb.append("${").append(e.toSource(0)).append("}");
+            }
+        }
+        sb.append("`");
+        return sb.toString();
+    }
+
+    /**
+     * Visits this node.
+     */
+    @Override
+    public void visit(NodeVisitor v) {
+        if (v.visit(this)) {
+            for (AstNode e : getElements()) {
+                e.visit(v);
+            }
+        }
+    }
+}

--- a/src/org/mozilla/javascript/ast/ScriptNode.java
+++ b/src/org/mozilla/javascript/ast/ScriptNode.java
@@ -27,6 +27,7 @@ public class ScriptNode extends Scope {
 
     private List<FunctionNode> functions;
     private List<RegExpLiteral> regexps;
+    private List<QuasiLiteral> quasis;
     private List<FunctionNode> EMPTY_LIST = Collections.emptyList();
 
     private List<Symbol> symbols = new ArrayList<Symbol>(4);
@@ -204,6 +205,25 @@ public class ScriptNode extends Scope {
             regexps = new ArrayList<RegExpLiteral>();
         regexps.add(re);
         re.putIntProp(REGEXP_PROP, regexps.size() - 1);
+    }
+
+    public int getQuasiCount() {
+        return quasis == null ? 0 : quasis.size();
+    }
+
+    public List<QuasiCharacters> getQuasiStrings(int index) {
+        return quasis.get(index).getQuasiStrings();
+    }
+
+    /**
+     * Called by IRFactory to add a Quasi to the quasi table.
+     */
+    public void addQuasi(QuasiLiteral quasi) {
+        if (quasi == null) codeBug();
+        if (quasis == null)
+            quasis = new ArrayList<QuasiLiteral>();
+        quasis.add(quasi);
+        quasi.putIntProp(QUASI_PROP, quasis.size() - 1);
     }
 
     public int getIndexForNameNode(Node nameNode) {

--- a/src/org/mozilla/javascript/optimizer/Block.java
+++ b/src/org/mozilla/javascript/optimizer/Block.java
@@ -526,6 +526,7 @@ class Block
             case Token.ARRAYCOMP:
             case Token.ARRAYLIT:
             case Token.OBJECTLIT:
+            case Token.QUASI:
                 return Optimizer.AnyType; // XXX: actually, we know it's not
             // number, but no type yet for that
 

--- a/testsrc/jstests/783507.jstest
+++ b/testsrc/jstests/783507.jstest
@@ -1,0 +1,632 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=783507
+
+function assertEquals(expected, actual) {
+  if (expected != actual) {
+    throw "Expected '" + expected + "' but was '" + actual + "'";
+  }
+}
+
+function assertSame(expected, actual) {
+  if (expected !== actual) {
+    throw "Expected '" + expected + "' but was '" + actual + "'";
+  }
+}
+
+function assertNotSame(expected, actual) {
+  if (expected === actual) {
+    throw "Expected not same but was '" + actual + "'";
+  }
+}
+
+function assertTrue(actual) {
+  assertSame(true, actual);
+}
+
+function assertFalse(actual) {
+  assertSame(false, actual);
+}
+
+function assertDescriptor(expected, actual) {
+  assertTrue("value" in actual);
+  assertTrue("writable" in actual);
+  assertTrue("enumerable" in actual);
+  assertTrue("configurable" in actual);
+  assertSame(expected.value, actual.value);
+  assertSame(expected.writable, actual.writable);
+  assertSame(expected.enumerable, actual.enumerable);
+  assertSame(expected.configurable, actual.configurable);
+}
+
+function assertNonEnumerable(object, key) {
+  for (var k in object) {
+    if (k === key) {
+      assertFalse(true);
+    }
+  }
+}
+
+function assertWritable(object, key) {
+  var oldValue = object[key];
+  var newValue = "test-writable";
+  try {
+    object[key] = newValue;
+    assertSame(newValue, object[key]);
+  } finally {
+    object[key] = oldValue;
+  }
+}
+
+function thrower(proto, key, value) {
+  var o = Object.create(proto);
+  Object.defineProperty(o, key, {get: function(){ throw value }});
+  return o;
+}
+
+function syntaxError(script) {
+  try {
+    eval(script);
+  } catch (e) {
+    if (e.name === "SyntaxError") {
+      return;
+    }
+  }
+  throw "Expected syntax error";
+}
+
+function Try(expected, fn) {
+  try {
+    var result = fn();
+  } catch (e) {
+    result = e;
+  }
+  assertSame(expected, result);
+}
+
+function _Try(error, fn) {
+  try {
+    fn();
+  } catch (e) {
+    var result = e instanceof error;
+  }
+  assertTrue(result);
+}
+
+// jstests run in a shared environment
+function _eval(script, o) {
+  try {
+    for (var name in o) {
+      eval("this")[name] = o[name];
+    }
+    return eval(script);
+  } finally {
+    for (var name in o) {
+      eval("delete this['" + name + "']");
+    }
+  }
+}
+
+function hex(i) {
+  return (i <= 0xF ? "0" : "") + i.toString(16);
+}
+
+function unicode(i) {
+  return (i <= 0xF ? "000" : i <= 0xFF ? "00" : i <= 0xFFF ? "0" : "") + i.toString(16);
+}
+
+function surrogate(i) {
+  var hi = ((i - 0x10000) >>> 10) + 0xD800;
+  var lo = ((i - 0x10000) & 0x3FF) + 0xDC00;
+  return String.fromCharCode(hi) + String.fromCharCode(lo);
+}
+
+/* TEST BEGIN */
+
+
+// unterminated quasi literal
+syntaxError("`");
+syntaxError("`${");
+syntaxError("`${}");
+syntaxError("`${1}");
+syntaxError("`${1 + 2}");
+
+
+// invalid quasi substitution
+syntaxError("`${`");
+syntaxError("`${}`");
+
+
+// character escape sequence (single escape character)
+assertSame("\'", `\'`);
+assertSame("\"", `\"`);
+assertSame("\\", `\\`);
+assertSame("\b", `\b`);
+assertSame("\f", `\f`);
+assertSame("\n", `\n`);
+assertSame("\r", `\r`);
+assertSame("\t", `\t`);
+assertSame("\v", `\v`);
+assertSame("\r\n", `\r\n`);
+
+
+// character escape sequence (non escape character)
+var escapeCharacters = {
+  "'": 0, '"': 0, "\\": 0, "b": 0, "f": 0,
+  "n": 0, "r": 0, "t": 0, "v": 0,
+  "0": 0, "1": 0, "2": 0, "3": 0, "4": 0,
+  "5": 0, "6": 0, "7": 0, "8": 0, "9": 0,
+  "x": 0, "u": 0,
+};
+var lineTerminator = {
+  "\n": 0, "\r": 0, "\u2028": 0, "\u2029": 0
+};
+
+/*
+var acc0 = "", acc1 = "";
+for (var i = 0; i <= 0xFFFF; ++i) {
+  var c = String.fromCharCode(i);
+  if (c in escapeCharacters) continue;
+  if (c in lineTerminator) continue;
+  // assertSame(c, eval("`\\" + c + "`"));
+  acc0 += c;
+  acc1 += "\\" + c;
+}
+assertSame(acc0, eval("`" + acc1 + "`"));
+*/
+
+assertSame("\0", eval("`\\" + String.fromCharCode(0) + "`"));
+assertSame("$", `\$`);
+assertSame(".", `\.`);
+assertSame("A", `\A`);
+assertSame("a", `\a`);
+
+
+// digit escape sequence
+assertSame("\0", `\0`);
+syntaxError("`\\1`");
+syntaxError("`\\2`");
+syntaxError("`\\3`");
+syntaxError("`\\4`");
+syntaxError("`\\5`");
+syntaxError("`\\6`");
+syntaxError("`\\7`");
+syntaxError("`\\8`");
+syntaxError("`\\9`");
+
+
+// hex escape sequence
+syntaxError("`\\x`");
+syntaxError("`\\x0`");
+syntaxError("`\\x0Z`");
+syntaxError("`\\xZ`");
+
+/*
+var acc0 = "", acc1 = "";
+for (var i = 0; i <= 0xFF; ++i) {
+  // assertSame(String.fromCharCode(i), eval("`\\x" + hex(i) + "`"));
+  acc0 += String.fromCharCode(i);
+  acc1 += "\\x" + hex(i);
+}
+assertSame(acc0, eval("`" + acc1 + "`"));
+*/
+
+assertSame("\0", `\x00`);
+assertSame("$", `\x24`);
+assertSame(".", `\x2E`);
+assertSame("A", `\x41`);
+assertSame("a", `\x61`);
+assertSame("AB", `\x41B`);
+assertSame(String.fromCharCode(0xFF), `\xFF`);
+
+
+// unicode escape sequence
+/*
+var acc0 = "", acc1 = "";
+for (var i = 0; i <= 0xFFFF; ++i) {
+  // assertSame(String.fromCharCode(i), eval("`\\u" + unicode(i) + "`"));
+  acc0 += String.fromCharCode(i);
+  acc1 += "\\u" + unicode(i);
+}
+assertSame(acc0, eval("`" + acc1 + "`"));
+*/
+
+assertSame("\0", `\u0000`);
+assertSame("$", `\u0024`);
+assertSame(".", `\u002E`);
+assertSame("A", `\u0041`);
+assertSame("a", `\u0061`);
+assertSame("AB", `\u0041B`);
+assertSame(String.fromCharCode(0xFFFF), `\uFFFF`);
+
+
+/*
+var acc0 = "", acc1 = "";
+for (var i = 0; i <= 0xFFFF; ++i) {
+  // assertSame(String.fromCharCode(i), eval("`\\u{" + unicode(i) + "}`"));
+  acc0 += String.fromCharCode(i);
+  acc1 += "\\u{" + unicode(i) + "}";
+}
+assertSame(acc0, eval("`" + acc1 + "`"));
+*/
+
+assertSame("\0", `\u{0000}`);
+assertSame("$", `\u{0024}`);
+assertSame(".", `\u{002E}`);
+assertSame("A", `\u{0041}`);
+assertSame("a", `\u{0061}`);
+assertSame("AB", `\u{0041}B`);
+assertSame(String.fromCharCode(0xFFFF), `\u{FFFF}`);
+
+
+/*
+var acc0 = "", acc1 = "";
+for (var i = 0; i <= 0xFFFF; ++i) {
+  // assertSame(String.fromCharCode(i), eval("`\\u{" + i.toString(16) + "}`"));
+  acc0 += String.fromCharCode(i);
+  acc1 += "\\u{" + i.toString(16) + "}";
+}
+assertSame(acc0, eval("`" + acc1 + "`"));
+*/
+
+assertSame("\0", `\u{0}`);
+assertSame("$", `\u{24}`);
+assertSame(".", `\u{2E}`);
+assertSame("A", `\u{41}`);
+assertSame("a", `\u{61}`);
+assertSame(String.fromCharCode(0x41B), `\u{41B}`);
+
+
+/*
+for (var start = 0x10000, end = 0x10FFFF + 1, step = 0xFFFF; start < end; start += step) {
+  var acc0 = "", acc1 = "";
+  for (var i = start, j = Math.min(start + step, end); i < j; ++i) {
+    var hi = ((i - 0x10000) >>> 10) + 0xD800;
+    var lo = ((i - 0x10000) & 0x3FF) + 0xDC00;
+    var c = String.fromCharCode(hi) + String.fromCharCode(lo);
+    // assertSame(c, eval("`\\u{" + i.toString(16) + "}`"));
+    acc0 += c;
+    acc1 += "\\u{" + i.toString(16) + "}";
+  }
+  assertSame(acc0, eval("`" + acc1 + "`"));
+}
+*/
+
+assertSame(surrogate(0x10000), `\u{10000}`);
+assertSame(surrogate(0x10FFFF), `\u{10FFFF}`);
+syntaxError("`\\u{110000}`");
+
+
+// line continuation
+assertSame("", eval("`\\\n`"))
+assertSame("", eval("`\\\r`"))
+assertSame("", eval("`\\\u2028`"))
+assertSame("", eval("`\\\u2029`"))
+
+
+// source character
+for (var i = 0; i < 0xFFFF; ++i) {
+  var c = String.fromCharCode(i);
+  if (c == "`" || c == "\\") continue;
+  assertSame(c, eval("`" + c + "`"));
+}
+
+assertSame("", ``);
+assertSame("`", `\``);
+assertSame("$", `$`);
+assertSame("$$", `$$`);
+assertSame("$$}", `$$}`);
+
+
+// simple variable substitution
+var foo = "FOO", bar = "BAR";
+assertSame("baz", `baz`);
+assertSame(foo, `${foo}`);
+assertSame("pre" + foo, `pre${foo}`);
+assertSame(foo + "post", `${foo}post`);
+assertSame("pre" + foo + "post", `pre${foo}post`);
+assertSame(foo + bar, `${foo}${bar}`);
+assertSame(foo + "-" + bar, `${foo}-${bar}`);
+
+
+// expression substitution
+assertSame("1", `${1}`);
+assertSame("12", `${1}${2}`);
+assertSame("3", `${1 + 2}`);
+assertSame("2", `${1, 2}`);
+
+
+// default quasis perform ToString() for each substitution
+assertSame("ToString-ValueOf", `\
+${{toString: function(){ return "ToString" }}}\
+-\
+${{valueOf: function(){ return "ValueOf" }}}\
+`);
+Try("ValueOf", function(){ return `\
+${{toString: function(){ throw "toString" }, valueOf: function() { return "ValueOf" }}}\
+`});
+Try("ToString", function() {
+  `${{toString: function(){ throw "ToString" }}}${{toString: function(){ throw "bad" }}}`
+});
+Try("ToString", function() {
+  `${{toString: function(){ return "bad" }}}${{toString: function(){ throw "ToString" }}}`
+});
+
+
+
+// 11.2.6 Tagged Quasis
+// 11.1.9 Quasi Literals [Runtime Semantics: ArgumentListEvaluation]
+// 11.1.9 Quasi Literals [Abstract Operation GetQuasiCallSite]
+
+var records = [];
+function recordingHandler(siteObj) {
+  var subs = [].splice.call(arguments, 1);
+  records.push({siteObj: siteObj, subs: subs});
+  return recordingHandler;
+}
+
+function cooked(siteObj) {
+  return siteObj[0];
+}
+
+function raw(siteObj) {
+  return siteObj.raw[0];
+}
+
+recordingHandler``;
+for (var i = 0; i < 2; ++i)
+  recordingHandler``;
+assertSame(3, records.length);
+
+// GetQuasiCallSite - step 1/12
+assertNotSame(records[0].siteObj, records[1].siteObj);
+assertSame(records[1].siteObj, records[2].siteObj);
+
+// GetQuasiCallSite - step 10
+assertTrue("raw" in records[0].siteObj);
+
+// GetQuasiCallSite - step 5
+assertTrue(Array.isArray(records[0].siteObj));
+
+// GetQuasiCallSite - step 6
+assertTrue(Array.isArray(records[0].siteObj.raw));
+
+// GetQuasiCallSite - step 8b/c
+assertSame(1, records[0].siteObj.length);
+assertSame("", records[0].siteObj[0]);
+
+// GetQuasiCallSite - step 8d/e
+assertSame(1, records[0].siteObj.raw.length);
+assertSame("", records[0].siteObj.raw[0]);
+
+// GetQuasiCallSite - step 9
+assertTrue(Object.isFrozen(records[0].siteObj.raw));
+
+// GetQuasiCallSite - step 11
+assertTrue(Object.isFrozen(records[0].siteObj));
+
+// Runtime Semantics: ArgumentListEvaluation
+assertSame(0, records[0].subs.length);
+
+
+// same call-site object for different handlers
+var a = [
+  function(siteObj){ return siteObj },
+  function(siteObj){ return siteObj }
+].map(function(fn) {
+  return fn``;
+});
+assertSame(a[0], a[1]);
+
+
+records.length = 0;
+recordingHandler`${foo}`;
+
+assertSame(1, records[0].subs.length);
+assertSame(foo, records[0].subs[0]);
+assertSame(2, records[0].siteObj.length);
+assertSame("", records[0].siteObj[0]);
+assertSame("", records[0].siteObj[1]);
+assertSame(2, records[0].siteObj.raw.length);
+assertSame("", records[0].siteObj.raw[0]);
+assertSame("", records[0].siteObj.raw[1]);
+
+
+records.length = 0;
+recordingHandler`a${foo}`;
+
+assertSame(1, records[0].subs.length);
+assertSame(foo, records[0].subs[0]);
+assertSame(2, records[0].siteObj.length);
+assertSame("a", records[0].siteObj[0]);
+assertSame("", records[0].siteObj[1]);
+assertSame(2, records[0].siteObj.raw.length);
+assertSame("a", records[0].siteObj.raw[0]);
+assertSame("", records[0].siteObj.raw[1]);
+
+
+records.length = 0;
+recordingHandler`${foo}b`;
+
+assertSame(1, records[0].subs.length);
+assertSame(foo, records[0].subs[0]);
+assertSame(2, records[0].siteObj.length);
+assertSame("", records[0].siteObj[0]);
+assertSame("b", records[0].siteObj[1]);
+assertSame(2, records[0].siteObj.raw.length);
+assertSame("", records[0].siteObj.raw[0]);
+assertSame("b", records[0].siteObj.raw[1]);
+
+
+records.length = 0;
+recordingHandler`a${foo}b`;
+
+assertSame(1, records[0].subs.length);
+assertSame(foo, records[0].subs[0]);
+assertSame(2, records[0].siteObj.length);
+assertSame("a", records[0].siteObj[0]);
+assertSame("b", records[0].siteObj[1]);
+assertSame(2, records[0].siteObj.raw.length);
+assertSame("a", records[0].siteObj.raw[0]);
+assertSame("b", records[0].siteObj.raw[1]);
+
+
+// LineTerminatorSequence
+assertSame("\n\r\u2028\u2029", _eval("cooked`\n\r\u2028\u2029`", {cooked: cooked}));
+assertSame("\n\r\u2028\u2029", _eval("raw`\n\r\u2028\u2029`", {raw: raw}));
+
+// LineContinuation
+assertSame("", _eval("cooked`\\\n\\\r\\\u2028\\\u2029`", {cooked: cooked}));
+assertSame("\\\n\\\r\\\u2028\\\u2029", _eval("raw`\\\n\\\r\\\u2028\\\u2029`", {raw: raw}));
+
+// Escape Sequences
+assertSame("\n\r\u2028\u2029", cooked`\n\r\u2028\u2029`);
+assertSame("\\n\\r\\u2028\\u2029", raw`\n\r\u2028\u2029`);
+
+assertSame("\0", cooked`\0`);
+assertSame("\\0", raw`\0`);
+
+assertSame("\0", cooked`\x00`);
+assertSame("\\x00", raw`\x00`);
+
+assertSame("\0", cooked`\u0000`);
+assertSame("\\u0000", raw`\u0000`);
+
+assertSame("\0", cooked`\u{0}`);
+assertSame("\\u{0}", raw`\u{0}`);
+
+assertSame("\'\"\\\b\f\n\r\t\v", cooked`\'\"\\\b\f\n\r\t\v`);
+assertSame("\\'\\\"\\\\\\b\\f\\n\\r\\t\\v", raw`\'\"\\\b\f\n\r\t\v`);
+
+assertSame("\r\n", cooked`\r\n`);
+assertSame("\\r\\n", raw`\r\n`);
+
+
+// MemberExpression, CallExpression, NewExpression
+
+var handler = {rec: recordingHandler, get: function(){ return recordingHandler }};
+handler.self = handler;
+
+records.length = 0;
+var nums = 0;
+nums += 1; handler.rec``;
+nums += 1; handler['rec']``;
+nums += 1; handler.get()``;
+nums += 1; handler['get']()``;
+nums += 1; handler.self.rec``;
+nums += 1; handler.self['rec']``;
+nums += 1; handler.self.get()``;
+nums += 1; handler.self['get']()``;
+nums += 1; (1,handler.rec)``;
+nums += 2; recordingHandler````;
+nums += 2; handler.rec````;
+assertSame(nums, records.length);
+
+
+assertTrue(new (function(){ return Object })`` instanceof Object);
+assertSame("A", (function(){ return {a: "A"} })``['a']);
+assertSame("A", (function(){ return {a: "A"} })``.a);
+assertSame("A", (function(){ return function(){ return "A" } })``());
+
+
+// nested quasi
+assertSame("baz", `${`baz`}`);
+assertSame(foo, `${`${foo}`}`);
+assertSame("<[" + foo + "]>", `<${`[${foo}]`}>`);
+
+
+
+
+// 15.5.3.4 String.raw
+
+assertTrue("raw" in String);
+assertSame("function", typeof String.raw);
+assertSame(1, String.raw.length);
+_Try(TypeError, function(){ new String.raw });
+assertDescriptor({
+  enumerable: false, configurable: true, writable: true, value: String.raw
+}, Object.getOwnPropertyDescriptor(String, "raw"));
+assertNonEnumerable(String, "raw");
+assertWritable(String, "raw");
+
+// 15.5.3.4 - step 1-3
+_Try(TypeError, function(){ String.raw() });
+_Try(TypeError, function(){ String.raw(null) });
+
+// 15.5.3.4 - step 4-6
+_Try(TypeError, function(){ String.raw({}) });
+Try("raw", function(){ String.raw(thrower(null, "raw", "raw")) });
+
+// 15.5.3.4 - step 7
+Try("raw-length", function(){ String.raw({raw: thrower(null, "length", "raw-length")}) });
+
+// 15.5.3.4 - step 8-9
+Try("raw-length-ToUint32", function(){
+  String.raw({raw: {length: {valueOf: function() { throw "raw-length-ToUint32" }}}})
+});
+
+// 15.5.3.4 - step 10
+assertSame("", String.raw({raw: {length: 0}}));
+assertSame("", String.raw({raw: {length: 0/0}}));
+assertSame("", String.raw({raw: {length: +1/0}}));
+assertSame("", String.raw({raw: {length: -1/0}}));
+
+// 15.5.3.4 - step 11-13
+assertSame("A", String.raw({raw: {length: 1, '0': "A"}}));
+assertSame("A", String.raw({raw: {length: 1, '0': "A"}}, "-"));
+assertSame("A", String.raw({raw: {length: 1, '0': "A", '1': "B"}}, "-"));
+assertSame("A-B", String.raw({raw: {length: 2, '0': "A", '1': "B"}}, "-"));
+assertSame("A-B_C", String.raw({raw: {length: 3, '0': "A", '1': "B", '2': "C"}}, "-", "_"));
+
+// 15.5.3.4 - step 13c
+assertSame("undefined", String.raw({raw: {length: 1}}));
+assertSame("undefined-undefined", String.raw({raw: {length: 2}}, "-"));
+assertSame("A-undefined", String.raw({raw: {length: 2, '0': "A"}}, "-"));
+assertSame("undefined-B", String.raw({raw: {length: 2, '1': "B"}}, "-"));
+
+// 15.5.3.4 - step 13h
+assertSame("AundefinedB", String.raw({raw: {length: 2, '0': "A", '1': "B"}}));
+
+// 15.5.3.4 - step 13c
+Try("ToString", function() {
+  String.raw({raw: {
+    length: 1,
+    '0': {
+      toString: function(){ throw "ToString" },
+      valueOf: function() { throw "ValueOf" }
+    }
+  }})
+});
+
+// 15.5.3.4 - step 13h
+Try("ToString", function() {
+  String.raw({raw: {length: 2, '0': 'A', '1': 'B'}}, {
+    toString: function(){ throw "ToString" },
+    valueOf: function() { throw "ValueOf" }
+  })
+});
+
+// 15.5.3.4 - step 13c
+Try("A", function() {
+  String.raw({raw: {
+    length: 2,
+    '0': {toString: function(){ throw "A" }},
+    '1': {toString: function(){ throw "B" }}
+  }}, {toString: function(){ throw "-" }})
+});
+
+// 15.5.3.4 - step 13h
+Try("-", function() {
+  String.raw({raw: {
+    length: 2,
+    '0': {toString: function(){ return "A" }},
+    '1': {toString: function(){ throw "B" }}
+  }}, {toString: function(){ throw "-" }})
+});
+
+
+/* TEST END */
+
+"success";

--- a/testsrc/org/mozilla/javascript/drivers/JsTestsBase.java
+++ b/testsrc/org/mozilla/javascript/drivers/JsTestsBase.java
@@ -48,7 +48,12 @@ public class JsTestsBase extends TestCase {
                 int length = (int) f.length(); // don't worry about very long
                                                // files
                 char[] buf = new char[length];
-                new FileReader(f).read(buf, 0, length);
+                FileReader reader = new FileReader(f);
+                try {
+                    reader.read(buf, 0, length);
+                } finally {
+                    reader.close();
+                }
                 String session = new String(buf);
                 runJsTest(cx, shared, f.getName(), session);
             }


### PR DESCRIPTION
This is a first stab at implementing quasi-literals (resp. the new official name "string templates"), it's still kind of rough and could need some clean-up, but should be sufficient as a starting point. I've used the current ES6 draft (July 8, 2012 Draft) for this patch.

There are four individual patches:
[Patch 1] fixes two bugs in the current code base which prevented the test cases to succeed
[Patch 2] contains the majority of the changes (frontend as well as backend)
[Patch 3] adds the new "String.raw" function
[Patch 4] adds some test cases for quasi-literals and String.raw
