### PR TITLE
Interface adapter: accept BoundFunction instances (in addition to NativeObject and NativeFunction)

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -361,7 +361,7 @@ WrapFactory#wrap(Context, Scriptable, Object, Class)}
                 }
             }
             else if (to.isInterface()) {
-                if (fromObj instanceof NativeObject || fromObj instanceof NativeFunction) {
+                if (fromObj instanceof NativeObject || fromObj instanceof NativeFunction || fromObj instanceof BoundFunction) {
                     // See comments in createInterfaceAdapter
                     return 1;
                 }
@@ -638,7 +638,7 @@ WrapFactory#wrap(Context, Scriptable, Object, Class)}
                 reportConversionError(value, type);
             }
             else if (type.isInterface() && (value instanceof NativeObject
-                    || value instanceof NativeFunction)) {
+                    || value instanceof NativeFunction || value instanceof BoundFunction)) {
                 // Try to use function/object as implementation of Java interface.
                 return createInterfaceAdapter(type, (ScriptableObject) value);
             } else {


### PR DESCRIPTION
This fixes code that tries to pass a bound function to a java method that takes a Callable, as in, for example, executorService.submit(callback.bind(this, item));
