### PR TITLE
Support for `arguments` object as TypedArray constructor argument

### DIFF
--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -6,6 +6,14 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.RandomAccess;
+
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ExternalArrayData;
 import org.mozilla.javascript.IdFunctionObject;
@@ -16,13 +24,6 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Symbol;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
-
-import java.lang.reflect.Array;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.RandomAccess;
 
 /**
  * This class is the abstract parent for all of the various typed arrays. Each one
@@ -156,9 +157,11 @@ public abstract class NativeTypedArrayView<T>
 
             return construct(na, byteOff, byteLen / getBytesPerElement());
 
-        } else if (args[0] instanceof NativeArray) {
+        } else if (ScriptRuntime.isArrayObject(args[0])) {
             // Copy elements of the array and convert them to the correct type
-            List l = (List)args[0];
+            List l = args[0] instanceof NativeArray ? (List)args[0]
+                              : Arrays.asList(ScriptRuntime.getArrayElements((Scriptable)args[0]));
+
             NativeArrayBuffer na = makeArrayBuffer(cx, scope, l.size() * getBytesPerElement());
             NativeTypedArrayView v = construct(na, 0, l.size());
             int p = 0;

--- a/testsrc/jstests/harmony/typed-array-ctor.js
+++ b/testsrc/jstests/harmony/typed-array-ctor.js
@@ -1,0 +1,26 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+var type;
+
+function foo() {
+  return new type(arguments);
+}
+
+for (var t = 0; t < types.length; t++) {
+  type = types[t];
+
+  var one = new foo([7]);
+  assertEquals("7", one.toString());
+
+  var two = new foo(7, 13);
+  assertEquals("7,13", two.toString());
+
+  var many = new foo(7,13,21,17,0,1,11);
+  assertEquals("7,13,21,17,0,1,11", many.toString());
+}
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/harmony/TypedArrayCtorTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/TypedArrayCtorTest.java
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-ctor.js")
+public class TypedArrayCtorTest extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
This is the same as #297 but includes a simple test