### PR TITLE
Naive ES6 symbol implementation

### DIFF
--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -10,6 +10,7 @@ public class NativeSymbol extends IdScriptableObject {
 
     public static final String SPECIES_PROPERTY = "@@species";
     public static final String ITERATOR_PROPERTY = "@@iterator";
+    public static final String TO_STRING_TAG_PROPERTY = "@@toStringTag";
 
     public static final String CLASS_NAME = "Symbol";
 
@@ -31,6 +32,7 @@ public class NativeSymbol extends IdScriptableObject {
         super.fillConstructorProperties(ctor);
         ctor.defineProperty("iterator", ITERATOR_PROPERTY, DONTENUM | READONLY | PERMANENT);
         ctor.defineProperty("species", SPECIES_PROPERTY, DONTENUM | READONLY | PERMANENT);
+        ctor.defineProperty("toStringTag", TO_STRING_TAG_PROPERTY, DONTENUM | READONLY | PERMANENT);
     }
 
     // #string_id_map#

--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -1,0 +1,81 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+public class NativeSymbol extends IdScriptableObject {
+
+    private static Object ITERATOR = new Object();
+
+    public static final String CLASS_NAME = "Symbol";
+
+    public static void init(Context cx, Scriptable scope, boolean sealed) {
+        NativeSymbol obj = new NativeSymbol();
+        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+    }
+
+    private NativeSymbol() {
+    }
+
+    @Override
+    public String getClassName() {
+        return CLASS_NAME;
+    }
+
+    @Override
+    protected void fillConstructorProperties(IdFunctionObject ctor) {
+        super.fillConstructorProperties(ctor);
+        ctor.defineProperty("iterator", ITERATOR, DONTENUM | READONLY | PERMANENT);
+    }
+
+    // #string_id_map#
+
+    @Override
+    protected int findPrototypeId(String s) {
+        int id = 0;
+// #generated# Last update: 2015-06-07 10:40:05 EEST
+        L0: { id = 0; String X = null;
+            if (s.length()==11) { X="constructor";id=Id_constructor; }
+            if (X!=null && X!=s && !X.equals(s)) id = 0;
+            break L0;
+        }
+// #/generated#
+        return id;
+    }
+
+    private static final int
+        Id_constructor          = 1,
+        MAX_PROTOTYPE_ID        = Id_constructor;
+
+    // #/string_id_map#
+
+
+    @Override
+    protected void initPrototypeId(int id)
+    {
+        String s = null;
+        int arity = -1;
+        switch (id) {
+            case Id_constructor:        arity = 0; s = "constructor"; break;
+            default:                    super.initPrototypeId(id);
+        }
+        initPrototypeMethod(CLASS_NAME, id, s, arity);
+    }
+
+    @Override
+    public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!f.hasTag(CLASS_NAME)) {
+            return super.execIdCall(f, cx, scope, thisObj, args);
+        }
+        int id = f.methodId();
+        switch (id) {
+            case Id_constructor:
+                return new NativeSymbol();
+        }
+        return super.execIdCall(f, cx, scope, thisObj, args);
+
+    }
+}

--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -8,7 +8,8 @@ package org.mozilla.javascript;
 
 public class NativeSymbol extends IdScriptableObject {
 
-    private static Object ITERATOR = new Object();
+    public static final String SPECIES_PROPERTY = "@@species";
+    public static final String ITERATOR_PROPERTY = "@@iterator";
 
     public static final String CLASS_NAME = "Symbol";
 
@@ -28,7 +29,8 @@ public class NativeSymbol extends IdScriptableObject {
     @Override
     protected void fillConstructorProperties(IdFunctionObject ctor) {
         super.fillConstructorProperties(ctor);
-        ctor.defineProperty("iterator", ITERATOR, DONTENUM | READONLY | PERMANENT);
+        ctor.defineProperty("iterator", ITERATOR_PROPERTY, DONTENUM | READONLY | PERMANENT);
+        ctor.defineProperty("species", SPECIES_PROPERTY, DONTENUM | READONLY | PERMANENT);
     }
 
     // #string_id_map#

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -253,6 +253,14 @@ public class ScriptRuntime {
                                  "org.mozilla.javascript.typedarrays.NativeDataView",
                                  sealed, true);
         }
+
+        if (cx.getLanguageVersion() >= Context.VERSION_1_8) {
+            new LazilyLoadedCtor(scope, NativeSymbol.CLASS_NAME,
+                NativeSymbol.class.getName(),
+                sealed, true);
+
+        }
+
      
         if (scope instanceof TopLevel) {
             ((TopLevel)scope).cacheBuiltins();

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -254,7 +254,7 @@ public class ScriptRuntime {
                                  sealed, true);
         }
 
-        if (cx.getLanguageVersion() >= Context.VERSION_1_8) {
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             new LazilyLoadedCtor(scope, NativeSymbol.CLASS_NAME,
                 NativeSymbol.class.getName(),
                 sealed, true);

--- a/testsrc/jstests/harmony/symbols.js
+++ b/testsrc/jstests/harmony/symbols.js
@@ -1,0 +1,21 @@
+load("testsrc/assert.js");
+
+assertTrue(Symbol.iterator !== undefined);
+let desc = Object.getOwnPropertyDescriptor(Symbol, "iterator");
+assertFalse(desc.writable);
+assertFalse(desc.configurable);
+assertFalse(desc.enumerable);
+
+assertTrue(Symbol.toStringTag !== undefined);
+desc = Object.getOwnPropertyDescriptor(Symbol, "toStringTag");
+assertFalse(desc.writable);
+assertFalse(desc.configurable);
+assertFalse(desc.enumerable);
+
+assertTrue(Symbol.species !== undefined);
+desc = Object.getOwnPropertyDescriptor(Symbol, "species");
+assertFalse(desc.writable);
+assertFalse(desc.configurable);
+assertFalse(desc.enumerable);
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
@@ -8,7 +8,7 @@ import org.mozilla.javascript.drivers.RhinoTest;
 import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 @RhinoTest(
-    inline = "print(Symbol.iterator);\n"
+    inline = "assertNotNull(Symbol.iterator);\n"
 )
 public class SymbolTest extends ScriptTestsBase
 {

--- a/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest(
+    inline = "print(Symbol.iterator);\n"
+)
+public class SymbolTest extends ScriptTestsBase
+{
+}

--- a/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
@@ -4,10 +4,13 @@
 
 package org.mozilla.javascript.tests.harmony;
 
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
 import org.mozilla.javascript.drivers.RhinoTest;
 import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 @RhinoTest("testsrc/jstests/harmony/symbols.js")
+@LanguageVersion(Context.VERSION_ES6)
 public class SymbolTest extends ScriptTestsBase
 {
 }

--- a/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/SymbolTest.java
@@ -7,9 +7,7 @@ package org.mozilla.javascript.tests.harmony;
 import org.mozilla.javascript.drivers.RhinoTest;
 import org.mozilla.javascript.drivers.ScriptTestsBase;
 
-@RhinoTest(
-    inline = "assertNotNull(Symbol.iterator);\n"
-)
+@RhinoTest("testsrc/jstests/harmony/symbols.js")
 public class SymbolTest extends ScriptTestsBase
 {
 }


### PR DESCRIPTION
This is just a naive `Symbol` implementation not intended to resolve #161 
Instead this PR can be helpful to unblock implementing other ES6 related features because reduces number of failed assertions while running `test262` test suite.