### PR TITLE
add eclipse support to the gradle script and ignore special eclipse d…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ target/
 .classpath
 .project
 test262
+bin/
+.settings/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 apply plugin: 'jacoco'
 apply plugin: 'distribution'


### PR DESCRIPTION
…irectories

We have to update the source/target jdk level to 1.8 also, but at the moment i got one failing test with 1.8.

org.mozilla.javascript.tests.MozillaSuiteTest > runMozillaTest[1336, js=testsrc\tests\js1_5\GC\regress-383269-01.js, opt=-1] FAILED
    junit.framework.AssertionFailedError at MozillaSuiteTest.java:192