### PR TITLE
adding gitignore for build directories and artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# os specific
+.DS_Store
+
+# build directories
+build/
+lib/
+
+# artifacts
+*.zip
+


### PR DESCRIPTION
Running `ant all` no longer generates files that git thinks are new. Issue #94 talks about this a bit.