### PR TITLE
431 update expiry of cached commonjs entity if no change on filesystem

### DIFF
--- a/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
+++ b/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
@@ -278,7 +278,7 @@ public class UrlModuleSourceProvider extends ModuleSourceProviderBase
                 return ((HttpURLConnection)urlConnection).getResponseCode() ==
                     HttpURLConnection.HTTP_NOT_MODIFIED;
             }
-            return lastModified == urlConnection.getLastModified();
+            return lastModified != urlConnection.getLastModified();
         }
 
         private long calculateExpiry(URLConnection urlConnection,


### PR DESCRIPTION
Upon commonjs entity cache expiration, subsequent filesystem resolution needs to update the expiry of the cache entry if the module has not changed on the filesystem. The isResourceChanged method should return true if the lastModified value of the cached entry does NOT equal the lastModified value of the UrlConnection pointing to the file.
With this change, the cached value will once again be used to resolve a require reference; without this change, the paths will be consulted to load the corresponding filesystem artifact with every require reference following initial cache period expiration. 