### PR TITLE
Patch for Bug 783797 ("Function calls across multiple global scopes are not handled properly")

### DIFF
--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -1224,19 +1224,21 @@ switch (op) {
     }
     case Token.DELPROP :
     case Icode_DELNAME : {
-        stackTop = doDelName(cx, op, stack, sDbl, stackTop);
+        stackTop = doDelName(cx, frame, op, stack, sDbl, stackTop);
         continue Loop;
     }
     case Token.GETPROPNOWARN : {
         Object lhs = stack[stackTop];
         if (lhs == DBL_MRK) lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop] = ScriptRuntime.getObjectPropNoWarn(lhs, stringReg, cx);
+        stack[stackTop] = ScriptRuntime.getObjectPropNoWarn(lhs, stringReg,
+                                                            cx, frame.scope);
         continue Loop;
     }
     case Token.GETPROP : {
         Object lhs = stack[stackTop];
         if (lhs == DBL_MRK) lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop] = ScriptRuntime.getObjectProp(lhs, stringReg, cx, frame.scope);
+        stack[stackTop] = ScriptRuntime.getObjectProp(lhs, stringReg,
+                                                      cx, frame.scope);
         continue Loop;
     }
     case Token.SETPROP : {
@@ -1245,14 +1247,16 @@ switch (op) {
         --stackTop;
         Object lhs = stack[stackTop];
         if (lhs == DBL_MRK) lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop] = ScriptRuntime.setObjectProp(lhs, stringReg, rhs, cx);
+        stack[stackTop] = ScriptRuntime.setObjectProp(lhs, stringReg, rhs,
+                                                      cx, frame.scope);
         continue Loop;
     }
     case Icode_PROP_INC_DEC : {
         Object lhs = stack[stackTop];
         if (lhs == DBL_MRK) lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
         stack[stackTop] = ScriptRuntime.propIncrDecr(lhs, stringReg,
-                                                     cx, iCode[frame.pc]);
+                                                     cx, frame.scope,
+                                                     iCode[frame.pc]);
         ++frame.pc;
         continue Loop;
     }
@@ -1261,7 +1265,7 @@ switch (op) {
         continue Loop;
     }
     case Token.SETELEM : {
-        stackTop = doSetElem(cx, stack, sDbl, stackTop);
+        stackTop = doSetElem(cx, frame, stack, sDbl, stackTop);
         continue Loop;
     }
     case Icode_ELEM_INC_DEC: {
@@ -1278,7 +1282,7 @@ switch (op) {
         if (value == DBL_MRK) value = ScriptRuntime.wrapNumber(sDbl[stackTop]);
         --stackTop;
         Ref ref = (Ref)stack[stackTop];
-        stack[stackTop] = ScriptRuntime.refSet(ref, value, cx);
+        stack[stackTop] = ScriptRuntime.refSet(ref, value, cx, frame.scope);
         continue Loop;
     }
     case Token.DEL_REF : {
@@ -1288,7 +1292,8 @@ switch (op) {
     }
     case Icode_REF_INC_DEC : {
         Ref ref = (Ref)stack[stackTop];
-        stack[stackTop] = ScriptRuntime.refIncrDecr(ref, cx, iCode[frame.pc]);
+        stack[stackTop] = ScriptRuntime.refIncrDecr(ref, cx, frame.scope,
+                                                    iCode[frame.pc]);
         ++frame.pc;
         continue Loop;
     }
@@ -1325,7 +1330,8 @@ switch (op) {
         if (obj == DBL_MRK) obj = ScriptRuntime.wrapNumber(sDbl[stackTop - 1]);
         Object id = stack[stackTop];
         if (id == DBL_MRK) id = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop - 1] = ScriptRuntime.getElemFunctionAndThis(obj, id, cx);
+        stack[stackTop - 1] = ScriptRuntime.getElemFunctionAndThis(obj, id, cx,
+                                                                   frame.scope);
         stack[stackTop] = ScriptRuntime.lastStoredScriptable(cx);
         continue Loop;
     }
@@ -1652,7 +1658,7 @@ switch (op) {
                        op == Token.ENUM_INIT_VALUES
                          ? ScriptRuntime.ENUMERATE_VALUES :
                        ScriptRuntime.ENUMERATE_ARRAY;
-        stack[indexReg] = ScriptRuntime.enumInit(lhs, cx, enumType);
+        stack[indexReg] = ScriptRuntime.enumInit(lhs, cx, frame.scope, enumType);
         continue Loop;
     }
     case Token.ENUM_NEXT :
@@ -1669,7 +1675,8 @@ switch (op) {
         //stringReg: name of special property
         Object obj = stack[stackTop];
         if (obj == DBL_MRK) obj = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop] = ScriptRuntime.specialRef(obj, stringReg, cx);
+        stack[stackTop] = ScriptRuntime.specialRef(obj, stringReg,
+                                                   cx, frame.scope);
         continue Loop;
     }
     case Token.REF_MEMBER: {
@@ -2182,14 +2189,15 @@ switch (op) {
         return stackTop;
     }
 
-    private static int doDelName(Context cx, int op, Object[] stack,
-                                 double[] sDbl, int stackTop) {
+    private static int doDelName(Context cx, CallFrame frame, int op,
+                                 Object[] stack, double[] sDbl, int stackTop) {
         Object rhs = stack[stackTop];
         if (rhs == DOUBLE_MARK) rhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
         --stackTop;
         Object lhs = stack[stackTop];
         if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop] = ScriptRuntime.delete(lhs, rhs, cx, op == Icode_DELNAME);
+        stack[stackTop] = ScriptRuntime.delete(lhs, rhs, cx, frame.scope,
+                                               op == Icode_DELNAME);
         return stackTop;
     }
 
@@ -2206,14 +2214,14 @@ switch (op) {
             value = ScriptRuntime.getObjectElem(lhs, id, cx, frame.scope);
         } else {
             double d = sDbl[stackTop + 1];
-            value = ScriptRuntime.getObjectIndex(lhs, d, cx);
+            value = ScriptRuntime.getObjectIndex(lhs, d, cx, frame.scope);
         }
         stack[stackTop] = value;
         return stackTop;
     }
 
