### PR TITLE
String.prototype[Symbol.iterator].call(undefined) has to throw becaus…

### DIFF
--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -544,7 +544,7 @@ final class NativeString extends IdScriptableObject
                 }
 
               case SymbolId_iterator:
-                  return new NativeStringIterator(scope, thisObj);
+                  return new NativeStringIterator(scope, requireObjectCoercible(cx, thisObj, f));
 
             }
             throw new IllegalArgumentException("String.prototype has no method: " + f.getFunctionName());

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -846,7 +846,6 @@ built-ins/String
     ! prototype/substring/S15.5.4.15_A1_T5.js
     ! prototype/toLocaleLowerCase/special_casing_conditional.js
     ! prototype/toLowerCase/special_casing_conditional.js
-    ! prototype/Symbol.iterator/this-val-non-obj-coercible.js
     ! raw/length.js
     ! raw/name.js
     ! raw/raw.js


### PR DESCRIPTION
…e undefined is not coercible