### PR TITLE
Adding secure configuration for XML parsers

### DIFF
--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -347,6 +347,13 @@ public class Context
      */
     public static final int FEATURE_LITTLE_ENDIAN = 19;
 
+    /**
+     * Configure the XMLProcessor to parse XML with security features or not.
+     * Security features include not fetching remote entity references and disabling XIncludes
+     * @since 1.7 Release 12
+     */
+    public static final int FEATURE_ENABLE_XML_SECURE_PARSING = 20;
+    
     public static final String languageVersionProperty = "language version";
     public static final String errorReporterProperty   = "error reporter";
 

--- a/src/org/mozilla/javascript/ContextFactory.java
+++ b/src/org/mozilla/javascript/ContextFactory.java
@@ -298,6 +298,9 @@ public class ContextFactory
 
           case Context.FEATURE_LITTLE_ENDIAN:
               return false;
+
+          case Context.FEATURE_ENABLE_XML_SECURE_PARSING:
+              return true;
         }
         // It is a bug to call the method with unknown featureIndex
         throw new IllegalArgumentException(String.valueOf(featureIndex));

--- a/testsrc/org/mozilla/javascript/tests/CustomTestDBF.java
+++ b/testsrc/org/mozilla/javascript/tests/CustomTestDBF.java
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class CustomTestDBF extends DocumentBuilderFactory {
+    public static final String INTENTIONAL_CONFIG_EXCEPTION = "Intentionally thrown";
+    
+    @Override
+    public Object getAttribute(String arg0) throws IllegalArgumentException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean getFeature(String name) throws ParserConfigurationException {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        throw new ParserConfigurationException(INTENTIONAL_CONFIG_EXCEPTION);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) throws IllegalArgumentException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) throws ParserConfigurationException {
+        // TODO Auto-generated method stub
+    }
+    
+    @Override
+    public void setExpandEntityReferences(boolean expandEntityRef) {
+        super.setExpandEntityReferences(expandEntityRef);
+        org.mozilla.javascript.tests.XMLSecureParserTest.CALLED_BY_XML_PARSER = true;
+    } 
+
+}

--- a/testsrc/org/mozilla/javascript/tests/CustomTestDBF.java
+++ b/testsrc/org/mozilla/javascript/tests/CustomTestDBF.java
@@ -36,13 +36,9 @@ public class CustomTestDBF extends DocumentBuilderFactory {
 
     @Override
     public void setFeature(String name, boolean value) throws ParserConfigurationException {
-        // TODO Auto-generated method stub
+        if("http://apache.org/xml/features/disallow-doctype-decl".equals(name)){
+            org.mozilla.javascript.tests.XMLSecureParserTest.CALLED_BY_XML_PARSER = true;
+        }
     }
     
-    @Override
-    public void setExpandEntityReferences(boolean expandEntityRef) {
-        super.setExpandEntityReferences(expandEntityRef);
-        org.mozilla.javascript.tests.XMLSecureParserTest.CALLED_BY_XML_PARSER = true;
-    } 
-
 }

