### PR TITLE
Fixes for calling several Object.prototype members.

### DIFF
--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -160,9 +160,15 @@ public class NativeObject extends IdScriptableObject implements Map
           }
 
           case Id_valueOf:
+              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+              }
             return thisObj;
 
           case Id_hasOwnProperty: {
+              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+              }
               boolean result;
               Object arg = args.length < 1 ? Undefined.instance : args[0];
               if (arg instanceof Symbol) {
@@ -180,6 +186,10 @@ public class NativeObject extends IdScriptableObject implements Map
           }
 
           case Id_propertyIsEnumerable: {
+              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+              }
+              
             boolean result;
             Object arg = args.length < 1 ? Undefined.instance : args[0];
 
@@ -224,6 +234,10 @@ public class NativeObject extends IdScriptableObject implements Map
           }
 
           case Id_isPrototypeOf: {
+              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+              }
+              
             boolean result = false;
             if (args.length != 0 && args[0] instanceof Scriptable) {
                 Scriptable v = (Scriptable) args[0];

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -519,15 +519,9 @@ built-ins/Object
     ! keys/proxy-keys.js
     ! preventExtensions/15.2.3.10-3-23.js
     ! preventExtensions/symbol-object-contains-symbol-properties-strict.js
-    ! prototype/hasOwnProperty/S15.2.4.5_A12.js
-    ! prototype/hasOwnProperty/S15.2.4.5_A13.js
     ! prototype/hasOwnProperty/symbol_property_toPrimitive.js
     ! prototype/hasOwnProperty/symbol_property_toString.js
     ! prototype/hasOwnProperty/symbol_property_valueOf.js
-    ! prototype/isPrototypeOf/S15.2.4.6_A12.js
-    ! prototype/isPrototypeOf/S15.2.4.6_A13.js
-    ! prototype/propertyIsEnumerable/S15.2.4.7_A12.js
-    ! prototype/propertyIsEnumerable/S15.2.4.7_A13.js
     ! prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     ! prototype/propertyIsEnumerable/symbol_property_toString.js
     ! prototype/propertyIsEnumerable/symbol_property_valueOf.js
@@ -539,8 +533,6 @@ built-ins/Object
     ! prototype/toString/symbol-tag-override-instances.js
     ! prototype/toString/symbol-tag-override-primitives.js
     ! prototype/toString/symbol-tag-str.js
-    ! prototype/valueOf/S15.2.4.4_A12.js
-    ! prototype/valueOf/S15.2.4.4_A13.js
     ! prototype/valueOf/S15.2.4.4_A14.js
     ! prototype/valueOf/S15.2.4.4_A15.js
     ! seal/15.2.3.8-2-a-9.js


### PR DESCRIPTION
Fixes for calling several Object.prototype members with an owner value of either undefined or null, now throws a TypeError. Affected methods: valueOf, hasOwnProperty, propertyIsEnumerable, isPrototypeOf.