### PR TITLE
Print exception message in case of JavaScriptException in ScriptTestsBase

### DIFF
--- a/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -53,7 +53,7 @@ public abstract class ScriptTestsBase {
 
       return cx.evaluateReader(scope, script, suiteName, 1, null);
     } catch (JavaScriptException ex) {
-      fail(ex.getScriptStackTrace());
+      fail(String.format("%s%n%s", ex.getMessage(), ex.getScriptStackTrace()));
       return null;
     }catch (Exception e) {
       fail(e.getMessage());


### PR DESCRIPTION
From this:
```
java.lang.AssertionError:   at testsrc/assert.js:178 (fail)
    at testsrc/assert.js:259 (assertEquals)
    at testsrc/jstests/harmony/array-find.js:175 (anonymous)
    ...
```

to this:
```
java.lang.AssertionError: Failure: expected <4> found <3> (testsrc/assert.js#178)
    at testsrc/assert.js:178 (fail)
    at testsrc/assert.js:259 (assertEquals)
    at testsrc/jstests/harmony/array-find.js:175 (anonymous)
    ...
```
in tests that use `assert.js`.

It would be great to also remove first two items from top of the stack trace, but I was not able to find a way to do this from JS.

---
Sorry for disappearing. I think I became overwhelmed by amount of work required to do what I thought was a simple task. Now I'd like to make smaller steps.