### PR TITLE
Use our own sort for Array.prototype.sort to avoid comparator compatibility problems.

### DIFF
--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -3384,11 +3384,12 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * This comparator sorts property fields in spec-compliant order. Numeric ids first, in numeric
-     * order, folowed by string ids, in insertion order. Since this class already keeps string keys
+     * order, followed by string ids, in insertion order. Since this class already keeps string keys
      * in insertion-time order, we treat all as equal. The "Arrays.sort" method will then not
-     * change their order, but simply move all the numeric properties to the front.
+     * change their order, but simply move all the numeric properties to the front, since this
+     * method is defined to be stable.
      */
-    private static final class KeyComparator
+    public static final class KeyComparator
         implements Comparator<Object>
     {
         @Override

--- a/src/org/mozilla/javascript/Sorting.java
+++ b/src/org/mozilla/javascript/Sorting.java
@@ -1,0 +1,94 @@
+package org.mozilla.javascript;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+public final class Sorting {
+    private static final int SMALLSORT = 16;
+
+    public static void insertionSort(Object[] a, Comparator<Object> cmp)
+    {
+        insertionSort(a, 0, a.length - 1, cmp);
+    }
+
+    public static void insertionSort(Object[] a, int start, int end, Comparator<Object> cmp)
+    {
+        int i = start;
+        while (i <= end) {
+            Object x = a[i];
+            int j = i - 1;
+            while ((j >= start) && (cmp.compare(a[j], x) > 0)) {
+                a[j + 1] = a[j];
+                j--;
+            }
+            a[j + 1] = x;
+            i++;
+        }
+    }
+
+    /*
+    Hybrid sorting mechanism similar to Introsort by David Musser. Uses quicksort's
+    partitioning mechanism recursively until the resulting array is small or the
+    recursion is too deep, and then use insertion sort for the rest.
+    This is the same basic algorithm used by the GNU Standard C++ library.
+    */
+    public static void hybridSort(Object[] a, Comparator<Object> cmp)
+    {
+        hybridSort(a, 0, a.length - 1, cmp, log2(a.length) * 2);
+    }
+
+    private static void hybridSort(Object[] a, int start, int end, Comparator<Object> cmp, int maxdepth)
+    {
+        if (start < end) {
+            if ((maxdepth == 0) || ((end - start) <= SMALLSORT)) {
+                insertionSort(a, start, end, cmp);
+            } else {
+                int p = partition(a, start, end, cmp);
+                hybridSort(a, start, p, cmp, maxdepth - 1);
+                hybridSort(a, p + 1, end, cmp, maxdepth - 1);
+            }
+        }
+    }
+
+    /*
+    Quicksort-style partitioning, using the Hoare partition scheme described on Wikipedia.
+    Use the "median of three" method to determine which index to pivot on, and then
+    separate the array into two halves based on the pivot.
+    */
+    private static int partition(Object[] a, int start, int end, Comparator<Object> cmp) {
+        Object pivot = a[median(start, end, start + ((end - start) / 2))];
+        int i = start - 1;
+        int j = end + 1;
+        while (true) {
+            do {
+                i++;
+            } while (cmp.compare(a[i], pivot) < 0);
+            do {
+                j--;
+            } while (cmp.compare(a[j], pivot) > 0);
+            if (i >= j) {
+                return j;
+            }
+            swap(a, i, j);
+        }
+    }
+
+    private static void swap(Object[] a, int l, int h)
+    {
+        Object tmp = a[l];
+        a[l] = a[h];
+        a[h] = tmp;
+    }
+
+    private static int log2(int n)
+    {
+        return (int)(Math.log10(n) / Math.log10(2.0));
+    }
+
+    private static int median(int n1, int n2, int n3)
+    {
+        int[] a = {n1, n2, n3};
+        Arrays.sort(a);
+        return a[1];
+    }
+}

--- a/testsrc/jstests/extensions/custom-comparators.js
+++ b/testsrc/jstests/extensions/custom-comparators.js
@@ -1,0 +1,40 @@
+load("testsrc/assert.js");
+
+function makeArray(length) {
+  var a  = [];
+  for (var i = 0; i < length; i++) {
+    a.push(Math.trunc(Math.random() * 100000));
+  }
+  return a;
+}
+
+function ensureSorted(a) {
+  var last = 0;
+  for (var i in a) {
+    assertTrue(a[i] >= last);
+     last = a[i];
+  }
+}
+
+function compareIntGood(a, b) {
+  if (a < b) {
+    return -1;
+  }
+  if (b < a) {
+    return 1;
+  }
+  return 0;
+}
+
+function compareIntBad(a, b) {
+  return (Math.random() * 10) - 5;
+}
+
+var a = makeArray(100);
+a.sort(compareIntGood);
+ensureSorted(a);
+
+a = makeArray(10000);
+a.sort(compareIntBad);
+// Make sure that this does not throw.
+// However, at this point we should not assume that the array is properly sorted!

--- a/testsrc/org/mozilla/javascript/tests/ComparatorTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ComparatorTest.java
@@ -1,0 +1,92 @@
+package org.mozilla.javascript.tests;
+
+import java.io.FileReader;
+import java.io.IOException;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeArray;
+import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.tools.shell.Global;
+
+import static org.junit.Assert.*;
+
+public class ComparatorTest {
+
+  /*
+  Check the comparator and ensure that it is consistent.
+  An inconsistent comparator will result in an IllegalArgumentException
+  with the message "Comparison method violates its general contract!"
+  */
+  private void idChk(Object o1, Object o2, int expected) {
+    assertEquals(expected, new ScriptableObject.KeyComparator().compare(o1, o2));
+    assertEquals(-expected, new ScriptableObject.KeyComparator().compare(o2, o1));
+  }
+
+  /*
+  This comparator is used only in the generation of object IDs for iteration. It makes sure
+  that numeric property names are in numeric order without changing string property names,
+  as per the spec.
+   */
+  @Test
+  public void testObjectIDComparator() {
+    idChk(0, 0, 0);
+    idChk(1, 0, 1);
+    idChk(0, 1, -1);
+    idChk("a", "a", 0);
+    idChk("b", "a", 0);
+    idChk("a", "b", 0);
+    idChk("a", 1, 1);
+    idChk(1, "a", -1);
+  }
+
+  private void aChk(Object o1, Object o2, int expected) {
+    assertEquals(expected, new NativeArray.ElementComparator().compare(o1, o2));
+    assertEquals(-expected, new NativeArray.ElementComparator().compare(o2, o1));
+  }
+
+  /*
+  This comparator is used in Arrays.sort. It ensures that unset properties go at the
+  very end, undefined references go right before that, and everything else is sorted as
+  a string.
+   */
+  @Test
+  public void testArrayComparator() {
+    aChk("a", "b", -1);
+    aChk("b", "a", 1);
+    aChk("a", "a", 0);
+    aChk(Scriptable.NOT_FOUND, "a", 1);
+    aChk("a", Scriptable.NOT_FOUND, -1);
+    aChk(Scriptable.NOT_FOUND, Scriptable.NOT_FOUND, 0);
+    aChk(Undefined.instance, "a", 1);
+    aChk("a", Undefined.instance, -1);
+    aChk(Undefined.instance, Undefined.instance, 0);
+    aChk(Undefined.instance, Scriptable.NOT_FOUND, -1);
+    aChk(Scriptable.NOT_FOUND, Undefined.instance, 1);
+  }
+
+  /*
+  Run some tests in JavaScript to verify the custom comparators that are supported
+  on Array.sort.
+   */
+  @Test
+  public void testCustomComparator()
+    throws IOException
+  {
+    Context cx = Context.enter();
+    Global global = new Global(cx);
+    Scriptable root = cx.newObject(global);
+    FileReader fr = new FileReader("testsrc/jstests/extensions/custom-comparators.js");
+
+    try {
+      cx.evaluateReader(root, fr, "custom-comparators.js", 1, null);
+    } catch (RhinoException re) {
+      System.err.println(re.getScriptStackTrace());
+      throw re;
+    } finally {
+      Context.exit();
+    }
+  }
+}

--- a/testsrc/org/mozilla/javascript/tests/SortingTest.java
+++ b/testsrc/org/mozilla/javascript/tests/SortingTest.java
@@ -1,0 +1,199 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mozilla.javascript.Sorting;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class SortingTest {
+    private static final int BIG_ARRAY = 100000;
+    private static final int ITERATIONS = 4;
+
+    private static final Random rand = new Random();
+
+    private static Object[] bigRandom;
+
+    @BeforeClass
+    public static void init()
+    {
+        bigRandom = randomArray(BIG_ARRAY);
+    }
+
+    private void insertionSort(Object[] expected)
+    {
+        Object[] after = Arrays.copyOf(expected, expected.length);
+        Sorting.insertionSort(after, new IntComparator());
+        Arrays.sort(expected, new IntComparator());
+        assertArrayEquals(expected, after);
+    }
+
+    @Test
+    public void testInsertionSort()
+    {
+        insertionSort(forwardArray(100));
+        insertionSort(reverseArray(100));
+        insertionSort(randomArray(100));
+        insertionSort(sameArray(100));
+        insertionSort(new Object[] {});
+        insertionSort(randomArray(10000));
+    }
+
+    private void hybridSort(Object[] expected)
+    {
+        Object[] after = Arrays.copyOf(expected, expected.length);
+        Sorting.hybridSort(after, new IntComparator());
+        Arrays.sort(expected, new IntComparator());
+        assertArrayEquals(expected, after);
+    }
+
+    @Test
+    public void testHybridSort()
+    {
+        hybridSort(randomArray(10));
+        hybridSort(forwardArray(100));
+        hybridSort(reverseArray(100));
+        hybridSort(randomArray(100));
+        hybridSort(sameArray(100));
+        hybridSort(new Object[] {});
+        hybridSort(randomArray(10000));
+    }
+
+    /*
+    @Test
+    public void testBenchInsertionRandom()
+    {
+        Object[] a = Arrays.copyOf(bigRandom, bigRandom.length);
+        Sorting.insertionSort(a, new IntComparator());
+    }
+    */
+
+    @Test
+    public void testBenchRandomHybrid()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = Arrays.copyOf(bigRandom, bigRandom.length);
+            Sorting.hybridSort(a, new IntComparator());
+        }
+    }
+
+    @Test
+    public void testBenchRandomJavaUtil()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = Arrays.copyOf(bigRandom, bigRandom.length);
+            Arrays.sort(a, new IntComparator());
+        }
+    }
+
+    /*
+    @Test
+    public void testBenchInsertionReverse()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = reverseArray(BIG_ARRAY);
+            Sorting.insertionSort(a, new IntComparator());
+        }
+    }
+    */
+
+    @Test
+    public void testBenchReverseHybrid()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = reverseArray(BIG_ARRAY);
+            Sorting.hybridSort(a, new IntComparator());
+        }
+    }
+
+    @Test
+    public void testBenchReverseJavaUtil()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = reverseArray(BIG_ARRAY);
+            Arrays.sort(a, new IntComparator());
+        }
+    }
+
+    @Test
+    public void testBenchSequentialInsertion()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = forwardArray(BIG_ARRAY);
+            Sorting.insertionSort(a, new IntComparator());
+        }
+    }
+
+    @Test
+    public void testBenchSequentialHybrid()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = forwardArray(BIG_ARRAY);
+            Sorting.hybridSort(a, new IntComparator());
+        }
+    }
+
+    @Test
+    public void testBenchSequentialJavaUtil()
+    {
+        for (int i = 0; i < ITERATIONS; i++) {
+            Object[] a = forwardArray(BIG_ARRAY);
+            Arrays.sort(a, new IntComparator());
+        }
+    }
+
+    private static Integer[] forwardArray(int length)
+    {
+        Integer[] a = new Integer[length];
+        for (int i = 0; i < length; i++) {
+            a[i] = i;
+        }
+        return a;
+    }
+
+    private static Integer[] reverseArray(int length)
+    {
+        Integer[] a = new Integer[length];
+        for (int i = 0; i < length; i++) {
+            a[i] = length - i - 1;
+        }
+        return a;
+    }
+
+    private static Integer[] randomArray(int length)
+    {
+        Integer[] a = new Integer[length];
+        for (int i = 0; i < length; i++) {
+            a[i] = rand.nextInt();
+        }
+        return a;
+    }
+
+    private static Integer[] sameArray(int length)
+    {
+        Integer[] a = new Integer[length];
+        Arrays.fill(a, 1);
+        return a;
+    }
+
+    private final class IntComparator
+        implements Comparator<Object>
+    {
+        @Override
+        public int compare(Object a, Object b) {
+            Integer ia = (Integer)a;
+            Integer ib = (Integer)b;
+            if (ia < ib) {
+                return -1;
+            }
+            if (ia > ib) {
+                return 1;
+            }
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests for comparators.
Ensure that they always return a consistent result.
Throw a JavaScript error if sorting fails.