### PR TITLE
Fix JSON.stringify on a RegExp Object

### DIFF
--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -310,23 +310,15 @@ public final class NativeJSON extends IdScriptableObject
             }
             return "null";
         }
-
-        if (value instanceof NativeArray) {
-            return ja((NativeArray) value, state);
-        }
-
-        if (isObject(value)) {
+        
+        if (value instanceof Scriptable && !(value instanceof Callable)) {
+            if (value instanceof NativeArray) {
+                return ja((NativeArray) value, state);
+            }
             return jo((Scriptable) value, state);
         }
 
         return Undefined.instance;
-    }
-
-    private static boolean isObject(Object value) {
-        if (value instanceof NativeRegExp) {
-            return true;
-        }
-        return value instanceof Scriptable && !(value instanceof Callable);
     }
 
     private static String join(Collection<Object> objs, String delimiter) {

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Stack;
 
 import org.mozilla.javascript.json.JsonParser;
-import org.mozilla.javascript.regexp.NativeRegExp;
 
 /**
  * This class implements the JSON native object.
@@ -310,7 +309,7 @@ public final class NativeJSON extends IdScriptableObject
             }
             return "null";
         }
-        
+
         if (value instanceof Scriptable && !(value instanceof Callable)) {
             if (value instanceof NativeArray) {
                 return ja((NativeArray) value, state);

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Stack;
 
 import org.mozilla.javascript.json.JsonParser;
+import org.mozilla.javascript.regexp.NativeRegExp;
 
 /**
  * This class implements the JSON native object.
@@ -310,14 +311,22 @@ public final class NativeJSON extends IdScriptableObject
             return "null";
         }
 
-        if (value instanceof Scriptable && !(value instanceof Callable)) {
-            if (value instanceof NativeArray) {
-                return ja((NativeArray) value, state);
-            }
+        if (value instanceof NativeArray) {
+            return ja((NativeArray) value, state);
+        }
+
+        if (isObject(value)) {
             return jo((Scriptable) value, state);
         }
 
         return Undefined.instance;
+    }
+
+    private static boolean isObject(Object value) {
+        if (value instanceof NativeRegExp) {
+            return true;
+        }
+        return value instanceof Scriptable && !(value instanceof Callable);
     }
 
     private static String join(Collection<Object> objs, String delimiter) {

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -9,7 +9,6 @@ package org.mozilla.javascript.regexp;
 import java.io.Serializable;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Function;
 import org.mozilla.javascript.IdFunctionObject;
 import org.mozilla.javascript.IdScriptableObject;
 import org.mozilla.javascript.Kit;
@@ -37,7 +36,7 @@ import org.mozilla.javascript.Undefined;
 
 
 
-public class NativeRegExp extends IdScriptableObject implements Function
+public class NativeRegExp extends IdScriptableObject
 {
     private static final long serialVersionUID = 4965263491464903264L;
 
@@ -115,7 +114,7 @@ public class NativeRegExp extends IdScriptableObject implements Function
     public static void init(Context cx, Scriptable scope, boolean sealed)
     {
 
-        NativeRegExp proto = new NativeRegExp();
+        NativeRegExp proto = NativeRegExpInstantiator.withLanguageVersion(cx.getLanguageVersion());
         proto.re = compileRE(cx, "", null, false);
         proto.activatePrototypeMap(MAX_PROTOTYPE_ID);
         proto.setParentScope(scope);
@@ -160,26 +159,6 @@ public class NativeRegExp extends IdScriptableObject implements Function
     public String getTypeOf()
     {
         return "object";
-    }
-
-    @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
-        if (cx.getLanguageVersion() < Context.VERSION_ES6) {
-            return execSub(cx, scope, args, MATCH);
-        }
-
-        throw ScriptRuntime.notFunctionError(thisObj);
-    }
-
-    @Override
-    public Scriptable construct(Context cx, Scriptable scope, Object[] args)
-    {
-        if (cx.getLanguageVersion() < Context.VERSION_ES6) {
-            return (Scriptable)execSub(cx, scope, args, MATCH);
-        }
-
-        throw ScriptRuntime.notFunctionError(this);
     }
 
     Scriptable compile(Context cx, Scriptable scope, Object[] args)
@@ -255,8 +234,8 @@ public class NativeRegExp extends IdScriptableObject implements Function
         return s;
     }
 
-    private Object execSub(Context cx, Scriptable scopeObj,
-                           Object[] args, int matchType)
+    Object execSub(Context cx, Scriptable scopeObj,
+                   Object[] args, int matchType)
     {
         RegExpImpl reImpl = getImpl(cx);
         String str;

--- a/src/org/mozilla/javascript/regexp/NativeRegExpCallable.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExpCallable.java
@@ -1,0 +1,29 @@
+package org.mozilla.javascript.regexp;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Legacy implementation of RegExp was callable, this class exists to preserve this functionality
+ */
+class NativeRegExpCallable extends NativeRegExp implements Function {
+
+    NativeRegExpCallable(Scriptable scope, RECompiled compiled) {
+        super(scope, compiled);
+    }
+
+    NativeRegExpCallable() {
+        super();
+    }
+
+    @Override
+    public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        return execSub(cx, scope, args, MATCH);
+    }
+
+    @Override
+    public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
+        return (Scriptable) execSub(cx, scope, args, MATCH);
+    }
+}

