### PR TITLE
use the right method name if available

### DIFF
--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -246,20 +246,22 @@ public abstract class ScriptableObject implements Scriptable,
             if (getter == null && setter == null) {
                 desc.defineProperty("writable", (attr & READONLY) == 0, EMPTY);
             }
+
+            String fName = name == null ? "f" : name.toString();
             if (getter != null) {
-                if( getter instanceof MemberBox ) {
-                    desc.defineProperty("get", new FunctionObject("f", ((MemberBox)getter).member(),scope), EMPTY);
-                } else if( getter instanceof Member ) {
-                    desc.defineProperty("get", new FunctionObject("f",(Member)getter,scope), EMPTY);
+                if ( getter instanceof MemberBox ) {
+                    desc.defineProperty("get", new FunctionObject(fName, ((MemberBox)getter).member(), scope), EMPTY);
+                } else if ( getter instanceof Member ) {
+                    desc.defineProperty("get", new FunctionObject(fName, (Member)getter, scope), EMPTY);
                 } else {
                     desc.defineProperty("get", getter, EMPTY);
                 }
             }
             if (setter != null) {
-                if( setter instanceof MemberBox ) {
-                    desc.defineProperty("set", new FunctionObject("f", ((MemberBox)setter).member(),scope), EMPTY);
-                } else if( setter instanceof Member ) {
-                    desc.defineProperty("set", new FunctionObject("f",(Member)setter,scope), EMPTY);
+                if ( setter instanceof MemberBox ) {
+                    desc.defineProperty("set", new FunctionObject(fName, ((MemberBox) setter).member(), scope), EMPTY);
+                } else if ( setter instanceof Member ) {
+                    desc.defineProperty("set", new FunctionObject(fName, (Member) setter, scope), EMPTY);
                 } else {
                     desc.defineProperty("set", setter, EMPTY);
                 }

--- a/testsrc/org/mozilla/javascript/tests/MemberBoxCallTest.java
+++ b/testsrc/org/mozilla/javascript/tests/MemberBoxCallTest.java
@@ -7,7 +7,6 @@ package org.mozilla.javascript.tests;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import org.mozilla.javascript.*;
 import org.mozilla.javascript.annotations.*;
@@ -18,17 +17,54 @@ public class MemberBoxCallTest {
 
     @Test
     public void testPrototypeProperty() {
-		Context cx = Context.enter();
-		try {
-			assertEquals(evaluate(cx, 
-				"var hostObj = new AnnotatedHostObject(); " +
-				"var valueProperty = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(hostObj), \"foo\");" +
-				"var result = 'failed';" +
-				"if( valueProperty.get && valueProperty.set ) {" +
-					"valueProperty.set.call(hostObj, 'superVal');" +
-					"result = valueProperty.get.call(hostObj);" +
-				"}"+
-				"result;"), "SUPERVAL");
+        Context cx = Context.enter();
+        try {
+            assertEquals("SUPERVAL",
+                evaluate(cx, 
+                    "var hostObj = new AnnotatedHostObject(); " +
+                    "var valueProperty = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(hostObj), \"foo\");" +
+                    "var result = 'failed';" +
+                    "if( valueProperty.get && valueProperty.set ) {" +
+                        "valueProperty.set.call(hostObj, 'superVal');" +
+                        "result = valueProperty.get.call(hostObj);" +
+                    "}" +
+                    "result;"));
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testPropertyGetterName() {
+        Context cx = Context.enter();
+        try {
+            assertEquals("foo",
+                evaluate(cx, 
+                    "var hostObj = new AnnotatedHostObject(); " +
+                    "var valueProperty = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(hostObj), \"foo\");" +
+                    "var result = 'failed';" +
+                    "if( valueProperty.get && valueProperty.set ) {" +
+                        "result = '' + valueProperty.get.name;" +
+                    "}" +
+                    "result;"));
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testPropertySetterName() {
+        Context cx = Context.enter();
+        try {
+            assertEquals("foo",
+                evaluate(cx, 
+                    "var hostObj = new AnnotatedHostObject(); " +
+                    "var valueProperty = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(hostObj), \"foo\");" +
+                    "var result = 'failed';" +
+                    "if( valueProperty.get && valueProperty.set ) {" +
+                        "result = '' + valueProperty.set.name;" +
+                    "}" +
+                    "result;"));
         } finally {
             Context.exit();
         }


### PR DESCRIPTION
with the commit 

> Adding wrappers for getter and setter MemberBox properties when accessed using getPropertyDescriptor

the method name got lost (was replaced by"f"). This brings back the old (and correct - tested with firefox - behavior)