### PR TITLE
Debugger fixes for FlatLaf:

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
@@ -1119,7 +1119,7 @@ class EvalTextArea
         doc.addDocumentListener(this);
         addKeyListener(this);
         setLineWrap(true);
-        setFont(new Font("Monospaced", 0, 12));
+        setFont(new Font("Monospaced", 0, Math.max(12, UIManager.getFont("Label.font").getSize())));
         append("% ");
         outputMark = doc.getLength();
     }
@@ -1519,7 +1519,7 @@ class FileTextArea
         popup.addPopupMenuListener(this);
         addMouseListener(this);
         addKeyListener(this);
-        setFont(new Font("Monospaced", 0, 12));
+        setFont(new Font("Monospaced", 0, Math.max(12, UIManager.getFont("Label.font").getSize())));
     }
 
     /**
@@ -2882,6 +2882,8 @@ class MyTreeTable extends JTreeTable {
         if (tree.getRowHeight() < 1) {
             // Metal looks better like this.
             setRowHeight(18);
+        } else if (tree.getRowHeight() != getRowHeight()) {
+            tree.setRowHeight(getRowHeight());
         }
 
         // Install the tree editor renderer and editor.

--- a/toolsrc/org/mozilla/javascript/tools/debugger/treetable/JTreeTable.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/treetable/JTreeTable.java
@@ -162,6 +162,9 @@ public class JTreeTable extends JTable {
 
         public TreeTableCellRenderer(TreeModel model) {
             super(model);
+
+            // Make sure that there is no border.
+            setBorder(null);
         }
 
         /**


### PR DESCRIPTION
This PR fixes issues reported here https://github.com/JFormDesigner/FlatLaf/issues/120 in debugger Swing GUI when using [FlatLaf](https://github.com/JFormDesigner/FlatLaf) L&F (or other 3rd party L&Fs):
- make renderer tree row height same as table row height
- increase monospaced font size in script source and evaluation view if L&F uses larger font
- remove renderer tree border if L&F sets one (built in L&F do not)

This screenshot shows the problems of the debugger using FlatLaf running in Java 8 on a screen that is scales 150%:

![grafik](https://user-images.githubusercontent.com/5604048/86513576-8b58ed00-be0b-11ea-9625-70afa13a6674.png)

With this PR applied:

![grafik](https://user-images.githubusercontent.com/5604048/86513630-133ef700-be0c-11ea-8548-cdae47b567f1.png)

(the gray background on "Boolean" will be fixed in FlatLaf)

Test program:

~~~java
import org.mozilla.javascript.Context;
import org.mozilla.javascript.ContextFactory;
import org.mozilla.javascript.ImporterTopLevel;
import org.mozilla.javascript.tools.debugger.Main;

public class RhinoDebuggerTest {
    public static void main(String[] args) throws Exception {
        // init FlatLaf
        com.formdev.flatlaf.FlatLightLaf.install();

        ContextFactory factory = new ContextFactory();
        Main dbg = Main.mainEmbedded("A Sample Test");
        dbg.attachTo(factory);

        Context context = factory.enterContext();
        ImporterTopLevel scope = new ImporterTopLevel(context);
        dbg.setBreakOnEnter(true);
        dbg.setVisible(true);
        dbg.setExitAction(() -> {
            // close the debug window
            dbg.dispose();
        });

        context.evaluateString(scope,
                "importPackage(javax.swing);"
                        + "\n// JOptionPane.showMessageDialog(null, 'Hello');\n",
                "A Sample Test", 1, null);
    }
}
~~~

Also tested with Windows L&F and Metal L&F without issues.