### PR TITLE
Fix index out of bounds exception in EmbeddedSlotMap.

### DIFF
--- a/src/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/src/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -196,14 +196,24 @@ public class EmbeddedSlotMap
 
                 newSlot.value = slot.value;
                 newSlot.next = slot.next;
-                // add new slot to linked list
-                if (lastAdded != null) {
-                    lastAdded.orderedNext = newSlot;
-                }
-                if (firstAdded == null) {
+
+                // Replace new slot in linked list, keeping same order
+                if (slot == firstAdded) {
                     firstAdded = newSlot;
+                } else {
+                    ScriptableObject.Slot ps = firstAdded;
+                    while ((ps != null) && (ps.orderedNext != slot)) {
+                        ps = ps.orderedNext;
+                    }
+                    if (ps != null) {
+                        ps.orderedNext = newSlot;
+                    }
                 }
-                lastAdded = newSlot;
+                newSlot.orderedNext = slot.orderedNext;
+                if (slot == lastAdded) {
+                    lastAdded = newSlot;
+                }
+
                 // add new slot to hash table
                 if (prev == slot) {
                     slots[insertPos] = newSlot;

--- a/testsrc/jstests/redefine-properties.js
+++ b/testsrc/jstests/redefine-properties.js
@@ -1,0 +1,61 @@
+load("testsrc/assert.js");
+
+// Test for some corner cases in the EmbeddedSlotMap code
+
+var obj = {};
+
+// We should be able to define and redefine a property with an accessor
+Object.defineProperty(obj, 'a',
+  {
+    configurable:true,
+    get:function() {
+      return 1;
+    },
+    set:function(arg){ }});
+assertEquals(1, obj.a);
+
+Object.defineProperty(obj, 'a', { value:42 });
+assertEquals(42, obj.a);
+
+Object.defineProperty(obj, 'b', {
+  configurable: true,
+  value:43 });
+assertEquals(43, obj.b);
+
+Object.defineProperty(obj, 'b',
+  {
+    get:function() {
+      return 1;
+    },
+    set:function(arg){ }});
+assertEquals(1, obj.b);
+
+obj.c = 44;
+assertEquals(44, obj.c);
+
+Object.defineProperty(obj, 'c',
+  {
+    get:function() {
+      return 1;
+    },
+    set:function(arg){ }});
+assertEquals(1, obj.c);
+
+Object.defineProperty(obj, 'd',
+  {
+    configurable:true,
+    get:function() {
+      return 1;
+    },
+    set:function(arg){ }});
+assertEquals(1, obj.d);
+
+Object.defineProperty(obj, 'd',
+  {
+    get:function() {
+      return 11;
+    },
+    set:function(arg){ }});
+assertEquals(11, obj.d);
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/RedefinePropertyTest.java
+++ b/testsrc/org/mozilla/javascript/tests/RedefinePropertyTest.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest(
+    value = "testsrc/jstests/redefine-properties.js"
+)
+public class RedefinePropertyTest
+    extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
Fix EmbeddedSlotMap.createSlot to manage linked list properly
when a node is replaced using CONVERT_ACCESSOR_TO_DATA or
MODIFY_GETTER_SETTER.

https://github.com/mozilla/rhino/issues/390
