### PR TITLE
fix undefined script value become a string value after pass java call…

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -489,7 +489,7 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
         case JSTYPE_UNDEFINED:
             if (type == ScriptRuntime.StringClass ||
                 type == ScriptRuntime.ObjectClass) {
-                return "undefined";
+            	return null;
             }
             else {
                 reportConversionError("undefined", type);


### PR DESCRIPTION
….below to reproduce:

js code:
TestObj.testValue(notExist);

java code:
public void testValue(Object val){
   System.out.println(val); //become "undefined" string
}
