### PR TITLE
Improvements to MemberBox

### DIFF
--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -91,7 +91,7 @@ public class FunctionObject extends BaseFunction
         }
         String methodName = member.getName();
         this.functionName = name;
-        Class<?>[] types = member.argTypes;
+        Class<?>[] types = member.argTypes();
         int arity = types.length;
         if (arity == 4 && (types[1].isArray() || types[2].isArray())) {
             // Either variable args or an error.
@@ -134,8 +134,7 @@ public class FunctionObject extends BaseFunction
         }
 
         if (member.isMethod()) {
-            Method method = member.method();
-            Class<?> returnType = method.getReturnType();
+            Class<?> returnType = member.getReturnType();
             if (returnType == Void.TYPE) {
                 hasVoidReturn = true;
             } else {
@@ -235,13 +234,9 @@ public class FunctionObject extends BaseFunction
     /**
      * Get Java method or constructor this function represent.
      */
-    public Member getMethodOrConstructor()
+    public Executable getMethodOrConstructor()
     {
-        if (member.isMethod()) {
-            return member.method();
-        } else {
-            return member.ctor();
-        }
+        return member.member();
     }
 
     static Method findSingleMethod(Method[] methods, String name)
@@ -506,15 +501,14 @@ public class FunctionObject extends BaseFunction
     {
         in.defaultReadObject();
         if (parmsLength > 0) {
-            Class<?>[] types = member.argTypes;
+            Class<?>[] types = member.argTypes();
             typeTags = new byte[parmsLength];
             for (int i = 0; i != parmsLength; ++i) {
                 typeTags[i] = (byte)getTypeTag(types[i]);
             }
         }
         if (member.isMethod()) {
-            Method method = member.method();
-            Class<?> returnType = method.getReturnType();
+            Class<?> returnType = member.getReturnType();
             if (returnType == Void.TYPE) {
                 hasVoidReturn = true;
             } else {

--- a/src/org/mozilla/javascript/JavaMembers.java
+++ b/src/org/mozilla/javascript/JavaMembers.java
@@ -83,7 +83,7 @@ class JavaMembers
                 if (bp.getter == null)
                     return Scriptable.NOT_FOUND;
                 rval = bp.getter.invoke(javaObject, Context.emptyArgs);
-                type = bp.getter.method().getReturnType();
+                type = bp.getter.getReturnType();
             } else {
                 Field field = (Field) member;
                 rval = field.get(isStatic ? null : javaObject);
@@ -123,7 +123,7 @@ class JavaMembers
             // main setter. Otherwise, let the NativeJavaMethod decide which
             // setter to use:
             if (bp.setters == null || value == null) {
-                Class<?> setType = bp.setter.argTypes[0];
+                Class<?> setType = bp.setter.argTypes()[0];
                 Object[] args = { Context.jsToJava(value, setType) };
                 try {
                     bp.setter.invoke(javaObject, args);
@@ -239,7 +239,7 @@ class JavaMembers
 
         if (methodsOrCtors != null) {
             for (MemberBox methodsOrCtor : methodsOrCtors) {
-                Class<?>[] type = methodsOrCtor.argTypes;
+                Class<?>[] type = methodsOrCtor.argTypes();
                 String sig = liveConnectSignature(type);
                 if (sigStart + sig.length() == name.length()
                         && name.regionMatches(sigStart, sig, 0, sig.length()))
@@ -602,7 +602,7 @@ class JavaMembers
                             if (getter != null) {
                                 // We have a getter. Now, do we have a matching
                                 // setter?
-                                Class<?> type = getter.method().getReturnType();
+                                Class<?> type = getter.getReturnType();
                                 setter = extractSetMethod(type, njmSet.methods,
                                                             isStatic);
                             } else {
@@ -713,8 +713,8 @@ class JavaMembers
         for (MemberBox method : methods) {
             // Does getter method have an empty parameter list with a return
             // value (eg. a getSomething() or isSomething())?
-            if (method.argTypes.length == 0 && (!isStatic || method.isStatic())) {
-                Class<?> type = method.method().getReturnType();
+            if (method.member().getParameterCount() == 0 && (!isStatic || method.isStatic())) {
+                Class<?> type = method.getReturnType();
                 if (type != Void.TYPE) {
                     return method;
                 }
@@ -738,7 +738,7 @@ class JavaMembers
         for (int pass = 1; pass <= 2; ++pass) {
             for (MemberBox method : methods) {
                 if (!isStatic || method.isStatic()) {
-                    Class<?>[] params = method.argTypes;
+                    Class<?>[] params = method.argTypes();
                     if (params.length == 1) {
                         if (pass == 1) {
                             if (params[0] == type) {
@@ -763,8 +763,8 @@ class JavaMembers
 
         for (MemberBox method : methods) {
             if (!isStatic || method.isStatic()) {
-                if (method.method().getReturnType() == Void.TYPE) {
-                    if (method.argTypes.length == 1) {
+                if (method.getReturnType() == Void.TYPE) {
+                    if (method.member().getParameterCount() == 1) {
                         return method;
                     }
                 }

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -211,9 +211,9 @@ public class NativeJavaClass extends NativeJavaObject implements Function
 
     static Object constructInternal(Object[] args, MemberBox ctor)
     {
-        Class<?>[] argTypes = ctor.argTypes;
+        Class<?>[] argTypes = ctor.argTypes();
 
-        if (ctor.vararg) {
+        if (ctor.vararg()) {
             // marshall the explicit parameter
             Object[] newArgs = new Object[argTypes.length];
             for (int i = 0; i < argTypes.length-1; i++) {

--- a/src/org/mozilla/javascript/NativeJavaConstructor.java
+++ b/src/org/mozilla/javascript/NativeJavaConstructor.java
@@ -41,7 +41,7 @@ public class NativeJavaConstructor extends BaseFunction
     @Override
     public String getFunctionName()
     {
-        String sig = JavaMembers.liveConnectSignature(ctor.argTypes);
+        String sig = JavaMembers.liveConnectSignature(ctor.argTypes());
         return "<init>".concat(sig);
     }
 

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -293,7 +293,7 @@ public abstract class ScriptableObject implements Scriptable,
                 Context cx = Context.getContext();
                 if (setter instanceof MemberBox) {
                     MemberBox nativeSetter = (MemberBox)setter;
-                    Class<?> pTypes[] = nativeSetter.argTypes;
+                    Class<?> pTypes[] = nativeSetter.argTypes();
                     // XXX: cache tag since it is already calculated in
                     // defineProperty ?
                     Class<?> valueType = pTypes[pTypes.length - 1];


### PR DESCRIPTION
Fixes #429 by allowing serialization of `MemberBox.delegateTo`. 

It also adds some more improvements enabled by the fact that in modern Java, we now have `java.lang.reflect.Executable` as a unifying type for both `Method` and `Constructor`. Using it reduces the need to typecheck and cast and it also allows unified access to parameter types and vararg flag, so they no longer need to be duplicated in the `MemberBox`.
