### PR TITLE
Un-do recent addition to the Scriptable interface.

### DIFF
--- a/examples/Matrix.java
+++ b/examples/Matrix.java
@@ -159,16 +159,6 @@ public class Matrix implements Scriptable {
     public void put(String name, Scriptable start, Object value) {
     }
 
-
-    /**
-     * Set a named property.
-     *
-     * We do nothing here, so all properties are effectively read-only.
-     */
-    @Override
-    public void put(Symbol symbol, Scriptable start, Object value) {
-    }
-
     /**
      * Set an indexed property.
      *

--- a/src/org/mozilla/javascript/Delegator.java
+++ b/src/org/mozilla/javascript/Delegator.java
@@ -23,7 +23,8 @@ package org.mozilla.javascript;
  * @author Matthias Radestock
  */
 
-public class Delegator implements Function {
+public class Delegator
+    implements Function, SymbolScriptable {
 
     protected Scriptable obj = null;
 
@@ -99,6 +100,15 @@ public class Delegator implements Function {
         return getDelegee().get(name,start);
     }
 
+    @Override
+    public Object get(Symbol key, Scriptable start) {
+        final Scriptable delegee = getDelegee();
+        if (delegee instanceof SymbolScriptable) {
+            return ((SymbolScriptable) delegee).get(key, start);
+        }
+        return Scriptable.NOT_FOUND;
+    }
+
     /**
      * @see org.mozilla.javascript.Scriptable#get(int, Scriptable)
      */
@@ -113,6 +123,15 @@ public class Delegator implements Function {
     @Override
     public boolean has(String name, Scriptable start) {
         return getDelegee().has(name,start);
+    }
+
+    @Override
+    public boolean has(Symbol key, Scriptable start) {
+        final Scriptable delegee = getDelegee();
+        if (delegee instanceof SymbolScriptable) {
+            return ((SymbolScriptable) delegee).has(key, start);
+        }
+        return false;
     }
 
     /**
@@ -136,7 +155,10 @@ public class Delegator implements Function {
      */
     @Override
     public void put(Symbol symbol, Scriptable start, Object value) {
-        getDelegee().put(symbol,start,value);
+        final Scriptable delegee = getDelegee();
+        if (delegee instanceof SymbolScriptable) {
+            ((SymbolScriptable) delegee).put(symbol, start, value);
+        }
     }
 
     /**
@@ -153,6 +175,14 @@ public class Delegator implements Function {
     @Override
     public void delete(String name) {
         getDelegee().delete(name);
+    }
+
+    @Override
+    public void delete(Symbol key) {
+        final Scriptable delegee = getDelegee();
+        if (delegee instanceof SymbolScriptable) {
+            ((SymbolScriptable) delegee).delete(key);
+        }
     }
 
     /**

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -213,7 +213,9 @@ public abstract class IdScriptableObject extends ScriptableObject
                     int nameSlot = (id  - 1) * SLOT_SPAN + NAME_SLOT;
                     Object name = valueArray[nameSlot];
                     if (name instanceof Symbol) {
-                        start.put((Symbol)name, start, value);
+                        if (start instanceof SymbolScriptable) {
+                            ((SymbolScriptable)start).put((Symbol) name, start, value);
+                        }
                     } else {
                         start.put((String)name, start, value);
                     }

--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -27,7 +27,8 @@ import java.util.Map;
  * @see NativeJavaClass
  */
 
-public class NativeJavaObject implements Scriptable, Wrapper, Serializable
+public class NativeJavaObject
+    implements Scriptable, SymbolScriptable, Wrapper, Serializable
 {
     private static final long serialVersionUID = -6948590651130498591L;
 
@@ -73,6 +74,11 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
     }
 
     @Override
+    public boolean has(Symbol key, Scriptable start) {
+        return false;
+    }
+
+    @Override
     public Object get(String name, Scriptable start) {
         if (fieldAndMethods != null) {
             Object result = fieldAndMethods.get(name);
@@ -83,6 +89,12 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
         // TODO: passing 'this' as the scope is bogus since it has
         //  no parent scope
         return members.get(this, name, javaObject, false);
+    }
+
+    @Override
+    public Object get(Symbol key, Scriptable start) {
+        // Native Java objects have no Symbol members
+        return Scriptable.NOT_FOUND;
     }
 
     @Override
@@ -107,10 +119,11 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
         // prototype. Since we can't add a property to a Java object,
         // we modify it in the prototype rather than copy it down.
         String name = symbol.toString();
-        if (prototype == null || members.has(name, false))
+        if (prototype == null || members.has(name, false)) {
             members.put(this, name, javaObject, value, false);
-        else
-            prototype.put(symbol, prototype, value);
+        } else if (prototype instanceof SymbolScriptable) {
+            ((SymbolScriptable)prototype).put(symbol, prototype, value);
+        }
     }
 
     @Override
@@ -126,6 +139,10 @@ public class NativeJavaObject implements Scriptable, Wrapper, Serializable
 
     @Override
     public void delete(String name) {
+    }
+
+    @Override
+    public void delete(Symbol key) {
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeWith.java
+++ b/src/org/mozilla/javascript/NativeWith.java
@@ -14,7 +14,8 @@ import java.io.Serializable;
  * It simply delegates every action to its prototype except
  * for operations on its parent.
  */
-public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
+public class NativeWith
+    implements Scriptable, SymbolScriptable, IdFunctionCall, Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -54,6 +55,15 @@ public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
     }
 
     @Override
+    public boolean has(Symbol key, Scriptable start)
+    {
+        if (prototype instanceof SymbolScriptable) {
+            return ((SymbolScriptable)prototype).has(key, prototype);
+        }
+        return false;
+    }
+
+    @Override
     public boolean has(int index, Scriptable start)
     {
         return prototype.has(index, prototype);
@@ -62,16 +72,30 @@ public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
     @Override
     public Object get(String id, Scriptable start)
     {
-        if (start == this)
+        if (start == this) {
             start = prototype;
+        }
         return prototype.get(id, start);
+    }
+
+    @Override
+    public Object get(Symbol key, Scriptable start)
+    {
+        if (start == this) {
+            start = prototype;
+        }
+        if (prototype instanceof SymbolScriptable) {
+            return ((SymbolScriptable)prototype).get(key, start);
+        }
+        return Scriptable.NOT_FOUND;
     }
 
     @Override
     public Object get(int index, Scriptable start)
     {
-        if (start == this)
+        if (start == this) {
             start = prototype;
+        }
         return prototype.get(index, start);
     }
 
@@ -86,9 +110,12 @@ public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
     @Override
     public void put(Symbol symbol, Scriptable start, Object value)
     {
-        if (start == this)
+        if (start == this) {
             start = prototype;
-        prototype.put(symbol, start, value);
+        }
+        if (prototype instanceof SymbolScriptable) {
+            ((SymbolScriptable)prototype).put(symbol, start, value);
+        }
     }
 
     @Override
@@ -104,6 +131,15 @@ public class NativeWith implements Scriptable, IdFunctionCall, Serializable {
     {
         prototype.delete(id);
     }
+
+    @Override
+    public void delete(Symbol key)
+    {
+        if (prototype instanceof SymbolScriptable) {
+            ((SymbolScriptable)prototype).delete(key);
+        }
+    }
+
 
     @Override
     public void delete(int index)

--- a/src/org/mozilla/javascript/Scriptable.java
+++ b/src/org/mozilla/javascript/Scriptable.java
@@ -178,21 +178,6 @@ public interface Scriptable {
     public void put(String name, Scriptable start, Object value);
 
     /**
-     * Sets an property named by an symbol in this object.
-     * <p>
-     * The property is specified by an symbol
-     * as defined for <code>get</code>.<p>
-     *
-     * Identical to <code>put(String, Scriptable, Object)</code> except that
-     * an symbol is used to select the property.
-     *
-     * @param symbol the symbol for the property
-     * @param start the object whose property is being set
-     * @param value value to set the property to
-     */
-    public void put(Symbol symbol, Scriptable start, Object value);
-
-    /**
      * Sets an indexed property in this object.
      * <p>
      * The property is specified by an integral index


### PR DESCRIPTION
More of the classes inside Rhino need the new methods that handle
Symbol properties. However, for backward compatibility we cannot
add new methods to the Scriptable interface, or existing code
will break.