### PR TITLE
fixes for version handling

### DIFF
--- a/src/org/mozilla/javascript/Arguments.java
+++ b/src/org/mozilla/javascript/Arguments.java
@@ -35,8 +35,7 @@ final class Arguments extends IdScriptableObject
         calleeObj = f;
 
         int version = f.getLanguageVersion();
-        if (version <= Context.VERSION_1_3
-            && version != Context.VERSION_DEFAULT)
+        if (version <= Context.VERSION_1_3)
         {
             callerObj = null;
         } else {

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -71,6 +71,15 @@ public class Context
     public static final int VERSION_UNKNOWN =   -1;
 
     /**
+     * The default version.
+     * <p>Be aware, this version will not support many of the newer
+     * language features and will not change in the future.</p>
+     * <p>Please use one of the other constants like VERSION_ES6 to
+     * get support for recent language features.</p>
+     */
+    public static final int VERSION_DEFAULT =    0;
+
+    /**
      * JavaScript 1.0
      */
     public static final int VERSION_1_0 =      100;
@@ -119,12 +128,6 @@ public class Context
      * ECMAScript 6.
      */
     public static final int VERSION_ES6 =      200;
-
-    /**
-     * The default version.
-     * Same as VERSION_1_8.
-     */
-    public static final int VERSION_DEFAULT =    VERSION_1_8;
 
     /**
      * Controls behaviour of <tt>Date.prototype.getYear()</tt>.
@@ -690,6 +693,7 @@ public class Context
     public static boolean isValidLanguageVersion(int version)
     {
         switch (version) {
+            case VERSION_DEFAULT:
             case VERSION_1_0:
             case VERSION_1_1:
             case VERSION_1_2:
@@ -2653,7 +2657,7 @@ public class Context
 
     final boolean isVersionECMA1()
     {
-        return version >= VERSION_1_3;
+        return version == VERSION_DEFAULT || version >= VERSION_1_3;
     }
 
 // The method must NOT be public or protected

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -71,11 +71,6 @@ public class Context
     public static final int VERSION_UNKNOWN =   -1;
 
     /**
-     * The default version.
-     */
-    public static final int VERSION_DEFAULT =    0;
-
-    /**
      * JavaScript 1.0
      */
     public static final int VERSION_1_0 =      100;
@@ -124,6 +119,12 @@ public class Context
      * ECMAScript 6.
      */
     public static final int VERSION_ES6 =      200;
+
+    /**
+     * The default version.
+     * Same as VERSION_1_8.
+     */
+    public static final int VERSION_DEFAULT =    VERSION_1_8;
 
     /**
      * Controls behaviour of <tt>Date.prototype.getYear()</tt>.
@@ -689,7 +690,6 @@ public class Context
     public static boolean isValidLanguageVersion(int version)
     {
         switch (version) {
-            case VERSION_DEFAULT:
             case VERSION_1_0:
             case VERSION_1_1:
             case VERSION_1_2:
@@ -2653,7 +2653,7 @@ public class Context
 
     final boolean isVersionECMA1()
     {
-        return version == VERSION_DEFAULT || version >= VERSION_1_3;
+        return version >= VERSION_1_3;
     }
 
 // The method must NOT be public or protected

--- a/src/org/mozilla/javascript/ContextFactory.java
+++ b/src/org/mozilla/javascript/ContextFactory.java
@@ -256,8 +256,7 @@ public class ContextFactory
 
           case Context.FEATURE_E4X:
             version = cx.getLanguageVersion();
-            return (version == Context.VERSION_DEFAULT
-                    || version >= Context.VERSION_1_6);
+            return (version >= Context.VERSION_1_6);
 
           case Context.FEATURE_DYNAMIC_SCOPE:
             return false;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4070,7 +4070,7 @@ public class ScriptRuntime {
 
     static void checkDeprecated(Context cx, String name) {
         int version = cx.getLanguageVersion();
-        if (version >= Context.VERSION_1_4 || version == Context.VERSION_DEFAULT) {
+        if (version >= Context.VERSION_1_4) {
             String msg = getMessage1("msg.deprec.ctor", name);
             if (version == Context.VERSION_DEFAULT)
                 Context.reportWarning(msg);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4070,7 +4070,7 @@ public class ScriptRuntime {
 
     static void checkDeprecated(Context cx, String name) {
         int version = cx.getLanguageVersion();
-        if (version >= Context.VERSION_1_4) {
+        if (version >= Context.VERSION_1_4 || version == Context.VERSION_DEFAULT) {
             String msg = getMessage1("msg.deprec.ctor", name);
             if (version == Context.VERSION_DEFAULT)
                 Context.reportWarning(msg);

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -390,8 +390,7 @@ public class RegExpImpl implements RegExpProxy {
 
         /* Allow a real backslash (literal "\\") to escape "$1" etc. */
         int version = cx.getLanguageVersion();
-        if (version != Context.VERSION_DEFAULT
-            && version <= Context.VERSION_1_4)
+        if (version <= Context.VERSION_1_4)
         {
             if (dp > 0 && da.charAt(dp - 1) == '\\')
                 return null;
@@ -403,8 +402,7 @@ public class RegExpImpl implements RegExpProxy {
         dc = da.charAt(dp + 1);
         if (NativeRegExp.isDigit(dc)) {
             int cp;
-            if (version != Context.VERSION_DEFAULT
-                && version <= Context.VERSION_1_4)
+            if (version <= Context.VERSION_1_4)
             {
                 if (dc == '0')
                     return null;
@@ -591,8 +589,7 @@ public class RegExpImpl implements RegExpProxy {
             }
             ip[0] = match + matchlen[0];
 
-            if (version < Context.VERSION_1_3
-                && version != Context.VERSION_DEFAULT)
+            if (version < Context.VERSION_1_3)
             {
         /*
          * Deviate from ECMA to imitate Perl, which omits a final
@@ -688,8 +685,7 @@ public class RegExpImpl implements RegExpProxy {
          * string into a non-empty array (an array of length 1 that contains the
          * empty string).
          */
-        if (version != Context.VERSION_DEFAULT && version < Context.VERSION_1_3
-            && length == 0)
+        if (version < Context.VERSION_1_3 && length == 0)
             return -1;
 
         /*

--- a/testsrc/doctests/433878.doctest
+++ b/testsrc/doctests/433878.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> version(170)
-0
+170
 js> function f(a,b,c) {
   >   let sum = a + b + c;
   >   return sum / 3;

--- a/testsrc/doctests/757410.doctest
+++ b/testsrc/doctests/757410.doctest
@@ -5,7 +5,7 @@
 // https://bugzilla.mozilla.org/show_bug.cgi?id=757410
 
 js> version(180)
-0
+180
 js> function gen() {
   > [yield 1];
   > ({x: yield 2});

--- a/testsrc/doctests/expressionclosure.doctest
+++ b/testsrc/doctests/expressionclosure.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> version(180)
-0
+180
 js> x = function(x) x;
 
 function (x) x

--- a/testsrc/doctests/iteratorKeys.doctest
+++ b/testsrc/doctests/iteratorKeys.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> version(170)
-0
+170
 js> var foo = {
   >   __iterator__ : function(onlyKeys) {
   >     print(onlyKeys);

--- a/testsrc/doctests/version.doctest
+++ b/testsrc/doctests/version.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> version()
-180
+0
 js> version(100)
 100
 js> version(110)
@@ -22,8 +22,7 @@ js> version(170)
 170
 js> version(180)
 180
-
-js> version(130)
-130
+js> version(200)
+200
 js> version(0)
-180
+0

--- a/testsrc/doctests/version.doctest
+++ b/testsrc/doctests/version.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> version()
-0
+180
 js> version(100)
 100
 js> version(110)
@@ -22,5 +22,8 @@ js> version(170)
 170
 js> version(180)
 180
+
+js> version(130)
+130
 js> version(0)
-0
+180

--- a/testsrc/doctests/version.doctest
+++ b/testsrc/doctests/version.doctest
@@ -2,12 +2,25 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+js> version()
+0
+js> version(100)
+100
+js> version(110)
+110
+js> version(120)
+120
+js> version(130)
+130
+js> version(140)
+140
+js> version(150)
+150
+js> version(160)
+160
+js> version(170)
+170
 js> version(180)
 180
-js> try {
-  > (function({a}) { return a }).foo()
-  > } catch (e) {
-  > e.message.indexOf("function ({a}) {...}") != -1;
-  > }
-true
-
+js> version(0)
+0

--- a/testsrc/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug783797Test.java
@@ -5,6 +5,7 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.mozilla.javascript.tests.Utils.runWithAllOptimizationLevels;
 
@@ -392,12 +393,17 @@ public class Bug783797Test {
         String fn = "function test(){ return this }";
         runWithAllOptimizationLevels(action(fn, new Action() {
             public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
-                assertSame(scope2, eval(cx, scope2, "test()"));
-                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
-                assertSame(scope2, eval(cx, scope1, "scope2.test()"));
-                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
-                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
-                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+                cx.setLanguageVersion(Context.VERSION_1_7);
+                try {
+                    assertSame(scope2, eval(cx, scope2, "test()"));
+                    assertSame(scope2, eval(cx, scope2, "test.call(null)"));
+                    assertSame(scope2, eval(cx, scope1, "scope2.test()"));
+                    assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
+                    assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
+                    assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+                } finally {
+                    cx.setLanguageVersion(Context.VERSION_DEFAULT);
+                }
             }
         }));
     }
@@ -422,20 +428,25 @@ public class Bug783797Test {
         String fn = "function test(o){ return (function(){ return this }).call(o) }";
         runWithAllOptimizationLevels(action(fn, new Action() {
             public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
-                assertSame(scope2, eval(cx, scope2, "test()"));
-                assertSame(scope2, eval(cx, scope2, "test(null)"));
-                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
-                assertSame(scope2, eval(cx, scope2, "test.call(null, null)"));
+                cx.setLanguageVersion(Context.VERSION_1_7);
+                try {
+                    assertSame(scope2, eval(cx, scope2, "test()"));
+                    assertSame(scope2, eval(cx, scope2, "test(null)"));
+                    assertSame(scope2, eval(cx, scope2, "test.call(null)"));
+                    assertSame(scope2, eval(cx, scope2, "test.call(null, null)"));
 
-                assertSame(scope1, eval(cx, scope1, "scope2.test()"));
-                assertSame(scope1, eval(cx, scope1, "scope2.test(null)"));
-                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
-                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null, null)"));
+                    assertSame(scope1, eval(cx, scope1, "scope2.test()"));
+                    assertSame(scope1, eval(cx, scope1, "scope2.test(null)"));
+                    assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
+                    assertSame(scope1, eval(cx, scope1, "scope2.test.call(null, null)"));
 
-                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
-                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t(null)"));
-                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
-                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null, null)"));
+                    assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
+                    assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t(null)"));
+                    assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null)"));
+                    assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t.call(null, null)"));
+                } finally {
+                    cx.setLanguageVersion(Context.VERSION_DEFAULT);
+                }
             }
         }));
     }
@@ -475,12 +486,17 @@ public class Bug783797Test {
         String fn = "function test(){ return this.String.prototype }";
         runWithAllOptimizationLevels(action(fn, new Action() {
             public void run(Context cx, ScriptableObject scope1, ScriptableObject scope2) {
-                assertTRUE(eval(cx, scope2, "String.prototype === test()"));
-                assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
-                assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
-                assertTRUE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
-                assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
-                assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+                cx.setLanguageVersion(Context.VERSION_1_7);
+                try {
+                    assertTRUE(eval(cx, scope2, "String.prototype === test()"));
+                    assertTRUE(eval(cx, scope2, "String.prototype === test.call(null)"));
+                    assertFALSE(eval(cx, scope1, "String.prototype === scope2.test()"));
+                    assertTRUE(eval(cx, scope1, "String.prototype === scope2.test.call(null)"));
+                    assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t()"));
+                    assertTRUE(eval(cx, scope1, "var t=scope2.test; String.prototype === t.call(null)"));
+                } finally {
+                    cx.setLanguageVersion(Context.VERSION_DEFAULT);
+                }
             }
         }));
     }

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -248,6 +248,7 @@ public class Global extends ImporterTopLevel
         if (args.length > 0) {
             double d = Context.toNumber(args[0]);
             cx.setLanguageVersion((int) d);
+            result = cx.getLanguageVersion();
         }
         return result;
     }

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -250,6 +250,7 @@ public class Global extends ImporterTopLevel
                 d = Context.VERSION_DEFAULT;
             }
             cx.setLanguageVersion((int) d);
+            result = cx.getLanguageVersion();
         }
         return cx.getLanguageVersion();
     }

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -244,13 +244,14 @@ public class Global extends ImporterTopLevel
     public static double version(Context cx, Scriptable thisObj,
                                  Object[] args, Function funObj)
     {
-        double result = cx.getLanguageVersion();
         if (args.length > 0) {
             double d = Context.toNumber(args[0]);
+            if (d == 0.0) {
+                d = Context.VERSION_DEFAULT;
+            }
             cx.setLanguageVersion((int) d);
-            result = cx.getLanguageVersion();
         }
-        return result;
+        return cx.getLanguageVersion();
     }
 
     /**


### PR DESCRIPTION
method version(xxx) should return the new version identifier if the version was updated

 make the default version more explicit because:

* there was no chance to get an idea about the current meaning of the default version
* we had to do always a double check for the version and the default version (i fear we had some places in the code where the check for the default version is missing)

Hope this makes the code more maintainable...