### PR TITLE
Resolve VJET's fork of Rhino adding extensions to Rhino

### DIFF
--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -30,6 +30,7 @@ import org.mozilla.javascript.debug.DebuggableScript;
 import org.mozilla.javascript.debug.Debugger;
 import org.mozilla.javascript.xml.XMLLib;
 
+
 /**
  * This class represents the runtime context of an executing script.
  *
@@ -2621,4 +2622,20 @@ public class Context
 
     // Generate an observer count on compiled code
     public boolean generateObserverCount = false;
+    
+	public void registerConverter(Class<? extends IJsJavaConvertible> type, IJsJavaConverter converter) {
+		m_ConverterMap.put(type, converter);
+	}
+	
+	public IJsJavaConvertible convert(Scriptable s, Class<? extends IJsJavaConvertible> type) {
+		IJsJavaConverter converter = m_ConverterMap.get(type);
+		if (converter != null) {
+			return converter.convert(s);
+		}
+		return null;
+	}
+	
+	private Map<Class<? extends IJsJavaConvertible>, IJsJavaConverter> m_ConverterMap
+		= new HashMap<Class<? extends IJsJavaConvertible>, IJsJavaConverter>();
+    
 }

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -11,6 +11,7 @@ package org.mozilla.javascript;
 import java.lang.reflect.*;
 import java.io.*;
 
+
 public class FunctionObject extends BaseFunction
 {
     static final long serialVersionUID = -5332312783643935019L;
@@ -171,7 +172,8 @@ public class FunctionObject extends BaseFunction
             return JAVA_SCRIPTABLE_TYPE;
         if (type == ScriptRuntime.ObjectClass)
             return JAVA_OBJECT_TYPE;
-
+        if (ScriptRuntime.WillBeScriptableClass.isAssignableFrom(type))
+            return JAVA_WILL_BE_SCRIPTABLE_TYPE;
         // Note that the long type is not supported; see the javadoc for
         // the constructor for this class
 
@@ -199,6 +201,7 @@ public class FunctionObject extends BaseFunction
             if (arg instanceof Double)
                 return arg;
             return new Double(ScriptRuntime.toNumber(arg));
+          case JAVA_WILL_BE_SCRIPTABLE_TYPE: // here is moment of truth
           case JAVA_SCRIPTABLE_TYPE:
               return ScriptRuntime.toObjectOrNull(cx, arg, scope);
           case JAVA_OBJECT_TYPE:
@@ -534,6 +537,7 @@ public class FunctionObject extends BaseFunction
     public static final int JAVA_DOUBLE_TYPE      = 4;
     public static final int JAVA_SCRIPTABLE_TYPE  = 5;
     public static final int JAVA_OBJECT_TYPE      = 6;
+    public static final int JAVA_WILL_BE_SCRIPTABLE_TYPE = 7;
 
     MemberBox member;
     private String functionName;

--- a/src/org/mozilla/javascript/IJsJavaConverter.java
+++ b/src/org/mozilla/javascript/IJsJavaConverter.java
@@ -1,0 +1,43 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ * ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ * 
+ * Portions created by eBay are Copyright (c) 2005, 2012 eBay Inc. All rights reserved.
+ * 
+ * Contributor(s):
+ *   Yitao Yao
+ *   Justin Early
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * the GNU General Public License Version 2 or later (the "GPL"), in which
+ * case the provisions of the GPL are applicable instead of those above. If
+ * you wish to allow use of your version of this file only under the terms of
+ * the GPL and not to allow others to use your version of this file under the
+ * MPL, indicate your decision by deleting the provisions above and replacing
+ * them with the notice and other provisions required by the GPL. If you do
+ * not delete the provisions above, a recipient may use your version of this
+ * file under either the MPL or the GPL.
+ * ***** END LICENSE BLOCK ***** */
+package org.mozilla.javascript;
+
+/**
+ * A interface for custom data type converter to convert
+ * native js object to typed java object
+ * 
+ * an eBay extension to Rhino - EBAY MOD
+ */
+public interface IJsJavaConverter {
+	
+	IJsJavaConvertible convert(Scriptable s);
+
+}

