### PR TITLE
Fix AST toSource emission for ES6 arrow function

### DIFF
--- a/src/org/mozilla/javascript/ast/FunctionNode.java
+++ b/src/org/mozilla/javascript/ast/FunctionNode.java
@@ -377,15 +377,17 @@ public class FunctionNode extends ScriptNode {
     @Override
     public String toSource(int depth) {
         StringBuilder sb = new StringBuilder();
+        boolean isArrow = functionType == ARROW_FUNCTION;
         if (!isMethod()) {
             sb.append(makeIndent(depth));
-            sb.append("function");
+            if (!isArrow) {
+                sb.append("function");
+            }
         }
         if (functionName != null) {
             sb.append(" ");
             sb.append(functionName.toSource(0));
         }
-        boolean isArrow = functionType == ARROW_FUNCTION;
         if (params == null) {
             sb.append("() ");
         } else if (isArrow && lp == -1) {

--- a/testsrc/org/mozilla/javascript/tests/harmony/ToSourceTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/ToSourceTest.java
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.ast.AstRoot;
+
+
+public class ToSourceTest {
+
+  private void assertSource(String source, String expectedOutput) {
+    CompilerEnvirons env = new CompilerEnvirons();
+    env.setLanguageVersion(Context.VERSION_ES6);
+    Parser parser = new Parser(env);
+    AstRoot root = parser.parse(source, null, 0);
+    Assert.assertEquals(expectedOutput, root.toSource());
+  }
+
+
+  /**
+   * Tests that var declaration AST nodes is properly decompiled.
+   */
+  @Test
+  public void testArrowFunctionToSource() {
+    assertSource("var a3 = a.map(s => s.length);", "var a3 = a.map(s => s.length);\n");
+  }
+
+}


### PR DESCRIPTION
Minor adjustment to https://github.com/mozilla/rhino/pull/120. Please double check.