### PR TITLE
Fix NullPointerException in __defineGetter__

### DIFF
--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -241,7 +241,7 @@ public class NativeObject extends IdScriptableObject implements Map
                 if (!(thisObj instanceof ScriptableObject)) {
                     throw Context.reportRuntimeError2(
                         "msg.extend.scriptable",
-                        thisObj.getClass().getName(),
+                        thisObj == null ? "null" : thisObj.getClass().getName(),
                         String.valueOf(args[0]));
                 }
                 ScriptableObject so = (ScriptableObject)thisObj;

--- a/testsrc/jstests/extensions/getset-null.js
+++ b/testsrc/jstests/extensions/getset-null.js
@@ -1,0 +1,30 @@
+/*
+ * Test a particular regression in which calling __defineGetter__ on "null" would
+ * result in a Java exception. Other behaviors of __defineGetter__ and _defineSetter__
+ * are tested in other test suites.
+ */
+
+load("testsrc/assert.js");
+
+// Positive case, as a sanity check
+var saved;
+var o = {};
+__defineGetter__.call(o, 'foo', function() { return 'bar'; });
+assertEquals(o.foo, 'bar');
+
+__defineSetter__.call(o, 'foo', function(x) { saved = x; });
+o.foo = 'baz';
+assertEquals(saved, 'baz');
+assertEquals(o.foo, 'bar');
+
+// Negative case -- should just throw a JavaScript exception
+assertThrows(function() {
+  __defineGetter__.call(null, 'foo', function() {});
+});
+
+// Negative case -- should just throw a JavaScript exception
+assertThrows(function() {
+  __defineSetter__.call(null, 'foo', function(x) {});
+});
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/es5/GetSetNullTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es5/GetSetNullTest.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript.tests.es5;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/extensions/getset-null.js")
+@LanguageVersion(Context.VERSION_1_8)
+public class GetSetNullTest extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
__defineGetter__ and __defineSetter__ throw an NPE when called
with "null" as "this." This was causing tests from the Kangax
"compat-table" project to crash.