### PR TITLE
Fixes Parser.throwStatement()

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -1754,7 +1754,7 @@ public class Parser
             reportError("msg.bad.throw.eol");
         }
         AstNode expr = expr();
-        ThrowStatement pn = new ThrowStatement(pos, getNodeEnd(expr), expr);
+        ThrowStatement pn = new ThrowStatement(pos, expr);
         pn.setLineno(lineno);
         return pn;
     }

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1247,6 +1247,11 @@ public class ParserTest extends TestCase {
       parse("({import:1}).import;");
     }
 
+    public void testThrowStatement() {
+        environment.setStrictMode(true);
+        parse("function A(a) { switch (a) { default: throw \"some error\" } }", null, new String[]{"missing ; after statement"}, true);
+    }
+
     public void testParseErrorRecovery() {
         expectErrorWithRecovery(")", 1);
     }


### PR DESCRIPTION
Fixes Parser.throwStatement() creating ThrowStatement with incorect length