### PR TITLE
Allow comparing continuations for equality.

### DIFF
--- a/src/org/mozilla/javascript/ArrowFunction.java
+++ b/src/org/mozilla/javascript/ArrowFunction.java
@@ -72,4 +72,8 @@ public class ArrowFunction extends BaseFunction {
         }
         return super.decompile(indent, flags);
     }
+    
+    static boolean equalObjectGraphs(ArrowFunction f1, ArrowFunction f2, EqualObjectGraphs eq) {
+        return  eq.equalGraphs(f1.boundThis, f2.boundThis) && eq.equalGraphs(f1.targetFunction, f2.targetFunction);
+    }
 }

--- a/src/org/mozilla/javascript/BoundFunction.java
+++ b/src/org/mozilla/javascript/BoundFunction.java
@@ -80,4 +80,8 @@ public class BoundFunction extends BaseFunction {
     System.arraycopy(second, 0, args, first.length, second.length);
     return args;
   }
+  
+  static boolean equalObjectGraphs(BoundFunction f1, BoundFunction f2, EqualObjectGraphs eq) {
+      return  eq.equalGraphs(f1.boundThis, f2.boundThis) && eq.equalGraphs(f1.targetFunction, f2.targetFunction) && eq.equalGraphs(f1.boundArgs, f2.boundArgs);
+  }
 }

