### PR TITLE
Removing mentioning of ES5 features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Rhino is licensed under the [MPL 2.0](./LICENSE.txt).
 [Release Notes](./RELEASE-NOTES.md) for recent releases.
 
 [Compatibility table](http://mozilla.github.io/rhino/compat/engines.html) which shows which advanced JavaScript
-features from ES5, 6, and 7 are implemented in Rhino.
+features from ES6, and ES2016+ are implemented in Rhino.
 
 ## Documentation
 


### PR DESCRIPTION
No such features are a part of the compatibility table