### PR TITLE
	Check before getting "toJSON" property because some built-in objects…

### DIFF
--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -276,7 +276,7 @@ public final class NativeJSON extends IdScriptableObject
             value = getProperty(holder, ((Number) key).intValue());
         }
 
-        if (value instanceof Scriptable) {
+        if (value instanceof Scriptable && hasProperty((Scriptable) value, "toJSON")) {
             Object toJSON = getProperty((Scriptable) value, "toJSON");
             if (toJSON instanceof Callable) {
                 value = callMethod(state.cx, (Scriptable) value, "toJSON",

--- a/testsrc/jstests/stringify-e4x-replacer.jstest
+++ b/testsrc/jstests/stringify-e4x-replacer.jstest
@@ -1,0 +1,16 @@
+// Ensure that a stringify replacer function gets a chance to do something sane with E4X XML object
+
+var e4x = <xxx/>;
+var expected = JSON.stringify(e4x.toXMLString());
+try {
+  var actual = JSON.stringify(e4x, function(key, value) {
+    return ((typeof value) === "xml") ? value.toXMLString() : value;
+  });
+} catch (ud) {
+  throw "JSON.stringify(<xxx/>, replacer) threw an Exception"
+}
+if (actual !== expected) {
+  throw "Expected '" + expected + "', got '" + actual + "'";
+}
+
+"success";

--- a/testsrc/jstests/stringify-jarray-replacer.jstest
+++ b/testsrc/jstests/stringify-jarray-replacer.jstest
@@ -1,0 +1,22 @@
+// Ensure that a stringify replacer function gets a chance to do something sane with native java array
+
+var nja = java.lang.String.valueOf("a,b,c").split(",");
+var expected = JSON.stringify("a,b,c".split(/,/));
+try {
+  var actual = JSON.stringify(nja, function(key, value) {
+    if (value instanceof java.lang.Object) {
+      if (value instanceof Array)
+        return value.slice();
+      if (value instanceof java.lang.CharSequence)
+        return String(value);
+    }
+    return value;
+  });
+} catch (e) {
+  throw "JSON.stringify(nja, replacer) threw an Exception: " + JSON.stringify(e);
+}
+if (actual !== expected) {
+  throw "Expected '" + expected + "', got '" + actual + "'";
+}
+
+"success";


### PR DESCRIPTION
… (NativeJavaArray and XML) throw an exception if you try to get a non-existent property. This allows for a JSON.stringify replacer function to actually get called and have a chance to do something sane with these objects instead of just barfing.