### PR TITLE
Implement octal and binary literals

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -2957,11 +2957,14 @@ public class Parser
           case Token.NUMBER: {
               consumeToken();
               String s = ts.getString();
-              if (this.inUseStrictDirective && ts.isNumberOctal()) {
-                  reportError("msg.no.octal.strict");
+              if (this.inUseStrictDirective && ts.isNumberOldOctal()) {
+                  reportError("msg.no.old.octal.strict");
+              }
+              if (ts.isNumberOldOctal()) {
+                  s = "0"+s;
               }
               if (ts.isNumberOctal()) {
-                  s = "0"+s;
+                  s = "0o"+s;
               }
               if (ts.isNumberHex()) {
                   s = "0x"+s;

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -2960,6 +2960,9 @@ public class Parser
               if (this.inUseStrictDirective && ts.isNumberOldOctal()) {
                   reportError("msg.no.old.octal.strict");
               }
+              if (ts.isNumberBinary()) {
+                  s = "0b"+s;
+              }
               if (ts.isNumberOldOctal()) {
                   s = "0"+s;
               }

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -582,6 +582,7 @@ class TokenStream
                 stringBufferTop = 0;
                 int base = 10;
                 isHex = isOldOctal = isOctal = isBinary = false;
+                boolean es6 = parser.compilerEnv.getLanguageVersion() >= Context.VERSION_ES6;
 
                 if (c == '0') {
                     c = getChar();
@@ -589,11 +590,11 @@ class TokenStream
                         base = 16;
                         isHex = true;
                         c = getChar();
-                    } else if (c == 'o' || c == 'O') {
+                    } else if (es6 && (c == 'o' || c == 'O')) {
                         base = 8;
                         isOctal = true;
                         c = getChar();
-                    } else if (c == 'b' || c == 'B') {
+                    } else if (es6 && (c == 'b' || c == 'B')) {
                         base = 2;
                         isBinary = true;
                         c = getChar();

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -498,8 +498,8 @@ msg.var.hides.arg =\
 msg.destruct.assign.no.init =\
     Missing = in destructuring declaration
 
-msg.no.octal.strict =\
-    Octal numbers prohibited in strict mode.
+msg.no.old.octal.strict =\
+    Old octal numbers prohibited in strict mode.
 
 msg.dup.obj.lit.prop.strict =\
     Property "{0}" already defined in this object literal.

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -266,8 +266,3 @@ expressions/prefix-decrement
 expressions/prefix-increment
 
 language/literals/numeric
-# "0x" and "0X" are invalid numeric literals.
-    ! S7.8.3_A6.1_T1.js
-    ! S7.8.3_A6.1_T2.js
-# BinaryIntegerLiteral
-    ! /binary

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -264,3 +264,10 @@ expressions/postfix-decrement
 expressions/postfix-increment
 expressions/prefix-decrement
 expressions/prefix-increment
+
+language/literals/numeric
+# "0x" and "0X" are invalid numeric literals.
+    ! S7.8.3_A6.1_T1.js
+    ! S7.8.3_A6.1_T2.js
+# BinaryIntegerLiteral
+    ! /binary


### PR DESCRIPTION
https://github.com/mozilla/rhino/issues/242

This test case is wrong.
https://github.com/tc39/test262/blob/0d9733e93be9e6783f56a3fd4163a4ca083b159c/test/language/literals/numeric/octal-invalid-truncated.js
https://github.com/tc39/test262/issues/433