### PR TITLE
Fixed bug when repeated an empty string MAX_INT times

### DIFF
--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -475,7 +475,7 @@ final class NativeString extends IdScriptableObject
 
                     long size = str.length() * (long) cnt;
                     // Check for overflow
-                    if (cnt >= Integer.MAX_VALUE || size >= Integer.MAX_VALUE) {
+                    if (cnt > Integer.MAX_VALUE || size > Integer.MAX_VALUE) {
                         size = Integer.MAX_VALUE;
                     }
 

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -487,7 +487,9 @@ final class NativeString extends IdScriptableObject
                         retval.append(retval);
                         i *= 2;
                     }
-                    while (i++ < cnt) retval.append(str);
+                    if (i < cnt) {
+                        retval.append(retval.substring(0, str.length() * (int)(cnt - i)));
+                    }
 
                     return retval.toString();
                 }

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -467,11 +467,11 @@ final class NativeString extends IdScriptableObject
                     String str = ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, f));
                     double cnt = ScriptRuntime.toInteger(args, 0);
 
-                    if (cnt == 0) {
+                    if (cnt < 0 || cnt == Double.POSITIVE_INFINITY) throw rangeError("Invalid count value");
+
+                    if (cnt == 0 || str.length() == 0) {
                         return "";
                     }
-
-                    if (cnt < 0 || cnt == Double.POSITIVE_INFINITY) throw rangeError("Invalid count value");
 
                     long size = str.length() * (long) cnt;
                     // Check for overflow

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -476,7 +476,7 @@ final class NativeString extends IdScriptableObject
                     long size = str.length() * (long) cnt;
                     // Check for overflow
                     if (cnt > Integer.MAX_VALUE || size > Integer.MAX_VALUE) {
-                        size = Integer.MAX_VALUE;
+                        throw rangeError("Size too large");
                     }
 
                     StringBuilder retval = new StringBuilder((int) size);

--- a/testsrc/jstests/harmony/string-repeat.js
+++ b/testsrc/jstests/harmony/string-repeat.js
@@ -69,8 +69,8 @@ assertThrows('"a".repeat(Number.POSITIVE_INFINITY)', RangeError);
 assertThrows('"a".repeat(Infinity)', RangeError);
 assertThrows('"a".repeat(+Infinity)', RangeError);
 
-//assertThrows('"a".repeat(Math.pow(2, 30))', RangeError);
-//assertThrows('"a".repeat(Math.pow(2, 40))', RangeError);
+assertThrows('"a".repeat(Math.pow(2, 32))', RangeError);
+assertThrows('"a".repeat(Math.pow(2, 40))', RangeError);
 
 var myobj = {
   toString: function() {

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -8,15 +8,14 @@ built-ins/String
     ! prototype/substring/S15.5.4.15_A1_T5.js
     ! raw
     ! fromCodePoint
-    ! predicate-call-this-strict
-	! prototype/Symbol.iterator/this-val-non-obj-coercible.js
-	! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
-	! prototype/includes/return-abrupt-from-searchstring-regexp-test.js
-	! prototype/includes/return-true-if-searchstring-is-empty.js
-	! prototype/normalize/return-normalized-string-using-default-parameter.js
-	! prototype/replace/cstm-replace-get-err.js
-	! prototype/replace/cstm-replace-invocation.js
-	! prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
+    ! prototype/Symbol.iterator/this-val-non-obj-coercible.js
+    ! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
+    ! prototype/includes/return-abrupt-from-searchstring-regexp-test.js
+    ! prototype/includes/return-true-if-searchstring-is-empty.js
+    ! prototype/normalize/return-normalized-string-using-default-parameter.js
+    ! prototype/replace/cstm-replace-get-err.js
+    ! prototype/replace/cstm-replace-invocation.js
+    ! prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
     ! prototype/toLocaleLowerCase/special_casing_conditional.js
     ! prototype/toLowerCase/special_casing_conditional.js
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -9,13 +9,11 @@ built-ins/String
     ! raw
     ! fromCodePoint
     ! predicate-call-this-strict
-
 	! prototype/Symbol.iterator/this-val-non-obj-coercible.js
 	! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
 	! prototype/includes/return-abrupt-from-searchstring-regexp-test.js
 	! prototype/includes/return-true-if-searchstring-is-empty.js
 	! prototype/normalize/return-normalized-string-using-default-parameter.js
-	! prototype/repeat/empty-string-returns-empty.js
 	! prototype/replace/cstm-replace-get-err.js
 	! prototype/replace/cstm-replace-invocation.js
 	! prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js


### PR DESCRIPTION
Fixed bug `empty-string-returns-empty.js` that is test case on test262.

```js
''.repeat(MAX_INT);  // expected results is empty string, but different.
```