### PR TITLE
Attach jsdoc nodes to function params

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -698,7 +698,12 @@ public class Parser
                 destructuring.put(pname, expr);
             } else {
                 if (mustMatchToken(Token.NAME, "msg.no.parm")) {
-                    fnNode.addParam(createNameNode());
+                    Name paramNameNode = createNameNode();
+                    Comment jsdocNodeForName = getAndResetJsDoc();
+                    if (jsdocNodeForName != null) {
+                      paramNameNode.setJsDocNode(jsdocNodeForName);
+                    }
+                    fnNode.addParam(paramNameNode);
                     String paramName = ts.getString();
                     defineSymbol(Token.LP, paramName);
                     if (this.inUseStrictDirective) {
@@ -1379,7 +1384,12 @@ public class Parser
                     lp = ts.tokenBeg;
 
                 mustMatchToken(Token.NAME, "msg.bad.catchcond");
+
                 Name varName = createNameNode();
+                Comment jsdocNodeForName = getAndResetJsDoc();
+                if (jsdocNodeForName != null) {
+                  varName.setJsDocNode(jsdocNodeForName);
+                }
                 String varNameString = varName.getIdentifier();
                 if (inUseStrictDirective) {
                     if ("eval".equals(varNameString) ||

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1037,6 +1037,29 @@ public class ParserTest extends TestCase {
         assertNotNull(st.getJsDoc());
     }
 
+    public void testJSDocAttachment17() {
+      AstRoot root = parse(
+      "try { throw 'a'; } catch (/** @type {string} */ e) {\n" +
+      "}\n");
+      assertNotNull(root.getComments());
+      assertEquals(1, root.getComments().size());
+
+      TryStatement tryNode = (TryStatement) root.getFirstChild();
+      CatchClause catchNode = tryNode.getCatchClauses().get(0);
+      assertNotNull(catchNode.getVarName().getJsDoc());
+    }
+
+    public void testJSDocAttachment18() {
+      AstRoot root = parse(
+      "function f(/** @type {string} */ e) {}\n");
+      assertNotNull(root.getComments());
+      assertEquals(1, root.getComments().size());
+
+      FunctionNode function = (FunctionNode) root.getFirstChild();
+      AstNode param = function.getParams().get(0);
+      assertNotNull(param.getJsDoc());
+    }
+
     public void testParsingWithoutJSDoc() {
         AstRoot root = parse("var a = /** @type number */(x);", false);
         assertNotNull(root.getComments());


### PR DESCRIPTION
Hopefully, this should be a straightforward and non-controversial parser change. Thanks!
