### PR TITLE
Fix Array.includes returns a wrapped Boolean and align with specs

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -351,7 +351,7 @@ public class NativeArray extends IdScriptableObject implements List
                 return js_lastIndexOf(cx, scope, thisObj, args);
 
               case Id_includes:
-                return ScriptRuntime.toObject(cx, scope, ((long) js_indexOf(cx, scope, thisObj, args)) > -1);
+                return Boolean.valueOf(((long) js_indexOf(cx, scope, thisObj, args)) > -1);
 
               case Id_fill:
                 return js_fill(cx, scope, thisObj, args);

--- a/testsrc/jstests/es7-array-includes.js
+++ b/testsrc/jstests/es7-array-includes.js
@@ -1,0 +1,5 @@
+load("testsrc/assert.js");
+
+assertEquals(2, [1, 2, 3, 4].filter(t => [1, 2].includes(t)).length);
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/ES7ArrayIncludesTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ES7ArrayIncludesTest.java
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es7-array-includes.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ES7ArrayIncludesTest extends ScriptTestsBase {
+}
+

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -90,22 +90,6 @@ built-ins/Array
     ! prototype/Symbol.unscopables/value.js
     # Not throwing properly on unwritable
     ! prototype/copyWithin/return-abrupt-from-delete-target.js
-    # No "valueOf" yet.
-    ! prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
-    ! prototype/includes/fromIndex-infinity.js
-    ! prototype/includes/fromIndex-minus-zero.js
-    ! prototype/includes/get-prop.js
-    ! prototype/includes/length-boundaries.js
-    ! prototype/includes/length-zero-returns-false.js
-    ! prototype/includes/no-arg.js
-    ! prototype/includes/samevaluezero.js
-    ! prototype/includes/search-found-returns-true.js
-    ! prototype/includes/search-not-found-returns-false.js
-    ! prototype/includes/sparse.js
-    ! prototype/includes/tointeger-fromindex.js
-    ! prototype/includes/tolength-length.js
-    ! prototype/includes/using-fromindex.js
-    ! prototype/includes/values-are-not-cached.js
 
     # Expects a particular string value
     ! prototype/Symbol.iterator.js


### PR DESCRIPTION
I have noticed a bug when executing this line in the latest version (master and 1.7.11):
```
js> [1,2,3,4].filter(t => [1,2].includes(t));
1,2,3,4
```
Now of course this should be `[1,2]`. So I started to dig: both `filter` and `includes` work fine for themselves. However when combining them something goes wrong.
`includes` returns a `NativeBoolean` and the `filter` function checks the result of the callback using `ScriptRuntime.toBoolean`. 
However in JS this is true: `!(new Boolean(false)) == false`. So NativeBoolean objects are always true. Therefore `includes` should return an java `Boolean`.