### PR TITLE
Conversion of JSObject gives priority to Map than Interface implementation.

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -362,9 +362,13 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
                 }
             }
             else if (to.isInterface()) {
-                if (fromObj instanceof NativeObject || fromObj instanceof NativeFunction) {
+
+                if (fromObj instanceof NativeFunction) {
                     // See comments in createInterfaceAdapter
                     return 1;
+                }
+                if (fromObj instanceof NativeObject) {
+                    return 2;
                 }
                 return 12;
             }

--- a/testsrc/org/mozilla/javascript/tests/OverloadTest.java
+++ b/testsrc/org/mozilla/javascript/tests/OverloadTest.java
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ *
+ */
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextAction;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.Scriptable;
+
+public class OverloadTest {
+
+    public static String x(Collection<String> x) {
+        return "collection";
+    }
+    public static String x(Map<String, String> x) {
+        return "map";
+    }
+    public static String x(Runnable r) {
+        return "runnable";
+    }
+
+
+    @Test
+    public void testJSObjectToMap() {
+        assertEvaluates("map", "String(org.mozilla.javascript.tests.OverloadTest.x({}));");
+        assertEvaluates("map", "String(org.mozilla.javascript.tests.OverloadTest.x({ run: function() {} }));");
+    }
+
+    @Test
+    public void testJSArrayToCollection() {
+        assertEvaluates("collection", "String(org.mozilla.javascript.tests.OverloadTest.x([]));");
+    }
+
+    @Test
+    public void testJSFunctionToInterface() {
+        assertThrows(EvaluatorException.class, "String(org.mozilla.javascript.tests.OverloadTest.x(function() {}));");
+    }
+
+    private void assertEvaluates(final Object expected, final String source) {
+        final ContextAction action = new ContextAction() {
+            public Object run(Context cx) {
+                final Scriptable scope = cx.initStandardObjects();
+                final Object rep = cx.evaluateString(scope, source, "test.js",
+                        0, null);
+                assertEquals(expected, rep);
+                return null;
+            }
+        };
+        Utils.runWithAllOptimizationLevels(action);
+    }
+
+    private void assertThrows(final Class<? extends Exception> exceptionClass, final String source) {
+        final ContextAction action = new ContextAction() {
+            public Object run(Context cx) {
+                final Scriptable scope = cx.initStandardObjects();
+                try {
+                    cx.evaluateString(scope, source, "test.js", 0, null);
+                    fail("Did not throw exception");
+                } catch (Exception e) {
+                    assertTrue(exceptionClass.isInstance(e));
+                }
+                return null;
+            }
+        };
+        Utils.runWithAllOptimizationLevels(action);
+    }
+ }


### PR DESCRIPTION
```java
public class Overload {
    public static String x(Collection<String> x) {
        return "collection";
    }
    public static String x(Map<String, String> x) {
        return "map";
    }
}
```
Rhino 1.7R3
```
js> Packages.Overload.x([])
collection
js> Packages.Overload.x({})
map
```
1.7R4 or later
```
js> Packages.Overload.x([])
collection
js> Packages.Overload.x({})
js: The choice of Java method Overload.x matching JavaScript argument types (object) is ambiguous; candidate methods are: 
    class java.lang.String x(java.util.Collection)
    class java.lang.String x(java.util.Map)
```
The cause is this commit.
https://github.com/mozilla/rhino/commit/3e83f18588cda4fe6701ba388afd3d99b5849d53#diff-b08a68e60375aeef7bb378b20d93ea93L400

Conversion to Map is same priority as Interface implementation.