### PR TITLE
Fix AST empty switch to source

### DIFF
--- a/src/org/mozilla/javascript/ast/SwitchStatement.java
+++ b/src/org/mozilla/javascript/ast/SwitchStatement.java
@@ -155,8 +155,10 @@ public class SwitchStatement extends Jump {
         sb.append("switch (");
         sb.append(expression.toSource(0));
         sb.append(") {\n");
-        for (SwitchCase sc : cases) {
-            sb.append(sc.toSource(depth + 1));
+        if (cases != null) {
+            for (SwitchCase sc : cases) {
+                sb.append(sc.toSource(depth + 1));
+            }
         }
         sb.append(pad);
         sb.append("}\n");

--- a/testsrc/org/mozilla/javascript/tests/Bug491621Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug491621Test.java
@@ -114,4 +114,10 @@ public class Bug491621Test {
     {
         assertSource("0xff;\n9;\n07;\n1;", "0xff;\n9;\n07;\n1;\n");
     }
+
+    @Test
+    public void testEmptySwitchToSource()
+    {
+        assertSource("switch(1){}", "switch (1) {\n}\n");
+    }
 }


### PR DESCRIPTION
AST toSource for an empty switch statement throws NPE. See test case.