### PR TITLE
Limit "use strict" in functions to "ES6" language level.

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -58,7 +58,7 @@ class CodeGenerator extends Icode {
             System.out.println(tree.toStringTree(tree));
         }
 
-        new NodeTransformer().transform(tree);
+        new NodeTransformer().transform(tree, compilerEnv);
 
         if (Token.printTrees) {
             System.out.println("after transform:");

--- a/src/org/mozilla/javascript/NodeTransformer.java
+++ b/src/org/mozilla/javascript/NodeTransformer.java
@@ -28,18 +28,24 @@ public class NodeTransformer
     {
     }
 
-    public final void transform(ScriptNode tree)
+    public final void transform(ScriptNode tree, CompilerEnvirons env)
     {
-        transform(tree, false);
+        transform(tree, false, env);
     }
 
-    public final void transform(ScriptNode tree, boolean inStrictMode)
+    public final void transform(ScriptNode tree, boolean inStrictMode, CompilerEnvirons env)
     {
-        inStrictMode = inStrictMode || tree.isInStrictMode();
-        transformCompilationUnit(tree, inStrictMode);
+        boolean useStrictMode = inStrictMode;
+        // Support strict mode inside a function only for "ES6" language level
+        // and above. Otherwise, we will end up breaking backward compatibility for
+        // many existing scripts.
+        if ((env.getLanguageVersion() >= Context.VERSION_ES6) && tree.isInStrictMode()) {
+          useStrictMode = true;
+        }
+        transformCompilationUnit(tree, useStrictMode);
         for (int i = 0; i != tree.getFunctionCount(); ++i) {
             FunctionNode fn = tree.getFunctionNode(i);
-            transform(fn, inStrictMode);
+            transform(fn, useStrictMode, env);
         }
     }
 

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -219,7 +219,7 @@ public class Codegen implements Evaluator
 
         OptTransformer ot = new OptTransformer(possibleDirectCalls,
                                                directCallTargets);
-        ot.transform(tree);
+        ot.transform(tree, compilerEnv);
 
         if (optLevel > 0) {
             (new Optimizer()).optimize(tree);

--- a/testsrc/jstests/backwardcompat/backward-use-strict.js
+++ b/testsrc/jstests/backwardcompat/backward-use-strict.js
@@ -1,0 +1,13 @@
+// In previous versions of Rhino, this code will run fine because "use strict"
+// was not enforced inside a function definition.
+// With ES6 mode enabled it will throw an exception on line 9.
+
+load("testsrc/assert.js");
+
+function strictlySetIt() {
+  'use strict';
+  foo = 'bar';
+  assertEquals(foo, 'bar');
+}
+
+strictlySetIt();

--- a/testsrc/org/mozilla/javascript/tests/backwardcompat/BackwardUseStrict.java
+++ b/testsrc/org/mozilla/javascript/tests/backwardcompat/BackwardUseStrict.java
@@ -1,0 +1,109 @@
+package org.mozilla.javascript.tests.backwardcompat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.tools.shell.Global;
+
+import static org.junit.Assert.*;
+
+public class BackwardUseStrict {
+  private static String source;
+
+  @BeforeClass
+  public static void init()
+      throws IOException
+  {
+    InputStream is = BackwardUseStrict.class.getResourceAsStream(
+        "/jstests/backwardcompat/backward-use-strict.js");
+    assertNotNull(is);
+    try {
+      InputStreamReader rdr = new InputStreamReader(is);
+      StringBuilder sb = new StringBuilder();
+      char[] buf = new char[4096];
+      int r;
+      do {
+        r = rdr.read(buf);
+        if (r > 0) {
+          sb.append(buf, 0, r);
+        }
+      } while (r > 0);
+      rdr.close();
+      source = sb.toString();
+    } finally {
+      is.close();
+    }
+  }
+
+  private void strictIgnored(int opt)
+  {
+    Context cx = Context.enter();
+    cx.setLanguageVersion(Context.VERSION_1_8);
+    cx.setOptimizationLevel(opt);
+    try {
+      Global root = new Global(cx);
+      cx.evaluateString(root, source, "[test]", 1, null);
+    } catch (RhinoException re) {
+      System.err.println(re.getScriptStackTrace());
+      assertTrue("Unexpected code error: " + re, false);
+    } finally {
+      Context.exit();
+    }
+  }
+
+  private void strictHonored(int opt)
+  {
+    Context cx = Context.enter();
+    cx.setLanguageVersion(Context.VERSION_ES6);
+    cx.setOptimizationLevel(opt);
+    try {
+      Global root = new Global(cx);
+      cx.evaluateString(root, source, "[test]", 1, null);
+      assertTrue("Expected a runtime exception", false);
+    } catch (RhinoException re) {
+      // We expect an error here.
+    } finally {
+      Context.exit();
+    }
+  }
+
+  @Test
+  public void testStrictIgnored0()
+  {
+    strictIgnored(0);
+  }
+
+  @Test
+  public void testStrictIgnored1()
+  {
+    strictIgnored(1);
+  }
+
+  @Test
+  public void testStrictIgnored9()
+  {
+    strictIgnored(9);
+  }
+
+  @Test
+  public void testStrictHonored0()
+  {
+    strictHonored(0);
+  }
+
+  @Test
+  public void testStrictHonored1()
+  {
+    strictHonored(1);
+  }
+
+  @Test
+  public void testStrictHonored9()
+  {
+    strictHonored(9);
+  }
+}


### PR DESCRIPTION
Ensure that when "use strict" is used inside a function definition
that it only takes effect when the language level is "ES6" (200)
or higher.

This mitigates a change in 1.7.7.2 that caused some failures of scripts
that worked on previous versions of Rhino to fail with no recourse
but to use an older version.