### PR TITLE
Attempt to invoke method on an undefined object

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2474,7 +2474,9 @@ public class ScriptRuntime {
           String property, Context cx, Scriptable thisObj)
     {
         if (thisObj == null) {
-            throw undefCallError(obj, property);
+            throw Context.throwAsScriptRuntimeEx(Context.reportRuntimeError(
+                    "Attempt to invoke method '" + property +
+                    "' on an undefined object"));
         }
 
         Object value = ScriptableObject.getProperty(thisObj, property);


### PR DESCRIPTION
Handle this condition more gracefully, producing a SEVERE warning in the
log and also throwing a proper JavaScript exception.  The behavior is
now consistent with, e.g., invalid arguments to querySelector().