### PR TITLE
Implement ES6 Arrow Function

### DIFF
--- a/src/org/mozilla/javascript/ArrowFunction.java
+++ b/src/org/mozilla/javascript/ArrowFunction.java
@@ -1,0 +1,75 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+/**
+ * The class for  Arrow Function Definitions
+ * EcmaScript 6 Rev 14, March 8, 2013 Draft spec , 13.2
+ */
+public class ArrowFunction extends BaseFunction {
+    
+    static final long serialVersionUID = -7377989503697220633L;
+    
+    private final Callable targetFunction;
+    private final Scriptable boundThis;
+
+    public ArrowFunction(Context cx, Scriptable scope, Callable targetFunction, Scriptable boundThis)
+    {
+        this.targetFunction = targetFunction;
+        this.boundThis = boundThis;
+
+        ScriptRuntime.setFunctionProtoAndParent(this, scope);
+
+        Function thrower = ScriptRuntime.typeErrorThrower();
+        NativeObject throwing = new NativeObject();
+        throwing.put("get", throwing, thrower);
+        throwing.put("set", throwing, thrower);
+        throwing.put("enumerable", throwing, false);
+        throwing.put("configurable", throwing, false);
+        throwing.preventExtensions();
+
+        this.defineOwnProperty(cx, "caller", throwing, false);
+        this.defineOwnProperty(cx, "arguments", throwing, false);
+    }
+
+    @Override
+    public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
+    {
+        Scriptable callThis = boundThis != null ? boundThis : ScriptRuntime.getTopCallScope(cx);
+        return targetFunction.call(cx, scope, callThis, args);
+    }
+
+    @Override
+    public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
+        throw ScriptRuntime.typeError1("msg.not.ctor", decompile(0, 0));
+    }
+
+    @Override
+    public boolean hasInstance(Scriptable instance) {
+        if (targetFunction instanceof Function) {
+            return ((Function) targetFunction).hasInstance(instance);
+        }
+        throw ScriptRuntime.typeError0("msg.not.ctor");
+    }
+
+    @Override
+    public int getLength() {
+        if (targetFunction instanceof BaseFunction) {
+            return ((BaseFunction) targetFunction).getLength();
+        }
+        return 0;
+    }
+
+    @Override
+    String decompile(int indent, int flags)
+    {
+        if (targetFunction instanceof BaseFunction) {
+            return ((BaseFunction)targetFunction).decompile(indent, flags);
+        }
+        return super.decompile(indent, flags);
+    }
+}

