### PR TITLE
Change MozillaSuiteBenchmark to not fork threads.

### DIFF
--- a/testsrc/opt-1.tests
+++ b/testsrc/opt-1.tests
@@ -19,7 +19,6 @@ e4x/Expressions/regress-301545.js
 e4x/Expressions/regress-302531.js
 e4x/Expressions/regress-340024.js
 e4x/Expressions/regress-496113.js
-e4x/GC/regress-280844-1.js
 e4x/GC/regress-292455.js
 e4x/GC/regress-313952-01.js
 e4x/GC/regress-324117.js
@@ -55,7 +54,6 @@ e4x/Regress/regress-301553.js
 e4x/Regress/regress-301573.js
 e4x/Regress/regress-301596.js
 e4x/Regress/regress-301692.js
-e4x/Regress/regress-309897.js
 e4x/Regress/regress-313799.js
 e4x/Regress/regress-318922.js
 e4x/Regress/regress-325425.js
@@ -74,7 +72,6 @@ e4x/Regress/regress-354145-03.js
 e4x/Regress/regress-354145-04.js
 e4x/Regress/regress-354145-05.js
 e4x/Regress/regress-354145-07.js
-e4x/Regress/regress-354998.js
 e4x/Regress/regress-355474-02.js
 e4x/Regress/regress-356238-01.js
 e4x/Regress/regress-369032.js
@@ -1333,7 +1330,6 @@ js1_5/Function/regress-292215.js
 js1_5/Function/regress-344052.js
 js1_5/Function/regress-364023.js
 js1_5/GC/regress-104584.js
-js1_5/GC/regress-203278-2.js
 js1_5/GC/regress-203278-3.js
 js1_5/GC/regress-278725.js
 js1_5/GC/regress-306788.js
@@ -1566,7 +1562,6 @@ js1_5/Regress/regress-449627.js
 js1_5/Regress/regress-449666.js
 js1_5/Regress/regress-450369.js
 js1_5/Regress/regress-450833.js
-js1_5/Regress/regress-451322.js
 js1_5/Regress/regress-451884.js
 js1_5/Regress/regress-451946.js
 js1_5/Regress/regress-452008.js

--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -20,7 +20,6 @@ e4x/Expressions/regress-301545.js
 e4x/Expressions/regress-302531.js
 e4x/Expressions/regress-340024.js
 e4x/Expressions/regress-496113.js
-e4x/GC/regress-280844-1.js
 e4x/GC/regress-280844-2.js
 e4x/GC/regress-292455.js
 e4x/GC/regress-313952-01.js
@@ -58,7 +57,6 @@ e4x/Regress/regress-301573.js
 e4x/Regress/regress-301596.js
 e4x/Regress/regress-301692.js
 e4x/Regress/regress-308111.js
-e4x/Regress/regress-309897.js
 e4x/Regress/regress-313799.js
 e4x/Regress/regress-318922.js
 e4x/Regress/regress-325425.js
@@ -1336,7 +1334,6 @@ js1_5/Function/regress-292215.js
 js1_5/Function/regress-344052.js
 js1_5/Function/regress-364023.js
 js1_5/GC/regress-104584.js
-js1_5/GC/regress-203278-2.js
 js1_5/GC/regress-203278-3.js
 js1_5/GC/regress-278725.js
 js1_5/GC/regress-306788.js
@@ -1571,7 +1568,6 @@ js1_5/Regress/regress-449627.js
 js1_5/Regress/regress-449666.js
 js1_5/Regress/regress-450369.js
 js1_5/Regress/regress-450833.js
-js1_5/Regress/regress-451322.js
 js1_5/Regress/regress-451884.js
 js1_5/Regress/regress-451946.js
 js1_5/Regress/regress-452008.js
@@ -1909,7 +1905,6 @@ js1_6/extensions/regress-455464-01.js
 js1_6/extensions/regress-455464-02.js
 js1_6/extensions/regress-455464-03.js
 js1_6/extensions/regress-455464-04.js
-js1_6/extensions/regress-456826.js
 js1_6/extensions/regress-457521.js
 js1_6/extensions/regress-472508.js
 js1_6/extensions/regress-475144.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -19,7 +19,6 @@ e4x/Expressions/regress-301545.js
 e4x/Expressions/regress-302531.js
 e4x/Expressions/regress-340024.js
 e4x/Expressions/regress-496113.js
-e4x/GC/regress-280844-1.js
 e4x/GC/regress-280844-2.js
 e4x/GC/regress-292455.js
 e4x/GC/regress-313952-01.js
@@ -57,7 +56,6 @@ e4x/Regress/regress-301573.js
 e4x/Regress/regress-301596.js
 e4x/Regress/regress-301692.js
 e4x/Regress/regress-308111.js
-e4x/Regress/regress-309897.js
 e4x/Regress/regress-313799.js
 e4x/Regress/regress-318922.js
 e4x/Regress/regress-325425.js
@@ -1335,7 +1333,6 @@ js1_5/Function/regress-292215.js
 js1_5/Function/regress-344052.js
 js1_5/Function/regress-364023.js
 js1_5/GC/regress-104584.js
