### PR TITLE
Add manual OSGi manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,11 @@ jar {
             "Implementation-Vendor": "Mozilla Foundation",
             "Implementation-URL": "http://www.mozilla.org/rhino",
             "Built-Date": new Date().format("yyyy-MM-dd"),
-            "Built-Time": new Date().format("HH:mm:ss")
+            "Built-Time": new Date().format("HH:mm:ss"),
+			"Bundle-ManifestVersion": "2",
+			"Bundle-SymbolicName": "org.mozilla.rhino",
+			"Bundle-Version": project.version.replaceAll("-.*", ""),
+			"Export-Package": "org.mozilla.javascript,org.mozilla.javascript.ast,org.mozilla.javascript.annotations"
         )
     }
 }


### PR DESCRIPTION
As Rhino project already manually extends the MANIFEST.MF, it is very easy (and completely trouble-free) to add the OSGi headers so that the library can be readily utilized in OSGi environment. Only thing worth noting is, that OSGi version numbers only support <major>.<minor>[.<patch>] format, so I added a small regex to remove the possible -RCx, -BETA, -SNAPSHOT etc. endings from the version. 