### PR TITLE
XmlMemberGet toSource implementation

### DIFF
--- a/src/org/mozilla/javascript/ast/XmlMemberGet.java
+++ b/src/org/mozilla/javascript/ast/XmlMemberGet.java
@@ -87,8 +87,24 @@ public class XmlMemberGet extends InfixExpression {
         StringBuilder sb = new StringBuilder();
         sb.append(makeIndent(depth));
         sb.append(getLeft().toSource(0));
-        sb.append(operatorToString(getType()));
+        sb.append(dotsToString());
         sb.append(getRight().toSource(0));
         return sb.toString();
+    }
+
+    /**
+     * Gives string representation of inner dots token.
+     * @return  String representation of inner dots token (e.g. '.' or '..')
+     * @throws IllegalArgumentException on unexpected token type
+     */
+    private String dotsToString() {
+        switch (getType()) {
+            case Token.DOT:
+                return ".";
+            case Token.DOTDOT:
+                return "..";
+            default:
+                throw new IllegalArgumentException("Invalid type of XmlMemberGet: " + getType());
+        }
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/BugXmlMemberGetToSource.java
+++ b/testsrc/org/mozilla/javascript/tests/BugXmlMemberGetToSource.java
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.javascript.tests;
+
+import org.junit.*;
+import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.ast.XmlMemberGet;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test resembles issue #483 with {@link XmlMemberGet#toSource()} implementation.
+ * {@code toSource()} implementation calls {@link org.mozilla.javascript.ast.AstNode#operatorToString(int)}
+ * passing in node's type, which is {@link org.mozilla.javascript.Token#DOT} or
+ * {@link org.mozilla.javascript.Token#DOTDOT} by documentation. This causes {@link IllegalArgumentException}, as
+ * {@code DOT} and {@code DOTDOT} are not treated as operators in {@code AstNode}.
+ */
+public class BugXmlMemberGetToSource {
+    private CompilerEnvirons environment;
+
+    @Before
+    public void setUp() {
+        environment = new CompilerEnvirons();
+    }
+
+    @Test
+    public void testXmlMemberGetToSourceDotAt() {
+        String script = "a.@b;";
+        Parser parser = new Parser(environment);
+        AstRoot root = parser.parse(script, null, 1);
+        /* up to 1.7.9 following will throw IllegalArgumentException */
+        assertEquals("a.@b;", root.toSource().trim());
+    }
+
+    @Test
+    public void testXmlMemberGetToSourceDotDot() {
+        String script = "a..b;";
+        Parser parser = new Parser(environment);
+        AstRoot root = parser.parse(script, null, 1);
+        /* up to 1.7.9 following will throw IllegalArgumentException */
+        assertEquals("a..b;", root.toSource().trim());
+    }
+}


### PR DESCRIPTION
This fixes #483.

`XmlMemberGet` (E4X support) node is parsed correctly, but calling `toSource()` causes `IllegalArgumentException`

As `Token.DOT` and `Token.DOTDOT` are not included to operators map in `AstNode` class, I've created helper method in `XmlMemberGet` to get string representation of the dots.

Another option is to add these tokens to the _operatorNames_ map in `AstNode`, so `operatorToString` could deal with them. Please, feel free to correct me, I'll update the code.