### PR TITLE
remove this constant because SubString is not immutable

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2469,7 +2469,7 @@ public class NativeRegExp extends IdScriptableObject implements Function
 
         if (re.parenCount == 0) {
             res.parens = null;
-            res.lastParen = SubString.emptySubString;
+            res.lastParen = new SubString();
         } else {
             SubString parsub = null;
             int num;

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -282,7 +282,7 @@ public class RegExpImpl implements RegExpProxy {
                 return parsub;
             }
         }
-        return SubString.emptySubString;
+        return new SubString();
     }
 
     /*

--- a/src/org/mozilla/javascript/regexp/SubString.java
+++ b/src/org/mozilla/javascript/regexp/SubString.java
@@ -36,8 +36,6 @@ public class SubString {
                : str.substring(index, index + length);
     }
 
-    public static final SubString emptySubString = new SubString();
-
     String str;
     int    index;
     int    length;


### PR DESCRIPTION
remove this constant because SubString is not immutable and using/manipulation this instance has side effects
In the past there was already a bunch of fixes because of this. To avoid to get trapped again i think we have to remove this in general. As far as i can see there are no negative side effects for performance and/or memory (we use this patch in HtmlUnit already for a while)