### PR TITLE
Delegator: improve the design for flexible subclassing

### DIFF
--- a/src/org/mozilla/javascript/Delegator.java
+++ b/src/org/mozilla/javascript/Delegator.java
@@ -72,6 +72,7 @@ public class Delegator implements Function {
     public Scriptable getDelegee() {
         return obj;
     }
+
     /**
      * Set the delegee.
      *
@@ -81,90 +82,105 @@ public class Delegator implements Function {
     public void setDelegee(Scriptable obj) {
         this.obj = obj;
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#getClassName
      */
     public String getClassName() {
-        return obj.getClassName();
+        return getDelegee().getClassName();
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#get(String, Scriptable)
      */
     public Object get(String name, Scriptable start) {
-        return obj.get(name,start);
+        return getDelegee().get(name,start);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#get(int, Scriptable)
      */
     public Object get(int index, Scriptable start) {
-        return obj.get(index,start);
-        }
+        return getDelegee().get(index,start);
+    }
+
     /**
      * @see org.mozilla.javascript.Scriptable#has(String, Scriptable)
      */
     public boolean has(String name, Scriptable start) {
-        return obj.has(name,start);
-        }
+        return getDelegee().has(name,start);
+    }
+
     /**
      * @see org.mozilla.javascript.Scriptable#has(int, Scriptable)
      */
     public boolean has(int index, Scriptable start) {
-        return obj.has(index,start);
-        }
+        return getDelegee().has(index,start);
+    }
+
     /**
      * @see org.mozilla.javascript.Scriptable#put(String, Scriptable, Object)
      */
     public void put(String name, Scriptable start, Object value) {
-        obj.put(name,start,value);
+        getDelegee().put(name,start,value);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#put(int, Scriptable, Object)
      */
     public void put(int index, Scriptable start, Object value) {
-        obj.put(index,start,value);
+        getDelegee().put(index,start,value);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#delete(String)
      */
     public void delete(String name) {
-        obj.delete(name);
+        getDelegee().delete(name);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#delete(int)
      */
     public void delete(int index) {
-        obj.delete(index);
+        getDelegee().delete(index);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#getPrototype
      */
     public Scriptable getPrototype() {
-        return obj.getPrototype();
+        return getDelegee().getPrototype();
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#setPrototype
      */
     public void setPrototype(Scriptable prototype) {
-        obj.setPrototype(prototype);
+        getDelegee().setPrototype(prototype);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#getParentScope
      */
     public Scriptable getParentScope() {
-        return obj.getParentScope();
+        return getDelegee().getParentScope();
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#setParentScope
      */
     public void setParentScope(Scriptable parent) {
-        obj.setParentScope(parent);
+        getDelegee().setParentScope(parent);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#getIds
      */
     public Object[] getIds() {
-        return obj.getIds();
+        return getDelegee().getIds();
     }
+
     /**
      * Note that this method does not get forwarded to the delegee if
      * the <code>hint</code> parameter is null,
@@ -181,21 +197,23 @@ public class Delegator implements Function {
         return (hint == null ||
                 hint == ScriptRuntime.ScriptableClass ||
                 hint == ScriptRuntime.FunctionClass) ?
-            this : obj.getDefaultValue(hint);
+            this : getDelegee().getDefaultValue(hint);
     }
+
     /**
      * @see org.mozilla.javascript.Scriptable#hasInstance
      */
     public boolean hasInstance(Scriptable instance) {
-        return obj.hasInstance(instance);
+        return getDelegee().hasInstance(instance);
     }
+
     /**
      * @see org.mozilla.javascript.Function#call
      */
     public Object call(Context cx, Scriptable scope, Scriptable thisObj,
                        Object[] args)
     {
-        return ((Function)obj).call(cx,scope,thisObj,args);
+        return ((Function)getDelegee()).call(cx,scope,thisObj,args);
     }
 
     /**
@@ -215,9 +233,9 @@ public class Delegator implements Function {
      */
     public Scriptable construct(Context cx, Scriptable scope, Object[] args)
     {
-        if (obj == null) {
-            //this little trick allows us to declare prototype objects for
-            //Delegators
+        Scriptable myDelegee = getDelegee();
+        if (myDelegee == null) {
+            //this little trick allows us to declare prototype objects for Delegators
             Delegator n = newInstance();
             Scriptable delegee;
             if (args.length == 0) {
@@ -229,7 +247,7 @@ public class Delegator implements Function {
             return n;
         }
         else {
-            return ((Function)obj).construct(cx,scope,args);
+            return ((Function)myDelegee).construct(cx, scope, args);
         }
     }
 }


### PR DESCRIPTION
For HtmlUnit we have so subclasses of Delegator. This patch makes it possible (or simple) to implement different ways of delegee resolution by simply overwrite the getDelegee() method.
Benefits of this:
* simpler design, you can implement lazy resolution
* you are more flexible regarding the object you have to store for delegee access, no need to store the delegee itself it is sufficient to store an object that knows the delegee

```
    @Override
    public Window getDelegee() {
        return webWindow_.getScriptableObject();
    }
```