### PR TITLE
Fix a regression introduced recently to MemberBox.

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaMethod.java
+++ b/src/org/mozilla/javascript/NativeJavaMethod.java
@@ -364,7 +364,7 @@ public class NativeJavaMethod extends BaseFunction
                         // When FEATURE_ENHANCED_JAVA_ACCESS gives us access
                         // to non-public members, continue to prefer public
                         // methods in overloading
-                        if (bestFit.isPublic())
+                        if (!bestFit.isPublic())
                             ++betterCount;
                         else
                             ++worseCount;


### PR DESCRIPTION
Fix an inverted "is public" check introduced recently during refactoring. There doesn't seem to be test coverage for this part of Rhino and it's not clear how to get it.