### PR TITLE
fixes for #437 and #449

### DIFF
--- a/src/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/src/org/mozilla/javascript/EqualObjectGraphs.java
@@ -15,8 +15,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
 import org.mozilla.javascript.debug.DebuggableObject;
-import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
 import org.mozilla.javascript.typedarrays.NativeTypedArrayView;
 
 /**
@@ -303,10 +303,7 @@ final class EqualObjectGraphs  {
             try {
                 return ((ScriptableObject)s).getIds(true, true);
             } catch (IllegalArgumentException e) {
-                if (s instanceof NativeArrayBuffer) {
-                    // TODO: remove this once https://github.com/mozilla/rhino/issues/437 is fixed
-                    return new String[0];
-                } else if (s instanceof NativeTypedArrayView) {
+                if (s instanceof NativeTypedArrayView) {
                     // TODO: remove this once https://github.com/mozilla/rhino/issues/449 is fixed
                     return s.getIds();
                 }

--- a/src/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/src/org/mozilla/javascript/EqualObjectGraphs.java
@@ -17,7 +17,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.mozilla.javascript.debug.DebuggableObject;
-import org.mozilla.javascript.typedarrays.NativeTypedArrayView;
 
 /**
  * An object that implements deep equality test of objects, including their 
@@ -300,15 +299,7 @@ final class EqualObjectGraphs  {
     private static Object[] getIds(final Scriptable s) {
         if (s instanceof ScriptableObject) {
             // Grabs symbols too
-            try {
-                return ((ScriptableObject)s).getIds(true, true);
-            } catch (IllegalArgumentException e) {
-                if (s instanceof NativeTypedArrayView) {
-                    // TODO: remove this once https://github.com/mozilla/rhino/issues/449 is fixed
-                    return s.getIds();
-                }
-                throw e;
-            }
+            return ((ScriptableObject)s).getIds(true, true);
         } else if (s instanceof DebuggableObject) {
             return ((DebuggableObject)s).getAllIds();
         } else {

--- a/src/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -164,11 +164,10 @@ public class NativeArrayBuffer
     protected int findPrototypeId(String s)
     {
         int id;
-// #generated#
+// #generated# Last update: 2018-07-20 08:21:54 MESZ
         L0: { id = 0; String X = null;
             int s_length = s.length();
             if (s_length==5) { X="slice";id=Id_slice; }
-            else if (s_length==6) { X="isView";id=Id_isView; }
             else if (s_length==11) { X="constructor";id=Id_constructor; }
             if (X!=null && X!=s && !X.equals(s)) id = 0;
             break L0;
@@ -181,14 +180,13 @@ public class NativeArrayBuffer
     private static final int
         Id_constructor          = 1,
         Id_slice                = 2,
-        Id_isView               = 3,
-        MAX_PROTOTYPE_ID        = Id_isView;
+        MAX_PROTOTYPE_ID        = Id_slice;
 
 // #/string_id_map#
 
     // Constructor (aka static) functions here
 
-    private static final int ConstructorId_isView = -Id_isView;
+    private static final int ConstructorId_isView = -1;
 
     @Override
     protected void fillConstructorProperties(IdFunctionObject ctor)

--- a/src/org/mozilla/javascript/typedarrays/NativeArrayBufferView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeArrayBufferView.java
@@ -144,7 +144,10 @@ public abstract class NativeArrayBufferView
     private static final int
         Id_buffer               = 1,
         Id_byteOffset           = 2,
-        Id_byteLength           = 3,
+        Id_byteLength           = 3;
+
+    // to be visible by subclasses
+    protected static final int
         MAX_INSTANCE_ID         = Id_byteLength;
 
 // #/string_id_map#

--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -442,8 +442,8 @@ public abstract class NativeTypedArrayView<T>
      * These must not conflict with ids in the parent since we delegate there for property dispatching.
      */
     private static final int
-        Id_length               = 10,
-        Id_BYTES_PER_ELEMENT    = 11,
+        Id_length               = NativeArrayBufferView.MAX_INSTANCE_ID + 1,
+        Id_BYTES_PER_ELEMENT    = Id_length + 1,
         MAX_INSTANCE_ID         = Id_BYTES_PER_ELEMENT;
 
 // #/string_id_map#

