### PR TITLE
fixes position for ParenthesizedExpression nodes (#129)

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3212,20 +3212,20 @@ public class Parser
             if (peekToken() == Token.FOR) {
                 return generatorExpression(e, begin);
             }
-            ParenthesizedExpression pn = new ParenthesizedExpression(e);
+            mustMatchToken(Token.RP, "msg.no.paren", true);
+            if (e.getType() == Token.EMPTY && peekToken() != Token.ARROW) {
+              reportError("msg.syntax");
+              return makeErrorNode();
+            }
+            int length = ts.tokenEnd - begin;
+            ParenthesizedExpression pn = new ParenthesizedExpression(begin, length, e);
+            pn.setLineno(lineno);
             if (jsdocNode == null) {
                 jsdocNode = getAndResetJsDoc();
             }
             if (jsdocNode != null) {
                 pn.setJsDocNode(jsdocNode);
             }
-            mustMatchToken(Token.RP, "msg.no.paren", true);
-            if (e.getType() == Token.EMPTY && peekToken() != Token.ARROW) {
-              reportError("msg.syntax");
-              return makeErrorNode();
-            }
-            pn.setLength(ts.tokenEnd - pn.getPosition());
-            pn.setLineno(lineno);
             return pn;
         } finally {
             inForInit = wasInForInit;

--- a/testsrc/org/mozilla/javascript/tests/ArrowFnPositionBugTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ArrowFnPositionBugTest.java
@@ -63,12 +63,8 @@ public class ArrowFnPositionBugTest {
     @Test
     public void testArrowFnWithArgsPosition() {
         FunctionNode arrowFn = parseAndExtractArrowFn("var a = (b, c) => b + c;");
-        // ParenthesisedExpression copies position from its child, so
-        // with an EmptyExpression it will be a position of opening paren,
-        // but when there's parameters it's a start of parameters list
-        // (i.e. it's shifted by one char compared to no-parameters case)
-        assertEquals(5, arrowFn.getPosition());
-        assertEquals(9, arrowFn.getAbsolutePosition());
+        assertEquals(4, arrowFn.getPosition());
+        assertEquals(8, arrowFn.getAbsolutePosition());
     }
 
     @Test

--- a/testsrc/org/mozilla/javascript/tests/Issue129Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue129Test.java
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.javascript.tests;
+
+import org.junit.*;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.Token;
+import org.mozilla.javascript.ast.AstNode;
+import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.ast.NodeVisitor;
+import org.mozilla.javascript.ast.ParenthesizedExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests position of ParenthesizedExpression node in  source code in different cases.
+ */
+public class Issue129Test {
+    private static final String SOURCE_URI = "issue129test.js";
+
+    private Parser parser;
+
+    @Before
+    public void setUp() {
+        parser = new Parser();
+    }
+
+    @Test
+    public void testGetPosition() {
+        String script = "(a);";
+        AstRoot root = parser.parse(script, SOURCE_URI, 0);
+        ParenthesizedExprVisitor visitor = new ParenthesizedExprVisitor();
+        root.visitAll(visitor);
+
+        ParenthesizedExpression pe = visitor.getFirstExpression();
+        assertNotNull(pe);
+        assertEquals(0, pe.getPosition());
+    }
+
+    @Test
+    public void testGetLength() {
+        String script = "(a);";
+        AstRoot root = parser.parse(script, SOURCE_URI, 0);
+        ParenthesizedExprVisitor visitor = new ParenthesizedExprVisitor();
+        root.visitAll(visitor);
+
+        ParenthesizedExpression pe = visitor.getFirstExpression();
+        assertNotNull(pe);
+        assertEquals(3, pe.getLength());
+    }
+
+    @Test
+    public void testGetAbsolutePosition() {
+        String script = "var a = (b).c()";
+        AstRoot root = parser.parse(script, SOURCE_URI, 0);
+        ParenthesizedExprVisitor visitor = new ParenthesizedExprVisitor();
+        root.visitAll(visitor);
+
+        ParenthesizedExpression pe = visitor.getFirstExpression();
+        assertNotNull(pe);
+        assertEquals(8, pe.getAbsolutePosition());
+    }
+
+    @Test
+    public void testMultiline() {
+        String script = "var a =\n" +
+            "b +\n" +
+            "(c +\n" +
+            "d);";
+        AstRoot root = parser.parse(script, SOURCE_URI, 0);
+        ParenthesizedExprVisitor visitor = new ParenthesizedExprVisitor();
+        root.visitAll(visitor);
+
+        ParenthesizedExpression pe = visitor.getFirstExpression();
+        assertNotNull(pe);
+        assertEquals("(c +\nd)", getFromSource(script, pe));
+    }
+
+    @Test
+    public void testNested() {
+        String script = "var a = (b * (c + d));";
+        AstRoot root = parser.parse(script, SOURCE_URI, 0);
+        ParenthesizedExprVisitor visitor = new ParenthesizedExprVisitor();
+        root.visitAll(visitor);
+
+        List<ParenthesizedExpression> exprs = visitor.getExpressions();
+        assertEquals(2, exprs.size());
+        for (ParenthesizedExpression pe : exprs) {
+            if (pe.getExpression().getType() == Token.MUL)
+                assertEquals("(b * (c + d))", getFromSource(script, pe));
+            else
+                assertEquals("(c + d)", getFromSource(script, pe));
+        }
+    }
+
+    private String getFromSource(String source, AstNode node) {
+        return source.substring(node.getAbsolutePosition(), node.getAbsolutePosition() + node.getLength());
+    }
+
+    /**
+     * Visitor stores all visited ParenthesizedExpression nodes.
+     */
+    private static class ParenthesizedExprVisitor implements NodeVisitor {
+        private List<ParenthesizedExpression> expressions = new ArrayList<>();
+
+        /**
+         * Gets first encountered ParenthesizedExpression node.
+         * @return  First found ParenthesizedExpression node or {@code null} if no nodes of this type were found
+         */
+        public ParenthesizedExpression getFirstExpression() {
+            return expressions.isEmpty() ? null : expressions.get(0);
+        }
+
+        /**
+         * Gets all found ParenthesizedExpression nodes.
+         * @return  Found nodes
+         */
+        public List<ParenthesizedExpression> getExpressions() {
+            return expressions;
+        }
+
+        @Override
+        public boolean visit(AstNode node) {
+            if (node instanceof ParenthesizedExpression) expressions.add((ParenthesizedExpression) node);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #129 by setting position explicitly for _ParenthesizedExpression_ nodes while parsing.
It avoids mapping of ParenthesizedExpression to source with only right paren included, which seems to be unwanted.

One test has broken: `ArrowFnPositionBugTest#testArrowFnWithArgsPosition()`. But there was a notice about inconsistent position evaluation for ParenthesizedExpression nodes, so as far as this inconsistency is eliminated, we can update the test. Please, make a retrospective look at #303 and PR #363 and confirm that it's ok.