--- a/src/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/src/org/mozilla/javascript/EqualObjectGraphs.java
@@ -1,0 +1,320 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.mozilla.javascript.debug.DebuggableObject;
+
+/**
+ * An object that implements deep equality test of objects, including their 
+ * reference graph topology, that is in addition to establishing by-value
+ * equality of objects, it also establishes that their reachable object graphs 
+ * have identical shape. It is capable of custom-comparing a wide range of 
+ * various objects, including various Rhino Scriptables, Java arrays, Java 
+ * Lists, and to some degree Java Maps and Sets (sorted Maps are okay, as well 
+ * as Sets with elements that can be sorted using their Comparable 
+ * implementation, and Maps whose keysets work the same). The requirement for 
+ * sortable maps and sets is to ensure deterministic order of traversal, which 
+ * is necessary for establishing structural equality of object graphs.
+ * 
+ * An instance of this object is stateful in that it memoizes pairs of objects
+ * that already compared equal, so reusing an instance for repeated equality 
+ * tests of potentially overlapping object graph is beneficial for performance
+ * as long as all equality test invocations returns true. Reuse is not advised 
+ * after an equality test returned false since there is a heuristic in comparing
+ * cyclic data structures that can memoize false equalities if two cyclic data 
+ * structures end up being unequal.
+ */
+final class EqualObjectGraphs  {
+    private static final ThreadLocal<EqualObjectGraphs> instance = new ThreadLocal<>();
+    
+    // Object pairs already known to be equal. Used to short-circuit repeated traversals of objects reachable through
+    // different paths as well as to detect structural inequality.
+    private final Map<Object, Object> knownEquals = new IdentityHashMap<>();
+    // Currently compared objects; used to avoid infinite recursion over cyclic object graphs.
+    private final Map<Object, Object> currentlyCompared = new IdentityHashMap<>();
+    
+    static <T> T withThreadLocal(java.util.function.Function<EqualObjectGraphs, T> action) {
+        final EqualObjectGraphs currEq = instance.get();
+        if (currEq == null) {
+            final EqualObjectGraphs eq = new EqualObjectGraphs();
+            instance.set(eq);
+            try {
+                return action.apply(eq);
+            } finally {
+                instance.set(null);
+            }
+        }
+        return action.apply(currEq);
+    }
+    
+    boolean equalGraphs(Object o1, Object o2) {
+        if (o1 == o2) {
+            return true;
+        } else if (o1 == null || o2 == null) {
+            return false;
+        }
+
+        final Object curr2 = currentlyCompared.get(o1);
+        if (curr2 == o2) {
+            // Provisionally afford that if we're already recursively comparing
+            // (o1, o2) that they'll be equal. NOTE: this is the heuristic 
+            // mentioned in the class JavaDoc that can drive memoizing false 
+            // equalities if cyclic data structures end up being unequal. 
+            // While it would be possible to fix that with additional code, the
+            // usual usage of equality comparisons is short-circuit-on-false anyway,
+            // so this edge case should not arise in normal usage and the additional
+            // code complexity to guard against it is not worth it.
+            return true;
+        } else if (curr2 != null) {
+            // If we're already recursively comparing o1 to some other object,
+            // this comparison is structurally false.
+            return false;
+        }
+        
+        final Object prev2 = knownEquals.get(o1);
+        if (prev2 == o2) {
+            // o1 known to be equal to o2.
+            return true;
+        } else if (prev2 != null) {
+            // o1 known to be equal to something other than o2.
+            return false;
+        }
+        
+        final Object prev1 = knownEquals.get(o2);
+        assert prev1 != o1; // otherwise we would've already returned at prev2 == o2
+        if (prev1 != null) {
+            // o2 known to be equal to something other than o1.
+            return false;
+        }
+
+        currentlyCompared.put(o1, o2);
+        final boolean eq = equalGraphsNoMemo(o1, o2);
+        if (eq) {
+            knownEquals.put(o1, o2);
+            knownEquals.put(o2, o1);
+        }
+        currentlyCompared.remove(o1);
+        return eq;
+    }
+    
+    private boolean equalGraphsNoMemo(Object o1, Object o2) {
+        if (o1 instanceof Wrapper) {
+            return o2 instanceof Wrapper && equalGraphs(((Wrapper)o1).unwrap(), ((Wrapper)o2).unwrap());
+        } else if (o1 instanceof Scriptable) {
+            return o2 instanceof Scriptable && equalScriptables((Scriptable)o1, (Scriptable)o2);
+        } else if (o1 instanceof ConsString) {
+            return ((ConsString)o1).toString().equals(o2);
+        } else if (o2 instanceof ConsString) {
+            return o1.equals(((ConsString)o2).toString());
+        } else if (o1 instanceof SymbolKey) {
+            return o2 instanceof SymbolKey && equalGraphs(((SymbolKey)o1).getName(), ((SymbolKey)o2).getName());
+        } else if (o1 instanceof Object[]) {
+            return o2 instanceof Object[] && equalObjectArrays((Object[])o1, (Object[])o2);
+        } else if (o1.getClass().isArray()) {
+            return Objects.deepEquals(o1,  o2);
+        } else if (o1 instanceof List<?>) {
+            return o2 instanceof List<?> && equalLists((List<?>)o1, (List<?>)o2);
+        } else if (o1 instanceof Map<?, ?>) {
+            return o2 instanceof Map<?, ?> && equalMaps((Map<?, ?>)o1, (Map<?, ?>)o2);
+        } else if (o1 instanceof Set<?>) {
+            return o2 instanceof Set<?> && equalSets((Set<?>)o1, (Set<?>)o2);
+        } else if (o1 instanceof NativeGlobal) {
+            return o2 instanceof NativeGlobal; // stateless objects
+        } else if (o1 instanceof JavaAdapter) {
+            return o2 instanceof JavaAdapter; // stateless objects
+        } else if (o1 instanceof NativeJavaTopPackage) {
+            return o2 instanceof NativeJavaTopPackage; // stateless objects
+        }
+
+        // Fallback case for everything else.
+        return o1.equals(o2);
+    }
+    
+    private boolean equalScriptables(final Scriptable s1, final Scriptable s2) {
+        final Object[] ids1 = getSortedIds(s1);
+        final Object[] ids2 = getSortedIds(s2);
+        if (!equalObjectArrays(ids1, ids2)) {
+            return false;
+        }
+        final int l = ids1.length;
+        for(int i = 0; i < l; ++i) {
+            if (!equalGraphs(getValue(s1, ids1[i]), getValue(s2, ids2[i]))) {
+                return false;
+            }
+        }
+        if (!equalGraphs(s1.getPrototype(), s2.getPrototype())) {
+            return false;
+        } else if (!equalGraphs(s1.getParentScope(), s2.getParentScope())) {
+            return false;
+        }
+        
+        // Handle special Scriptable implementations
+        if (s1 instanceof NativeContinuation) {
+            return s2 instanceof NativeContinuation && NativeContinuation.equalImplementations((NativeContinuation)s1, (NativeContinuation)s2);
+        } else if (s1 instanceof NativeJavaPackage) {
+            return s1.equals(s2); // Overridden appropriately
+        } else if (s1 instanceof IdFunctionObject) {
+            return s2 instanceof IdFunctionObject && IdFunctionObject.equalObjectGraphs((IdFunctionObject)s1, (IdFunctionObject)s2, this);
+        } else if (s1 instanceof InterpretedFunction) {
+            return s2 instanceof InterpretedFunction && equalInterpretedFunctions((InterpretedFunction)s1, (InterpretedFunction)s2);
+        } else if (s1 instanceof ArrowFunction) {
+            return s2 instanceof ArrowFunction && ArrowFunction.equalObjectGraphs((ArrowFunction)s1, (ArrowFunction)s2, this);
+        } else if (s1 instanceof BoundFunction) {
+            return s2 instanceof BoundFunction && BoundFunction.equalObjectGraphs((BoundFunction)s1, (BoundFunction)s2, this);
+        } else if (s1 instanceof NativeSymbol) {
+            return s2 instanceof NativeSymbol && equalGraphs(((NativeSymbol)s1).getKey(), ((NativeSymbol)s2).getKey()); 
+        }
+        return true;
+    }
+
+    private boolean equalObjectArrays(final Object[] a1, final Object[] a2) {
+        if (a1.length != a2.length) {
+            return false;
+        }
+        for(int i = 0; i < a1.length; ++i) {
+            if (!equalGraphs(a1[i], a2[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean equalLists(final List<?> l1, final List<?> l2) {
+        if (l1.size() != l2.size()) {
+            return false;
+        }
+        final Iterator<?> i1 = l1.iterator();
+        final Iterator<?> i2 = l2.iterator();
+        while(i1.hasNext() && i2.hasNext()) {
+            if (!equalGraphs(i1.next(), i2.next())) {
+                return false;
+            }
+        }
+        assert !(i1.hasNext() || i2.hasNext());
+        return true;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    private boolean equalMaps(final Map<?, ?> m1, final Map<?, ?> m2) {
+        if (m1.size() != m2.size()) {
+            return false;
+        }
+        final Iterator<Map.Entry> i1 = sortedEntries(m1);
+        final Iterator<Map.Entry> i2 = sortedEntries(m2);
+        
+        while(i1.hasNext() && i2.hasNext()) {
+            final Map.Entry kv1 = i1.next();
+            final Map.Entry kv2 = i2.next();
+            if (!(equalGraphs(kv1.getKey(), kv2.getKey()) && equalGraphs(kv1.getValue(), kv2.getValue()))) {
+                return false;
+            }
+        }
+        assert !(i1.hasNext() || i2.hasNext());
+        // TODO: assert linked maps traversal order?
+        return true;
+        
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Iterator<Map.Entry> sortedEntries(final Map m) {
+        // Yes, this throws ClassCastException if the keys aren't comparable. That's okay. We only support maps with 
+        // deterministic traversal order.
+        final Map sortedMap = (m instanceof SortedMap<?, ?> ? m : new TreeMap(m));
+        return sortedMap.entrySet().iterator(); 
+    }
+    
+    private boolean equalSets(final Set<?> s1, final Set<?> s2) {
+        return equalObjectArrays(sortedSet(s1), sortedSet(s2));
+    }
+    
+    private static Object[] sortedSet(final Set<?> s) {
+        final Object[] a = s.toArray();
+        Arrays.sort(a); // ClassCastException possible
+        return a;
+    }
+
+    private static boolean equalInterpretedFunctions(final InterpretedFunction f1, final InterpretedFunction f2) {
+        return Objects.equals(f1.getEncodedSource(), f2.getEncodedSource());
+    }
+
+    // Sort IDs deterministically
+    private static Object[] getSortedIds(final Scriptable s) {
+        final Object[] ids = getIds(s);
+        Arrays.sort(ids, (a, b) -> {
+            if (a instanceof Integer) {
+                if (b instanceof Integer) {
+                    return ((Integer)a).compareTo((Integer)b);
+                } else if (b instanceof String || b instanceof Symbol) {
+                    return -1; // ints before strings or symbols
+                }
+            } else if (a instanceof String) {
+                if (b instanceof String) {
+                    return ((String)a).compareTo((String)b);
+                } else if (b instanceof Integer) {
+                    return 1; // strings after ints
+                } else if (b instanceof Symbol) {
+                    return -1; // strings before symbols
+                }
+            } else if (a instanceof Symbol) {
+                if (b instanceof Symbol) {
+                    // As long as people bother to reasonably name their symbols,
+                    // this will work. If there's clashes in symbol names (e.g.
+                    // lots of unnamed symbols) it can lead to false inequalities.
+                    return getSymbolName((Symbol)a).compareTo(getSymbolName((Symbol)b));
+                } else if (b instanceof Integer || b instanceof String) {
+                    return 1; // symbols after ints and strings
+                }
+            }
+            // We can only compare Rhino key types: Integer, String, Symbol
+            throw new ClassCastException();
+        });
+        return ids;
+    }
+
+    private static String getSymbolName(final Symbol s) {
+        if (s instanceof SymbolKey) {
+            return ((SymbolKey)s).getName();
+        } else if (s instanceof NativeSymbol) {
+            return ((NativeSymbol)s).getKey().getName();
+        } else {
+            // We can only handle native Rhino Symbol types
+            throw new ClassCastException();
+        }
+    }
+
+    private static Object[] getIds(final Scriptable s) {
+        if (s instanceof ScriptableObject) {
+            // Grabs symbols too
+            return ((ScriptableObject)s).getIds(true, true);
+        } else if (s instanceof DebuggableObject) {
+            return ((DebuggableObject)s).getAllIds();
+        } else {
+            return s.getIds();
+        }
+    }
+
+    private static Object getValue(final Scriptable s, final Object id) {
+        if (id instanceof Symbol) {
+            return ScriptableObject.getProperty(s, (Symbol)id);
+        } else if (id instanceof Integer) {
+            return ScriptableObject.getProperty(s, (Integer)id);
+        } else if (id instanceof String) {
+            return ScriptableObject.getProperty(s, (String)id);
+        } else {
+            throw new ClassCastException();
+        }
+    }
+}

--- a/src/org/mozilla/javascript/IdFunctionObject.java
+++ b/src/org/mozilla/javascript/IdFunctionObject.java
@@ -158,6 +158,10 @@ public class IdFunctionObject extends BaseFunction
             "BAD FUNCTION ID="+methodId+" MASTER="+idcall);
     }
 
+    static boolean equalObjectGraphs(IdFunctionObject f1, IdFunctionObject f2, EqualObjectGraphs eq) {
+        return f1.methodId == f2.methodId && f1.hasTag(f2.tag) && eq.equalGraphs(f1.idcall, f2.idcall);
+    }
+
     private final IdFunctionCall idcall;
     private final Object tag;
     private final int methodId;

--- a/src/org/mozilla/javascript/InterpreterData.java
+++ b/src/org/mozilla/javascript/InterpreterData.java
@@ -7,7 +7,7 @@
 package org.mozilla.javascript;
 
 import java.io.Serializable;
-
+import java.util.Arrays;
 import org.mozilla.javascript.debug.DebuggableScript;
 
 final class InterpreterData implements Serializable, DebuggableScript
@@ -89,6 +89,8 @@ final class InterpreterData implements Serializable, DebuggableScript
 
     boolean evalScriptFlag; // true if script corresponds to eval() code
 
+    private int icodeHashCode = 0;
+           
     public boolean isTopLevel()
     {
         return topLevel;
@@ -152,5 +154,14 @@ final class InterpreterData implements Serializable, DebuggableScript
     public DebuggableScript getParent()
     {
          return parentData;
+    }
+
+    public int icodeHashCode()
+    {
+        int h = icodeHashCode;
+        if (h == 0) {
+            icodeHashCode = h = Arrays.hashCode(itsICode);
+        }
+        return h;
     }
 }

--- a/src/org/mozilla/javascript/NativeContinuation.java
+++ b/src/org/mozilla/javascript/NativeContinuation.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import java.util.Objects;
+
 public final class NativeContinuation extends IdScriptableObject
     implements Function
 {
@@ -54,6 +56,17 @@ public final class NativeContinuation extends IdScriptableObject
             return true;
         }
         return false;
+    }
+    
+    /**
+     * Returns true if both continuations have equal implementations.
+     * @param c1 one continuation
+     * @param c2 another continuation
+     * @return true if the implementations of both continuations are equal, or they are both null.
+     * @throws NullPointerException if either continuation is null
+     */
+    public static boolean equalImplementations(NativeContinuation c1, NativeContinuation c2) {
+        return Objects.equals(c1.implementation, c2.implementation);
     }
 
     @Override

--- a/testsrc/org/mozilla/javascript/EqualObjectGraphsTest.java
+++ b/testsrc/org/mozilla/javascript/EqualObjectGraphsTest.java
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import junit.framework.TestCase;
+
+public class EqualObjectGraphsTest extends TestCase {
+    public void testCyclic() {
+        assertTrue(equal(makeCyclic("foo"), makeCyclic("foo")));
+        // countertest; make unequal ones and make sure they test unequal
+        assertFalse(equal(makeCyclic("foo"), makeCyclic("bar")));
+    }
+    
+    private static boolean equal(Object o1, Object o2) {
+        return new EqualObjectGraphs().equalGraphs(o1, o2);
+    }
+    
+    private static Object makeCyclic(String key) {
+        Object[] o1 = new Object[1];
+        List<Object> o2 = new ArrayList<>();
+        Map<String, Object> o3 = new HashMap<>();
+        o1[0] = o2;
+        o2.add(o3);
+        o3.put(key, o1);
+        return o1;
+    }
+
+    public void testSameValueDifferentTopology() {
+        Object[] o1 = new Object[2];
+        Object[] o2 = new Object[2];
+        String s1 = new String("foo");
+        String s2 = new String("foo");
+        o1[0] = s1;
+        o1[1] = s2;
+        String s3 = new String("foo");
+        String s4 = new String("foo");
+        o2[0] = s3;
+        o2[1] = s4;
+        
+        // Same values, same topology
+        assertTrue(equal(o1, o2));
+
+        // Same values, different topology
+        o2[1] = s3;
+        assertFalse(equal(o1, o2));
+    }
+    
+    public void testHeterogenousScriptables() {
+        Context cx = Context.enter();
+        ScriptableObject top = cx.initStandardObjects();
+        ScriptRuntime.doTopCall((Callable)(c, scope, thisObj, args) -> {
+            assertTrue(equal(makeHeterogenousScriptable(cx, "v1"), makeHeterogenousScriptable(cx, "v1")));
+            assertFalse(equal(makeHeterogenousScriptable(cx, "v1"), makeHeterogenousScriptable(cx, "v2")));
+            return null;
+        }, cx, top, top, null, false);
+        Context.exit();
+    }
+
+    private static Object makeHeterogenousScriptable(Context cx, String discriminator) {
+        ScriptableObject global = cx.initStandardObjects();
+        ScriptableObject s = (ScriptableObject)cx.newObject(global);
+        s.put(0, s, "i0");
+        s.put(1, s, "i1");
+        s.put(2, s, "i2");
+        s.put("s0", s, "v0");
+        s.put("s1", s, discriminator);
+        s.put("s2", s, "v2");
+        return s;
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/ContinuationComparisonTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ContinuationComparisonTest.java
@@ -1,0 +1,50 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.concurrent.atomic.AtomicReference;
+import junit.framework.TestCase;
+import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Interpreter;
+import org.mozilla.javascript.NativeContinuation;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.ScriptableObject;
+
+public class ContinuationComparisonTest extends TestCase {
+
+    public void test1() throws Exception {
+        // Create two identical executions
+        NativeContinuation c1 = createContinuation();
+        NativeContinuation c2 = createContinuation();
+
+        assertTrue(NativeContinuation.equalImplementations(c1, c2));
+    }
+    
+    private NativeContinuation createContinuation() throws Exception {
+        Context cx = Context.enter();
+        cx.setOptimizationLevel(-1); // interpreter for continuations
+        ScriptableObject global = cx.initStandardObjects();
+        final AtomicReference<NativeContinuation> captured = new AtomicReference<>();
+        ScriptableObject.putProperty(global, "capture", (Callable)(c, scope, thisObj, args) -> {
+            captured.set(Interpreter.captureContinuation(c));
+            return null;
+        });
+
+        // Evaluate program
+        try(Reader r = new InputStreamReader(getClass().getResourceAsStream("ContinuationComparisonTest.js"))) {
+            cx.executeScriptWithContinuations(cx.compileReader(r, "ContinuationComparisonTest.js", 1, null), global);
+        }
+        // Make the global standard again
+        ScriptableObject.deleteProperty(global, "capture");
+        Context.exit();
+        return captured.get(); 
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/ContinuationComparisonTest.js
+++ b/testsrc/org/mozilla/javascript/tests/ContinuationComparisonTest.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+function f1(x, y) {
+    return f2(y, x)
+}
+
+function f2(x, y) {
+    return f3(x, x)
+}
+
+function f3(x, y) {
+    capture()
+}
+
+f1("a", 5)


### PR DESCRIPTION
Implements #401.

This PR is separated into 4 commits for ease of review:
- First one simply adds a convenience static method to `NativeContinuation` to compare two continuations' implementations using vanilla `Objects.equal`. This is done instead of overriding `NativeContinuation.equals` in order to avoid backwards compatibility concerns. (`NativeContinuation` is a `ScriptableObject` and Rhino doesn't override `equals` for majority of them, except, curiously, for `NativeJavaPackage`,  but I digress…) 
- Second one introduces an algorithm for structural equality comparison of object graphs, specifically tailored to Rhino objects as well as Java collections. It also provides package-private static methods that act as hooks into bespoke structural comparison of some Rhino-specific objects (notably, `ArrowFunction`, `BoundFunction`, and `IdFunctionObject`). This comparison is "structural" in the sense that different object layouts of even semantically equivalent objects compare as false, e.g.
```javascript
var a1 = { 'foo': 42 }
var a2 = { 'foo': 42 }
var b = { 'a1': a1, 'a2': a2 }
var c = { 'a1': a1, 'a2': a1 }
```
`b` and `c` would not be considered structurally equivalent, since `b.a1 !== b.a2` but `c.a1 === c.a2`. This is important as we compare continuations, because if `b` occurs in one continuation being compared and `c` occurs in another continuation being compared, they must compare unequal otherwise if the continuations contain such strict comparison expressions as per above we'd fail to recognize their inequality.
- Third commit finally uses the previously defined structural comparison as the implementation for `Interpreter$CallFrame.equals` – the class that is used as the actual underlying state of Rhino interpreter continuations. It also adds an equals-consistent `hashCode` implementation.
- Finally, the fourth commit serves to put in place workarounds for two issues in Rhino I have identified while working on this that would otherwise block it. The workarounds are thus in a separate, marked commit so they can be easily found once the issues were fixed to remove them.

A reasonable amount of tests has also been provided.