### PR TITLE
Fix a code generation bug for generators.

### DIFF
--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -2130,6 +2130,9 @@ class BodyCodegen
                     ret.tableLabel = cfw.acquireLabel();
                     cfw.add(ByteCode.GOTO, ret.tableLabel);
 
+                    // After this GOTO we expect stack to be empty again!
+                    cfw.setStackTop((short)0);
+
                     releaseWordLocal((short)finallyRegister);
                     cfw.markLabel(finallyEnd);
                 }
@@ -3053,6 +3056,8 @@ class BodyCodegen
         FinallyReturnPoint ret = finallys.get(target);
         cfw.addLoadConstant(ret.jsrPoints.size());
         addGoto(target, ByteCode.GOTO);
+        // Don't leave something on the stack here!
+        cfw.add(ByteCode.POP);
         int retLabel = cfw.acquireLabel();
         cfw.markLabel(retLabel);
         ret.jsrPoints.add(Integer.valueOf(retLabel));

--- a/testsrc/jstests/extensions/obsolete-generators.js
+++ b/testsrc/jstests/extensions/obsolete-generators.js
@@ -1,0 +1,131 @@
+load("testsrc/assert.js");
+
+// Basic generator
+function basicGenerator(count) {
+  for (var i = 0; i < count; i++) {
+    yield i;
+  }
+}
+
+var basic = basicGenerator(10);
+for (var i = 0; i < 10; i++) {
+  var result = basic.next();
+  assertEquals(i, result);
+}
+
+// Try..catch
+function tcGenerator(shouldThrow) {
+  var gv = 0;
+  try {
+    gv = 1;
+    yield gv;
+    if (shouldThrow) {
+      throw 'Throwing!';
+    }
+  } catch (e) {
+    yield 999;
+  }
+  gv = 90;
+  yield gv;
+}
+
+var tc = tcGenerator(false);
+assertEquals(1, tc.next());
+assertEquals(90, tc.next());
+
+tc = tcGenerator(true);
+assertEquals(1, tc.next());
+assertEquals(999, tc.next());
+assertEquals(90, tc.next());
+
+// Try..finally
+function tfGenerator() {
+  var gv = 0;
+  try {
+    gv = 1;
+    yield gv;
+  } finally {
+    gv = 2;
+    yield gv;
+  }
+  gv = 90;
+  yield gv;
+}
+
+var tf = tfGenerator();
+assertEquals(1, tf.next());
+assertEquals(2, tf.next());
+assertEquals(90, tf.next());
+
+// try..catch..finally
+function tcfGenerator(shouldThrow) {
+  var gv = 0;
+  try {
+    gv++;
+    yield gv;
+    if (shouldThrow) {
+      throw 'Throwing!';
+    }
+  } catch (e) {
+    gv = 10;
+    yield 999;
+  } finally {
+    gv++;
+    yield gv;
+  }
+  gv++;
+  yield gv;
+}
+
+var tcf = tcfGenerator(false);
+assertEquals(1, tcf.next());
+assertEquals(2, tcf.next());
+assertEquals(3, tcf.next());
+
+tcf = tcfGenerator(true);
+assertEquals(1, tcf.next());
+assertEquals(999, tcf.next());
+assertEquals(11, tcf.next());
+assertEquals(12, tcf.next());
+
+// nested tries
+function nested(shouldThrow) {
+  yield 1;
+  try {
+    yield 2;
+    try {
+      yield 3;
+      if (shouldThrow) {
+        yield 4;
+        throw 'Nested throw!';
+      }
+    } catch (e) {
+      yield 5;
+    } finally {
+      yield 6;
+    }
+  } finally {
+    yield 7;
+  }
+  yield 8;
+}
+
+var nest = nested(false);
+assertEquals(1, nest.next());
+assertEquals(2, nest.next());
+assertEquals(3, nest.next());
+assertEquals(6, nest.next());
+assertEquals(7, nest.next());
+assertEquals(8, nest.next());
+
+var nest = nested(true);
+assertEquals(1, nest.next());
+assertEquals(2, nest.next());
+assertEquals(3, nest.next());
+assertEquals(4, nest.next());
+assertEquals(5, nest.next());
+assertEquals(6, nest.next());
+assertEquals(7, nest.next());
+assertEquals(8, nest.next());
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/ObsoleteGeneratorTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ObsoleteGeneratorTest.java
@@ -1,0 +1,11 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/extensions/obsolete-generators.js")
+@LanguageVersion(Context.VERSION_1_8)
+public class ObsoleteGeneratorTest extends ScriptTestsBase {
+}


### PR DESCRIPTION
This cropped up when generators were used in a function that
had a try..catch..finally block and a yield after the finally.
It caused an exception during code generation.

This bug now unblocks work to implement proper ES6 generators.

This fixes https://github.com/mozilla/rhino/issues/539
