### PR TITLE
Apply a argument for error message.

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -253,7 +253,7 @@ public class Parser
     void reportError(String messageId, String messageArg, int position,
                      int length)
     {
-        addError(messageId, position, length);
+        addError(messageId, messageArg, position, length);
 
         if (!compilerEnv.recoverFromErrors()) {
             throw new ParserException();

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1183,6 +1183,11 @@ public class ParserTest extends TestCase {
       parse("({import:1}).import;");
     }
 
+    public void testReportError() {
+      expectParseErrors("'use strict';(function(eval) {})();",
+                        new String[] { "\"eval\" is not a valid identifier for this use in strict mode." });
+    }
+
     private void expectParseErrors(String string, String [] errors) {
       parse(string, errors, null, false);
     }


### PR DESCRIPTION
```
js> 'use strict';(function(eval) {})();
js: "<stdin>", line 6: "{0}" is not a valid identifier for this use in strict mode.
```