### PR TITLE
Enable SpotBugs plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+plugins {
+    id 'java'
+    id 'idea'
+    id 'eclipse'
+    id 'maven-publish'
+    id 'jacoco'
+    id 'distribution'
+    id 'checkstyle'
+    id 'com.github.spotbugs' version '2.0.0'
+}
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
@@ -208,6 +218,14 @@ publishing {
 
 jacoco {
     toolVersion = "0.8.3"
+}
+
+spotbugs {
+    toolVersion = "3.1.12"
+    effort = "min"
+    reportLevel = "high"
+    sourceSets = [sourceSets.main]
+    excludeFilter = file("./spotbugs-exclude.xml")
 }
 
 jacocoTestReport.dependsOn test

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<FindBugsFilter>
+  <Match>
+    <Class name="org.mozilla.javascript.Interpreter" />
+    <Bug pattern="INT_BAD_COMPARISON_WITH_SIGNED_BYTE" />
+  </Match>
+  <Match>
+    <Class name="org.mozilla.classfile.ClassFileWriter" />
+    <Bug pattern="INT_BAD_COMPARISON_WITH_NONNEGATIVE_VALUE" />
+  </Match>
+  <Match>
+    <Class name="org.mozilla.javascript.NativeArray" />
+    <Bug pattern="UC_USELESS_CONDITION" />
+  </Match>
+  <Match>
+    <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
+  </Match>
+  <Match>
+    <Bug pattern="JLM_JSR166_UTILCONCURRENT_MONITORENTER" />
+  </Match>
+  <Match>
+    <Bug pattern="DM_DEFAULT_ENCODING" />
+  </Match>
+  <Match>
+    <Bug pattern="MS_SHOULD_BE_FINAL" />
+  </Match>
+  <Match>
+    <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
It's configured now not to break the build for anything, although
it might prevent new bugs.

(SpotBugs used to be "FindBugs".)