### PR TITLE
Add option to run tests once only

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ git submodule update
 ```
 Build and run all the tests.
 ```
+./gradlew test -Dquick
+```
+The tests in Test262Suite and MozillaSuiteTest are run 3 times by default (at differing optimization levels).
+The `quick` parameter can be used to only run them once.
+
+It is also possible to limit the Test262Suite to 1 run by setting the environment variable 
+TEST_262_OPTLEVEL to for example -1.
+```
 ./gradlew testBenchmark
 ```
 Build and run benchmark tests.

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ test {
     systemProperty 'user.country', 'US'
     systemProperty 'user.timezone', 'America/Los_Angeles'
     systemProperty 'file.encoding', 'UTF-8'
+    if (System.getProperty('quick') != null) {
+        systemProperty 'TEST_OPTLEVEL', -1
+    }
     maxHeapSize = "1g"
     testLogging.showStandardStreams = true
     // Many tests do not clean up contexts properly. This makes the tests much

--- a/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -49,7 +49,17 @@ public class MozillaSuiteTest {
     private final File jsFile;
     private final int optimizationLevel;
 
-    static final int[] OPT_LEVELS = { -1, 0, 9 };
+    private static final int[] OPT_LEVELS;
+
+    static {
+        // Reduce the number of tests that we run by a factor of three...
+        String overriddenLevel = System.getProperty("TEST_OPTLEVEL");
+        if (overriddenLevel != null) {
+            OPT_LEVELS = new int[]{Integer.parseInt(overriddenLevel)};
+        } else {
+            OPT_LEVELS = new int[]{-1, 0, 9};
+        }
+    }
 
     public MozillaSuiteTest(File jsFile, int optimizationLevel) {
         this.jsFile = jsFile;

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -92,12 +92,20 @@ public class Test262SuiteTest {
 
     static {
         // Reduce the number of tests that we run by a factor of three...
-        String optLevel = System.getenv("TEST_262_OPTLEVEL");
-        if (optLevel != null) {
-            OPT_LEVELS = new int[]{Integer.valueOf(optLevel)};
+        String overriddenLevel = getOverriddenLevel();
+        if (overriddenLevel != null) {
+            OPT_LEVELS = new int[]{Integer.parseInt(overriddenLevel)};
         } else {
             OPT_LEVELS = new int[]{-1, 0, 9};
         }
+    }
+
+    private static String getOverriddenLevel() {
+        String optLevel = System.getenv("TEST_262_OPTLEVEL");
+        if (optLevel == null) {
+            optLevel = System.getProperty("TEST_OPTLEVEL");
+        }
+        return optLevel;
     }
 
     @BeforeClass


### PR DESCRIPTION
I was looking for a way to speed up the tests. Running the 2 test suites at just 1 optimization level doesn't speed them up that much (from ~12.5 minutes to ~9.5 minutes), but it's still a speed up, so please let me know if you think this is a useful change.

Would it be worthwhile to pull in a recent version of the test262 project?

Also, I see 1 of the tests always failing on my machine, is anyone familiar with what's going on?
java.lang.AssertionError: In "testsrc/tests/ecma/String/15.5.4.12-3.js":
 FAILED! var s = new String( String.fromCharCode(4304) ); s.toUpperCase().charCodeAt(0) = 7312 expected: 4304
 FAILED! var s = new String( String.fromCharCode(4305) ); s.toUpperCase().charCodeAt(0) = 7313 expected: 4305
etc...