### PR TITLE
Force UTF-8 encoding for test JS files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ test {
     systemProperty 'user.language', 'en'
     systemProperty 'user.country', 'US'
     systemProperty 'user.timezone', 'America/Los_Angeles'
+    systemProperty 'file.encoding', 'UTF-8'
     maxHeapSize = "256m"
     testLogging.showStandardStreams = true
     ignoreFailures = true
@@ -61,6 +62,7 @@ test {
 task testBenchmark(type: Test) {
     include "**/benchmarks/*Benchmark*"
     systemProperty 'rhino.benchmark.report', "${buildDir.absolutePath}"
+    systemProperty 'file.encoding', 'UTF-8'
     workingDir = file("testsrc/benchmarks")
     maxHeapSize = "256m"
     testLogging.showStandardStreams = true

--- a/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -12,10 +12,7 @@ import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.*;
 
 import static org.junit.Assert.*;
 
@@ -45,7 +42,7 @@ public abstract class ScriptTestsBase {
         Context cx = Context.enter();
         try {
             if (!"".equals(anno.value())) {
-                script = new FileReader(anno.value());
+                script = new InputStreamReader(new FileInputStream(anno.value()), "UTF-8");
                 suiteName = anno.value();
             } else if (!"".equals(anno.inline())) {
                 script = new StringReader("load('testsrc/assert.js');\n" + anno.inline() + "\n" + "'success';");


### PR DESCRIPTION
When default system encoding is used - some tests can fail because they contain UTF-8 characters.
This PR forces UTF-8 encoding for test input files.