### PR TITLE
Debugger: fix NPE in variables view when showing "CallSite > prototype"

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
@@ -2738,6 +2738,9 @@ class VariableModel implements TreeTableModel {
                 result = debugger.objectToString(getValue(node));
             } catch (RuntimeException exc) {
                 result = exc.getMessage();
+                if (result == null) {
+                    result = exc.toString();
+                }
             }
             StringBuilder buf = new StringBuilder();
             int len = result.length();


### PR DESCRIPTION
This PR fixes a NPE in debugger variables view when expanding node "CallSite" and showing row "CallSite > prototype".

To reproduce the NPE start following program and expand node "CallSite" in variables view:

~~~java
import org.mozilla.javascript.Context;
import org.mozilla.javascript.ContextFactory;
import org.mozilla.javascript.ImporterTopLevel;
import org.mozilla.javascript.tools.debugger.Main;

public class RhinoDebuggerTest {
    public static void main(String[] args) throws Exception {
        ContextFactory factory = new ContextFactory();
        Main dbg = Main.mainEmbedded("A Sample Test");
        dbg.attachTo(factory);

        Context context = factory.enterContext();
        ImporterTopLevel scope = new ImporterTopLevel(context);
        dbg.setBreakOnEnter(true);
        dbg.setVisible(true);
        dbg.setExitAction(() -> {
            // close the debug window
            dbg.dispose();
        });

        context.evaluateString(scope,
                "importPackage(javax.swing);"
                        + "\n// JOptionPane.showMessageDialog(null, 'Hello');\n",
                "A Sample Test", 1, null);
    }
}
~~~

This is the exception:

~~~
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at org.mozilla.javascript.tools.debugger.VariableModel.getValueAt(SwingGui.java:2743)
	at org.mozilla.javascript.tools.debugger.treetable.TreeTableModelAdapter.getValueAt(TreeTableModelAdapter.java:125)
	at javax.swing.JTable.getValueAt(JTable.java:2720)
	at javax.swing.JTable.prepareRenderer(JTable.java:5712)
	at javax.swing.plaf.basic.BasicTableUI.paintCell(BasicTableUI.java:2114)
	at javax.swing.plaf.basic.BasicTableUI.paintCells(BasicTableUI.java:2016)
	at javax.swing.plaf.basic.BasicTableUI.paint(BasicTableUI.java:1812)
	at javax.swing.plaf.ComponentUI.update(ComponentUI.java:161)
	at javax.swing.JComponent.paintComponent(JComponent.java:780)
	at javax.swing.JComponent.paint(JComponent.java:1056)
...
~~~

With this PR applied it looks like this:

![grafik](https://user-images.githubusercontent.com/5604048/86509352-a31e7a00-bde7-11ea-8cbf-699e085f206f.png)
