### PR TITLE
Functions as var

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -6,9 +6,14 @@
 
 package org.mozilla.javascript;
 
+import org.mozilla.javascript.ast.AstNode;
+import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.ast.Block;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
+import org.mozilla.javascript.ast.Scope;
 import org.mozilla.javascript.ast.ScriptNode;
+import org.mozilla.javascript.ast.VariableInitializer;
 
 /**
  * Generates bytecode for the Interpreter.
@@ -104,6 +109,8 @@ class CodeGenerator extends Icode {
             itsData.isStrict = true;
         }
 
+        itsData.declaredAsVar = (theFunction.getParent() instanceof VariableInitializer);
+
         generateICodeFromTree(theFunction.getLastChild());
     }
 
@@ -191,6 +198,13 @@ class CodeGenerator extends Icode {
             gen.itsData = new InterpreterData(itsData);
             gen.generateFunctionICode();
             array[i] = gen.itsData;
+
+            final AstNode fnParent = fn.getParent();
+            if (!(fnParent instanceof AstRoot
+                    || fnParent instanceof Scope
+                    || fnParent instanceof Block)) {
+                        gen.itsData.declaredAsFunctionExpression = true;
+            }
         }
         itsData.itsNestedFunctions = array;
     }

--- a/src/org/mozilla/javascript/InterpretedFunction.java
+++ b/src/org/mozilla/javascript/InterpretedFunction.java
@@ -177,5 +177,16 @@ final class InterpretedFunction extends NativeFunction implements Script
     {
         return idata.argIsConst[index];
     }
+
+    boolean hasFunctionNamed(String name) {
+        for (int f = 0; f < idata.getFunctionCount(); f++) {
+            InterpreterData functionData = (InterpreterData) idata.getFunction(f);
+            if (!functionData.declaredAsFunctionExpression
+                    && name.equals(functionData.getFunctionName())) {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 

--- a/src/org/mozilla/javascript/InterpreterData.java
+++ b/src/org/mozilla/javascript/InterpreterData.java
@@ -92,6 +92,12 @@ final class InterpreterData implements Serializable, DebuggableScript
 
     private int icodeHashCode = 0;
 
+    /** true if the function has been declared like "var foo = function() {...}" */
+    boolean declaredAsVar;
+
+    /** true if the function has been declared like "!function() {}". */
+    boolean declaredAsFunctionExpression;
+
     @Override
     public boolean isTopLevel()
     {

--- a/src/org/mozilla/javascript/NativeCall.java
+++ b/src/org/mozilla/javascript/NativeCall.java
@@ -61,10 +61,12 @@ public final class NativeCall extends IdScriptableObject
             for (int i = paramCount; i < paramAndVarCount; ++i) {
                 String name = function.getParamOrVarName(i);
                 if (!super.has(name, this)) {
-                    if (function.getParamOrVarConst(i))
+                    if (function.getParamOrVarConst(i)) {
                         defineProperty(name, Undefined.instance, CONST);
-                    else
+                    } else if (!(function instanceof InterpretedFunction)
+                                || ((InterpretedFunction) function).hasFunctionNamed(name)) {
                         defineProperty(name, Undefined.instance, PERMANENT);
+                    }
                 }
             }
         }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3635,10 +3635,11 @@ public class ScriptRuntime {
                     if (isConst) {
                         ScriptableObject.defineConstProperty(varScope, name);
                     } else if (!evalScript) {
-                        // Global var definitions are supposed to be DONTDELETE
-                        ScriptableObject.defineProperty(
-                            varScope, name, Undefined.instance,
-                            ScriptableObject.PERMANENT);
+                        if (!(funObj instanceof InterpretedFunction)
+                            || ((InterpretedFunction) funObj).hasFunctionNamed(name)) {
+                            // Global var definitions are supposed to be DONTDELETE
+                            ScriptableObject.defineProperty(varScope, name, Undefined.instance, ScriptableObject.PERMANENT);
+                        }
                     } else {
                         varScope.put(name, varScope, Undefined.instance);
                     }

--- a/testsrc/org/mozilla/javascript/tests/DoctestsTest.java
+++ b/testsrc/org/mozilla/javascript/tests/DoctestsTest.java
@@ -96,7 +96,7 @@ public class DoctestsTest {
             int testsPassed = global.runDoctest(cx, global, source, name, 1);
             assertTrue(testsPassed > 0);
         } catch (Exception ex) {
-          System.out.println(name + "(" + optimizationLevel + "): FAILED due to "+ex);
+          System.out.println(name + "(" + optimizationLevel + "): FAILED due to " + ex);
           throw ex;
         } finally {
             Context.exit();

--- a/testsrc/org/mozilla/javascript/tests/FunctionTest.java
+++ b/testsrc/org/mozilla/javascript/tests/FunctionTest.java
@@ -7,15 +7,16 @@
  */
 package org.mozilla.javascript.tests;
 
-import org.mozilla.javascript.Scriptable;
+import static org.junit.Assert.assertEquals;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import org.mozilla.javascript.Scriptable;
 
 /**
  * Unit tests for Function.
  * @author Marc Guillemot
  */
-public class FunctionTest extends TestCase {
+public class FunctionTest {
 
     /**
      * Test for bug #600479
@@ -23,8 +24,131 @@ public class FunctionTest extends TestCase {
      * Syntax of function built from Function's constructor string parameter was not correct
      * when this string contained "//".
      */
+    @Test
     public void testFunctionWithSlashSlash() {
         assertEvaluates(true, "new Function('return true//;').call()");
+    }
+
+    @Test
+    public void functionHasNameOfVarStrictMode() throws Exception {
+      final String script = ""
+              + "'use strict';\n"
+              + "var result = '';\n"
+              + "var abc = 1;\n"
+              + "var foo = function abc() { result += '-inner abc = ' + typeof abc; };\n"
+              + "result += '-outer abc = ' + abc;\n"
+              + "foo();\n"
+              + "result;";
+
+      assertEvaluates("-outer abc = 1-inner abc = function", script);
+    }
+
+    @Test
+    public void innerFunctionWithSameName() throws Exception {
+      final String script = ""
+              + "var result = '';\n"
+              + "var a = function () {\n"
+              + "  var x = (function x () { result += 'a'; });\n"
+              + "  return function () { x(); };\n"
+              + "}();\n"
+
+              + "var b = function () {\n"
+              + "  var x = (function x () { result += 'b'; });\n"
+              + "  return function () { x(); };\n"
+              + "}();\n"
+
+              + "a();\n"
+              + "b();\n"
+              + "result;";
+
+      assertEvaluates("ab", script);
+    }
+
+    @Test
+    public void innerFunctionWithSameNameAsOutsideStrict() throws Exception {
+      final String script = ""
+              + "var result = '';\n"
+              + "'use strict';\n"
+              + "var a = function () {\n"
+              + "  var x = (function x () { result += 'a'; });\n"
+              + "  return function () { x(); };\n"
+              + "}();\n"
+
+              + "var x = function () { result += 'x'; };\n"
+
+              + "a();\n"
+              + "result;";
+
+      assertEvaluates("a", script);
+    }
+
+    @Test
+    public void secondFunctionWithSameNameStrict() throws Exception {
+      final String script = ""
+              + "var result = '';\n"
+              + "'use strict';\n"
+              + "function norm(foo) { return ('' + foo).replace(/(\\s)/gm,''); }\n"
+
+              + "function func () { result += 'outer'; }\n"
+
+              + "var x = function func() { result += norm(func); };\n"
+
+              + "x();\n"
+              + "func();\n"
+              + "result;";
+
+      assertEvaluates("functionfunc(){result+=norm(func);}outer", script);
+    }
+
+    @Test
+    public void functioNamesExceptionsStrict() throws Exception {
+      final String script = ""
+              + "var result = '';\n"
+              + "  'use strict';\n"
+
+              + "  function f1() {"
+              + "    result += 'f1';"
+              + "    function f9() { result += 'f9'; }"
+              + "  }\n"
+
+              + "  var f2 = function () { result += 'f2'; };\n"
+              + "  var f3 = function f4() { result += 'f3'; };\n"
+              + "  var f5 = function f5() { result += 'f5'; };\n"
+
+              + "  !function f6() { result += 'f6'; };\n"
+              + "  (function f7() { result += 'f7'; });\n"
+
+              + "  void function f8() { result += 'f8'; };\n"
+
+              + "  try { f1(); } catch (e) { result += '!f1'; }"
+              + "  try { f2(); } catch (e) { result += '!f2'; }"
+              + "  try { f3(); } catch (e) { result += '!f3'; }"
+              + "  try { f4(); } catch (e) { result += '!f4'; }"
+              + "  try { f5(); } catch (e) { result += '!f5'; }"
+              + "  try { f6(); } catch (e) { result += '!f6'; }"
+              + "  try { f7(); } catch (e) { result += '!f7'; }"
+              + "  try { f8(); } catch (e) { result += '!f8'; }"
+
+              + "  {\n"
+              + "    function f10() { result += 'f10'; }\n"
+              + "    var f11 = function () { result += 'f11'; };\n"
+              + "    var f12 = function f12() { result += 'f12'; };\n"
+              + "    f10();\n"
+              + "    f11();\n"
+              + "    f12();\n"
+              + "  }\n"
+
+              // does not work so far
+              // + "  try { f10(); } catch (e) { result += '!f10'; }"
+              + "  try { f11(); } catch (e) { result += '!f11'; }"
+              + "  try { f12(); } catch (e) { result += '!f12'; }"
+
+              + "  function f13() { result += 'f13'; } + 1;"
+              + "  try { f13(); } catch (e) { '!f13'; }"
+              + "result;";
+
+      // assertEvaluates("f1f2f3!f4f5!f6!f7!f8f10f11f12!f10f11f12f13", script);
+      assertEvaluates("f1f2f3!f4f5!f6!f7!f8f10f11f12f11f12f13", script);
     }
 
     private void assertEvaluates(final Object expected, final String source) {


### PR DESCRIPTION
functions declared as var f = function f() {...} within a function should not impact higher scope variable with the same name
