### PR TITLE
Update and improve test262 integration

### DIFF
--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -14,55 +14,7 @@
 #   that contain it in their paths. It affects only files added
 #   by directory inclusion defined on a closest line above it
 
-built-ins/String
-    ! prototype/replace/15.5.4.11-1.js
-    ! prototype/replace/S15.5.4.11_A12.js
-    ! prototype/S15.5.4_A1.js
-    ! prototype/S15.5.4_A2.js
-    ! prototype/S15.5.4_A3.js
-    ! prototype/split/S15.5.4.14_A2_T37.js
-    ! prototype/substring/S15.5.4.15_A1_T5.js
-    ! raw
-    ! fromCodePoint
-    ! prototype/Symbol.iterator/this-val-non-obj-coercible.js
-    ! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
-    ! prototype/includes/return-abrupt-from-searchstring-regexp-test.js
-    ! prototype/includes/return-true-if-searchstring-is-empty.js
-    ! prototype/normalize/return-normalized-string-using-default-parameter.js
-    ! prototype/replace/cstm-replace-get-err.js
-    ! prototype/replace/cstm-replace-invocation.js
-    ! prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
-    ! prototype/toLocaleLowerCase/special_casing_conditional.js
-    ! prototype/toLowerCase/special_casing_conditional.js
-
-built-ins/StringIteratorPrototype
-
-language/statements/for-of
-    ! Array.prototype.entries.js
-    ! Array.prototype.keys.js
-    ! body-dstr-assign-error.js
-    ! body-put-error.js
-    ! for-of/break
-    ! const-bound-names-fordecl-tdz-for-of.js
-    ! const-fresh-binding-per-iteration-for-of.js
-    ! for-of/continue
-    ! for-of/generator
-    ! generic-iterable.js
-    ! iterator-as-proxy.js
-    ! iterator-close-get-method-error.js
-    ! iterator-close-non-object.js
-    ! iterator-close-via-break.js
-    ! iterator-close-via-return.js
-    ! iterator-close-via-throw.js
-    ! iterator-next-result-type.js
-    ! let-bound-names-fordecl-tdz-for-of.js
-    ! let-fresh-binding-per-iteration-for-of.js
-    ! for-of/map
-    ! nested.js
-    ! for-of/return
-    ! for-of/set
-    ! for-of/throw
-    ! for-of/yield
+######### BUILT-INS #########
 
 built-ins/Array
 # incorrect length handling
@@ -165,171 +117,594 @@ built-ins/Array
     ! prototype/toLocaleString/primitive_this_value.js
     ! prototype/toLocaleString/primitive_this_value_getter.js
 # not implemented
-    ! prototype/Symbol.iterator.js
-    ! symbol-species-name.js
-    ! symbol-species.js
+    ! Symbol.species/
+    ! flatMap/
+    ! flatten/
     ! from/
     ! of/
-    ! fill/
-    ! concat/
-    ! entries/
-    ! keys/
-    ! copyWithin
-    ! values
+    ! prototype/Symbol.unscopables/
+    ! prototype/copyWithin/
+    ! prototype/fill/
+    ! prototype/entries/
+    ! prototype/includes/
+    ! prototype/keys/
+    ! prototype/values/
+    ! prototype/Symbol.iterator.js
+# new
+    ! prototype/concat/Array.prototype.concat_array-like
+    ! prototype/concat/Array.prototype.concat_holey-sloppy-arguments.js
+    ! prototype/concat/Array.prototype.concat_large-typed-array.js
+    ! prototype/concat/Array.prototype.concat_length-throws.js
+    ! prototype/concat/Array.prototype.concat_non-array.js
+    ! prototype/concat/Array.prototype.concat_sloppy-
+    ! prototype/concat/Array.prototype.concat_small-typed-array.js
+    ! prototype/concat/Array.prototype.concat_spreadable-
+    ! prototype/concat/Array.prototype.concat_strict-arguments.js
+    ! prototype/concat/is-concat-spreadable-get-err.js
+    ! prototype/concat/is-concat-spreadable-val-falsey.js
+    ! prototype/concat/is-concat-spreadable-val-truthy.js
+    ! prototype/map/create-non-array-invalid-len.js
+    ! prototype/reverse/length-exceeding-integer-limit-with-object.js
+    ! prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+    ! prototype/slice/create-non-array-invalid-len.js
+    ! prototype/slice/create-species-neg-zero.js
+    ! prototype/slice/length-exceeding-integer-limit-proxied-array.js
+    ! prototype/slice/length-exceeding-integer-limit.js
+    ! prototype/sort/comparefn-nonfunction-call-throws.js
+    ! prototype/splice/clamps-length-to-integer-limit.js
+    ! prototype/splice/create-non-array-invalid-len.js
+    ! prototype/splice/create-species-length-exceeding-integer-limit.js
+    ! prototype/splice/create-species-neg-zero.js
+    ! prototype/splice/length-and-deleteCount-exceeding-integer-limit.js
+    ! prototype/splice/length-exceeding-integer-limit-shrink-array.js
+    ! prototype/splice/length-near-integer-limit-grow-array.js
+# several similar tests for filter, map, etc.
+    ! create-ctor-non-object.js
+    ! create-ctor-poisoned.js
+    ! create-species-abrupt.js
+    ! create-species-non-ctor.js
+    ! create-species-poisoned.js
+    ! create-species.js
+    ! clamps-to-integer-limit.js
+    ! length-near-integer-limit.js
+    ! throws-if-integer-limit-exceeded.js
 
 built-ins/ArrayIteratorPrototype
