### PR TITLE
make typechecking and casting a bit more generic to be able to provide better error messages

### DIFF
--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -335,11 +335,7 @@ public class BaseFunction extends IdScriptableObject implements Function
         if (x instanceof Delegator) {
             x = ((Delegator)x).getDelegee();
         }
-        if (x instanceof BaseFunction) {
-            return (BaseFunction)x;
-        }
-        throw ScriptRuntime.typeError1("msg.incompat.call",
-                                       f.getFunctionName());
+        return ensureType(x, BaseFunction.class, f);
     }
 
     /**

--- a/src/org/mozilla/javascript/ES6Generator.java
+++ b/src/org/mozilla/javascript/ES6Generator.java
@@ -86,11 +86,7 @@ public final class ES6Generator extends IdScriptableObject {
         }
         int id = f.methodId();
 
-        if (!(thisObj instanceof ES6Generator)) {
-            throw incompatibleCallError(f);
-        }
-
-        ES6Generator generator = (ES6Generator) thisObj;
+        ES6Generator generator = ensureType(thisObj, ES6Generator.class, f);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
 
         switch (id) {

--- a/src/org/mozilla/javascript/ES6Iterator.java
+++ b/src/org/mozilla/javascript/ES6Iterator.java
@@ -72,10 +72,7 @@ public abstract class ES6Iterator extends IdScriptableObject {
         }
         int id = f.methodId();
 
-        if (!(thisObj instanceof ES6Iterator))
-            throw incompatibleCallError(f);
-
-        ES6Iterator iterator = (ES6Iterator) thisObj;
+        ES6Iterator iterator = ensureType(thisObj, ES6Iterator.class, f);
 
         switch (id) {
         case Id_next:

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -417,8 +417,7 @@ public class FunctionObject extends BaseFunction
                     }
                     if (!compatible) {
                         // Couldn't find an object to call this on.
-                        throw ScriptRuntime.typeError1("msg.incompat.call",
-                                                       functionName);
+                        throw ScriptRuntime.typeError1("msg.incompat.call", functionName);
                     }
                 }
             }

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -881,25 +881,20 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     }
 
     /**
-     * Utility method to construct type error to indicate incompatible call
-     * when converting script thisObj to a particular type is not possible.
+     * Utility method to check the type and do the cast or throw an incompatible call
+     * error.
      * Possible usage would be to have a private function like realThis:
      * <pre>
-     *  private static NativeSomething realThis(Scriptable thisObj,
-     *                                          IdFunctionObject f)
+     *  private static NativeSomething realThis(Scriptable thisObj, IdFunctionObject f)
      *  {
-     *      if (!(thisObj instanceof NativeSomething))
-     *          throw incompatibleCallError(f);
-     *      return (NativeSomething)thisObj;
+     *      return ensureType(thisObj, NativeSomething.class, f);
      * }
      * </pre>
-     * Note that although such function can be implemented universally via
-     * java.lang.Class.isInstance(), it would be much more slower.
-     * @param f function that is attempting to convert 'this'
-     * object.
-     * @return Scriptable object suitable for a check by the instanceof
-     * operator.
-     * @throws RuntimeException if no more instanceof target can be found
+     * @param obj the object to check/cast
+     * @param clazz the target type
+     * @param f function that is attempting to convert 'this' object.
+     * @return obj casted to the target type
+     * @throws EcmaError if the cast failed.
      */
     protected static <T> T ensureType(Object obj, Class<T> clazz, IdFunctionObject f)
     {

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -14,18 +14,18 @@ import java.io.Serializable;
 /**
  * Base class for native object implementation that uses IdFunctionObject to
  * export its methods to script via &lt;class-name&gt;.prototype object.
- * 
+ *
  * Any descendant should implement at least the following methods:
  * findInstanceIdInfo getInstanceIdName execIdCall methodArity
- * 
+ *
  * To define non-function properties, the descendant should override
  * getInstanceIdValue setInstanceIdValue to get/set property value and provide
  * its default attributes.
- * 
- * 
+ *
+ *
  * To customize initialization of constructor and prototype objects, descendant
  * may override scopeInit or fillConstructorProperties methods.
- * 
+ *
  */
 public abstract class IdScriptableObject extends ScriptableObject implements IdFunctionCall {
     private static final long serialVersionUID = -3744239272168621609L;
@@ -901,10 +901,15 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
      * operator.
      * @throws RuntimeException if no more instanceof target can be found
      */
-    protected static EcmaError incompatibleCallError(IdFunctionObject f)
+    protected static <T> T ensureType(Object obj, Class<T> clazz, IdFunctionObject f)
     {
-        throw ScriptRuntime.typeError1("msg.incompat.call",
-                                       f.getFunctionName());
+        if (clazz.isInstance(obj)) {
+            return (T) obj;
+        }
+        if (obj == null) {
+            throw ScriptRuntime.typeError3("msg.incompat.call.details", f.getFunctionName(), "null", clazz.getName());
+        }
+        throw ScriptRuntime.typeError3("msg.incompat.call.details", f.getFunctionName(), obj.getClass().getName(), clazz.getName());
     }
 
     private IdFunctionObject newIdFunction(Object tag, int id, String name,

--- a/src/org/mozilla/javascript/ImporterTopLevel.java
+++ b/src/org/mozilla/javascript/ImporterTopLevel.java
@@ -251,9 +251,7 @@ public class ImporterTopLevel extends TopLevel {
             // function that ignore thisObj
             return this;
         }
-        if (!(thisObj instanceof ImporterTopLevel))
-            throw incompatibleCallError(f);
-        return (ImporterTopLevel)thisObj;
+        return ensureType(thisObj, ImporterTopLevel.class, f);
     }
 
 // #string_id_map#

--- a/src/org/mozilla/javascript/NativeBoolean.java
+++ b/src/org/mozilla/javascript/NativeBoolean.java
@@ -90,10 +90,7 @@ final class NativeBoolean extends IdScriptableObject
         }
 
         // The rest of Boolean.prototype methods require thisObj to be Boolean
-
-        if (!(thisObj instanceof NativeBoolean))
-            throw incompatibleCallError(f);
-        boolean value = ((NativeBoolean)thisObj).booleanValue;
+        boolean value = ensureType(thisObj, NativeBoolean.class, f).booleanValue;
 
         switch (id) {
 

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -194,10 +194,7 @@ final class NativeDate extends IdScriptableObject
         }
 
         // The rest of Date.prototype methods require thisObj to be Date
-
-        if (!(thisObj instanceof NativeDate))
-            throw incompatibleCallError(f);
-        NativeDate realThis = (NativeDate)thisObj;
+        NativeDate realThis = ensureType(thisObj, NativeDate.class, f);
         double t = realThis.date;
 
         switch (id) {

--- a/src/org/mozilla/javascript/NativeGenerator.java
+++ b/src/org/mozilla/javascript/NativeGenerator.java
@@ -96,10 +96,7 @@ public final class NativeGenerator extends IdScriptableObject {
         }
         int id = f.methodId();
 
-        if (!(thisObj instanceof NativeGenerator))
-            throw incompatibleCallError(f);
-
-        NativeGenerator generator = (NativeGenerator) thisObj;
+        NativeGenerator generator = ensureType(thisObj, NativeGenerator.class, f);
 
         switch (id) {
 

--- a/src/org/mozilla/javascript/NativeIterator.java
+++ b/src/org/mozilla/javascript/NativeIterator.java
@@ -129,10 +129,7 @@ public final class NativeIterator extends IdScriptableObject {
             return jsConstructor(cx, scope, thisObj, args);
         }
 
-        if (!(thisObj instanceof NativeIterator))
-            throw incompatibleCallError(f);
-
-        NativeIterator iterator = (NativeIterator) thisObj;
+        NativeIterator iterator = ensureType(thisObj, NativeIterator.class, f);
 
         switch (id) {
 

--- a/src/org/mozilla/javascript/NativeMap.java
+++ b/src/org/mozilla/javascript/NativeMap.java
@@ -218,19 +218,13 @@ public class NativeMap extends IdScriptableObject {
 
     private static NativeMap realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (thisObj == null) {
-            throw incompatibleCallError(f);
+        final NativeMap nm = ensureType(thisObj, NativeMap.class, f);
+        if (!nm.instanceOfMap) {
+            // Check for "Map internal data tag"
+            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
         }
-        try {
-            final NativeMap nm = (NativeMap)thisObj;
-            if (!nm.instanceOfMap) {
-                // Check for "Map internal data tag"
-                throw incompatibleCallError(f);
-            }
-            return nm;
-        } catch (ClassCastException cce) {
-            throw incompatibleCallError(f);
-        }
+
+        return nm;
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -123,10 +123,7 @@ final class NativeNumber extends IdScriptableObject
         }
 
         // The rest of Number.prototype methods require thisObj to be Number
-
-        if (!(thisObj instanceof NativeNumber))
-            throw incompatibleCallError(f);
-        double value = ((NativeNumber)thisObj).doubleValue;
+        double value = ensureType(thisObj, NativeNumber.class, f).doubleValue;
 
         switch (id) {
 

--- a/src/org/mozilla/javascript/NativeScript.java
+++ b/src/org/mozilla/javascript/NativeScript.java
@@ -141,9 +141,7 @@ class NativeScript extends BaseFunction
 
     private static NativeScript realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeScript))
-            throw incompatibleCallError(f);
-        return (NativeScript)thisObj;
+        return ensureType(thisObj, NativeScript.class, f);
     }
 
     private static Script compile(Context cx, String source)

--- a/src/org/mozilla/javascript/NativeSet.java
+++ b/src/org/mozilla/javascript/NativeSet.java
@@ -184,19 +184,13 @@ public class NativeSet extends IdScriptableObject {
 
     private static NativeSet realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (thisObj == null) {
-            throw incompatibleCallError(f);
+        final NativeSet ns = ensureType(thisObj, NativeSet.class, f);
+        if (!ns.instanceOfSet) {
+            // If we get here, then this object doesn't have the "Set internal data slot."
+            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
         }
-        try {
-            final NativeSet ns = (NativeSet)thisObj;
-            if (!ns.instanceOfSet) {
-                // If we get here, then this object doesn't have the "Set internal data slot."
-                throw incompatibleCallError(f);
-            }
-            return ns;
-        } catch (ClassCastException cce) {
-            throw incompatibleCallError(f);
-        }
+
+        return ns;
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -553,9 +553,7 @@ final class NativeString extends IdScriptableObject
 
     private static NativeString realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeString))
-            throw incompatibleCallError(f);
-        return (NativeString)thisObj;
+        return ensureType(thisObj, NativeString.class, f);
     }
 
     /*

--- a/src/org/mozilla/javascript/NativeWeakMap.java
+++ b/src/org/mozilla/javascript/NativeWeakMap.java
@@ -115,19 +115,13 @@ public class NativeWeakMap extends IdScriptableObject {
     }
 
     private static NativeWeakMap realThis(Scriptable thisObj, IdFunctionObject f) {
-        if (thisObj == null) {
-            throw incompatibleCallError(f);
+        final NativeWeakMap nm = ensureType(thisObj, NativeWeakMap.class, f);
+        if (!nm.instanceOfWeakMap) {
+            // Check for "Map internal data tag"
+            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
         }
-        try {
-            final NativeWeakMap nm = (NativeWeakMap)thisObj;
-            if (!nm.instanceOfWeakMap) {
-                // Check for "Map internal data tag"
-                throw incompatibleCallError(f);
-            }
-            return nm;
-        } catch (ClassCastException cce) {
-            throw incompatibleCallError(f);
-        }
+
+        return nm;
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeWeakSet.java
+++ b/src/org/mozilla/javascript/NativeWeakSet.java
@@ -94,19 +94,13 @@ public class NativeWeakSet extends IdScriptableObject {
     }
 
     private static NativeWeakSet realThis(Scriptable thisObj, IdFunctionObject f) {
-        if (thisObj == null) {
-            throw incompatibleCallError(f);
+        final NativeWeakSet ns = ensureType(thisObj, NativeWeakSet.class, f);
+        if (!ns.instanceOfWeakSet) {
+            // Check for "Set internal data tag"
+            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
         }
-        try {
-            final NativeWeakSet ns = (NativeWeakSet)thisObj;
-            if (!ns.instanceOfWeakSet) {
-                // Check for "Set internal data tag"
-                throw incompatibleCallError(f);
-            }
-            return ns;
-        } catch (ClassCastException cce) {
-            throw incompatibleCallError(f);
-        }
+
+        return ns;
     }
 
     @Override

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2742,9 +2742,7 @@ public class NativeRegExp extends IdScriptableObject
 
     private static NativeRegExp realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeRegExp))
-            throw incompatibleCallError(f);
-        return (NativeRegExp)thisObj;
+        return ensureType(thisObj, NativeRegExp.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -68,6 +68,9 @@ msg.varargs.fun =\
 msg.incompat.call =\
     Method "{0}" called on incompatible object.
 
+msg.incompat.call.details =\
+    Method "{0}" called on incompatible object ({1} is not an instance of {2}).
+
 msg.bad.parms =\
     Unsupported parameter type "{0}" in method "{1}".
 

--- a/src/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -146,9 +146,7 @@ public class NativeArrayBuffer
 
     private static NativeArrayBuffer realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeArrayBuffer))
-            throw incompatibleCallError(f);
-        return (NativeArrayBuffer)thisObj;
+        return ensureType(thisObj, NativeArrayBuffer.class, f);
     }
 
     private static boolean isArg(Object[] args, int i)

--- a/src/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -68,9 +68,7 @@ public class NativeDataView
 
     private static NativeDataView realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeDataView))
-            throw incompatibleCallError(f);
-        return (NativeDataView)thisObj;
+        return ensureType(thisObj, NativeDataView.class, f);
     }
 
     private static NativeDataView js_constructor(Object[] args)

--- a/src/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
@@ -66,10 +66,7 @@ public class NativeFloat32Array
     @Override
     protected NativeFloat32Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeFloat32Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeFloat32Array)thisObj;
+        return ensureType(thisObj, NativeFloat32Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
@@ -66,10 +66,7 @@ public class NativeFloat64Array
     @Override
     protected NativeFloat64Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeFloat64Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeFloat64Array)thisObj;
+        return ensureType(thisObj, NativeFloat64Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeInt16Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeInt16Array.java
@@ -65,10 +65,7 @@ public class NativeInt16Array
     @Override
     protected NativeInt16Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeInt16Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeInt16Array)thisObj;
+        return ensureType(thisObj, NativeInt16Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeInt32Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeInt32Array.java
@@ -66,10 +66,7 @@ public class NativeInt32Array
     @Override
     protected NativeInt32Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeInt32Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeInt32Array)thisObj;
+        return ensureType(thisObj, NativeInt32Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeInt8Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeInt8Array.java
@@ -64,10 +64,7 @@ public class NativeInt8Array
     @Override
     protected NativeInt8Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeInt8Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeInt8Array)thisObj;
+        return ensureType(thisObj, NativeInt8Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeUint16Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeUint16Array.java
@@ -65,10 +65,7 @@ public class NativeUint16Array
     @Override
     protected NativeUint16Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeUint16Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeUint16Array)thisObj;
+        return ensureType(thisObj, NativeUint16Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeUint32Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeUint32Array.java
@@ -65,10 +65,7 @@ public class NativeUint32Array
     @Override
     protected NativeUint32Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeUint32Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeUint32Array)thisObj;
+        return ensureType(thisObj, NativeUint32Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeUint8Array.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeUint8Array.java
@@ -64,10 +64,7 @@ public class NativeUint8Array
     @Override
     protected NativeUint8Array realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeUint8Array)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeUint8Array)thisObj;
+        return ensureType(thisObj, NativeUint8Array.class, f);
     }
 
     @Override

--- a/src/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
@@ -65,10 +65,7 @@ public class NativeUint8ClampedArray
     @Override
     protected NativeUint8ClampedArray realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if (!(thisObj instanceof NativeUint8ClampedArray)) {
-            throw incompatibleCallError(f);
-        }
-        return (NativeUint8ClampedArray)thisObj;
+        return ensureType(thisObj, NativeUint8ClampedArray.class, f);
     }
 
     @Override

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/Namespace.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/Namespace.java
@@ -224,9 +224,7 @@ class Namespace extends IdScriptableObject
     }
 
     private Namespace realThis(Scriptable thisObj, IdFunctionObject f) {
-        if(!(thisObj instanceof Namespace))
-            throw incompatibleCallError(f);
-        return (Namespace)thisObj;
+        return ensureType(thisObj, Namespace.class, f);
     }
 
     Namespace newNamespace(String uri) {

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/QName.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/QName.java
@@ -252,9 +252,7 @@ final class QName extends IdScriptableObject
 
     private QName realThis(Scriptable thisObj, IdFunctionObject f)
     {
-        if(!(thisObj instanceof QName))
-            throw incompatibleCallError(f);
-        return (QName)thisObj;
+        return ensureType(thisObj, QName.class, f);
     }
 
     QName newQName(XMLLibImpl lib, String q_uri, String q_localName, String q_prefix) {

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
@@ -620,9 +620,7 @@ abstract class XMLObjectImpl extends XMLObject {
         }
 
         // All (XML|XMLList).prototype methods require thisObj to be XML
-        if (!(thisObj instanceof XMLObjectImpl))
-            throw incompatibleCallError(f);
-        XMLObjectImpl realThis = (XMLObjectImpl)thisObj;
+        XMLObjectImpl realThis = ensureType(thisObj, XMLObjectImpl.class, f);
 
         XML xml = realThis.getXML();
         switch (id) {


### PR DESCRIPTION
It's really hard to find the reason for issues like https://github.com/HtmlUnit/htmlunit/issues/274 in huge libraries. Because of this i tried to make the error message a bit more explicit.

Hope you like it.

Will do a performance test for this change by applying this to the htmlunit rhino fork and check if there is some negative impact.
Will report the results here.