### PR TITLE
Test cases and a small fix for native arrays.

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1335,7 +1335,11 @@ public class NativeArray extends IdScriptableObject implements List
                 Object temp = getRawElem(thisObj, last);
                 setRawElem(cx, thisObj, last + delta, temp);
             }
-            for (long k = length + delta; k < length; ++k) {
+            // Do this backwards because some implementations might use a
+            // non-sparse array and therefore might not be able to handle
+            // deleting elements "in the middle". This makes us compatible
+            // with older Rhino releases.
+            for (long k = length - 1; k >= length + delta; --k) {
                 deleteElem(thisObj, k);
             }
         }

--- a/testsrc/jstests/wrapped-arrays.js
+++ b/testsrc/jstests/wrapped-arrays.js
@@ -1,0 +1,100 @@
+/*
+ * This script tests some of the more complex features of arrays against both
+ * array-like objects and also against native Java objects that implement the
+ * contract, and finally native java arrays.
+ */
+
+load('testsrc/assert.js');
+
+var fixedSize = false;
+
+// Assume that there is a function in the scope called "makeTestArray()" which returns an
+// array with the values ['one', 'two', 'three', 'four']. That function, in turn,
+// might just call one of the functions below.
+
+function makeNativeArray() {
+  return ['one', 'two', 'three', 'four'];
+}
+
+function makeArrayLikeArray() {
+  return {
+    0: 'one',
+    1: 'two',
+    2: 'three',
+    3: 'four',
+    length: 4
+  };
+}
+
+function makeJavaArray() {
+  fixedSize = true;
+  let ja = java.lang.reflect.Array.newInstance(java.lang.String, 4);
+  ja[0] = 'one';
+  ja[1] = 'two';
+  ja[2] = 'three';
+  ja[3] = 'four';
+  return ja;
+}
+
+let list = makeTestArray();
+assertArrayEquals(['one', 'two', 'three', 'four'], list);
+assertEquals(4, list.length);
+
+let jv = Array.prototype.join.call(list, ',');
+assertEquals('one,two,three,four', jv);
+
+if (!fixedSize) {
+  // JavaArray instances can't grow and shrink like other arrays.
+  list = makeTestArray();
+  let pv = Array.prototype.push.call(list, 'five');
+  assertArrayEquals(['one', 'two', 'three', 'four', 'five'], list);
+  assertEquals(5, pv);
+  pv = Array.prototype.push.call(list, '6', '7');
+  assertArrayEquals(['one', 'two', 'three', 'four', 'five', '6', '7'], list);
+  assertEquals(7, pv);
+
+  list = makeTestArray();
+  pv = Array.prototype.pop.call(list);
+  assertArrayEquals(['one', 'two', 'three'], list);
+  assertEquals('four', pv);
+  pv = Array.prototype.pop.call(list);
+  assertArrayEquals(['one', 'two'], list);
+  assertEquals('three', pv);
+
+  list = makeTestArray();
+  let sv = Array.prototype.shift.call(list);
+  assertArrayEquals(['two', 'three', 'four'], list);
+  assertEquals('one', sv);
+  sv = Array.prototype.shift.call(list);
+  assertArrayEquals(['three', 'four'], list);
+  assertEquals('two', sv);
+
+  list = makeTestArray();
+  let uv = Array.prototype.unshift.call(list, 'five');
+  assertArrayEquals(['five', 'one', 'two', 'three', 'four'], list);
+  assertEquals(5, uv);
+  uv = Array.prototype.unshift.call(list, '6', '7');
+  assertArrayEquals(['6', '7', 'five', 'one', 'two', 'three', 'four'], list);
+  assertEquals(7, uv);
+
+  list = makeTestArray();
+  sv = Array.prototype.splice.call(list, 1, 2);
+  assertArrayEquals(['two', 'three'], sv);
+  assertEquals(2, sv.length);
+  assertArrayEquals(['one', 'four'], list);
+  assertEquals(2, list.length);
+}
+
+list = makeTestArray();
+sv = Array.prototype.slice.call(list, 1, 3);
+assertArrayEquals(['two', 'three'], sv);
+assertEquals(2, sv.length);
+assertArrayEquals(['one', 'two', 'three', 'four'], list);
+assertEquals(4, list.length);
+
+list = makeTestArray();
+Array.prototype.sort.call(list);
+assertArrayEquals(['four', 'one', 'three', 'two'], list);
+assertEquals(4, list.length);
+
+'success';

