### PR TITLE
travis ci: switch from trusty to xenial + set explicit -Xss in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-dist: trusty
+dist: xenial
 jdk: 
   - openjdk8
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
 test {
     useJUnit()
     exclude "**/benchmarks/**"
+    
+    jvmArgs += '-Xss1152k'
 
     jacoco.excludes = ['**/testsrc_tests_ecma_3_RegExp_perlstress*']
 


### PR DESCRIPTION
Hi, this PR fix the travis CI build. See https://travis-ci.org/github/syjer/rhino/builds/700382792 .

Currently (https://travis-ci.org/github/mozilla/rhino/builds/700365658#L530) it fails due to reaching the limit of the stack size by most likely a small amount.

Setting it explicitly in the test task (with a value that is in the normal range) fix the build.

I've also updated the distribution.