### PR TITLE
Override getArity

### DIFF
--- a/src/org/mozilla/javascript/ArrowFunction.java
+++ b/src/org/mozilla/javascript/ArrowFunction.java
@@ -65,6 +65,11 @@ public class ArrowFunction extends BaseFunction {
     }
 
     @Override
+    public int getArity() {
+        return getLength();
+    }
+
+    @Override
     String decompile(int indent, int flags)
     {
         if (targetFunction instanceof BaseFunction) {

--- a/testsrc/jstests/harmony/function-arity.js
+++ b/testsrc/jstests/harmony/function-arity.js
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+// Check correctness of function properties length and arity
+// NOTE: arity is non-standard
+
+// arity is the same for arrow functions and regular anonymous functions
+assertEquals(((a,b) => {}).arity, (function (a,b) {}).arity);
+assertEquals((() => {}).arity, (function () {}).arity);
+
+// length is the same for arrow functions and regular anonymous functions
+assertEquals(((a,b) => {}).length, (function (a,b) {}).length);
+assertEquals((() => {}).length, (function () {}).length);
+
+// arity and length are the same for a given arrow function
+assertEquals(((a,b) => {}).arity, ((a,b) => {}).length);
+assertEquals((() => {}).arity, (() => {}).length);
+
+// length is right
+assertEquals(((a,b) => {}).length, 2);
+assertEquals((() => {}).length, 0);
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/harmony/FunctionArityTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/FunctionArityTest.java
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/function-arity.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class FunctionArityTest extends ScriptTestsBase
+{
+}


### PR DESCRIPTION
This override fixes getArity unconditionaly returning 0 instead of returning what getLength returns on ArrowFunction objects.