--- a/testsrc/org/mozilla/javascript/tests/XMLSecureParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/XMLSecureParserTest.java
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Wrapper;
+
+import junit.framework.TestCase;
+
+/**
+ * Test for secure xml parsing
+ * @author Chris Smith
+ */
+public class XMLSecureParserTest extends TestCase {
+    
+    private static final String XML_PROPERTY = "javax.xml.parsers.DocumentBuilderFactory";
+    private static final String DBF_CLASSNAME = "org.mozilla.javascript.tests.CustomTestDBF";
+    
+    public static boolean CALLED_BY_XML_PARSER = false;
+    
+    /**
+     * Test first that XML can be run directly with the default XML parser for this JRE. 
+     * Then inject a custom parser to test that the security settings are being applied properly
+     */
+    public void testXmlSecureConfiguration() {
+        CALLED_BY_XML_PARSER = false;
+
+        // run with defaults for this JRE
+        executeXML(ContextFactory.getGlobal().enterContext());
+        assertFalse(CALLED_BY_XML_PARSER);
+        
+        // store the original setting for xml, if any
+        String original = System.getProperty(XML_PROPERTY);
+        try{
+            // inject our own xml parser
+            System.setProperty(XML_PROPERTY, DBF_CLASSNAME);
+            // run with our injected parser
+            executeXML(ContextFactory.getGlobal().enterContext());
+        } catch(RuntimeException e){
+            // Our parser immediately throws a ParserConfigurationException on creating a documentbuilder, 
+            // so catch it and make sure it is the correct type of exception with the correct message 
+            //(in case another PCE is thrown for some reason)
+            assertTrue(e.getCause() instanceof ParserConfigurationException);
+            ParserConfigurationException pce = (ParserConfigurationException)e.getCause();
+            assertEquals(org.mozilla.javascript.tests.CustomTestDBF.INTENTIONAL_CONFIG_EXCEPTION, pce.getMessage());
+        } finally{
+            // if we found an xml config in the system properties, replace it
+            if(original != null) {
+                System.setProperty(XML_PROPERTY, original);
+            } else{
+                System.clearProperty(XML_PROPERTY);
+            }
+        }
+        // Our parser will set a flag on this class when configured properly, check that this happened
+        assertTrue(CALLED_BY_XML_PARSER);
+    }    
+    
+    /**
+     * Test the same as above, but with the insecure configuration. This means neither the default xml parser
+     * nor the custom xml parser should be configured with the secure features.
+     */
+    public void testXmlInsecureConfiguration() {
+        CALLED_BY_XML_PARSER = false;
+        
+        // run with defaults for this JRE
+        executeXML(new InsecureContextFactory().enterContext());
+        assertFalse(CALLED_BY_XML_PARSER);
+        
+        // store the original setting for xml, if any
+        String original = System.getProperty(XML_PROPERTY);
+        try{
+            // inject our own xml parser
+            System.setProperty(XML_PROPERTY, DBF_CLASSNAME);
+            // run with our injected parser
+            executeXML(new InsecureContextFactory().enterContext());
+        } catch(RuntimeException e){
+            // Our parser immediately throws a ParserConfigurationException on creating a documentbuilder, 
+            // so catch it and make sure it is the correct type of exception with the correct message 
+            //(in case another PCE is thrown for some reason)
+            assertTrue(e.getCause() instanceof ParserConfigurationException);
+            ParserConfigurationException pce = (ParserConfigurationException)e.getCause();
+            assertEquals(org.mozilla.javascript.tests.CustomTestDBF.INTENTIONAL_CONFIG_EXCEPTION, pce.getMessage());
+        } finally{
+            // if we found an xml config in the system properties, replace it
+            if(original != null) {
+                System.setProperty(XML_PROPERTY, original);
+            } else{
+                System.clearProperty(XML_PROPERTY);
+            }
+            ContextFactory.initGlobal(new ContextFactory());
+        }
+        // Our parser will not set this flag as we skipped all security feature settings
+        assertFalse(CALLED_BY_XML_PARSER);
+    }   
+    
+    private void executeXML(Context cx){
+        try {
+            Scriptable scope = cx.initStandardObjects();
+            cx.evaluateString(scope,
+                    "new XML('<a></a>').toXMLString();",
+                    "source", 1, null);
+        } finally {
+            Context.exit();
+        }
+    }
+    
+    class InsecureContextFactory extends ContextFactory {
+
+        @Override
+        protected boolean hasFeature(Context cx, int featureIndex) {
+            switch (featureIndex) {
+            case Context.FEATURE_ENABLE_XML_SECURE_PARSING:
+                return false;
+            }
+            return super.hasFeature(cx, featureIndex);
+        }
+    }
+}

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlProcessor.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlProcessor.java
@@ -11,7 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.mozilla.javascript.Context;
@@ -45,12 +47,62 @@ class XmlProcessor implements Serializable {
 
     private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
         stream.defaultReadObject();
-        this.dom = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        this.dom = getSecureDBF();
         this.dom.setNamespaceAware(true);
         this.dom.setIgnoringComments(false);
+        //create TF and set settings to secure it from XSLT attacks if given a malicious node in toXMLString
         this.xform = javax.xml.transform.TransformerFactory.newInstance();
+        this.xform.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        this.xform.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         int poolSize = Runtime.getRuntime().availableProcessors() * 2;
         this.documentBuilderPool = new LinkedBlockingDeque<DocumentBuilder>(poolSize);
+    }
+    
+    /*
+     * Secure implementation of a DocumentBuilderFactory to prevent XXE and SSRF attacks
+     * Copied directly from OWASP: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+     */
+    private DocumentBuilderFactory getSecureDBF(){
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        String FEATURE = null;
+        try {
+            // This is the PRIMARY defense. If DTDs (doctypes) are disallowed, almost all 
+            // XML entity attacks are prevented
+            // Xerces 2 only - http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl
+            FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+            dbf.setFeature(FEATURE, true);
+
+            // If you can't completely disable DTDs, then at least do the following:
+            // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-general-entities
+            // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-general-entities
+            // JDK7+ - http://xml.org/sax/features/external-general-entities
+            FEATURE = "http://xml.org/sax/features/external-general-entities";
+            dbf.setFeature(FEATURE, false);
+
+            // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-parameter-entities
+            // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities
+            // JDK7+ - http://xml.org/sax/features/external-parameter-entities
+            FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+            dbf.setFeature(FEATURE, false);
+
+            // Disable external DTDs as well
+            FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(FEATURE, false);
+			
+            // and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+
+            // And, per Timothy Morgan: "If for some reason support for inline DOCTYPEs are a requirement, then
+            // ensure the entity settings are disabled (as shown above) and beware that SSRF attacks
+            // (http://cwe.mitre.org/data/definitions/918.html) and denial
+            // of service attacks (such as billion laughs or decompression bombs via "jar:") are a risk."
+
+        } catch (ParserConfigurationException e) {
+            // Following the other config exception handling0
+			throw new RuntimeException("XML parser cannot be securely configured.", e);
+        }
+        return dbf;
     }
 
     private static class RhinoSAXErrorHandler implements ErrorHandler, Serializable {
@@ -77,10 +129,13 @@ class XmlProcessor implements Serializable {
 
     XmlProcessor() {
         setDefault();
-        this.dom = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        this.dom = getSecureDBF();
         this.dom.setNamespaceAware(true);
         this.dom.setIgnoringComments(false);
+        //create TF and set settings to secure it from XSLT attacks if given a malicious node in toXMLString
         this.xform = javax.xml.transform.TransformerFactory.newInstance();
+        this.xform.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        this.xform.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         int poolSize = Runtime.getRuntime().availableProcessors() * 2;
         this.documentBuilderPool = new LinkedBlockingDeque<DocumentBuilder>(poolSize);
     }

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlProcessor.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlProcessor.java
@@ -88,7 +88,7 @@ class XmlProcessor implements Serializable {
             // Disable external DTDs as well
             FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
             dbf.setFeature(FEATURE, false);
-			
+
             // and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
             dbf.setXIncludeAware(false);
             dbf.setExpandEntityReferences(false);
@@ -100,7 +100,7 @@ class XmlProcessor implements Serializable {
 
         } catch (ParserConfigurationException e) {
             // Following the other config exception handling0
-			throw new RuntimeException("XML parser cannot be securely configured.", e);
+            throw new RuntimeException("XML parser cannot be securely configured.", e);
         }
         return dbf;
     }


### PR DESCRIPTION
This PR properly configures both the DocumentBuilderFactory and TransformerFactory instances in the XmlProcessor class to prevent XML eXternal Entity (XXE) attacks as recommended by OWASP.

A side note for anybody reading this in the future: The original implementation was not actually vulnerable to this attack using default built-in DBF or TF instances as by a set of slightly unique occurrences the code dodged all of the known attack types.

For example, XXE attacks are typically run by adding DOCTYPE and ENTITY declarations to the XML to trick the Java parsers into making protocol requests for more information to resolve malicious entities - file:// pulls in file and directory information into the XML doc, and http(s):// (s)ftp:// can trick the target server into making requests on behalf of an attacker (this is known as SSRF). Because the XmlProcessor wraps all incoming xml in a synthetic parent, This attack is nullified as DOCTYPEs and ENTITY defs can only be made before the first data tag.

The other attack vectors usually rely on XML implementations (XSLT and XSD) that require gathering more information from external sources, but the TransformerFactory's usage of output=XML and DOMSource negate that as well.

The good news about this is that this code fix should not have any behavior changes, as this will further enforce a case that can't happen out of the box.

All this being said, the PR should be included as this codefix protects against cases where an application may be using a non-default XML parser (most Java XML parsers are loaded via Service Loading or system properties at runtime with a fallback of one of the defaults). The PR sets all available best practice features or properties to catch these additional implementations.