### PR TITLE
remove methods find and findIndex from the prototoye

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -170,10 +170,6 @@ public class NativeArray extends IdScriptableObject implements List
                 "map", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_some,
                 "some", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_find,
-                "find", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findIndex,
-                "findIndex", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduce,
                 "reduce", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduceRight,
@@ -253,8 +249,6 @@ public class NativeArray extends IdScriptableObject implements List
               case ConstructorId_forEach:
               case ConstructorId_map:
               case ConstructorId_some:
-              case ConstructorId_find:
-              case ConstructorId_findIndex:
               case ConstructorId_reduce:
               case ConstructorId_reduceRight: {
                 // this is a small trick; we will handle all the ConstructorId_xxx calls
@@ -2101,8 +2095,6 @@ public class NativeArray extends IdScriptableObject implements List
         ConstructorId_forEach              = -Id_forEach,
         ConstructorId_map                  = -Id_map,
         ConstructorId_some                 = -Id_some,
-        ConstructorId_find                 = -Id_find,
-        ConstructorId_findIndex            = -Id_findIndex,
         ConstructorId_reduce               = -Id_reduce,
         ConstructorId_reduceRight          = -Id_reduceRight,
         ConstructorId_isArray              = -26;

--- a/testsrc/doctests/array.every.doctest
+++ b/testsrc/doctests/array.every.doctest
@@ -2,10 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.every;
+js> function isSmall(n) { return n < 10; };
+
+js> [1, 4, 9, 16].every;
 function every() { [native code for Array.every, arity=1] }
 
-js> function isSmall(n) { return n < 10; };
+js> [1, 4, 9, 16].every(isSmall);
+false
+
+js> [1, 4, 9].every(isSmall);
+true
+
+js> Array.every;
+function every() { [native code for Array.every, arity=1] }
 
 js> Array.every([1, 4, 9, 16], isSmall);
 false

--- a/testsrc/doctests/array.filter.doctest
+++ b/testsrc/doctests/array.filter.doctest
@@ -2,10 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.filter;
+js> function isSmall(n) { return n < 10; };
+
+js> [1, 13, 4, 16, 42].filter;
 function filter() { [native code for Array.filter, arity=1] }
 
-js> function isSmall(n) { return n < 10; };
+js> "" + [1, 13, 4, 16, 42].filter(isSmall);
+1,4
+
+js> Array.filter;
+function filter() { [native code for Array.filter, arity=1] }
 
 js> "" + Array.filter([1, 13, 4, 16, 42], isSmall);
 1,4

--- a/testsrc/doctests/array.find.doctest
+++ b/testsrc/doctests/array.find.doctest
@@ -2,10 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.find;
-function find() { [native code for Array.find, arity=1] }
-
 js> function isSmall(n) { return n < 10; };
 
-js> Array.find([13, 4, 17], isSmall);
+js> [13, 4, 17].find;
+function find() { [native code for Array.find, arity=1] }
+
+js> [13, 4, 17].find(isSmall);
 4
+
+js> Array.find;
+

--- a/testsrc/doctests/array.findIndex.doctest
+++ b/testsrc/doctests/array.findIndex.doctest
@@ -2,10 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
-
 js> function isSmall(n) { return n < 10; };
 
-js> Array.findIndex([13, 4, 17], isSmall);
+js> [13, 4, 17].findIndex;
+function findIndex() { [native code for Array.findIndex, arity=1] }
+
+js> [13, 4, 17].findIndex(isSmall);
 1
+
+js> Array.findIndex;
+

--- a/testsrc/doctests/array.forEach.doctest
+++ b/testsrc/doctests/array.forEach.doctest
@@ -2,6 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+js> [1, 13, 4].forEach;
+function forEach() { [native code for Array.forEach, arity=1] }
+
+js> res = '';
+js> [1, 13, 4].forEach(function(elem) { res += elem });
+js> res
+1134
+
 js> Array.forEach;
 function forEach() { [native code for Array.forEach, arity=1] }
 

--- a/testsrc/doctests/array.map.doctest
+++ b/testsrc/doctests/array.map.doctest
@@ -2,6 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+js> [9, 16, 25].map;
+function map() { [native code for Array.map, arity=1] }
+
+js> "" + [9, 16, 25].map(Math.sqrt);
+3,4,5
+
 js> Array.map;
 function map() { [native code for Array.map, arity=1] }
 

--- a/testsrc/doctests/array.reduce.doctest
+++ b/testsrc/doctests/array.reduce.doctest
@@ -2,10 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.reduce;
+js> function sum(acc, val) { return acc + val; };
+
+js> [1, 4, 9, 16].reduce;
 function reduce() { [native code for Array.reduce, arity=1] }
 
-js> function sum(acc, val) { return acc + val; };
+js> [1, 4, 9, 16].reduce(sum);
+30
+
+js> Array.reduce;
+function reduce() { [native code for Array.reduce, arity=1] }
 
 js> Array.reduce([1, 4, 9, 16], sum);
 30

--- a/testsrc/doctests/array.reduceRight.doctest
+++ b/testsrc/doctests/array.reduceRight.doctest
@@ -2,10 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.reduceRight;
+js> function diff(acc, val) { return acc - val; };
+
+js> [1, 4, 9, 16].reduceRight;
 function reduceRight() { [native code for Array.reduceRight, arity=1] }
 
-js> function diff(acc, val) { return acc - val; };
+js> [1, 4, 9, 16].reduceRight(diff);
+2
+
+js> Array.reduceRight;
+function reduceRight() { [native code for Array.reduceRight, arity=1] }
 
 js> Array.reduceRight([1, 4, 9, 16], diff);
 2

--- a/testsrc/doctests/array.some.doctest
+++ b/testsrc/doctests/array.some.doctest
@@ -2,10 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-js> Array.some;
+js> function isSmall(n) { return n < 10; };
+
+js> [1, 4, 9, 16].some;
 function some() { [native code for Array.some, arity=1] }
 
-js> function isSmall(n) { return n < 10; };
+js> [1, 4, 9, 16].some(isSmall);
+true
+
+js> [19, 42].some(isSmall);
+false
+
+js> Array.some;
+function some() { [native code for Array.some, arity=1] }
 
 js> Array.some([1, 4, 9, 16], isSmall);
 true


### PR DESCRIPTION
the methods find and findIndex are not available on the prototoye in real browsers (tested with chrome, ff and ie). Because of this i think we have to remove this methods.
Have added simple test for the method calls on array objects.