### PR TITLE
Make CallFrame objects partially immutable

### DIFF
--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -2688,7 +2688,7 @@ switch (op) {
             CallFrame x = cjump.capturedFrame;
             for (int i = 0; i != rewindCount; ++i) {
                 if (!x.frozen) Kit.codeBug();
-                if (isFrameEnterExitRequired(x)) {
+                if (x.useActivation) {
                     if (enterFrames == null) {
                         // Allocate enough space to store the rest
                         // of rewind frames in case all of them
@@ -2826,11 +2826,6 @@ switch (op) {
         frame.initializeArgs(cx, callerScope, args, argsDbl, argShift, argCount);
         enterFrame(cx, frame, args, false);
         return frame;
-    }
-
-    private static boolean isFrameEnterExitRequired(CallFrame frame)
-    {
-        return frame.debuggerFrame != null || frame.idata.itsNeedsActivation;
     }
 
     private static void enterFrame(Context cx, CallFrame frame, Object[] args,


### PR DESCRIPTION
`CallFrame` is an important interpreter class, but it's not trivial to reason about because of all the mutable fields and arcane initialization. I made as many of its fields final as possible, and moved their initialization into the constructor (obviously as they're final) and out of `initFrame`.

Historical note: it used to be possible to reuse `CallFrame` objects in tail calls which would be an argument against their partial immutability (if you look into removed code in `initFrame` you can see there was some behavior driven by the `stackReuse` variable). However, tail calls [aren't reusing frames](https://github.com/mozilla/rhino/blob/master/src/org/mozilla/javascript/Interpreter.java#L1384) since _ages_ as the reuse had some badly defined failure cases. So that logic got axed too for simplicity. (Tail calls still don't blow, we're just releasing the current frame and allocating a new one; modern GCs are great with that usage pattern.)

FWIW, I intend to improve Rhino's continuation handling; this change is part of that series.