### PR TITLE
Show word in “identifier is a reserved word” error

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3084,7 +3084,7 @@ public class Parser
 
           case Token.RESERVED:
               consumeToken();
-              reportError("msg.reserved.id");
+              reportError("msg.reserved.id", ts.getString());
               break;
 
           case Token.ERROR:

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -426,7 +426,7 @@ msg.no.paren =\
     missing ) in parenthetical
 
 msg.reserved.id =\
-    identifier is a reserved word
+    identifier is a reserved word: {0}
 
 msg.no.paren.catch =\
     missing ( before catch-block condition

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1219,6 +1219,12 @@ public class ParserTest extends TestCase {
         expectErrorWithRecovery(")))", 5);
     }
 
+    public void testIdentifierIsReservedWordMessage() {
+        environment.setReservedKeywordAsIdentifier(false);
+        expectParseErrors("interface: while (true){ }",
+                new String[] { "identifier is a reserved word: interface" });
+    }
+
     // Check that error recovery is working by returning a parsing exception, but only
     // when thrown by runtimeError. This is testing a regression in which the error recovery in
     // certain cases would trigger an infinite loop. We do this by counting the number


### PR DESCRIPTION
This change updates the `reserved.id` message property to add a message
argument for indicating the offending reserved word. The change also
updates the `reserved.id` error call site to add the message argument to
the call (with the serialization of the current token as the value).