### PR TITLE
Fix positions recording around arrow functions

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3106,7 +3106,7 @@ public class Parser
             Comment jsdocNode = getAndResetJsDoc();
             int lineno = ts.lineno;
             int begin = ts.tokenBeg;
-            AstNode e = (peekToken() == Token.RP ? new EmptyExpression() : expr());
+            AstNode e = (peekToken() == Token.RP ? new EmptyExpression(begin) : expr());
             if (peekToken() == Token.FOR) {
                 return generatorExpression(e, begin);
             }

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -713,8 +713,8 @@ public class Parser
         pn.setLineno(ts.lineno);
         try {
             if (isExpressionClosure) {
-                ReturnStatement n = new ReturnStatement(ts.lineno);
-                n.setReturnValue(assignExpr());
+                AstNode returnValue = assignExpr();
+                ReturnStatement n = new ReturnStatement(returnValue.getPosition(), returnValue.getLength(), returnValue);
                 // expression closure flag is required on both nodes
                 n.putProp(Node.EXPRESSION_CLOSURE_PROP, Boolean.TRUE);
                 pn.putProp(Node.EXPRESSION_CLOSURE_PROP, Boolean.TRUE);

--- a/testsrc/org/mozilla/javascript/tests/ArrowFnPositionBugTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ArrowFnPositionBugTest.java
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.ast.AstNode;
+import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.ast.NodeVisitor;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
+public class ArrowFnPositionBugTest {
+    /**
+     * Util class that sifts through nodes for first arrow function,
+     * then stores it and stops
+     */
+    private static class ArrowFnExtractor implements NodeVisitor {
+        private FunctionNode functionNode;
+        @Override
+        public boolean visit(AstNode node) {
+            if (functionNode != null) return false;
+            if (node instanceof FunctionNode) {
+                FunctionNode fn = (FunctionNode) node;
+                if (fn.getFunctionType() == FunctionNode.ARROW_FUNCTION) {
+                    functionNode = fn;
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Parses given source line and extracts a first (top) arrow function node
+     */
+    private FunctionNode parseAndExtractArrowFn(String src) {
+        ArrowFnExtractor arrowFnExtractor = new ArrowFnExtractor();
+        Parser p = new Parser();
+        p.parse(src, "eval", 1).visit(arrowFnExtractor);
+        return Objects.requireNonNull(arrowFnExtractor.functionNode);
+    }
+
+    @Test
+    public void testArrowFnPositionInAssignment() {
+        FunctionNode arrowFn = parseAndExtractArrowFn("var a = () => 1;");
+        assertEquals(4, arrowFn.getPosition());
+        assertEquals(8, arrowFn.getAbsolutePosition());
+    }
+
+    @Test
+    public void testArrowFnPositionInCall() {
+        FunctionNode arrowFn = parseAndExtractArrowFn("test(() => { return 2; }, a);");
+        assertEquals(5, arrowFn.getPosition());
+        assertEquals(5, arrowFn.getAbsolutePosition());
+    }
+
+    @Test
+    public void testArrowFnWithArgsPosition() {
+        FunctionNode arrowFn = parseAndExtractArrowFn("var a = (b, c) => b + c;");
+        // ParenthesisedExpression copies position from its child, so
+        // with an EmptyExpression it will be a position of opening paren,
+        // but when there's parameters it's a start of parameters list
+        // (i.e. it's shifted by one char compared to no-parameters case)
+        assertEquals(5, arrowFn.getPosition());
+        assertEquals(9, arrowFn.getAbsolutePosition());
+    }
+
+}

--- a/testsrc/org/mozilla/javascript/tests/ArrowFnPositionBugTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ArrowFnPositionBugTest.java
@@ -9,6 +9,7 @@ import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.AstNode;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.NodeVisitor;
+import org.mozilla.javascript.ast.ReturnStatement;
 
 import java.util.Objects;
 
@@ -68,6 +69,15 @@ public class ArrowFnPositionBugTest {
         // (i.e. it's shifted by one char compared to no-parameters case)
         assertEquals(5, arrowFn.getPosition());
         assertEquals(9, arrowFn.getAbsolutePosition());
+    }
+
+    @Test
+    public void testArrowFnReturnPosition() {
+        FunctionNode arrowFn = parseAndExtractArrowFn("test((cb) => cb() + 1);");
+        ReturnStatement returnStatement = (ReturnStatement) arrowFn.getBody().getFirstChild();
+        assertEquals(0, returnStatement.getPosition());
+        assertEquals(13, returnStatement.getAbsolutePosition());
+        assertEquals(8, returnStatement.getLength());
     }
 
 }


### PR DESCRIPTION
Two actual fixes:
* record position of the parameterless arrow function (fix by @nabice, fixes #303)
* record position and length of the 'fake' return statement inside function's expression body

Tests are passing locally; doesn't introduce new checkstyle violations.