### PR TITLE
Make stack property available on new Error() too

### DIFF
--- a/src/org/mozilla/javascript/NativeError.java
+++ b/src/org/mozilla/javascript/NativeError.java
@@ -40,10 +40,11 @@ final class NativeError extends IdScriptableObject
         obj.setPrototype(proto);
         obj.setParentScope(scope);
 
+        String message = null;
         int arglen = args.length;
         if (arglen >= 1) {
-            ScriptableObject.putProperty(obj, "message",
-                    ScriptRuntime.toString(args[0]));
+        	message = ScriptRuntime.toString(args[0]);
+            ScriptableObject.putProperty(obj, "message", message);
             if (arglen >= 2) {
                 ScriptableObject.putProperty(obj, "fileName", args[1]);
                 if (arglen >= 3) {
@@ -53,6 +54,9 @@ final class NativeError extends IdScriptableObject
                 }
             }
         }
+        final RhinoException rhinoException = ScriptRuntime.constructError("NativeError", message, 0);
+        obj.setStackProvider(rhinoException);
+
         return obj;
     }
 
@@ -111,7 +115,6 @@ final class NativeError extends IdScriptableObject
         // overwritable like an ordinary property. Hence this setup with
         // the getter and setter below.
         if (stackProvider == null) {
-            stackProvider = re;
             try {
                 defineProperty("stack", null,
                         NativeError.class.getMethod("getStack"),
@@ -121,6 +124,7 @@ final class NativeError extends IdScriptableObject
                 throw new RuntimeException(nsm);
             }
         }
+        stackProvider = re;
     }
 
     public Object getStack() {

--- a/testsrc/org/mozilla/javascript/tests/ErrorPropertiesTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ErrorPropertiesTest.java
@@ -65,13 +65,22 @@ public class ErrorPropertiesTest {
 
     @Test
     public void mozillaStack() {
+    	testMozillaStack("null.method()");
+    }
+
+    private void testMozillaStack(final String throwingCode) {
         RhinoException.useMozillaStackStyle(true);
-        testScriptStackTrace("null.method()", "@myScript.js:1" + LS);
-        final String script = "function f() \n{\n  null.method();\n}\nf();\n";
+        testScriptStackTrace(throwingCode, "@myScript.js:1" + LS);
+        final String script = "function f() \n{\n  " + throwingCode + ";\n}\nf();\n";
         testScriptStackTrace(script, "f()@myScript.js:3" + LS + "@myScript.js:5" + LS);
-        testIt("try { null.method() } catch (e) { e.stack }", "@myScript.js:1" + LS);
+        testIt("try { " + throwingCode + " } catch (e) { e.stack }", "@myScript.js:1" + LS);
         final String expectedStack = "f()@myScript.js:2" + LS + "@myScript.js:4" + LS;
-        testIt("function f() {\n null.method(); \n}\n try { f() } catch (e) { e.stack }", expectedStack);
+        testIt("function f() {\n " + throwingCode + " \n}\n try { f() } catch (e) { e.stack }", expectedStack);
+	}
+
+	@Test
+    public void mozillaStack_newError() {
+    	testMozillaStack("throw new Error()");
     }
 
     private void testIt(final String script, final Object expected) {


### PR DESCRIPTION
The exception thrown by something like:

``` javascript
null.foo()
```

has the stacktrace available as `stack` property but the exception thrown by

``` javascript
throw new Error()
```

doesn't.

This pull request fixes this problem (including unit test)
