### PR TITLE
Implement @@isConcatSpreadable and make Java arrays spreadable

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaArray.java
+++ b/src/org/mozilla/javascript/NativeJavaArray.java
@@ -89,7 +89,10 @@ public class NativeJavaArray
 
     @Override
     public Object get(Symbol key, Scriptable start) {
-        return (SymbolKey.IS_CONCAT_SPREADABLE.equals(key));
+        if (SymbolKey.IS_CONCAT_SPREADABLE.equals(key)) {
+            return true;
+        }
+        return Scriptable.NOT_FOUND;
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeJavaArray.java
+++ b/src/org/mozilla/javascript/NativeJavaArray.java
@@ -17,7 +17,9 @@ import java.lang.reflect.Array;
  * @see NativeJavaPackage
  */
 
-public class NativeJavaArray extends NativeJavaObject
+public class NativeJavaArray
+    extends NativeJavaObject
+    implements SymbolScriptable
 {
     private static final long serialVersionUID = -924022554283675333L;
 
@@ -57,6 +59,11 @@ public class NativeJavaArray extends NativeJavaObject
     }
 
     @Override
+    public boolean has(Symbol key, Scriptable start) {
+        return SymbolKey.IS_CONCAT_SPREADABLE.equals(key);
+    }
+
+    @Override
     public Object get(String id, Scriptable start) {
         if (id.equals("length"))
             return Integer.valueOf(length);
@@ -81,6 +88,11 @@ public class NativeJavaArray extends NativeJavaObject
     }
 
     @Override
+    public Object get(Symbol key, Scriptable start) {
+        return (SymbolKey.IS_CONCAT_SPREADABLE.equals(key));
+    }
+
+    @Override
     public void put(String id, Scriptable start, Object value) {
         // Ignore assignments to "length"--it's readonly.
         if (!id.equals("length"))
@@ -98,6 +110,11 @@ public class NativeJavaArray extends NativeJavaObject
                 "msg.java.array.index.out.of.bounds", String.valueOf(index),
                 String.valueOf(length - 1));
         }
+    }
+
+    @Override
+    public void delete(Symbol key) {
+        // All symbols are read-only
     }
 
     @Override

--- a/testsrc/jstests/array-concat-pre-es6.js
+++ b/testsrc/jstests/array-concat-pre-es6.js
@@ -1,0 +1,103 @@
+/*
+ * This is a set of tests for array concatenation as it was implemented before
+ * ES6 and the @isConcatSpreadable annotation.
+ * This comes from section 15.4.4.4 of the 1999 ECMAScript spec.
+ */
+load("testsrc/assert.js");
+
+function makeArrayLike(len) {
+  var al = {
+    length: len
+  };
+  for (var i = 0; i < len; i++) {
+    al[i] = i + 1;
+  }
+  return al;
+}
+
+function makeJavaArray(len) {
+  var ja = java.lang.reflect.Array.newInstance(java.lang.Integer, len);
+  for (var i = 0; i < len; i++) {
+    ja[i] = i + 1;
+  }
+  return ja;
+}
+
+// Existing test case, now being run in a different way
+var a = ['a0', 'a1'];
+a[3] = 'a3';
+var b = ['b1', 'b2'];
+var cr = b.concat(a);
+assertArrayEquals(['b1', 'b2', 'a0', 'a1', undefined, 'a3'], cr);
+
+// Two native arrays
+cr = [1, 2, 3].concat([4, 5, 6]);
+assertArrayEquals([1, 2, 3, 4, 5, 6], cr);
+
+// Native array plus individual elements
+cr = [1, 2, 3].concat('four', 'five');
+assertArrayEquals([1, 2, 3, 'four', 'five'], cr);
+
+// Native array plus object
+var no = {
+  foo: 'bar'
+};
+cr = ['foo'].concat(no);
+assertArrayEquals(['foo', no], cr);
+
+// Native array plus array-like object
+var al = makeArrayLike(4);
+cr = [1, 2, 3].concat(makeArrayLike(4));
+assertArrayEquals([1, 2, 3, al], cr);
+
+// Array-like object plus native array. Only "real" arrays get copied this way...
+al = makeArrayLike(2);
+cr = Array.prototype.concat.call(al, [3, 4]);
+assertArrayEquals([al, 3, 4], cr);
+
+// Non-array plus native array
+cr = Array.prototype.concat.call('one', [2, 3]);
+// ToObject conversion makes this comparision different
+assertEquals(3, cr.length);
+assertEquals('object', typeof cr[0]);
+assertTrue('one' == cr[0]);
+assertEquals(2, cr[1]);
+assertEquals(3, cr[2]);
+
+// Three non-arrays
+cr = Array.prototype.concat.call('one', 'two', 'three');
+assertEquals(3, cr.length);
+assertEquals('object', typeof cr[0]);
+assertTrue('one' == cr[0]);
+assertEquals('two', cr[1]);
+assertEquals('three', cr[2]);
+
+// Native array plus Java array. Java arrays are "arrays" for the purposes of this
+// function, and this is how things functioned in previous Rhino releases.
+cr = [1, 2].concat(makeJavaArray(2));
+// Java object conversion makes array comparision harder
+assertEquals(4, cr.length);
+assertTrue(cr[0] == 1);
+assertTrue(cr[1] == 2);
+assertTrue(cr[2] == 1);
+assertTrue(cr[3] == 2);
+
+// Java array plus native array
+cr = Array.prototype.concat.call(makeJavaArray(2), [3, 4]);
+assertEquals(4, cr.length);
+assertTrue(cr[0] == 1);
+assertTrue(cr[1] == 2);
+assertTrue(cr[2] == 3);
+assertTrue(cr[3] == 4);
+
+// Two java arrays
+cr = Array.prototype.concat.call(makeJavaArray(2), makeJavaArray(3));
+assertEquals(5, cr.length);
+assertTrue(cr[0] == 1);
+assertTrue(cr[1] == 2);
+assertTrue(cr[2] == 1);
+assertTrue(cr[3] == 2);
+assertTrue(cr[4] == 3);
+
+'success';
+

