### PR TITLE
Fixed some specifications violation for arrow function.

### DIFF
--- a/src/org/mozilla/javascript/NodeTransformer.java
+++ b/src/org/mozilla/javascript/NodeTransformer.java
@@ -31,14 +31,20 @@ public class NodeTransformer
 
     public final void transform(ScriptNode tree)
     {
-        transformCompilationUnit(tree);
+        transform(tree, false);
+    }
+
+    public final void transform(ScriptNode tree, boolean inStrictMode)
+    {
+        inStrictMode = inStrictMode || tree.isInStrictMode();
+        transformCompilationUnit(tree, inStrictMode);
         for (int i = 0; i != tree.getFunctionCount(); ++i) {
             FunctionNode fn = tree.getFunctionNode(i);
-            transform(fn);
+            transform(fn, inStrictMode);
         }
     }
 
-    private void transformCompilationUnit(ScriptNode tree)
+    private void transformCompilationUnit(ScriptNode tree, boolean inStrictMode)
     {
         loops = new ObjArray();
         loopEnds = new ObjArray();
@@ -53,8 +59,6 @@ public class NodeTransformer
 
         //uncomment to print tree before transformation
         if (Token.printTrees) System.out.println(tree.toStringTree(tree));
-        boolean inStrictMode = tree instanceof AstRoot &&
-                               ((AstRoot)tree).isInStrictMode();
         transformCompilationUnit_r(tree, tree, tree, createScopeObjects,
                                    inStrictMode);
     }

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -2713,7 +2713,7 @@ public class Parser
             int maybeName = nextToken();
             if (maybeName != Token.NAME
                     && !(compilerEnv.isReservedKeywordAsIdentifier()
-                    && TokenStream.isKeyword(ts.getString()))) {
+                    && TokenStream.isKeyword(ts.getString(), compilerEnv.getLanguageVersion(), inUseStrictDirective))) {
               reportError("msg.no.name.after.dot");
             }
 
@@ -2749,6 +2749,13 @@ public class Parser
               //          '@::attr', '@::*', '@*', '@*::attr', '@*::*'
               ref = attributeAccess();
               break;
+
+          case Token.RESERVED: {
+              String name = ts.getString();
+              saveNameTokenData(ts.tokenBeg, name, ts.lineno);
+              ref = propertyName(-1, name, memberTypeFlags);
+              break;
+          }
 
           default:
               if (compilerEnv.isReservedKeywordAsIdentifier()) {
@@ -3477,7 +3484,7 @@ public class Parser
 
           default:
               if (compilerEnv.isReservedKeywordAsIdentifier()
-                      && TokenStream.isKeyword(ts.getString())) {
+                      && TokenStream.isKeyword(ts.getString(), compilerEnv.getLanguageVersion(), inUseStrictDirective)) {
                   // convert keyword to property name, e.g. ({if: 1})
                   pname = createNameNode();
                   break;
@@ -4102,5 +4109,9 @@ public class Parser
 
     public void setDefaultUseStrictDirective(boolean useStrict) {
         defaultUseStrictDirective = useStrict;
+    }
+
+    public boolean inUseStrictDirective() {
+        return inUseStrictDirective;
     }
 }

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3595,10 +3595,12 @@ public class Parser
             return;
         }
         boolean activation = false;