--- a/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExpCtor.java
@@ -65,7 +65,7 @@ class NativeRegExpCtor extends BaseFunction
     @Override
     public Scriptable construct(Context cx, Scriptable scope, Object[] args)
     {
-        NativeRegExp re = new NativeRegExp();
+        NativeRegExp re = NativeRegExpInstantiator.withLanguageVersion(cx.getLanguageVersion());
         re.compile(cx, scope, args);
         ScriptRuntime.setBuiltinProtoAndParent(re, scope, TopLevel.Builtins.RegExp);
         return re;

--- a/src/org/mozilla/javascript/regexp/NativeRegExpInstantiator.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExpInstantiator.java
@@ -1,0 +1,25 @@
+package org.mozilla.javascript.regexp;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+public class NativeRegExpInstantiator {
+
+    private NativeRegExpInstantiator() {}
+
+    static NativeRegExp withLanguageVersion(int languageVersion) {
+        if (languageVersion < Context.VERSION_ES6) {
+            return new NativeRegExpCallable();
+        } else {
+            return new NativeRegExp();
+        }
+    }
+
+    static NativeRegExp withLanguageVersionScopeCompiled(int languageVersion, Scriptable scope, RECompiled compiled) {
+        if (languageVersion < Context.VERSION_ES6) {
+            return new NativeRegExpCallable(scope, compiled);
+        } else {
+            return new NativeRegExp(scope, compiled);
+        }
+    }
+}

--- a/src/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/src/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -35,7 +35,8 @@ public class RegExpImpl implements RegExpProxy {
     public Scriptable wrapRegExp(Context cx, Scriptable scope,
                                  Object compiled)
     {
-        return new NativeRegExp(scope, (RECompiled) compiled);
+        return NativeRegExpInstantiator
+                .withLanguageVersionScopeCompiled(cx.getLanguageVersion(), scope, (RECompiled) compiled);
     }
 
     @Override
@@ -154,7 +155,7 @@ public class RegExpImpl implements RegExpProxy {
         Scriptable topScope = ScriptableObject.getTopLevelScope(scope);
         if (args.length == 0 || args[0] == Undefined.instance) {
             RECompiled compiled = NativeRegExp.compileRE(cx, "", "", false);
-            re = new NativeRegExp(topScope, compiled);
+            re = NativeRegExpInstantiator.withLanguageVersionScopeCompiled(cx.getLanguageVersion(), topScope, compiled);
         } else if (args[0] instanceof NativeRegExp) {
             re = (NativeRegExp) args[0];
         } else {
@@ -167,7 +168,7 @@ public class RegExpImpl implements RegExpProxy {
                 opt = null;
             }
             RECompiled compiled = NativeRegExp.compileRE(cx, src, opt, forceFlat);
-            re = new NativeRegExp(topScope, compiled);
+            re = NativeRegExpInstantiator.withLanguageVersionScopeCompiled(cx.getLanguageVersion(), topScope, compiled);
         }
         return re;
     }

--- a/testsrc/jstests/stringify-on-regexp-object.js
+++ b/testsrc/jstests/stringify-on-regexp-object.js
@@ -1,0 +1,10 @@
+load("testsrc/assert.js");
+
+const regexp = new RegExp();
+assertEquals('{}', JSON.stringify(regexp))
+
+const regExpWithProperties = new RegExp();
+regExpWithProperties.color = 'red';
+assertEquals('{"color":"red"}', JSON.stringify(regExpWithProperties));
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/StringifyOnRegExpObject.java
+++ b/testsrc/org/mozilla/javascript/tests/StringifyOnRegExpObject.java
@@ -10,6 +10,6 @@ import org.mozilla.javascript.drivers.RhinoTest;
 import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 @RhinoTest("testsrc/jstests/stringify-on-regexp-object.js")
-@LanguageVersion(Context.VERSION_DEFAULT)
+@LanguageVersion(Context.VERSION_ES6)
 public class StringifyOnRegExpObject extends ScriptTestsBase {
 }

--- a/testsrc/org/mozilla/javascript/tests/StringifyOnRegExpObject.java
+++ b/testsrc/org/mozilla/javascript/tests/StringifyOnRegExpObject.java
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/stringify-on-regexp-object.js")
+@LanguageVersion(Context.VERSION_DEFAULT)
+public class StringifyOnRegExpObject extends ScriptTestsBase {
+}


### PR DESCRIPTION
Calling JSON.stringify() on a RegExp object should return an object, not undefined

resolves #762