### PR TITLE
Make Object.prototype.toString behavior to conform to ECMA-262 15.2.4.2

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -842,6 +842,10 @@ public class ScriptRuntime {
 
     static String defaultObjectToString(Scriptable obj)
     {
+        if (obj == null)
+            return "[object Null]";
+        if (Undefined.isUndefined(obj))
+            return "[object Undefined]";
         return "[object " + obj.getClassName() + ']';
     }
 

--- a/testsrc/org/mozilla/javascript/tests/es5/ObjectToStringNullUndefinedTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es5/ObjectToStringNullUndefinedTest.java
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Tests for Object.prototype.toString.call(...) on null & undefined
+ */
+package org.mozilla.javascript.tests.es5;
+
+import org.junit.After;
+import org.junit.Before;
+import org.mozilla.javascript.*;
+
+import static org.mozilla.javascript.tests.Evaluator.eval;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ObjectToStringNullUndefinedTest {
+    private Context cx;
+    private ScriptableObject scope;
+
+    @Before
+    public void setUp() {
+        cx = Context.enter();
+        cx.setLanguageVersion(200);
+        scope = cx.initStandardObjects();
+    }
+
+    @After
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void testToStringNullUndefined() {
+        Object result0 = cx.evaluateString(
+                scope, "Object.prototype.toString.call(null)",
+                "15.2.4.2", 1, null
+        );
+        assertEquals("[object Null]", result0);
+
+        Object result1 = cx.evaluateString(
+                scope, "Object.prototype.toString.call(undefined)",
+                "15.2.4.2", 1, null
+        );
+        assertEquals("[object Undefined]", result1);
+    }
+}


### PR DESCRIPTION
Object.prototype.toString.call(null) should return [object Null]
Object.prototype.toString.call(undefined) should return [object Undefined]

Fixes #233