### PR TITLE
Fix some issues with Array.prototype.{find, findIndex}

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1661,9 +1661,9 @@ public class NativeArray extends IdScriptableObject implements List
                 break;
               case Id_find:
                 if (ScriptRuntime.toBoolean(result))
-                  return elem;
+                    return elem;
                 break;
-            case Id_findIndex:
+              case Id_findIndex:
                 if (ScriptRuntime.toBoolean(result))
                     return ScriptRuntime.wrapNumber(i);
                 break;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import org.mozilla.javascript.regexp.NativeRegExp;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -1612,7 +1614,13 @@ public class NativeArray extends IdScriptableObject implements List
         Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
         if (callbackArg == null || !(callbackArg instanceof Function)) {
             throw ScriptRuntime.notFunctionError(callbackArg);
-        } else if ((id == Id_find || id == Id_findIndex) && !(callbackArg instanceof NativeFunction)) {
+        }
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6 && (callbackArg instanceof NativeRegExp)) {
+            // Previously, it was allowed to pass RegExp instance as a callback (it implements Function)
+            // But according to ES2015 21.2.6 Properties of RegExp Instances:
+            // > RegExp instances are ordinary objects that inherit properties from the RegExp prototype object.
+            // > RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]].
+            // so, no [[Call]] for RegExp-s
             throw ScriptRuntime.notFunctionError(callbackArg);
         }
 

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1642,7 +1642,7 @@ public class NativeArray extends IdScriptableObject implements List
         for (long i=0; i < length; i++) {
             Object[] innerArgs = new Object[3];
             Object elem = getRawElem(thisObj, i);
-            if (elem == Scriptable.NOT_FOUND) {
+            if (elem == Scriptable.NOT_FOUND && !(id == Id_find || id == Id_findIndex)) {
                 continue;
             }
             innerArgs[0] = elem;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1642,8 +1642,12 @@ public class NativeArray extends IdScriptableObject implements List
         for (long i=0; i < length; i++) {
             Object[] innerArgs = new Object[3];
             Object elem = getRawElem(thisObj, i);
-            if (elem == Scriptable.NOT_FOUND && !(id == Id_find || id == Id_findIndex)) {
-                continue;
+            if (elem == Scriptable.NOT_FOUND) {
+                if (id == Id_find || id == Id_findIndex) {
+                    elem = Undefined.instance;
+                } else {
+                    continue;
+                }
             }
             innerArgs[0] = elem;
             innerArgs[1] = Long.valueOf(i);

--- a/testsrc/jstests/harmony/array-find.js
+++ b/testsrc/jstests/harmony/array-find.js
@@ -42,11 +42,11 @@ load("testsrc/assert.js");
 
     // `InterpretedFunction` or `? extends NativeFunction`
     assertEquals(a[0], a.find(function () { return true; }));
-    // FIXME:
     // `IdScriptableObject`
-    //assertEquals(a[0], a.find(Object.prototype.toString));
+    assertEquals(a[0], a.find(Object.prototype.toString));
+    assertEquals(a[0], a.find(String));
     // `BoundFunction`
-    //assertEquals(a[0], a.find((function () { return true; }).bind({})))
+    assertEquals(a[0], a.find((function () { return true; }).bind({})))
 })();
 
 //

--- a/testsrc/jstests/harmony/array-find.js
+++ b/testsrc/jstests/harmony/array-find.js
@@ -4,216 +4,303 @@
 
 load("testsrc/assert.js");
 
-assertEquals(1, Array.prototype.find.length);
+//
+// Test The length of 'Array.prototype.find' is 1
+// (22.1.3.8)
+(function () {
+    assertEquals(1, Array.prototype.find.length);
+})();
 
-var a = [21, 22, 23, 24];
-assertEquals(undefined, a.find(function() { return false; }));
-assertEquals(21, a.find(function() { return true; }));
-assertEquals(undefined, a.find(function(val) { return 121 === val; }));
-assertEquals(24, a.find(function(val) { return 24 === val; }));
-assertEquals(23, a.find(function(val) { return 23 === val; }), null);
-assertEquals(22, a.find(function(val) { return 22 === val; }), undefined);
+//
+// Quick check for base cases
+//
+(function () {
+    var a = [21, 22, 23, 24];
 
+    // well, it works
+    assertEquals(a[0], a.find(function () { return true; }));
+
+    // predicate is called with current value, index and object on which `find()` was called
+    assertEquals(a[3], a.find(function (val, i, array) { return array === a && i === 3; }));
+
+    // 'this' can be augmented by second optional parameter
+    var thisArg = {};
+    assertEquals(a[0], a.find(function () { return this === thisArg; }, thisArg));
+
+    // when nothing found, `undefined` is returned
+    assertEquals(undefined, a.find(function () { return false; }));
+
+    // it is not required to return Boolean, it will be automatically casted
+    assertEquals(a[2], a.find(function (val) { return (val === a[2] ? "true" : null); }));
+})();
+
+//
+// Test predicate is anything that has [[Call]] internal method
+//
+(function () {
+    var a = [21, 22, 23, 24];
+
+    // `InterpretedFunction` or `? extends NativeFunction`
+    assertEquals(a[0], a.find(function () { return true; }));
+    // FIXME:
+    // `IdScriptableObject`
+    //assertEquals(a[0], a.find(Object.prototype.toString));
+    // `BoundFunction`
+    //assertEquals(a[0], a.find((function () { return true; }).bind({})))
+})();
 
 //
 // Test predicate is not called when array is empty
 //
-(function() {
-  var a = [];
-  var l = -1;
-  var o = -1;
-  var v = -1;
-  var k = -1;
+(function () {
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
 
-  a.find(function(val, key, obj) {
-    o = obj;
-    l = obj.length;
-    v = val;
-    k = key;
+    [].find(function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
 
-    return false;
-  });
+        return false;
+    });
 
-  assertEquals(-1, l);
-  assertEquals(-1, o);
-  assertEquals(-1, v);
-  assertEquals(-1, k);
+    assertEquals(-1, l);
+    assertEquals(-1, o);
+    assertEquals(-1, v);
+    assertEquals(-1, k);
 })();
 
-
 //
-// Test predicate is called with correct argumetns
+// Test predicate is called with correct arguments
 //
-(function() {
-  var a = ["b"];
-  var l = -1;
-  var o = -1;
-  var v = -1;
-  var k = -1;
+(function () {
+    var a = ["b"];
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
 
-  var found = a.find(function(val, key, obj) {
-    o = obj;
-    l = obj.length;
-    v = val;
-    k = key;
+    var found = a.find(function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
 
-    return false;
-  });
+        return false;
+    });
 
-  assertArrayEquals(a, o);
-  assertEquals(a.length, l);
-  assertEquals("b", v);
-  assertEquals(0, k);
-  assertEquals(undefined, found);
+    assertArrayEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("b", v);
+    assertEquals(0, k);
+    assertEquals(undefined, found);
 })();
-
 
 //
 // Test predicate is called array.length times
 //
-(function() {
-  var a = [1, 2, 3, 4, 5];
-  var l = 0;
-  var found = a.find(function() {
-    l++;
-    return false;
-  });
+(function () {
+    var a = [1, 2, 3, 4, 5];
+    var l = 0;
+    var predicate = function p() {
+        l++;
+    };
 
-  assertEquals(a.length, l);
-  assertEquals(undefined, found);
+    a.find(predicate);
+    assertEquals(a.length, l);
+
+    // even for sparse arrays
+    // FIXME:
+    //a = new Array(10);
+    //l = 0;
+    //a.find(predicate);
+    //assertEquals(a.length, l);
+    //
+    //a = [];
+    //a[10] = 1;
+    //l = 0;
+    //a.find(predicate);
+    //assertEquals(a.length, l);
 })();
 
 
 //
-// Test Array.prototype.find works with String
+// Test Array.prototype.find is generic and works with String
 //
-(function() {
-  var a = "abcd";
-  var l = -1;
-  var o = -1;
-  var v = -1;
-  var k = -1;
-  var found = Array.prototype.find.call(a, function(val, key, obj) {
-    o = obj.toString();
-    l = obj.length;
-    v = val;
-    k = key;
+(function () {
+    var a = "abcd";
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+    var found = Array.prototype.find.call(a, function (val, key, obj) {
+        o = obj.toString();
+        l = obj.length;
+        v = val;
+        k = key;
 
-    return false;
-  });
+        return false;
+    });
 
-  assertEquals(a, o);
-  assertEquals(a.length, l);
-  assertEquals("d", v);
-  assertEquals(3, k);
-  assertEquals(undefined, found);
+    assertEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("d", v);
+    assertEquals(3, k);
+    assertEquals(undefined, found);
 
-  found = Array.prototype.find.apply(a, [function(val, key, obj) {
-    o = obj.toString();
-    l = obj.length;
-    v = val;
-    k = key;
+    found = Array.prototype.find.apply(a, [function (val, key, obj) {
+        o = obj.toString();
+        l = obj.length;
+        v = val;
+        k = key;
 
-    return true;
-  }]);
+        return true;
+    }]);
 
-  assertEquals(a, o);
-  assertEquals(a.length, l);
-  assertEquals("a", v);
-  assertEquals(0, k);
-  assertEquals("a", found);
+    assertEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("a", v);
+    assertEquals(0, k);
+    assertEquals("a", found);
 })();
 
-
 //
-// Test Array.prototype.find works with exotic object
+// Test Array.prototype.find works with simple arraylike objects
 //
-(function() {
-  var l = -1;
-  var o = -1;
-  var v = -1;
-  var k = -1;
-  var a = {
-    prop1: "val1",
-    prop2: "val2",
-    isValid: function() {
-      return this.prop1 === "val1" && this.prop2 === "val2";
-    }
-  };
+(function () {
+    var o = {0: 0, 1: 1, 2: 2, length: 3};
+    assertEquals(o[2], Array.prototype.find.call(o, function (v) { return v == o[2]; }));
+    assertEquals(o[1], Array.prototype.find.apply(o, [function (v) { return v == o[1]; }]));
 
-  Array.prototype.push.apply(a, [30, 31, 32]);
-  var found = Array.prototype.find.call(a, function(val, key, obj) {
-    o = obj;
-    l = obj.length;
-    v = val;
-    k = key;
-
-    return !obj.isValid();
-  });
-
-  assertArrayEquals(a, o);
-  assertEquals(3, l);
-  assertEquals(32, v);
-  assertEquals(2, k);
-  assertEquals(undefined, found);
+    // object without `length` property defined,
+    // behaves as if it has `length` set 0
+    var empty = {0: 0, 1: 1, 2: 2};
+    var called = false;
+    Array.prototype.find.call(empty, function () { called = true; });
+    assertEquals(false, called);
 })();
 
+//
+// Test Array.prototype.find works with mixed arraylike objects
+//
+(function () {
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+    var a = {
+        prop1: "val1",
+        prop2: "val2",
+        isValid: function () {
+            return this.prop1 === "val1" && this.prop2 === "val2";
+        },
+        length: 0
+    };
+
+    Array.prototype.push.apply(a, [30, 31, 32]);
+    var found = Array.prototype.find.call(a, function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return !obj.isValid();
+    });
+
+    assertArrayEquals(a, o);
+    assertEquals(3, l);
+    assertEquals(32, v);
+    assertEquals(2, k);
+    assertEquals(undefined, found);
+})();
+
+//
+// Test Array.prototype.find works with arraylike object with getters
+//
+(function () {
+    var count = 0;
+    var a = {get 0() { return count++; }, length: 1};
+    // FIXME: right now, Rhino will get raw getter function
+    //        during iteration and use it as a value passed to predicate
+    //Array.prototype.find.call(a, (function () { return true; }));
+    //assertEquals(1, count);
+})();
+
+//
+// Test Array.prototype.find iteration includes inherited properties
+//
+(function () {
+    var o1 = {0: 0, 1: 1};
+    var o2 = {2: 2, length: 3};
+    // FIXME: use Object.setPrototypeOf instead
+    o2.__proto__ = o1;
+    var a = [];
+    Array.prototype.find.call(o2, function (v) { a.push(v); });
+    assertEquals([0, 1, 2], a);
+    assertEquals(o1[0], Array.prototype.find.call(o2, function () { return true; }));
+})();
 
 //
 // Test array modifications
 //
-(function() {
-  var a = [1, 2, 3];
-  var found = a.find(function(val) { a.push(val); return false; });
-  assertArrayEquals([1, 2, 3, 1, 2, 3], a);
-  assertEquals(6, a.length);
-  assertEquals(undefined, found);
+(function () {
+    var a = [1, 2, 3];
+    var found = a.find(function (val) {
+        a.push(val);
+        return false;
+    });
+    assertArrayEquals([1, 2, 3, 1, 2, 3], a);
+    assertEquals(6, a.length);
+    assertEquals(undefined, found);
 
-  a = [1, 2, 3];
-  found = a.find(function(val, key) { a[key] = ++val; return false; });
-  assertArrayEquals([2, 3, 4], a);
-  assertEquals(3, a.length);
-  assertEquals(undefined, found);
+    a = [1, 2, 3];
+    found = a.find(function (val, key) {
+        a[key] = ++val;
+        return false;
+    });
+    assertArrayEquals([2, 3, 4], a);
+    assertEquals(3, a.length);
+    assertEquals(undefined, found);
 })();
-
-
-//
-// Test predicate is only called for existing elements
-//
-(function() {
-  var a = new Array(30);
-  a[11] = 21;
-  a[7] = 10;
-  a[29] = 31;
-
-  var count = 0;
-  a.find(function() { count++; return false; });
-  assertEquals(3, count);
-})();
-
 
 //
 // Test thisArg
 //
-(function() {
-  // Test String as a thisArg
-  var found = [1, 2, 3].find(function(val, key) {
-    return this.charAt(Number(key)) === String(val);
-  }, "321");
-  assertEquals(2, found);
+(function () {
+    // If thisArg is not provided, predicate is invoked with this set to `undefined`
+    // FIXME:
+    // var o = -1;
+    //[1,2].find(function () { o = this; });
+    //assertEquals(undefined, o);
 
-  // Test object as a thisArg
-  var thisArg = {
-    elementAt: function(key) {
-      return this[key];
-    }
-  };
-  Array.prototype.push.apply(thisArg, ["c", "b", "a"]);
+    // Test String as a thisArg
+    var found = [1, 2, 3].find(function (val, key) {
+        return this.charAt(Number(key)) === String(val);
+    }, "321");
+    assertEquals(2, found);
 
-  found = ["a", "b", "c"].find(function(val, key) {
-    return this.elementAt(key) === val;
-  }, thisArg);
-  assertEquals("b", found);
+    // Test object as a thisArg
+    var thisArg = {
+        elementAt: function (key) {
+            return this[key];
+        }
+    };
+    Array.prototype.push.apply(thisArg, ["c", "b", "a"]);
+
+    found = ["a", "b", "c"].find(function (val, key) {
+        return this.elementAt(key) === val;
+    }, thisArg);
+    assertEquals("b", found);
+
+    // Test array itself as thisArg
+    var a = [1, 2];
+    var o;
+    // FIXME:
+    //a.find(function () { o = this; }, a);
+    //assertEquals(a, o);
 })();
 
 // Test exceptions

--- a/testsrc/jstests/harmony/array-find.js
+++ b/testsrc/jstests/harmony/array-find.js
@@ -105,24 +105,30 @@ load("testsrc/assert.js");
 (function () {
     var a = [1, 2, 3, 4, 5];
     var l = 0;
-    var predicate = function p() {
+    var sawUndefined = false;
+    var predicate = function p(v) {
         l++;
+        sawUndefined = sawUndefined || (v === undefined);
     };
 
     a.find(predicate);
     assertEquals(a.length, l);
+    assertFalse(sawUndefined);
 
     // even for sparse arrays
     a = new Array(10);
     l = 0;
     a.find(predicate);
     assertEquals(a.length, l);
+    assertTrue(sawUndefined);
 
     a = [];
     a[10] = 1;
     l = 0;
+    sawUndefined = false;
     a.find(predicate);
     assertEquals(a.length, l);
+    assertTrue(sawUndefined);
 })();
 
 

--- a/testsrc/jstests/harmony/array-find.js
+++ b/testsrc/jstests/harmony/array-find.js
@@ -113,17 +113,16 @@ load("testsrc/assert.js");
     assertEquals(a.length, l);
 
     // even for sparse arrays
-    // FIXME:
-    //a = new Array(10);
-    //l = 0;
-    //a.find(predicate);
-    //assertEquals(a.length, l);
-    //
-    //a = [];
-    //a[10] = 1;
-    //l = 0;
-    //a.find(predicate);
-    //assertEquals(a.length, l);
+    a = new Array(10);
+    l = 0;
+    a.find(predicate);
+    assertEquals(a.length, l);
+
+    a = [];
+    a[10] = 1;
+    l = 0;
+    a.find(predicate);
+    assertEquals(a.length, l);
 })();
 
 

--- a/testsrc/jstests/harmony/array-find.js
+++ b/testsrc/jstests/harmony/array-find.js
@@ -295,11 +295,10 @@ load("testsrc/assert.js");
     assertEquals("b", found);
 
     // Test array itself as thisArg
-    var a = [1, 2];
     var o;
-    // FIXME:
-    //a.find(function () { o = this; }, a);
-    //assertEquals(a, o);
+    var a = [1, 2];
+    a.find(function () { o = this; }, a);
+    assertEquals(a, o);
 })();
 
 // Test exceptions

--- a/testsrc/jstests/harmony/array-findIndex.js
+++ b/testsrc/jstests/harmony/array-findIndex.js
@@ -295,11 +295,10 @@ load("testsrc/assert.js");
     assertEquals(1, found);
 
     // Test array itself as thisArg
-    var a = [1, 2];
     var o;
-    // FIXME:
-    //a.findIndex(function () { o = this; }, a);
-    //assertEquals(a, o);
+    var a = [1, 2];
+    a.findIndex(function () { o = this; }, a);
+    assertEquals(a, o);
 })();
 
 // Test exceptions

--- a/testsrc/jstests/harmony/array-findIndex.js
+++ b/testsrc/jstests/harmony/array-findIndex.js
@@ -105,24 +105,30 @@ load("testsrc/assert.js");
 (function () {
     var a = [1, 2, 3, 4, 5];
     var l = 0;
-    var predicate = function p() {
+    var sawUndefined = false;
+    var predicate = function p(v) {
         l++;
+        sawUndefined = sawUndefined || (v === undefined);
     };
 
     a.findIndex(predicate);
     assertEquals(a.length, l);
+    assertFalse(sawUndefined);
 
     // even for sparse arrays
     a = new Array(10);
     l = 0;
     a.findIndex(predicate);
     assertEquals(a.length, l);
+    assertTrue(sawUndefined);
 
     a = [];
     a[10] = 1;
     l = 0;
+    sawUndefined = false;
     a.findIndex(predicate);
     assertEquals(a.length, l);
+    assertTrue(sawUndefined);
 })();
 
 

--- a/testsrc/jstests/harmony/array-findIndex.js
+++ b/testsrc/jstests/harmony/array-findIndex.js
@@ -42,11 +42,11 @@ load("testsrc/assert.js");
 
     // `InterpretedFunction` or `? extends NativeFunction`
     assertEquals(0, a.findIndex(function () { return true; }));
-    // FIXME:
     // `IdScriptableObject`
-    //assertEquals(0, a.findIndex(Object.prototype.toString));
+    assertEquals(0, a.findIndex(Object.prototype.toString));
+    assertEquals(0, a.findIndex(String));
     // `BoundFunction`
-    //assertEquals(0, a.findIndex((function () { return true; }).bind({})))
+    assertEquals(0, a.findIndex((function () { return true; }).bind({})))
 })();
 
 //

--- a/testsrc/jstests/harmony/array-findIndex.js
+++ b/testsrc/jstests/harmony/array-findIndex.js
@@ -1,27 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 load("testsrc/assert.js");
 
-assertEquals(1, Array.prototype.findIndex.length);
+//
+// Test The length of 'Array.prototype.findIndex' is 1
+// (22.1.3.9)
+(function () {
+    assertEquals(1, Array.prototype.findIndex.length);
+})();
 
-var a = [21, 22, 23, 24];
-assertEquals(-1, a.findIndex(function() { return false; }));
-assertEquals(-1, a.findIndex(function(val) { return 121 === val; }));
-assertEquals(0, a.findIndex(function() { return true; }));
-assertEquals(1, a.findIndex(function(val) { return 22 === val; }), undefined);
-assertEquals(2, a.findIndex(function(val) { return 23 === val; }), null);
-assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
+//
+// Quick check for base cases
+//
+(function () {
+    var a = [21, 22, 23, 24];
 
+    // well, it works
+    assertEquals(0, a.findIndex(function () { return true; }));
+
+    // predicate is called with current value, index and object on which `findIndex()` was called
+    assertEquals(3, a.findIndex(function (val, i, array) { return array === a && i === 3; }));
+
+    // 'this' can be augmented by second optional parameter
+    var thisArg = {};
+    assertEquals(0, a.findIndex(function () { return this === thisArg; }, thisArg));
+
+    // when nothing found, `-1` is returned
+    assertEquals(-1, a.findIndex(function () { return false; }));
+
+    // it is not required to return Boolean, it will be automatically casted
+    assertEquals(2, a.findIndex(function (val) { return (val === a[2] ? "true" : null); }));
+})();
+
+//
+// Test predicate is anything that has [[Call]] internal method
+//
+(function () {
+    var a = [21, 22, 23, 24];
+
+    // `InterpretedFunction` or `? extends NativeFunction`
+    assertEquals(0, a.findIndex(function () { return true; }));
+    // FIXME:
+    // `IdScriptableObject`
+    //assertEquals(0, a.findIndex(Object.prototype.toString));
+    // `BoundFunction`
+    //assertEquals(0, a.findIndex((function () { return true; }).bind({})))
+})();
 
 //
 // Test predicate is not called when array is empty
 //
-(function() {
-    var a = [];
+(function () {
     var l = -1;
     var o = -1;
     var v = -1;
     var k = -1;
 
-    a.findIndex(function(val, key, obj) {
+    [].findIndex(function (val, key, obj) {
         o = obj;
         l = obj.length;
         v = val;
@@ -36,18 +73,17 @@ assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
     assertEquals(-1, k);
 })();
 
-
 //
-// Test predicate is called with correct argumetns
+// Test predicate is called with correct arguments
 //
-(function() {
+(function () {
     var a = ["b"];
     var l = -1;
     var o = -1;
     var v = -1;
     var k = -1;
 
-    var index = a.findIndex(function(val, key, obj) {
+    var found = a.findIndex(function (val, key, obj) {
         o = obj;
         l = obj.length;
         v = val;
@@ -60,37 +96,47 @@ assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
     assertEquals(a.length, l);
     assertEquals("b", v);
     assertEquals(0, k);
-    assertEquals(-1, index);
+    assertEquals(-1, found);
 })();
-
 
 //
 // Test predicate is called array.length times
 //
-(function() {
+(function () {
     var a = [1, 2, 3, 4, 5];
     var l = 0;
-
-    a.findIndex(function() {
+    var predicate = function p() {
         l++;
-        return false;
-    });
+    };
 
+    a.findIndex(predicate);
     assertEquals(a.length, l);
+
+    // even for sparse arrays
+    // FIXME:
+    //a = new Array(10);
+    //l = 0;
+    //a.findIndex(predicate);
+    //assertEquals(a.length, l);
+    //
+    //a = [];
+    //a[10] = 1;
+    //l = 0;
+    //a.findIndex(predicate);
+    //assertEquals(a.length, l);
 })();
 
 
 //
-// Test Array.prototype.findIndex works with String
+// Test Array.prototype.findIndex is generic and works with String
 //
-(function() {
+(function () {
     var a = "abcd";
     var l = -1;
     var o = -1;
     var v = -1;
     var k = -1;
-
-    var index = Array.prototype.findIndex.call(a, function(val, key, obj) {
+    var found = Array.prototype.findIndex.call(a, function (val, key, obj) {
         o = obj.toString();
         l = obj.length;
         v = val;
@@ -103,9 +149,9 @@ assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
     assertEquals(a.length, l);
     assertEquals("d", v);
     assertEquals(3, k);
-    assertEquals(-1, index);
+    assertEquals(-1, found);
 
-    index = Array.prototype.findIndex.apply(a, [function(val, key, obj) {
+    found = Array.prototype.findIndex.apply(a, [function (val, key, obj) {
         o = obj.toString();
         l = obj.length;
         v = val;
@@ -118,14 +164,29 @@ assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
     assertEquals(a.length, l);
     assertEquals("a", v);
     assertEquals(0, k);
-    assertEquals(0, index);
+    assertEquals(0, found);
 })();
 
+//
+// Test Array.prototype.findIndex works with simple arraylike objects
+//
+(function () {
+    var o = {0: 0, 1: 1, 2: 2, length: 3};
+    assertEquals(2, Array.prototype.findIndex.call(o, function (v) { return v == o[2]; }));
+    assertEquals(1, Array.prototype.findIndex.apply(o, [function (v) { return v == o[1]; }]));
+
+    // object without `length` property defined,
+    // behaves as if it has `length` set 0
+    var empty = {0: 0, 1: 1, 2: 2};
+    var called = false;
+    Array.prototype.findIndex.call(empty, function () { called = true; });
+    assertEquals(false, called);
+})();
 
 //
-// Test Array.prototype.findIndex works with exotic object
+// Test Array.prototype.findIndex works with mixed arraylike objects
 //
-(function() {
+(function () {
     var l = -1;
     var o = -1;
     var v = -1;
@@ -133,14 +194,14 @@ assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
     var a = {
         prop1: "val1",
         prop2: "val2",
-        isValid: function() {
+        isValid: function () {
             return this.prop1 === "val1" && this.prop2 === "val2";
-        }
+        },
+        length: 0
     };
 
     Array.prototype.push.apply(a, [30, 31, 32]);
-
-    var index = Array.prototype.findIndex.call(a, function(val, key, obj) {
+    var found = Array.prototype.findIndex.call(a, function (val, key, obj) {
         o = obj;
         l = obj.length;
         v = val;
@@ -153,63 +214,93 @@ assertEquals(3, a.findIndex(function(val) { return 24 === val; }));
     assertEquals(3, l);
     assertEquals(32, v);
     assertEquals(2, k);
-    assertEquals(-1, index);
+    assertEquals(-1, found);
 })();
 
+//
+// Test Array.prototype.findIndex works with arraylike object with getters
+//
+(function () {
+    var count = 0;
+    var a = {get 0() { return count++; }, length: 1};
+    // FIXME: right now, Rhino will get raw getter function
+    //        during iteration and use it as a value passed to predicate
+    //Array.prototype.findIndex.call(a, (function () { return true; }));
+    //assertEquals(1, count);
+})();
+
+//
+// Test Array.prototype.findIndex iteration includes inherited properties
+//
+(function () {
+    var o1 = {0: 0, 1: 1};
+    var o2 = {2: 2, length: 3};
+    // FIXME: use Object.setPrototypeOf instead
+    o2.__proto__ = o1;
+    var a = [];
+    Array.prototype.findIndex.call(o2, function (v) { a.push(v); });
+    assertEquals([0, 1, 2], a);
+    assertEquals(0, Array.prototype.findIndex.call(o2, function () { return true; }));
+})();
 
 //
 // Test array modifications
 //
-(function() {
+(function () {
     var a = [1, 2, 3];
-    a.findIndex(function(val) { a.push(val); return false; });
+    var found = a.findIndex(function (val) {
+        a.push(val);
+        return false;
+    });
     assertArrayEquals([1, 2, 3, 1, 2, 3], a);
     assertEquals(6, a.length);
+    assertEquals(-1, found);
 
     a = [1, 2, 3];
-    a.findIndex(function(val, key) { a[key] = ++val; return false; });
+    found = a.findIndex(function (val, key) {
+        a[key] = ++val;
+        return false;
+    });
     assertArrayEquals([2, 3, 4], a);
     assertEquals(3, a.length);
+    assertEquals(-1, found);
 })();
-
-
-//
-// Test predicate is only called for existing elements
-//
-(function() {
-    var a = new Array(30);
-    a[11] = 21;
-    a[7] = 10;
-    a[29] = 31;
-
-    var count = 0;
-    a.findIndex(function() { count++; return false; });
-    assertEquals(3, count);
-})();
-
 
 //
 // Test thisArg
 //
-(function() {
-//    Test String as a thisArg
-    var index = [1, 2, 3].findIndex(function(val, key) {
+(function () {
+    // If thisArg is not provided, predicate is invoked with this set to `undefined`
+    // FIXME:
+    // var o = -1;
+    //[1,2].findIndex(function () { o = this; });
+    //assertEquals(undefined, o);
+
+    // Test String as a thisArg
+    var found = [1, 2, 3].findIndex(function (val, key) {
         return this.charAt(Number(key)) === String(val);
     }, "321");
-    assertEquals(1, index);
+    assertEquals(1, found);
 
-//    Test object as a thisArg
+    // Test object as a thisArg
     var thisArg = {
-        elementAt: function(key) {
+        elementAt: function (key) {
             return this[key];
         }
     };
     Array.prototype.push.apply(thisArg, ["c", "b", "a"]);
 
-    index = ["a", "b", "c"].findIndex(function(val, key) {
+    found = ["a", "b", "c"].findIndex(function (val, key) {
         return this.elementAt(key) === val;
     }, thisArg);
-    assertEquals(1, index);
+    assertEquals(1, found);
+
+    // Test array itself as thisArg
+    var a = [1, 2];
+    var o;
+    // FIXME:
+    //a.findIndex(function () { o = this; }, a);
+    //assertEquals(a, o);
 })();
 
 // Test exceptions

--- a/testsrc/jstests/harmony/array-findIndex.js
+++ b/testsrc/jstests/harmony/array-findIndex.js
@@ -113,17 +113,16 @@ load("testsrc/assert.js");
     assertEquals(a.length, l);
 
     // even for sparse arrays
-    // FIXME:
-    //a = new Array(10);
-    //l = 0;
-    //a.findIndex(predicate);
-    //assertEquals(a.length, l);
-    //
-    //a = [];
-    //a[10] = 1;
-    //l = 0;
-    //a.findIndex(predicate);
-    //assertEquals(a.length, l);
+    a = new Array(10);
+    l = 0;
+    a.findIndex(predicate);
+    assertEquals(a.length, l);
+
+    a = [];
+    a[10] = 1;
+    l = 0;
+    a.findIndex(predicate);
+    assertEquals(a.length, l);
 })();
 
 


### PR DESCRIPTION
Fixes for apigee/rhino#24

### Done
- Don't skip holes in sparse arrays:
```
var a = [];
a[10] = 1;
var l = 0;
a.find(predicate);
assertEquals(a.length, l);
```
- Allow passing array itself as `thisArg`:
```js
var a = [1, 2];
var o;
a.findIndex(function () { o = this; }, a);
assertEquals(a, o);
```
- Allow passing any instance of Function, but do not allow RegExp-s:
```js
var a = [21, 22, 23, 24];

// `InterpretedFunction` or `? extends NativeFunction`
assertEquals(a[0], a.find(function () { return true; }));
// `IdScriptableObject`
assertEquals(a[0], a.find(Object.prototype.toString));
assertEquals(a[0], a.find(String));
// `BoundFunction`
assertEquals(a[0], a.find((function () { return true; }).bind({})))
// `NativeRegExp`
assertThrows('Array.prototype.findIndex.apply(a, /\d+/)', TypeError);
```

Also, I've updated tests: fixed those that were not in line with latest ES2015 spec (e.g. about iterating over sparse arrays) and added some cases from [Gecko's test suite](https://github.com/mozilla/gecko-dev/blob/5c2f080f015199ee58717612ae931ce0b186adac/js/src/tests/ecma_6/Array/find_findindex.js).

### Not done
I wasn't sure I'd have time to fix these in my short “sprint”, as each of them deserves its own separate issue. Additionally, some will require adding new language version or a flag.

- Allow iterating over objects where numeric properties have custom getter, like this:
```js
var count = 0;
var a = {get 0() { return count++; }, length: 1};
Array.prototype.find.call(a, (function () { return true; }));
```
- When `thisArg` is not passed, `this` inside predicate should be undefined even in non-strict mode:
```js
var o = -1;
[1,2].find(function () { o = this; });
assertEquals(undefined, o);
```
- When called with `thisObj` set to `null` or `undefined`, `TypeError` should be thrown:
```js
assertThrows('Array.prototype.find.call(null, function() { })', TypeError);
assertThrows('Array.prototype.find.call(undefined, function() { })', TypeError);
assertThrows('Array.prototype.find.apply(null, function() { }, [])', TypeError);
assertThrows('Array.prototype.find.apply(undefined, function() { }, [])', TypeError);
```
Right now, when `fn.call(null)` is executed, `this` for `fn` is set to global (as per ES3), but in ES2015 `ToObject()` should be called on whatever was passed as `this` and it will throw on `null` and `undefined` values.

//cc @eshepelyuk