### PR TITLE
Enable to call default method on java8

### DIFF
--- a/src/build.xml
+++ b/src/build.xml
@@ -14,8 +14,10 @@ Requires Ant version 1.2
 
   <available property="jdk15"
              classname="java.lang.reflect.ParameterizedType" />
+  <available property="jdk18"
+             classname="java.util.stream.Stream" />
 
-  <target name="compile" depends="compile-most,compile-jdk15">
+  <target name="compile" depends="compile-most,compile-jdk15,compile-jdk18">
   </target>
 
   <target name="shell" depends="compile">
@@ -30,13 +32,15 @@ Requires Ant version 1.2
     <javac srcdir="src"
            destdir="${classes}"
            includes="org/**/*.java"
-           excludes="org/**/jdk15/*.java"
            deprecation="on"
            debug="${debug}"
            includeAntRuntime="false"
            encoding="UTF-8"
            target="${target-jvm}"
-           source="${source-level}" />
+           source="${source-level}">
+      <exclude name="org/**/jdk15/*.java"/>
+      <exclude name="org/**/jdk18/*.java"/>
+    </javac>
     <copy todir="${classes}">
       <fileset dir="src" includes="org/**/*.properties" />
       <filterset>
@@ -50,6 +54,19 @@ Requires Ant version 1.2
     <javac srcdir="src"
            destdir="${classes}"
            includes="org/**/jdk15/*.java"
+           excludes="org/**/jdk18/*.java"
+           deprecation="on"
+           debug="${debug}"
+           includeAntRuntime="false"
+           encoding="UTF-8"
+           target="${target-jvm}"
+           source="${source-level}" />
+  </target>
+
+  <target name="compile-jdk18" if="jdk18">
+    <javac srcdir="src"
+           destdir="${classes}"
+           includes="org/**/jdk18/*.java"
            deprecation="on"
            debug="${debug}"
            includeAntRuntime="false"

--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -384,7 +384,8 @@ public final class JavaAdapter implements IdFunctionCall
             for (int j = 0; j < methods.length; j++) {
                 Method method = methods[j];
                 int mods = method.getModifiers();
-                if (Modifier.isStatic(mods) || Modifier.isFinal(mods)) {
+                if (Modifier.isStatic(mods) || Modifier.isFinal(mods) ||
+                    VMBridge.instance.isDefaultMethod(method)) {
                     continue;
                 }
                 String methodName = method.getName();

--- a/src/org/mozilla/javascript/JavaMembers.java
+++ b/src/org/mozilla/javascript/JavaMembers.java
@@ -327,6 +327,11 @@ class JavaMembers
                                     }
                                 }
                             }
+                            Class<?>[] interfaces = clazz.getInterfaces();
+                            for (Class<?> intface : interfaces) {
+                                discoverAccessibleMethods(intface, map, includeProtected,
+                                                          includePrivate);
+                            }
                             clazz = clazz.getSuperclass();
                         } catch (SecurityException e) {
                             // Some security settings (i.e., applets) disallow

--- a/src/org/mozilla/javascript/VMBridge.java
+++ b/src/org/mozilla/javascript/VMBridge.java
@@ -21,6 +21,7 @@ public abstract class VMBridge
     {
         String[] classNames = {
             "org.mozilla.javascript.VMBridge_custom",
+            "org.mozilla.javascript.jdk18.VMBridge_jdk18",
             "org.mozilla.javascript.jdk15.VMBridge_jdk15",
             "org.mozilla.javascript.jdk13.VMBridge_jdk13",
             "org.mozilla.javascript.jdk11.VMBridge_jdk11",
@@ -145,5 +146,9 @@ public abstract class VMBridge
             return iterator;
         }
         return null;
+    }
+
+    public boolean isDefaultMethod(Method method) {
+        return false;
     }
 }

--- a/src/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
+++ b/src/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
@@ -1,0 +1,21 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.jdk18;
+
+import java.lang.reflect.Method;
+
+public class VMBridge_jdk18 extends org.mozilla.javascript.jdk15.VMBridge_jdk15
+{
+    public VMBridge_jdk18() throws SecurityException, InstantiationException {
+        super();
+    }
+
+    @Override
+    public boolean isDefaultMethod(Method method) {
+        return method.isDefault();
+    }
+}

--- a/testsrc/jstests/java8/call-default-method.js
+++ b/testsrc/jstests/java8/call-default-method.js
@@ -1,0 +1,19 @@
+load("testsrc/assert.js");
+
+function startsWith(str, prefix) {
+  return str.lastIndexOf(prefix, prefix.length) === 0;
+}
+
+if (startsWith(''+java.util.stream.Stream, '[JavaClass')) {
+  var p = new java.util.function.Predicate({
+    test: function(t) {
+      return true;
+    }
+  });
+  assertInstanceof(p.negate(), java.util.function.Predicate);
+  assertFalse(p.negate().test(0));
+  assertInstanceof(p.isEqual(null), java.util.function.Predicate);
+  assertTrue(p.isEqual(null).test(null));
+}
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/java8/CallDefaultMethodTest.java
+++ b/testsrc/org/mozilla/javascript/tests/java8/CallDefaultMethodTest.java
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.java8;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/java8/call-default-method.js")
+public class CallDefaultMethodTest extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
When call `Predicate#negate` (default method) in java8.
https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html#negate--

``` js
var p = java.util.function.Predicate({
  test: function(t) {
    return true;
  }
}).negate();
p; // null
```

By right, the method return `Predicate`'s instance, but returned null.
The `negate` method is generated from JavaAdapter in Rhino, and that body is empty.

So I made this:
- Do not generate default method in JavaAdapter.
- Add default method to JavaMember.