--- a/testsrc/org/mozilla/javascript/tests/NativeArrayBufferTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeArrayBufferTest.java
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
+
+public class NativeArrayBufferTest {
+
+    /**
+     * Test case for issue {@link https://github.com/mozilla/rhino/issues/437}
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void test() throws Exception {
+        Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        Scriptable global = cx.initStandardObjects();
+        Object result = cx.evaluateString(global, "(new ArrayBuffer(5)).isView", "", 1, null);
+        Assert.assertEquals(Undefined.instance, result);
+        Context.exit();
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/harmony/TypedArrayJavaTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/TypedArrayJavaTest.java
@@ -1,16 +1,9 @@
 package org.mozilla.javascript.tests.harmony;
 
-import org.junit.Test;
-import org.mozilla.javascript.typedarrays.NativeFloat32Array;
-import org.mozilla.javascript.typedarrays.NativeFloat64Array;
-import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
-import org.mozilla.javascript.typedarrays.NativeInt16Array;
-import org.mozilla.javascript.typedarrays.NativeInt32Array;
-import org.mozilla.javascript.typedarrays.NativeInt8Array;
-import org.mozilla.javascript.typedarrays.NativeUint16Array;
-import org.mozilla.javascript.typedarrays.NativeUint32Array;
-import org.mozilla.javascript.typedarrays.NativeUint8Array;
-import org.mozilla.javascript.typedarrays.NativeUint8ClampedArray;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,7 +12,20 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
+import org.mozilla.javascript.typedarrays.NativeFloat32Array;
+import org.mozilla.javascript.typedarrays.NativeFloat64Array;
+import org.mozilla.javascript.typedarrays.NativeInt16Array;
+import org.mozilla.javascript.typedarrays.NativeInt32Array;
+import org.mozilla.javascript.typedarrays.NativeInt8Array;
+import org.mozilla.javascript.typedarrays.NativeUint16Array;
+import org.mozilla.javascript.typedarrays.NativeUint32Array;
+import org.mozilla.javascript.typedarrays.NativeUint8Array;
+import org.mozilla.javascript.typedarrays.NativeUint8ClampedArray;
 
 /**
  * Ensure that the "List" contract is valid for a typed array.
@@ -291,5 +297,36 @@ public class TypedArrayJavaTest
             assertFalse("Expected exception", true);
         } catch (UnsupportedOperationException e) {
         }
+    }
+
+    /**
+     * Test case for {@link https://github.com/mozilla/rhino/issues/449}
+     *
+     * @throws Exception if test failed
+     */
+    @Test
+    public void getAllIds() throws Exception {
+        String[] allNativeTypes = {
+                "Float32Array",
+                "Float64Array",
+                "Int8Array",
+                "Int16Array",
+                "Int32Array",
+                "Uint8Array",
+                "Uint16Array",
+                "Uint32Array",
+                "Uint8ClampedArray"
+        };
+
+        Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        Scriptable global = cx.initStandardObjects();
+
+        for (String type : allNativeTypes) {
+            ScriptableObject obj = (ScriptableObject)cx.evaluateString(global, "new " + type + "(5)", "", 1, null);
+            obj.getAllIds();
+        }
+
+        Context.exit();
     }
 }

--- a/toolsrc/org/mozilla/javascript/tools/idswitch/CodePrinter.java
+++ b/toolsrc/org/mozilla/javascript/tools/idswitch/CodePrinter.java
@@ -10,7 +10,7 @@ class CodePrinter {
 // length of u-type escape like \u12AB
     private static final int LITERAL_CHAR_MAX_SIZE = 6;
 
-    private String lineTerminator = "\n";
+    private String lineTerminator = System.lineSeparator();
 
     private int indentStep = 4;
     private int indentTabSize = 8;
@@ -159,7 +159,7 @@ class CodePrinter {
     }
 
     public void nl() {
-        p('\n');
+        p(getLineTerminator());
     }
 
     public void line(int indent_level, String s) {
@@ -175,7 +175,4 @@ class CodePrinter {
     public String toString() {
         return new String(buffer, 0, offset);
     }
-
-
-
 }


### PR DESCRIPTION
Should be fixed now, have not added many more unit tests but org.mozilla.javascript.tests.harmony.TypedArraysTest already includes tests for the isView function already.

Side note: the call in the issue is 'invalid'; the isView function is a static one. Calling isView on an object returns undefined (checked with ff)