### PR TITLE
Absolutely switch the build to use Java 1.8 bytecode.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'jacoco'
 apply plugin: 'distribution'
 apply plugin: 'checkstyle'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 tasks.withType(JavaCompile) { options.encoding = "UTF-8" }
 


### PR DESCRIPTION
We didn't change this in build.gradle. This will make the next release generate bytecode that only works with Java 8.