### PR TITLE
Fix a JavaDoc link

### DIFF
--- a/src/org/mozilla/javascript/VMBridge.java
+++ b/src/org/mozilla/javascript/VMBridge.java
@@ -96,7 +96,7 @@ public abstract class VMBridge
     /**
      * Create proxy object for {@link InterfaceAdapter}. The proxy should call
      * {@link InterfaceAdapter#invoke(ContextFactory, Object, Scriptable,
-     *                                Method, Object[])}
+     *                                Object, Method, Object[])}
      * as implementation of interface methods associated with
      * <tt>proxyHelper</tt>. {@link Method}
      *


### PR DESCRIPTION
Eliminates a JavaDoc warning on gradle build.