--- a/testsrc/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
@@ -1,0 +1,184 @@
+package org.mozilla.javascript.tests;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.tools.shell.Global;
+
+import static org.junit.Assert.*;
+
+/**
+ * This is a set of tests for the case in which functions of the built-in Array type are used with a
+ * native Java class.
+ */
+public class NativeWrappedArrayTest {
+
+  private Context cx;
+  private Scriptable global;
+
+  @Before
+  public void init() {
+    cx = Context.enter();
+    cx.setLanguageVersion(Context.VERSION_ES6);
+    cx.getWrapFactory().setJavaPrimitiveWrap(false);
+    global = new Global(cx);
+  }
+
+  @After
+  public void terminate() {
+    Context.exit();
+  }
+
+  @Test
+  public void testNativeArray()
+    throws IOException {
+    final String setFunc =
+        "function makeTestArray() { return makeNativeArray(); }";
+    cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
+
+    try (InputStreamReader rdr =
+        new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+      Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
+      assertEquals("success", ret);
+    } catch (RhinoException re) {
+      fail(re.getMessage() + '\n' + re.getScriptStackTrace());
+    }
+  }
+
+  @Test
+  public void testArrayLikeArray()
+      throws IOException {
+    final String setFunc =
+        "function makeTestArray() { return makeArrayLikeArray(); }";
+    cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
+
+    try (InputStreamReader rdr =
+        new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+      Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
+      assertEquals("success", ret);
+    } catch (RhinoException re) {
+      fail(re.getMessage() + '\n' + re.getScriptStackTrace());
+    }
+  }
+
+  @Test
+  public void testJavaArray()
+      throws IOException {
+    final String setFunc =
+        "function makeTestArray() { return makeJavaArray(); }";
+    cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
+
+    try (InputStreamReader rdr =
+        new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+      Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
+      assertEquals("success", ret);
+    } catch (RhinoException re) {
+      fail(re.getMessage() + '\n' + re.getScriptStackTrace());
+    }
+  }
+
+  @Test
+  public void testCustomArray()
+    throws IOException {
+    ((ScriptableObject)global).defineFunctionProperties(
+        new String[]{"makeCustomArray"},
+        NativeWrappedArrayTest.class, 0);
+
+    final String setFunc =
+        "function makeTestArray() { return makeCustomArray(); }";
+    cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
+
+    try (InputStreamReader rdr =
+        new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+      Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
+      assertEquals("success", ret);
+    } catch (RhinoException re) {
+      fail(re.getMessage() + '\n' + re.getScriptStackTrace());
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static Object makeCustomArray(Context cx, Scriptable thisObj,
+    Object[] args, Function fn) {
+    ArrayList<String> a = new ArrayList<>(4);
+    a.add("one");
+    a.add("two");
+    a.add("three");
+    a.add("four");
+    return new WrappedArray(thisObj, a);
+  }
+
+  static class WrappedArray
+      extends ScriptableObject {
+
+    private final ArrayList<String> list;
+    private int length;
+
+    WrappedArray(Scriptable scope, ArrayList<String> l) {
+      super(scope, ScriptableObject.getArrayPrototype(scope));
+      this.list = l;
+      this.length = l.size();
+    }
+
+    @Override
+    public String getClassName() {
+      return null;
+    }
+
+    @Override
+    public Object get(int ix, Scriptable start) {
+      return list.get(ix);
+    }
+
+    @Override
+    public Object get(String n, Scriptable start) {
+      if ("length".equals(n)) {
+        return length;
+      }
+      return Scriptable.NOT_FOUND;
+    }
+
+    @Override
+    public void put(int ix, Scriptable start, Object val) {
+      // Ensure enough capacity for array expansion
+      // by automatically expanding the array like JavaScript sort of does.
+      for (int ax = list.size(); ax <= ix; ax++) {
+        list.add(null);
+      }
+      list.set(ix, val.toString());
+    }
+
+    @Override
+    public void put(String n, Scriptable start, Object val) {
+      if ("length".equals(n)) {
+        length = ScriptRuntime.toInt32(val);
+      }
+    }
+
+    @Override
+    public void delete(int ix) {
+      list.set(ix, null);
+    }
+
+    @Override
+    public Object[] getIds() {
+      Object[] ids = new Object[list.size()];
+      for (int i = 0; i < list.size(); i++) {
+        ids[i] = i;
+      }
+      return ids;
+    }
+  }
+}


### PR DESCRIPTION
Change the direction in which we traverse the array while deleting
elements in the "splice" call for compatibility with old Rhino
code. Add better tests for this and other use cases.

This addresses https://github.com/mozilla/rhino/issues/541
