### PR TITLE
Support ES6/ES2015 MethodDefinition

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -1086,6 +1086,9 @@ class CodeGenerator extends Icode {
             } else if (childType == Token.SET) {
                 visitExpression(child.getFirstChild(), 0);
                 addIcode(Icode_LITERAL_SETTER);
+            } else if (childType == Token.METHOD) {
+                visitExpression(child.getFirstChild(), 0);
+                addIcode(Icode_LITERAL_SET);
             } else {
                 visitExpression(child, 0);
                 addIcode(Icode_LITERAL_SET);

--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -323,7 +323,12 @@ public class Decompiler
             switch(source.charAt(i)) {
             case Token.GET:
             case Token.SET:
-                result.append(source.charAt(i) == Token.GET ? "get " : "set ");
+            case Token.METHOD:
+                if (source.charAt(i) == Token.GET) {
+                    result.append("get ");
+                } else if (source.charAt(i) == Token.SET) {
+                    result.append("set ");
+                }
                 ++i;
                 i = printSourceString(source, i + 1, false, result);
                 // Now increment one more to get past the FUNCTION token

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -854,25 +854,29 @@ public final class IRFactory extends Parser
             int size = elems.size(), i = 0;
             properties = new Object[size];
             for (ObjectProperty prop : elems) {
-                if (prop.isGetter()) {
+                if (prop.isGetterMethod()) {
                     decompiler.addToken(Token.GET);
-                } else if (prop.isSetter()) {
+                } else if (prop.isSetterMethod()) {
                     decompiler.addToken(Token.SET);
+                } else if (prop.isNormalMethod()) {
+                    decompiler.addToken(Token.METHOD);
                 }
 
                 properties[i++] = getPropKey(prop.getLeft());
 
                 // OBJECTLIT is used as ':' in object literal for
                 // decompilation to solve spacing ambiguity.
-                if (!(prop.isGetter() || prop.isSetter())) {
+                if (!(prop.isMethod())) {
                     decompiler.addToken(Token.OBJECTLIT);
                 }
 
                 Node right = transform(prop.getRight());
-                if (prop.isGetter()) {
+                if (prop.isGetterMethod()) {
                     right = createUnary(Token.GET, right);
-                } else if (prop.isSetter()) {
+                } else if (prop.isSetterMethod()) {
                     right = createUnary(Token.SET, right);
+                } else if (prop.isNormalMethod()) {
+                    right = createUnary(Token.METHOD, right);
                 }
                 object.addChildToBack(right);
 

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3221,12 +3221,12 @@ public class Parser
                           && peeked != Token.COLON
                           && peeked != Token.RC)
                   {
-                      if ("get".equals(propertyName)) {
+                      if (peeked == Token.LP) {
+                          entryKind = METHOD_ENTRY;
+                      } else if ("get".equals(propertyName)) {
                           entryKind = GET_ENTRY;
                       } else if ("set".equals(propertyName)) {
                           entryKind = SET_ENTRY;
-                      } else {
-                          entryKind = METHOD_ENTRY;
                       }
                       AstNode pname;
                       if (entryKind == METHOD_ENTRY) {

--- a/src/org/mozilla/javascript/Token.java
+++ b/src/org/mozilla/javascript/Token.java
@@ -228,7 +228,8 @@ public class Token
         DEBUGGER       = 160,
         COMMENT        = 161,
         GENEXPR        = 162,
-        LAST_TOKEN     = 163;
+        METHOD         = 163,  // ES6 MethodDefinition
+        LAST_TOKEN     = 164;
 
     /**
      * Returns a name for the token.  If Rhino is compiled with certain
@@ -413,6 +414,7 @@ public class Token
           case DEBUGGER:        return "DEBUGGER";
           case COMMENT:         return "COMMENT";
           case GENEXPR:         return "GENEXPR";
+          case METHOD:          return "METHOD";
         }
 
         // Token without name

--- a/src/org/mozilla/javascript/ast/FunctionNode.java
+++ b/src/org/mozilla/javascript/ast/FunctionNode.java
@@ -64,7 +64,7 @@ public class FunctionNode extends ScriptNode {
     public static final int FUNCTION_EXPRESSION           = 2;
     public static final int FUNCTION_EXPRESSION_STATEMENT = 3;
 
-    public static enum Form { FUNCTION, GETTER, SETTER }
+    public static enum Form { FUNCTION, GETTER, SETTER, METHOD }
 
     private static final List<AstNode> NO_PARAMS =
         Collections.unmodifiableList(new ArrayList<AstNode>());
@@ -325,24 +325,32 @@ public class FunctionNode extends ScriptNode {
         functionType = type;
     }
 
-    public boolean isGetterOrSetter() {
-        return functionForm == Form.GETTER || functionForm == Form.SETTER;
+    public boolean isMethod() {
+        return functionForm == Form.GETTER || functionForm == Form.SETTER || functionForm == Form.METHOD;
     }
 
-    public boolean isGetter() {
+    public boolean isGetterMethod() {
         return functionForm == Form.GETTER;
     }
 
-    public boolean isSetter() {
+    public boolean isSetterMethod() {
         return functionForm == Form.SETTER;
     }
 
-    public void setFunctionIsGetter() {
+    public boolean isNormalMethod() {
+        return functionForm == Form.METHOD;
+    }
+
+    public void setFunctionIsGetterMethod() {
         functionForm = Form.GETTER;
     }
 
-    public void setFunctionIsSetter() {
+    public void setFunctionIsSetterMethod() {
         functionForm = Form.SETTER;
+    }
+
+    public void setFunctionIsNormalMethod() {
+        functionForm = Form.METHOD;
     }
 
     /**
@@ -368,7 +376,7 @@ public class FunctionNode extends ScriptNode {
     @Override
     public String toSource(int depth) {
         StringBuilder sb = new StringBuilder();
-        if (!isGetterOrSetter()) {
+        if (!isMethod()) {
             sb.append(makeIndent(depth));
             sb.append("function");
         }
@@ -400,7 +408,7 @@ public class FunctionNode extends ScriptNode {
         } else {
             sb.append(getBody().toSource(depth).trim());
         }
-        if (functionType == FUNCTION_STATEMENT || isGetterOrSetter()) {
+        if (functionType == FUNCTION_STATEMENT || isMethod()) {
             sb.append("\n");
         }
         return sb.toString();

--- a/src/org/mozilla/javascript/ast/ObjectProperty.java
+++ b/src/org/mozilla/javascript/ast/ObjectProperty.java
@@ -44,7 +44,8 @@ public class ObjectProperty extends InfixExpression {
     public void setNodeType(int nodeType) {
         if (nodeType != Token.COLON
             && nodeType != Token.GET
-            && nodeType != Token.SET)
+            && nodeType != Token.SET
+            && nodeType != Token.METHOD)
             throw new IllegalArgumentException("invalid node type: "
                                                + nodeType);
         setType(nodeType);
@@ -64,29 +65,41 @@ public class ObjectProperty extends InfixExpression {
     /**
      * Marks this node as a "getter" property.
      */
-    public void setIsGetter() {
+    public void setIsGetterMethod() {
         type = Token.GET;
     }
 
     /**
      * Returns true if this is a getter function.
      */
-    public boolean isGetter() {
+    public boolean isGetterMethod() {
         return type == Token.GET;
     }
 
     /**
      * Marks this node as a "setter" property.
      */
-    public void setIsSetter() {
+    public void setIsSetterMethod() {
         type = Token.SET;
     }
 
     /**
      * Returns true if this is a setter function.
      */
-    public boolean isSetter() {
+    public boolean isSetterMethod() {
         return type == Token.SET;
+    }
+
+    public void setIsNormalMethod() {
+        type = Token.METHOD;
+    }
+
+    public boolean isNormalMethod() {
+        return type == Token.METHOD;
+    }
+
+    public boolean isMethod() {
+        return isGetterMethod() || isSetterMethod() || isNormalMethod();
     }
 
     @Override
@@ -94,9 +107,9 @@ public class ObjectProperty extends InfixExpression {
         StringBuilder sb = new StringBuilder();
         sb.append("\n");
         sb.append(makeIndent(depth+1));
-        if (isGetter()) {
+        if (isGetterMethod()) {
             sb.append("get ");
-        } else if (isSetter()) {
+        } else if (isSetterMethod()) {
             sb.append("set ");
         }
         sb.append(left.toSource(getType()==Token.COLON ? 0 : depth));

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -3151,7 +3151,7 @@ class BodyCodegen
             // see bug 757410 for an explanation why we need to split this
             for (int i = 0; i != count; ++i) {
                 int childType = child.getType();
-                if (childType == Token.GET || childType == Token.SET) {
+                if (childType == Token.GET || childType == Token.SET || childType == Token.METHOD) {
                     generateExpression(child.getFirstChild(), node);
                 } else {
                     generateExpression(child, node);
@@ -3173,7 +3173,7 @@ class BodyCodegen
                 cfw.add(ByteCode.DUP);
                 cfw.addPush(i);
                 int childType = child2.getType();
-                if (childType == Token.GET || childType == Token.SET) {
+                if (childType == Token.GET || childType == Token.SET || childType == Token.METHOD) {
                     generateExpression(child2.getFirstChild(), node);
                 } else {
                     generateExpression(child2, node);

--- a/testsrc/jstests/harmony/method-definition.js
+++ b/testsrc/jstests/harmony/method-definition.js
@@ -19,6 +19,18 @@ assertEquals("abcefg", {
   }
 }.efg());
 
+assertEquals(123, {
+  get() {
+    return 123;
+  }
+}.get());
+
+assertEquals(123, {
+  set() {
+    return 123;
+  }
+}.set());
+
 assertEquals("\n" +
 "function () {\n" +
 "    +{f() {\n" +

--- a/testsrc/jstests/harmony/method-definition.js
+++ b/testsrc/jstests/harmony/method-definition.js
@@ -39,33 +39,36 @@ assertEquals("\n" +
 "}\n", (function() { +{ f() { print(1); }}; }).toString());
 
 // Allow reserved word
-// assertEquals(123, {
-//   if() {
-//     return 123;
-//   }
-// }.a());
+assertEquals(123, {
+  if() {
+    return 123;
+  }
+}.if());
 
 // Allow NumericLiteral
-// assertEquals(123, {
-//   123() {
-//     return 123;
-//   }
-// }[123]());
+assertEquals(123, {
+  123() {
+    return 123;
+  }
+}[123]());
 
 // Allow StringLiteral
-// assertEquals(123, {
-//   'abc'() {
-//     return 123;
-//   }
-// }.abc());
+assertEquals(123, {
+  'abc'() {
+    return 123;
+  }
+}.abc());
 
 // Method is the kind of function, that is non-constructor.
 // assertThrows('new (({ a() {} }).a)', TypeError);
 
-// assertEquals(, Object.getOwnPropertyDescriptor({
-//   a() {
-//     return 123;
-//   }
-// }, 'a'));
+var desc = Object.getOwnPropertyDescriptor({
+  a() {
+    return 123;
+  }
+}, 'a');
+assertEquals(true, desc.writable);
+assertEquals(true, desc.enumerable);
+assertEquals(true, desc.configurable);
 
 "success";

--- a/testsrc/jstests/harmony/method-definition.js
+++ b/testsrc/jstests/harmony/method-definition.js
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+assertEquals(123, {
+  a() {
+    return 123;
+  }
+}.a());
+
+assertEquals("abcefg", {
+  abc() {
+    return "abc";
+  },
+  efg() {
+    return this.abc() + "efg";
+  }
+}.efg());
+
+assertEquals("\n" +
+"function () {\n" +
+"    +{f() {\n" +
+"        print(1);\n" +
+"    }};\n" +
+"}\n", (function() { +{ f() { print(1); }}; }).toString());
+
+// Allow reserved word
+// assertEquals(123, {
+//   if() {
+//     return 123;
+//   }
+// }.a());
+
+// Allow NumericLiteral
+// assertEquals(123, {
+//   123() {
+//     return 123;
+//   }
+// }[123]());
+
+// Allow StringLiteral
+// assertEquals(123, {
+//   'abc'() {
+//     return 123;
+//   }
+// }.abc());
+
+// Method is the kind of function, that is non-constructor.
+// assertThrows('new (({ a() {} }).a)', TypeError);
+
+// assertEquals(, Object.getOwnPropertyDescriptor({
+//   a() {
+//     return 123;
+//   }
+// }, 'a'));
+
+"success";

--- a/testsrc/jstests/harmony/method-definition.js
+++ b/testsrc/jstests/harmony/method-definition.js
@@ -4,11 +4,15 @@
 
 load("testsrc/assert.js");
 
-assertEquals(123, {
+var obj;
+
+obj = {
   a() {
     return 123;
   }
-}.a());
+};
+assertEquals(123, obj.a());
+// assertEquals("a", obj.a.name);
 
 assertEquals("abcefg", {
   abc() {
@@ -19,17 +23,21 @@ assertEquals("abcefg", {
   }
 }.efg());
 
-assertEquals(123, {
+obj = {
   get() {
     return 123;
   }
-}.get());
+};
+assertEquals(123, obj.get());
+// assertEquals("get", obj.get.name);
 
-assertEquals(123, {
+obj = {
   set() {
     return 123;
   }
-}.set());
+};
+assertEquals(123, obj.set());
+// assertEquals("set", obj.set.name);
 
 assertEquals("\n" +
 "function () {\n" +

--- a/testsrc/org/mozilla/javascript/tests/harmony/MethodDefinitionTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/MethodDefinitionTest.java
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/method-definition.js")
+public class MethodDefinitionTest extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
This patch is not implemented this specifications. (I've see ecma-262_6th_edition_final_draft_-04-14-15.pdf).

# non-constructor

```js
assertThrows('new (({ a() {} }).a)', TypeError);
```

> 14.3.8 Runtime Semantics: DefineMethod
>  5. If functionPrototype was passed as a parameter, let kind be Normal; otherwise let kind be Method.

> 9.2.5 FunctionCreate (kind, ParameterList, Body, Scope, Strict, prototype)
>  2. If kind is not Normal, let allocKind be "non-constructor".

# function name property

```js
assertEquals("a", { a() {} }.a.name);
```

> 12.2.6.9 Runtime Semantics: PropertyDefinitionEvaluation
>  6. If IsAnonymousFunctionDefinition(AssignmentExpression) is true, then
>   c. If hasNameProperty is false, perform SetFunctionName(propValue, propKey).

# computed property

```js
assertEquals(123, {
  ['abc' + 'efg']() {
    return 123;
  }
}.abcefg());
```
