### PR TITLE
fix wrong error when trying to instantiate abstract class

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -165,9 +165,6 @@ public class NativeJavaClass extends NativeJavaObject implements Function
             // Found the constructor, so try invoking it.
             return constructSpecific(cx, scope, args, ctors.methods[index]);
         } else {
-            if (args.length == 0) {
-                throw Context.reportRuntimeError0("msg.adapter.zero.args");
-            }
             Scriptable topLevel = ScriptableObject.getTopLevelScope(this);
             String msg = "";
             try {


### PR DESCRIPTION
i don't understand all the implications but it seems the JavaAdapter will complain itself when it gets the wrong args.

without this change:

```
js> new javax.swing.text.AbstractDocument()
js: JavaAdapter requires at least one argument.
```

after:

```
js> new javax.swing.text.AbstractDocument()
js: error instantiating (0): class javax.swing.text.AbstractDocument is interface or abstract
```
