### PR TITLE
load() doesn't update global scope with -require option set

### DIFF
--- a/src/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/src/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -24,7 +24,7 @@ public class ModuleScope extends TopLevel {
     public ModuleScope(Scriptable prototype, URI uri, URI base) {
         this.uri = uri;
         this.base = base;
-        setPrototype(prototype);
+        setParentScope(prototype);
         cacheBuiltins();
     }
 


### PR DESCRIPTION
**test.js**

``` javascript
load(["underscore.js"]);

_.each([1,2,3], function(n){ print(n); });
```

**Without -require**

```
$ java -jar ~/dev/rhino/build/rhino1_7R5pre/js.jar test.js
1
2
3
```

**With -require**

```
$ java -jar ~/dev/rhino/build/rhino1_7R5pre/js.jar -require test.js
js: uncaught JavaScript runtime exception: ReferenceError: "_" is not defined.
```

_The same with 1.7R4_
