### PR TITLE
try to fix circle, increase Xss

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ test {
     useJUnit()
     exclude "**/benchmarks/**"
     
-    jvmArgs += '-Xss1152k'
+    jvmArgs += '-Xss1280k'
 
     jacoco.excludes = ['**/testsrc_tests_ecma_3_RegExp_perlstress*']
 


### PR DESCRIPTION
Hi, this PR increase a little bit more the Xss for circle ci.

Currently it fail https://app.circleci.com/pipelines/github/mozilla/rhino/39/workflows/97f3c138-2e1e-4f09-9b7e-e43580af8d2f/jobs/44/steps , with the increase, it seems to pass there too https://app.circleci.com/pipelines/github/syjer/rhino/4/workflows/b7280c33-48da-4587-af30-61096c5307ba/jobs/4/parallel-runs/0/steps/0-107 (I hope it's public).

Looks like there is a difference in the version of the openjdk 8 in use on both ci environment, I would guess this can cause this difference in behavior.
