### PR TITLE
Memberbox delegate

### DIFF
--- a/src/org/mozilla/javascript/MemberBox.java
+++ b/src/org/mozilla/javascript/MemberBox.java
@@ -135,11 +135,14 @@ final class MemberBox implements Serializable
     /**
      * Function returned by calls to __lookupGetter__
      */
-    Function asGetterFunction(final String name, final Scriptable scope, final Scriptable prototype) {
+    Function asGetterFunction(final String name, final Scriptable scope) {
+        // Note: scope is the scriptable this function is related to; therefore this function
+        // is constant for this member box.
+        // Because of this we can cache the function in the attribute
         if (asGetterFunction == null) {
-            asGetterFunction = new BaseFunction(scope, prototype) {
+            asGetterFunction = new BaseFunction(scope, ScriptableObject.getFunctionPrototype(scope)) {
                 @Override
-                public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] originalArgs) {
+                public Object call(Context cx, Scriptable callScope, Scriptable thisObj, Object[] originalArgs) {
                     MemberBox nativeGetter = MemberBox.this;
                     Object getterThis;
                     Object[] args;
@@ -166,11 +169,14 @@ final class MemberBox implements Serializable
     /**
      * Function returned by calls to __lookupSetter__
      */
-    Function asSetterFunction(final String name, final Scriptable scope, final Scriptable prototype) {
+    Function asSetterFunction(final String name, final Scriptable scope) {
+        // Note: scope is the scriptable this function is related to; therefore this function
+        // is constant for this member box.
+        // Because of this we can cache the function in the attribute
         if (asSetterFunction == null) {
-            asSetterFunction = new BaseFunction(scope, prototype) {
+            asSetterFunction = new BaseFunction(scope, ScriptableObject.getFunctionPrototype(scope)) {
                 @Override
-                public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] originalArgs) {
+                public Object call(Context cx, Scriptable callScope, Scriptable thisObj, Object[] originalArgs) {
                     MemberBox nativeSetter = MemberBox.this;
                     Object setterThis;
                     Object[] args;

--- a/src/org/mozilla/javascript/MemberBox.java
+++ b/src/org/mozilla/javascript/MemberBox.java
@@ -30,10 +30,11 @@ final class MemberBox implements Serializable
 
     private transient Member memberObject;
     transient Class<?>[] argTypes;
-    transient Object delegateTo;
     transient boolean vararg;
+
     transient Function asGetterFunction;
     transient Function asSetterFunction;
+    transient Object delegateTo;
 
     MemberBox(Method method)
     {

--- a/src/org/mozilla/javascript/NativeError.java
+++ b/src/org/mozilla/javascript/NativeError.java
@@ -311,11 +311,13 @@ final class NativeError extends IdScriptableObject
             }
         }
 
-        // Define a property on the specified object to get that stack
-        // that delegates to our new error. Build the stack trace lazily
-        // using the "getStack" code from NativeError.
-        obj.defineProperty("stack", err,
-                           ERROR_DELEGATE_GET_STACK, ERROR_DELEGATE_SET_STACK, 0);
+        // from https://v8.dev/docs/stack-trace-api
+        // Error.captureStackTrace(error, constructorOpt)
+        // adds a stack property to the given error object that yields the stack trace
+        // at the time captureStackTrace was called. Stack traces collected through
+        // Error.captureStackTrace are immediately collected, formatted,
+        // and attached to the given error object.
+        obj.defineProperty("stack", err.get("stack"), ScriptableObject.DONTENUM);
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -306,8 +306,12 @@ public class NativeObject extends IdScriptableObject implements Map
                       else
                           break;
                   }
-                  if (gs != null)
+                  if (gs != null) {
+                      if (gs instanceof MemberBox) {
+                          gs = ((MemberBox) gs).asFunction(s.stringId, f.getParentScope(), f.getPrototype());
+                      }
                       return gs;
+                  }
               }
               return Undefined.instance;
 

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -308,7 +308,11 @@ public class NativeObject extends IdScriptableObject implements Map
                   }
                   if (gs != null) {
                       if (gs instanceof MemberBox) {
-                          gs = ((MemberBox) gs).asFunction(s.stringId, f.getParentScope(), f.getPrototype());
+                          if (isSetter) {
+                              gs = ((MemberBox) gs).asSetterFunction(s.stringId, f.getParentScope(), f.getPrototype());
+                          } else {
+                              gs = ((MemberBox) gs).asGetterFunction(s.stringId, f.getParentScope(), f.getPrototype());
+                          }
                       }
                       return gs;
                   }

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -309,9 +309,9 @@ public class NativeObject extends IdScriptableObject implements Map
                   if (gs != null) {
                       if (gs instanceof MemberBox) {
                           if (isSetter) {
-                              gs = ((MemberBox) gs).asSetterFunction(s.stringId, f.getParentScope(), f.getPrototype());
+                              gs = ((MemberBox) gs).asSetterFunction(s.stringId, this);
                           } else {
-                              gs = ((MemberBox) gs).asGetterFunction(s.stringId, f.getParentScope(), f.getPrototype());
+                              gs = ((MemberBox) gs).asGetterFunction(s.stringId, this);
                           }
                       }
                       return gs;

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -249,7 +249,7 @@ public abstract class ScriptableObject implements Scriptable,
             String fName = name == null ? "f" : name.toString();
             if (getter != null) {
                 if ( getter instanceof MemberBox ) {
-                    desc.defineProperty("get", ((MemberBox) getter).asGetterFunction(fName, scope, ScriptableObject.getFunctionPrototype(scope)), EMPTY);
+                    desc.defineProperty("get", ((MemberBox) getter).asGetterFunction(fName, scope), EMPTY);
                 } else if ( getter instanceof Member ) {
                     desc.defineProperty("get", new FunctionObject(fName, (Member)getter, scope), EMPTY);
                 } else {
@@ -258,7 +258,7 @@ public abstract class ScriptableObject implements Scriptable,
             }
             if (setter != null) {
                 if ( setter instanceof MemberBox ) {
-                    desc.defineProperty("set", ((MemberBox) setter).asSetterFunction(fName, scope, ScriptableObject.getFunctionPrototype(scope)), EMPTY);
+                    desc.defineProperty("set", ((MemberBox) setter).asSetterFunction(fName, scope), EMPTY);
                 } else if ( setter instanceof Member ) {
                     desc.defineProperty("set", new FunctionObject(fName, (Member) setter, scope), EMPTY);
                 } else {

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -249,7 +249,7 @@ public abstract class ScriptableObject implements Scriptable,
             String fName = name == null ? "f" : name.toString();
             if (getter != null) {
                 if ( getter instanceof MemberBox ) {
-                    desc.defineProperty("get", new FunctionObject(fName, ((MemberBox)getter).member(), scope), EMPTY);
+                    desc.defineProperty("get", ((MemberBox) getter).asGetterFunction(fName, scope, ScriptableObject.getFunctionPrototype(scope)), EMPTY);
                 } else if ( getter instanceof Member ) {
                     desc.defineProperty("get", new FunctionObject(fName, (Member)getter, scope), EMPTY);
                 } else {
@@ -258,7 +258,7 @@ public abstract class ScriptableObject implements Scriptable,
             }
             if (setter != null) {
                 if ( setter instanceof MemberBox ) {
-                    desc.defineProperty("set", new FunctionObject(fName, ((MemberBox) setter).member(), scope), EMPTY);
+                    desc.defineProperty("set", ((MemberBox) setter).asSetterFunction(fName, scope, ScriptableObject.getFunctionPrototype(scope)), EMPTY);
                 } else if ( setter instanceof Member ) {
                     desc.defineProperty("set", new FunctionObject(fName, (Member) setter, scope), EMPTY);
                 } else {
@@ -297,8 +297,7 @@ public abstract class ScriptableObject implements Scriptable,
                     // defineProperty ?
                     Class<?> valueType = pTypes[pTypes.length - 1];
                     int tag = FunctionObject.getTypeTag(valueType);
-                    Object actualArg = FunctionObject.convertArg(cx, start,
-                                                                 value, tag);
+                    Object actualArg = FunctionObject.convertArg(cx, start, value, tag);
                     Object setterThis;
                     Object[] args;
                     if (nativeSetter.delegateTo == null) {
@@ -311,8 +310,7 @@ public abstract class ScriptableObject implements Scriptable,
                     nativeSetter.invoke(setterThis, args);
                 } else if (setter instanceof Function) {
                     Function f = (Function)setter;
-                    f.call(cx, f.getParentScope(), start,
-                           new Object[] { value });
+                    f.call(cx, f.getParentScope(), start, new Object[] { value });
                 }
                 return true;
             }

--- a/testsrc/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/testsrc/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextAction;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+
+public class LookupSetterTest {
+    private final String defineSetterAndGetterX =
+        "Foo.__defineSetter__('x', function() {}); \n"
+        + "Foo.__defineGetter__('x', function() {return 'hello' });\n";
+
+    @Test
+    public void typeof() throws Exception {
+        test("function", "typeof Foo.__lookupSetter__('x');");
+        test("function", "typeof Foo.__lookupGetter__('x');");
+        test("function", "typeof (new Foo()).__lookupSetter__('s')");
+        test("function", "typeof (new Foo()).__lookupGetter__('s')");
+    }
+
+    @Test
+    public void callLookedUpGetter() throws Exception {
+        test("hello", "new Foo().s;");
+        test("hello", "var f = new Foo(); f.__lookupGetter__('s').call(f);");
+    }
+
+    @Test
+    public void lookedUpGetter_toString() throws Exception {
+        test("function s() {\n\t[native code, arity=0]\n}\n", "new Foo().__lookupGetter__('s').toString()");
+    }
+
+    @Test
+    public void lookedUpGetter_equals() throws Exception {
+        test("true", "new Foo().__lookupGetter__('s') == new Foo().__lookupGetter__('s')");
+    }
+
+    private void test(final String expected, final String src) throws Exception {
+        final ContextAction<String> action = new ContextAction<String>() {
+            @Override
+            public String run(final Context cx) {
+                try {
+                    final Scriptable scope = cx.initStandardObjects(new TopScope());
+                    ScriptableObject.defineClass(scope, Foo.class);
+                    cx.evaluateString(scope, defineSetterAndGetterX, "initX", 1, null);
+                    Object result = String.valueOf(cx.evaluateString(scope, src, "test", 1, null));
+                    assertEquals(expected, result);
+                    return null;
+                } catch (final Exception e) {
+                    if (e instanceof RuntimeException) {
+                        throw (RuntimeException) e;
+                    }
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        Utils.runWithAllOptimizationLevels(action);
+    }
+
+    public static class Foo extends ScriptableObject {
+        private String s = "hello";
+
+        public Foo() { /* Empty. */
+        }
+
+        public String jsGet_s() {
+            return this.s;
+        }
+
+        public void jsSet_s(String string) {
+            this.s = string;
+        }
+
+        @Override
+        public String getClassName() {
+            return "Foo";
+        }
+    }
+
+    public static class TopScope extends ScriptableObject {
+        @Override
+        public String getClassName() {
+            return "TopScope";
+        }
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/testsrc/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -24,6 +24,12 @@ public class LookupSetterTest {
 
         test("function", "typeof (new Foo()).__lookupGetter__('s')");
         test("function", "typeof (new Foo()).__lookupSetter__('s')");
+
+        test("true", "Object.getPrototypeOf((new Foo()).__lookupGetter__('s')) === Function.prototype");
+        test("true", "Object.getPrototypeOf((new Foo()).__lookupSetter__('s')) === Function.prototype");
+
+        test("true", "Object.getPrototypeOf(Foo.__lookupGetter__('x')) === Function.prototype");
+        test("true", "Object.getPrototypeOf(Foo.__lookupSetter__('x')) === Function.prototype");
     }
 
     @Test
@@ -42,6 +48,15 @@ public class LookupSetterTest {
         test("true", "new Foo().__lookupGetter__('s') == new Foo().__lookupGetter__('s')");
     }
 
+
+    @Test
+    public void getOwnPropertyDescriptor_equals() throws Exception {
+        test("true", "Object.getOwnPropertyDescriptor(Foo, 'x').get === Object.getOwnPropertyDescriptor(Foo, 'x').get");
+        test("true", "Object.getOwnPropertyDescriptor(Foo, 'x').set === Object.getOwnPropertyDescriptor(Foo, 'x').set");
+
+        test("true", "Object.getOwnPropertyDescriptor(Object.getPrototypeOf(new Foo()), 's').get === Object.getOwnPropertyDescriptor(Object.getPrototypeOf(new Foo()), 's').get");
+        test("true", "Object.getOwnPropertyDescriptor(Object.getPrototypeOf(new Foo()), 's').set === Object.getOwnPropertyDescriptor(Object.getPrototypeOf(new Foo()), 's').set");
+    }
 
     @Test
     public void callLookedUpSetter() throws Exception {

--- a/testsrc/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/testsrc/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -14,15 +14,16 @@ import org.mozilla.javascript.ScriptableObject;
 
 public class LookupSetterTest {
     private final String defineSetterAndGetterX =
-        "Foo.__defineSetter__('x', function() {}); \n"
-        + "Foo.__defineGetter__('x', function() {return 'hello' });\n";
+        "Foo.__defineSetter__('x', function(val) { Foo.value = val; }); \n"
+        + "Foo.__defineGetter__('x', function() {return 'hello' + value; });\n";
 
     @Test
     public void typeof() throws Exception {
-        test("function", "typeof Foo.__lookupSetter__('x');");
         test("function", "typeof Foo.__lookupGetter__('x');");
-        test("function", "typeof (new Foo()).__lookupSetter__('s')");
+        test("function", "typeof Foo.__lookupSetter__('x');");
+
         test("function", "typeof (new Foo()).__lookupGetter__('s')");
+        test("function", "typeof (new Foo()).__lookupSetter__('s')");
     }
 
     @Test
@@ -39,6 +40,23 @@ public class LookupSetterTest {
     @Test
     public void lookedUpGetter_equals() throws Exception {
         test("true", "new Foo().__lookupGetter__('s') == new Foo().__lookupGetter__('s')");
+    }
+
+
+    @Test
+    public void callLookedUpSetter() throws Exception {
+        test("newValue", "var f = new Foo(); f.s = 'newValue'; f.s");
+        test("newValue", "var f = new Foo(); f.__lookupSetter__('s').call(f, 'newValue'); f.s");
+    }
+
+    @Test
+    public void lookedUpSetter_toString() throws Exception {
+        test("function s() {\n\t[native code, arity=0]\n}\n", "new Foo().__lookupSetter__('s').toString()");
+    }
+
+    @Test
+    public void lookedUpSetter_equals() throws Exception {
+        test("true", "new Foo().__lookupSetter__('s') == new Foo().__lookupSetter__('s')");
     }
 
     private void test(final String expected, final String src) throws Exception {

--- a/testsrc/org/mozilla/javascript/tests/NativeObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeObjectTest.java
@@ -47,7 +47,8 @@ public class NativeObjectTest {
                 + "var desc = Object.getOwnPropertyDescriptor(myError, 'stack');"
                 + "'' + desc.get + '-' + desc.set + '-' + desc.value;",
                 "", 1, null);
-        Assert.assertEquals("undefined-undefined-\tat :2\r\n", result);
+        Assert.assertTrue(result instanceof String);
+        Assert.assertEquals("undefined-undefined-\tat :2", ((String) result).replaceAll("\\r|\\n", ""));
         Context.exit();
     }
 

--- a/testsrc/org/mozilla/javascript/tests/NativeObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeObjectTest.java
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+public class NativeObjectTest {
+
+    /**
+     * Freeze has to take care of MemberBox based properties
+     * with a delegateTo defined.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void freeze_captureStackTrace() throws Exception {
+        Context cx = Context.enter();
+        Scriptable global = cx.initStandardObjects();
+        Object result = cx.evaluateString(global,
+                "var myError = {};\n"
+                + "Error.captureStackTrace(myError);\n"
+                + "Object.freeze(myError);"
+                + "myError.stack;",
+                "", 1, null);
+        Assert.assertTrue(result instanceof String);
+        Context.exit();
+    }
+
+    /**
+     * getOwnPropertyDescriptor has to take care of MemberBox based properties
+     * with a delegateTo defined.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void getOwnPropertyDescriptor_captureStackTrace() throws Exception {
+        Context cx = Context.enter();
+        Scriptable global = cx.initStandardObjects();
+        Object result = cx.evaluateString(global,
+                "var myError = {};\n"
+                + "Error.captureStackTrace(myError);\n"
+                + "var desc = Object.getOwnPropertyDescriptor(myError, 'stack');"
+                + "'' + desc.get + '-' + desc.set + '-' + desc.value;",
+                "", 1, null);
+        Assert.assertEquals("undefined-undefined-\tat :2\r\n", result);
+        Context.exit();
+    }
+
+    /**
+     * getOwnPropertyDescriptor has to take care of MemberBox based properties
+     * with a delegateTo defined.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void getOwnPropertyDescriptorAttributes_captureStackTrace() throws Exception {
+        Context cx = Context.enter();
+        Scriptable global = cx.initStandardObjects();
+        Object result = cx.evaluateString(global,
+                "var myError = {};\n"
+                + "Error.captureStackTrace(myError);\n"
+                + "var desc = Object.getOwnPropertyDescriptor(myError, 'stack');"
+                + "desc.writable + ' ' + desc.configurable + ' ' + desc.enumerable",
+                "", 1, null);
+        Assert.assertEquals("true true false", result);
+        Context.exit();
+    }
+}


### PR DESCRIPTION
This is related to https://github.com/HtmlUnit/htmlunit/issues/274.

We do some magic at least with the stack trace handling - in  fact so far the delegate stuff of the member box was ignored at some places.

This pr merges some HtmlUnit changes and improves these fixes.
Additionally i have change the impl. of captureStackTrace.

Have done a test with all this changes using the HtmlUnit test suite - works fine so far and makes a lot more pojo tests passing (see https://jenkins.wetator.org/job/HtmlUnit%20-%20Headless/ and https://jenkins.wetator.org/job/HtmlUnit%20-%20Library%20Build/).

@gbrail  Not sure if it will be possible to improve this more but if i have an idea i will submit another pr. Will be great if you can merge this soon to let me go forward in HtmlUnit.