### PR TITLE
Fix a parsing regression.

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -2573,9 +2573,9 @@ public class Parser
     {
         AstNode node;
         int tt = peekToken();
-        if(tt == Token.COMMENT) {
+        if (tt == Token.COMMENT) {
             consumeToken();
-            tt = peekToken();
+            tt = peekUntilNonComment(tt);
         }
         int line = ts.lineno;
 

--- a/testsrc/org/mozilla/javascript/tests/ParserIDETest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserIDETest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.ast.AstRoot;
 
+import static org.junit.Assert.*;
+
 /**
  * Tests for specific parser features targeted at IDE environments, namely the ability
  * to warn about missing semicolons for JavaScript programmers who follow that style.
@@ -20,6 +22,10 @@ public class ParserIDETest {
 
   private AstRoot parse(String script, String[] errors, String[] warnings) {
     return ParserTest.parse(script, errors, warnings, false, environment);
+  }
+
+  private AstRoot parse(String script) {
+    return ParserTest.parse(script, new String[]{}, new String[]{}, false, environment);
   }
 
   @Test
@@ -81,5 +87,38 @@ public class ParserIDETest {
     };
 
     parse("var a = [1, 2, 3,];", errors, warnings);
+  }
+
+  @Test
+  public void testNewlineAndCommentsFunction() {
+    AstRoot root = parse(
+        "f('1234', // Before\n'2345' // Second arg\n);");
+    assertNotNull(root.getComments());
+    assertEquals(2, root.getComments().size());
+  }
+
+  @Test
+  public void testNewlineAndCommentsFunction2() {
+    AstRoot root = parse(
+        "f('1234', // Before\n// Middle\n'2345' // Second arg\n);");
+    assertNotNull(root.getComments());
+    assertEquals(3, root.getComments().size());
+  }
+
+  @Test
+  public void testNewlineAndCommentsFunction3() {
+    AstRoot root = parse(
+        "f('1234', // Before\n// Middle\n// Middler\n'2345' // Second arg\n);");
+    assertNotNull(root.getComments());
+    assertEquals(4, root.getComments().size());
+  }
+
+  @Test
+  public void testObjectLiteralComments() {
+    AstRoot root = parse(
+        //"var o = {foo: '1234', // Before\nbar: '2345' // Second arg};\n);");
+        "var o = {foo: 1 // One\n, // Two\n bar: // bar\n2 // Two\n};");
+    assertNotNull(root.getComments());
+    assertEquals(4, root.getComments().size());
   }
 }

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -92,6 +92,20 @@ public class ParserTest extends TestCase {
         assertEquals("var s = 3;\n/* */\n\n/* txt */\n\nvar t = 1;\n", root.toSource());
     }
 
+    public void testNewlineAndCommentsFunction() {
+        AstRoot root = parse(
+            "f('2345' // Second arg\n);");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+    }
+
+    public void testNewlineAndCommentsFunction2() {
+        AstRoot root = parse(
+            "f('1234',\n// Before\n'2345' // Second arg\n);");
+        assertNotNull(root.getComments());
+        assertEquals(2, root.getComments().size());
+    }
+
     public void testAutoSemiBeforeComment1() {
         parse("var a = 1\n/** a */ var b = 2");
     }


### PR DESCRIPTION
When the parser was asked to retain comments (which is not the default)
it could not handle multi-line comments in front of a
function parameter. This was a regression since 1.7.10.