### PR TITLE
Fix static analysis around NaN values.

### DIFF
--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -2325,7 +2325,7 @@ public final class IRFactory extends Parser
             return ALWAYS_TRUE_BOOLEAN;
           case Token.NUMBER: {
             double num = node.getDouble();
-            if (num == num && num != 0.0) {
+            if (!Double.isNaN(num) && num != 0.0) {
                 return ALWAYS_TRUE_BOOLEAN;
             }
             return ALWAYS_FALSE_BOOLEAN;

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -3111,12 +3111,12 @@ switch (op) {
             return false;
         } else if (x == UniqueTag.DOUBLE_MARK) {
             double d = frame.sDbl[i];
-            return d == d && d != 0.0;
+            return !Double.isNaN(d) && d != 0.0;
         } else if (x == null || x == Undefined.instance) {
             return false;
         } else if (x instanceof Number) {
             double d = ((Number)x).doubleValue();
-            return (d == d && d != 0.0);
+            return (!Double.isNaN(d) && d != 0.0);
         } else if (x instanceof Boolean) {
             return ((Boolean)x).booleanValue();
         } else {

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -431,7 +431,7 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     private static long toArrayIndex(double d) {
-        if (d == d) {
+        if (!Double.isNaN(d)) {
             long index = ScriptRuntime.toUint32(d);
             if (index == d && index != 4294967295L) {
                 return index;

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -172,7 +172,7 @@ final class NativeDate extends IdScriptableObject
                 Object tv = ScriptRuntime.toPrimitive(o, ScriptRuntime.NumberClass);
                 if (tv instanceof Number) {
                     double d = ((Number) tv).doubleValue();
-                    if (d != d || Double.isInfinite(d)) {
+                    if (Double.isNaN(d) || Double.isInfinite(d)) {
                         return null;
                     }
                 }
@@ -211,7 +211,7 @@ final class NativeDate extends IdScriptableObject
           case Id_toString:
           case Id_toTimeString:
           case Id_toDateString:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 return date_format(t, id);
             }
             return js_NaN_date_str;
@@ -219,13 +219,13 @@ final class NativeDate extends IdScriptableObject
           case Id_toLocaleString:
           case Id_toLocaleTimeString:
           case Id_toLocaleDateString:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 return toLocale_helper(t, id);
             }
             return js_NaN_date_str;
 
           case Id_toUTCString:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 return js_toUTCString(t);
             }
             return js_NaN_date_str;
@@ -240,7 +240,7 @@ final class NativeDate extends IdScriptableObject
           case Id_getYear:
           case Id_getFullYear:
           case Id_getUTCFullYear:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id != Id_getUTCFullYear) t = LocalTime(t);
                 t = YearFromTime(t);
                 if (id == Id_getYear) {
@@ -257,7 +257,7 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getMonth:
           case Id_getUTCMonth:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getMonth) t = LocalTime(t);
                 t = MonthFromTime(t);
             }
@@ -265,7 +265,7 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getDate:
           case Id_getUTCDate:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getDate) t = LocalTime(t);
                 t = DateFromTime(t);
             }
@@ -273,7 +273,7 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getDay:
           case Id_getUTCDay:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getDay) t = LocalTime(t);
                 t = WeekDay(t);
             }
@@ -281,7 +281,7 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getHours:
           case Id_getUTCHours:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getHours) t = LocalTime(t);
                 t = HourFromTime(t);
             }
@@ -289,7 +289,7 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getMinutes:
           case Id_getUTCMinutes:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getMinutes) t = LocalTime(t);
                 t = MinFromTime(t);
             }
@@ -297,7 +297,7 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getSeconds:
           case Id_getUTCSeconds:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getSeconds) t = LocalTime(t);
                 t = SecFromTime(t);
             }
