### PR TITLE
Dynamic scope fix

### DIFF
--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -433,7 +433,7 @@ public class NativeObject extends IdScriptableObject implements Map
                 Object arg = args.length < 1 ? Undefined.instance : args[0];
                 ScriptableObject obj = ensureScriptableObject(arg);
                 Object propsObj = args.length < 2 ? Undefined.instance : args[1];
-                Scriptable props = Context.toObject(propsObj, getParentScope());
+                Scriptable props = Context.toObject(propsObj, scope);
                 obj.defineOwnProperties(cx, ensureScriptableObject(props));
                 return obj;
               }
@@ -443,11 +443,11 @@ public class NativeObject extends IdScriptableObject implements Map
                 Scriptable obj = (arg == null) ? null : ensureScriptable(arg);
 
                 ScriptableObject newObject = new NativeObject();
-                newObject.setParentScope(getParentScope());
+                newObject.setParentScope(scope);
                 newObject.setPrototype(obj);
 
                 if (args.length > 1 && args[1] != Undefined.instance) {
-                  Scriptable props = Context.toObject(args[1], getParentScope());
+                  Scriptable props = Context.toObject(args[1], scope);
                   newObject.defineOwnProperties(cx, ensureScriptableObject(props));
                 }
 


### PR DESCRIPTION
A given scope was ignored by the implementations of Object.create and Object.defineProperties.

The important part was in "case ConstructorId_create:" that newObject.setParentScope(scope); happens, instead of "inheriting" the scope from the given prototype object (first parameter of Object.create).

The rest is only for completion sake. Implementation of Object.defineProperties and handling of the second argument of Object.create both end up ignoring the given scope anyway. Even if Context.toObject(propsObj, scope) returns a new object that has the given scope, the call to obj.defineOwnproperties(cx, ensureScriptableObject(props)) does nothing with it. Only in some fringe edge case scenario with a custom WrapperFactory impl would that matter.