### PR TITLE
Add addError(String messageId, int c) method

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -237,6 +237,12 @@ public class Parser
                  ts.tokenEnd - ts.tokenBeg);
     }
 
+    void addError(String messageId, int c) {
+        String messageArg = Character.toString ((char) c);
+        addError(messageId, messageArg, ts.tokenBeg,
+                 ts.tokenEnd - ts.tokenBeg);
+    }
+
     void addError(String messageId, String messageArg, int position, int length)
     {
         ++syntaxErrorCount;

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -538,7 +538,7 @@ class TokenStream
                                 isUnicodeEscapeStart = true;
                                 containsEscape = true;
                             } else {
-                                parser.addError("msg.illegal.character");
+                                parser.addError("msg.illegal.character", c);
                                 return Token.ERROR;
                             }
                         } else {
@@ -1035,7 +1035,7 @@ class TokenStream
                 return c;
 
             default:
-                parser.addError("msg.illegal.character");
+                parser.addError("msg.illegal.character", c);
                 return Token.ERROR;
             }
         }

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -741,7 +741,7 @@ msg.no.re.input.for =\
     no input for {0}
 
 msg.illegal.character =\
-    illegal character
+    illegal character: {0}
 
 msg.invalid.escape =\
     invalid Unicode escape sequence

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1219,6 +1219,11 @@ public class ParserTest extends TestCase {
         expectErrorWithRecovery(")))", 5);
     }
 
+    public void testIllegalCharacterMessage() {
+        expectParseErrors("\u0060",
+                new String[] { "illegal character: \u0060" });
+    }
+
     // Check that error recovery is working by returning a parsing exception, but only
     // when thrown by runtimeError. This is testing a regression in which the error recovery in
     // certain cases would trigger an infinite loop. We do this by counting the number


### PR DESCRIPTION
This change adds an `addError(String messageId, int c)` method. The
intent of it is for cases like the “illegal character” error, to cite
the offending character in the error message.

So this change also updates the `illegal.character` message property to
add a message argument to it, and updates the `illegal.character` error
call sites to use the `addError(String messageId, int c)` method.

Thus the method expects to be called with a character value for the `c`
int arg, and makes a string from it by first casting that int to a char.