### PR TITLE
FIX: NativeJavaObject.getDefaultValue recognizes numbers correctly

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -217,6 +217,9 @@ public class NativeJavaObject
             if (javaObject instanceof Boolean) {
                 hint = ScriptRuntime.BooleanClass;
             }
+            if (javaObject instanceof Number) {
+                hint = ScriptRuntime.NumberClass;
+            }
         }
         if (hint == null || hint == ScriptRuntime.StringClass) {
             value = javaObject.toString();

--- a/testsrc/org/mozilla/javascript/tests/JavaAcessibilityTest.java
+++ b/testsrc/org/mozilla/javascript/tests/JavaAcessibilityTest.java
@@ -111,6 +111,26 @@ public class JavaAcessibilityTest extends TestCase {
       result = runScript(importClass +
       "var x = new PrivateAccessClass(); x.javaBeanProperty = 4; x.javaBeanProperty + ' ' + x.setterCalled;");
       assertEquals("4 true", result);
+      
+      // assume javaObjectProperty is 'false'
+      result = runScript(importClass +
+              "var x = new PrivateAccessClass(); x.javaObjectProperty = x.javaObjectProperty || true; x.javaObjectProperty + ' ' + x.setterCalled;");
+      assertEquals("true true", result);
+
+      // performs a bitxor, so integer/number is returned;
+      result = runScript(importClass +
+              "var x = new PrivateAccessClass(); x.javaObjectProperty ^= true; x.javaObjectProperty + ' ' + x.setterCalled;");
+      assertEquals("1.0 true", result);
+
+      // assume javaObjectProperty is '0'
+      result = runScript(importClass +
+              "var x = new PrivateAccessClass(); x.javaObjectProperty = x.javaObjectProperty + 7; x.javaObjectProperty + ' ' + x.setterCalled;");
+      assertEquals("7.0 true", result);
+
+      // perform simple addition, shoud return "10.0" and not "3.0" + "7" = "3.07"
+      result = runScript(importClass +
+              "var x = new PrivateAccessClass(); x.javaObjectProperty = 3; x.javaObjectProperty = x.javaObjectProperty + 7; x.javaObjectProperty + ' ' + x.setterCalled;");
+      assertEquals("10.0 true", result);
   }
 
   public void testOverloadFunctionRegression() {

--- a/testsrc/org/mozilla/javascript/tests/PrivateAccessClass.java
+++ b/testsrc/org/mozilla/javascript/tests/PrivateAccessClass.java
@@ -44,6 +44,7 @@ public class PrivateAccessClass
   protected int protectedMethod() { return 5; }
 
   private int javaBeanProperty = 6;
+  private Object javaObjectProperty;
   public boolean getterCalled = false;
   public boolean setterCalled = false;
   public int getJavaBeanProperty() {
@@ -53,6 +54,14 @@ public class PrivateAccessClass
   public void setJavaBeanProperty(int i) {
       setterCalled = true;
       javaBeanProperty = i;
+  }
+  public Object getJavaObjectProperty() {
+      getterCalled = true;
+      return javaObjectProperty;
+  }
+  public void setJavaObjectProperty(Object o) {
+    setterCalled = true;
+    this.javaObjectProperty = o;
   }
 
   /*

--- a/testsrc/tests/lc2/Objects/object-005.js
+++ b/testsrc/tests/lc2/Objects/object-005.js
@@ -48,8 +48,43 @@ a[i++] = new TestObject(
   "new java.lang.Integer(2134)",
   new java.lang.Integer(2134),
   "0 + ",
-  "21340",
-  "string" );
+  2134,
+  "number" );
+
+a[i++] = new TestObject(
+  "new java.lang.Integer(2134)",
+  new java.lang.Integer(2134),
+  "1 + ",
+  2135,
+  "number" );
+
+a[i++] = new TestObject(
+  "new java.lang.Integer(2134)",
+  new java.lang.Integer(2134),
+  "+ 1 ",
+  2135,
+  "number" );
+
+a[i++] = new TestObject(
+  "new java.lang.Double(21.34)",
+  new java.lang.Double(21.34),
+  "0 + ",
+  21.34,
+  "number" );
+
+a[i++] = new TestObject(
+  "new java.lang.Double(21.34)",
+  new java.lang.Double(21.34),
+  "1 + ",
+  22.34,
+  "number" );
+
+a[i++] = new TestObject(
+  "new java.lang.Double(21.34)",
+  new java.lang.Double(21.34),
+  "+ 1 ",
+  22.34,
+  "number" );
 
 a[i++] = new TestObject(
   "new java.lang.Integer(666)",
@@ -79,8 +114,8 @@ function CompareValues( t ) {
 }
 function TestObject( description, javaobject, converter, expect, type ) {
   this.description = description;
-  this.javavalue = javaobject
-    this.converter = converter;
+  this.javavalue = javaobject;
+  this.converter = converter;
   this.expect = expect;
   this.type = type;
 
@@ -88,6 +123,8 @@ function TestObject( description, javaobject, converter, expect, type ) {
   case( "Number" ) :  this.actual = Number( javaobject ); break;
   case( "String" ) :  this.actual = String( javaobject ); break;
   case( "Boolean") :  this.actual = Boolean(javaobject ); break;
+  case( "1 + " ) :    this.actual = 1 + javaobject; break;
+  case( "+ 1 " ) :    this.actual = javaobject + 1; break;
   default:            this.actual = javaobject + 0;
   }
   return this;


### PR DESCRIPTION
This fixes an issue when dealing with numbers.

originating issue was a 'javaBean' with an 'javaObject' property where an interger (e.g. 3) was stored.
The javaScript code tried to increment the value with `bean.javaObject += 1`
The result was the string `"3.01"` instead of `4.0`

I also extended the `object-005` test case. 
Here is a list of test results (actual = current, expected=fix with this PR):

- `(new java.lang.Integer(2134)) + 0` Actual: `"12340"` Expected: `1234`
- `(new java.lang.Integer(2134)) + 1` Actual: `"12341"` Expected: `1235`
- `1 + (new java.lang.Integer(2134))` Actual: `"11234"` Expected: `1235`
- `(new java.lang.Double(21.34)) + 0` Actual: `"21.340"` Expected: `21.34`
- `(new java.lang.Double(21.34)) + 1` Actual: `"21.341"` Expected: `22.34`
- `1 + (new java.lang.Double(21.34))` Actual: `"121.34"` Expected: `22.34`

Cheers
Roland
