### PR TITLE
Modernizing the ContextAction

### DIFF
--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -512,7 +512,7 @@ public class Context
      * @return The result of {@link ContextAction#run(Context)}.
      */
     @Deprecated
-    public static Object call(ContextAction action)
+    public static <T> T call(ContextAction<T> action)
     {
         return call(ContextFactory.getGlobal(), action);
     }
@@ -545,7 +545,7 @@ public class Context
     /**
      * The method implements {@link ContextFactory#call(ContextAction)} logic.
      */
-    static Object call(ContextFactory factory, ContextAction action) {
+    static <T> T call(ContextFactory factory, ContextAction<T> action) {
         Context cx = enter(null, factory);
         try {
             return action.run(cx);

--- a/src/org/mozilla/javascript/ContextAction.java
+++ b/src/org/mozilla/javascript/ContextAction.java
@@ -11,8 +11,9 @@ package org.mozilla.javascript;
 /**
  * Interface to represent arbitrary action that requires to have Context
  * object associated with the current thread for its execution.
+ * @param T the type of the return value of action execution
  */
-public interface ContextAction
+public interface ContextAction<T>
 {
     /**
      * Execute action using the supplied Context instance.
@@ -21,6 +22,6 @@ public interface ContextAction
      *
      * @see ContextFactory#call(ContextAction)
      */
-    public Object run(Context cx);
+    public T run(Context cx);
 }
 

--- a/src/org/mozilla/javascript/ContextFactory.java
+++ b/src/org/mozilla/javascript/ContextFactory.java
@@ -512,7 +512,7 @@ public class ContextFactory
      *                   Scriptable scope, Scriptable thisObj,
      *                   Object[] args)
      */
-    public final Object call(ContextAction action)
+    public final <T> T call(ContextAction<T> action)
     {
         return Context.call(this, action);
     }

--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -604,7 +604,7 @@ public final class JavaAdapter implements IdFunctionCall
 
     public static Scriptable runScript(final Script script)
     {
-        return (Scriptable)ContextFactory.getGlobal().call(cx -> {
+        return ContextFactory.getGlobal().call(cx -> {
             ScriptableObject global = ScriptRuntime.getGlobal(cx);
             script.exec(cx, global);
             return global;

--- a/testsrc/org/mozilla/javascript/tests/Bug708801Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug708801Test.java
@@ -50,7 +50,7 @@ public class Bug708801Test {
         }
     };
 
-    private static abstract class Action implements ContextAction {
+    private static abstract class Action implements ContextAction<Object> {
         protected Context cx;
         protected ScriptableObject scope;
 

--- a/testsrc/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug783797Test.java
@@ -23,7 +23,7 @@ public class Bug783797Test {
         void run(Context cx, ScriptableObject scope1, ScriptableObject scope2);
     }
 
-    private static ContextAction action(final String fn, final Action a) {
+    private static ContextAction<Void> action(final String fn, final Action a) {
         return cx -> {
             ScriptableObject scope1 = cx.initStandardObjects();
             ScriptableObject scope2 = cx.initStandardObjects();

--- a/testsrc/org/mozilla/javascript/tests/GeneratedClassNameTest.java
+++ b/testsrc/org/mozilla/javascript/tests/GeneratedClassNameTest.java
@@ -32,7 +32,7 @@ public class GeneratedClassNameTest extends TestCase
 	private void doTest(final String expectedName, final String scriptName)
 	    throws Exception
 	{
-	    final Script script = (Script)ContextFactory.getGlobal().call(cx -> cx.compileString("var f = 1", scriptName, 1, null));
+	    final Script script = ContextFactory.getGlobal().call(cx -> cx.compileString("var f = 1", scriptName, 1, null));
 
 	    // remove serial number
 	    String name = script.getClass().getSimpleName();

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -1214,7 +1214,7 @@ public class Global extends ImporterTopLevel
 }
 
 
-class Runner implements Runnable, ContextAction {
+class Runner implements Runnable, ContextAction<Object> {
 
     Runner(Scriptable scope, Function func, Object[] args) {
         this.scope = scope;

--- a/toolsrc/org/mozilla/javascript/tools/shell/Main.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Main.java
@@ -76,7 +76,7 @@ public class Main
     /**
      * Proxy class to avoid proliferation of anonymous classes.
      */
-    private static class IProxy implements ContextAction, QuitAction
+    private static class IProxy implements ContextAction<Object>, QuitAction
     {
         private static final int PROCESS_FILES = 1;
         private static final int EVAL_INLINE_SCRIPT = 2;


### PR DESCRIPTION
Parametrized return type of ContextAction, to reduce casts in client code. 
Replaced Rhino usages of ContextAction with lambdas.

This PR probably makes sense to be reviewed with `?w=1` at the end of the URL.