### PR TITLE
fix the isSymbol detection to no longer detect the prototype as symbol

### DIFF
--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -59,9 +59,14 @@ public class NativeSymbol
         }
     }
 
+    /**
+     * This has to be used only for constructing the prototype instance.
+     * This sets symbolData to null (see isSymbol() for more).
+     * @param desc the description
+     */
     private NativeSymbol(String desc) {
         this.key = new SymbolKey(desc);
-        this.symbolData = this;
+        this.symbolData = null;
     }
 
     private NativeSymbol(SymbolKey key) {
@@ -233,7 +238,7 @@ public class NativeSymbol
             return new NativeSymbol((SymbolKey) args[1]);
         }
 
-        return new NativeSymbol(desc);
+        return new NativeSymbol(new SymbolKey(desc));
     }
 
     private Object js_valueOf() {

--- a/testsrc/jstests/harmony/symbols.js
+++ b/testsrc/jstests/harmony/symbols.js
@@ -85,4 +85,11 @@ obj[callMeSym] = callMeTwice;
 assertEquals("maybe", obj.callMe());
 assertEquals("maybemaybe", obj[callMeSym]());
 
+// Symbol prototype 
+assertEquals("object", typeof Symbol.prototype);
+
+Symbol.prototype.myCustomFunction = function() {};
+assertEquals("function", typeof Symbol.prototype.myCustomFunction);
+
+
 "success";

--- a/testsrc/jstests/harmony/v8-symbols.js
+++ b/testsrc/jstests/harmony/v8-symbols.js
@@ -164,8 +164,7 @@ function TestEquality() {
   for (var i in symbols) {
     assertSame(symbols[i], symbols[i])
     assertEquals(symbols[i], symbols[i])
-    // TODO Rhino no "is"
-    //assertTrue(Object.is(symbols[i], symbols[i]))
+    assertTrue(Object.is(symbols[i], symbols[i]))
     assertTrue(symbols[i] === symbols[i])
     assertTrue(symbols[i] == symbols[i])
     assertFalse(symbols[i] === Object(symbols[i]))
@@ -239,8 +238,7 @@ Symbol.prototype.getThisProto = function () {
 }
 function TestCall() {
   for (var i in symbols) {
-    //assertTrue(symbols[i].getThisProto() === Symbol.prototype)
-    // TODO something going on with the above
+    assertTrue(symbols[i].getThisProto() === Symbol.prototype)
     assertTrue(Object.getPrototypeOf(symbols[i]) === Symbol.prototype)
   }
 }


### PR DESCRIPTION
and another fix; have added two new test cases and found two old cases we can enable