### PR TITLE
Support replacing prototype functions of native objects.

### DIFF
--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -939,6 +939,13 @@ public abstract class IdScriptableObject extends ScriptableObject
                   }
                 }
                 prototypeValues.setAttributes(id, applyDescriptorToAttributeBitset(attr, desc));
+
+                // Handle the regular slot that was created if this property was previously replaced
+                // with an accessor descriptor.
+                if (super.has(name, this)) {
+                  super.delete(name);
+                }
+
                 return;
               }
             }

--- a/testsrc/jstests/replace-prototype.js
+++ b/testsrc/jstests/replace-prototype.js
@@ -1,0 +1,81 @@
+/*
+ * This script tests the ability to change prototypes of objects in various ways,
+ * including for some native objects, which handle them differently.
+ */
+
+load("testsrc/assert.js");
+
+TestObj = function() {
+}
+
+TestObj.prototype.func = function() {
+  return 'foo';
+}
+
+function replacePropertyNormally(obj, name) {
+   var to = new obj();
+   var origFunc = obj.prototype[name];
+   var origValue = to[name]();
+
+   // Re-define the prototype property with one that returns a fixed value
+   obj.prototype[name] = function() {
+     return 'bar';
+   }
+   assertEquals('bar', to[name]());
+
+   // Do it again
+    obj.prototype[name] = function() {
+        return 'baz';
+      }
+      assertEquals('baz', to[name]());
+
+   // Set the prototype property back to the original value
+   // and ensure that it still works.
+   obj.prototype[name] = origFunc;
+   assertEquals(origValue, to[name]());
+}
+
+// Same as above but using a "getter" function.
+function replacePropertyWithGetter(obj, name) {
+   var to = new obj();
+   var origFunc = obj.prototype[name];
+   var origValue = to[name]();
+
+   // Re-define the prototype property with one that returns a fixed value
+   Object.defineProperty(obj.prototype, name, {
+      configurable: true,
+      get: function() {
+        return function() {
+          return 'bar';
+        }
+      }
+   });
+   assertEquals('bar', to[name]());
+
+   // Again
+   Object.defineProperty(obj.prototype, name, {
+       configurable: true,
+       get: function() {
+         return function() {
+           return 'baz';
+         }
+       }
+    });
+    assertEquals('baz', to[name]());
+
+   // Set the prototype property back to the original value
+   // and ensure that it still works.
+   Object.defineProperty(obj.prototype, name, {
+     value: origFunc
+   });
+   assertEquals(origValue, to[name]());
+}
+
+// Verify that the above works for regular objects as well as native objects
+// that inherit from IdScriptableObject.
+replacePropertyNormally(TestObj, 'func');
+replacePropertyWithGetter(TestObj, 'func');
+replacePropertyNormally(String, 'substring');
+replacePropertyWithGetter(String, 'substring');
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/ReplacePrototypeTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ReplacePrototypeTest.java
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/replace-prototype.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ReplacePrototypeTest
+    extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
If a prototype function of a native object derived from IdScriptableObject
is replaced with an accessor function, then it was not possible to
re-set it back to the original value. This caused some of the
newer V8 tests to fail as native classes like String don't work
like regular objects.