### PR TITLE
add more info to the error message

### DIFF
--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -276,7 +276,12 @@ public abstract class ScriptableObject implements Scriptable,
                         // Based on TC39 ES3.1 Draft of 9-Feb-2009, 8.12.4, step 2,
                         // we should throw a TypeError in this case.
                         cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
-                        throw ScriptRuntime.typeError1("msg.set.prop.no.setter", name);
+
+                        String prop = "";
+                        if (name != null) {
+                            prop = "[" + start.getClassName() + "]." + name.toString();
+                        }
+                        throw ScriptRuntime.typeError2("msg.set.prop.no.setter", prop, Context.toString(value));
                     }
                     // Assignment to a property with only a getter defined. The
                     // assignment is ignored. See bug 478047.

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -550,7 +550,7 @@ msg.prop.not.found =\
     Property {0} not found.
 
 msg.set.prop.no.setter =\
-    Cannot set property {0} that has only a getter.
+    Cannot set property {0} that has only a getter to value ''{1}''.
 
 msg.invalid.type =\
     Invalid JavaScript value of type {0}

--- a/testsrc/org/mozilla/javascript/tests/WriteReadOnlyPropertyTest.java
+++ b/testsrc/org/mozilla/javascript/tests/WriteReadOnlyPropertyTest.java
@@ -41,7 +41,7 @@ public class WriteReadOnlyPropertyTest {
 			Assert.fail();
 		}
 		catch (EcmaError e) {
-			Assert.assertTrue(e.getMessage(), e.getMessage().contains("Cannot set property myProp that has only a getter"));
+			Assert.assertTrue(e.getMessage(), e.getMessage().contains("Cannot set property [Foo].myProp that has only a getter to value '123'"));
 		}
 	}
 


### PR DESCRIPTION
Found this small improvement while checking the differences between the HtmlUnit fork of Rhino and the latest version. I think adding more info to error messages is always a good idea. Hope you like this also :-)