### PR TITLE
Disable recursion tests.

### DIFF
--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -1638,9 +1638,7 @@ js1_5/Regress/regress-76054.js
 js1_5/Regress/regress-82306.js
 js1_5/Regress/regress-89474.js
 js1_5/Regress/regress-90445.js
-js1_5/Regress/regress-96128-n.js
 js1_5/Regress/regress-96526-001.js
-js1_5/Regress/regress-98901.js
 js1_5/Scope/regress-154693.js
 js1_5/Scope/regress-184107.js
 js1_5/Scope/regress-185485.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -1639,9 +1639,7 @@ js1_5/Regress/regress-76054.js
 js1_5/Regress/regress-82306.js
 js1_5/Regress/regress-89474.js
 js1_5/Regress/regress-90445.js
-js1_5/Regress/regress-96128-n.js
 js1_5/Regress/regress-96526-001.js
-js1_5/Regress/regress-98901.js
 js1_5/Scope/regress-154693.js
 js1_5/Scope/regress-184107.js
 js1_5/Scope/regress-185485.js

--- a/testsrc/tests/js1_5/extensions/regress-226507.js
+++ b/testsrc/tests/js1_5/extensions/regress-226507.js
@@ -55,8 +55,10 @@ var expectedvalues = [];
 /*
  * With stack limit 100K on Linux debug build even N=30 already can cause
  * stack overflow; use 35 to trigger it for sure.
+ * But we need to trigger this consistently but not a Java exception, so back
+ * to 35.
  */
-var N = 350;
+var N = 35;
 
 var counter = 0;
 function f()


### PR DESCRIPTION
These tests appear to be testing for something that the interpreter
did, but that Rhino does not do in compiled mode. In compiled mode
they just correctly throw StackOverflowError.