### PR TITLE
#511 fixing InterfaceAdapter abstract name lookup.

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -692,7 +692,8 @@ public class NativeJavaObject
                 reportConversionError(value, type);
             }
             else if (type.isInterface() && (value instanceof NativeObject
-                    || value instanceof NativeFunction)) {
+                    || value instanceof NativeFunction
+                    || value instanceof ArrowFunction)) {
                 // Try to use function/object as implementation of Java interface.
                 return createInterfaceAdapter(type, (ScriptableObject) value);
             } else {

--- a/testsrc/org/mozilla/javascript/tests/InterfaceAdapterTest.java
+++ b/testsrc/org/mozilla/javascript/tests/InterfaceAdapterTest.java
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Wrapper;
+
+import junit.framework.TestCase;
+
+/*
+ * This testcase tests the support of converting javascript functions to
+ * functional interface adapters
+ *
+ */
+public class InterfaceAdapterTest extends TestCase {
+
+    private void testIt(String js, Object expected) {
+        Utils.runWithAllOptimizationLevels(cx -> {
+            final ScriptableObject scope = cx.initStandardObjects();
+            scope.put("list", scope, createList());
+            Object o = cx.evaluateString(scope, js,
+                    "testNativeFunction.js", 1, null);
+            if (o instanceof Wrapper) {
+                o = ((Wrapper) o).unwrap();
+            }
+            assertEquals(expected, o);
+
+            return null;
+        });
+    }
+
+    private List<String> createList() {
+        List<String> list = new ArrayList<>();
+        list.add("foo");
+        list.add("bar");
+        return list;
+    }
+
+    @Test
+    public void testNativeFunctionAsConsumer() {
+        String js = "var ret = '';\n"
+                + "list.forEach(function(elem) {  ret += elem });\n"
+                + "ret";
+
+        testIt(js, "foobar");
+    }
+
+    @Test
+    public void testArrowFunctionAsConsumer() {
+        List<String> list = new ArrayList<>();
+        list.add("foo");
+        list.add("bar");
+
+        String js = "var ret = '';\n"
+                + "list.forEach(elem => ret += elem);\n"
+                + "ret";
+
+        testIt(js, "foobar");
+    }
+
+    @Test
+    public void testArrowFunctionAsComparator() {
+        String js = "list";
+        testIt(js, Arrays.asList("foo", "bar"));
+
+        js = "list.sort((a,b) => a > b ? 1:-1)\n"
+                + "list";
+        testIt(js, Arrays.asList("bar", "foo"));
+    }
+    @Test
+    public void testNativeFunctionAsComparator() {
+        String js = "list";
+        testIt(js, Arrays.asList("foo", "bar"));
+        
+        js = "list.sort(function(a,b) { return a > b ? 1:-1 })\n"
+                + "list";
+        testIt(js, Arrays.asList("bar", "foo"));
+    }
+
+}


### PR DESCRIPTION
this is a follow up to #511 and #512 

It fixes the lookup:
- take only abstract methods (ignore default methods)
- skip "equals", "hashCode" and "toString"

There are also tests now.
