### PR TITLE
Extract default method when interface be implemented by a single function

### DIFF
--- a/src/org/mozilla/javascript/InterfaceAdapter.java
+++ b/src/org/mozilla/javascript/InterfaceAdapter.java
@@ -7,6 +7,7 @@
 package org.mozilla.javascript;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 
 /**
  * Adapter to use JS function as implementation of Java interfaces with
@@ -46,12 +47,20 @@ public class InterfaceAdapter
                         "msg.no.empty.interface.conversion", cl.getName());
                 }
                 if (length > 1) {
-                    String methodName = methods[0].getName();
-                    for (int i = 1; i < length; i++) {
-                        if (!methodName.equals(methods[i].getName())) {
-                            throw Context.reportRuntimeError1(
-                                    "msg.no.function.interface.conversion",
-                                    cl.getName());
+                    ArrayList<Method> abstractMethods = new ArrayList<Method>();
+                    for (Method m : methods) {
+                        if (!m.isDefault()) {
+                            abstractMethods.add(m);
+                        }
+                    }
+                    if (abstractMethods.size() > 1) {
+                        String methodName = abstractMethods.get(0).getName();
+                        for (int i = 1; i < abstractMethods.size(); i++) {
+                            if (!methodName.equals(abstractMethods.get(i).getName())) {
+                                throw Context.reportRuntimeError1(
+                                                                  "msg.no.function.interface.conversion",
+                                                                  cl.getName());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I want to use the Stream API in JDK8.
```js
java.nio.file.Files.readAllLines(java.nio.file.Paths.get('test.js'),
                                 java.nio.charset.Charset.defaultCharset()).stream()
    .forEach(function(line) {
      print(line);
    });
```
But error.
```
js: Cannot convert function to interface java.util.function.Consumer since it contains methods with different names
```

Rhino can convert JavaScript functions to Java interfaces if interface has only one method.
https://developer.mozilla.org/ja/docs/Rhino/Scripting_Java#JavaScript_Functions_as_Java_Interfaces

`Consumer` has two method, but `andThen` is default method.
http://docs.oracle.com/javase/8/docs/api/java/util/function/Consumer.html

I think it is acceptable to convert in this case.