-js1_5/GC/regress-203278-2.js
 js1_5/GC/regress-203278-3.js
 js1_5/GC/regress-278725.js
 js1_5/GC/regress-306788.js
@@ -1570,7 +1567,6 @@ js1_5/Regress/regress-449627.js
 js1_5/Regress/regress-449666.js
 js1_5/Regress/regress-450369.js
 js1_5/Regress/regress-450833.js
-js1_5/Regress/regress-451322.js
 js1_5/Regress/regress-451884.js
 js1_5/Regress/regress-451946.js
 js1_5/Regress/regress-452008.js
@@ -1909,7 +1905,6 @@ js1_6/extensions/regress-455464-01.js
 js1_6/extensions/regress-455464-02.js
 js1_6/extensions/regress-455464-03.js
 js1_6/extensions/regress-455464-04.js
-js1_6/extensions/regress-456826.js
 js1_6/extensions/regress-457521.js
 js1_6/extensions/regress-472508.js
 js1_6/extensions/regress-475144.js

--- a/testsrc/org/mozilla/javascript/drivers/ShellTest.java
+++ b/testsrc/org/mozilla/javascript/drivers/ShellTest.java
@@ -360,6 +360,90 @@ public class ShellTest {
         }
     }
 
+    public static void runNoFork(final ShellContextFactory shellContextFactory,
+        final File jsFile, final Parameters parameters,
+        final Status status) throws Exception {
+        final Global global = new Global();
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final PrintStream p = new PrintStream(out);
+        global.setOut(p);
+        global.setErr(p);
+        global.defineFunctionProperties(
+            new String[] { "options" }, ShellTest.class,
+            ScriptableObject.DONTENUM | ScriptableObject.PERMANENT |
+                ScriptableObject.READONLY);
+        // test suite expects keywords to be disallowed as identifiers
+        shellContextFactory.setAllowReservedKeywords(false);
+        final TestState testState = new TestState();
+        if (jsFile.getName().endsWith("-n.js")) {
+            status.setNegative();
+        }
+        final Throwable thrown[] = {null};
+
+        try {
+            shellContextFactory.call(cx ->
+            {
+                status.running(jsFile);
+                testState.errors = new ErrorReporterWrapper(cx.getErrorReporter());
+                cx.setErrorReporter(testState.errors);
+                global.init(cx);
+                try {
+                    runFileIfExists(cx, global,
+                        new File(jsFile.getParentFile().getParentFile().getParentFile(),
+                            "shell.js"));
+                    runFileIfExists(cx, global,
+                        new File(jsFile.getParentFile().getParentFile(), "shell.js"));
+                    runFileIfExists(cx, global, new File(jsFile.getParentFile(), "shell.js"));
+                    runFileIfExists(cx, global, jsFile);
+                    status
+                        .hadErrors(jsFile, testState.errors.errors.toArray(new Status.JsError[0]));
+                } catch (Throwable t) {
+                    status.threw(t);
+                }
+                return null;
+            });
+        } catch (Error t) {
+            thrown[0] = t;
+        } catch (RuntimeException t) {
+            thrown[0] = t;
+        } finally {
+            testState.finished = true;
+        }
+
+        int expectedExitCode = 0;
+        p.flush();
+        status.outputWas(new String(out.toByteArray()));
+        BufferedReader r = new BufferedReader(new InputStreamReader(
+            new ByteArrayInputStream(out.toByteArray())));
+        String failures = "";
+        for(;;)
+        {
+            String s = r.readLine();
+            if(s == null)
+            {
+                break;
+            }
+            if(s.indexOf("FAILED!") != -1)
+            {
+                failures += s + '\n';
+            }
+            int expex = s.indexOf("EXPECT EXIT CODE ");
+            if(expex != -1)
+            {
+                expectedExitCode = s.charAt(expex + "EXPECT EXIT CODE ".length()) - '0';
+            }
+        }
+        if (thrown[0] != null)
+        {
+            status.threw(thrown[0]);
+        }
+        status.exitCodesWere(expectedExitCode, testState.exitCode);
+        if(failures != "")
+        {
+            status.failed(failures);
+        }
+    }
+
     // Global function to mimic options() function in spidermonkey.
     // It looks like this toggles jit compiler mode in spidermonkey
     // when called with "jit" as argument. Our version is a no-op

--- a/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -54,6 +54,7 @@ public class MozillaSuiteTest {
     public MozillaSuiteTest(File jsFile, int optimizationLevel) {
         this.jsFile = jsFile;
         this.optimizationLevel = optimizationLevel;
+        ShellTest.cacheFramework();
     }
 
     public static File getTestDir() throws IOException {

--- a/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -194,7 +194,7 @@ public class MozillaSuiteTest {
         shellContextFactory.setOptimizationLevel(optimizationLevel);
         ShellTestParameters params = new ShellTestParameters();
         JunitStatus status = new JunitStatus();
-        ShellTest.run(shellContextFactory, jsFile, params, status);
+        ShellTest.runNoFork(shellContextFactory, jsFile, params, status);
     }
 
 


### PR DESCRIPTION
We have other ways to do timeouts on tests. We hope that this
change might make this suite run faster.