### PR TITLE
Fix flag tests that assume Context is available.

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -564,7 +564,8 @@ public class NativeJavaObject
             }
             else if (type == ScriptRuntime.ObjectClass) {
                 Context context = Context.getCurrentContext();
-                if(context.hasFeature(Context.FEATURE_INTEGER_WITHOUT_DECIMAL_PLACE)) {
+                if ((context != null) &&
+                    context.hasFeature(Context.FEATURE_INTEGER_WITHOUT_DECIMAL_PLACE)) {
                     //to process numbers like 2.0 as 2 without decimal place
                     long roundedValue = Math.round(toDouble(value));
                     if(roundedValue == toDouble(value)) {

--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -280,12 +280,17 @@ public class NativeSymbol
 
     // Symbol objects have a special property that one cannot add properties.
 
+    private boolean isStrictMode() {
+        final Context cx = Context.getCurrentContext();
+        return (cx != null) && cx.isStrictMode();
+    }
+
     @Override
     public void put(String name, Scriptable start, Object value)
     {
         if (!isSymbol()) {
             super.put(name, start, value);
-        } else if (Context.getCurrentContext().isStrictMode()) {
+        } else if (isStrictMode()) {
             throw ScriptRuntime.typeError0("msg.no.assign.symbol.strict");
         }
     }
@@ -295,7 +300,7 @@ public class NativeSymbol
     {
         if (!isSymbol()) {
             super.put(index, start, value);
-        } else if (Context.getCurrentContext().isStrictMode()) {
+        } else if (isStrictMode()) {
             throw ScriptRuntime.typeError0("msg.no.assign.symbol.strict");
         }
     }
@@ -305,7 +310,7 @@ public class NativeSymbol
     {
         if (!isSymbol()) {
             super.put(key, start, value);
-        } else if (Context.getCurrentContext().isStrictMode()) {
+        } else if (isStrictMode()) {
             throw ScriptRuntime.typeError0("msg.no.assign.symbol.strict");
         }
     }


### PR DESCRIPTION
This fixes https://github.com/mozilla/rhino/issues/550.

I found another place where we are doing the same thing. It makes sense to fix both.

There are other places where we assume that Context.getCurrentContext() returns non-null, but those are more deeply embedded.