-
-built-ins/Symbol
-    ! prototype/Symbol.toStringTag
-    ! species
-
-language/expressions/arrow-function
-# not implemented
-## strict mode
-    ! ArrowFunction_restricted-properties.js
-## class syntax
-    ! lexical-new.target-closure-returned.js
-    ! lexical-new.target.js
-    ! lexical-super-call-from-within-constructor.js
-    ! lexical-super-property-from-within-constructor.js
-    ! lexical-super-property.js
-    ! lexical-supercall-from-immediately-invoked-arrow.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-no-yield.js
-## generator
-    ! syntax/arrowparameters-bindingidentifier-yield.js
-    ! syntax/arrowparameters-cover-formalparameters-yield.js
-    ! syntax/early-errors/arrowparameters-cover-no-yield.js
-## spread operator
-    ! syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
-    ! syntax/arrowparameters-cover-rest-concisebody-functionbody.js
-    ! syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-rest.js
-## default parameter
-    ! syntax/arrowparameters-cover-initialize-1.js
-    ! syntax/arrowparameters-cover-initialize-2.js
-## destructuring assignment
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-3.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-4.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-5.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-rest.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates.js
-
-language/arguments-object
-   ! arguments-object/mapped/Symbol.iterator.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-3.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-delete-1.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-delete-2.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-delete-3.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-delete-4.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-1.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-2.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-3.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-4.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-5.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-1.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-2.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-3.js
-   ! arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-4.js
-   ! arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-1.js
-   ! arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-2.js
-   ! arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-3.js
-   ! arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-4.js
-   ! arguments-object/unmapped/Symbol.iterator.js
-
-language/types/reference
-    ! S8.7.2_A1_T1.js
-    ! S8.7.2_A1_T2.js
-    ! 8.7.2-3-a-1gs.js
-
-built-ins/Object/defineProperties/15.2.3.7-6-a-26.js
-built-ins/Object/defineProperties/15.2.3.7-6-a-27.js
-built-ins/Object/defineProperties/15.2.3.7-6-a-32.js
-built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-230.js
-
-language/expressions/delete/11.4.1-4-a-1-s.js
-language/expressions/delete/11.4.1-4-a-2-s.js
-language/expressions/delete/11.4.1-4-a-4-s.js
-language/expressions/delete/11.4.1-4.a-2.js
-language/expressions/delete/11.4.1-4.a-3-s.js
-language/expressions/delete/11.4.1-4.a-3.js
-language/expressions/delete/11.4.1-4.a-4.js
-language/expressions/delete/11.4.1-4.a-8-s.js
-language/expressions/delete/11.4.1-4.a-9-s.js
-language/expressions/delete/11.4.1-4.a-9.js
-language/expressions/delete/11.4.4-4.a-3-s.js
-
-language/keywords
-# expected:<ReferenceError> but was:<SyntaxError>
-    ! S7.6.1.1_A1.18.js
-
-language/future-reserved-words
-
-language/expressions/postfix-decrement
-    ! postfix-decrement/11.3.2-2-1-s.js
-    ! postfix-decrement/11.3.2-2-2-s.js
-    ! postfix-decrement/S11.3.2_A6_T1.js
-    ! postfix-decrement/S11.3.2_A6_T2.js
-    ! postfix-decrement/S11.3.2_A6_T3.js
-    ! postfix-decrement/non-simple.js
-language/expressions/postfix-increment
-    ! postfix-increment/11.3.1-2-1-s.js
-    ! postfix-increment/11.3.1-2-2-s.js
-    ! postfix-increment/11.3.1-2-1gs.js
-    ! postfix-increment/S11.3.1_A6_T1.js
-    ! postfix-increment/S11.3.1_A6_T2.js
-    ! postfix-increment/S11.3.1_A6_T3.js
-    ! postfix-increment/non-simple.js
-language/expressions/prefix-decrement
-    ! prefix-decrement/11.4.5-2-1-s.js
-    ! prefix-decrement/11.4.5-2-2-s.js
-    ! prefix-decrement/11.4.5-2-2gs.js
-    ! prefix-decrement/S11.4.5_A6_T1.js
-    ! prefix-decrement/S11.4.5_A6_T2.js
-    ! prefix-decrement/S11.4.5_A6_T3.js
-    ! prefix-decrement/non-simple.js
-language/expressions/prefix-increment
-    ! prefix-increment/11.4.4-2-1-s.js
-    ! prefix-increment/11.4.4-2-2-s.js
-    ! prefix-increment/S11.4.4_A6_T1.js
-    ! prefix-increment/S11.4.4_A6_T2.js
-    ! prefix-increment/S11.4.4_A6_T3.js
-    ! prefix-increment/non-simple.js
-
-language/literals/numeric
+    ! Symbol.toStringTag/property-descriptor.js
+    ! next/detach-typedarray-in-progress.js
 
 built-ins/Date
