### PR TITLE
Enable java 11 build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 dist: xenial
 jdk: 
   - openjdk8
+  - openjdk11
 script:
   - travis_wait 30 ./gradlew check
 

--- a/src/org/mozilla/classfile/ConstantPool.java
+++ b/src/org/mozilla/classfile/ConstantPool.java
@@ -144,8 +144,8 @@ final class ConstantPool
   }
 
   /**
-   * Get maximum i such that <tt>start <= i <= end</tt> and
-   * <tt>s.substring(start, i)</tt> fits JVM UTF string encoding limit.
+   * Get maximum i such that <code>start <= i <= end</code> and
+   * <code>s.substring(start, i)</code> fits JVM UTF string encoding limit.
    */
   int getUtfEncodingLimit(String s, int start, int end)
   {

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -412,9 +412,9 @@ public class BaseFunction extends IdScriptableObject implements Function
     /**
      * Creates new script object.
      * The default implementation of {@link #construct} uses the method to
-     * to get the value for <tt>thisObj</tt> argument when invoking
+     * to get the value for <code>thisObj</code> argument when invoking
      * {@link #call}.
-     * The methos is allowed to return <tt>null</tt> to indicate that
+     * The methos is allowed to return <code>null</code> to indicate that
      * {@link #call} will create a new object itself. In this case
      * {@link #construct} will set scope and prototype on the result
      * {@link #call} unless they are already set.

--- a/src/org/mozilla/javascript/ClassCache.java
+++ b/src/org/mozilla/javascript/ClassCache.java
@@ -100,7 +100,7 @@ public class ClassCache implements Serializable
      * Set whether to cache some values.
      * <p>
      * By default, the engine will cache the results of
-     * <tt>Class.getMethods()</tt> and similar calls.
+     * <code>Class.getMethods()</code> and similar calls.
      * This can speed execution dramatically, but increases the memory
      * footprint. Also, with caching enabled, references may be held to
      * objects past the lifetime of any real usage.

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -126,8 +126,8 @@ public class Context
     public static final int VERSION_ES6 =      200;
 
     /**
-     * Controls behaviour of <tt>Date.prototype.getYear()</tt>.
-     * If <tt>hasFeature(FEATURE_NON_ECMA_GET_YEAR)</tt> returns true,
+     * Controls behaviour of <code>Date.prototype.getYear()</code>.
+     * If <code>hasFeature(FEATURE_NON_ECMA_GET_YEAR)</code> returns true,
      * Date.prototype.getYear subtructs 1900 only if 1900 &lt;= date &lt; 2000.
      * The default behavior of {@link #hasFeature(int)} is always to subtruct
      * 1900 as rquired by ECMAScript B.2.4.
@@ -136,9 +136,9 @@ public class Context
 
     /**
      * Control if member expression as function name extension is available.
-     * If <tt>hasFeature(FEATURE_MEMBER_EXPR_AS_FUNCTION_NAME)</tt> returns
-     * true, allow <tt>function memberExpression(args) { body }</tt> to be
-     * syntax sugar for <tt>memberExpression = function(args) { body }</tt>,
+     * If <code>hasFeature(FEATURE_MEMBER_EXPR_AS_FUNCTION_NAME)</code> returns
+     * true, allow <code>function memberExpression(args) { body }</code> to be
+     * syntax sugar for <code>memberExpression = function(args) { body }</code>,
      * when memberExpression is not a simple identifier.
      * See ECMAScript-262, section 11.2 for definition of memberExpression.
      * By default {@link #hasFeature(int)} returns false.
@@ -147,7 +147,7 @@ public class Context
 
     /**
      * Control if reserved keywords are treated as identifiers.
-     * If <tt>hasFeature(RESERVED_KEYWORD_AS_IDENTIFIER)</tt> returns true,
+     * If <code>hasFeature(RESERVED_KEYWORD_AS_IDENTIFIER)</code> returns true,
      * treat future reserved keyword (see  Ecma-262, section 7.5.3) as ordinary
      * identifiers but warn about this usage.
      *
@@ -156,14 +156,14 @@ public class Context
     public static final int FEATURE_RESERVED_KEYWORD_AS_IDENTIFIER = 3;
 
     /**
-     * Control if <tt>toString()</tt> should returns the same result
-     * as  <tt>toSource()</tt> when applied to objects and arrays.
-     * If <tt>hasFeature(FEATURE_TO_STRING_AS_SOURCE)</tt> returns true,
-     * calling <tt>toString()</tt> on JS objects gives the same result as
-     * calling <tt>toSource()</tt>. That is it returns JS source with code
+     * Control if <code>toString()</code> should returns the same result
+     * as  <code>toSource()</code> when applied to objects and arrays.
+     * If <code>hasFeature(FEATURE_TO_STRING_AS_SOURCE)</code> returns true,
+     * calling <code>toString()</code> on JS objects gives the same result as
+     * calling <code>toSource()</code>. That is it returns JS source with code
      * to create an object with all enumeratable fields of the original object
-     * instead of printing <tt>[object <i>result of
-     * {@link Scriptable#getClassName()}</i>]</tt>.
+     * instead of printing <code>[object <i>result of
+     * {@link Scriptable#getClassName()}</i>]</code>.
      * <p>
      * By default {@link #hasFeature(int)} returns true only if
      * the current JS version is set to {@link #VERSION_1_2}.
@@ -171,18 +171,18 @@ public class Context
     public static final int FEATURE_TO_STRING_AS_SOURCE = 4;
 
     /**
-     * Control if properties <tt>__proto__</tt> and <tt>__parent__</tt>
+     * Control if properties <code>__proto__</code> and <code>__parent__</code>
      * are treated specially.
-     * If <tt>hasFeature(FEATURE_PARENT_PROTO_PROPERTIES)</tt> returns true,
-     * treat <tt>__parent__</tt> and <tt>__proto__</tt> as special properties.
+     * If <code>hasFeature(FEATURE_PARENT_PROTO_PROPERTIES)</code> returns true,
+     * treat <code>__parent__</code> and <code>__proto__</code> as special properties.
      * <p>
      * The properties allow to query and set scope and prototype chains for the
      * objects. The special meaning of the properties is available
      * only when they are used as the right hand side of the dot operator.
-     * For example, while <tt>x.__proto__ = y</tt> changes the prototype
-     * chain of the object <tt>x</tt> to point to <tt>y</tt>,
-     * <tt>x["__proto__"] = y</tt> simply assigns a new value to the property
-     * <tt>__proto__</tt> in <tt>x</tt> even when the feature is on.
+     * For example, while <code>x.__proto__ = y</code> changes the prototype
+     * chain of the object <code>x</code> to point to <code>y</code>,
+     * <code>x["__proto__"] = y</code> simply assigns a new value to the property
+     * <code>__proto__</code> in <code>x</code> even when the feature is on.
      *
      * By default {@link #hasFeature(int)} returns true.
      */
@@ -505,7 +505,7 @@ public class Context
      * Call {@link ContextAction#run(Context cx)}
      * using the Context instance associated with the current thread.
      * If no Context is associated with the thread, then
-     * <tt>ContextFactory.getGlobal().makeContext()</tt> will be called to
+     * <code>ContextFactory.getGlobal().makeContext()</code> will be called to
      * construct new Context instance. The instance will be temporary
      * associated with the thread during call to
      * {@link ContextAction#run(Context)}.
@@ -530,7 +530,7 @@ public class Context
      * new Context instance. The instance will be temporary associated
      * with the thread during call to {@link ContextAction#run(Context)}.
      * <p>
-     * It is allowed but not advisable to use null for <tt>factory</tt>
+     * It is allowed but not advisable to use null for <code>factory</code>
      * argument in which case the global static singleton ContextFactory
      * instance will be used to create new context instances.
      * @see ContextFactory#call(ContextAction)
@@ -621,9 +621,9 @@ public class Context
      * including calling {@link #enter()} and {@link #exit()} methods will
      * throw an exception.
      * <p>
-     * If <tt>sealKey</tt> is not null, calling
+     * If <code>sealKey</code> is not null, calling
      * {@link #unseal(Object sealKey)} with the same key unseals
-     * the object. If <tt>sealKey</tt> is null, unsealing is no longer possible.
+     * the object. If <code>sealKey</code> is null, unsealing is no longer possible.
      *
      * @see #isSealed()
      * @see #unseal(Object)
@@ -637,8 +637,8 @@ public class Context
 
     /**
      * Unseal previously sealed Context object.
-     * The <tt>sealKey</tt> argument should not be null and should match
-     * <tt>sealKey</tt> suplied with the last call to
+     * The <code>sealKey</code> argument should not be null and should match
+     * <code>sealKey</code> suplied with the last call to
      * {@link #seal(Object)} or an exception will be thrown.
      *
      * @see #isSealed()
@@ -1795,7 +1795,7 @@ public class Context
      * <p>
      * Note that for Number instances during any arithmetic operation in
      * JavaScript the engine will always use the result of
-     * <tt>Number.doubleValue()</tt> resulting in a precision loss if
+     * <code>Number.doubleValue()</code> resulting in a precision loss if
      * the number can not fit into double.
      * <p>
      * If value is an instance of Character, it will be converted to string of
@@ -2057,7 +2057,7 @@ public class Context
     /**
      * Set the security controller for this context.
      * <p> SecurityController may only be set if it is currently null
-     * and {@link SecurityController#hasGlobal()} is <tt>false</tt>.
+     * and {@link SecurityController#hasGlobal()} is <code>false</code>.
      * Otherwise a SecurityException is thrown.
      * @param controller a SecurityController object
      * @throws SecurityException if there is already a SecurityController

--- a/src/org/mozilla/javascript/ContextAction.java
+++ b/src/org/mozilla/javascript/ContextAction.java
@@ -17,7 +17,7 @@ public interface ContextAction<T>
 {
     /**
      * Execute action using the supplied Context instance.
-     * When Rhino runtime calls the method, <tt>cx</tt> will be associated
+     * When Rhino runtime calls the method, <code>cx</code> will be associated
      * with the current thread as active context.
      *
      * @see ContextFactory#call(ContextAction)

--- a/src/org/mozilla/javascript/ContextFactory.java
+++ b/src/org/mozilla/javascript/ContextFactory.java
@@ -207,7 +207,7 @@ public class ContextFactory
      * thread.
      * This is a callback method used by Rhino to create {@link Context}
      * instance when it is necessary to associate one with the current
-     * execution thread. <tt>makeContext()</tt> is allowed to call
+     * execution thread. <code>makeContext()</code> is allowed to call
      * {@link Context#seal(Object)} on the result to prevent
      * {@link Context} changes by hostile scripts or applets.
      */
@@ -543,7 +543,7 @@ public class ContextFactory
      *          Context.exit();
      *      }
      * </pre>
-     * Instead of using <tt>enterContext()</tt>, <tt>exit()</tt> pair consider
+     * Instead of using <code>enterContext()</code>, <code>exit()</code> pair consider
      * using {@link #call(ContextAction)} which guarantees proper association
      * of Context instances with the current thread.
      * With this method the above example becomes:

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -157,7 +157,7 @@ public class FunctionObject extends BaseFunction
     }
 
     /**
-     * @return One of <tt>JAVA_*_TYPE</tt> constants to indicate desired type
+     * @return One of <code>JAVA_*_TYPE</code> constants to indicate desired type
      *         or {@link #JAVA_UNSUPPORTED_TYPE} if the convertion is not
      *         possible
      */

--- a/src/org/mozilla/javascript/InterfaceAdapter.java
+++ b/src/org/mozilla/javascript/InterfaceAdapter.java
@@ -22,7 +22,7 @@ public class InterfaceAdapter
      * call the supplied JS function when called.
      * Only interfaces were all methods have the same signature is supported.
      *
-     * @return The glue object or null if <tt>cl</tt> is not interface or
+     * @return The glue object or null if <code>cl</code> is not interface or
      *         has methods with different signatures.
      */
     static Object create(Context cx, Class<?> cl, ScriptableObject object)

--- a/src/org/mozilla/javascript/Kit.java
+++ b/src/org/mozilla/javascript/Kit.java
@@ -80,8 +80,8 @@ public class Kit
     }
 
     /**
-     * If character <tt>c</tt> is a hexadecimal digit, return
-     * <tt>accumulator</tt> * 16 plus corresponding
+     * If character <code>c</code> is a hexadecimal digit, return
+     * <code>accumulator</code> * 16 plus corresponding
      * number. Otherise return -1.
      */
     public static int xDigitToInt(int c, int accumulator)
@@ -366,8 +366,8 @@ public class Kit
     /**
      * Throws RuntimeException to indicate failed assertion.
      * The function never returns and its return type is RuntimeException
-     * only to be able to write <tt>throw Kit.codeBug()</tt> if plain
-     * <tt>Kit.codeBug()</tt> triggers unreachable code error.
+     * only to be able to write <code>throw Kit.codeBug()</code> if plain
+     * <code>Kit.codeBug()</code> triggers unreachable code error.
      */
     public static RuntimeException codeBug()
         throws RuntimeException
@@ -381,8 +381,8 @@ public class Kit
     /**
      * Throws RuntimeException to indicate failed assertion.
      * The function never returns and its return type is RuntimeException
-     * only to be able to write <tt>throw Kit.codeBug()</tt> if plain
-     * <tt>Kit.codeBug()</tt> triggers unreachable code error.
+     * only to be able to write <code>throw Kit.codeBug()</code> if plain
+     * <code>Kit.codeBug()</code> triggers unreachable code error.
      */
     public static RuntimeException codeBug(String msg)
         throws RuntimeException

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -1757,13 +1757,12 @@ final class NativeDate extends IdScriptableObject
     /* cached values */
     private static final TimeZone thisTimeZone = TimeZone.getDefault();
     private static final double LocalTZA = thisTimeZone.getRawOffset();
+
+    //not thread safe
     private static final DateFormat timeZoneFormatter = new SimpleDateFormat("zzz");
-    private static final DateFormat localeDateTimeFormatter =
-        DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG);
-    private static final DateFormat localeDateFormatter =
-        DateFormat.getDateInstance(DateFormat.LONG);
-    private static final DateFormat localeTimeFormatter =
-        DateFormat.getTimeInstance(DateFormat.LONG);
+    private static final DateFormat localeDateTimeFormatter = new SimpleDateFormat("MMMM d, yyyy h:mm:ss a z");
+    private static final DateFormat localeDateFormatter = new SimpleDateFormat("MMMM d, yyyy");
+    private static final DateFormat localeTimeFormatter = new SimpleDateFormat("h:mm:ss a z");
 
     private double date;
 }

--- a/src/org/mozilla/javascript/NativeFunction.java
+++ b/src/org/mozilla/javascript/NativeFunction.java
@@ -121,14 +121,14 @@ public abstract class NativeFunction extends BaseFunction
 
     /**
      * Get parameter or variable name.
-     * If <tt>index &lt; {@link #getParamCount()}</tt>, then return the name of the
+     * If <code>index &lt; {@link #getParamCount()}</code>, then return the name of the
      * corresponding parameter. Otherwise return the name of variable.
      */
     protected abstract String getParamOrVarName(int index);
 
     /**
      * Get parameter or variable const-ness.
-     * If <tt>index &lt; {@link #getParamCount()}</tt>, then return the const-ness
+     * If <code>index &lt; {@link #getParamCount()}</code>, then return the const-ness
      * of the corresponding parameter. Otherwise return whether the variable is
      * const.
      */

--- a/src/org/mozilla/javascript/Node.java
+++ b/src/org/mozilla/javascript/Node.java
@@ -527,7 +527,7 @@ public class Node implements Iterable<Node>
         this.lineno = lineno;
     }
 
-    /** Can only be called when <tt>getType() == Token.NUMBER</tt> */
+    /** Can only be called when <code>getType() == Token.NUMBER</code> */
     public final double getDouble() {
         return ((NumberLiteral)this).getNumber();
     }

--- a/src/org/mozilla/javascript/RhinoException.java
+++ b/src/org/mozilla/javascript/RhinoException.java
@@ -74,7 +74,7 @@ public abstract class RhinoException extends RuntimeException
      * Initialize the uri of the script source containing the error.
      *
      * @param sourceName the uri of the script source responsible for the error.
-     *                   It should not be <tt>null</tt>.
+     *                   It should not be <code>null</code>.
      *
      * @throws IllegalStateException if the method is called more then once.
      */
@@ -144,7 +144,7 @@ public abstract class RhinoException extends RuntimeException
      * Initialize the text of the source line containing the error.
      *
      * @param lineSource the text of the source line responsible for the error.
-     *                   It should not be <tt>null</tt>.
+     *                   It should not be <code>null</code>.
      *
      * @throws IllegalStateException if the method is called more then once.
      */

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3593,10 +3593,10 @@ public class ScriptRuntime {
     }
 
     /**
-     * Return <tt>possibleDynamicScope</tt> if <tt>staticTopScope</tt>
-     * is present on its prototype chain and return <tt>staticTopScope</tt>
+     * Return <code>possibleDynamicScope</code> if <code>staticTopScope</code>
+     * is present on its prototype chain and return <code>staticTopScope</code>
      * otherwise.
-     * Should only be called when <tt>staticTopScope</tt> is top scope.
+     * Should only be called when <code>staticTopScope</code> is top scope.
      */
     static Scriptable checkDynamicScope(Scriptable possibleDynamicScope,
                                         Scriptable staticTopScope)

--- a/src/org/mozilla/javascript/Scriptable.java
+++ b/src/org/mozilla/javascript/Scriptable.java
@@ -54,7 +54,7 @@ public interface Scriptable {
      * Depending on the property selector, the runtime will call
      * this method or the form of <code>get</code> that takes an
      * integer:
-     * <table summary='mapping js code to java code'>
+     * <table>
      * <tr><th>JavaScript code</th><th>Java code</th></tr>
      * <tr><td>a.b      </td><td>a.get("b", a)</td></tr>
      * <tr><td>a["foo"] </td><td>a.get("foo", a)</td></tr>

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -1123,17 +1123,17 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Custom <tt>==</tt> operator.
+     * Custom <code>==</code> operator.
      * Must return {@link Scriptable#NOT_FOUND} if this object does not
      * have custom equality operator for the given value,
-     * <tt>Boolean.TRUE</tt> if this object is equivalent to <tt>value</tt>,
-     * <tt>Boolean.FALSE</tt> if this object is not equivalent to
-     * <tt>value</tt>.
+     * <code>Boolean.TRUE</code> if this object is equivalent to <code>value</code>,
+     * <code>Boolean.FALSE</code> if this object is not equivalent to
+     * <code>value</code>.
      * <p>
      * The default implementation returns Boolean.TRUE
-     * if <tt>this == value</tt> or {@link Scriptable#NOT_FOUND} otherwise.
+     * if <code>this == value</code> or {@link Scriptable#NOT_FOUND} otherwise.
      * It indicates that by default custom equality is available only if
-     * <tt>value</tt> is <tt>this</tt> in which case true is returned.
+     * <code>value</code> is <code>this</code> in which case true is returned.
      */
     protected Object equivalentValues(Object value)
     {

--- a/src/org/mozilla/javascript/SecurityController.java
+++ b/src/org/mozilla/javascript/SecurityController.java
@@ -141,7 +141,7 @@ public abstract class SecurityController
      * allowed only if it is allowed according to the Java stack on the
      * moment of the <i>execWithDomain</i> call and <i>securityDomain</i>.
      * Any call to {@link #getDynamicSecurityDomain(Object)} during
-     * execution of <tt>callable.call(cx, scope, thisObj, args)</tt>
+     * execution of <code>callable.call(cx, scope, thisObj, args)</code>
      * should return a domain incorporate restrictions imposed by
      * <i>securityDomain</i> and Java stack on the moment of callWithDomain
      * invocation.

--- a/src/org/mozilla/javascript/VMBridge.java
+++ b/src/org/mozilla/javascript/VMBridge.java
@@ -57,7 +57,7 @@ public abstract class VMBridge
 
     /**
      * Associate {@link Context} instance with the current thread or remove
-     * the current association if <tt>cx</tt> is null.
+     * the current association if <code>cx</code> is null.
      *
      * @param contextHelper The result of {@link #getThreadContextHelper()}
      *                      called from the current thread.
@@ -96,7 +96,7 @@ public abstract class VMBridge
      * {@link InterfaceAdapter#invoke(ContextFactory, Object, Scriptable,
      *                                Object, Method, Object[])}
      * as implementation of interface methods associated with
-     * <tt>proxyHelper</tt>. {@link Method}
+     * <code>proxyHelper</code>. {@link Method}
      *
      * @param proxyHelper The result of the previous call to
      *        {@link #getInterfaceProxyHelper(ContextFactory, Class[])}.

--- a/src/org/mozilla/javascript/WrapFactory.java
+++ b/src/org/mozilla/javascript/WrapFactory.java
@@ -105,7 +105,7 @@ public class WrapFactory
      * <p>
      * {@link #wrap(Context, Scriptable, Object, Class)} and
      * {@link #wrapNewObject(Context, Scriptable, Object)} call this method
-     * when they can not convert <tt>javaObject</tt> to JavaScript primitive
+     * when they can not convert <code>javaObject</code> to JavaScript primitive
      * value or JavaScript array.
      * <p>
      * Subclasses can override the method to provide custom wrappers

--- a/src/org/mozilla/javascript/debug/DebuggableScript.java
+++ b/src/org/mozilla/javascript/debug/DebuggableScript.java
@@ -48,8 +48,8 @@ public interface DebuggableScript
 
     /**
      * Get name of a declared parameter or local variable.
-     * <tt>index</tt> should be less then {@link #getParamAndVarCount()}.
-     * If <tt>index&nbsp;&lt;&nbsp;{@link #getParamCount()}</tt>, return
+     * <code>index</code> should be less then {@link #getParamAndVarCount()}.
+     * If <code>index&nbsp;&lt;&nbsp;{@link #getParamCount()}</code>, return
      * the name of the corresponding parameter, otherwise return the name
      * of variable.
      * If this script is not function, return the name of the declared
@@ -65,8 +65,8 @@ public interface DebuggableScript
 
     /**
      * Returns true if this script or function were runtime-generated
-     * from JavaScript using <tt>eval</tt> function or <tt>Function</tt>
-     * or <tt>Script</tt> constructors.
+     * from JavaScript using <code>eval</code> function or <code>Function</code>
+     * or <code>Script</code> constructors.
      */
     public boolean isGeneratedScript();
 

--- a/src/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/src/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -39,10 +39,10 @@ public class ClassCompiler
     /**
      * Set the class name to use for main method implementation.
      * The class must have a method matching
-     * <tt>public static void main(Script sc, String[] args)</tt>, it will be
-     * called when <tt>main(String[] args)</tt> is called in the generated
+     * <code>public static void main(Script sc, String[] args)</code>, it will be
+     * called when <code>main(String[] args)</code> is called in the generated
      * class. The class name should be fully qulified name and include the
-     * package name like in <tt>org.foo.Bar</tt>.
+     * package name like in <code>org.foo.Bar</code>.
      */
     public void setMainMethodClass(String className)
     {

--- a/src/org/mozilla/javascript/xml/XMLObject.java
+++ b/src/org/mozilla/javascript/xml/XMLObject.java
@@ -84,7 +84,7 @@ public abstract class XMLObject extends IdScriptableObject
     public abstract NativeWith enterDotQuery(Scriptable scope);
 
     /**
-     * Custom <tt>+</tt> operator.
+     * Custom <code>+</code> operator.
      * Should return {@link Scriptable#NOT_FOUND} if this object does not have
      * custom addition operator for the given value,
      * or the result of the addition operation.

--- a/testsrc/doctests/string.trim.doctest
+++ b/testsrc/doctests/string.trim.doctest
@@ -18,7 +18,7 @@ js> var str = "" +
   >   // ecma whitespace
   >   chr(0x0009) + chr(0x000B) + chr(0x000C) + chr(0x0020) + chr(0x00A0) + chr(0xFEFF) + 
   >   // unicode whitespace
-  >   chr(0x1680) + chr(0x180E) + 
+  >   chr(0x1680) +
   >   chr(0x2000) + chr(0x2001) + chr(0x2002) + chr(0x2003) + chr(0x2004) + chr(0x2005) + chr(0x2006) + chr(0x2007) + chr(0x2008) + chr(0x2009) + chr(0x200A) + 
   >   chr(0x202F) + chr(0x205F) + chr(0x3000) + 
   >   // ecma line terminators

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -665,23 +665,23 @@ public class Global extends ImporterTopLevel
      * empty.
      * The following properties of the option object are processed:
      * <ul>
-     * <li><tt>args</tt> - provides an array of additional command arguments
-     * <li><tt>env</tt> - explicit environment object. All its enumerable
+     * <li><code>args</code> - provides an array of additional command arguments
+     * <li><code>env</code> - explicit environment object. All its enumerable
      *   properties define the corresponding environment variable names.
-     * <li><tt>input</tt> - the process input. If it is not
+     * <li><code>input</code> - the process input. If it is not
      *   java.io.InputStream, it is converted to string and sent to the process
      *   as its input. If not specified, no input is provided to the process.
-     * <li><tt>output</tt> - the process output instead of
+     * <li><code>output</code> - the process output instead of
      *   java.lang.System.out. If it is not instance of java.io.OutputStream,
      *   the process output is read, converted to a string, appended to the
      *   output property value converted to string and put as the new value of
      *   the output property.
-     * <li><tt>err</tt> - the process error output instead of
+     * <li><code>err</code> - the process error output instead of
      *   java.lang.System.err. If it is not instance of java.io.OutputStream,
      *   the process error output is read, converted to a string, appended to
      *   the err property value converted to string and put as the new
      *   value of the err property.
-     * <li><tt>dir</tt> - the working direcotry to run the commands.
+     * <li><code>dir</code> - the working direcotry to run the commands.
      * </ul>
      */
     public static Object runCommand(Context cx, Scriptable thisObj,

--- a/toolsrc/org/mozilla/javascript/tools/shell/Main.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Main.java
@@ -687,9 +687,9 @@ public class Main
     }
 
     /**
-     * Read file or url specified by <tt>path</tt>.
-     * @return file or url content as <tt>byte[]</tt> or as <tt>String</tt> if
-     * <tt>convertToString</tt> is true.
+     * Read file or url specified by <code>path</code>.
+     * @return file or url content as <code>byte[]</code> or as <code>String</code> if
+     * <code>convertToString</code> is true.
      */
     private static Object readFileOrUrl(String path, boolean convertToString)
             throws IOException


### PR DESCRIPTION
Hi, this PR add java 11 in the travis test matrix.

There are 3 fixes:
 - removal of a character in `string.trim.doctest` which is no more considered as a whitespace. See https://github.com/mozilla/rhino/commit/7ec73c035668398aa02839eaa0717b917adb0f36 . To be noted, the test with the problematic character fail on chrome and FF, so it was likely obsolete/no more correct.
 - use of explicit format for DateFormat in `NativeDate`. During the java8 -> java9 transition, the pattern defined by using `FormatStyle.LONG` has changed. See https://github.com/mozilla/rhino/commit/64790dde7908e84a8b87328d99d87de076598b33 and https://stackoverflow.com/q/53317365
 - fix on the javadoc to make the linter happy

Everything build successfully: https://travis-ci.org/github/syjer/rhino/builds/702403837 :)