### PR TITLE
Missing properties are not enumerable when checking enumerability

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/es5/StringMissingPropertyIsNotEnumerableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es5/StringMissingPropertyIsNotEnumerableTest.java
@@ -1,0 +1,26 @@
+package org.mozilla.javascript.tests.es5;
+
+import org.junit.Test;
+import org.mozilla.javascript.NativeObject;
+
+import static org.junit.Assert.assertFalse;
+import static org.mozilla.javascript.tests.Evaluator.eval;
+
+/**
+ * When calling <b>propertyIsEnumerable</b> on a <b>String</b>, missing properties should return <b>false</b> instead of
+ * throwing a <b>Property {0} not found.</b> exception.
+ *
+ * @see <a href="https://github.com/mozilla/rhino/issues/415">https://github.com/mozilla/rhino/issues/415</a>
+ */
+public class StringMissingPropertyIsNotEnumerableTest {
+
+  @Test
+  public void testStringMissingPropertyIsNotEnumerable() {
+    NativeObject object = new NativeObject();
+
+    Object result = eval("'s'.propertyIsEnumerable(0)", "obj", object);
+
+    assertFalse((Boolean)result);
+  }
+
+}


### PR DESCRIPTION
When checking property enumerability _(`Object.prototype.propertyIsEnumerable`)_ on a `String`, missing properties should return `false` instead of throwing a `Property {0} not found.` exception.

Fixes #415 _(regression in `1.7.7.2`)_