--- a/src/org/mozilla/javascript/IJsJavaConvertible.java
+++ b/src/org/mozilla/javascript/IJsJavaConvertible.java
@@ -1,0 +1,41 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ * ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * Portions created by eBay are Copyright (c) 2005, 2012 eBay Inc. All rights reserved.
+ * 
+ * Contributor(s):
+ *   Yitao Yao
+ *   Justin Early
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * the GNU General Public License Version 2 or later (the "GPL"), in which
+ * case the provisions of the GPL are applicable instead of those above. If
+ * you wish to allow use of your version of this file only under the terms of
+ * the GPL and not to allow others to use your version of this file under the
+ * MPL, indicate your decision by deleting the provisions above and replacing
+ * them with the notice and other provisions required by the GPL. If you do
+ * not delete the provisions above, a recipient may use your version of this
+ * file under either the MPL or the GPL.  
+ * ***** END LICENSE BLOCK ***** */
+package org.mozilla.javascript;
+
+/**
+ * A tag interface to indicate a java type which could
+ * be converted from native js via customized converter
+ * 
+ * an eBay extension to Rhino - EBAY MOD
+ */
+public interface IJsJavaConvertible {
+
+}

--- a/src/org/mozilla/javascript/IJsJavaProxy.java
+++ b/src/org/mozilla/javascript/IJsJavaProxy.java
@@ -1,0 +1,44 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ * ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * Portions created by eBay are Copyright (c) 2005, 2012 eBay Inc. All rights reserved.
+ * 
+ * Contributor(s):
+ *   Yitao Yao
+ *   Justin Early
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * the GNU General Public License Version 2 or later (the "GPL"), in which
+ * case the provisions of the GPL are applicable instead of those above. If
+ * you wish to allow use of your version of this file only under the terms of
+ * the GPL and not to allow others to use your version of this file under the
+ * MPL, indicate your decision by deleting the provisions above and replacing
+ * them with the notice and other provisions required by the GPL. If you do
+ * not delete the provisions above, a recipient may use your version of this
+ * file under either the MPL or the GPL.
+ * ***** END LICENSE BLOCK ***** */
+package org.mozilla.javascript;
+
+/**
+ * Java Proxy for Native JavaScript Object
+ * 
+ * an eBay extension to Rhino - EBAY MOD
+ */
+public interface IJsJavaProxy {
+	
+	String JS_JAVA_PROXY = "_js_java_proxy";
+	
+	Scriptable getJsNative();
+
+}

--- a/src/org/mozilla/javascript/IWillBeScriptable.java
+++ b/src/org/mozilla/javascript/IWillBeScriptable.java
@@ -1,0 +1,42 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ * ***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * Portions created by eBay are Copyright (c) 2005, 2012 eBay Inc. All rights reserved.
+ * 
+ * Contributor(s):
+ *   Yitao Yao
+ *   Justin Early
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * the GNU General Public License Version 2 or later (the "GPL"), in which
+ * case the provisions of the GPL are applicable instead of those above. If
+ * you wish to allow use of your version of this file only under the terms of
+ * the GPL and not to allow others to use your version of this file under the
+ * MPL, indicate your decision by deleting the provisions above and replacing
+ * them with the notice and other provisions required by the GPL. If you do
+ * not delete the provisions above, a recipient may use your version of this
+ * file under either the MPL or the GPL.
+ * ***** END LICENSE BLOCK ***** */
+package org.mozilla.javascript;
+
+/**
+ * A marker interface to identify a Java interface that has a concrete implementation
+ * which implements Rhino's Scriptable interface.
+ * 
+ * an eBay extension to Rhino - EBAY MOD
+ */
+public interface IWillBeScriptable {
+	
+
+}

--- a/src/org/mozilla/javascript/NativeJavaMethod.java
+++ b/src/org/mozilla/javascript/NativeJavaMethod.java
@@ -223,6 +223,14 @@ public class NativeJavaMethod extends BaseFunction
         }
 
         Object retval = meth.invoke(javaObject, args);
