### PR TITLE
Fix the conversions in typedarrays.Conversions.

### DIFF
--- a/src/org/mozilla/javascript/typedarrays/Conversions.java
+++ b/src/org/mozilla/javascript/typedarrays/Conversions.java
@@ -14,33 +14,14 @@ import org.mozilla.javascript.ScriptRuntime;
 
 public class Conversions
 {
-    public static final int EIGHT_BIT = 1 << 8;
-    public static final int SIXTEEN_BIT = 1 << 16;
-    public static final long THIRTYTWO_BIT = 1L << 32L;
-
     public static int toInt8(Object arg)
     {
-        int iv;
-        if (arg instanceof Integer) {
-            iv = (Integer)arg;
-        } else {
-            iv = ScriptRuntime.toInt32(arg);
-        }
-
-        int int8Bit = iv % EIGHT_BIT;
-        return (int8Bit >= (1 << 7)) ? (int8Bit - EIGHT_BIT) : int8Bit;
+        return (int)(byte)ScriptRuntime.toInt32(arg);
     }
 
     public static int toUint8(Object arg)
     {
-        int iv;
-        if (arg instanceof Integer) {
-            iv = ((Integer)arg);
-        } else {
-            iv = ScriptRuntime.toInt32(arg);
-        }
-
-        return iv % EIGHT_BIT;
+        return ScriptRuntime.toInt32(arg) & 0xff;
     }
 
     public static int toUint8Clamp(Object arg)
@@ -69,39 +50,21 @@ public class Conversions
 
     public static int toInt16(Object arg)
     {
-        int iv;
-        if (arg instanceof Integer) {
-            iv = ((Integer)arg);
-        } else {
-            iv = ScriptRuntime.toInt32(arg);
-        }
-
-        int int16Bit = iv % SIXTEEN_BIT;
-        return (int16Bit >= (1 << 15)) ? (int16Bit - SIXTEEN_BIT) : int16Bit;
+        return (int)(short)ScriptRuntime.toInt32(arg);
     }
 
     public static int toUint16(Object arg)
     {
-        int iv;
-        if (arg instanceof Integer) {
-            iv = ((Integer)arg);
-        } else {
-            iv = ScriptRuntime.toInt32(arg);
-        }
-
-        return iv % SIXTEEN_BIT;
+        return ScriptRuntime.toInt32(arg) & 0xffff;
     }
 
     public static int toInt32(Object arg)
     {
-        long lv = (long)ScriptRuntime.toNumber(arg);
-        long int32Bit = lv % THIRTYTWO_BIT;
-        return (int)((int32Bit >= (1L << 31L)) ? (int32Bit - THIRTYTWO_BIT) : int32Bit);
+        return ScriptRuntime.toInt32(arg);
     }
 
     public static long toUint32(Object arg)
     {
-        long lv = (long)ScriptRuntime.toNumber(arg);
-        return lv % THIRTYTWO_BIT;
+        return ScriptRuntime.toUint32(arg);
     }
 }

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -368,6 +368,10 @@ built-ins/Symbol
 
 built-ins/Math/imul
 
+built-ins/TypedArrays/internals/Set
+    ! detached-buffer.js
+    ! tonumber-value-throws.js
+
 
 ######### LANGUAGE #########
 


### PR DESCRIPTION
Their implementation did not account for

a) the wrapping of number values larger than Integer.MAX_VALUE  or lower than Integer.MIN_VALUE.
b) the behavior of `%` for negative values.

The complex problem of a) is already dealt with by `ScriptRuntime.toInt32`, which we now leverage. Instead of `%` to implement the `modulo` operation from the ECMAScript specification (which is incorrect), we use sign-extending conversions such as `(int)(byte)x` and bitwise ands such as `& 0xff`.

This fixes the test262 test in `built-ins/TypedArrays/internals/Set/conversion-operation.js`. It does not affect any other test in `built-ins/TypedArrays/` (neither progression nor regression).

I stumbled upon the implementations of `Conversions` while trying to fix `Math.imul`, and noticed they were buggy for pretty much the same reason `js_imul` was buggy. So I figured I'd send a fix.