### PR TITLE
Fix #448: Correctly wrap the result of Math.imul as an Int32.

### DIFF
--- a/src/org/mozilla/javascript/NativeMath.java
+++ b/src/org/mozilla/javascript/NativeMath.java
@@ -6,8 +6,6 @@
 
 package org.mozilla.javascript;
 
-import org.mozilla.javascript.typedarrays.Conversions;
-
 /**
  * This class implements the Math native object.
  * See ECMA 15.8.
@@ -364,17 +362,15 @@ final class NativeMath extends IdScriptableObject
     }
 
     // From EcmaScript 6 section 20.2.2.19
-    private Object js_imul(Object[] args)
+    private int js_imul(Object[] args)
     {
-        if ((args == null) || (args.length < 2)) {
-            return ScriptRuntime.wrapNumber(ScriptRuntime.NaN);
+        if (args == null) {
+            return 0;
         }
 
-        long x = Conversions.toUint32(args[0]);
-        long y = Conversions.toUint32(args[1]);
-        long product = (x * y) % Conversions.THIRTYTWO_BIT;
-        long result = (product >= (1L << 31L)) ? (product - Conversions.THIRTYTWO_BIT) : product;
-        return ScriptRuntime.toNumber(result);
+        int x = ScriptRuntime.toInt32(args, 0);
+        int y = ScriptRuntime.toInt32(args, 1);
+        return x * y;
     }
 
 // #string_id_map#

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -366,6 +366,8 @@ built-ins/Symbol
     ! /length.js
     ! this-val-non-obj.js
 
+built-ins/Math/imul
+
 
 ######### LANGUAGE #########
 


### PR DESCRIPTION
The test https://github.com/tc39/test262/blob/041da54c02ae7d17edb8c134ab7691c4f643bafe/test/built-ins/Math/imul/results.js did not pass before this change, and passes after. I assume enabling the corresponding test262 directory is enough testing for the fix.