### PR TITLE
Fix error when creating context in "sealed" mode at ES6 level.

### DIFF
--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -32,7 +32,7 @@ public class NativeSymbol
 
     public static void init(Context cx, Scriptable scope, boolean sealed) {
         NativeSymbol obj = new NativeSymbol("");
-        ScriptableObject ctor = obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+        ScriptableObject ctor = obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, false);
 
         cx.putThreadLocal(CONSTRUCTOR_SLOT, Boolean.TRUE);
         try {
@@ -48,8 +48,14 @@ public class NativeSymbol
             createStandardSymbol(cx, scope, ctor, "search", SymbolKey.SEARCH);
             createStandardSymbol(cx, scope, ctor, "split", SymbolKey.SPLIT);
             createStandardSymbol(cx, scope, ctor, "unscopables", SymbolKey.UNSCOPABLES);
+
         } finally {
             cx.removeThreadLocal(CONSTRUCTOR_SLOT);
+        }
+
+        if (sealed) {
+            // Can't seal until we have created all the stuff above!
+            ctor.sealObject();
         }
     }
 

--- a/testsrc/org/mozilla/javascript/tests/InitializationTest.java
+++ b/testsrc/org/mozilla/javascript/tests/InitializationTest.java
@@ -1,0 +1,79 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptableObject;
+
+import static org.junit.Assert.*;
+
+public class InitializationTest
+{
+  private static final String BASIC_SCRIPT = "'Hello, ' + 'World!';";
+
+  @Test
+  public void testStandard()
+  {
+    Context cx = Context.enter();
+    try {
+      ScriptableObject root = cx.initStandardObjects();
+      Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
+      assertEquals("Hello, World!", result);
+    } finally {
+      Context.exit();
+    }
+  }
+
+  @Test
+  public void testStandardES6()
+  {
+    Context cx = Context.enter();
+    try {
+      cx.setLanguageVersion(Context.VERSION_ES6);
+      ScriptableObject root = cx.initStandardObjects();
+      Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
+      assertEquals("Hello, World!", result);
+    } finally {
+      Context.exit();
+    }
+  }
+
+  @Test
+  public void testSafeStandard()
+  {
+    Context cx = Context.enter();
+    try {
+      ScriptableObject root = cx.initSafeStandardObjects();
+      Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
+      assertEquals("Hello, World!", result);
+    } finally {
+      Context.exit();
+    }
+  }
+
+  @Test
+  public void testStandardSealed()
+  {
+    Context cx = Context.enter();
+    try {
+      ScriptableObject root = cx.initStandardObjects(null, true);
+      Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
+      assertEquals("Hello, World!", result);
+    } finally {
+      Context.exit();
+    }
+  }
+
+  @Test
+  public void testStandardSealedES6()
+  {
+    Context cx = Context.enter();
+    try {
+      cx.setLanguageVersion(Context.VERSION_ES6);
+      ScriptableObject root = cx.initStandardObjects(null, true);
+      Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
+      assertEquals("Hello, World!", result);
+    } finally {
+      Context.exit();
+    }
+  }
+}


### PR DESCRIPTION
Fix Symbol initialization so that "sealed" initialization works with ES6 language level.