+        
+        // active java extension
+        if (retval instanceof IJsJavaProxy) {
+        	// get native scriptable object if extension is used
+        	return ((IJsJavaProxy)retval).getJsNative();
+        }
+        
+        
         Class<?> staticType = meth.method().getReturnType();
 
         if (debug) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -119,7 +119,10 @@ public class ScriptRuntime {
         FunctionClass
             = Kit.classOrNull("org.mozilla.javascript.Function"),
         ScriptableObjectClass
-            = Kit.classOrNull("org.mozilla.javascript.ScriptableObject");
+            = Kit.classOrNull("org.mozilla.javascript.ScriptableObject"),
+	    WillBeScriptableClass
+	    	= Kit.classOrNull("org.mozilla.mod.javascript.IWillBeScriptable");
+    
     public static final Class<Scriptable> ScriptableClass =
         Scriptable.class;
 

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -23,12 +23,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import org.mozilla.javascript.debug.DebuggableObject;
 import org.mozilla.javascript.annotations.JSConstructor;
 import org.mozilla.javascript.annotations.JSFunction;
 import org.mozilla.javascript.annotations.JSGetter;
 import org.mozilla.javascript.annotations.JSSetter;
 import org.mozilla.javascript.annotations.JSStaticFunction;
+import org.mozilla.javascript.debug.DebuggableObject;
 
 /**
  * This is the default implementation of the Scriptable interface. This
@@ -449,6 +449,9 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
      */
     public Object get(String name, Scriptable start)
     {
+    	if (IJsJavaProxy.JS_JAVA_PROXY.equals(name)) {
+    		return m_javaProxy;
+    	}
         Slot slot = getSlot(name, 0, SLOT_QUERY);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
@@ -489,6 +492,11 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
      */
     public void put(String name, Scriptable start, Object value)
     {
+    	if (IJsJavaProxy.JS_JAVA_PROXY.equals(name)
+        		&& value instanceof IJsJavaProxy) {
+        		m_javaProxy = (IJsJavaProxy)value;
+        		return;
+        	}
         if (putImpl(name, 0, start, value))
             return;
 
@@ -3103,5 +3111,7 @@ public abstract class ScriptableObject implements Scriptable, Serializable,
             return value;
         }
     }
+    
+    private IJsJavaProxy m_javaProxy = null;
 
 }


### PR DESCRIPTION
In an attempt to resolve the fork between the open source Rhino and
VJET project's modified Rhino. VJET's active runtime leverages these extensions
 to Rhino allows users to author Java code or JavaScript and run
both under Rhino without making their Java objects implement
Scriptable. I am proposing these changes to the Rhino engine to support
the following:
1. Support defered Scriptable support allows java objects to become
   scriptable at runtime rather than author time. (IWillBeScriptable)
   Interface example:
   https://github.com/ebayopensource/vjet/blob/18c5a638089af44c1f7b8ca749b33b6045f6b537/core/org.ebayopensource.vjet.core.jsnative/src/org/ebayopensource/dsf/jsnative/events/Event.java

   Example where scriptable is populated at runtime:
   https://github.com/ebayopensource/vjet/blob/18c5a638089af44c1f7b8ca749b33b6045f6b537/core/runtime/org.ebayopensource.vjet.rt.active/src/org/ebayopensource/dsf/active/client/ActiveObject.java#L71
2. Support Java proxies to javascript. Allows Java objects to be
   registered but proxies javascript user defined or native objects. Examples from ebayopensource vjet repo: 
   Object literal proxy: https://github.com/ebayopensource/vjet/blob/18c5a638089af44c1f7b8ca749b33b6045f6b537/core/runtime/org.ebayopensource.vjet.rt.active/src/org/ebayopensource/dsf/dap/proxy/Ol.java
   Function proxy: https://github.com/ebayopensource/vjet/blob/18c5a638089af44c1f7b8ca749b33b6045f6b537/core/runtime/org.ebayopensource.vjet.rt.active/src/org/ebayopensource/dsf/dap/proxy/JFunction.java
3. Support for extending Rhino by writing a custom converter to convert
   the native js object to a typed java object (IJsJavaConvertible)
