### PR TITLE
Fix standard objects that have Symbols in their prototypes

### DIFF
--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -589,6 +589,23 @@ public abstract class IdScriptableObject extends ScriptableObject
     }
 
     @Override
+    public int getAttributes(Symbol key)
+    {
+        int info = findInstanceIdInfo(key);
+        if (info != 0) {
+            int attr = (info >>> 16);
+            return attr;
+        }
+        if (prototypeValues != null) {
+            int id = prototypeValues.findId(key);
+            if (id != 0) {
+                return prototypeValues.getAttributes(id);
+            }
+        }
+        return super.getAttributes(key);
+    }
+
+    @Override
     public void setAttributes(String name, int attributes)
     {
         ScriptableObject.checkValidAttributes(attributes);

--- a/testsrc/jstests/es6/prototype-symbols.js
+++ b/testsrc/jstests/es6/prototype-symbols.js
@@ -1,0 +1,16 @@
+/*
+Check for a specific bug in Rhino that makes it impossible to check the attributes
+of a Symbol-keyed property on the prototype of a built-in type. For instance, the
+Symbol.toStringTag property of various types.
+*/
+
+load('testsrc/assert.js');
+
+var s = Symbol('testsym1');
+assertEquals('Symbol', s[Symbol.toStringTag]);
+assertFalse(s.hasOwnProperty(Symbol.toStringTag));
+assertFalse(s.propertyIsEnumerable(Symbol.toStringTag));
+assertTrue(Symbol.prototype.hasOwnProperty(Symbol.toStringTag));
+assertFalse(Symbol.prototype.propertyIsEnumerable(Symbol.toStringTag));
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/es6/PrototypeSymbolTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/PrototypeSymbolTest.java
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es6;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es6/prototype-symbols.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class PrototypeSymbolTest extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
This affects standard types that inherit from IdScriptableObject and
have slots in their prototype with Symbol keys. For instance,
Symbol.prototype[Symbol.toStringTag].

This came up while working on passing test262 tests for some new types.