### PR TITLE
Patch for Bug 784358 ("Defining const variable within eval() throws redeclaration error")

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3161,14 +3161,13 @@ public class ScriptRuntime {
                 // Don't overwrite existing def if already defined in object
                 // or prototypes of object.
                 if (!ScriptableObject.hasProperty(scope, name)) {
-                    if (!evalScript) {
+                    if (isConst) {
+                        ScriptableObject.defineConstProperty(varScope, name);
+                    } else if (!evalScript) {
                         // Global var definitions are supposed to be DONTDELETE
-                        if (isConst)
-                            ScriptableObject.defineConstProperty(varScope, name);
-                        else
-                            ScriptableObject.defineProperty(
-                                varScope, name, Undefined.instance,
-                                ScriptableObject.PERMANENT);
+                        ScriptableObject.defineProperty(
+                            varScope, name, Undefined.instance,
+                            ScriptableObject.PERMANENT);
                     } else {
                         varScope.put(name, varScope, Undefined.instance);
                     }

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -2303,10 +2303,10 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
             ConstProperties cp = (ConstProperties)base;
 
             if (cp.isConst(name))
-                throw Context.reportRuntimeError1("msg.const.redecl", name);
+                throw ScriptRuntime.typeError1("msg.const.redecl", name);
         }
         if (isConst)
-            throw Context.reportRuntimeError1("msg.var.redecl", name);
+            throw ScriptRuntime.typeError1("msg.var.redecl", name);
     }
     /**
      * Returns whether an indexed property is defined in an object or any object

--- a/testsrc/doctests/784358.doctest
+++ b/testsrc/doctests/784358.doctest
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// https://bugzilla.mozilla.org/show_bug.cgi?id=784358
+
+js> var v1=1
+js> v1
+1
+js> eval("var v2=1")
+js> v2
+1
+js> const c1=1
+js> c1
+1
+js> eval("const c2=1")
+js> c2
+1
+js> try {eval("const v1=2")}catch(e){e instanceof TypeError}
+true
+js> try {eval("const v1=2")}catch(e){e instanceof TypeError}
+true
+js> try{eval("const c1=1")}catch(e){e instanceof TypeError}
+true
+js> try{eval("const c2=1")}catch(e){e instanceof TypeError}
+true
+js> try{eval("var c1=1")}catch(e){e instanceof TypeError}
+true
+js> try{eval("var c2=1")}catch(e){e instanceof TypeError}
+true
+js> try {(1,eval)("const v1=2")}catch(e){e instanceof TypeError}
+true
+js> try {(1,eval)("const v1=2")}catch(e){e instanceof TypeError}
+true
+js> try{(1,eval)("const c1=1")}catch(e){e instanceof TypeError}
+true
+js> try{(1,eval)("const c2=1")}catch(e){e instanceof TypeError}
+true
+js> try{(1,eval)("var c1=1")}catch(e){e instanceof TypeError}
+true
+js> try{(1,eval)("var c2=1")}catch(e){e instanceof TypeError}
+true
+js> (function(){eval("const v1=2"); return v1})()
+2
+js> (function(){eval("const v2=2"); return v2})()
+2
+js> (function(){eval("const c1=2"); return c1})()
+2
+js> (function(){eval("const c2=2"); return c2})()
+2
+js> (function(){eval("var c1=2"); return c1})()
+2
+js> (function(){eval("var c2=2"); return c2})()
+2
+js> try{ (function(){(1,eval)("const v1=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){(1,eval)("const v2=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){(1,eval)("const c1=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){(1,eval)("const c2=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){(1,eval)("var c1=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){(1,eval)("var c2=1")})() }catch(e){e instanceof TypeError}
+true
+js> (v1 = 3, v1)
+3
+js> (v2 = 3, v2)
+3
+js> (c1 = 3, c1)
+1
+js> (c2 = 3, c2)
+1
+js> delete v1
+false
+js> delete v2
+true
+js> delete c1
+false
+js> delete c2
+false
+js> try{ (function(){const c1=1; eval("const c1=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){eval("const c1=1"); const c1=1})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){eval("const c1=1"); eval("const c1=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){const c1=1; eval("var c1=1")})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){eval("var c1=1"); const c1=1})() }catch(e){e instanceof TypeError}
+true
+js> try{ (function(){var c1=1; eval("const c1=1")})() }catch(e){e instanceof TypeError}
+true


### PR DESCRIPTION
initScript() only needs to special case the 'var' case for eval'ed code. Also throw a catchable TypeError when redeclaring a constant instead of calling Context.reportRuntimeError1().
