### PR TITLE
Improve UX around Test262

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -55,7 +55,7 @@ public class Test262SuiteTest {
         TestUtils.setGlobalContextFactory(null);
     }
 
-    private static final Pattern EXCLUDE_PATTERN = Pattern.compile("\\s{1,4}!\\s*(.+)");
+    private static final Pattern EXCLUDE_PATTERN = Pattern.compile("!\\s*(.+)");
 
     private final String jsFilePath;
     private final String jsFileStr;
@@ -145,7 +145,7 @@ public class Test262SuiteTest {
 
         while (true) {
             curLine = nxtLine;
-            nxtLine = scanner.hasNextLine() ? scanner.nextLine() : null;
+            nxtLine = scanner.hasNextLine() ? scanner.nextLine().trim() : null;
 
             if (curLine == null) break;
 
@@ -160,7 +160,7 @@ public class Test262SuiteTest {
 
                 while (true) {
                     curLine = nxtLine;
-                    nxtLine = scanner.hasNextLine() ? scanner.nextLine() : null;
+                    nxtLine = scanner.hasNextLine() ? scanner.nextLine().trim() : null;
 
                     if (curLine == null) {
                         testFiles.addAll(dirFiles);
@@ -171,10 +171,11 @@ public class Test262SuiteTest {
 
                     Matcher m = EXCLUDE_PATTERN.matcher(curLine);
                     if (m.matches()) {
+                        String excludeSubstring = m.group(1);
                         Iterator<File> it = dirFiles.iterator();
                         while (it.hasNext()) {
                             String path = it.next().getPath().replaceAll("\\\\", "/");
-                            if (path.contains(m.group(1))) it.remove();
+                            if (path.contains(excludeSubstring)) it.remove();
                         }
                     } else {
                         testFiles.addAll(dirFiles);

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -153,12 +153,6 @@ built-ins/Array
 # strictness issues
     ! every/15.4.4.16-5-1-s
     ! filter/15.4.4.20-5-1-s
-    ! find/Array.prototype.find_this-arg
-    ! find/Array.prototype.find_this-arg-receiver-primitive
-    ! find/Array.prototype.find_this-undefined
-    ! findIndex/Array.prototype.findIndex_this-arg
-    ! findIndex/Array.prototype.findIndex_this-arg-receiver-coercion
-    ! findIndex/Array.prototype.findIndex_this-arg-receiver-primitive
     ! forEach/15.4.4.18-5-1-s
     ! map/15.4.4.19-5-1-s
     ! reduce/15.4.4.21-9-c-ii-4-s
@@ -170,12 +164,10 @@ built-ins/Array
     ! prototype/splice/set_length_no_args.js
     ! prototype/toLocaleString/primitive_this_value.js
     ! prototype/toLocaleString/primitive_this_value_getter.js
-
 # not implemented
     ! prototype/Symbol.iterator.js
     ! symbol-species-name.js
     ! symbol-species.js
-    ! Proxy
     ! from/
     ! of/
     ! fill/

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -278,10 +278,36 @@ language/keywords
 
 language/future-reserved-words
 
-expressions/postfix-decrement
-expressions/postfix-increment
-expressions/prefix-decrement
-expressions/prefix-increment
+language/expressions/postfix-decrement
+    ! postfix-decrement/11.3.2-2-1-s.js
+    ! postfix-decrement/11.3.2-2-2-s.js
+    ! postfix-decrement/S11.3.2_A6_T1.js
+    ! postfix-decrement/S11.3.2_A6_T2.js
+    ! postfix-decrement/S11.3.2_A6_T3.js
+    ! postfix-decrement/non-simple.js
+language/expressions/postfix-increment
+    ! postfix-increment/11.3.1-2-1-s.js
+    ! postfix-increment/11.3.1-2-2-s.js
+    ! postfix-increment/11.3.1-2-1gs.js
+    ! postfix-increment/S11.3.1_A6_T1.js
+    ! postfix-increment/S11.3.1_A6_T2.js
+    ! postfix-increment/S11.3.1_A6_T3.js
+    ! postfix-increment/non-simple.js
+language/expressions/prefix-decrement
+    ! prefix-decrement/11.4.5-2-1-s.js
+    ! prefix-decrement/11.4.5-2-2-s.js
+    ! prefix-decrement/11.4.5-2-2gs.js
+    ! prefix-decrement/S11.4.5_A6_T1.js
+    ! prefix-decrement/S11.4.5_A6_T2.js
+    ! prefix-decrement/S11.4.5_A6_T3.js
+    ! prefix-decrement/non-simple.js
+language/expressions/prefix-increment
+    ! prefix-increment/11.4.4-2-1-s.js
+    ! prefix-increment/11.4.4-2-2-s.js
+    ! prefix-increment/S11.4.4_A6_T1.js
+    ! prefix-increment/S11.4.4_A6_T2.js
+    ! prefix-increment/S11.4.4_A6_T3.js
+    ! prefix-increment/non-simple.js
 
 language/literals/numeric
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,3 +1,19 @@
+# This is a configuration file for Test262SuiteTest.java.
+#
+# Lines that start with a # (like this one) are comments.
+# There is no support for inline comments.
+#
+# Each non-commented out line adds either an inclusion or exclusion:
+# * inclusions are lines that don't have any special syntax.
+#   They are paths relative to '/test262/tests' directory
+#   of either a single file or a directory that will be executed
+#   as part of the test
+#
+# * exclusions start with a ! (with optional spaces around it)
+#   Each exclusion defines a substring that will make test ignore files
+#   that contain it in their paths. It affects only files added
+#   by directory inclusion defined on a closest line above it
+
 built-ins/String
     ! prototype/replace/15.5.4.11-1.js
     ! prototype/replace/S15.5.4.11_A12.js


### PR DESCRIPTION
This addresses several small annoyances with how working with test262 cases goes:

1. adds an explanation of the format to the file itself, since it's not very obvious
1. allows leading and trailing whitespace for all the lines
1. `Test262SuiteTest` now throws exception with an informative error message when path from `test262.properties` doesn't exist, before it was just ignored and a couple of paths were wrong
1. `Test262SuiteTest` now prints out warning to the console when an exclusion pattern didn't match anything
1. streamlines code around the `test262.properties` parsing (less duplication) and adds comments, I hope it's now easier to follow

As a bonus, fixing the third point brought the number of test262 cases from 25752 to 26229 (+477) 🎉 