-    private static int doSetElem(Context cx, Object[] stack, double[] sDbl,
-                                 int stackTop) {
+    private static int doSetElem(Context cx, CallFrame frame, Object[] stack,
+                                 double[] sDbl, int stackTop) {
         stackTop -= 2;
         Object rhs = stack[stackTop + 2];
         if (rhs == DOUBLE_MARK) {
@@ -2226,10 +2234,10 @@ switch (op) {
         Object value;
         Object id = stack[stackTop + 1];
         if (id != DOUBLE_MARK) {
-            value = ScriptRuntime.setObjectElem(lhs, id, rhs, cx);
+            value = ScriptRuntime.setObjectElem(lhs, id, rhs, cx, frame.scope);
         } else {
             double d = sDbl[stackTop + 1];
-            value = ScriptRuntime.setObjectIndex(lhs, d, rhs, cx);
+            value = ScriptRuntime.setObjectIndex(lhs, d, rhs, cx, frame.scope);
         }
         stack[stackTop] = value;
         return stackTop;
@@ -2242,7 +2250,7 @@ switch (op) {
         --stackTop;
         Object lhs = stack[stackTop];
         if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
-        stack[stackTop] = ScriptRuntime.elemIncrDecr(lhs, rhs, cx,
+        stack[stackTop] = ScriptRuntime.elemIncrDecr(lhs, rhs, cx, frame.scope,
                                                      iCode[frame.pc]);
         ++frame.pc;
         return stackTop;
@@ -2657,7 +2665,7 @@ switch (op) {
             Object obj = stack[stackTop + 2];
             if (obj == DOUBLE_MARK)
                 obj = ScriptRuntime.wrapNumber(sDbl[stackTop + 2]);
-            applyThis = ScriptRuntime.toObjectOrNull(cx, obj);
+            applyThis = ScriptRuntime.toObjectOrNull(cx, obj, frame.scope);
         }
         else {
             applyThis = null;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -242,7 +242,7 @@ public class NativeArray extends IdScriptableObject implements List
               case ConstructorId_reduce:
               case ConstructorId_reduceRight: {
                 if (args.length > 0) {
-                    thisObj = ScriptRuntime.toObject(scope, args[0]);
+                    thisObj = ScriptRuntime.toObject(cx, scope, args[0]);
                     Object[] newArgs = new Object[args.length-1];
                     for (int i=0; i < newArgs.length; i++)
                         newArgs[i] = args[i+1];
@@ -835,7 +835,7 @@ public class NativeArray extends IdScriptableObject implements List
                             Callable fun;
                             Scriptable funThis;
                             fun = ScriptRuntime.getPropFunctionAndThis(
-                                      elem, "toLocaleString", cx);
+                                      elem, "toLocaleString", cx, scope);
                             funThis = ScriptRuntime.lastStoredScriptable(cx);
                             elem = fun.call(cx, scope, funThis,
                                             ScriptRuntime.emptyArgs);

--- a/src/org/mozilla/javascript/NativeIterator.java
+++ b/src/org/mozilla/javascript/NativeIterator.java
@@ -143,7 +143,7 @@ public final class NativeIterator extends IdScriptableObject {
             throw ScriptRuntime.typeError1("msg.no.properties",
                                            ScriptRuntime.toString(argument));
         }
-        Scriptable obj = ScriptRuntime.toObject(scope, args[0]);
+        Scriptable obj = ScriptRuntime.toObject(cx, scope, args[0]);
         boolean keyOnly = args.length > 1 && ScriptRuntime.toBoolean(args[1]);
         if (thisObj != null) {
             // Called as a function. Convert to iterator if possible.
@@ -170,7 +170,7 @@ public final class NativeIterator extends IdScriptableObject {
 
         // Otherwise, just set up to iterate over the properties of the object.
         // Do not call __iterator__ method.
-        Object objectIterator = ScriptRuntime.enumInit(obj, cx,
+        Object objectIterator = ScriptRuntime.enumInit(obj, cx, scope,
             keyOnly ? ScriptRuntime.ENUMERATE_KEYS_NO_ITERATOR
                     : ScriptRuntime.ENUMERATE_ARRAY_NO_ITERATOR);
         ScriptRuntime.setEnumNumbers(objectIterator, true);

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -195,14 +195,14 @@ final class NativeString extends IdScriptableObject
               case ConstructorId_localeCompare:
               case ConstructorId_toLocaleLowerCase: {
                 if (args.length > 0) {
-                    thisObj = ScriptRuntime.toObject(scope,
+                    thisObj = ScriptRuntime.toObject(cx, scope,
                             ScriptRuntime.toCharSequence(args[0]));
                     Object[] newArgs = new Object[args.length-1];
                     for (int i=0; i < newArgs.length; i++)
                         newArgs[i] = args[i+1];
                     args = newArgs;
                 } else {
-                    thisObj = ScriptRuntime.toObject(scope,
+                    thisObj = ScriptRuntime.toObject(cx, scope,
                             ScriptRuntime.toCharSequence(thisObj));
                 }
                 id = -id;

--- a/src/org/mozilla/javascript/Ref.java
+++ b/src/org/mozilla/javascript/Ref.java
@@ -24,7 +24,16 @@ public abstract class Ref implements Serializable
 
     public abstract Object get(Context cx);
 
+    /**
+     * @deprecated Use {@link #set(Context, Scriptable, Object)} instead
+     */
+    @Deprecated
     public abstract Object set(Context cx, Object value);
+
+    public Object set(Context cx, Scriptable scope, Object value)
+    {
+        return set(cx, value);
+    }
 
     public boolean delete(Context cx)
     {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -937,8 +937,12 @@ public class ScriptRuntime {
     }
 
     /**
-     * Warning: this doesn't allow to resolve primitive prototype properly when many top scopes are involved
+     * <strong>Warning</strong>: This doesn't allow to resolve primitive
+     * prototype properly when many top scopes are involved
+     *
+     * @deprecated Use {@link #toObjectOrNull(Context, Object, Scriptable)} instead
      */
+    @Deprecated
     public static Scriptable toObjectOrNull(Context cx, Object obj)
     {
         if (obj instanceof Scriptable) {
@@ -953,7 +957,7 @@ public class ScriptRuntime {
      * @param scope the scope that should be used to resolve primitive prototype
      */
     public static Scriptable toObjectOrNull(Context cx, Object obj,
-                                            final Scriptable scope)
+                                            Scriptable scope)
     {
         if (obj instanceof Scriptable) {
             return (Scriptable)obj;
@@ -966,6 +970,7 @@ public class ScriptRuntime {
     /**
      * @deprecated Use {@link #toObject(Scriptable, Object)} instead.
      */
+    @Deprecated
     public static Scriptable toObject(Scriptable scope, Object val,
                                       Class<?> staticClass)
     {
@@ -1018,6 +1023,7 @@ public class ScriptRuntime {
     /**
      * @deprecated Use {@link #toObject(Context, Scriptable, Object)} instead.
      */
+    @Deprecated
     public static Scriptable toObject(Context cx, Scriptable scope, Object val,
                                       Class<?> staticClass)
     {
@@ -1027,6 +1033,7 @@ public class ScriptRuntime {
     /**
      * @deprecated The method is only present for compatibility.
      */
+    @Deprecated
     public static Object call(Context cx, Object fun, Object thisArg,
                               Object[] args, Scriptable scope)
     {
@@ -1034,7 +1041,7 @@ public class ScriptRuntime {
             throw notFunctionError(toString(fun));
         }
         Function function = (Function)fun;
-        Scriptable thisObj = toObjectOrNull(cx, thisArg);
+        Scriptable thisObj = toObjectOrNull(cx, thisArg, scope);
         if (thisObj == null) {
             throw undefCallError(thisObj, "function");
         }
@@ -1416,7 +1423,10 @@ public class ScriptRuntime {
 
     /**
      * Call obj.[[Get]](id)
+     *
+     * @deprecated Use {@link #getObjectElem(Object, Object, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Object getObjectElem(Object obj, Object elem, Context cx)
     {
     	return getObjectElem(obj, elem, cx, getTopCallScope(cx));
@@ -1425,7 +1435,7 @@ public class ScriptRuntime {
     /**
      * Call obj.[[Get]](id)
      */
-    public static Object getObjectElem(Object obj, Object elem, Context cx, final Scriptable scope)
+    public static Object getObjectElem(Object obj, Object elem, Context cx, Scriptable scope)
     {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
@@ -1461,22 +1471,23 @@ public class ScriptRuntime {
 
     /**
      * Version of getObjectElem when elem is a valid JS identifier name.
+     *
+     * @deprecated Use {@link #getObjectProp(Object, String, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Object getObjectProp(Object obj, String property,
                                        Context cx)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
-        if (sobj == null) {
-            throw undefReadError(obj, property);
-        }
-        return getObjectProp(sobj, property, cx);
+        return getObjectProp(obj, property, cx, getTopCallScope(cx));
     }
 
     /**
+     * Version of getObjectElem when elem is a valid JS identifier name.
+     *
      * @param scope the scope that should be used to resolve primitive prototype
      */
     public static Object getObjectProp(Object obj, String property,
-                                       Context cx, final Scriptable scope)
+                                       Context cx, Scriptable scope)
     {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
@@ -1501,10 +1512,20 @@ public class ScriptRuntime {
         return result;
     }
 
+    /**
+     * @deprecated Use {@link #getObjectPropNoWarn(Object, String, Context, Scriptable)} instead
+     */
+    @Deprecated
     public static Object getObjectPropNoWarn(Object obj, String property,
                                              Context cx)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        return getObjectPropNoWarn(obj, property, cx, getTopCallScope(cx));
+    }
+
+    public static Object getObjectPropNoWarn(Object obj, String property,
+                                             Context cx, Scriptable scope)
+    {
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw undefReadError(obj, property);
         }
@@ -1515,14 +1536,27 @@ public class ScriptRuntime {
         return result;
     }
 
-    /*
+    /**
+     * A cheaper and less general version of the above for well-known argument
+     * types.
+     *
+     * @deprecated Use {@link #getObjectIndex(Object, double, Context, Scriptable)} instead
+     */
+    @Deprecated
+    public static Object getObjectIndex(Object obj, double dblIndex,
+                                        Context cx)
+    {
+        return getObjectIndex(obj, dblIndex, cx, getTopCallScope(cx));
+    }
+
+    /**
      * A cheaper and less general version of the above for well-known argument
      * types.
      */
     public static Object getObjectIndex(Object obj, double dblIndex,
-                                        Context cx)
+                                        Context cx, Scriptable scope)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw undefReadError(obj, toString(dblIndex));
         }
@@ -1539,7 +1573,6 @@ public class ScriptRuntime {
     public static Object getObjectIndex(Scriptable obj, int index,
                                         Context cx)
     {
-
         Object result = ScriptableObject.getProperty(obj, index);
         if (result == Scriptable.NOT_FOUND) {
             result = Undefined.instance;
@@ -1548,13 +1581,25 @@ public class ScriptRuntime {
         return result;
     }
 
-    /*
+    /**
      * Call obj.[[Put]](id, value)
+     *
+     * @deprecated Use {@link #setObjectElem(Object, Object, Object, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Object setObjectElem(Object obj, Object elem, Object value,
                                        Context cx)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        return setObjectElem(obj, elem, value, cx, getTopCallScope(cx));
+    }
+
+    /**
+     * Call obj.[[Put]](id, value)
+     */
+    public static Object setObjectElem(Object obj, Object elem, Object value,
+                                       Context cx, Scriptable scope)
+    {
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw undefWriteError(obj, elem, value);
         }
@@ -1581,11 +1626,24 @@ public class ScriptRuntime {
 
     /**
      * Version of setObjectElem when elem is a valid JS identifier name.
+     *
+     * @deprecated Use {@link #setObjectProp(Object, String, Object, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Object setObjectProp(Object obj, String property,
                                        Object value, Context cx)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        return setObjectProp(obj, property, value, cx, getTopCallScope(cx));
+    }
+
+    /**
+     * Version of setObjectElem when elem is a valid JS identifier name.
+     */
+    public static Object setObjectProp(Object obj, String property,
+                                       Object value, Context cx,
+                                       Scriptable scope)
+    {
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw undefWriteError(obj, property, value);
         }
@@ -1599,14 +1657,28 @@ public class ScriptRuntime {
         return value;
     }
 
-    /*
+    /**
+     * A cheaper and less general version of the above for well-known argument
+     * types.
+     *
+     * @deprecated Use {@link #setObjectIndex(Object, double, Object, Context, Scriptable)} instead
+     */
+    @Deprecated
+    public static Object setObjectIndex(Object obj, double dblIndex,
+                                        Object value, Context cx)
+    {
+        return setObjectIndex(obj, dblIndex, value, cx, getTopCallScope(cx));
+    }
+
+    /**
      * A cheaper and less general version of the above for well-known argument
      * types.
      */
     public static Object setObjectIndex(Object obj, double dblIndex,
-                                        Object value, Context cx)
+                                        Object value, Context cx,
+                                        Scriptable scope)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw undefWriteError(obj, String.valueOf(dblIndex), value);
         }
@@ -1662,9 +1734,19 @@ public class ScriptRuntime {
         return ref.get(cx);
     }
 
+    /**
+     * @deprecated Use {@link #refSet(Ref, Object, Context, Scriptable)} instead
+     */
+    @Deprecated
     public static Object refSet(Ref ref, Object value, Context cx)
     {
-        return ref.set(cx, value);
+        return refSet(ref, value, cx, getTopCallScope(cx));
+    }
+
+    public static Object refSet(Ref ref, Object value, Context cx,
+                                Scriptable scope)
+    {
+        return ref.set(cx, scope, value);
     }
 
     public static Object refDel(Ref ref, Context cx)
@@ -1677,15 +1759,26 @@ public class ScriptRuntime {
         return s.equals("__proto__") || s.equals("__parent__");
     }
 
+    /**
+     * @deprecated Use {@link #specialRef(Object, String, Context, Scriptable)} instead
+     */
+    @Deprecated
     public static Ref specialRef(Object obj, String specialProperty,
                                  Context cx)
     {
-        return SpecialRef.createSpecial(cx, obj, specialProperty);
+        return specialRef(obj, specialProperty, cx, getTopCallScope(cx));
+    }
+
+    public static Ref specialRef(Object obj, String specialProperty,
+                                 Context cx, Scriptable scope)
+    {
+        return SpecialRef.createSpecial(cx, scope, obj, specialProperty);
     }
 
     /**
-     * @deprecated
+     * @deprecated Use {@link #delete(Object, Object, Context, Scriptable, boolean)} instead
      */
+    @Deprecated
     public static Object delete(Object obj, Object id, Context cx)
     {
         return delete(obj, id, cx, false);
@@ -1701,10 +1794,30 @@ public class ScriptRuntime {
      * the definition of the [[Delete]] operator (8.6.2.5) does not
      * define a return value. Here we assume that the [[Delete]]
      * method doesn't return a value.
+     *
+     * @deprecated Use {@link #delete(Object, Object, Context, Scriptable, boolean)} instead
      */
+    @Deprecated
     public static Object delete(Object obj, Object id, Context cx, boolean isName)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        return delete(obj, id, cx, getTopCallScope(cx), isName);
+    }
+
+    /**
+     * The delete operator
+     *
+     * See ECMA 11.4.1
+     *
+     * In ECMA 0.19, the description of the delete operator (11.4.1)
+     * assumes that the [[Delete]] method returns a value. However,
+     * the definition of the [[Delete]] operator (8.6.2.5) does not
+     * define a return value. Here we assume that the [[Delete]]
+     * method doesn't return a value.
+     */
+    public static Object delete(Object obj, Object id, Context cx,
+                                Scriptable scope, boolean isName)
+    {
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             if (isName) {
                 return Boolean.TRUE;
@@ -2001,7 +2114,12 @@ public class ScriptRuntime {
         return null;
     }
 
-    // for backwards compatibility with generated class files
+    /**
+     * For backwards compatibility with generated class files
+     *
+     * @deprecated Use {@link #enumInit(Object, Context, Scriptable, int)} instead
+     */
+    @Deprecated
     public static Object enumInit(Object value, Context cx, boolean enumValues)
     {
         return enumInit(value, cx, enumValues ? ENUMERATE_VALUES
@@ -2015,10 +2133,20 @@ public class ScriptRuntime {
     public static final int ENUMERATE_VALUES_NO_ITERATOR = 4;
     public static final int ENUMERATE_ARRAY_NO_ITERATOR = 5;
 
+    /**
+     * @deprecated Use {@link #enumInit(Object, Context, Scriptable, int)} instead
+     */
+    @Deprecated
     public static Object enumInit(Object value, Context cx, int enumType)
     {
+        return enumInit(value, cx, getTopCallScope(cx), enumType);
+    }
+
+    public static Object enumInit(Object value, Context cx, Scriptable scope,
+                                  int enumType)
+    {
         IdEnumeration x = new IdEnumeration();
-        x.obj = toObjectOrNull(cx, value);
+        x.obj = toObjectOrNull(cx, value, scope);
         if (x.obj == null) {
             // null or undefined do not cause errors but rather lead to empty
             // "for in" loop
@@ -2194,18 +2322,34 @@ public class ScriptRuntime {
      * as ScriptRuntime.lastStoredScriptable() for consumption as thisObj.
      * The caller must call ScriptRuntime.lastStoredScriptable() immediately
      * after calling this method.
+     *
+     * @deprecated Use {@link #getElemFunctionAndThis(Object, Object, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Callable getElemFunctionAndThis(Object obj,
                                                   Object elem,
                                                   Context cx)
     {
+        return getElemFunctionAndThis(obj, elem, cx, getTopCallScope(cx));
+    }
+
+    /**
+     * Prepare for calling obj[id](...): return function corresponding to
+     * obj[id] and make obj properly converted to Scriptable available
+     * as ScriptRuntime.lastStoredScriptable() for consumption as thisObj.
+     * The caller must call ScriptRuntime.lastStoredScriptable() immediately
+     * after calling this method.
+     */
+    public static Callable getElemFunctionAndThis(Object obj, Object elem,
+                                                  Context cx, Scriptable scope)
+    {
         String str = toStringIdOrIndex(cx, elem);
         if (str != null) {
-            return getPropFunctionAndThis(obj, str, cx);
+            return getPropFunctionAndThis(obj, str, cx, scope);
         }
         int index = lastIndexResult(cx);
 
-        Scriptable thisObj = toObjectOrNull(cx, obj);
+        Scriptable thisObj = toObjectOrNull(cx, obj, scope);
         if (thisObj == null) {
             throw undefCallError(obj, String.valueOf(index));
         }
@@ -2227,13 +2371,15 @@ public class ScriptRuntime {
      * after calling this method.
      * Warning: this doesn't allow to resolve primitive prototype properly when
      * many top scopes are involved.
+     *
+     * @deprecated Use {@link #getPropFunctionAndThis(Object, String, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Callable getPropFunctionAndThis(Object obj,
                                                   String property,
                                                   Context cx)
     {
-        Scriptable thisObj = toObjectOrNull(cx, obj);
-        return getPropFunctionAndThisHelper(obj, property, cx, thisObj);
+        return getPropFunctionAndThis(obj, property, cx, getTopCallScope(cx));
     }
 
     /**
@@ -2245,7 +2391,7 @@ public class ScriptRuntime {
      */
     public static Callable getPropFunctionAndThis(Object obj,
                                                   String property,
-                                                  Context cx, final Scriptable scope)
+                                                  Context cx, Scriptable scope)
     {
         Scriptable thisObj = toObjectOrNull(cx, obj, scope);
         return getPropFunctionAndThisHelper(obj, property, cx, thisObj);
@@ -2405,7 +2551,7 @@ public class ScriptRuntime {
 
         Scriptable callThis = null;
         if (L != 0) {
-            callThis = toObjectOrNull(cx, args[0]);
+            callThis = toObjectOrNull(cx, args[0], scope);
         }
         if (callThis == null) {
             // This covers the case of args[0] == (null|undefined) as well.
@@ -2594,8 +2740,11 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated The method is only present for compatibility.
+     * The method is only present for compatibility.
+     *
+     * @deprecated Use {@link #nameIncrDecr(Scriptable, String, Context, int)} instead
      */
+    @Deprecated
     public static Object nameIncrDecr(Scriptable scopeChain, String id,
                                       int incrDecrMask)
     {
@@ -2632,10 +2781,21 @@ public class ScriptRuntime {
                                     incrDecrMask);
     }
 
+    /**
+     * @deprecated Use {@link #propIncrDecr(Object, String, Context, Scriptable, int)} instead
+     */
+    @Deprecated
     public static Object propIncrDecr(Object obj, String id,
                                       Context cx, int incrDecrMask)
     {
-        Scriptable start = toObjectOrNull(cx, obj);
+        return propIncrDecr(obj, id, cx, getTopCallScope(cx), incrDecrMask);
+    }
+
+    public static Object propIncrDecr(Object obj, String id,
+                                      Context cx, Scriptable scope,
+                                      int incrDecrMask)
+    {
+        Scriptable start = toObjectOrNull(cx, obj, scope);
         if (start == null) {
             throw undefReadError(obj, id);
         }
@@ -2688,10 +2848,21 @@ public class ScriptRuntime {
         }
     }
 
+    /**
+     * @deprecated Use {@link #elemIncrDecr(Object, Object, Context, Scriptable, int)} instead
+     */
+    @Deprecated
     public static Object elemIncrDecr(Object obj, Object index,
                                       Context cx, int incrDecrMask)
     {
-        Object value = getObjectElem(obj, index, cx);
+        return elemIncrDecr(obj, index, cx, getTopCallScope(cx), incrDecrMask);
+    }
+
+    public static Object elemIncrDecr(Object obj, Object index,
+                                      Context cx, Scriptable scope,
+                                      int incrDecrMask)
+    {
+        Object value = getObjectElem(obj, index, cx, scope);
         boolean post = ((incrDecrMask & Node.POST_FLAG) != 0);
         double number;
         if (value instanceof Number) {
@@ -2709,7 +2880,7 @@ public class ScriptRuntime {
             --number;
         }
         Number result = wrapNumber(number);
-        setObjectElem(obj, index, result, cx);
+        setObjectElem(obj, index, result, cx, scope);
         if (post) {
             return value;
         } else {
@@ -2717,7 +2888,17 @@ public class ScriptRuntime {
         }
     }
 
+    /**
+     * @deprecated Use {@link #refIncrDecr(Ref, Context, Scriptable, int)} instead
+     */
+    @Deprecated
     public static Object refIncrDecr(Ref ref, Context cx, int incrDecrMask)
+    {
+        return refIncrDecr(ref, cx, getTopCallScope(cx), incrDecrMask);
+    }
+
+    public static Object refIncrDecr(Ref ref, Context cx, Scriptable scope,
+                                     int incrDecrMask)
     {
         Object value = ref.get(cx);
         boolean post = ((incrDecrMask & Node.POST_FLAG) != 0);
@@ -2737,7 +2918,7 @@ public class ScriptRuntime {
             --number;
         }
         Number result = wrapNumber(number);
-        ref.set(cx, result);
+        ref.set(cx, scope, result);
         if (post) {
             return value;
         } else {
@@ -3343,7 +3524,7 @@ public class ScriptRuntime {
     public static Scriptable enterWith(Object obj, Context cx,
                                        Scriptable scope)
     {
-        Scriptable sobj = toObjectOrNull(cx, obj);
+        Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw typeError1("msg.undef.with", toString(obj));
         }
@@ -3488,19 +3669,20 @@ public class ScriptRuntime {
         return array;
     }
 
-  /**
-   * This method is here for backward compat with existing compiled code.  It
-   * is called when an object literal is compiled.  The next instance will be
-   * the version called from new code.
-   * @deprecated This method only present for compatibility.
-   */
+    /**
+     * This method is here for backward compat with existing compiled code.  It
+     * is called when an object literal is compiled.  The next instance will be
+     * the version called from new code.
+     * <strong>This method only present for compatibility.</strong>
+     * @deprecated Use {@link #newObjectLiteral(Object[], Object[], int[], Context, Scriptable)} instead
+     */
+    @Deprecated
     public static Scriptable newObjectLiteral(Object[] propertyIds,
                                               Object[] propertyValues,
                                               Context cx, Scriptable scope)
     {
         // Passing null for getterSetters means no getters or setters
         return newObjectLiteral(propertyIds, propertyValues, null, cx, scope);
-
     }
 
     public static Scriptable newObjectLiteral(Object[] propertyIds,
@@ -3516,7 +3698,8 @@ public class ScriptRuntime {
             if (id instanceof String) {
                 if (getterSetter == 0) {
                     if (isSpecialProperty((String)id)) {
-                        specialRef(object, (String)id, cx).set(cx, value);
+                        Ref ref = specialRef(object, (String)id, cx, scope);
+                        ref.set(cx, scope, value);
                     } else {
                         object.put((String)id, object, value);
                     }

--- a/src/org/mozilla/javascript/SpecialRef.java
+++ b/src/org/mozilla/javascript/SpecialRef.java
@@ -25,9 +25,10 @@ class SpecialRef extends Ref
         this.name = name;
     }
 
-    static Ref createSpecial(Context cx, Object object, String name)
+    static Ref createSpecial(Context cx, Scriptable scope, Object object,
+                             String name)
     {
-        Scriptable target = ScriptRuntime.toObjectOrNull(cx, object);
+        Scriptable target = ScriptRuntime.toObjectOrNull(cx, object, scope);
         if (target == null) {
             throw ScriptRuntime.undefReadError(object, name);
         }
@@ -65,7 +66,13 @@ class SpecialRef extends Ref
     }
 
     @Override
-    public Object set(Context cx, Object value)
+    @Deprecated
+    public Object set(Context cx, Object value) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Object set(Context cx, Scriptable scope, Object value)
     {
         switch (type) {
           case SPECIAL_NONE:
@@ -73,7 +80,7 @@ class SpecialRef extends Ref
           case SPECIAL_PROTO:
           case SPECIAL_PARENT:
             {
-                Scriptable obj = ScriptRuntime.toObjectOrNull(cx, value);
+                Scriptable obj = ScriptRuntime.toObjectOrNull(cx, value, scope);
                 if (obj != null) {
                     // Check that obj does not contain on its prototype/scope
                     // chain to prevent cycles

--- a/src/org/mozilla/javascript/commonjs/module/Require.java
+++ b/src/org/mozilla/javascript/commonjs/module/Require.java
@@ -339,7 +339,7 @@ public class Require extends BaseFunction
         executeOptionalScript(preExec, cx, executionScope);
         moduleScript.getScript().exec(cx, executionScope);
         executeOptionalScript(postExec, cx, executionScope);
-        return ScriptRuntime.toObject(nativeScope,
+        return ScriptRuntime.toObject(cx, nativeScope,
                 ScriptableObject.getProperty(moduleObject, "exports"));
     }
 

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -2001,6 +2001,7 @@ class BodyCodegen
               case Token.ENUM_INIT_ARRAY:
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
+                cfw.addALoad(variableObjectLocal);
                 int enumType = type == Token.ENUM_INIT_KEYS
                                    ? ScriptRuntime.ENUMERATE_KEYS :
                                type == Token.ENUM_INIT_VALUES
@@ -2010,6 +2011,7 @@ class BodyCodegen
                 addScriptRuntimeInvoke("enumInit",
                                        "(Ljava/lang/Object;"
                                        +"Lorg/mozilla/javascript/Context;"
+                                       +"Lorg/mozilla/javascript/Scriptable;"
                                        +"I"
                                        +")Ljava/lang/Object;");
                 cfw.addAStore(getLocalBlockRegister(node));
@@ -2613,11 +2615,13 @@ class BodyCodegen
                     }
                     generateExpression(child, node);
                     cfw.addALoad(contextLocal);
+                    cfw.addALoad(variableObjectLocal);
                     addScriptRuntimeInvoke(
                         "refSet",
                         "(Lorg/mozilla/javascript/Ref;"
                         +"Ljava/lang/Object;"
                         +"Lorg/mozilla/javascript/Context;"
+                        +"Lorg/mozilla/javascript/Scriptable;"
                         +")Ljava/lang/Object;");
                 }
                 break;
@@ -2674,11 +2678,13 @@ class BodyCodegen
                     generateExpression(child, node);
                     cfw.addPush(special);
                     cfw.addALoad(contextLocal);
+                    cfw.addALoad(variableObjectLocal);
                     addScriptRuntimeInvoke(
                         "specialRef",
                         "(Ljava/lang/Object;"
                         +"Ljava/lang/String;"
                         +"Lorg/mozilla/javascript/Context;"
+                        +"Lorg/mozilla/javascript/Scriptable;"
                         +")Lorg/mozilla/javascript/Ref;");
                 }
                 break;
@@ -3590,11 +3596,13 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                 if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1)
                     addDoubleWrap();
                 cfw.addALoad(contextLocal);
+                cfw.addALoad(variableObjectLocal);
                 addScriptRuntimeInvoke(
                     "getElemFunctionAndThis",
                     "(Ljava/lang/Object;"
                     +"Ljava/lang/Object;"
                     +"Lorg/mozilla/javascript/Context;"
+                    +"Lorg/mozilla/javascript/Scriptable;"
                     +")Lorg/mozilla/javascript/Callable;");
             }
             break;
@@ -4372,11 +4380,13 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
             generateExpression(getPropChild, node);
             generateExpression(getPropChild.getNext(), node);
             cfw.addALoad(contextLocal);
+            cfw.addALoad(variableObjectLocal);
             cfw.addPush(incrDecrMask);
             addScriptRuntimeInvoke("propIncrDecr",
                                    "(Ljava/lang/Object;"
                                    +"Ljava/lang/String;"
                                    +"Lorg/mozilla/javascript/Context;"
+                                   +"Lorg/mozilla/javascript/Scriptable;"
                                    +"I)Ljava/lang/Object;");
             break;
           }
@@ -4385,12 +4395,14 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
             generateExpression(elemChild, node);
             generateExpression(elemChild.getNext(), node);
             cfw.addALoad(contextLocal);
+            cfw.addALoad(variableObjectLocal);
             cfw.addPush(incrDecrMask);
             if (elemChild.getNext().getIntProp(Node.ISNUMBER_PROP, -1) != -1) {
               addOptRuntimeInvoke("elemIncrDecr",
                   "(Ljava/lang/Object;"
                   +"D"
                   +"Lorg/mozilla/javascript/Context;"
+                  +"Lorg/mozilla/javascript/Scriptable;"
                   +"I"
                   +")Ljava/lang/Object;");
             } else {
@@ -4398,6 +4410,7 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                   "(Ljava/lang/Object;"
                   +"Ljava/lang/Object;"
                   +"Lorg/mozilla/javascript/Context;"
+                  +"Lorg/mozilla/javascript/Scriptable;"
                   +"I"
                   +")Ljava/lang/Object;");
             }
@@ -4407,11 +4420,13 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
             Node refChild = child.getFirstChild();
             generateExpression(refChild, node);
             cfw.addALoad(contextLocal);
+            cfw.addALoad(variableObjectLocal);
             cfw.addPush(incrDecrMask);
             addScriptRuntimeInvoke(
                 "refIncrDecr",
                 "(Lorg/mozilla/javascript/Ref;"
                 +"Lorg/mozilla/javascript/Context;"
+                +"Lorg/mozilla/javascript/Scriptable;"
                 +"I)Ljava/lang/Object;");
             break;
           }
@@ -4952,11 +4967,13 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
         generateExpression(nameChild, node);  // the name
         if (node.getType() == Token.GETPROPNOWARN) {
             cfw.addALoad(contextLocal);
+            cfw.addALoad(variableObjectLocal);
             addScriptRuntimeInvoke(
                 "getObjectPropNoWarn",
                 "(Ljava/lang/Object;"
                 +"Ljava/lang/String;"
                 +"Lorg/mozilla/javascript/Context;"
+                +"Lorg/mozilla/javascript/Scriptable;"
                 +")Ljava/lang/Object;");
             return;
         }
@@ -5014,22 +5031,26 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                     +")Ljava/lang/Object;");
             } else {
                 cfw.addALoad(contextLocal);
+                cfw.addALoad(variableObjectLocal);
                 addScriptRuntimeInvoke(
                     "getObjectProp",
                     "(Ljava/lang/Object;"
                     +"Ljava/lang/String;"
                     +"Lorg/mozilla/javascript/Context;"
+                    +"Lorg/mozilla/javascript/Scriptable;"
                     +")Ljava/lang/Object;");
             }
         }
         generateExpression(child, node);
         cfw.addALoad(contextLocal);
+        cfw.addALoad(variableObjectLocal);
         addScriptRuntimeInvoke(
             "setObjectProp",
             "(Ljava/lang/Object;"
             +"Ljava/lang/String;"
             +"Ljava/lang/Object;"
             +"Lorg/mozilla/javascript/Context;"
+            +"Lorg/mozilla/javascript/Scriptable;"
             +")Ljava/lang/Object;");
     }
 
@@ -5049,26 +5070,31 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                 //        -> ... object number object number
                 cfw.add(ByteCode.DUP2_X1);
                 cfw.addALoad(contextLocal);
-                addOptRuntimeInvoke(
+                cfw.addALoad(variableObjectLocal);
+                addScriptRuntimeInvoke(
                     "getObjectIndex",
                     "(Ljava/lang/Object;D"
                     +"Lorg/mozilla/javascript/Context;"
+                    +"Lorg/mozilla/javascript/Scriptable;"
                     +")Ljava/lang/Object;");
             } else {
                 // stack: ... object object indexObject
                 //        -> ... object indexObject object indexObject
                 cfw.add(ByteCode.DUP_X1);
                 cfw.addALoad(contextLocal);
+                cfw.addALoad(variableObjectLocal);
                 addScriptRuntimeInvoke(
                     "getObjectElem",
                     "(Ljava/lang/Object;"
                     +"Ljava/lang/Object;"
                     +"Lorg/mozilla/javascript/Context;"
+                    +"Lorg/mozilla/javascript/Scriptable;"
                     +")Ljava/lang/Object;");
             }
         }
         generateExpression(child, node);
         cfw.addALoad(contextLocal);
+        cfw.addALoad(variableObjectLocal);
         if (indexIsNumber) {
             addScriptRuntimeInvoke(
                 "setObjectIndex",
@@ -5076,6 +5102,7 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                 +"D"
                 +"Ljava/lang/Object;"
                 +"Lorg/mozilla/javascript/Context;"
+                +"Lorg/mozilla/javascript/Scriptable;"
                 +")Ljava/lang/Object;");
         } else {
             addScriptRuntimeInvoke(
@@ -5084,6 +5111,7 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                 +"Ljava/lang/Object;"
                 +"Ljava/lang/Object;"
                 +"Lorg/mozilla/javascript/Context;"
+                +"Lorg/mozilla/javascript/Scriptable;"
                 +")Ljava/lang/Object;");
         }
     }

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -103,10 +103,21 @@ public final class OptRuntime extends ScriptRuntime
         return new ConsString(toString(val1), (CharSequence)val2);
     }
 
+    /**
+     * @deprecated Use {@link #elemIncrDecr(Object, double, Context, Scriptable, int)} instead
+     */
+    @Deprecated
     public static Object elemIncrDecr(Object obj, double index,
                                       Context cx, int incrDecrMask)
     {
-        return ScriptRuntime.elemIncrDecr(obj, new Double(index), cx,
+        return elemIncrDecr(obj, index, cx, getTopCallScope(cx), incrDecrMask);
+    }
+
+    public static Object elemIncrDecr(Object obj, double index,
+                                      Context cx, Scriptable scope,
+                                      int incrDecrMask)
+    {
+        return ScriptRuntime.elemIncrDecr(obj, new Double(index), cx, scope,
                                           incrDecrMask);
     }
 

--- a/testsrc/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug783797Test.java
@@ -1,0 +1,545 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mozilla.javascript.tests.Utils.runWithAllOptimizationLevels;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextAction;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+
+/**
+ * @author André Bargull
+ *
+ */
+public class Bug783797Test {
+    private interface Action {
+        void run(Context cx, ScriptableObject scope1, ScriptableObject scope2);
+    }
+
+    private static ContextAction action(final String fn, final Action a) {
+        return new ContextAction() {
+            public Object run(Context cx) {
+                ScriptableObject scope1 = cx.initStandardObjects();
+                ScriptableObject scope2 = cx.initStandardObjects();
+                scope1.put("scope2", scope1, scope2);
+
+                eval(cx, scope2, fn);
+                a.run(cx, scope1, scope2);
+
+                return null;
+            }
+        };
+    }
+
+    private static Object eval(Context cx, Scriptable scope, String source) {
+        return cx.evaluateString(scope, source, "<eval>", 1, null);
+    }
+
+    private static void assertTRUE(Object actual) {
+        assertSame(Boolean.TRUE, actual);
+    }
+
+    private static void assertFALSE(Object actual) {
+        assertSame(Boolean.FALSE, actual);
+    }
+
+    @Test
+    public void test_getElem() {
+        String fn = "function test(){ return ''['foo'] }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = 'scope1'");
+                eval(cx, scope2, "String.prototype.foo = 'scope2'");
+
+                assertEquals("scope2", eval(cx, scope2, "test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test.call(null)"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t()"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_getProp() {
+        String fn = "function test(){ return ''.foo }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = 'scope1'");
+                eval(cx, scope2, "String.prototype.foo = 'scope2'");
+
+                assertEquals("scope2", eval(cx, scope2, "test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test.call(null)"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t()"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_getPropNoWarn1() {
+        String fn = "function test(){ if (''.foo) return true; return false; }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = 'scope1'");
+
+                assertFALSE(eval(cx, scope2, "test()"));
+                assertFALSE(eval(cx, scope1, "scope2.test()"));
+                assertFALSE(eval(cx, scope1, "scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_getPropNoWarn2() {
+        String fn = "function test(){ if (''.foo) return true; return false; }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope2, "String.prototype.foo = 'scope2'");
+
+                assertTRUE(eval(cx, scope2, "test()"));
+                assertTRUE(eval(cx, scope1, "scope2.test()"));
+                assertTRUE(eval(cx, scope1, "scope2.test.call(null)"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; t()"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setElem() {
+        String fn = "function test(){ ''['foo'] = '_' }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setProp() {
+        String fn = "function test(){ ''.foo = '_' }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setElemIncDec() {
+        String fn = "function test(){ ''['foo']++ }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setPropIncDec() {
+        String fn = "function test(){ ''.foo++ }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setElemOp1() {
+        String fn = "function test(){ return ''['foo'] += '_' }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setPropOp1() {
+        String fn = "function test(){ return ''.foo += '_' }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "String.prototype.d = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ },"
+                        + "  get: function(v){ this.__proto__.d++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.d"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.d"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setElemOp2() {
+        String fn = "function test(){ return ''['foo'] += '_' }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                String code = "";
+                code += "String.prototype.c = 0;";
+                code += "String.prototype.d = 0;";
+                code += "Object.defineProperty(String.prototype, 'foo', {"
+                        + "  set: function(v){ this.__proto__.c++ },"
+                        + "  get: function(v){ this.__proto__.d++ }})";
+                eval(cx, scope1, code);
+                eval(cx, scope2, code);
+
+                eval(cx, scope2, "test()");
+                eval(cx, scope1, "scope2.test()");
+                eval(cx, scope1, "scope2.test.call(null)");
+                eval(cx, scope1, "var t=scope2.test; t()");
+                eval(cx, scope1, "var t=scope2.test; t.call(null)");
+
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.c"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.c"));
+                assertTRUE(eval(cx, scope1, "0 == String.prototype.d"));
+                assertTRUE(eval(cx, scope2, "5 == String.prototype.d"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_setPropOp2() {
+        String fn = "function test(){ return ''.foo += '_' }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = 'scope1'");
+                eval(cx, scope2, "String.prototype.foo = 'scope2'");
+
+                assertEquals("scope2_", eval(cx, scope2, "test()"));
+                assertEquals("scope2_", eval(cx, scope1, "scope2.test()"));
+                assertEquals("scope2_", eval(cx, scope1, "scope2.test.call(null)"));
+                assertEquals("scope2_", eval(cx, scope1, "var t=scope2.test; t()"));
+                assertEquals("scope2_", eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_getElemCall() {
+        String fn = "function test(){ return ''['foo']() }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = function(){ return 'scope1' }");
+                eval(cx, scope2, "String.prototype.foo = function(){ return 'scope2' }");
+
+                assertEquals("scope2", eval(cx, scope2, "test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test.call(null)"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t()"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_getPropCall() {
+        String fn = "function test(){ return ''.foo() }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = function(){ return 'scope1' }");
+                eval(cx, scope2, "String.prototype.foo = function(){ return 'scope2' }");
+
+                assertEquals("scope2", eval(cx, scope2, "test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test()"));
+                assertEquals("scope2", eval(cx, scope1, "scope2.test.call(null)"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t()"));
+                assertEquals("scope2", eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_Enum1() {
+        String fn = "function test(){ for (var k in '') if (k == 'foo') return true; return false; }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope1, "String.prototype.foo = 'scope1'");
+
+                assertFALSE(eval(cx, scope2, "test()"));
+                assertFALSE(eval(cx, scope1, "scope2.test()"));
+                assertFALSE(eval(cx, scope1, "scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_Enum2() {
+        String fn = "function test(){ for (var k in '') if (k == 'foo') return true; return false; }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                eval(cx, scope2, "String.prototype.foo = 'scope1'");
+
+                assertTRUE(eval(cx, scope2, "test()"));
+                assertTRUE(eval(cx, scope1, "scope2.test()"));
+                assertTRUE(eval(cx, scope1, "scope2.test.call(null)"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; t()"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_Parent() {
+        String fn = "function test(){}";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertSame(scope2, eval(cx, scope2, "test.__parent__"));
+                assertSame(scope2, eval(cx, scope1, "scope2.test.__parent__"));
+                assertSame(scope2, eval(cx, scope1, "var t=scope2.test; t.__parent__"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_ReturnThis() {
+        String fn = "function test(){ return this }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertSame(scope2, eval(cx, scope2, "test()"));
+                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
+                assertSame(scope2, eval(cx, scope1, "scope2.test()"));
+                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
+                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
+                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_ReturnThisNested() {
+        String fn = "function test(){ return (function(){ return this })() }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertSame(scope2, eval(cx, scope2, "test()"));
+                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
+                assertSame(scope2, eval(cx, scope1, "scope2.test()"));
+                assertSame(scope2, eval(cx, scope1, "scope2.test.call(null)"));
+                assertSame(scope2, eval(cx, scope1, "var t=scope2.test; t()"));
+                assertSame(scope2, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_ReturnThisNestedCall() {
+        String fn = "function test(o){ return (function(){ return this }).call(o) }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertSame(scope2, eval(cx, scope2, "test()"));
+                assertSame(scope2, eval(cx, scope2, "test(null)"));
+                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
+                assertSame(scope2, eval(cx, scope2, "test.call(null, null)"));
+
+                assertSame(scope1, eval(cx, scope1, "scope2.test()"));
+                assertSame(scope1, eval(cx, scope1, "scope2.test(null)"));
+                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
+                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null, null)"));
+
+                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
+                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t(null)"));
+                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null, null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_NameStringPrototype() {
+        String fn = "function test(){ return String.prototype }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_NameStringPrototypeNested() {
+        String fn = "function test(){ return (function(){ return String.prototype })() }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_ThisStringPrototype() {
+        String fn = "function test(){ return this.String.prototype }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                assertTRUE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_ThisProto() {
+        String fn = "function test(){ return this.__proto__ }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call('')"));
+                assertTRUE(eval(cx, scope1, "String.prototype === scope2.test.call('')"));
+                assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call('')"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_StringLiteralProto() {
+        String fn = "function test(){ return ''.__proto__ }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_ThisProtoNested() {
+        String fn = "function test(){ return (function(){ return this.__proto__ }).call('') }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+            }
+        }));
+    }
+
+    @Test
+    public void test_StringLiteralProtoNested() {
+        String fn = "function test(){ return (function(){ return ''.__proto__ })() }";
+        runWithAllOptimizationLevels(action(fn, new Action() {
+            public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                assertFALSE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+            }
+        }));
+    }
+
+}


### PR DESCRIPTION
Accessing the global scope when creating wrapper types for primitive values wasn't done in a uniform manner, which could lead to inconsistent results when multiple scopes were involved. With this change the current scope is always explicitly passed to every method which may require to wrap primitive values.