--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -504,7 +504,8 @@ class CodeGenerator extends Icode {
                 int fnIndex = node.getExistingIntProp(Node.FUNCTION_PROP);
                 FunctionNode fn = scriptOrFn.getFunctionNode(fnIndex);
                 // See comments in visitStatement for Token.FUNCTION case
-                if (fn.getFunctionType() != FunctionNode.FUNCTION_EXPRESSION) {
+                if (fn.getFunctionType() != FunctionNode.FUNCTION_EXPRESSION &&
+                    fn.getFunctionType() != FunctionNode.ARROW_FUNCTION) {
                     throw Kit.codeBug();
                 }
                 addIndexOp(Icode_CLOSURE_EXPR, fnIndex);

--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -86,8 +86,10 @@ public class Decompiler
     int markFunctionStart(int functionType)
     {
         int savedOffset = getCurrentOffset();
-        addToken(Token.FUNCTION);
-        append((char)functionType);
+        if (functionType != FunctionNode.ARROW_FUNCTION) {
+            addToken(Token.FUNCTION);
+            append((char)functionType);
+        }
         return savedOffset;
     }
 
@@ -790,6 +792,10 @@ public class Decompiler
 
             case Token.DEBUGGER:
                 result.append("debugger;\n");
+                break;
+
+            case Token.ARROW:
+                result.append(" => ");
                 break;
 
             default:

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -943,8 +943,11 @@ public final class IRFactory extends Parser
 
     private Node transformReturn(ReturnStatement node) {
         boolean expClosure = Boolean.TRUE.equals(node.getProp(Node.EXPRESSION_CLOSURE_PROP));
+        boolean isArrow = Boolean.TRUE.equals(node.getProp(Node.ARROW_FUNCTION_PROP));
         if (expClosure) {
-            decompiler.addName(" ");
+            if (!isArrow) {
+                decompiler.addName(" ");
+            }
         } else {
             decompiler.addToken(Token.RETURN);
         }
@@ -2272,7 +2275,11 @@ public final class IRFactory extends Parser
         } else if (fn.getMemberExprNode() != null) {
             mexpr = transform(fn.getMemberExprNode());
         }
-        decompiler.addToken(Token.LP);
+        boolean isArrow = fn.getFunctionType() == FunctionNode.ARROW_FUNCTION;
+        boolean noParen = isArrow && fn.getLp() == -1;
+        if (!noParen) {
+            decompiler.addToken(Token.LP);
+        }
         List<AstNode> params = fn.getParams();
         for (int i = 0; i < params.size(); i++) {
             decompile(params.get(i));
@@ -2280,7 +2287,12 @@ public final class IRFactory extends Parser
                 decompiler.addToken(Token.COMMA);
             }
         }
-        decompiler.addToken(Token.RP);
+        if (!noParen) {
+            decompiler.addToken(Token.RP);
+        }
+        if (isArrow) {
+            decompiler.addToken(Token.ARROW);
+        }
         if (!fn.isExpressionClosure()) {
             decompiler.addEOL(Token.LC);
         }

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -1711,9 +1711,14 @@ switch (op) {
         stack[indexReg] = frame.scope;
         continue Loop;
     case Icode_CLOSURE_EXPR :
-        stack[++stackTop] = InterpretedFunction.createFunction(cx, frame.scope,
-                                                               frame.fnOrScript,
-                                                               indexReg);
+        InterpretedFunction fn = InterpretedFunction.createFunction(cx, frame.scope,
+                                                                    frame.fnOrScript,
+                                                                    indexReg);
+        if (fn.idata.itsFunctionType == FunctionNode.ARROW_FUNCTION) {
+            stack[++stackTop] = new ArrowFunction(cx, frame.scope, fn, frame.thisObj);
+        } else {
+            stack[++stackTop] = fn;
+        }
         continue Loop;
     case Icode_CLOSURE_STMT :
         initFunction(cx, frame.scope, frame.fnOrScript, indexReg);
@@ -2750,8 +2755,11 @@ switch (op) {
             scope = fnOrScript.getParentScope();
 
             if (useActivation) {
-                scope = ScriptRuntime.createFunctionActivation(
-                            fnOrScript, scope, args);
+                if (idata.itsFunctionType == FunctionNode.ARROW_FUNCTION) {
+                    scope = ScriptRuntime.createArrowFunctionActivation(fnOrScript, scope, args);
+                } else {
+                    scope = ScriptRuntime.createFunctionActivation(fnOrScript, scope, args);
+                }
             }
         } else {
             scope = callerScope;

--- a/src/org/mozilla/javascript/NativeCall.java
+++ b/src/org/mozilla/javascript/NativeCall.java
@@ -30,6 +30,11 @@ public final class NativeCall extends IdScriptableObject
 
     NativeCall(NativeFunction function, Scriptable scope, Object[] args)
     {
+        this(function, scope, args, false);
+    }
+
+    NativeCall(NativeFunction function, Scriptable scope, Object[] args, boolean isArrow)
+    {
         this.function = function;
 
         setParentScope(scope);
@@ -51,7 +56,7 @@ public final class NativeCall extends IdScriptableObject
 
         // initialize "arguments" property but only if it was not overridden by
         // the parameter with the same name
-        if (!super.has("arguments", this)) {
+        if (!super.has("arguments", this) && !isArrow) {
             defineProperty("arguments", new Arguments(this), PERMANENT);
         }
 

--- a/src/org/mozilla/javascript/Node.java
+++ b/src/org/mozilla/javascript/Node.java
@@ -63,7 +63,8 @@ public class Node implements Iterable<Node>
         JSDOC_PROP           = 24,
         EXPRESSION_CLOSURE_PROP = 25, // JS 1.8 expression closure pseudo-return
         DESTRUCTURING_SHORTHAND = 26, // JS 1.8 destructuring shorthand
-        LAST_PROP            = 26;
+        ARROW_FUNCTION_PROP  = 27,
+        LAST_PROP            = 27;
 
     // values of ISNUMBER_PROP to specify
     // which of the children are Number types

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -621,17 +621,18 @@ public class Parser
         return root;
     }
 
-    private AstNode parseFunctionBody()
+    private AstNode parseFunctionBody(int type)
         throws IOException
     {
         boolean isExpressionClosure = false;
         if (!matchToken(Token.LC)) {
-            if (compilerEnv.getLanguageVersion() < Context.VERSION_1_8) {
+            if (compilerEnv.getLanguageVersion() < Context.VERSION_1_8 && type != FunctionNode.ARROW_FUNCTION) {
                 reportError("msg.no.brace.body");
             } else {
                 isExpressionClosure = true;
             }
         }
+        boolean isArrow = type == FunctionNode.ARROW_FUNCTION;
         ++nestingOfFunction;
         int pos = ts.tokenBeg;
         Block pn = new Block(pos);  // starts at LC position
@@ -648,6 +649,9 @@ public class Parser
                 // expression closure flag is required on both nodes
                 n.putProp(Node.EXPRESSION_CLOSURE_PROP, Boolean.TRUE);
                 pn.putProp(Node.EXPRESSION_CLOSURE_PROP, Boolean.TRUE);
+                if (isArrow) {
+                    n.putProp(Node.ARROW_FUNCTION_PROP, Boolean.TRUE);
+                }
                 pn.addStatement(n);
             } else {
                 bodyLoop: for (;;) {
@@ -825,7 +829,7 @@ public class Parser
         PerFunctionVariables savedVars = new PerFunctionVariables(fnNode);
         try {
             parseFunctionParams(fnNode);
-            fnNode.setBody(parseFunctionBody());
+            fnNode.setBody(parseFunctionBody(type));
             fnNode.setEncodedSourceBounds(functionSourceStart, ts.tokenEnd);
             fnNode.setLength(ts.tokenEnd - functionSourceStart);
 
@@ -867,6 +871,93 @@ public class Parser
             fnNode.setParentScope(currentScope);
         }
         return fnNode;
+    }
+
+    private AstNode arrowFunction(AstNode params) throws IOException {
+        int baseLineno = ts.lineno;  // line number where source starts
+        int functionSourceStart = params != null ? params.getPosition() : -1;  // start of "function" kwd
+
+        FunctionNode fnNode = new FunctionNode(functionSourceStart);
+        fnNode.setFunctionType(FunctionNode.ARROW_FUNCTION);
+        fnNode.setJsDocNode(getAndResetJsDoc());
+
+        // Would prefer not to call createDestructuringAssignment until codegen,
+        // but the symbol definitions have to happen now, before body is parsed.
+        Map<String, Node> destructuring = new HashMap<String, Node>();
+        Set<String> paramNames = new HashSet<String>();
+
+        PerFunctionVariables savedVars = new PerFunctionVariables(fnNode);
+        try {
+            if (params instanceof ParenthesizedExpression) {
+                fnNode.setParens(0, params.getLength());
+                AstNode p = ((ParenthesizedExpression)params).getExpression();
+                if (!(p instanceof EmptyExpression)) {
+                    arrowFunctionParams(fnNode, p, destructuring, paramNames);
+                }
+            } else {
+                arrowFunctionParams(fnNode, params, destructuring, paramNames);
+            }
+
+            if (!destructuring.isEmpty()) {
+                Node destructuringNode = new Node(Token.COMMA);
+                // Add assignment helper for each destructuring parameter
+                for (Map.Entry<String, Node> param: destructuring.entrySet()) {
+                    Node assign = createDestructuringAssignment(Token.VAR,
+                                                                param.getValue(), createName(param.getKey()));
+                    destructuringNode.addChildToBack(assign);
+
+                }
+                fnNode.putProp(Node.DESTRUCTURING_PARAMS, destructuringNode);
+            }
+                
+            fnNode.setBody(parseFunctionBody(FunctionNode.ARROW_FUNCTION));
+            fnNode.setEncodedSourceBounds(functionSourceStart, ts.tokenEnd);
+            fnNode.setLength(ts.tokenEnd - functionSourceStart);
+        } finally {
+            savedVars.restore();
+        }
+
+        if (fnNode.isGenerator()) {
+            reportError("msg.arrowfunction.generator");
+            return makeErrorNode();
+        }
+
+        fnNode.setSourceName(sourceURI);
+        fnNode.setBaseLineno(baseLineno);
+        fnNode.setEndLineno(ts.lineno);
+
+        return fnNode;
+    }
+
+    private void arrowFunctionParams(FunctionNode fnNode, AstNode params, Map<String, Node> destructuring, Set<String> paramNames) {
+        if (params instanceof ArrayLiteral || params instanceof ObjectLiteral) {
+            markDestructuring(params);
+            fnNode.addParam(params);
+            String pname = currentScriptOrFn.getNextTempName();
+            defineSymbol(Token.LP, pname, false);
+            destructuring.put(pname, params);
+        } else if (params instanceof InfixExpression && params.getType() == Token.COMMA) {
+            arrowFunctionParams(fnNode, ((InfixExpression)params).getLeft(), destructuring, paramNames);
+            arrowFunctionParams(fnNode, ((InfixExpression)params).getRight(), destructuring, paramNames);
+        } else if (params instanceof Name) {
+            fnNode.addParam(params);
+            String paramName = ((Name)params).getIdentifier();
+            defineSymbol(Token.LP, paramName);
+
+            if (this.inUseStrictDirective) {
+                if ("eval".equals(paramName) ||
+                    "arguments".equals(paramName))
+                    {
+                        reportError("msg.bad.id.strict", paramName);
+                    }
+                if (paramNames.contains(paramName))
+                    addError("msg.dup.param.strict", paramName);
+                paramNames.add(paramName);
+            }
+        } else {
+            reportError("msg.no.parm", params.getPosition(), params.getLength());
+            fnNode.addParam(makeErrorNode());
+        }
     }
 
     // This function does not match the closing RC: the caller matches
@@ -2085,6 +2176,9 @@ public class Parser
             if (currentJsDocComment != null) {
                 pn.setJsDocNode(getAndResetJsDoc());
             }
+        } else if (tt == Token.ARROW) {
+            consumeToken();
+            pn = arrowFunction(pn);
         }
         return pn;
     }
@@ -2798,33 +2892,41 @@ public class Parser
     private AstNode primaryExpr()
         throws IOException
     {
-        int ttFlagged = nextFlaggedToken();
+        int ttFlagged = peekFlaggedToken();
         int tt = ttFlagged & CLEAR_TI_MASK;
 
         switch(tt) {
           case Token.FUNCTION:
+              consumeToken();
               return function(FunctionNode.FUNCTION_EXPRESSION);
 
           case Token.LB:
+              consumeToken();
               return arrayLiteral();
 
           case Token.LC:
+              consumeToken();
               return objectLiteral();
 
           case Token.LET:
+              consumeToken();
               return let(false, ts.tokenBeg);
 
           case Token.LP:
+              consumeToken();
               return parenExpr();
 
           case Token.XMLATTR:
+              consumeToken();
               mustHaveXML();
               return attributeAccess();
 
           case Token.NAME:
+              consumeToken();
               return name(ttFlagged, tt);
 
           case Token.NUMBER: {
+              consumeToken();
               String s = ts.getString();
               if (this.inUseStrictDirective && ts.isNumberOctal()) {
                   reportError("msg.no.octal.strict");
@@ -2841,10 +2943,12 @@ public class Parser
           }
 
           case Token.STRING:
+              consumeToken();
               return createStringLiteral();
 
           case Token.DIV:
           case Token.ASSIGN_DIV:
+              consumeToken();
               // Got / or /= which in this context means a regexp
               ts.readRegExp(tt);
               int pos = ts.tokenBeg, end = ts.tokenEnd;
@@ -2857,26 +2961,35 @@ public class Parser
           case Token.THIS:
           case Token.FALSE:
           case Token.TRUE:
+              consumeToken();
               pos = ts.tokenBeg; end = ts.tokenEnd;
               return new KeywordLiteral(pos, end - pos, tt);
 
+          case Token.RP:
+              return new EmptyExpression();
+
           case Token.RESERVED:
+              consumeToken();
               reportError("msg.reserved.id");
               break;
 
           case Token.ERROR:
+              consumeToken();
               // the scanner or one of its subroutines reported the error.
               break;
 
           case Token.EOF:
+              consumeToken();
               reportError("msg.unexpected.eof");
               break;
 
           default:
+              consumeToken();
               reportError("msg.syntax");
               break;
         }
         // should only be reachable in IDE/error-recovery mode
+        consumeToken();
         return makeErrorNode();
     }
 
@@ -2899,6 +3012,10 @@ public class Parser
                 pn.setJsDocNode(jsdocNode);
             }
             mustMatchToken(Token.RP, "msg.no.paren");
+            if (e.getType() == Token.EMPTY && peekToken() != Token.ARROW) {
+              reportError("msg.syntax");
+              return makeErrorNode();
+            }
             pn.setLength(ts.tokenEnd - pn.getPosition());
             pn.setLineno(lineno);
             return pn;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3376,6 +3376,12 @@ public class ScriptRuntime {
         return new NativeCall(funObj, scope, args);
     }
 
+    public static Scriptable createArrowFunctionActivation(NativeFunction funObj,
+                                                           Scriptable scope,
+                                                           Object[] args)
+    {
+        return new NativeCall(funObj, scope, args, true);
+    }
 
     public static void enterActivationFunction(Context cx,
                                                Scriptable scope)

--- a/src/org/mozilla/javascript/Token.java
+++ b/src/org/mozilla/javascript/Token.java
@@ -229,7 +229,8 @@ public class Token
         COMMENT        = 161,
         GENEXPR        = 162,
         METHOD         = 163,  // ES6 MethodDefinition
-        LAST_TOKEN     = 164;
+        ARROW          = 164,  // ES6 ArrowFunction
+        LAST_TOKEN     = 165;
 
     /**
      * Returns a name for the token.  If Rhino is compiled with certain

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -670,6 +670,8 @@ class TokenStream
                     } else {
                         return Token.EQ;
                     }
+                } else if (matchChar('>')) {
+                    return Token.ARROW;
                 } else {
                     return Token.ASSIGN;
                 }

--- a/src/org/mozilla/javascript/ast/FunctionNode.java
+++ b/src/org/mozilla/javascript/ast/FunctionNode.java
@@ -63,6 +63,7 @@ public class FunctionNode extends ScriptNode {
     public static final int FUNCTION_STATEMENT            = 1;
     public static final int FUNCTION_EXPRESSION           = 2;
     public static final int FUNCTION_EXPRESSION_STATEMENT = 3;
+    public static final int ARROW_FUNCTION                = 4;
 
     public static enum Form { FUNCTION, GETTER, SETTER, METHOD }
 
@@ -384,12 +385,20 @@ public class FunctionNode extends ScriptNode {
             sb.append(" ");
             sb.append(functionName.toSource(0));
         }
+        boolean isArrow = functionType == ARROW_FUNCTION;
         if (params == null) {
             sb.append("() ");
+        } else if (isArrow && lp == -1) {
+            // no paren
+            printList(params, sb);
+            sb.append(" ");
         } else {
             sb.append("(");
             printList(params, sb);
             sb.append(") ");
+        }
+        if (isArrow) {
+            sb.append("=> ");
         }
         if (isExpressionClosure) {
             AstNode body = getBody();

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -1617,12 +1617,17 @@ class BodyCodegen
 
 
         String debugVariableName;
+        boolean isArrow = false;
+        if (scriptOrFn instanceof FunctionNode) {
+            isArrow = ((FunctionNode)scriptOrFn).getFunctionType() == FunctionNode.ARROW_FUNCTION;
+        }
         if (fnCurrent != null) {
             debugVariableName = "activation";
             cfw.addALoad(funObjLocal);
             cfw.addALoad(variableObjectLocal);
             cfw.addALoad(argsLocal);
-            addScriptRuntimeInvoke("createFunctionActivation",
+            String methodName = isArrow ? "createArrowFunctionActivation" : "createFunctionActivation";
+            addScriptRuntimeInvoke(methodName,
                                    "(Lorg/mozilla/javascript/NativeFunction;"
                                    +"Lorg/mozilla/javascript/Scriptable;"
                                    +"[Ljava/lang/Object;"
@@ -2172,7 +2177,8 @@ class BodyCodegen
                     OptFunctionNode ofn = OptFunctionNode.get(scriptOrFn,
                                                              fnIndex);
                     int t = ofn.fnode.getFunctionType();
-                    if (t != FunctionNode.FUNCTION_EXPRESSION) {
+                    if (t != FunctionNode.FUNCTION_EXPRESSION &&
+                        t != FunctionNode.ARROW_FUNCTION) {
                         throw Codegen.badTree();
                     }
                     visitFunction(ofn, t);
@@ -2960,7 +2966,20 @@ class BodyCodegen
         cfw.addInvoke(ByteCode.INVOKESPECIAL, codegen.mainClassName,
                       "<init>", Codegen.FUNCTION_CONSTRUCTOR_SIGNATURE);
 
-        if (functionType == FunctionNode.FUNCTION_EXPRESSION) {
+        if (functionType == FunctionNode.ARROW_FUNCTION) {
+            cfw.addALoad(contextLocal);           // load 'cx'
+            cfw.addALoad(variableObjectLocal);
+            cfw.addALoad(thisObjLocal);
+            addOptRuntimeInvoke("bindThis",
+                                "(Lorg/mozilla/javascript/NativeFunction;"
+                                +"Lorg/mozilla/javascript/Context;"
+                                +"Lorg/mozilla/javascript/Scriptable;"
+                                +"Lorg/mozilla/javascript/Scriptable;"
+                                +")Lorg/mozilla/javascript/Function;");
+        }
+
+        if (functionType == FunctionNode.FUNCTION_EXPRESSION ||
+            functionType == FunctionNode.ARROW_FUNCTION) {
             // Leave closure object on stack and do not pass it to
             // initFunction which suppose to connect statements to scope
             return;

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -133,6 +133,11 @@ public final class OptRuntime extends ScriptRuntime
         ScriptRuntime.initFunction(cx, scope, fn, functionType, false);
     }
 
+    public static Function bindThis(NativeFunction fn, Context cx, Scriptable scope, Scriptable thisObj)
+    {
+        return new ArrowFunction(cx, scope, fn, thisObj);
+    }
+
     public static Object callSpecial(Context cx, Callable fun,
                                      Scriptable thisObj, Object[] args,
                                      Scriptable scope,

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -843,3 +843,6 @@ msg.called.null.or.undefined=\
 
 msg.first.arg.not.regexp=\
   First argument to {0}.prototype.{1} must not be a regular expression
+
+msg.arrowfunction.generator =\
+  arrow function can not become generator

--- a/testsrc/jstests/arrowfn.jstest
+++ b/testsrc/jstests/arrowfn.jstest
@@ -1,0 +1,182 @@
+function assertEq(actual, expected) {
+  if (expected !== actual) {
+    throw "Expected '" + expected + "' but was '" + actual + "'";
+  }
+}
+
+function assertException(exception, fn) {
+  try {
+    fn();
+  } catch (e if e instanceof exception) {
+    return;
+  }
+  throw "Expected to throw '" + exception + "' but not thrown";
+}
+
+var f = a => a * a;
+assertEq(f(2), 4);
+assertEq(f.toString(), '\na => a * a\n');
+
+var f = (a) => a * a;
+assertEq(f(2), 4);
+assertEq(f.toString(), '\n(a) => a * a\n');
+
+var f = (a, b) => a * b;
+assertEq(f(2, 3), 6);
+
+var f = (a, b, c) => a * b + c;
+assertEq(f(2, 3, 4), 10);
+
+var f = () => 10;
+assertEq(f(), 10);
+
+var f = () => 10 * 2;
+assertEq(f(), 20);
+
+assertException(SyntaxError, function() {
+  eval('var f = ) => a * b;');
+});
+
+assertException(SyntaxError, function() {
+  eval('var f = ();');
+});
+
+var f = ([a, b]) => a * b;
+assertEq(f([2, 3]), 6);
+
+var f = ({ a: a, b: b}) => a * b;
+assertEq(f({ a: 10, b: 20 }), 200);
+
+var f = a => {
+  return a * a;
+};
+assertEq(f(10), 100);
+assertEq(f.toString(), '\na => {\n    return a * a;\n}\n');
+
+var f = a => {
+  a * a;
+};
+assertEq(f(10), undefined);
+
+var f = (a) => {
+  return a * a;
+};
+assertEq(f(10), 100);
+
+var f = (a) => {
+  a * a;
+};
+assertEq(f(10), undefined);
+
+var f = () => {
+  return 10;
+};
+assertEq(f(), 10);
+
+var f = () => {
+  10;
+};
+assertEq(f(), undefined);
+
+assertException(SyntaxError, function() {
+  eval("function() { 'use strict'; var f = (a, a) => {} }");
+});
+
+assertException(SyntaxError, function() {
+  eval("function() { 'use strict'; var f = (eval) => {} }");
+});
+
+assertException(SyntaxError, function() {
+  eval("function() { 'use strict'; var f = (arguments) => {} }");
+});
+
+assertException(SyntaxError, function() {
+  eval("function() { 'use strict'; var f = (123) => {} }");
+});
+
+assertException(SyntaxError, function() {
+  eval("var f = () => { yield 10; };");
+});
+
+var o = {
+  a: 1
+};
+(function() {
+  var f = () => this;
+  assertEq(f(), o);
+  assertEq(f().a, 1);
+}).call(o);
+
+var o = {
+  a: 1
+};
+var f = (function() {
+  return () => this;
+}).call(o);
+assertEq(f(), o);
+assertEq(f().a, 1);
+
+var o = {};
+(function() {
+  var f = () => () => this;
+  assertEq(f()(), o);
+}).call(o);
+
+var o1 = {}, o2 = {};
+(function() {
+  (function() {
+    var f = () => this;
+    assertEq(f(), o2);
+  }).call(o2);
+}).call(o1);
+
+var o = {};
+(function() {
+  var f;
+  if (String) {
+    f = () => this;
+  }
+  assertEq(f(), o);
+}).call(o);
+
+var o = {};
+(function() {
+  var f;
+  with (String) {
+    f = () => this;
+  }
+  assertEq(f(), o);
+}).call(o);
+
+var f = (function() {
+  return () => this.a + 3;
+}).call({ a: 1 });
+assertEq(f(), 4);
+
+assertException(TypeError, function() {
+  var f = () => 10;
+  new f();
+});
+
+assertException(TypeError, function() {
+  var f = () => 10, g = f.bind();
+  new g();
+});
+
+var f = (function() {
+  return () => arguments[0] + arguments[1];
+})(1, 2);
+assertEq(f(3, 4), 3);
+
+var f = () => 10;
+assertEq(f.prototype, undefined);
+
+var f = () => {
+  var n = 0;
+  return () => n++;
+};
+var g = f();
+assertEq(g(), 0);
+assertEq(g(), 1);
+
+"success";


### PR DESCRIPTION
This patch is implementing Arrow Function syntax.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/arrow_functions
http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax

I've used the current ES6 draft (May 14, 2013 Draft) for this patch.

 * No support Rest parameters.
 * I'm not sure about the specification of sctrict mode.
 * When a Arrow Function have called as constructor, error message is unkind.

```js
var fn = () => 10;
new fn();
/*
js: "<stdin>", line 3: uncaught JavaScript runtime exception: TypeError: "
() => 10
" is not a constructor.
	at <stdin>:3
*/
```