### PR TITLE
Make array literal construction always set own properties of instance

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3804,7 +3804,7 @@ public class ScriptRuntime {
                 ++skip;
                 continue;
             }
-            ScriptableObject.putProperty(array, i, objects[j]);
+            array.put(i, array, objects[j]);
             ++j;
         }
         return array;

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -12,3 +12,5 @@ built-ins/String
     ! prototype/trim/15.5.4.20-1-2.js
     ! raw/special-characters.js
     ! raw/zero-literal-segments.js
+
+built-ins/Array/prototype/concat/15.4.4.4-5-b-iii-3-b-1.js


### PR DESCRIPTION
When new array created with array literal, previously we would create an array instance and call `ScriptableObject.putProperty()` for each defined element of array. That contradicts the spec that requires implementation to always set own property of newly created array instance, even when [[Set]], because of its recursive traversal nature, would update property on `Array.prototype`.

Consider the case, when `Array.prototype` has "0" property defined, with `writable` property set to `false` in its descriptor:
```js
    Object.defineProperty(Array.prototype, "0", {
        value: 10,
        configurable: true,
        enumerable: false,
        writable: false
    });
```
Now, all arrays that do not have "0" property defined, in [[Get]] would find a prototype property and return its value:

```js
    [][0]
    //> 10
```

But what's worse, when new array is created and it 1st element set to provided value, because `writable` property of its descriptor is `false`, `putProperty()` will not update the value:

```js
    [123][0]
    //> 10
```

This fix, ensures that when new array instance created from literal, only its own property will be set.

Also test262's [`Array/prototype/concat/15.4.4.4-5-b-iii-3-b-1.js`](https://github.com/tc39/test262/blob/master/test/built-ins/Array/prototype/concat/15.4.4.4-5-b-iii-3-b-1.js) now passes.