### PR TITLE
Fix bug about argment of Number.prototype.toFixed

### DIFF
--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -146,7 +146,7 @@ final class NativeNumber extends IdScriptableObject
             return ScriptRuntime.wrapNumber(value);
 
           case Id_toFixed:
-            int precisionMin = cx.version < Context.VERSION_ES6 ? -20 : 0;
+            int precisionMin = cx.version < Context.VERSION_ES6 ? 0 : -20;
             return num_to(value, args, DToA.DTOSTR_FIXED, DToA.DTOSTR_FIXED, precisionMin, 0);
 
           case Id_toExponential: {


### PR DESCRIPTION
Fixed #587

For the definition of argument of  `Number.prototype.toFixed` in ECMAScript-262, if the argument is less than 0, RangeError should be thrown in ES5, ES5.1, ES9 and the newer version, but it is not a necessary operation in ES6-ES8 because the implementation is permitted to extend. However, rhino does not throw RangeError if version < 200(ES6), and  it throws RangeError if version is 200. They are just opposite.

If rhino originally planned to extend it in ES6,  this is a solution. 

The references of ECMAScript-262 are as follows:
https://tc39.es/ecma262/#sec-number.prototype.tofixed
http://www.ecma-international.org/ecma-262/10.0/index.html#sec-number.prototype.tofixed
http://www.ecma-international.org/ecma-262/9.0/index.html#sec-number.prototype.tofixed
http://www.ecma-international.org/ecma-262/8.0/index.html#sec-number.prototype.tofixed
http://www.ecma-international.org/ecma-262/7.0/index.html#sec-number.prototype.tofixed
http://www.ecma-international.org/ecma-262/6.0/index.html#sec-number.prototype.tofixed
http://www.ecma-international.org/ecma-262/5.1/index.html#sec-11.9.1
[ES5](http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.pdf)