### PR TITLE
Bound functions must not leak global object into strict functions

### DIFF
--- a/src/org/mozilla/javascript/BoundFunction.java
+++ b/src/org/mozilla/javascript/BoundFunction.java
@@ -49,8 +49,7 @@ public class BoundFunction extends BaseFunction {
   @Override
   public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] extraArgs)
   {
-    Scriptable callThis = boundThis != null ? boundThis : ScriptRuntime.getTopCallScope(cx);
-    return targetFunction.call(cx, scope, callThis, concat(boundArgs, extraArgs));
+    return targetFunction.call(cx, scope, boundThis, concat(boundArgs, extraArgs));
   }
 
   @Override

--- a/testsrc/org/mozilla/javascript/tests/StrictBindThisTest.java
+++ b/testsrc/org/mozilla/javascript/tests/StrictBindThisTest.java
@@ -1,0 +1,14 @@
+package org.mozilla.javascript.tests;
+
+import junit.framework.TestCase;
+
+public class StrictBindThisTest extends TestCase {
+    public void testStrictBindThis() {
+        Utils.runWithAllOptimizationLevels(cx -> {
+            assertTrue((Boolean)cx.evaluateString(cx.initSafeStandardObjects(), 
+                "((function() { 'use strict'; return this == null }).bind(null))()", 
+                "testBindScope.js", 1, null));
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Fixes #442 