-  ! 15.9.1.15-1.js
-  ! construct_with_date.js
-  ! prototype/setFullYear/15.9.5.40_1.js
+    ! UTC/coercion-order.js
+    ! UTC/no-arg.js
+    ! coercion-order.js
+    ! construct_with_date.js
+    ! prototype/Symbol.toPrimitive/
+    ! prototype/toString/non-date-receiver.js
+    ! value-get-symbol-to-prim-err.js
+    ! /value-symbol-
+    ! /value-to-primitive-
+# Type coercion tests
+    ! prototype/setFullYear/15.9.5.40_1.js
+    ! prototype/setFullYear/arg-year-to-number.js
+    ! prototype/setHours/arg-hour-to-number.js
+    ! arg-to-number.js
+    ! arg-date-to-number.js
+    ! arg-min-to-number.js
+    ! arg-month-to-number.js
+    ! arg-ms-to-number.js
+    ! arg-sec-to-number.js
 
 built-ins/Object
-  ! defineProperties
-  ! defineProperty
-  ! freeze
-  ! getOwnPropertyDescriptor
-  ! getPrototypeOf
-  ! prototype/hasOwnProperty
-  ! prototype/propertyIsEnumerable
-  ! prototype/toLocaleString
-  ! prototype/toString
-  ! prototype/valueOf
-  ! isExtensible
-  ! isFrozen
-  ! isPrototypeOf
-  ! isSealed
-  ! preventExtensions
-  ! setPrototypeOf
-  ! seal
-# No Proxy object yet
-  ! assign/source-own-prop-desc-missing.js
-  ! assign/source-own-prop-error.js
-  ! assign/source-own-prop-keys-error.js
-# Disagreement on strict mode
-  ! assign/target-set-not-writable.js
-  ! create/15.2.3.5-4-311.js
+    ! assign/target-set-not-writable.js
+    ! create/15.2.3.5-4-311.js
+    ! defineProperties/15.2.3.7-6-a-112.js
+    ! defineProperties/15.2.3.7-6-a-113.js
+    ! defineProperties/15.2.3.7-6-a-118.js
+    ! defineProperties/15.2.3.7-6-a-164.js
+    ! defineProperties/15.2.3.7-6-a-165.js
+    ! defineProperties/15.2.3.7-6-a-166.js
+    ! defineProperties/15.2.3.7-6-a-168.js
+    ! defineProperties/15.2.3.7-6-a-169.js
+    ! defineProperties/15.2.3.7-6-a-170.js
+    ! defineProperties/15.2.3.7-6-a-172.js
+    ! defineProperties/15.2.3.7-6-a-173.js
+    ! defineProperties/15.2.3.7-6-a-175.js
+    ! defineProperties/15.2.3.7-6-a-176.js
+    ! defineProperties/15.2.3.7-6-a-184.js
+    ! defineProperties/15.2.3.7-6-a-185.js
+    ! defineProperties/15.2.3.7-6-a-231.js
+    ! defineProperties/15.2.3.7-6-a-282.js
+    ! defineProperty/15.2.3.6-4-116.js
+    ! defineProperty/15.2.3.6-4-117.js
+    ! defineProperty/15.2.3.6-4-122.js
+    ! defineProperty/15.2.3.6-4-168.js
+    ! defineProperty/15.2.3.6-4-169.js
+    ! defineProperty/15.2.3.6-4-170.js
+    ! defineProperty/15.2.3.6-4-172.js
+    ! defineProperty/15.2.3.6-4-173.js
+    ! defineProperty/15.2.3.6-4-174.js
+    ! defineProperty/15.2.3.6-4-176.js
+    ! defineProperty/15.2.3.6-4-177.js
+    ! defineProperty/15.2.3.6-4-188.js
+    ! defineProperty/15.2.3.6-4-189.js
+    ! defineProperty/15.2.3.6-4-206.js
+    ! defineProperty/15.2.3.6-4-242.js
+    ! defineProperty/15.2.3.6-4-254.js
+    ! defineProperty/15.2.3.6-4-255.js
+    ! defineProperty/15.2.3.6-4-256.js
+    ! defineProperty/15.2.3.6-4-293-1.js
+    ! defineProperty/15.2.3.6-4-293-3.js
+    ! defineProperty/15.2.3.6-4-293-4.js
+    ! defineProperty/15.2.3.6-4-336.js
+    ! defineProperty/15.2.3.6-4-538-1.js
+    ! defineProperty/15.2.3.6-4-538-5.js
+    ! defineProperty/15.2.3.6-4-538.js
+    ! /primitive-
+    ! entries/
+    ! freeze/15.2.3.9-1
+    ! freeze/15.2.3.9-2-a-12.js
+    ! freeze/15.2.3.9-2-a-8.js
+    ! freeze/15.2.3.9-2-c-2.js
+    ! freeze/15.2.3.9-2-c-3.js
+    ! freeze/15.2.3.9-2-c-4.js
+    ! freeze/15.2.3.9-2-d-3.js
+    ! freeze/frozen-object-contains-symbol-properties-non-strict.js
+    ! getOwnPropertyDescriptor/15.2.3.3-3-14.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-187.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-212.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-213.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-214.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-215.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-249.js
+    ! getOwnPropertyDescriptor/15.2.3.3-4-250.js
+    ! getOwnPropertyDescriptors/
+    ! getPrototypeOf/15.2.3.2-2-12.js
+    ! getPrototypeOf/15.2.3.2-2-13.js
+    ! getPrototypeOf/15.2.3.2-2-14.js
+    ! getPrototypeOf/15.2.3.2-2-15.js
+    ! getPrototypeOf/15.2.3.2-2-16.js
+    ! getPrototypeOf/15.2.3.2-2-17.js
+    ! internals/DefineOwnProperty/consistent-
+    ! isExtensible/15.2.3.13-1
+    ! isFrozen/15.2.3.12-1-1.js
+    ! isFrozen/15.2.3.12-1-2.js
+    ! isFrozen/15.2.3.12-1-3.js
+    ! isFrozen/15.2.3.12-1-4.js
+    ! isFrozen/15.2.3.12-1.js
+    ! isFrozen/15.2.3.12-2-a-12.js
+    ! isSealed/15.2.3.11-1.js
+    ! keys/proxy-keys.js
+    ! preventExtensions/15.2.3.10-1
+    ! preventExtensions/15.2.3.10-3-23.js
+    ! preventExtensions/symbol-object-contains-symbol-properties-strict.js
+    ! prototype/hasOwnProperty/S15.2.4.5_A12.js
+    ! prototype/hasOwnProperty/S15.2.4.5_A13.js
+    ! prototype/hasOwnProperty/symbol_property_
+    ! prototype/isPrototypeOf/S15.2.4.6_A12.js
+    ! prototype/isPrototypeOf/S15.2.4.6_A13.js
+    ! prototype/propertyIsEnumerable/S15.2.4.7_A12.js
+    ! prototype/propertyIsEnumerable/S15.2.4.7_A13.js
+    ! prototype/propertyIsEnumerable/symbol_property_
+    ! prototype/toLocaleString/S15.2.4.3_A12.js
+    ! prototype/toLocaleString/S15.2.4.3_A13.js
+    ! prototype/toLocaleString/primitive_this_value.js
+    ! prototype/toLocaleString/primitive_this_value_getter.js
+    ! prototype/toString/get-symbol-tag-err.js
+    ! prototype/toString/symbol-tag-override-instances.js
+    ! prototype/toString/symbol-tag-override-primitives.js
+    ! prototype/toString/symbol-tag-str.js
+    ! prototype/valueOf/S15.2.4.4_A12.js
+    ! prototype/valueOf/S15.2.4.4_A13.js
+    ! prototype/valueOf/S15.2.4.4_A14.js
+    ! prototype/valueOf/S15.2.4.4_A15.js
+    ! seal/15.2.3.8-1
+    ! seal/15.2.3.8-2-a-9.js
+    ! seal/15.2.3.8-2-b-
+    ! seal/15.2.3.8-2-c-3.js
+    ! seal/symbol-object-
+    ! setPrototypeOf/
+    ! values/
+
+built-ins/String
+    ! numeric-properties.js
+    ! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
+    ! prototype/includes/return-abrupt-from-searchstring-regexp-test.js
+    ! prototype/includes/return-true-if-searchstring-is-empty.js
+    ! prototype/match/cstm-matcher-get-err.js
+    ! prototype/match/cstm-matcher-invocation.js
+    ! prototype/match/invoke-builtin-match.js
+    ! prototype/normalize/return-normalized-string-using-default-parameter.js
+    ! prototype/replace/S15.5.4.11_A12.js
+    ! prototype/replace/cstm-replace-get-err.js
+    ! prototype/replace/cstm-replace-invocation.js
+    ! prototype/search/cstm-search-get-err.js
+    ! prototype/search/cstm-search-invocation.js
+    ! prototype/search/invoke-builtin-search-searcher-undef.js
+    ! prototype/search/invoke-builtin-search.js
+    ! prototype/split/cstm-split-get-err.js
+    ! prototype/split/cstm-split-invocation.js
+    ! prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
+    ! prototype/substring/S15.5.4.15_A1_T5.js
+    ! prototype/toLocaleLowerCase/special_casing_conditional.js
+    ! prototype/toLowerCase/special_casing_conditional.js
+    ! prototype/Symbol.iterator/prop-desc.js
+    ! prototype/Symbol.iterator/this-val-non-obj-coercible.js
+    # same test doesn't work for most of prototype methods
+    ! this-value-not-obj-coercible.js
+    # not implemented
+    ! fromCodePoint/
+    ! raw/
+    ! prototype/padStart
+    ! prototype/padEnd
+
+built-ins/StringIteratorPrototype
+    ! Symbol.toStringTag.js
+
+built-ins/Symbol
+    ! keyFor/arg-non-symbol.js
+    ! species/builtin-getter-name.js
+    ! species/subclassing.js
+    ! prototype/Symbol.toPrimitive/name.js
+    ! prototype/Symbol.toPrimitive/prop-desc.js
+    ! prototype/Symbol.toStringTag.js
+    ! prototype/toString/prop-desc.js
+    ! prototype/valueOf/prop-desc.js
+    ! /constructor.js
+    ! /length.js
+    ! this-val-non-obj.js
+
+
+######### LANGUAGE #########
+
+language/arguments-object
+    ! arguments-caller.js
+    ! -args-trailing-comma-
+    ! mapped/Symbol.iterator.js
+    ! mapped/mapped-arguments-nonconfigurable-3.js
+    ! mapped/mapped-arguments-nonconfigurable-delete-
+    ! mapped/mapped-arguments-nonconfigurable-nonwritable-
+    ! mapped/mapped-arguments-nonconfigurable-strict-delete-
+    ! mapped/mapped-arguments-nonwritable-nonconfigurable-
+    ! mapped/nonconfigurable-descriptors-
+    ! mapped/nonconfigurable-nonenumerable-
+    ! mapped/nonconfigurable-nonwritable-
+    ! mapped/nonwritable-nonconfigurable-descriptors-
+    ! mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
+    ! mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
+    ! mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
+    ! unmapped/via-params-dflt.js
+    ! unmapped/via-params-dstr.js
+    ! unmapped/via-params-rest.js
+
+language/asi
+    ! S7.9_A5.7_T1.js
+
+language/directive-prologue
+    ! 10.1.1-15-s.js
+    ! 10.1.1-16-s.js
+    ! 10.1.1-17-s.js
+    ! 10.1.1-18-s.js
+    ! 14.1-1-s.js
+    ! 14.1-2-s.js
+    ! 14.1-3-s.js
+    ! 14.1-4-s.js
+    ! 14.1-5-s.js
+    ! 14.1-6-s.js
+    ! 14.1-7-s.js
+    ! 14.1-8-s.js
+    ! 14.1-9-s.js
+    ! 14.1-10-s.js
+    ! 14.1-11-s.js
+    ! 14.1-12-s.js
+    ! 14.1-13-s.js
+    ! 14.1-14-s.js
+    ! 14.1-15-s.js
+    ! 14.1-16-s.js
+    ! 14.1-17-s.js
+
+language/expressions/arrow-function
+    ! -rest-
+    ! ArrowFunction_restricted-properties.js
+    ! dflt-params-trailing-comma.js
+    ! dstr-ary-init-iter-close.js
+    ! dstr-ary-init-iter-get-err.js
+    ! dstr-ary-ptrn-elem-ary-elem-init.js
+    ! dstr-ary-ptrn-elem-ary-elem-iter.js
+    ! dstr-ary-ptrn-elem-ary-empty-iter.js
+    ! dstr-ary-ptrn-elem-id-init-
+    ! dstr-ary-ptrn-elem-id-iter-step-err.js
+    ! dstr-ary-ptrn-elem-id-iter-val-err.js
+    ! dstr-ary-ptrn-elem-obj-
+    ! dstr-obj-init-null.js
+    ! dstr-obj-init-undefined.js
+    ! dstr-obj-ptrn-id-get-value-err.js
+    ! dstr-obj-ptrn-id-init-
+    ! dstr-obj-ptrn-id-trailing-comma.js
+    ! dstr-obj-ptrn-list-err.js
+    ! dstr-obj-ptrn-prop-ary-init.js
+    ! dstr-obj-ptrn-prop-ary-value-null.js
+    ! dstr-obj-ptrn-prop-ary.js
+    ! dstr-obj-ptrn-prop-eval-err.js
+    ! dstr-obj-ptrn-prop-id-get-value-err.js
+    ! dstr-obj-ptrn-prop-id-init
+    ! dstr-obj-ptrn-prop-obj
+    ! lexical-new.target
+    ! lexical-super
+    ! params-trailing-comma-multiple.js
+    ! params-trailing-comma-single.js
+    ! scope-body-lex-distinct.js
+    ! scope-param-elem-var-close.js
+    ! scope-param-elem-var-open.js
+    ! scope-paramsbody-var-close.js
+    ! scope-paramsbody-var-open.js
+    ! syntax/arrowparameters-bindingidentifier-yield.js
+    ! syntax/arrowparameters-cover-formalparameters-yield.js
+    ! syntax/arrowparameters-cover-initialize-1.js
+    ! syntax/arrowparameters-cover-initialize-2.js
+    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
+    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
+    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
+    ! syntax/early-errors/arrowparameters-cover-no-duplicates.js
+
+language/expressions/delete
+    ! 11.4.1-3-a-1-s.js
+    ! 11.4.1-5-a-
+
+language/expressions/postfix-decrement
+    ! 11.3.2-2-1-s.js
+    ! 11.3.2-2-2-s.js
+    ! S11.3.2_A6_T1.js
+    ! S11.3.2_A6_T2.js
+    ! S11.3.2_A6_T3.js
+    ! non-simple.js
+    ! target-cover-newtarget.js
+    ! target-newtarget.js
+language/expressions/postfix-increment
+    ! 11.3.1-2-1-s.js
+    ! 11.3.1-2-2-s.js
+    ! 11.3.1-2-1gs.js
+    ! S11.3.1_A6_T1.js
+    ! S11.3.1_A6_T2.js
+    ! S11.3.1_A6_T3.js
+    ! non-simple.js
+    ! target-cover-newtarget.js
+    ! target-newtarget.js
+language/expressions/prefix-decrement
+    ! 11.4.5-2-1-s.js
+    ! 11.4.5-2-2-s.js
+    ! 11.4.5-2-2gs.js
+    ! S11.4.5_A6_T1.js
+    ! S11.4.5_A6_T2.js
+    ! S11.4.5_A6_T3.js
+    ! non-simple.js
+    ! target-cover-newtarget.js
+    ! target-newtarget.js
+language/expressions/prefix-increment
+    ! 11.4.4-2-1-s.js
+    ! 11.4.4-2-2-s.js
+    ! S11.4.4_A6_T1.js
+    ! S11.4.4_A6_T2.js
+    ! S11.4.4_A6_T3.js
+    ! non-simple.js
+    ! target-cover-newtarget.js
+    ! target-newtarget.js
+
+language/future-reserved-words
+    ! -strict-escaped.js
+
+language/keywords
+
+language/literals
+    ! bigint/
+    ! regexp/7.8.5-1.js
+    ! regexp/S7.8.5_A1.1_T2.js
+    ! regexp/S7.8.5_A1.4_T2.js
+    ! regexp/S7.8.5_A1.5
+    ! regexp/S7.8.5_A2.1_T2.js
+    ! regexp/S7.8.5_A2.4_T2.js
+    ! regexp/S7.8.5_A2.5
+    ! regexp/invalid-braced-quantifier
+    ! regexp/u-astral.js
+    ! regexp/u-case-mapping.js
+    ! regexp/u-surrogate-pairs
+    ! regexp/u-unicode-esc.js
+    ! regexp/y-assertion-start.js
+    ! string/7.8.4-
+    ! string/S7.8.4_A4.3_T1.js
+    ! string/S7.8.4_A4.3_T2.js
+    ! string/S7.8.4_A7.1_T4.js
+    ! string/S7.8.4_A7.2
+    ! string/legacy-non-octal-escape-sequence-strict.js
+    ! string/legacy-octal-escape-sequence-strict.js
+# Weird case of SyntaxError thrown at the script execution ('runtime')
+# not on compilation ('early'), but only for opt levels >= 0
+    ! regexp/early-err-dup-flag.js
+    ! regexp/early-err-pattern.js
+
+language/statements/for-of
+    ! Array.prototype.entries.js
+    ! Array.prototype.keys.js
+    ! body-dstr-assign-error.js
+    ! body-put-error.js
+    ! cptn-
+    ! -rest-
+    ! decl-const.js
+    ! decl-fun.js
+    ! dstr-array-elem-init-
+    ! dstr-array-elem-iter-
+    ! dstr-array-elem-nested-array-yield-ident-valid.js
+    ! dstr-array-elem-nested-obj
+    ! dstr-array-elem-put-const.js
+    ! dstr-array-elem-put-let.js
+    ! dstr-array-elem-target-simple-strict.js
+    ! dstr-array-elem-target-yield-valid.js
+    ! dstr-array-elem-trlg-iter-
+    ! dstr-array-elision-iter-
+    ! dstr-array-elision-val-bool.js
+    ! dstr-array-elision-val-null.js
+    ! dstr-array-elision-val-num.js
+    ! dstr-array-elision-val-symbol.js
+    ! dstr-array-elision-val-undef.js
+    ! dstr-array-empty-iter-
+    ! dstr-array-empty-val-bool.js
+    ! dstr-array-empty-val-null.js
+    ! dstr-array-empty-val-num.js
+    ! dstr-array-empty-val-symbol.js
+    ! dstr-array-empty-val-undef.js
+    ! dstr-const-ary-init-iter-close.js
+    ! dstr-const-ary-init-iter-get-err.js
+    ! dstr-const-ary-init-iter-no-close.js
+    ! dstr-const-ary-name-iter-val.js
+    ! dstr-const-ary-ptrn-elem-
+    ! dstr-const-obj-init-null.js
+    ! dstr-const-obj-init-undefined.js
+    ! dstr-const-obj-ptrn-empty.js
+    ! dstr-const-obj-ptrn-id-get-value-err.js
+    ! dstr-const-obj-ptrn-id-init-
+    ! dstr-const-obj-ptrn-id-trailing-comma.js
+    ! dstr-const-obj-ptrn-list-err.js
+    ! dstr-const-obj-ptrn-prop-
+    ! dstr-let-ary-init-iter-close.js
+    ! dstr-let-ary-init-iter-get-err.js
+    ! dstr-let-ary-ptrn-elem-ary-elem-init.js
+    ! dstr-let-ary-ptrn-elem-ary-elem-iter.js
+    ! dstr-let-ary-ptrn-elem-ary-empty-iter.js
+    ! dstr-let-ary-ptrn-elem-id-init-
+    ! dstr-let-ary-ptrn-elem-id-iter-step-err.js
+    ! dstr-let-ary-ptrn-elem-id-iter-val-err.js
+    ! dstr-let-ary-ptrn-elem-obj-id-init.js
+    ! dstr-let-ary-ptrn-elem-obj-id.js
+    ! dstr-let-ary-ptrn-elem-obj-prop-id-init.js
+    ! dstr-let-ary-ptrn-elem-obj-prop-id.js
+    ! dstr-let-obj-init-null.js
+    ! dstr-let-obj-init-undefined.js
+    ! dstr-let-obj-ptrn-id-init-fn-name-arrow.js
+    ! dstr-let-obj-ptrn-id-init-fn-name-class.js
+    ! dstr-let-obj-ptrn-id-init-fn-name-cover.js
+    ! dstr-let-obj-ptrn-id-init-fn-name-fn.js
+    ! dstr-let-obj-ptrn-id-init-skipped.js
+    ! dstr-let-obj-ptrn-id-init-throws.js
+    ! dstr-let-obj-ptrn-id-init-unresolvable.js
+    ! dstr-let-obj-ptrn-list-err.js
+    ! dstr-let-obj-ptrn-prop-ary-init.js
+    ! dstr-let-obj-ptrn-prop-ary.js
+    ! dstr-let-obj-ptrn-prop-ary-value-null.js
+    ! dstr-let-obj-ptrn-prop-eval-err.js
+    ! dstr-let-obj-ptrn-prop-id-get-value-err.js
+    ! dstr-let-obj-ptrn-prop-id-init.js
+    ! dstr-let-obj-ptrn-prop-id-init-skipped.js
+    ! dstr-let-obj-ptrn-prop-id-init-throws.js
+    ! dstr-let-obj-ptrn-prop-id-init-unresolvable.js
+    ! dstr-let-obj-ptrn-prop-obj-init.js
+    ! dstr-let-obj-ptrn-prop-obj.js
+    ! dstr-let-obj-ptrn-prop-obj-value-null.js
+    ! dstr-let-obj-ptrn-prop-obj-value-undef.js
+    ! dstr-obj-empty-null.js
+    ! dstr-obj-empty-undef.js
+    ! dstr-obj-id-identifier-resolution-first.js
+    ! dstr-obj-id-identifier-resolution-last.js
+    ! dstr-obj-id-identifier-resolution-lone.js
+    ! dstr-obj-id-identifier-resolution-middle.js
+    ! dstr-obj-id-identifier-resolution-trlng.js
+    ! dstr-obj-id-identifier-yield-ident-valid.js
+    ! dstr-obj-id-init-assignment-missing.js
+    ! dstr-obj-id-init-assignment-null.js
+    ! dstr-obj-id-init-assignment-truthy.js
+    ! dstr-obj-id-init-assignment-undef.js
+    ! dstr-obj-id-init-evaluation.js
+    ! dstr-obj-id-init-fn-name-arrow.js
+    ! dstr-obj-id-init-fn-name-cover.js
+    ! dstr-obj-id-init-fn-name-fn.js
+    ! dstr-obj-id-init-in.js
+    ! dstr-obj-id-init-let.js
+    ! dstr-obj-id-init-order.js
+    ! dstr-obj-id-init-simple-no-strict.js
+    ! dstr-obj-id-init-yield-ident-valid.js
+    ! dstr-obj-id-put-const.js
+    ! dstr-obj-id-put-let.js
+    ! dstr-obj-id-put-unresolvable-no-strict.js
+    ! dstr-obj-id-put-unresolvable-strict.js
+    ! dstr-obj-id-simple-no-strict.js
+    ! dstr-obj-prop-elem-init-assignment
+    ! dstr-obj-prop-elem-init-evaluation.js
+    ! dstr-obj-prop-elem-init-fn-name-arrow.js
+    ! dstr-obj-prop-elem-init-fn-name-cover.js
+    ! dstr-obj-prop-elem-init-fn-name-fn.js
+    ! dstr-obj-prop-elem-init-in.js
+    ! dstr-obj-prop-elem-init-let.js
+    ! dstr-obj-prop-elem-init-yield-ident-valid.js
+    ! dstr-obj-prop-elem-target-yield-ident-valid.js
+    ! dstr-obj-prop-identifier-resolution-first.js
+    ! dstr-obj-prop-identifier-resolution-last.js
+    ! dstr-obj-prop-identifier-resolution-middle.js
+    ! dstr-obj-prop-name-evaluation-error.js
+    ! dstr-obj-prop-name-evaluation.js
+    ! dstr-obj-prop-nested-array-yield-ident-valid.js
+    ! dstr-obj-prop-nested-obj.js
+    ! dstr-obj-prop-nested-obj-null.js
+    ! dstr-obj-prop-nested-obj-undefined.js
+    ! dstr-obj-prop-nested-obj-undefined-own.js
+    ! dstr-obj-prop-nested-obj-yield-ident-valid.js
+    ! dstr-obj-prop-put-const.js
+    ! dstr-obj-prop-put-let.js
+    ! dstr-var-ary-init-iter-close.js
+    ! dstr-var-ary-init-iter-get-err.js
+    ! dstr-var-ary-ptrn-elem-ary-elem-init.js
+    ! dstr-var-ary-ptrn-elem-ary-elem-iter.js
+    ! dstr-var-ary-ptrn-elem-ary-empty-iter.js
+    ! dstr-var-ary-ptrn-elem-id-init-
+    ! dstr-var-ary-ptrn-elem-id-iter-step-err.js
+    ! dstr-var-ary-ptrn-elem-id-iter-val-err.js
+    ! dstr-var-ary-ptrn-elem-obj-id-init.js
+    ! dstr-var-ary-ptrn-elem-obj-id.js
+    ! dstr-var-ary-ptrn-elem-obj-prop-id-init.js
+    ! dstr-var-ary-ptrn-elem-obj-prop-id.js
+    ! dstr-var-obj-init-null.js
+    ! dstr-var-obj-init-undefined.js
+    ! dstr-var-obj-ptrn-id-init-
+    ! dstr-var-obj-ptrn-list-err.js
+    ! dstr-var-obj-ptrn-prop-ary-init.js
+    ! dstr-var-obj-ptrn-prop-ary.js
+    ! dstr-var-obj-ptrn-prop-ary-value-null.js
+    ! dstr-var-obj-ptrn-prop-eval-err.js
+    ! dstr-var-obj-ptrn-prop-id-get-value-err.js
+    ! dstr-var-obj-ptrn-prop-id-init.js
+    ! dstr-var-obj-ptrn-prop-id-init-skipped.js
+    ! dstr-var-obj-ptrn-prop-id-init-throws.js
+    ! dstr-var-obj-ptrn-prop-id-init-unresolvable.js
+    ! dstr-var-obj-ptrn-prop-obj-init.js
+    ! dstr-var-obj-ptrn-prop-obj.js
+    ! dstr-var-obj-ptrn-prop-obj-value-null.js
+    ! dstr-var-obj-ptrn-prop-obj-value-undef.js
+    ! escaped-of.js
+    ! head-const-bound-names-fordecl-tdz.js
+    ! head-const-fresh-binding-per-iteration.js
+    ! head-decl-no-expr.js
+    ! head-expr-no-expr.js
+    ! head-let-bound-names-dup.js
+    ! head-let-bound-names-fordecl-tdz.js
+    ! head-let-bound-names-in-stmt.js
+    ! head-let-fresh-binding-per-iteration.js
+    ! head-var-bound-names-let.js
+    ! head-var-no-expr.js
+    ! iterator-close-
+    ! iterator-next-reference.js
+    ! iterator-next-result-type.js
+    ! labelled-fn-stmt-let.js
+    ! labelled-fn-stmt-lhs.js
+    ! labelled-fn-stmt-var.js
+    ! let-array-with-newline.js
+    ! let-block-with-newline.js
+    ! let-identifier-with-newline.js
+    ! scope-body-
+    ! scope-head-
+
+language/types
+    ! boolean/S8.3_A2
+    ! number/S8.5_A10
+    ! number/S8.5_A4
+    ! object/S8.6.2_A8.js
+    ! reference/S8.7.2_A1_T1.js
+    ! reference/S8.7.2_A1_T2.js
+    ! reference/get-value-prop-base-primitive.js
+    ! undefined/S8.1_A3


