### PR TITLE
(Potential) fix for parsing of keywords (e.g. "null") at EOF to return correct length.

### DIFF
--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -369,7 +369,8 @@ class TokenStream
                         }
                     }
                 }
-                ungetChar(c);
+                if (c != EOF_CHAR)
+                    ungetChar(c);
 
                 String str = getStringFromBuffer();
                 if (!containsEscape) {

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1183,6 +1183,17 @@ public class ParserTest extends TestCase {
       parse("({import:1}).import;");
     }
 
+    public void testKeywordLengthAtEOF() {
+        AstRoot root = parse("null");
+        assertEquals(4, root.getLength());
+
+        root = parse("true");
+        assertEquals(4, root.getLength());
+
+        root = parse("false");
+        assertEquals(5, root.getLength());
+    }
+
     private void expectParseErrors(String string, String [] errors) {
       parse(string, errors, null, false);
     }


### PR DESCRIPTION
[This should be code-reviewed by somebody familiar with the rhino token parsing as I don't know if this is the correct way to fix this.]

Prior to this change, TokenStream would return an incorrect length for keywords ("null", "true", etc.) encountered immediately prior to the end-of-file.  I added a test to ParserTest to reproduce the issue and made a potential fix.

My fix is to not call ungetChar() if getChar() returned EOF_CHAR, since getChar() does not increment "cursor" when encountering EOF, but ungetChar() always decrements "cursor" thus leading to the incorrect length.
