### PR TITLE
Fix parseInt for numbers with a leading 0

### DIFF
--- a/src/org/mozilla/javascript/NativeGlobal.java
+++ b/src/org/mozilla/javascript/NativeGlobal.java
@@ -244,9 +244,6 @@ public class NativeGlobal implements Serializable, IdFunctionCall
                 if (c == 'x' || c == 'X') {
                     radix = 16;
                     start += 2;
-                } else if ('0' <= c && c <= '9') {
-                    radix = 8;
-                    start++;
                 }
             }
         }

--- a/testsrc/org/mozilla/javascript/tests/Issue594Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue594Test.java
@@ -1,0 +1,45 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptableObject;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class Issue594Test {
+    private static Context context;
+    private static ScriptableObject scope;
+
+    private final double expectedValue;
+    private final String script;
+
+    @Parameterized.Parameters(name="{0} === {1}")
+    public static Collection arguments() {
+        return asList(new Object[][]{{"parseInt(\"009\")", 9.0}, {"parseInt(\"-090\")", -90.0},
+                {"parseInt(\"-008\")", -8.0}});
+    }
+
+    @BeforeClass
+    public static void setupClass() {
+        context = Context.enter();
+        scope = context.initStandardObjects();
+    }
+
+    public Issue594Test(String script, double expectedValue) {
+        this.script = script;
+        this.expectedValue = expectedValue;
+    }
+
+    @Test
+    public void parseIntParsesLeadingZeros() {
+        double value = ((Number) context.evaluateString(scope, script, "testsrc", 1, null)).doubleValue();
+        assertEquals(expectedValue, value, 1e-12);
+    }
+}


### PR DESCRIPTION
Fixes #594. As discussed in the issue ES5 and later say that integers starting with a leading zero should be assumed have a radix of 10.