### PR TITLE
Added checking in Error function in Parser

### DIFF
--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -438,7 +438,6 @@ final class NativeDate extends IdScriptableObject
 
         double y = Math.floor(t / (msPerDay * 365.2425)) + 1970;
         double t2 = TimeFromYear(y);
-
         /*
          * Adjust the year if the approximation was wrong.  Since the year was
          * computed using the average number of ms per year, it will usually

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -233,8 +233,12 @@ public class Parser
     }
 
     void addError(String messageId, String messageArg) {
-        addError(messageId, messageArg, ts.tokenBeg,
-                 ts.tokenEnd - ts.tokenBeg);
+        int beg = -1, end = -1;
+        if (ts != null) {
+            beg = ts.tokenBeg;
+            end = ts.tokenEnd - ts.tokenBeg;
+        }
+        addError(messageId, messageArg, beg, end);
     }
 
     void addError(String messageId, String messageArg, int position, int length)


### PR DESCRIPTION
In cases of TokenStream not being defined. Like in issue#386 https://github.com/mozilla/rhino/issues/386