### PR TITLE
Eased validation in ScriptRuntime.enumInitOrder for host objects

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2271,15 +2271,11 @@ public class ScriptRuntime {
     }
 
     private static Object enumInitInOrder(Context cx, IdEnumeration x) {
-        if (!(x.obj instanceof ScriptableObject)) {
+        if (!(x.obj instanceof SymbolScriptable) || !ScriptableObject.hasProperty(x.obj, SymbolKey.ITERATOR)) {
             throw typeError1("msg.not.iterable", toString(x.obj));
         }
 
-        ScriptableObject xo = (ScriptableObject)x.obj;
-        if (!ScriptableObject.hasProperty(xo, SymbolKey.ITERATOR)) {
-            throw typeError1("msg.not.iterable", toString(x.obj));
-        }
-        Object iterator = ScriptableObject.getProperty(xo, SymbolKey.ITERATOR);
+        Object iterator = ScriptableObject.getProperty(x.obj, SymbolKey.ITERATOR);
         if (!(iterator instanceof Callable)) {
             throw typeError1("msg.not.iterable", toString(x.obj));
         }

--- a/testsrc/org/mozilla/javascript/tests/IterableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/IterableTest.java
@@ -1,12 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.javascript.tests;
 
 import junit.framework.TestCase;
 import org.mozilla.javascript.Context;
 import static org.mozilla.javascript.Context.VERSION_ES6;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Symbol;
@@ -24,18 +25,31 @@ import org.mozilla.javascript.Undefined;
  */
 public class IterableTest extends TestCase {
 
-    //Explicitly not a ScriptableObject
-    public static final class FooWithArrayIterator implements Scriptable, SymbolScriptable {
+    public static final class FooWithoutSymbols extends FooBoilerplate {
 
-        private final Scriptable scope;
+        public FooWithoutSymbols(final Scriptable scope) {
+            super(scope);
+        }
 
-        public FooWithArrayIterator(final Scriptable scope) {
-            this.scope = scope;
+    }
+
+    public static final class FooWithSymbols extends SymbolFooBoilerplate {
+
+        public FooWithSymbols(final Scriptable scope) {
+            super(scope);
         }
 
         @Override
-        public String getClassName() {
-            return this.getClass().getSimpleName();
+        public boolean has(Symbol key, Scriptable start) {
+            return false;
+        }
+
+    }
+
+    public static final class FooWithArrayIterator extends SymbolFooBoilerplate {
+
+        public FooWithArrayIterator(final Scriptable scope) {
+            super(scope);
         }
 
         @Override
@@ -55,6 +69,164 @@ public class IterableTest extends TestCase {
                 default:
                     return Undefined.instance;
             }
+        }
+
+        @Override
+        public Object get(Symbol key, Scriptable start) {
+            if (SymbolKey.ITERATOR.equals(key)) {
+                return ScriptableObject.getProperty(
+                        TopLevel.getArrayPrototype(scope),
+                        SymbolKey.ITERATOR
+                );
+            }
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean has(Symbol key, Scriptable start) {
+            return SymbolKey.ITERATOR.equals(key);
+        }
+
+    }
+
+    private final Scriptable top;
+
+    static {
+        ContextFactory.initGlobal(new ContextFactory() {
+            @Override
+            protected Context makeContext() {
+                return new Context(this) {
+                    {
+                        this.setLanguageVersion(VERSION_ES6);
+                    }
+                };
+            }
+        });
+    }
+
+    public IterableTest() {
+        Context cx = Context.enter();
+        try {
+            top = cx.initSafeStandardObjects();
+        } finally {
+            Context.exit();
+        }
+    }
+
+    /**
+     * Regression test for a Scriptable not implementing SymbolScriptable, used
+     * in for a for-of loop.
+     *
+     * Note: no spec is (knowingly) being adhered to with the "expected" in this
+     * test, merely the situation as-is being "noted".
+     */
+    public void testForOfUsingNonSymbolScriptable() {
+
+        Context cx = Context.enter();
+        try {
+            Scriptable foo = new FooWithoutSymbols(top);
+            ScriptableObject.putProperty(top, "foo", foo);
+
+            try {
+                cx.evaluateString(top, "(function(){for(x of foo) { return x; }})();", "<eval>", 0, null);
+
+            } catch (Throwable t) {
+                assertEquals(t.getClass(), EcmaError.class);
+                assertEquals(t.getMessage(), "TypeError: [object Object] is not iterable");
+            }
+        } finally {
+            Context.exit();
+        }
+    }
+
+    /**
+     * Regression test for a Scriptable implementing SymbolScriptable that
+     * doesn't implement the iterable protocol, used in for a for-of loop.
+     *
+     * Note: no spec is (knowingly) being adhered to with the "expected" in this
+     * test, merely the situation as-is being "noted".
+     */
+    public void testForOfUsingNonIterable() {
+        Context cx = Context.enter();
+        try {
+            Scriptable foo = new FooWithSymbols(top);
+            ScriptableObject.putProperty(top, "foo", foo);
+
+            try {
+                cx.evaluateString(top, "(function(){for(x of foo) { return x; }})();", "<eval>", 0, null);
+            } catch (Throwable t) {
+                assertEquals(t.getClass(), EcmaError.class);
+                assertEquals(t.getMessage(), "TypeError: [object Object] is not iterable");
+            }
+        } finally {
+            Context.exit();
+        }
+    }
+
+    /**
+     * Test for a host object to be able to supply an iterator, specifically
+     * Array.prototype[Symbol.iterator], for a for-of loop.
+     */
+    public void testForOfUsingArrayIterator() {
+        Context cx = Context.enter();
+        try {
+            Scriptable foo = new FooWithArrayIterator(top);
+            ScriptableObject.putProperty(top, "foo", foo);
+
+            assertEquals(
+                    true,
+                    cx.evaluateString(top, "foo[Symbol.iterator] === Array.prototype[Symbol.iterator]", "<eval>", 0, null)
+            );
+
+            assertEquals(
+                    123,
+                    cx.evaluateString(top, "(function(){for(x of foo) { return x; }})();", "<eval>", 0, null)
+            );
+        } finally {
+            Context.exit();
+        }
+    }
+
+    //Explicitly not a ScriptableObject
+    public static class FooBoilerplate implements Scriptable {
+
+        protected final Scriptable scope;
+
+        public FooBoilerplate(final Scriptable scope) {
+            this.scope = scope;
+        }
+
+        @Override
+        public String getClassName() {
+            return this.getClass().getSimpleName();
+        }
+
+        @Override
+        public Scriptable getParentScope() {
+            return scope;
+        }
+
+        @Override
+        public Object getDefaultValue(Class<?> hint) {
+            if (String.class == hint) {
+                return "[object Object]";
+            }
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Scriptable getPrototype() {
+            return TopLevel.getBuiltinPrototype(scope, TopLevel.Builtins.Object);
+        }
+
+        @Override
+        public Object get(String name, Scriptable start) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object get(int index, Scriptable start) {
+            throw new UnsupportedOperationException("Not supported yet.");
         }
 
         @Override
@@ -88,18 +260,8 @@ public class IterableTest extends TestCase {
         }
 
         @Override
-        public Scriptable getPrototype() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public void setPrototype(Scriptable prototype) {
             throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        public Scriptable getParentScope() {
-            return scope;
         }
 
         @Override
@@ -113,70 +275,37 @@ public class IterableTest extends TestCase {
         }
 
         @Override
-        public Object getDefaultValue(Class<?> hint) {
-            if(String.class == hint) {
-                return "[object Object]";
-            }
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public boolean hasInstance(Scriptable instance) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
+    }
+
+    public static class SymbolFooBoilerplate extends FooBoilerplate implements SymbolScriptable {
+
+        public SymbolFooBoilerplate(final Scriptable scope) {
+            super(scope);
+        }
+
         @Override
         public Object get(Symbol key, Scriptable start) {
-            if (SymbolKey.ITERATOR.equals(key)) {
-                return ScriptableObject.getProperty(
-                        TopLevel.getArrayPrototype(scope),
-                        SymbolKey.ITERATOR
-                );
-            }
-            throw new IllegalStateException();
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
         @Override
         public boolean has(Symbol key, Scriptable start) {
-            return SymbolKey.ITERATOR.equals(key);
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
         @Override
         public void put(Symbol key, Scriptable start, Object value) {
-            throw new UnsupportedOperationException("Not supported yet.");
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
         @Override
         public void delete(Symbol key) {
-            throw new UnsupportedOperationException("Not supported yet.");
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
     }
-
-    /**
-     * Test for a host object to be able to supply an iterator, specifically
-     * Array.prototype[Symbol.iterator], for a for-of loop.
-     */
-    public void testForOfUsingArrayIterator() {
-
-        Context cx = Context.enter();
-        cx.setLanguageVersion(VERSION_ES6);
-
-        final Scriptable top = cx.initSafeStandardObjects();
-
-        Scriptable foo = new FooWithArrayIterator(top);
-
-        ScriptableObject.putProperty(top, "foo", foo);
-
-        assertEquals(
-                true,
-                cx.evaluateString(top, "foo[Symbol.iterator] === Array.prototype[Symbol.iterator]", "<eval>", 0, null)
-        );
-
-        assertEquals(
-                123,
-                cx.evaluateString(top, "(function(){for(x of foo) { return x; }})()", "<eval>", 0, null)
-        );
-    }
-
 }

--- a/testsrc/org/mozilla/javascript/tests/IterableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/IterableTest.java
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import junit.framework.TestCase;
+import org.mozilla.javascript.Context;
+import static org.mozilla.javascript.Context.VERSION_ES6;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Symbol;
+import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.SymbolScriptable;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.Undefined;
+
+/**
+ * Tests for host objects implementing the iterable protocol.
+ *
+ * See https://github.com/mozilla/rhino/pull/599
+ *
+ * @author Stijn Kliemesch
+ */
+public class IterableTest extends TestCase {
+
+    //Explicitly not a ScriptableObject
+    public static final class FooWithArrayIterator implements Scriptable, SymbolScriptable {
+
+        private final Scriptable scope;
+
+        public FooWithArrayIterator(final Scriptable scope) {
+            this.scope = scope;
+        }
+
+        @Override
+        public String getClassName() {
+            return this.getClass().getSimpleName();
+        }
+
+        @Override
+        public Object get(String name, Scriptable start) {
+            switch (name) {
+                case "length":
+                    return 1;
+            }
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object get(int index, Scriptable start) {
+            switch (index) {
+                case 0:
+                    return 123;
+                default:
+                    return Undefined.instance;
+            }
+        }
+
+        @Override
+        public boolean has(String name, Scriptable start) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean has(int index, Scriptable start) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void put(String name, Scriptable start, Object value) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void put(int index, Scriptable start, Object value) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void delete(String name) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void delete(int index) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Scriptable getPrototype() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void setPrototype(Scriptable prototype) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Scriptable getParentScope() {
+            return scope;
+        }
+
+        @Override
+        public void setParentScope(Scriptable parent) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object[] getIds() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object getDefaultValue(Class<?> hint) {
+            if(String.class == hint) {
+                return "[object Object]";
+            }
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean hasInstance(Scriptable instance) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object get(Symbol key, Scriptable start) {
+            if (SymbolKey.ITERATOR.equals(key)) {
+                return ScriptableObject.getProperty(
+                        TopLevel.getArrayPrototype(scope),
+                        SymbolKey.ITERATOR
+                );
+            }
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean has(Symbol key, Scriptable start) {
+            return SymbolKey.ITERATOR.equals(key);
+        }
+
+        @Override
+        public void put(Symbol key, Scriptable start, Object value) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void delete(Symbol key) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+    }
+
+    /**
+     * Test for a host object to be able to supply an iterator, specifically
+     * Array.prototype[Symbol.iterator], for a for-of loop.
+     */
+    public void testForOfUsingArrayIterator() {
+
+        Context cx = Context.enter();
+        cx.setLanguageVersion(VERSION_ES6);
+
+        final Scriptable top = cx.initSafeStandardObjects();
+
+        Scriptable foo = new FooWithArrayIterator(top);
+
+        ScriptableObject.putProperty(top, "foo", foo);
+
+        assertEquals(
+                true,
+                cx.evaluateString(top, "foo[Symbol.iterator] === Array.prototype[Symbol.iterator]", "<eval>", 0, null)
+        );
+
+        assertEquals(
+                123,
+                cx.evaluateString(top, "(function(){for(x of foo) { return x; }})()", "<eval>", 0, null)
+        );
+    }
+
+}


### PR DESCRIPTION
This changeset eases the validation slightly, to allow host objects implementing Scriptable and SymbolScriptable, but not extending ScriptableObject specifically, to serve as an iterable in a for(... of ...) loop.

I'm not sure what unit test file I'd have to add a testcase to for this matter, any suggestions?

P.S. You'll have to pardon my commit message, I wasn't aware of the formatting that github assumes.