@@ -305,14 +305,14 @@ final class NativeDate extends IdScriptableObject
 
           case Id_getMilliseconds:
           case Id_getUTCMilliseconds:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 if (id == Id_getMilliseconds) t = LocalTime(t);
                 t = msFromTime(t);
             }
             return ScriptRuntime.wrapNumber(t);
 
           case Id_getTimezoneOffset:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 t = (t - LocalTime(t)) / msPerMinute;
             }
             return ScriptRuntime.wrapNumber(t);
@@ -371,7 +371,7 @@ final class NativeDate extends IdScriptableObject
             return ScriptRuntime.wrapNumber(t);
 
           case Id_toISOString:
-            if (t == t) {
+            if (!Double.isNaN(t)) {
                 return js_toISOString(t);
             }
             String msg = ScriptRuntime.getMessage0("msg.invalid.date");
@@ -706,7 +706,7 @@ final class NativeDate extends IdScriptableObject
 
     private static double TimeClip(double d)
     {
-        if (d != d ||
+        if (Double.isNaN(d) ||
             d == Double.POSITIVE_INFINITY ||
             d == Double.NEGATIVE_INFINITY ||
             Math.abs(d) > HalfTimeDomain)
@@ -747,7 +747,7 @@ final class NativeDate extends IdScriptableObject
         for (loop = 0; loop < MAXARGS; loop++) {
             if (loop < args.length) {
                 d = ScriptRuntime.toNumber(args[loop]);
-                if (d != d || Double.isInfinite(d)) {
+                if (Double.isNaN(d) || Double.isInfinite(d)) {
                     return ScriptRuntime.NaN;
                 }
                 array[loop] = ScriptRuntime.toInteger(args[loop]);
@@ -932,7 +932,7 @@ final class NativeDate extends IdScriptableObject
     private static double date_parseString(String s)
     {
         double d = parseISOString(s);
-        if (d == d) {
+        if (!Double.isNaN(d)) {
             return d;
         }
 
@@ -1448,7 +1448,7 @@ final class NativeDate extends IdScriptableObject
         double[] nums = new double[4];
         for (int i = 0; i < numNums; i++) {
             double d = ScriptRuntime.toNumber(args[i]);
-            if (d != d || Double.isInfinite(d)) {
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
                 hasNaN = true;
             } else {
                 nums[i] = ScriptRuntime.toInteger(d);
@@ -1457,7 +1457,7 @@ final class NativeDate extends IdScriptableObject
 
         // just return NaN if the date is already NaN,
         // limit checks that happen in MakeTime in ECMA.
-        if (hasNaN || date != date) {
+        if (hasNaN || Double.isNaN(date)) {
             return ScriptRuntime.NaN;
         }
 
@@ -1540,7 +1540,7 @@ final class NativeDate extends IdScriptableObject
         double[] nums = new double[3];
         for (int i = 0; i < numNums; i++) {
             double d = ScriptRuntime.toNumber(args[i]);
-            if (d != d || Double.isInfinite(d)) {
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
                 hasNaN = true;
             } else {
                 nums[i] = ScriptRuntime.toInteger(d);
@@ -1558,7 +1558,7 @@ final class NativeDate extends IdScriptableObject
 
         /* return NaN if date is NaN and we're not setting the year,
          * If we are, use 0 as the time. */
-        if (date != date) {
+        if (Double.isNaN(date)) {
             if (maxargs < 3) {
                 return ScriptRuntime.NaN;
             }

--- a/src/org/mozilla/javascript/NativeGlobal.java
+++ b/src/org/mozilla/javascript/NativeGlobal.java
@@ -380,7 +380,7 @@ public class NativeGlobal implements Serializable, IdFunctionCall
         int mask = URL_XALPHAS | URL_XPALPHAS | URL_PATH;
         if (args.length > 1) { // the 'mask' argument.  Non-ECMA.
             double d = ScriptRuntime.toNumber(args[1]);
-            if (d != d || ((mask = (int) d) != d) ||
+            if (Double.isNaN(d) || ((mask = (int) d) != d) ||
                 0 != (mask & ~(URL_XALPHAS | URL_XPALPHAS | URL_PATH)))
             {
                 throw Context.reportRuntimeError0("msg.bad.esc.mask");

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -307,7 +307,7 @@ public final class NativeJSON extends IdScriptableObject
 
         if (value instanceof Number) {
             double d = ((Number) value).doubleValue();
-            if (d == d && d != Double.POSITIVE_INFINITY &&
+            if (!Double.isNaN(d) && d != Double.POSITIVE_INFINITY &&
                 d != Double.NEGATIVE_INFINITY)
             {
                 return ScriptRuntime.toString(value);

--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -923,7 +923,7 @@ public class NativeJavaObject
         }
 
         if (staticType != null) {
-            out.writeObject(staticType.getClass().getName());
+            out.writeObject(staticType.getName());
         } else {
             out.writeObject(null);
         }

--- a/src/org/mozilla/javascript/NativeMath.java
+++ b/src/org/mozilla/javascript/NativeMath.java
@@ -102,6 +102,7 @@ final class NativeMath extends IdScriptableObject
         }
     }
 
+    @SuppressWarnings("SelfAssignment")
     @Override
     public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
                              Scriptable thisObj, Object[] args)
@@ -124,7 +125,7 @@ final class NativeMath extends IdScriptableObject
             case Id_acos:
             case Id_asin:
                 x = ScriptRuntime.toNumber(args, 0);
-                if (x == x && -1.0 <= x && x <= 1.0) {
+                if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
                     x = (methodId == Id_acos) ? Math.acos(x) : Math.asin(x);
                 } else {
                     x = Double.NaN;
@@ -133,7 +134,7 @@ final class NativeMath extends IdScriptableObject
 
             case Id_acosh:
                 x = ScriptRuntime.toNumber(args, 0);
-                if (x == x) {
+                if (!Double.isNaN(x)) {
                     return Math.log(x + Math.sqrt(x*x - 1.0));
                 }
                 return Double.NaN;
@@ -144,7 +145,7 @@ final class NativeMath extends IdScriptableObject
                         || x == Double.NEGATIVE_INFINITY) {
                     return x;
                 }
-                if (x == x) {
+                if (!Double.isNaN(x)) {
                     if (x == 0) {
                         if (1 / x > 0) {
                             return 0.0;
@@ -162,7 +163,7 @@ final class NativeMath extends IdScriptableObject
 
             case Id_atanh:
                 x = ScriptRuntime.toNumber(args, 0);
-                if (x == x && -1.0 <= x && x <= 1.0) {
+                if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
                     if (x == 0) {
                         if (1 / x > 0) {
                             return 0.0;
@@ -191,7 +192,7 @@ final class NativeMath extends IdScriptableObject
             case Id_clz32:
                 x = ScriptRuntime.toNumber(args, 0);
                 if (x == 0
-                        || x != x
+                        || Double.isNaN(x)
                         || x == Double.POSITIVE_INFINITY
                         || x == Double.NEGATIVE_INFINITY) {
                     return 32;
@@ -237,6 +238,7 @@ final class NativeMath extends IdScriptableObject
 
             case Id_fround:
                 x = ScriptRuntime.toNumber(args, 0);
+                // Rely on Java to truncate down to a "float" here"
                 x = (float) x;
                 break;
 
@@ -271,7 +273,7 @@ final class NativeMath extends IdScriptableObject
                     ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
                 for (int i = 0; i != args.length; ++i) {
                     double d = ScriptRuntime.toNumber(args[i]);
-                    if (d != d) {
+                    if (Double.isNaN(d)) {
                         x = d; // NaN
                         break;
                     }
@@ -295,7 +297,7 @@ final class NativeMath extends IdScriptableObject
 
             case Id_round:
                 x = ScriptRuntime.toNumber(args, 0);
-                if (x == x && x != Double.POSITIVE_INFINITY
+                if (!Double.isNaN(x) && x != Double.POSITIVE_INFINITY
                     && x != Double.NEGATIVE_INFINITY)
                 {
                     // Round only finite x
@@ -315,7 +317,7 @@ final class NativeMath extends IdScriptableObject
 
             case Id_sign:
                 x = ScriptRuntime.toNumber(args, 0);
-                if (x == x) {
+                if (!Double.isNaN(x)) {
                     if (x == 0) {
                         if (1 / x > 0) {
                             return 0.0;
@@ -366,7 +368,7 @@ final class NativeMath extends IdScriptableObject
     // See Ecma 15.8.2.13
     private static double js_pow(double x, double y) {
         double result;
-        if (y != y) {
+        if (Double.isNaN(y)) {
             // y is NaN, result is always NaN
             result = y;
         } else if (y == 0) {
@@ -387,7 +389,7 @@ final class NativeMath extends IdScriptableObject
             }
         } else {
             result = Math.pow(x, y);
-            if (result != result) {
+            if (Double.isNaN(result)) {
                 // Check for broken Java implementations that gives NaN
                 // when they should return something else
                 if (y == Double.POSITIVE_INFINITY) {

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -639,7 +639,7 @@ final class NativeString extends IdScriptableObject
         String search = ScriptRuntime.toString(args, 0);
         double end = ScriptRuntime.toNumber(args, 1);
 
-        if (end != end || end > target.length())
+        if (Double.isNaN(end) || end > target.length())
             end = target.length();
         else if (end < 0)
             end = 0;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -373,7 +373,7 @@ public class ScriptRuntime {
 
     public static Number wrapNumber(double x)
     {
-        if (x != x) {
+        if (Double.isNaN(x)) {
             return ScriptRuntime.NaNobj;
         }
         return new Double(x);
@@ -395,7 +395,7 @@ public class ScriptRuntime {
                 return ((CharSequence) val).length() != 0;
             if (val instanceof Number) {
                 double d = ((Number) val).doubleValue();
-                return (d == d && d != 0.0);
+                return (!Double.isNaN(d) && d != 0.0);
             }
             if (val instanceof Scriptable) {
                 if (val instanceof ScriptableObject &&
@@ -916,7 +916,7 @@ public class ScriptRuntime {
                 "msg.bad.radix", Integer.toString(base));
         }
 
-        if (d != d)
+        if (Double.isNaN(d))
             return "NaN";
         if (d == Double.POSITIVE_INFINITY)
             return "Infinity";
@@ -1216,7 +1216,7 @@ public class ScriptRuntime {
     // convenience method
     public static double toInteger(double d) {
         // if it's NaN
-        if (d != d)
+        if (Double.isNaN(d))
             return +0.0;
 
         if (d == 0.0 ||
@@ -3362,7 +3362,7 @@ public class ScriptRuntime {
             }
             // NaN check
             double d = ((Number)x).doubleValue();
-            return d == d;
+            return !Double.isNaN(d);
         }
         if (x == null || x == Undefined.instance || x == Undefined.SCRIPTABLE_UNDEFINED) {
             if ((x == Undefined.instance && y == Undefined.SCRIPTABLE_UNDEFINED)

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -1086,7 +1086,7 @@ public class Codegen implements Evaluator
                     "org/mozilla/javascript/optimizer/OptRuntime",
                     "minusOneObj", "Ljava/lang/Double;");
 
-        } else if (num != num) {
+        } else if (Double.isNaN(num)) { 
             cfw.add(ByteCode.GETSTATIC,
                     "org/mozilla/javascript/ScriptRuntime",
                     "NaNobj", "Ljava/lang/Double;");

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -180,7 +180,7 @@ public final class OptRuntime extends ScriptRuntime
             return oneObj;
         } else if (num == -1.0) {
             return minusOneObj;
-        } else if (num != num) {
+        } else if (Double.isNaN(num)) {
             return NaNobj;
         }
         return Double.valueOf(num);


### PR DESCRIPTION
This addresses an old coding pattern from the Java old days in which
we compare a double to itself to test if it is NaN. Replace those
checks with calls to Double.isNaN which is much easier to understand.