### PR TITLE
Added readline and write functions to Global

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -97,9 +97,11 @@ public class Global extends ImporterTopLevel
             "load",
             "loadClass",
             "print",
+            "write",
             "quit",
             "readFile",
             "readUrl",
+            "readline",
             "runCommand",
             "seal",
             "serialize",
@@ -188,6 +190,24 @@ public class Global extends ImporterTopLevel
                                Object[] args, Function funObj)
     {
         PrintStream out = getInstance(funObj).getOut();
+        write(cx, thisObj, args, funObj);
+        out.println();
+        return Context.getUndefinedValue();
+    }
+    
+    /**
+     * Print the string values of its arguments (without a new line).
+     *
+     * This method is defined as a JavaScript function.
+     * Note that its arguments are of the "varargs" form, which
+     * allows it to handle an arbitrary number of arguments
+     * supplied to the JavaScript function.
+     *
+     */
+    public static Object write(Context cx, Scriptable thisObj,
+                               Object[] args, Function funObj)
+    {
+        PrintStream out = getInstance(funObj).getOut();
         for (int i=0; i < args.length; i++) {
             if (i > 0)
                 out.print(" ");
@@ -197,7 +217,6 @@ public class Global extends ImporterTopLevel
 
             out.print(s);
         }
-        out.println();
         return Context.getUndefinedValue();
     }
 
@@ -779,7 +798,19 @@ public class Global extends ImporterTopLevel
             ((ScriptableObject)arg).sealObject();
         }
     }
-
+    
+    /**
+     * The readline reads one line from the standard input
+     * <p>
+     * Usage:
+     * <pre>
+     * readline()
+     * </pre>
+     */
+     public static Object readline(Context cx, Scriptable thisObj, Object[] args, Function funObj) throws IOException{
+         return new BufferedReader(new InputStreamReader(System.in)).readLine();
+     }
+     
     /**
      * The readFile reads the given file content and convert it to a string
      * using the specified character coding or default character coding if


### PR DESCRIPTION
I played with d8 from v8 chrome javascript engine, played as well with jaegermonkey from mozilla, and they both offer an easy way to interact with the command line.

I was missing a way to print without a newline so added the write function.

I was missing an easy way to ask questions in a command line and added the readline function.

I'm not sure the names are perfect but I chose write and readline so that my scripts are compatible with d8.

