### PR TITLE
Update .gitignore for eclipse generated files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ target/
 
 
 *~
+
+# eclipse
+.classpath
+.project


### PR DESCRIPTION
Eclipse automatically generates .classpath and .project files, which should not be committed by default, this change adds them to .gitignore.