### PR TITLE
Many small fixes suggested by FindBugs and other linters

### DIFF
--- a/benchmarks/org/mozilla/javascript/benchmarks/V8Benchmark.java
+++ b/benchmarks/org/mozilla/javascript/benchmarks/V8Benchmark.java
@@ -14,7 +14,6 @@ public class V8Benchmark {
   static abstract class AbstractState {
     Context cx;
     Scriptable scope;
-    Callable runFunc;
 
     Callable getFunc(String name) {
       Object f = ScriptableObject.getProperty(scope, name);

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ tasks.withType(JavaCompile) {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
     options.encoding = "UTF-8"
+    options.compilerArgs = [ "-Xlint:deprecation,unchecked" ]
+}
+
+compileTestJava {
+    options.compilerArgs = [ ]
 }
 
 repositories {
@@ -53,7 +58,6 @@ sourceSets {
 dependencies {
     testImplementation "junit:junit:4.13"
     testImplementation "org.yaml:snakeyaml:1.26"
-    testImplementation "net.trajano.caliper:caliper:1.2.1"
     jmhImplementation project
     jmhImplementation 'org.openjdk.jmh:jmh-core:1.23'
     jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.23'
@@ -358,8 +362,8 @@ publishing {
 }
 
 spotbugs {
-    effort = "min"
-    reportLevel = "high"
+    effort = "less"
+    reportLevel = "medium"
     excludeFilter = file("./spotbugs-exclude.xml")
 }
 

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <FindBugsFilter>
+  <!-- In general, do not run this on tests or generated benchmark classes -->
   <Match>
-    <Class name="~org\.mozilla\.javascript\.tests.*"/>
+    <Source name="~.*\/testsrc\/.*"/>
+  </Match>
+  <Match>
+    <Source name="~.*\/examples\/.*"/>
   </Match>
   <Match>
     <Class name="~org\.mozilla\.javascript\.benchmarks\.generated.*"/>
   </Match>
+
+  <!-- Things below are legit exemptions -->
   <Match>
     <!-- Existing "Token" constants have values to 255 -->
     <Class name="org.mozilla.javascript.Interpreter" />
@@ -27,12 +33,101 @@
     <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS" />
   </Match>
   <Match>
-      <Class name="org.mozilla.javascript.NativeSymbol"/>
-      <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS" />
+    <!-- SymbolKey and NativeSymbol objects may be compared directly. -->
+    <Class name="org.mozilla.javascript.NativeSymbol"/>
+    <Bug pattern="EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS" />
   </Match>
   <Match>
-      <!-- Legacy code depends on being able to reassign values in Main -->
-      <Class name="org.mozilla.javascript.tools.shell.Main"/>
-      <Bug pattern="MS_SHOULD_BE_FINAL"/>
+    <!-- Legacy code depends on being able to reassign values in Main -->
+    <Class name="org.mozilla.javascript.tools.shell.Main"/>
+    <Bug pattern="MS_SHOULD_BE_FINAL"/>
+  </Match>
+  <Match>
+    <!-- Legacy code depends on being able to reassign values in Main -->
+    <Class name="org.mozilla.javascript.tools.shell.Main"/>
+    <Bug pattern="MS_PKGPROTECT"/>
+  </Match>
+  <Match>
+    <!-- GUI code just loves to swallow exceptions -->
+    <Class name="org.mozilla.javascript.tools.debugger.SwingGui"/>
+    <Bug pattern="DE_MIGHT_IGNORE"/>
+  </Match>
+  <Match>
+    <!-- In general, the tools need to exit -->
+    <Class name="~org\.mozilla\.javascript\.tools.*"/>
+    <Bug pattern="DM_EXIT"/>
+  </Match>
+  <Match>
+    <!-- Fixing this would break our public API -->
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+  <Match>
+    <!-- We do this in a few places for performance in legacy code -->
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+  <Match>
+    <!-- We check for this in checkstyle using a different annotation -->
+    <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
+  </Match>
+  <Match>
+    <!-- We check for this in checkstyle using a different annotation -->
+    <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
+  </Match>
+  <Match>
+    <!-- Fixing this would break "DEBUG" -->
+    <Class name="org.mozilla.javascript.optimizer.Block"/>
+    <Bug pattern="UUF_UNUSED_FIELD"/>
+  </Match>
+  <Match>
+    <!-- Fixing this would break "DEBUG" -->
+    <Class name="org.mozilla.javascript.regexp.NativeRegExp"/>
+    <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
+  </Match>
+  <Match>
+    <!-- This is kind of a weird thing that's necessary for the security manager -->
+    <Class name="org.mozilla.javascript.tools.shell.JavaPolicySecurity"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+  </Match>
+  <Match>
+    <!-- And this is a weird thing related to maybe multithreading the GUI -->
+    <Class name="org.mozilla.javascript.tools.debugger.Dim"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+  </Match>
+  <Match>
+    <!-- Referenced in generated code -->
+    <Class name="org.mozilla.javascript.optimizer.OptRuntime$GeneratorState"/>
+    <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"/>
+  </Match>
+  <Match>
+    <!-- Referenced in generated code -->
+    <Class name="org.mozilla.javascript.optimizer.OptRuntime$GeneratorState"/>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+  </Match>
+  <!-- Complex legacy stuff -->
+  <!--<Match>
+    <Class name="org.mozilla.javascript.regexp.RegExpImpl"/>
+    <Bug pattern="RC_REF_COMPARISON_BAD_PRACTICE_BOOLEAN"/>
+  </Match>-->
+
+  <!-- Things below are things that we aspire to fix! -->
+  <Match>
+    <!-- We are planning to eliminate serialization -->
+    <Bug pattern="SE_BAD_FIELD"/>
+  </Match>
+  <Match>
+    <!-- We are planning to eliminate serialization -->
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+  </Match>
+  <Match>
+    <!-- We are planning to get rid of synchronization -->
+    <Bug pattern="DC_DOUBLECHECK"/>
+  </Match>
+  <Match>
+    <!-- We are planning to get rid of synchronization -->
+    <Bug pattern="IS2_INCONSISTENT_SYNC"/>
+  </Match>
+  <Match>
+    <!-- We are planning to get rid of synchronization -->
+    <Bug pattern="UG_SYNC_SET_UNSYNC_GET"/>
   </Match>
 </FindBugsFilter>

--- a/src/org/mozilla/classfile/ClassFileWriter.java
+++ b/src/org/mozilla/classfile/ClassFileWriter.java
@@ -1471,8 +1471,6 @@ public class ClassFileWriter {
                 }
             }
 
-            superBlockDeps = getSuperBlockDependencies();
-
             verify();
 
             if (DEBUGSTACKMAP) {
@@ -2596,7 +2594,6 @@ public class ClassFileWriter {
         private int workListTop;
 
         private SuperBlock[] superBlocks;
-        private SuperBlock[] superBlockDeps;
 
         private byte[] rawStackMap;
         private int rawStackMapTop;

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -11,22 +11,17 @@ package org.mozilla.javascript;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URL;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 import org.mozilla.classfile.ClassFileWriter.ClassFileFormatException;
 import org.mozilla.javascript.ast.AstRoot;
@@ -742,42 +737,8 @@ public class Context
      * @return a string that encodes the product, language version, release
      *         number, and date.
      */
-    public final String getImplementationVersion()
-    {
-        if (implementationVersion == null) {
-            Enumeration<URL> urls;
-            try {
-                urls = Context.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
-            } catch (IOException ioe) {
-                return null;
-            }
-
-            // There will be many manifests in the world -- enumerate all of them until we find the right one.
-            while (urls.hasMoreElements()) {
-                URL metaUrl = urls.nextElement();
-                InputStream is = null;
-                try {
-                    is = metaUrl.openStream();
-                    Manifest mf = new Manifest(is);
-                    Attributes attrs = mf.getMainAttributes();
-                    if ("Mozilla Rhino".equals(attrs.getValue("Implementation-Title"))) {
-                        implementationVersion =
-                            "Rhino " + attrs.getValue("Implementation-Version") + " " + attrs.getValue("Built-Date").replaceAll("-", " ");
-                        return implementationVersion;
-                    }
-                } catch (IOException e) {
-                    // Ignore this unlikely event
-                } finally {
-                    try {
-                        if (is != null) is.close();
-                    } catch (IOException e) {
-                        // Ignore this even unlikelier event
-                    }
-                }
-            }
-        }
-
-        return implementationVersion;
+    public final String getImplementationVersion() {
+        return ImplementationVersion.get();
     }
 
     /**
@@ -2723,8 +2684,6 @@ public class Context
     public final boolean isStrictMode() {
         return isTopLevelStrict || (currentActivationCall != null && currentActivationCall.isStrict);
     }
-
-    private static String implementationVersion;
 
     private final ContextFactory factory;
     private boolean sealed;

--- a/src/org/mozilla/javascript/ES6Generator.java
+++ b/src/org/mozilla/javascript/ES6Generator.java
@@ -278,7 +278,7 @@ public final class ES6Generator extends IdScriptableObject {
             throw re;
         } finally {
             if (state == State.COMPLETED) {
-                ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, true);
+                ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, Boolean.TRUE);
             } else {
                 state = State.SUSPENDED_YIELD;
             }
@@ -301,7 +301,7 @@ public final class ES6Generator extends IdScriptableObject {
             if (op == NativeGenerator.GENERATOR_THROW) {
                 throw new JavaScriptException(value, lineSource, lineNumber);
             }
-            ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, true);
+            ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, Boolean.TRUE);
             return result;
         }
 
@@ -351,7 +351,7 @@ public final class ES6Generator extends IdScriptableObject {
             // and we will never delegate to the delegee again
             if (state == State.COMPLETED) {
                 delegee = null;
-                ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, true);
+                ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, Boolean.TRUE);
             }
         }
         return result;

--- a/src/org/mozilla/javascript/ImplementationVersion.java
+++ b/src/org/mozilla/javascript/ImplementationVersion.java
@@ -1,0 +1,50 @@
+package org.mozilla.javascript;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * This class is a singleton that just exists to serve up the implementation version. This should
+ * encourage that it's safely but lazily loaded just once per VM.
+ */
+public class ImplementationVersion {
+
+    private String versionString;
+
+    private static final ImplementationVersion version = new ImplementationVersion();
+
+    public static String get() {
+        return version.versionString;
+    }
+
+    private ImplementationVersion() {
+        Enumeration<URL> urls;
+        try {
+            urls = ImplementationVersion.class.getClassLoader()
+                .getResources("META-INF/MANIFEST.MF");
+        } catch (IOException ioe) {
+            return;
+        }
+
+        // There will be many manifests in the world -- enumerate all of them until we find the right one.
+        while (urls.hasMoreElements()) {
+            URL metaUrl = urls.nextElement();
+            try (InputStream is = metaUrl.openStream()) {
+                Manifest mf = new Manifest(is);
+                Attributes attrs = mf.getMainAttributes();
+                if ("Mozilla Rhino".equals(attrs.getValue("Implementation-Title"))) {
+                    versionString =
+                        "Rhino " + attrs.getValue("Implementation-Version") + " " +
+                            attrs.getValue("Built-Date").replaceAll("-", " ");
+                    return;
+                }
+            } catch (IOException e) {
+                // Ignore this unlikely event
+            }
+        }
+    }
+}

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -3133,9 +3133,9 @@ switch (op) {
     private static boolean stack_boolean(CallFrame frame, int i)
     {
         Object x = frame.stack[i];
-        if (x == Boolean.TRUE) {
+        if (Boolean.TRUE.equals(x)) {
             return true;
-        } else if (x == Boolean.FALSE) {
+        } else if (Boolean.FALSE.equals(x)) {
             return false;
         } else if (x == UniqueTag.DOUBLE_MARK) {
             double d = frame.sDbl[i];
@@ -3145,8 +3145,6 @@ switch (op) {
         } else if (x instanceof Number) {
             double d = ((Number)x).doubleValue();
             return (!Double.isNaN(d) && d != 0.0);
-        } else if (x instanceof Boolean) {
-            return ((Boolean)x).booleanValue();
         } else {
             return ScriptRuntime.toBoolean(x);
         }

--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -918,8 +918,7 @@ public final class JavaAdapter implements IdFunctionCall
                 cfw.add(ByteCode.DRETURN);
                 break;
             default:
-                throw new RuntimeException("Unexpected return type " +
-                                           retType.toString());
+                throw new RuntimeException("Unexpected return type " + retType);
             }
 
         } else {

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -195,7 +195,6 @@ public final class NativeJSON extends IdScriptableObject
             this.gap = gap;
             this.replacer = replacer;
             this.propertyList = propertyList;
-            this.space = space;
         }
 
         Stack<Scriptable> stack = new Stack<Scriptable>();
@@ -203,7 +202,6 @@ public final class NativeJSON extends IdScriptableObject
         String gap;
         Callable replacer;
         List<Object> propertyList;
-        Object space;
 
         Context cx;
         Scriptable scope;
@@ -333,7 +331,7 @@ public final class NativeJSON extends IdScriptableObject
         if (!iter.hasNext()) return "";
         StringBuilder builder = new StringBuilder(iter.next().toString());
         while (iter.hasNext()) {
-            builder.append(delimiter).append(iter.next().toString());
+            builder.append(delimiter).append(iter.next());
         }
         return builder.toString();
     }

--- a/src/org/mozilla/javascript/NativeJavaList.java
+++ b/src/org/mozilla/javascript/NativeJavaList.java
@@ -11,6 +11,7 @@ public class NativeJavaList extends NativeJavaObject {
 
     private List<Object> list;
 
+    @SuppressWarnings("unchecked")
     public NativeJavaList(Scriptable scope, Object list) {
         super(scope, list, list.getClass());
         assert list instanceof List;

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -13,6 +13,7 @@ public class NativeJavaMap extends NativeJavaObject {
 
     private Map<Object, Object> map;
 
+    @SuppressWarnings("unchecked")
     public NativeJavaMap(Scriptable scope, Object map) {
         super(scope, map, map.getClass());
         assert map instanceof Map;

--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -345,6 +345,7 @@ public class NativeSymbol
         return key;
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, NativeSymbol> getGlobalMap() {
         ScriptableObject top = (ScriptableObject)getTopLevelScope(this);
         Map<String, NativeSymbol> map = (Map<String, NativeSymbol>)top.getAssociatedValue(GLOBAL_TABLE_KEY);

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -414,11 +414,9 @@ public class Parser
                 if (compilerEnv.isRecordingComments()) {
                     String comment = ts.getAndResetCurrentComment();
                     recordComment(lineno, comment);
-                    // Comments may contain multiple lines, get the number
-                    // of EoLs and increase the lineno
-                    lineno += getNumberOfEols(comment);
                     break;
-                }tt = ts.getToken();
+                }
+                tt = ts.getToken();
             }
         }
 

--- a/src/org/mozilla/javascript/RhinoException.java
+++ b/src/org/mozilla/javascript/RhinoException.java
@@ -47,9 +47,7 @@ public abstract class RhinoException extends RuntimeException
         }
         StringBuilder buf = new StringBuilder(details);
         buf.append(" (");
-        if (sourceName != null) {
-            buf.append(sourceName);
-        }
+        buf.append(sourceName);
         if (lineNumber > 0) {
             buf.append('#');
             buf.append(lineNumber);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -9,6 +9,7 @@ package org.mozilla.javascript;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -737,16 +738,11 @@ public class ScriptRuntime {
         if (count < args.length)
             return args;
 
-        int i;
         Object[] result = new Object[count];
-        for (i = 0; i < args.length; i++) {
-            result[i] = args[i];
+        System.arraycopy(args, 0, result, 0, args.length);
+        if (args.length < count) {
+            Arrays.fill(result, args.length, count, Undefined.instance);
         }
-
-        for (; i < count; i++) {
-            result[i] = Undefined.instance;
-        }
-
         return result;
     }
 
@@ -1163,7 +1159,7 @@ public class ScriptRuntime {
         Function function = (Function)fun;
         Scriptable thisObj = toObjectOrNull(cx, thisArg, scope);
         if (thisObj == null) {
-            throw undefCallError(thisObj, "function");
+            throw undefCallError(null, "function");
         }
         return function.call(cx, scope, thisObj, args);
     }
@@ -3010,7 +3006,7 @@ public class ScriptRuntime {
                 } while (target != null);
                 scopeChain = scopeChain.getParentScope();
             } while (scopeChain != null);
-            throw notFoundError(scopeChain, id);
+            throw notFoundError(null, id);
         }
         return doScriptableIncrDecr(target, id, scopeChain, value,
                                     incrDecrMask);

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -280,7 +280,7 @@ public abstract class ScriptableObject implements Scriptable,
 
                         String prop = "";
                         if (name != null) {
-                            prop = "[" + start.getClassName() + "]." + name.toString();
+                            prop = "[" + start.getClassName() + "]." + name;
                         }
                         throw ScriptRuntime.typeError2("msg.set.prop.no.setter", prop, Context.toString(value));
                     }

--- a/src/org/mozilla/javascript/Undefined.java
+++ b/src/org/mozilla/javascript/Undefined.java
@@ -45,7 +45,7 @@ public class Undefined implements Serializable
     static {
         SCRIPTABLE_UNDEFINED = (Scriptable) Proxy.newProxyInstance(Undefined.class.getClassLoader(), new Class[]{Scriptable.class}, new InvocationHandler() {
             @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            public Object invoke(Object proxy, Method method, Object[] args) {
                 if (method.getName().equals("toString")) return "undefined";
                 if (method.getName().equals("equals")) {
                     return args.length > 0 && isUndefined(args[0]);

--- a/src/org/mozilla/javascript/WrappedException.java
+++ b/src/org/mozilla/javascript/WrappedException.java
@@ -23,7 +23,7 @@ public class WrappedException extends EvaluatorException
      */
     public WrappedException(Throwable exception)
     {
-        super("Wrapped " + exception.toString());
+        super("Wrapped " + exception);
         this.exception = exception;
         this.initCause(exception);
 

--- a/src/org/mozilla/javascript/ast/ScriptNode.java
+++ b/src/org/mozilla/javascript/ast/ScriptNode.java
@@ -210,9 +210,10 @@ public class ScriptNode extends Scope {
     public int getIndexForNameNode(Node nameNode) {
         if (variableNames == null) codeBug();
         Scope node = nameNode.getScope();
-        Symbol symbol = node == null
-            ? null
-            : node.getSymbol(((Name)nameNode).getIdentifier());
+        Symbol symbol = null;
+        if (node != null && nameNode instanceof Name) {
+            symbol = node.getSymbol(((Name) nameNode).getIdentifier());
+        }
         return (symbol == null) ? -1 : symbol.getIndex();
     }
 

--- a/src/org/mozilla/javascript/commonjs/module/provider/SoftCachingModuleScriptProvider.java
+++ b/src/org/mozilla/javascript/commonjs/module/provider/SoftCachingModuleScriptProvider.java
@@ -105,6 +105,7 @@ public class SoftCachingModuleScriptProvider extends CachingModuleScriptProvider
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream in) throws IOException,
     ClassNotFoundException
     {

--- a/src/org/mozilla/javascript/engine/RhinoScriptEngine.java
+++ b/src/org/mozilla/javascript/engine/RhinoScriptEngine.java
@@ -245,6 +245,7 @@ public class RhinoScriptEngine
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> T getInterface(Class<T> clasz) {
     if ((clasz == null) || !clasz.isInterface()) {
@@ -265,6 +266,7 @@ public class RhinoScriptEngine
         new Class<?>[]{clasz}, new RhinoInvocationHandler(this, null));
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> T getInterface(Object thiz, Class<T> clasz) {
     if ((clasz == null) || !clasz.isInterface()) {

--- a/src/org/mozilla/javascript/engine/RhinoScriptEngineFactory.java
+++ b/src/org/mozilla/javascript/engine/RhinoScriptEngineFactory.java
@@ -32,15 +32,15 @@ public class RhinoScriptEngineFactory
   implements ScriptEngineFactory {
 
   public static final String NAME = "rhino";
-  public static final String LANGUAGE = "javascript";
-  public static final List<String> NAMES =
+  private static final String LANGUAGE = "javascript";
+  private static final List<String> NAMES =
       Arrays.asList("rhino", "Rhino", "javascript", "JavaScript");
-  public static final List<String> EXTENSIONS =
+  private static final List<String> EXTENSIONS =
       Collections.singletonList("js");
-  public static final List<String> MIME_TYPES =
+  private static final List<String> MIME_TYPES =
       Arrays.asList("application/javascript", "application/ecmascript",
           "text/javascript", "text/ecmascript");
-  public static final String LANGUAGE_VERSION =
+  private static final String LANGUAGE_VERSION =
       String.valueOf(RhinoScriptEngine.DEFAULT_LANGUAGE_VERSION);
 
   @Override

--- a/src/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
+++ b/src/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
@@ -21,7 +21,7 @@ import org.mozilla.javascript.VMBridge;
 
 public class VMBridge_jdk18 extends VMBridge
 {
-    private ThreadLocal<Object[]> contextLocal = new ThreadLocal<Object[]>();
+    private static final ThreadLocal<Object[]> contextLocal = new ThreadLocal<Object[]>();
 
     @Override
     protected Object getThreadContextHelper()

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -300,10 +300,12 @@ public final class OptRuntime extends ScriptRuntime
         static final String CLASS_NAME =
             "org/mozilla/javascript/optimizer/OptRuntime$GeneratorState";
 
+        @SuppressWarnings("unused")
         public int resumptionPoint;
         static final String resumptionPoint_NAME = "resumptionPoint";
         static final String resumptionPoint_TYPE = "I";
 
+        @SuppressWarnings("unused")
         public Scriptable thisObj;
         static final String thisObj_NAME = "thisObj";
         static final String thisObj_TYPE =

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -243,7 +243,7 @@ public class RegExpImpl implements RegExpProxy {
             ip[0] = i;
             Object ret = re.executeRegExp(cx, scope, this, target, ip,
                                           NativeRegExp.TEST);
-            if (ret != Boolean.TRUE) {
+            if (!Boolean.TRUE.equals(ret)) {
                 // Mismatch: ensure our caller advances i past end of string.
                 ip[0] = ipsave;
                 matchlen[0] = 1;

--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -128,6 +128,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView impl
 
         if (arg0 instanceof NativeTypedArrayView) {
             // Copy elements from the old array and convert them into our own
+            @SuppressWarnings("unchecked")
             NativeTypedArrayView<T> src = (NativeTypedArrayView<T>)arg0;
             NativeArrayBuffer na = makeArrayBuffer(cx, scope, src.length);
             NativeTypedArrayView<T> v = construct(na, 0, src.length);
@@ -302,7 +303,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView impl
                 NativeTypedArrayView<T> self = realThis(thisObj, f);
                 if (args[0] instanceof NativeTypedArrayView) {
                     int offset = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : 0;
-                    self.setRange((NativeTypedArrayView<T>)args[0], offset);
+                    @SuppressWarnings("unchecked")
+                    NativeTypedArrayView<T> nativeView = (NativeTypedArrayView<T>)args[0];
+                    self.setRange(nativeView, offset);
                     return Undefined.instance;
                 }
                 if (args[0] instanceof NativeArray) {
@@ -550,7 +553,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView impl
         return a;
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "unchecked"})
     @Override
     public <U> U[] toArray(U[] ts)
     {
@@ -595,6 +598,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView impl
     }
 
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean equals(Object o)
     {

--- a/testsrc/opt-1.tests
+++ b/testsrc/opt-1.tests
@@ -1086,7 +1086,6 @@ ecma_3/RegExp/regress-225343.js
 ecma_3/RegExp/regress-24712.js
 ecma_3/RegExp/regress-285219.js
 ecma_3/RegExp/regress-28686.js
-ecma_3/RegExp/regress-289669.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
@@ -1502,7 +1501,6 @@ js1_5/Regress/regress-344804.js
 js1_5/Regress/regress-344959.js
 js1_5/Regress/regress-346237.js
 js1_5/Regress/regress-346801.js
-js1_5/Regress/regress-347306-01.js
 js1_5/Regress/regress-349482-01.js
 js1_5/Regress/regress-349482-02.js
 js1_5/Regress/regress-349592.js
@@ -1544,7 +1542,6 @@ js1_5/Regress/regress-406769.js
 js1_5/Regress/regress-407024.js
 js1_5/Regress/regress-407323.js
 js1_5/Regress/regress-407957.js
-js1_5/Regress/regress-416628.js
 js1_5/Regress/regress-416737-01.js
 js1_5/Regress/regress-416737-02.js
 js1_5/Regress/regress-417893.js
@@ -1686,11 +1683,7 @@ js1_5/Scope/scope-003.js
 js1_5/Scope/scope-004.js
 js1_5/String/regress-107771.js
 js1_5/String/regress-112626.js
-js1_5/String/regress-157334-01.js
 js1_5/String/regress-179068.js
-js1_5/String/regress-314890.js
-js1_5/String/regress-56940-01.js
-js1_5/String/regress-56940-02.js
 js1_5/decompilation/regress-344120.js
 js1_5/decompilation/regress-349489.js
 js1_5/decompilation/regress-349663.js
@@ -1769,7 +1762,6 @@ js1_5/extensions/regress-341956-01.js
 js1_5/extensions/regress-341956-02.js
 js1_5/extensions/regress-341956-03.js
 js1_5/extensions/regress-346494-01.js
-js1_5/extensions/regress-347306-02.js
 js1_5/extensions/regress-350312-01.js
 js1_5/extensions/regress-350312-02.js
 js1_5/extensions/regress-350312-03.js

--- a/testsrc/opt0.tests
+++ b/testsrc/opt0.tests
@@ -1091,7 +1091,6 @@ ecma_3/RegExp/regress-225343.js
 ecma_3/RegExp/regress-24712.js
 ecma_3/RegExp/regress-285219.js
 ecma_3/RegExp/regress-28686.js
-ecma_3/RegExp/regress-289669.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
@@ -1508,7 +1507,6 @@ js1_5/Regress/regress-344804.js
 js1_5/Regress/regress-344959.js
 js1_5/Regress/regress-346237.js
 js1_5/Regress/regress-346801.js
-js1_5/Regress/regress-347306-01.js
 js1_5/Regress/regress-349482-01.js
 js1_5/Regress/regress-349482-02.js
 js1_5/Regress/regress-349592.js
@@ -1550,7 +1548,6 @@ js1_5/Regress/regress-406769.js
 js1_5/Regress/regress-407024.js
 js1_5/Regress/regress-407323.js
 js1_5/Regress/regress-407957.js
-js1_5/Regress/regress-416628.js
 js1_5/Regress/regress-416737-01.js
 js1_5/Regress/regress-416737-02.js
 js1_5/Regress/regress-417893.js
@@ -1691,12 +1688,7 @@ js1_5/Scope/scope-003.js
 js1_5/Scope/scope-004.js
 js1_5/String/regress-107771.js
 js1_5/String/regress-112626.js
-js1_5/String/regress-157334-01.js
 js1_5/String/regress-179068.js
-js1_5/String/regress-314890.js
-js1_5/String/regress-322772.js
-js1_5/String/regress-56940-01.js
-js1_5/String/regress-56940-02.js
 js1_5/decompilation/regress-344120.js
 js1_5/decompilation/regress-349489.js
 js1_5/decompilation/regress-349663.js
@@ -1774,7 +1766,6 @@ js1_5/extensions/regress-341956-01.js
 js1_5/extensions/regress-341956-02.js
 js1_5/extensions/regress-341956-03.js
 js1_5/extensions/regress-346494-01.js
-js1_5/extensions/regress-347306-02.js
 js1_5/extensions/regress-350312-01.js
 js1_5/extensions/regress-350312-02.js
 js1_5/extensions/regress-350312-03.js

--- a/testsrc/opt9.tests
+++ b/testsrc/opt9.tests
@@ -1090,7 +1090,6 @@ ecma_3/RegExp/regress-225343.js
 ecma_3/RegExp/regress-24712.js
 ecma_3/RegExp/regress-285219.js
 ecma_3/RegExp/regress-28686.js
-ecma_3/RegExp/regress-289669.js
 ecma_3/RegExp/regress-309840.js
 ecma_3/RegExp/regress-312351.js
 ecma_3/RegExp/regress-31316.js
@@ -1507,7 +1506,6 @@ js1_5/Regress/regress-344804.js
 js1_5/Regress/regress-344959.js
 js1_5/Regress/regress-346237.js
 js1_5/Regress/regress-346801.js
-js1_5/Regress/regress-347306-01.js
 js1_5/Regress/regress-349482-01.js
 js1_5/Regress/regress-349482-02.js
 js1_5/Regress/regress-349592.js
@@ -1549,7 +1547,6 @@ js1_5/Regress/regress-406769.js
 js1_5/Regress/regress-407024.js
 js1_5/Regress/regress-407323.js
 js1_5/Regress/regress-407957.js
-js1_5/Regress/regress-416628.js
 js1_5/Regress/regress-416737-01.js
 js1_5/Regress/regress-416737-02.js
 js1_5/Regress/regress-417893.js
@@ -1691,12 +1688,7 @@ js1_5/Scope/scope-003.js
 js1_5/Scope/scope-004.js
 js1_5/String/regress-107771.js
 js1_5/String/regress-112626.js
-js1_5/String/regress-157334-01.js
 js1_5/String/regress-179068.js
-js1_5/String/regress-314890.js
-js1_5/String/regress-322772.js
-js1_5/String/regress-56940-01.js
-js1_5/String/regress-56940-02.js
 js1_5/decompilation/regress-344120.js
 js1_5/decompilation/regress-349489.js
 js1_5/decompilation/regress-349663.js
@@ -1774,7 +1766,6 @@ js1_5/extensions/regress-341956-01.js
 js1_5/extensions/regress-341956-02.js
 js1_5/extensions/regress-341956-03.js
 js1_5/extensions/regress-346494-01.js
-js1_5/extensions/regress-347306-02.js
 js1_5/extensions/regress-350312-01.js
 js1_5/extensions/regress-350312-02.js
 js1_5/extensions/regress-350312-03.js

--- a/toolsrc/org/mozilla/javascript/tools/debugger/Dim.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/Dim.java
@@ -1018,6 +1018,7 @@ interruptedCheck:
          * Performs the action given by {@link #type} with the attached
          * {@link ContextFactory}.
          */
+        @SuppressWarnings("unchecked")
         private void withContext() {
             dim.contextFactory.call(this);
         }

--- a/toolsrc/org/mozilla/javascript/tools/idswitch/SwitchGenerator.java
+++ b/toolsrc/org/mozilla/javascript/tools/idswitch/SwitchGenerator.java
@@ -358,7 +358,7 @@ public class SwitchGenerator {
         int line1 = a.getLineNumber(), line2 = b.getLineNumber();
         if (line2 > line1) { int tmp = line1; line1 = line2; line2 = tmp; }
         String error_text = ToolErrorReporter.getMessage(
-            "msg.idswitch.same_string", a.id, new Integer(line2));
+            "msg.idswitch.same_string", a.id, line2);
         return R.runtimeError(error_text, source_file, line1, null, 0);
     }
 

--- a/toolsrc/org/mozilla/javascript/tools/jsc/Main.java
+++ b/toolsrc/org/mozilla/javascript/tools/jsc/Main.java
@@ -264,8 +264,8 @@ public class Main {
             for (int j = 0; j != compiled.length; j += 2) {
                 String className = (String)compiled[j];
                 byte[] bytes = (byte[])compiled[j + 1];
-                File outfile = getOutputFile(targetTopDir, className);
                 try {
+                    File outfile = getOutputFile(targetTopDir, className);
                     FileOutputStream os = new FileOutputStream(outfile);
                     try {
                         os.write(bytes);
@@ -297,7 +297,7 @@ public class Main {
         return null;
     }
 
-    private File getOutputFile(File parentDir, String className)
+    private File getOutputFile(File parentDir, String className) throws IOException
     {
         String path = className.replace('.', File.separatorChar);
         path = path.concat(".class");
@@ -306,7 +306,9 @@ public class Main {
         if (dirPath != null) {
             File dir = new File(dirPath);
             if (!dir.exists()) {
-                dir.mkdirs();
+                if (!dir.mkdirs()) {
+                    throw new IOException("Error making output directory " + dirPath);
+                }
             }
         }
         return f;

--- a/toolsrc/org/mozilla/javascript/tools/shell/Main.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Main.java
@@ -11,12 +11,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -468,7 +468,7 @@ public class Main
                 if (filename == null)
                     prompt = prompts[0];
                 console.flush();
-                String source = "";
+                StringBuilder source = new StringBuilder();
 
                 // Collect lines of source to compile.
                 while (true) {
@@ -484,20 +484,21 @@ public class Main
                         hitEOF = true;
                         break;
                     }
-                    source = source + newline + "\n";
+                    source.append(newline).append('\n');
                     lineno++;
-                    if (cx.stringIsCompilableUnit(source))
+                    if (cx.stringIsCompilableUnit(source.toString()))
                         break;
                     prompt = prompts[1];
                 }
                 try {
-                    Script script = cx.compileString(source, "<stdin>", lineno, null);
+                    String finalSource = source.toString();
+                    Script script = cx.compileString(finalSource, "<stdin>", lineno, null);
                     if (script != null) {
                         Object result = script.exec(cx, scope);
                         // Avoid printing out undefined or function definitions.
                         if (result != Context.getUndefinedValue() &&
                                 !(result instanceof Function &&
-                                        source.trim().startsWith("function")))
+                                        finalSource.trim().startsWith("function")))
                         {
                             try {
                                 console.println(Context.toString(result));
@@ -606,11 +607,7 @@ public class Main
 
         if (source != null) {
             if (source instanceof String) {
-                try {
-                    bytes = ((String)source).getBytes("UTF-8");
-                } catch (UnsupportedEncodingException ue) {
-                    bytes = ((String)source).getBytes();
-                }
+                bytes = ((String)source).getBytes(StandardCharsets.UTF_8);
             } else {
                 bytes = (byte[])source;
             }

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/QName.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/QName.java
@@ -355,7 +355,7 @@ final class QName extends IdScriptableObject
             if (!"*".equals(localName)) {
                 sb.append("null, ");
             }
-        } else {
+        } else if (uri != null) {
             Namespace.toSourceImpl(prefix, uri, sb);
             sb.append(", ");
         }

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XML.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XML.java
@@ -195,6 +195,7 @@ class XML extends XMLObjectImpl {
     }
 
     //    See ECMA 357, 11_2_2_1, Semantics, 3_f.
+    @SuppressWarnings("deprecation")
     @Override
     public Scriptable getExtraMethodSource(Context cx) {
         if (hasSimpleContent()) {

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLName.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLName.java
@@ -334,6 +334,7 @@ class XMLName extends Ref {
         return xmlObject.getXMLProperty(this);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Object set(Context cx, Object value) {
         if (xmlObject == null) {

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlNode.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlNode.java
@@ -744,13 +744,7 @@ class XmlNode implements Serializable {
                 if (node != null) {
                     lookupPrefix(node);
                 } else {
-                    if (namespace.getUri().equals("")) {
-                        namespace.setPrefix("");
-                    } else {
-                        //    TODO    I am not sure this is right, but if we are creating a standalone node, I think we can set the
-                        //            default namespace on the node itself and not worry about setting a prefix for that namespace.
-                        namespace.setPrefix("");
-                    }
+                    namespace.setPrefix("");
                 }
             }
             return qualify(namespace.getPrefix(), localName);


### PR DESCRIPTION
Change SpotBugs report level to "medium" from "high".

Enable and annotate Java lint warnings for main source tree.

Move implementation version handling to a separate class to eliminate
weird usage of static variables.

Small fixes to string concatenation, Boolean comparison,
null checks, and dead variables.