### PR DESCRIPTION
1. Update the test262 submodule to the latest version

    This brings more test cases to already enabled folders, but also
    requires more exclusions of currently failing checks. I wanted to
    avoid accidentally excluding passing files, so exclusion lists for
    some directories/features are quiet large. At some point I'd like
    to be able to generate the `test262.properties` automatically, but
    with more logging manual edits are good enough for now.

2. Improve test262 runner (Test262SuiteTest class)
    * Allow arbitrary names of expected exceptions and support the new
      structure of the 'negative' section in tests' metadata
    * Distinguish exception's phase, early vs runtime, for negative tests
    * Support for a 'raw' flag: no harness files, implies 'noStrict'
    * Add filtering by the 'features' lists
    * Exclude tests with a 'module' flag, as this isn't supported by Rhino
    * Exclude tests with an 'async' flag, which isn't yet supported by
      the Test262SuiteTest itself
    * Couple of other smaller fixes

3. Enable more tests, mostly from the 'language' folder

    This brings the total number of passing test cases to 45k, generated from 7779 files.
    The execution time incises, but not by _that_ much. Before it took around 1min 15s
    and now it's about 1min 50s on my laptop.

    Parameters generation (reading `test262.properties`, recursively walking folders,
    reading files and parsing their YAML headers) takes slightly more than 2s. For
    26k tests (4454 files) in master it takes 1.4s. I believe there are some possible
    improvements, but it's such a small component I didn't spent much time on it.
  