### PR TITLE
Fix parameter handling for Object.assign

### DIFF
--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -545,10 +545,13 @@ public class NativeObject extends IdScriptableObject implements Map
 
           case ConstructorId_assign:
           {
-            if (args.length < 1) {
-              throw ScriptRuntime.typeError1("msg.incompat.call", "assign");
+            Scriptable targetObj;
+            if (args.length > 0) {
+              targetObj = ScriptRuntime.toObject(cx, thisObj, args[0]);
             }
-            Scriptable targetObj = ScriptRuntime.toObject(cx, thisObj, args[0]);
+            else {
+              targetObj = ScriptRuntime.toObject(cx, thisObj, Undefined.instance);
+            }
             for (int i = 1; i < args.length; i++) {
               if ((args[i] == null) || Undefined.isUndefined(args[i])) {
                 continue;

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeObjectTest.java
@@ -57,6 +57,31 @@ public class NativeObjectTest {
     }
 
     @Test
+    public void testAssignOneParameter() {
+        Object result = cx.evaluateString(
+                scope, "var obj = {};"
+                        + "res = Object.assign(obj);"
+                        + "res === obj;",
+                "test", 1, null
+        );
+
+        assertEquals(true, result);
+    }
+
+
+    @Test
+    public void testAssignMissingParameters() {
+        Object result = cx.evaluateString(
+                scope, "try { "
+                        + "  Object.assign();"
+                        + "} catch (e) { e.message }",
+                "test", 1, null
+        );
+
+        assertEquals("Cannot convert undefined to an object.", result);
+    }
+
+    @Test
     public void testAssignNumericPropertyGetter() {
         Object result = cx.evaluateString(
                 scope, "var obj = Object.defineProperty({}, 1, {\n"


### PR DESCRIPTION
Another fix for wrong '"msg.incompat.call'.

@gbrail  looks like you did this some years ago but because you have added this function without a version check i think it is ok to chance the function. From my point of view this is only available in ES6 we do not need a version check here to be backward compatible. In fact this changes only the msg text.