### PR TITLE
[TypedArray].prototype.subarray() should not throw an exception

### DIFF
--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -324,10 +324,10 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView impl
             throw ScriptRuntime.constructError("Error", "invalid arguments");
 
         case Id_subarray:
-            if (args.length > 0) {
-                NativeTypedArrayView<T> self = realThis(thisObj, f);
-                int start = ScriptRuntime.toInt32(args[0]);
-                int end = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : self.length;
+            NativeTypedArrayView<T> self = realThis(thisObj, f);
+            int start = isArg(args, 0) ? ScriptRuntime.toInt32(args[0]) : 0;
+            int end = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : self.length;
+            if (cx.getLanguageVersion() >= Context.VERSION_ES6 || args.length > 0) {
                 return self.js_subarray(cx, scope, start, end);
             }
             throw ScriptRuntime.constructError("Error", "invalid arguments");

--- a/testsrc/org/mozilla/javascript/tests/es5/TypedArrayJavaTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es5/TypedArrayJavaTest.java
@@ -1,0 +1,47 @@
+package org.mozilla.javascript.tests.es5;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Test for TypedArrays.
+ */
+public class TypedArrayJavaTest
+{
+    /**
+     * Test case for {@link https://github.com/mozilla/rhino/issues/768}
+     * backward compatibility.
+     *
+     * @throws Exception if test failed
+     */
+    @Test
+    public void subarrayWithoutParams() throws Exception {
+        String[] allNativeTypes = {
+                "Float32Array",
+                "Float64Array",
+                "Int8Array",
+                "Int16Array",
+                "Int32Array",
+                "Uint8Array",
+                "Uint16Array",
+                "Uint32Array",
+                "Uint8ClampedArray"
+        };
+
+        Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_1_8);
+        Scriptable global = cx.initStandardObjects();
+
+        for (String type : allNativeTypes) {
+            String script = "var ta = new " + type + "([1, 2]);\n"
+                            + "try { ta.subarray(); } catch(e) { '' + e }";
+            Object obj = cx.evaluateString(global, script, "", 1, null);
+            assertEquals("Error: invalid arguments", obj);
+        }
+
+        Context.exit();
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/es6/TypedArrayJavaTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/TypedArrayJavaTest.java
@@ -1,0 +1,46 @@
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Test for TypedArrays.
+ */
+public class TypedArrayJavaTest
+{
+    /**
+     * Test case for {@link https://github.com/mozilla/rhino/issues/768}
+     *
+     * @throws Exception if test failed
+     */
+    @Test
+    public void subarrayWithoutParams() throws Exception {
+        String[] allNativeTypes = {
+                "Float32Array",
+                "Float64Array",
+                "Int8Array",
+                "Int16Array",
+                "Int32Array",
+                "Uint8Array",
+                "Uint16Array",
+                "Uint32Array",
+                "Uint8ClampedArray"
+        };
+
+        Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        Scriptable global = cx.initStandardObjects();
+
+        for (String type : allNativeTypes) {
+            String script = "var ta = new " + type + "([1, 2]);\n"
+                            + "'' + ta.subarray();";
+            Object obj = cx.evaluateString(global, script, "", 1, null);
+            assertEquals("1,2", obj);
+        }
+
+        Context.exit();
+    }
+}

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -548,8 +548,8 @@ built-ins/GeneratorFunction
     ! invoked-as-function-multiple-arguments.js
     ! invoked-as-function-no-arguments.js
     ! invoked-as-function-single-argument.js
-    ! length.js
-    ! name.js
+    ! /length.js
+    ! /name.js
     ! proto-from-ctor-realm.js
 
 built-ins/GeneratorPrototype
@@ -596,8 +596,8 @@ built-ins/global
 built-ins/Infinity
 
 built-ins/isFinite
-    ! length.js
-    ! name.js
+    ! /length.js
+    ! /name.js
     ! toprimitive-call-abrupt.js
     ! toprimitive-get-abrupt.js
     ! toprimitive-not-callable-throws.js
@@ -606,8 +606,8 @@ built-ins/isFinite
     ! toprimitive-valid-result.js
 
 built-ins/isNaN
-    ! length.js
-    ! name.js
+    ! /length.js
+    ! /name.js
     ! toprimitive-call-abrupt.js
     ! toprimitive-get-abrupt.js
     ! toprimitive-not-callable-throws.js
@@ -1695,7 +1695,7 @@ built-ins/TypedArray
     ! Symbol.species/result.js
     ! invoked.js
     ! /length.js
-    ! name.js
+    ! /name.js
     ! prototype.js
 
 built-ins/TypedArrays


### PR DESCRIPTION
[TypedArray].prototype.subarray() should not throw an exception if called without parameters (ES6)

fixes #768