### PR TITLE
Fix syntax error for comments in array

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3272,10 +3272,9 @@ public class Parser
                     elements.add(new EmptyExpression(ts.tokenBeg, 1));
                     skipCount++;
                 }
-            }else if(tt == Token.COMMENT) {
+            } else if(tt == Token.COMMENT) {
                 consumeToken();
-            }
-            else if (tt == Token.RB) {
+            } else if (tt == Token.RB) {
                 consumeToken();
                 // for ([a,] in obj) is legal, but for ([a] in obj) is
                 // not since we have both key and value supplied. The

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3272,7 +3272,10 @@ public class Parser
                     elements.add(new EmptyExpression(ts.tokenBeg, 1));
                     skipCount++;
                 }
-            } else if (tt == Token.RB) {
+            }else if(tt == Token.COMMENT) {
+                consumeToken();
+            }
+            else if (tt == Token.RB) {
                 consumeToken();
                 // for ([a,] in obj) is legal, but for ([a] in obj) is
                 // not since we have both key and value supplied. The

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -81,6 +81,32 @@ public class ParserTest extends TestCase {
 
         assertEquals("var s = 3;\nvar t = 1;\n", root.toSource());
     }
+    
+    public void testCommentInArray() throws IOException{
+        //Test a single comment
+        AstRoot root = parseAsReader(
+                "var array = [/**/];");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+        assertEquals(root.toSource(),"var array = [];\n");
+        //Test multiple comments
+        root = parseAsReader(
+                "var array = [/*Hello*/ /*World*/ 1,2];");
+        assertNotNull(root.getComments());
+        assertEquals(2, root.getComments().size());
+        assertEquals(root.toSource(),"var array = [1, 2];\n");
+        //Test no comments
+        root = parseAsReader(
+                "var array = [1,2];");
+        assertNull(root.getComments());
+        assertEquals(root.toSource(),"var array = [1, 2];\n");
+        root = parseAsReader(
+                "var array = [1,/*hello*/2,/*World*/3];");
+        //Test comments in middle
+        assertNotNull(root.getComments());
+        assertEquals(2, root.getComments().size());
+        assertEquals(root.toSource(),"var array = [1, 2, 3];\n");
+    }
 
     public void testNewlineAndComments() throws IOException {
         AstRoot root = parseAsReader(


### PR DESCRIPTION
Fixes #602 

The error came from the fact that token type comment was not expected within array literal, so added that case to handle that error. Also added multiple test cases in ```testsrc/org/mozilla/javascript/tests/ParserTest.java``` under the function ```testCommentInArray()``` to check all possible cases (single/multiple/no comments, and comments between literals)

Please mention if something else needs to be fixed for this PR 😄 