### PR TITLE
Fix bug that caused modified JavaScript files to never be reloaded

### DIFF
--- a/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
+++ b/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
@@ -152,7 +152,7 @@ public class UrlModuleSourceProvider extends ModuleSourceProviderBase
         try {
             urlConnection.connect();
             if(applicableValidator != null &&
-                    applicableValidator.updateValidator(urlConnection,
+                    !applicableValidator.updateValidator(urlConnection,
                             request_time, urlConnectionExpiryCalculator))
             {
                 close(urlConnection);


### PR DESCRIPTION
Fix bug related to reloading JavaScript files that have been modified.

The function,

```
        boolean updateValidator(URLConnection urlConnection, long request_time,
                UrlConnectionExpiryCalculator urlConnectionExpiryCalculator)
        throws IOException
        {
            boolean isResourceChanged = isResourceChanged(urlConnection);
            if(!isResourceChanged) {
                expiry = calculateExpiry(urlConnection, request_time,
                        urlConnectionExpiryCalculator);
            }
            return isResourceChanged;
        }
```

checks if a resource has changed, which means that it was modified. The bug was to consider this as not-modified in the conditional statement.