### PR TITLE
Undo changes to use new Executable interface from 1.8.

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -213,9 +213,9 @@ public class NativeJavaClass extends NativeJavaObject implements Function
 
     static Object constructInternal(Object[] args, MemberBox ctor)
     {
-        Class<?>[] argTypes = ctor.getParameterTypes();
+        Class<?>[] argTypes = ctor.argTypes;
 
-        if (ctor.isVarArgs()) {
+        if (ctor.vararg) {
             // marshall the explicit parameter
             Object[] newArgs = new Object[argTypes.length];
             for (int i = 0; i < argTypes.length-1; i++) {

--- a/src/org/mozilla/javascript/NativeJavaConstructor.java
+++ b/src/org/mozilla/javascript/NativeJavaConstructor.java
@@ -41,7 +41,7 @@ public class NativeJavaConstructor extends BaseFunction
     @Override
     public String getFunctionName()
     {
-        String sig = JavaMembers.liveConnectSignature(ctor.getParameterTypes());
+        String sig = JavaMembers.liveConnectSignature(ctor.argTypes);
         return "<init>".concat(sig);
     }
 

--- a/src/org/mozilla/javascript/NativeJavaMethod.java
+++ b/src/org/mozilla/javascript/NativeJavaMethod.java
@@ -114,15 +114,15 @@ public class NativeJavaMethod extends BaseFunction
         StringBuilder sb = new StringBuilder();
         for (int i = 0, N = methods.length; i != N; ++i) {
             // Check member type, we also use this for overloaded constructors
-            MemberBox member = methods[i];
-            if (member.isMethod()) {
-                sb.append(JavaMembers.javaSignature(member.getReturnType()));
+            if (methods[i].isMethod()) {
+                Method method = methods[i].method();
+                sb.append(JavaMembers.javaSignature(method.getReturnType()));
                 sb.append(' ');
-                sb.append(member.getName());
+                sb.append(method.getName());
             } else {
-                sb.append(member.getName());
+                sb.append(methods[i].getName());
             }
-            sb.append(JavaMembers.liveConnectSignature(member.getParameterTypes()));
+            sb.append(JavaMembers.liveConnectSignature(methods[i].argTypes));
             sb.append('\n');
         }
         return sb.toString();
@@ -139,16 +139,16 @@ public class NativeJavaMethod extends BaseFunction
 
         int index = findCachedFunction(cx, args);
         if (index < 0) {
-            Class<?> c = methods[0].member().getDeclaringClass();
+            Class<?> c = methods[0].method().getDeclaringClass();
             String sig = c.getName() + '.' + getFunctionName() + '(' +
                          scriptSignature(args) + ')';
             throw Context.reportRuntimeError1("msg.java.no_such_method", sig);
         }
 
         MemberBox meth = methods[index];
-        Class<?>[] argTypes = meth.getParameterTypes();
+        Class<?>[] argTypes = meth.argTypes;
 
-        if (meth.isVarArgs()) {
+        if (meth.vararg) {
             // marshall the explicit parameters
             Object[] newArgs = new Object[argTypes.length];
             for (int i = 0; i < argTypes.length-1; i++) {
@@ -224,7 +224,7 @@ public class NativeJavaMethod extends BaseFunction
         }
 
         Object retval = meth.invoke(javaObject, args);
-        Class<?> staticType = meth.getReturnType();
+        Class<?> staticType = meth.method().getReturnType();
 
         if (debug) {
             Class<?> actualType = (retval == null) ? null
@@ -288,10 +288,10 @@ public class NativeJavaMethod extends BaseFunction
             return -1;
         } else if (methodsOrCtors.length == 1) {
             MemberBox member = methodsOrCtors[0];
-            Class<?>[] argTypes = member.getParameterTypes();
+            Class<?>[] argTypes = member.argTypes;
             int alength = argTypes.length;
 
-            if (member.isVarArgs()) {
+            if (member.vararg) {
                 alength--;
                 if ( alength > args.length) {
                     return -1;
@@ -319,9 +319,9 @@ public class NativeJavaMethod extends BaseFunction
       search:
         for (int i = 0; i < methodsOrCtors.length; i++) {
             MemberBox member = methodsOrCtors[i];
-            Class<?>[] argTypes = member.getParameterTypes();
+            Class<?>[] argTypes = member.argTypes;
             int alength = argTypes.length;
-            if (member.isVarArgs()) {
+            if (member.vararg) {
                 alength--;
                 if ( alength > args.length) {
                     continue search;
@@ -370,9 +370,9 @@ public class NativeJavaMethod extends BaseFunction
                             ++worseCount;
                     } else {
                         int preference = preferSignature(args, argTypes,
-                                                         member.isVarArgs(),
-                                                         bestFit.getParameterTypes(),
-                                                         bestFit.isVarArgs() );
+                                                         member.vararg,
+                                                         bestFit.argTypes,
+                                                         bestFit.vararg );
                         if (preference == PREFERENCE_AMBIGUOUS) {
                             break;
                         } else if (preference == PREFERENCE_FIRST_ARG) {
@@ -460,14 +460,14 @@ public class NativeJavaMethod extends BaseFunction
         String memberName = firstFitMember.getName();
         String memberClass = firstFitMember.getDeclaringClass().getName();
 
-        if (methodsOrCtors[0].isMethod()) {
-            throw Context.reportRuntimeError4(
-                    "msg.method.ambiguous", memberClass,
-                    memberName, scriptSignature(args), buf.toString());
-        }
-        throw Context.reportRuntimeError3(
+        if (methodsOrCtors[0].isCtor()) {
+            throw Context.reportRuntimeError3(
                 "msg.constructor.ambiguous",
                 memberName, scriptSignature(args), buf.toString());
+        }
+        throw Context.reportRuntimeError4(
+            "msg.method.ambiguous", memberClass,
+            memberName, scriptSignature(args), buf.toString());
     }
 
     /** Types are equal */
@@ -546,7 +546,7 @@ public class NativeJavaMethod extends BaseFunction
             if (member.isMethod()) {
                 sb.append(member.getName());
             }
-            sb.append(JavaMembers.liveConnectSignature(member.getParameterTypes()));
+            sb.append(JavaMembers.liveConnectSignature(member.argTypes));
             sb.append(" for arguments (");
             sb.append(scriptSignature(args));
             sb.append(')');


### PR DESCRIPTION
This reverts a change made during development of 1.7.11 that
caused incompatibilities for some older Android releases.

This change does not revert all changes made to Rhino for
1.8 compatibility but this particular one caused particular problems.

Developers on Java platforms other than Android should still
only expect full Rhino functionality on Java 1.8 and above.