-        if ("arguments".equals(name)
-            || (compilerEnv.getActivationNames() != null
-                && compilerEnv.getActivationNames().contains(name)))
-        {
+        if ("arguments".equals(name) &&
+            // An arrow function not generate arguments. So it not need activation.
+            ((FunctionNode)currentScriptOrFn).getFunctionType() != FunctionNode.ARROW_FUNCTION) {
+            activation = true;
+        } else if (compilerEnv.getActivationNames() != null
+                && compilerEnv.getActivationNames().contains(name)) {
             activation = true;
         } else if ("length".equals(name)) {
             if (token == Token.GETPROP

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -2172,7 +2172,12 @@ public class Parser
             return returnOrYield(tt, true);
         }
         AstNode pn = condExpr();
-        tt = peekToken();
+        boolean hasEOL = false;
+        tt = peekTokenOrEOL();
+        if (tt == Token.EOL) {
+            hasEOL = true;
+            tt = peekToken();
+        }
         if (Token.FIRST_ASSIGN <= tt && tt <= Token.LAST_ASSIGN) {
             consumeToken();
 
@@ -2193,7 +2198,7 @@ public class Parser
             if (currentJsDocComment != null) {
                 pn.setJsDocNode(getAndResetJsDoc());
             }
-        } else if (tt == Token.ARROW) {
+        } else if (!hasEOL && tt == Token.ARROW) {
             consumeToken();
             pn = arrowFunction(pn);
         }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -784,7 +784,7 @@ public class ScriptRuntime {
         return (sb == null) ? s : sb.toString();
     }
 
-    static boolean isValidIdentifierName(String s)
+    static boolean isValidIdentifierName(String s, Context cx, boolean isStrict)
     {
         int L = s.length();
         if (L == 0)
@@ -795,7 +795,7 @@ public class ScriptRuntime {
             if (!Character.isJavaIdentifierPart(s.charAt(i)))
                 return false;
         }
-        return !TokenStream.isKeyword(s);
+        return !TokenStream.isKeyword(s, cx.getLanguageVersion(), isStrict);
     }
 
     public static CharSequence toCharSequence(Object val) {
@@ -974,7 +974,7 @@ public class ScriptRuntime {
                             continue;   // a property has been removed
                         if (i > 0)
                             result.append(", ");
-                        if (ScriptRuntime.isValidIdentifierName(strId)) {
+                        if (ScriptRuntime.isValidIdentifierName(strId, cx, cx.isStrictMode())) {
                             result.append(strId);
                         } else {
                             result.append('\'');

--- a/src/org/mozilla/javascript/Token.java
+++ b/src/org/mozilla/javascript/Token.java
@@ -418,6 +418,7 @@ public class Token
           case COMMENT:         return "COMMENT";
           case GENEXPR:         return "GENEXPR";
           case METHOD:          return "METHOD";
+          case ARROW:           return "ARROW";
         }
 
         // Token without name

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -74,12 +74,24 @@ class TokenStream
         return "";
     }
 
-    static boolean isKeyword(String s)
+    static boolean isKeyword(String s, int version, boolean isStrict)
     {
-        return Token.EOF != stringToKeyword(s);
+        return Token.EOF != stringToKeyword(s, version, isStrict);
     }
 
-    private static int stringToKeyword(String name)
+    private static int stringToKeyword(String name, int version, boolean isStrict)
+    {
+        if (version < Context.VERSION_ES6) {
+            return stringToKeywordForJS(name);
+        } else {
+            return stringToKeywordForES(name, isStrict);
+        }
+    }
+
+    /**
+     * JavaScript 1.8 and earlier
+     */
+    private static int stringToKeywordForJS(String name)
     {
 // #string_id_map#
 // The following assumes that Token.EOF == 0
@@ -255,6 +267,161 @@ class TokenStream
         return id & 0xff;
     }
 
+    /**
+     * ECMAScript 6.
+     */
+    private static int stringToKeywordForES(String name, boolean isStrict)
+    {
+// #string_id_map#
+// The following assumes that Token.EOF == 0
+        final int
+            // 11.6.2.1 Keywords (ECMAScript2015)
+            Id_break         = Token.BREAK,
+            Id_case          = Token.CASE,
+            Id_catch         = Token.CATCH,
+            Id_class         = Token.RESERVED,
+            Id_const         = Token.CONST,
+            Id_continue      = Token.CONTINUE,
+            Id_debugger      = Token.DEBUGGER,
+            Id_default       = Token.DEFAULT,
+            Id_delete        = Token.DELPROP,
+            Id_do            = Token.DO,
+            Id_else          = Token.ELSE,
+            Id_export        = Token.RESERVED,
+            Id_extends       = Token.RESERVED,
+            Id_finally       = Token.FINALLY,
+            Id_for           = Token.FOR,
+            Id_function      = Token.FUNCTION,
+            Id_if            = Token.IF,
+            Id_import        = Token.RESERVED,
+            Id_in            = Token.IN,
+            Id_instanceof    = Token.INSTANCEOF,
+            Id_new           = Token.NEW,
+            Id_return        = Token.RETURN,
+            Id_super         = Token.RESERVED,
+            Id_switch        = Token.SWITCH,
+            Id_this          = Token.THIS,
+            Id_throw         = Token.THROW,
+            Id_try           = Token.TRY,
+            Id_typeof        = Token.TYPEOF,
+            Id_var           = Token.VAR,
+            Id_void          = Token.VOID,
+            Id_while         = Token.WHILE,
+            Id_with          = Token.WITH,
+            Id_yield         = Token.YIELD,
+
+            // 11.6.2.2 Future Reserved Words
+            Id_await         = Token.RESERVED,
+            Id_enum          = Token.RESERVED,
+
+            // 11.6.2.2 NOTE Strict Future Reserved Words
+            Id_implements    = Token.RESERVED,
+            Id_interface     = Token.RESERVED,
+            Id_package       = Token.RESERVED,
+            Id_private       = Token.RESERVED,
+            Id_protected     = Token.RESERVED,
+            Id_public        = Token.RESERVED,
+
+            // 11.8 Literals
+            Id_false         = Token.FALSE,
+            Id_null          = Token.NULL,
+            Id_true          = Token.TRUE,
+
+            // Non ReservedWord, but Non IdentifierName in strict mode code.
+            // 12.1.1 Static Semantics: Early Errors
+            Id_let           = Token.LET,   // TODO : Valid IdentifierName in non-strict mode.
+            Id_static        = Token.RESERVED; 
+
+        int id;
+        String s = name;
+// #generated# Last update: 2007-04-18 13:53:30 PDT
+        L0: { id = 0; String X = null; int c;
+            L: switch (s.length()) {
+            case 2: c=s.charAt(1);
+                if (c=='f') { if (s.charAt(0)=='i') {id=Id_if; break L0;} }
+                else if (c=='n') { if (s.charAt(0)=='i') {id=Id_in; break L0;} }
+                else if (c=='o') { if (s.charAt(0)=='d') {id=Id_do; break L0;} }
+                break L;
+            case 3: switch (s.charAt(0)) {
+                case 'f': if (s.charAt(2)=='r' && s.charAt(1)=='o') {id=Id_for; break L0;} break L;
+                case 'l': if (s.charAt(2)=='t' && s.charAt(1)=='e') {id=Id_let; break L0;} break L;
+                case 'n': if (s.charAt(2)=='w' && s.charAt(1)=='e') {id=Id_new; break L0;} break L;
+                case 't': if (s.charAt(2)=='y' && s.charAt(1)=='r') {id=Id_try; break L0;} break L;
+                case 'v': if (s.charAt(2)=='r' && s.charAt(1)=='a') {id=Id_var; break L0;} break L;
+                } break L;
+            case 4: switch (s.charAt(0)) {
+                case 'c': c=s.charAt(3);
+                    if (c=='e') { if (s.charAt(2)=='s' && s.charAt(1)=='a') {id=Id_case; break L0;} }
+                    break L;
+                case 'e': c=s.charAt(3);
+                    if (c=='e') { if (s.charAt(2)=='s' && s.charAt(1)=='l') {id=Id_else; break L0;} }
+                    else if (c=='m') { if (s.charAt(2)=='u' && s.charAt(1)=='n') {id=Id_enum; break L0;} }
+                    break L;
+                case 'n': X="null";id=Id_null; break L;
+                case 't': c=s.charAt(3);
+                    if (c=='e') { if (s.charAt(2)=='u' && s.charAt(1)=='r') {id=Id_true; break L0;} }
+                    else if (c=='s') { if (s.charAt(2)=='i' && s.charAt(1)=='h') {id=Id_this; break L0;} }
+                    break L;
+                case 'v': X="void";id=Id_void; break L;
+                case 'w': X="with";id=Id_with; break L;
+                } break L;
+            case 5: switch (s.charAt(2)) {
+                case 'a': c=s.charAt(0);
+                    if (c=='c') { X="class";id=Id_class; }
+                    else if (c=='a') { X="await";id=Id_await; }
+                    break L;
+                case 'e': c=s.charAt(0);
+                    if (c=='b') { X="break";id=Id_break; }
+                    else if (c=='y') { X="yield";id=Id_yield; }
+                    break L;
+                case 'i': X="while";id=Id_while; break L;
+                case 'l': X="false";id=Id_false; break L;
+                case 'n': X="const";id=Id_const; break L;
+                case 'p': X="super";id=Id_super; break L;
+                case 'r': X="throw";id=Id_throw; break L;
+                case 't': X="catch";id=Id_catch; break L;
+                } break L;
+            case 6: switch (s.charAt(1)) {
+                case 'e': c=s.charAt(0);
+                    if (c=='d') { X="delete";id=Id_delete; }
+                    else if (c=='r') { X="return";id=Id_return; }
+                    break L;
+                case 'm': X="import";id=Id_import; break L;
+                case 't': if (isStrict) { X="static";id=Id_static; break L; }
+                case 'u': if (isStrict) { X="public";id=Id_public; break L; }
+                case 'w': X="switch";id=Id_switch; break L;
+                case 'x': X="export";id=Id_export; break L;
+                case 'y': X="typeof";id=Id_typeof; break L;
+                } break L;
+            case 7: switch (s.charAt(1)) {
+                case 'a': if (isStrict) { X="package";id=Id_package; break L; }
+                case 'e': X="default";id=Id_default; break L;
+                case 'i': X="finally";id=Id_finally; break L;
+                case 'r': if (isStrict) { X="private";id=Id_private; break L; }
+                case 'x': X="extends";id=Id_extends; break L;
+                } break L;
+            case 8: switch (s.charAt(0)) {
+                case 'c': X="continue";id=Id_continue; break L;
+                case 'd': X="debugger";id=Id_debugger; break L;
+                case 'f': X="function";id=Id_function; break L;
+                } break L;
+            case 9: c=s.charAt(0);
+                if (c=='i' && isStrict) { X="interface";id=Id_interface; }
+                else if (c=='p' && isStrict) { X="protected";id=Id_protected; }
+                break L;
+            case 10: c=s.charAt(1);
+                if (c=='m' && isStrict) { X="implements";id=Id_implements; }
+                else if (c=='n') { X="instanceof";id=Id_instanceof; }
+                break L;
+            }
+            if (X!=null && X!=s && !X.equals(s)) id = 0;
+        }
+// #/generated#
+// #/string_id_map#
+        if (id == 0) { return Token.EOF; }
+        return id & 0xff;
+    }
+
     final String getSourceString() { return sourceString; }
 
     final int getLineno() { return lineno; }
@@ -378,7 +545,7 @@ class TokenStream
                     // check if it's a keyword.
 
                     // Return the corresponding token if it's a keyword
-                    int result = stringToKeyword(str);
+                    int result = stringToKeyword(str, parser.compilerEnv.getLanguageVersion(), parser.inUseStrictDirective());
                     if (result != Token.EOF) {
                         if ((result == Token.LET || result == Token.YIELD) &&
                             parser.compilerEnv.getLanguageVersion()
@@ -393,13 +560,13 @@ class TokenStream
                         this.string = (String)allStrings.intern(str);
                         if (result != Token.RESERVED) {
                             return result;
-                        } else if (!parser.compilerEnv.
-                                        isReservedKeywordAsIdentifier())
-                        {
+                        } else if (parser.compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
+                            return result;
+                        } else if (!parser.compilerEnv.isReservedKeywordAsIdentifier()) {
                             return result;
                         }
                     }
-                } else if (isKeyword(str)) {
+                } else if (isKeyword(str, parser.compilerEnv.getLanguageVersion(), parser.inUseStrictDirective())) {
                     // If a string contains unicodes, and converted to a keyword,
                     // we convert the last character back to unicode
                     str = convertLastCharToHex(str);

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -209,10 +209,6 @@ language/expressions/arrow-function
     ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
     ! syntax/early-errors/arrowparameters-cover-no-duplicates-rest.js
     ! syntax/early-errors/arrowparameters-cover-no-duplicates.js
-# syntax issues
-    ! syntax/early-errors/asi-restriction-invalid-parenless-parameters-expression-body.js
-    ! syntax/early-errors/asi-restriction-invalid-parenless-parameters.js
-    ! syntax/early-errors/asi-restriction-invalid.js
 
 language/arguments-object
    ! arguments-object/mapped/Symbol.iterator.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -178,13 +178,6 @@ language/expressions/arrow-function
 ## strict mode
     ! ArrowFunction_restricted-properties.js
     ! strict.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-identifier-futurereservedword.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-identifier-strict-futurereservedword.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-identifier.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-no-arguments.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-no-eval.js
-    ! syntax/early-errors/arrowparameters-cover-no-arguments.js
-    ! syntax/early-errors/arrowparameters-cover-no-eval.js
 ## class syntax
     ! lexical-new.target-closure-returned.js
     ! lexical-new.target.js
@@ -265,3 +258,9 @@ language/expressions/delete/11.4.1-4.a-8-s.js
 language/expressions/delete/11.4.1-4.a-9-s.js
 language/expressions/delete/11.4.1-4.a-9.js
 language/expressions/delete/11.4.4-4.a-3-s.js
+
+language/keywords
+# expected:<ReferenceError> but was:<SyntaxError>
+    ! S7.6.1.1_A1.18.js
+
+language/future-reserved-words

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -177,7 +177,6 @@ language/expressions/arrow-function
 # not implemented
 ## strict mode
     ! ArrowFunction_restricted-properties.js
-    ! strict.js
 ## class syntax
     ! lexical-new.target-closure-returned.js
     ! lexical-new.target.js


### PR DESCRIPTION
These test cases have come to pass.

## Can not use reserved word for identifier
```js
// SyntaxError
var af = enum => 1;
```
## Transform to STRICT_SETNAME when outer function is strict mode
```js
'use strict';
assert.throws(ReferenceError, function() {
  var af = _ => {
    foo = 1;
  };

  af();
});
```
## Line terminator not allowed between arguments and arrow
```js
// SyntaxError
var af = ()
=> {};
```