### PR TITLE
Add a setting to CompilerEnvirons to allow the 'use strict' directive…

### DIFF
--- a/src/org/mozilla/javascript/CompilerEnvirons.java
+++ b/src/org/mozilla/javascript/CompilerEnvirons.java
@@ -23,6 +23,7 @@ public class CompilerEnvirons
         optimizationLevel = 0;
         generatingSource = true;
         strictMode = false;
+        ignoreStrictDirective = false;
         warningAsError = false;
         generateObserverCount = false;
         allowSharpComments = false;
@@ -146,6 +147,16 @@ public class CompilerEnvirons
     public final boolean isStrictMode()
     {
         return strictMode;
+    }
+
+    public final boolean ignoreStrictDirective()
+    {
+        return ignoreStrictDirective;
+    }
+
+    public final void setIgnoreStrictDirective(boolean b)
+    {
+        ignoreStrictDirective = b;
     }
 
     public void setStrictMode(boolean strict)
@@ -283,6 +294,7 @@ public class CompilerEnvirons
     private int optimizationLevel;
     private boolean generatingSource;
     private boolean strictMode;
+    private boolean ignoreStrictDirective;
     private boolean warningAsError;
     private boolean generateObserverCount;
     private boolean recordingComments;

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -644,7 +644,7 @@ public class Parser
                         String directive = getDirective(n);
                         if (directive == null) {
                             inDirectivePrologue = false;
-                        } else if (directive.equals("use strict")) {
+                        } else if (isUseStrictDirective(directive)) {
                             inUseStrictDirective = true;
                             root.setInStrictMode(true);
                         }
@@ -688,6 +688,10 @@ public class Parser
         root.setBaseLineno(baseLineno);
         root.setEndLineno(ts.lineno);
         return root;
+    }
+
+    private boolean isUseStrictDirective(String directive) {
+        return !compilerEnv.ignoreStrictDirective() && directive.equals("use strict");
     }
 
     private AstNode parseFunctionBody(int type, FunctionNode fnNode)
@@ -742,7 +746,7 @@ public class Parser
                                 String directive = getDirective(n);
                                 if (directive == null) {
                                     inDirectivePrologue = false;
-                                } else if (directive.equals("use strict")) {
+                                } else if (isUseStrictDirective(directive)) {
                                     inUseStrictDirective = true;
                                     fnNode.setInStrictMode(true);
                                     if (!savedStrictMode) {

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -29,6 +29,29 @@ public class ParserTest extends TestCase {
       environment = new CompilerEnvirons();
     }
 
+
+    public void testUseStrictDirective() {
+        AstRoot root = parse("'use strict'; i=1;");
+
+        AstNode directive = ((ExpressionStatement)
+                root.getFirstChild()).getExpression();
+
+        assertTrue(root.isInStrictMode());
+        assertEquals("'use strict'", directive.toSource());
+    }
+
+    public void testIgnoreUseStrictDirective() {
+        environment.setIgnoreStrictDirective(true);
+        AstRoot root = parse("'use strict'; i=1;");
+
+        AstNode directive = ((ExpressionStatement)
+                root.getFirstChild()).getExpression();
+
+        assertFalse(root.isInStrictMode());
+        assertEquals("'use strict'", directive.toSource());
+    }
+
+
     public void testAutoSemiColonBetweenNames() {
         AstRoot root = parse("\nx\ny\nz\n");
         AstNode first = ((ExpressionStatement)


### PR DESCRIPTION
… to be ignored.

The directive implementation changed between 1.7.1 and 1.7.2, for backward compatibility the user may want to disable it.