### PR TITLE
Fix 'Test262SuiteTest#test262()' to not expect any return value

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -197,6 +197,6 @@ public class Test262SuiteTest {
 
     @Test
     public void test262() throws Exception {
-        assertNotNull(executeRhinoScript());
+        executeRhinoScript();
     }
 }


### PR DESCRIPTION
Some of the test262 test files end with the `if` statement, that doesn't produce any return value, and such files were considered failing even if all assertions passed.

For example, see test [`Array/prototype/join/S15.4.4.5_A2_T1.js`](https://github.com/tc39/test262/blob/master/test/built-ins/Array/prototype/join/S15.4.4.5_A2_T1.js#L46).

Every actual test failure will result in exception thrown, so it should be safe.

//cc @eshepelyuk 