### PR TITLE
Fix for #616

### DIFF
--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -2804,20 +2804,18 @@ public abstract class ScriptableObject implements Scriptable,
     {
         // This method is very hot (basically called on each assignment)
         // so we inline the extensible/sealed checks below.
-        if (!isExtensible) {
-            Context cx = Context.getContext();
-            if (cx.isStrictMode()) {
-                throw ScriptRuntime.typeError0("msg.not.extensible");
-            }
-        }
         Slot slot;
         if (this != start) {
             slot = slotMap.query(key, index);
+            if(!isExtensible && Context.getContext().isStrictMode() && (slot == null || !(slot instanceof GetterSlot)))
+                throw ScriptRuntime.typeError0("msg.not.extensible");
             if (slot == null) {
                 return false;
             }
         } else if (!isExtensible) {
             slot = slotMap.query(key, index);
+            if(Context.getContext().isStrictMode() && (slot == null || !(slot instanceof GetterSlot)))
+                throw ScriptRuntime.typeError0("msg.not.extensible");
             if (slot == null) {
                 return true;
             }

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -481,9 +481,6 @@ built-ins/Object
     ! entries/tamper-with-object-keys.js
     ! freeze/15.2.3.9-2-a-12.js
     ! freeze/15.2.3.9-2-a-8.js
-    ! freeze/15.2.3.9-2-c-2.js
-    ! freeze/15.2.3.9-2-c-3.js
-    ! freeze/15.2.3.9-2-c-4.js
     ! freeze/15.2.3.9-2-d-3.js
     ! freeze/frozen-object-contains-symbol-properties-non-strict.js
     ! getOwnPropertyDescriptor/15.2.3.3-3-14.js


### PR DESCRIPTION
Affects strict mode only.

No longer prematurely throws a TypeError in ScriptableObject.putImpl(Object,int,Scriptable,Object) when instance member isExtensible is false.

Instead, now it first queries the slotmap, so that if a GetterSlot instance is returned, any present setter may be called. All other outcomes of this method should be unaffected.