--- a/testsrc/org/mozilla/javascript/tests/ArrayConcatTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ArrayConcatTest.java
@@ -5,28 +5,18 @@
 package org.mozilla.javascript.tests;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
 
-import junit.framework.TestCase;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 /**
  * Test for overloaded array concat with non-dense arg.
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=477604
  * @author Marc Guillemot
  */
-public class ArrayConcatTest extends TestCase {
-
-    public void testArrayConcat() {
-        final String script = "var a = ['a0', 'a1'];\n"
-            + "a[3] = 'a3';\n"
-            + "var b = ['b1', 'b2'];\n"
-            + "b.concat(a)";
-
-        Utils.runWithAllOptimizationLevels(_cx -> {
-            final ScriptableObject scope = _cx.initStandardObjects();
-            final Object result = _cx.evaluateString(scope, script, "test script", 0, null);
-            assertEquals("b1,b2,a0,a1,,a3", Context.toString(result));
-            return null;
-        });
-    }
+@RhinoTest("testsrc/jstests/array-concat-pre-es6.js")
+@LanguageVersion(Context.VERSION_1_8)
+public class ArrayConcatTest extends ScriptTestsBase {
+    // Original test case code moved to the JS file above.
 }

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -171,32 +171,17 @@ built-ins/Array
 
     ! prototype/Symbol.iterator.js
 # new
-    ! prototype/concat/Array.prototype.concat_array-like-length-to-string-throws.js
-    ! prototype/concat/Array.prototype.concat_array-like-length-value-of-throws.js
-    ! prototype/concat/Array.prototype.concat_array-like-negative-length.js
-    ! prototype/concat/Array.prototype.concat_array-like-primitive-non-number-length.js
-    ! prototype/concat/Array.prototype.concat_array-like-string-length.js
-    ! prototype/concat/Array.prototype.concat_array-like-to-length-throws.js
-    ! prototype/concat/Array.prototype.concat_array-like.js
-    ! prototype/concat/Array.prototype.concat_holey-sloppy-arguments.js
-    ! prototype/concat/Array.prototype.concat_large-typed-array.js
-    ! prototype/concat/Array.prototype.concat_length-throws.js
-    ! prototype/concat/Array.prototype.concat_non-array.js
-    ! prototype/concat/Array.prototype.concat_sloppy-arguments-throws.js
-    ! prototype/concat/Array.prototype.concat_sloppy-arguments-with-dupes.js
-    ! prototype/concat/Array.prototype.concat_sloppy-arguments.js
-    ! prototype/concat/Array.prototype.concat_small-typed-array.js
+     ! prototype/concat/Array.prototype.concat_large-typed-array.js
+# No class support yet
+     ! prototype/concat/Array.prototype.concat_non-array.js
+     ! prototype/concat/Array.prototype.concat_small-typed-array.js
+# isConcatSpreadable doesn't propagate from the prototype to new objects
     ! prototype/concat/Array.prototype.concat_spreadable-boolean-wrapper.js
     ! prototype/concat/Array.prototype.concat_spreadable-function.js
-    ! prototype/concat/Array.prototype.concat_spreadable-getter-throws.js
     ! prototype/concat/Array.prototype.concat_spreadable-number-wrapper.js
     ! prototype/concat/Array.prototype.concat_spreadable-reg-exp.js
     ! prototype/concat/Array.prototype.concat_spreadable-sparse-object.js
     ! prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
-    ! prototype/concat/Array.prototype.concat_strict-arguments.js
-    ! prototype/concat/is-concat-spreadable-get-err.js
-    ! prototype/concat/is-concat-spreadable-val-falsey.js
-    ! prototype/concat/is-concat-spreadable-val-truthy.js
     ! prototype/map/create-non-array-invalid-len.js
     ! prototype/reverse/length-exceeding-integer-limit-with-object.js
     ! prototype/reverse/length-exceeding-integer-limit-with-proxy.js


### PR DESCRIPTION
Array.prototype.concat will now honor the @@isConcatSpreadable symbol,
by treating arguments with the symbol set to a truthy value as
arrays that should be spread apart, and everything other than
a native array as a single object.

In addition, mark native Java arrays (the "JavaArray") class as
"spreadable" to preserve backward compatibility with older releases.

This fixes https://github.com/mozilla/rhino/issues/219