### PR TITLE
Refactor: Variadic getMessage

### DIFF
--- a/src/org/mozilla/javascript/Arguments.java
+++ b/src/org/mozilla/javascript/Arguments.java
@@ -431,7 +431,7 @@ final class Arguments extends IdScriptableObject
 
         @Override
         public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-            throw ScriptRuntime.typeError1("msg.arguments.not.access.strict", propertyName);
+            throw ScriptRuntime.typeErrorById("msg.arguments.not.access.strict", propertyName);
         }
     }
 

--- a/src/org/mozilla/javascript/ArrowFunction.java
+++ b/src/org/mozilla/javascript/ArrowFunction.java
@@ -45,7 +45,7 @@ public class ArrowFunction extends BaseFunction {
 
     @Override
     public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
-        throw ScriptRuntime.typeError1("msg.not.ctor", decompile(0, 0));
+        throw ScriptRuntime.typeErrorById("msg.not.ctor", decompile(0, 0));
     }
 
     @Override
@@ -53,7 +53,7 @@ public class ArrowFunction extends BaseFunction {
         if (targetFunction instanceof Function) {
             return ((Function) targetFunction).hasInstance(instance);
         }
-        throw ScriptRuntime.typeError0("msg.not.ctor");
+        throw ScriptRuntime.typeErrorById("msg.not.ctor");
     }
 
     @Override

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -93,7 +93,7 @@ public class BaseFunction extends IdScriptableObject implements Function
         if (protoProp instanceof Scriptable) {
             return ScriptRuntime.jsDelegatesTo(instance, (Scriptable)protoProp);
         }
-        throw ScriptRuntime.typeError1("msg.instanceof.bad.prototype",
+        throw ScriptRuntime.typeErrorById("msg.instanceof.bad.prototype",
                                        getFunctionName());
     }
 

--- a/src/org/mozilla/javascript/BoundFunction.java
+++ b/src/org/mozilla/javascript/BoundFunction.java
@@ -58,7 +58,7 @@ public class BoundFunction extends BaseFunction {
     if (targetFunction instanceof Function) {
       return ((Function) targetFunction).construct(cx, scope, concat(boundArgs, extraArgs));
     }
-    throw ScriptRuntime.typeError0("msg.not.ctor");
+    throw ScriptRuntime.typeErrorById("msg.not.ctor");
   }
 
   @Override
@@ -66,7 +66,7 @@ public class BoundFunction extends BaseFunction {
     if (targetFunction instanceof Function) {
       return ((Function) targetFunction).hasInstance(instance);
     }
-    throw ScriptRuntime.typeError0("msg.not.ctor");
+    throw ScriptRuntime.typeErrorById("msg.not.ctor");
   }
 
   @Override

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -975,12 +975,26 @@ public class Context
         throw new EvaluatorException(message, sourceName, lineno, lineSource, lineOffset);
     }
 
+    static EvaluatorException reportRuntimeErrorById(String messageId, Object... args)
+    {
+        String msg = ScriptRuntime.getMessageById(messageId, args);
+        return reportRuntimeError(msg);
+    }
+
+    /**
+     * @deprecated Use {@link #reportRuntimeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     static EvaluatorException reportRuntimeError0(String messageId)
     {
         String msg = ScriptRuntime.getMessageById(messageId);
         return reportRuntimeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #reportRuntimeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     static EvaluatorException reportRuntimeError1(String messageId,
                                                   Object arg1)
     {
@@ -988,6 +1002,10 @@ public class Context
         return reportRuntimeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #reportRuntimeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     static EvaluatorException reportRuntimeError2(String messageId,
                                                   Object arg1, Object arg2)
     {
@@ -995,6 +1013,10 @@ public class Context
         return reportRuntimeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #reportRuntimeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     static EvaluatorException reportRuntimeError3(String messageId,
                                                   Object arg1, Object arg2,
                                                   Object arg3)
@@ -1003,6 +1025,10 @@ public class Context
         return reportRuntimeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #reportRuntimeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     static EvaluatorException reportRuntimeError4(String messageId,
                                                   Object arg1, Object arg2,
                                                   Object arg3, Object arg4)

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -977,21 +977,21 @@ public class Context
 
     static EvaluatorException reportRuntimeError0(String messageId)
     {
-        String msg = ScriptRuntime.getMessage0(messageId);
+        String msg = ScriptRuntime.getMessageById(messageId);
         return reportRuntimeError(msg);
     }
 
     static EvaluatorException reportRuntimeError1(String messageId,
                                                   Object arg1)
     {
-        String msg = ScriptRuntime.getMessage1(messageId, arg1);
+        String msg = ScriptRuntime.getMessageById(messageId, arg1);
         return reportRuntimeError(msg);
     }
 
     static EvaluatorException reportRuntimeError2(String messageId,
                                                   Object arg1, Object arg2)
     {
-        String msg = ScriptRuntime.getMessage2(messageId, arg1, arg2);
+        String msg = ScriptRuntime.getMessageById(messageId, arg1, arg2);
         return reportRuntimeError(msg);
     }
 
@@ -999,7 +999,7 @@ public class Context
                                                   Object arg1, Object arg2,
                                                   Object arg3)
     {
-        String msg = ScriptRuntime.getMessage3(messageId, arg1, arg2, arg3);
+        String msg = ScriptRuntime.getMessageById(messageId, arg1, arg2, arg3);
         return reportRuntimeError(msg);
     }
 
@@ -1008,7 +1008,7 @@ public class Context
                                                   Object arg3, Object arg4)
     {
         String msg
-            = ScriptRuntime.getMessage4(messageId, arg1, arg2, arg3, arg4);
+            = ScriptRuntime.getMessageById(messageId, arg1, arg2, arg3, arg4);
         return reportRuntimeError(msg);
     }
 

--- a/src/org/mozilla/javascript/ES6Generator.java
+++ b/src/org/mozilla/javascript/ES6Generator.java
@@ -215,7 +215,7 @@ public final class ES6Generator extends IdScriptableObject {
             return ES6Iterator.makeIteratorResult(cx, scope, Boolean.TRUE);
         }
         if (state == State.EXECUTING) {
-            throw ScriptRuntime.typeError0("msg.generator.executing");
+            throw ScriptRuntime.typeErrorById("msg.generator.executing");
         }
 
         Scriptable result = ES6Iterator.makeIteratorResult(cx, scope, Boolean.FALSE);
@@ -285,7 +285,7 @@ public final class ES6Generator extends IdScriptableObject {
     private Scriptable resumeAbruptLocal(Context cx, Scriptable scope, int op, Object value)
     {
         if (state == State.EXECUTING) {
-            throw ScriptRuntime.typeError0("msg.generator.executing");
+            throw ScriptRuntime.typeErrorById("msg.generator.executing");
         }
         if (state == State.SUSPENDED_START) {
             // Throw right away if we never started
@@ -361,7 +361,7 @@ public final class ES6Generator extends IdScriptableObject {
             delegee, ES6Iterator.RETURN_METHOD, cx, scope);
         if (!Undefined.instance.equals(retFnObj)) {
             if (!(retFnObj instanceof Callable)) {
-                throw ScriptRuntime.typeError2("msg.isnt.function", ES6Iterator.RETURN_METHOD,
+                throw ScriptRuntime.typeErrorById("msg.isnt.function", ES6Iterator.RETURN_METHOD,
                     ScriptRuntime.typeof(retFnObj));
             }
             return ((Callable)retFnObj).call(cx, scope, ensureScriptable(delegee), retArgs);

--- a/src/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/src/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -293,7 +293,7 @@ public class EmbeddedSlotMap
                 if ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0) {
                     Context cx = Context.getContext();
                     if (cx.isStrictMode()) {
-                        throw ScriptRuntime.typeError1("msg.delete.property.with.configurable.false", key);
+                        throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false", key);
                     }
                     return;
                 }

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -417,7 +417,7 @@ public class FunctionObject extends BaseFunction
                     }
                     if (!compatible) {
                         // Couldn't find an object to call this on.
-                        throw ScriptRuntime.typeError1("msg.incompat.call", functionName);
+                        throw ScriptRuntime.typeErrorById("msg.incompat.call", functionName);
                     }
                 }
             }

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -106,7 +106,7 @@ public class FunctionObject extends BaseFunction
                     types[2] != ScriptRuntime.FunctionClass ||
                     types[3] != Boolean.TYPE)
                 {
-                    throw Context.reportRuntimeError1(
+                    throw Context.reportRuntimeErrorById(
                         "msg.varargs.ctor", methodName);
                 }
                 parmsLength = VARARGS_CTOR;
@@ -117,7 +117,7 @@ public class FunctionObject extends BaseFunction
                     types[2].getComponentType() != ScriptRuntime.ObjectClass ||
                     types[3] != ScriptRuntime.FunctionClass)
                 {
-                    throw Context.reportRuntimeError1(
+                    throw Context.reportRuntimeErrorById(
                         "msg.varargs.fun", methodName);
                 }
                 parmsLength = VARARGS_METHOD;
@@ -129,7 +129,7 @@ public class FunctionObject extends BaseFunction
                 for (int i = 0; i != arity; ++i) {
                     int tag = getTypeTag(types[i]);
                     if (tag == JAVA_UNSUPPORTED_TYPE) {
-                        throw Context.reportRuntimeError2(
+                        throw Context.reportRuntimeErrorById(
                             "msg.bad.parms", types[i].getName(), methodName);
                     }
                     typeTags[i] = (byte)tag;
@@ -148,7 +148,7 @@ public class FunctionObject extends BaseFunction
         } else {
             Class<?> ctorType = member.getDeclaringClass();
             if (!ScriptRuntime.ScriptableClass.isAssignableFrom(ctorType)) {
-                throw Context.reportRuntimeError1(
+                throw Context.reportRuntimeErrorById(
                     "msg.bad.ctor.return", ctorType.getName());
             }
         }
@@ -255,7 +255,7 @@ public class FunctionObject extends BaseFunction
             Method method = methods[i];
             if (method != null && name.equals(method.getName())) {
                 if (found != null) {
-                    throw Context.reportRuntimeError2(
+                    throw Context.reportRuntimeErrorById(
                         "msg.no.overload", name,
                         method.getDeclaringClass().getName());
                 }
@@ -355,7 +355,7 @@ public class FunctionObject extends BaseFunction
     {
         int tag = getTypeTag(desired);
         if (tag == JAVA_UNSUPPORTED_TYPE) {
-            throw Context.reportRuntimeError1
+            throw Context.reportRuntimeErrorById
                 ("msg.cant.convert", desired.getName());
         }
         return convertArg(cx, scope, arg, tag);

--- a/src/org/mozilla/javascript/HashSlotMap.java
+++ b/src/org/mozilla/javascript/HashSlotMap.java
@@ -114,7 +114,7 @@ public class HashSlotMap
             if ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0) {
                 Context cx = Context.getContext();
                 if (cx.isStrictMode()) {
-                    throw ScriptRuntime.typeError1("msg.delete.property.with.configurable.false", key);
+                    throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false", key);
                 }
                 return;
             }

--- a/src/org/mozilla/javascript/IdFunctionObject.java
+++ b/src/org/mozilla/javascript/IdFunctionObject.java
@@ -110,7 +110,7 @@ public class IdFunctionObject extends BaseFunction
         // to satisfy ECMAScript standard (see bugzilla 202019).
         // To follow current (2003-05-01) SpiderMonkey behavior, change it to:
         // return super.createObject(cx, scope);
-        throw ScriptRuntime.typeError1("msg.not.ctor", functionName);
+        throw ScriptRuntime.typeErrorById("msg.not.ctor", functionName);
     }
 
     @Override

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -450,7 +450,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         int info = findInstanceIdInfo(name);
         if (info != 0) {
             if (start == this && isSealed()) {
-                throw Context.reportRuntimeError1("msg.modify.sealed",
+                throw Context.reportRuntimeErrorById("msg.modify.sealed",
                                                   name);
             }
             int attr = (info >>> 16);
@@ -469,7 +469,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
             int id = prototypeValues.findId(name);
             if (id != 0) {
                 if (start == this && isSealed()) {
-                    throw Context.reportRuntimeError1("msg.modify.sealed",
+                    throw Context.reportRuntimeErrorById("msg.modify.sealed",
                                                       name);
                 }
                 prototypeValues.set(id, start, value);
@@ -485,7 +485,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         int info = findInstanceIdInfo(key);
         if (info != 0) {
             if (start == this && isSealed()) {
-                throw Context.reportRuntimeError0("msg.modify.sealed");
+                throw Context.reportRuntimeErrorById("msg.modify.sealed");
             }
             int attr = (info >>> 16);
             if ((attr & READONLY) == 0) {
@@ -503,7 +503,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
             int id = prototypeValues.findId(key);
             if (id != 0) {
                 if (start == this && isSealed()) {
-                    throw Context.reportRuntimeError0("msg.modify.sealed");
+                    throw Context.reportRuntimeErrorById("msg.modify.sealed");
                 }
                 prototypeValues.set(id, start, value);
                 return;

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -227,7 +227,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                 if (cx.isStrictMode()) {
                     int nameSlot = (id  - 1) * SLOT_SPAN + NAME_SLOT;
                     String name = (String)valueArray[nameSlot];
-                    throw ScriptRuntime.typeError1("msg.delete.property.with.configurable.false", name);
+                    throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false", name);
                 }
             } else {
                 int valueSlot = (id  - 1) * SLOT_SPAN;
@@ -524,7 +524,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                 if ((attr & PERMANENT) != 0) {
                     Context cx = Context.getContext();
                     if (cx.isStrictMode()) {
-                        throw ScriptRuntime.typeError1("msg.delete.property.with.configurable.false", name);
+                        throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false", name);
                     }
                 } else {
                     int id = (info & 0xFFFF);
@@ -557,7 +557,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                 if ((attr & PERMANENT) != 0) {
                     Context cx = Context.getContext();
                     if (cx.isStrictMode()) {
-                        throw ScriptRuntime.typeError0("msg.delete.property.with.configurable.false");
+                        throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false");
                     }
                 } else {
                     int id = (info & 0xFFFF);
@@ -902,9 +902,9 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
             return (T) obj;
         }
         if (obj == null) {
-            throw ScriptRuntime.typeError3("msg.incompat.call.details", f.getFunctionName(), "null", clazz.getName());
+            throw ScriptRuntime.typeErrorById("msg.incompat.call.details", f.getFunctionName(), "null", clazz.getName());
         }
-        throw ScriptRuntime.typeError3("msg.incompat.call.details", f.getFunctionName(), obj.getClass().getName(), clazz.getName());
+        throw ScriptRuntime.typeErrorById("msg.incompat.call.details", f.getFunctionName(), obj.getClass().getName(), clazz.getName());
     }
 
     private IdFunctionObject newIdFunction(Object tag, int id, String name,

--- a/src/org/mozilla/javascript/ImporterTopLevel.java
+++ b/src/org/mozilla/javascript/ImporterTopLevel.java
@@ -114,7 +114,7 @@ public class ImporterTopLevel extends TopLevel {
                 if (result == NOT_FOUND) {
                     result = v;
                 } else {
-                    throw Context.reportRuntimeError2(
+                    throw Context.reportRuntimeErrorById(
                         "msg.ambig.import", result.toString(), v.toString());
                 }
             }
@@ -142,7 +142,7 @@ public class ImporterTopLevel extends TopLevel {
             } else if (arg instanceof NativeJavaPackage) {
                 result.importPackage((NativeJavaPackage)arg);
             } else {
-                throw Context.reportRuntimeError1(
+                throw Context.reportRuntimeErrorById(
                     "msg.not.class.not.pkg", Context.toString(arg));
             }
         }
@@ -161,7 +161,7 @@ public class ImporterTopLevel extends TopLevel {
         for (int i = 0; i != args.length; i++) {
             Object arg = args[i];
             if (!(arg instanceof NativeJavaClass)) {
-                throw Context.reportRuntimeError1(
+                throw Context.reportRuntimeErrorById(
                     "msg.not.class", Context.toString(arg));
             }
             importClass((NativeJavaClass)arg);
@@ -174,7 +174,7 @@ public class ImporterTopLevel extends TopLevel {
         for (int i = 0; i != args.length; i++) {
             Object arg = args[i];
             if (!(arg instanceof NativeJavaPackage)) {
-                throw Context.reportRuntimeError1(
+                throw Context.reportRuntimeErrorById(
                     "msg.not.pkg", Context.toString(arg));
             }
             importPackage((NativeJavaPackage)arg);
@@ -203,7 +203,7 @@ public class ImporterTopLevel extends TopLevel {
         String n = s.substring(s.lastIndexOf('.')+1);
         Object val = get(n, this);
         if (val != NOT_FOUND && val != cl) {
-            throw Context.reportRuntimeError1("msg.prop.defined", n);
+            throw Context.reportRuntimeErrorById("msg.prop.defined", n);
         }
         //defineProperty(n, cl, DONTENUM);
         put(n, this, cl);

--- a/src/org/mozilla/javascript/InterfaceAdapter.java
+++ b/src/org/mozilla/javascript/InterfaceAdapter.java
@@ -123,7 +123,7 @@ public class InterfaceAdapter
                 // We really should throw an error here, but for the sake of
                 // compatibility with JavaAdapter we silently ignore undefined
                 // methods.
-                Context.reportWarning(ScriptRuntime.getMessage1(
+                Context.reportWarning(ScriptRuntime.getMessageById(
                         "msg.undefined.function.interface", methodName));
                 Class<?> resultType = method.getReturnType();
                 if (resultType == Void.TYPE) {

--- a/src/org/mozilla/javascript/InterfaceAdapter.java
+++ b/src/org/mozilla/javascript/InterfaceAdapter.java
@@ -43,7 +43,7 @@ public class InterfaceAdapter
                 // the same function to be invoked anyway).
                 int length = methods.length;
                 if (length == 0) {
-                    throw Context.reportRuntimeError1(
+                    throw Context.reportRuntimeErrorById(
                         "msg.no.empty.interface.conversion", cl.getName());
                 }
                 if (length > 1) {
@@ -55,7 +55,7 @@ public class InterfaceAdapter
                             if (methodName == null) {
                                 methodName = method.getName();
                             } else if (!methodName.equals(method.getName())) {
-                                throw Context.reportRuntimeError1(
+                                throw Context.reportRuntimeErrorById(
                                     "msg.no.function.interface.conversion",
                                     cl.getName());
                             }
@@ -132,7 +132,7 @@ public class InterfaceAdapter
                 return Context.jsToJava(null, resultType);
             }
             if (!(value instanceof Callable)) {
-                throw Context.reportRuntimeError1(
+                throw Context.reportRuntimeErrorById(
                         "msg.not.function.interface",methodName);
             }
             function = (Callable)value;

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -2845,7 +2845,7 @@ switch (op) {
     {
           if (generatorState.operation == NativeGenerator.GENERATOR_CLOSE) {
               // Error: no yields when generator is closing
-              throw ScriptRuntime.typeError0("msg.yield.closing");
+              throw ScriptRuntime.typeErrorById("msg.yield.closing");
           }
           // return to our caller (which should be a method of NativeGenerator)
           frame.frozen = true;

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -2519,7 +2519,7 @@ switch (op) {
                                      int[] varAttributes, int indexReg) {
         if (!frame.useActivation) {
             if ((varAttributes[indexReg] & ScriptableObject.READONLY) == 0) {
-                throw Context.reportRuntimeError1("msg.var.redecl",
+                throw Context.reportRuntimeErrorById("msg.var.redecl",
                                                   frame.idata.argNames[indexReg]);
             }
             if ((varAttributes[indexReg] & ScriptableObject.UNINITIALIZED_CONST)

--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -203,7 +203,7 @@ public final class JavaAdapter implements IdFunctionCall
                 int index = ctors.findCachedFunction(cx, ctorArgs);
                 if (index < 0) {
                     String sig = NativeJavaMethod.scriptSignature(args);
-                    throw Context.reportRuntimeError2(
+                    throw Context.reportRuntimeErrorById(
                             "msg.no.java.ctor", adapterClass.getName(), sig);
                 }
 
@@ -984,7 +984,7 @@ public final class JavaAdapter implements IdFunctionCall
         if (parms.length > 64) {
             // If it will be an issue, then passing a static boolean array
             // can be an option, but for now using simple bitmask
-            throw Context.reportRuntimeError0(
+            throw Context.reportRuntimeErrorById(
                 "JavaAdapter can not subclass methods with more then"
                 +" 64 arguments.");
         }

--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -133,7 +133,7 @@ public final class JavaAdapter implements IdFunctionCall
     {
         int N = args.length;
         if (N == 0) {
-            throw ScriptRuntime.typeError0("msg.adapter.zero.args");
+            throw ScriptRuntime.typeErrorById("msg.adapter.zero.args");
         }
 
         // Expected arguments:
@@ -153,7 +153,7 @@ public final class JavaAdapter implements IdFunctionCall
                 break;
             }
             if (!(arg instanceof NativeJavaClass)) {
-                throw ScriptRuntime.typeError2("msg.not.java.class.arg",
+                throw ScriptRuntime.typeErrorById("msg.not.java.class.arg",
                                                String.valueOf(classCount),
                                                ScriptRuntime.toString(arg));
             }
@@ -165,7 +165,7 @@ public final class JavaAdapter implements IdFunctionCall
             Class<?> c = ((NativeJavaClass) args[i]).getClassObject();
             if (!c.isInterface()) {
                 if (superClass != null) {
-                    throw ScriptRuntime.typeError2("msg.only.one.super",
+                    throw ScriptRuntime.typeErrorById("msg.only.one.super",
                               superClass.getName(), c.getName());
                 }
                 superClass = c;

--- a/src/org/mozilla/javascript/JavaMembers.java
+++ b/src/org/mozilla/javascript/JavaMembers.java
@@ -41,7 +41,7 @@ class JavaMembers
             Context cx = ContextFactory.getGlobal().enterContext();
             ClassShutter shutter = cx.getClassShutter();
             if (shutter != null && !shutter.visibleToScripts(cl.getName())) {
-                throw Context.reportRuntimeError1("msg.access.prohibited",
+                throw Context.reportRuntimeErrorById("msg.access.prohibited",
                                                   cl.getName());
             }
             this.members = new HashMap<String,Object>();
@@ -150,7 +150,7 @@ class JavaMembers
             if (!(member instanceof Field)) {
                 String str = (member == null) ? "msg.java.internal.private"
                                               : "msg.java.method.assign";
-                throw Context.reportRuntimeError1(str, name);
+                throw Context.reportRuntimeErrorById(str, name);
             }
             Field field = (Field)member;
             Object javaValue = Context.jsToJava(value, field.getType());
@@ -163,7 +163,7 @@ class JavaMembers
                 }
                 throw Context.throwAsScriptRuntimeEx(accessEx);
             } catch (IllegalArgumentException argEx) {
-                throw Context.reportRuntimeError3(
+                throw Context.reportRuntimeErrorById(
                     "msg.java.internal.field.type",
                     value.getClass().getName(), field,
                     javaObject.getClass().getName());
@@ -852,7 +852,7 @@ class JavaMembers
 
     RuntimeException reportMemberNotFound(String memberName)
     {
-        return Context.reportRuntimeError2(
+        return Context.reportRuntimeErrorById(
             "msg.java.member.not.found", cl.getName(), memberName);
     }
 
@@ -901,7 +901,7 @@ class FieldAndMethods extends NativeJavaMethod
             rval = field.get(javaObject);
             type = field.getType();
         } catch (IllegalAccessException accEx) {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.java.internal.private", field.getName());
         }
         Context cx  = Context.getContext();

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -652,7 +652,7 @@ public class NativeArray extends IdScriptableObject implements List
         }
         long len = ScriptRuntime.toUint32(arg0);
         if (len != ((Number)arg0).doubleValue()) {
-            String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+            String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
         return new NativeArray(len);
@@ -791,7 +791,7 @@ public class NativeArray extends IdScriptableObject implements List
         double d = ScriptRuntime.toNumber(val);
         long longVal = ScriptRuntime.toUint32(d);
         if (longVal != d) {
-            String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+            String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
 
@@ -864,7 +864,7 @@ public class NativeArray extends IdScriptableObject implements List
         double doubleLen = ScriptRuntime.toNumber(len);
         if (doubleLen > NativeNumber.MAX_SAFE_INTEGER) {
             if (throwIfTooLarge) {
-                String msg = ScriptRuntime.getMessage0("msg.arraylength.bad");
+                String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
                 throw ScriptRuntime.rangeError(msg);
             }
             return (int) NativeNumber.MAX_SAFE_INTEGER;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -694,7 +694,7 @@ public class NativeArray extends IdScriptableObject implements List
 
         if (mapping) {
             if (!(mapArg instanceof Function)) {
-                throw ScriptRuntime.typeError0("msg.map.function.not");
+                throw ScriptRuntime.typeErrorById("msg.map.function.not");
             }
             mapFn = (Function)mapArg;
             if (args.length >= 3) {
@@ -2035,7 +2035,7 @@ public class NativeArray extends IdScriptableObject implements List
         }
         if (value == Scriptable.NOT_FOUND) {
             // reproduce spidermonkey error message
-            throw ScriptRuntime.typeError0("msg.empty.array.reduce");
+            throw ScriptRuntime.typeErrorById("msg.empty.array.reduce");
         }
         return value;
     }

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1047,7 +1047,7 @@ public class NativeArray extends IdScriptableObject implements List
         long llength = getLengthProperty(cx, o, false);
         int length = (int)llength;
         if (llength != length) {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.arraylength.too.big", String.valueOf(llength));
         }
         // if no args, use "," as separator
@@ -1173,7 +1173,7 @@ public class NativeArray extends IdScriptableObject implements List
         long llength = getLengthProperty(cx, o, false);
         final int length = (int) llength;
         if (llength != length) {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.arraylength.too.big", String.valueOf(llength));
         }
         // copy the JS array into a working array, so it can be

--- a/src/org/mozilla/javascript/NativeCall.java
+++ b/src/org/mozilla/javascript/NativeCall.java
@@ -107,7 +107,7 @@ public final class NativeCall extends IdScriptableObject
         int id = f.methodId();
         if (id == Id_constructor) {
             if (thisObj != null) {
-                throw Context.reportRuntimeError1("msg.only.from.new", "Call");
+                throw Context.reportRuntimeErrorById("msg.only.from.new", "Call");
             }
             ScriptRuntime.checkDeprecated(cx, "Call");
             NativeCall result = new NativeCall();

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -365,7 +365,7 @@ final class NativeDate extends IdScriptableObject
             if (!Double.isNaN(t)) {
                 return js_toISOString(t);
             }
-            String msg = ScriptRuntime.getMessage0("msg.invalid.date");
+            String msg = ScriptRuntime.getMessageById("msg.invalid.date");
             throw ScriptRuntime.rangeError(msg);
 
           default: throw new IllegalArgumentException(String.valueOf(id));

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -172,12 +172,12 @@ final class NativeDate extends IdScriptableObject
                 }
                 Object toISO = ScriptableObject.getProperty(o, toISOString);
                 if (toISO == NOT_FOUND) {
-                    throw ScriptRuntime.typeError2("msg.function.not.found.in",
+                    throw ScriptRuntime.typeErrorById("msg.function.not.found.in",
                             toISOString,
                             ScriptRuntime.toString(o));
                 }
                 if ( !(toISO instanceof Callable) ) {
-                    throw ScriptRuntime.typeError3("msg.isnt.function.in",
+                    throw ScriptRuntime.typeErrorById("msg.isnt.function.in",
                             toISOString,
                             ScriptRuntime.toString(o),
                             ScriptRuntime.toString(toISO));
@@ -185,7 +185,7 @@ final class NativeDate extends IdScriptableObject
                 Object result = ((Callable) toISO).call(cx, scope, o,
                             ScriptRuntime.emptyArgs);
                 if ( !ScriptRuntime.isPrimitive(result) ) {
-                    throw ScriptRuntime.typeError1("msg.toisostring.must.return.primitive",
+                    throw ScriptRuntime.typeErrorById("msg.toisostring.must.return.primitive",
                             ScriptRuntime.toString(result));
                 }
                 return result;

--- a/src/org/mozilla/javascript/NativeGenerator.java
+++ b/src/org/mozilla/javascript/NativeGenerator.java
@@ -114,7 +114,7 @@ public final class NativeGenerator extends IdScriptableObject {
           case Id_send: {
             Object arg = args.length > 0 ? args[0] : Undefined.instance;
             if (generator.firstTime && !arg.equals(Undefined.instance)) {
-                throw ScriptRuntime.typeError0("msg.send.newborn");
+                throw ScriptRuntime.typeErrorById("msg.send.newborn");
             }
             return generator.resume(cx, scope, GENERATOR_SEND, arg);
           }
@@ -151,7 +151,7 @@ public final class NativeGenerator extends IdScriptableObject {
               // non-reentrant.
               // See https://bugzilla.mozilla.org/show_bug.cgi?id=349263
               if (locked)
-                  throw ScriptRuntime.typeError0("msg.already.exec.gen");
+                  throw ScriptRuntime.typeErrorById("msg.already.exec.gen");
               locked = true;
             }
             return function.resumeGenerator(cx, scope, operation, savedState,

--- a/src/org/mozilla/javascript/NativeGlobal.java
+++ b/src/org/mozilla/javascript/NativeGlobal.java
@@ -722,7 +722,7 @@ public class NativeGlobal implements Serializable, IdFunctionCall
 
     private static EcmaError uriError() {
         return ScriptRuntime.constructError("URIError",
-                ScriptRuntime.getMessage0("msg.bad.uri"));
+                ScriptRuntime.getMessageById("msg.bad.uri"));
     }
 
     private static final String URI_DECODE_RESERVED = ";/?:@&=+$,#";

--- a/src/org/mozilla/javascript/NativeGlobal.java
+++ b/src/org/mozilla/javascript/NativeGlobal.java
@@ -386,7 +386,7 @@ public class NativeGlobal implements Serializable, IdFunctionCall
             if (Double.isNaN(d) || ((mask = (int) d) != d) ||
                 0 != (mask & ~(URL_XALPHAS | URL_XPALPHAS | URL_PATH)))
             {
-                throw Context.reportRuntimeError0("msg.bad.esc.mask");
+                throw Context.reportRuntimeErrorById("msg.bad.esc.mask");
             }
         }
 

--- a/src/org/mozilla/javascript/NativeIterator.java
+++ b/src/org/mozilla/javascript/NativeIterator.java
@@ -153,7 +153,7 @@ public final class NativeIterator extends IdScriptableObject {
             args[0] == Undefined.instance)
         {
             Object argument = args.length == 0 ? Undefined.instance : args[0];
-            throw ScriptRuntime.typeError1("msg.no.properties",
+            throw ScriptRuntime.typeErrorById("msg.no.properties",
                                            ScriptRuntime.toString(argument));
         }
         Scriptable obj = ScriptRuntime.toObject(cx, scope, args[0]);

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -339,7 +339,7 @@ public final class NativeJSON extends IdScriptableObject
 
     private static String jo(Scriptable value, StringifyState state) {
         if (state.stack.search(value) != -1) {
-            throw ScriptRuntime.typeError0("msg.cyclic.value");
+            throw ScriptRuntime.typeErrorById("msg.cyclic.value");
         }
         state.stack.push(value);
 
@@ -388,7 +388,7 @@ public final class NativeJSON extends IdScriptableObject
 
     private static String ja(NativeArray value, StringifyState state) {
         if (state.stack.search(value) != -1) {
-            throw ScriptRuntime.typeError0("msg.cyclic.value");
+            throw ScriptRuntime.typeErrorById("msg.cyclic.value");
         }
         state.stack.push(value);
 

--- a/src/org/mozilla/javascript/NativeJavaArray.java
+++ b/src/org/mozilla/javascript/NativeJavaArray.java
@@ -71,7 +71,7 @@ public class NativeJavaArray
         if (result == NOT_FOUND &&
             !ScriptableObject.hasProperty(getPrototype(), id))
         {
-            throw Context.reportRuntimeError2(
+            throw Context.reportRuntimeErrorById(
                 "msg.java.member.not.found", array.getClass().getName(), id);
         }
         return result;
@@ -99,7 +99,7 @@ public class NativeJavaArray
     public void put(String id, Scriptable start, Object value) {
         // Ignore assignments to "length"--it's readonly.
         if (!id.equals("length"))
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.java.array.member.not.found", id);
     }
 
@@ -109,7 +109,7 @@ public class NativeJavaArray
             Array.set(array, index, Context.jsToJava(value, cls));
         }
         else {
-            throw Context.reportRuntimeError2(
+            throw Context.reportRuntimeErrorById(
                 "msg.java.array.index.out.of.bounds", String.valueOf(index),
                 String.valueOf(length - 1));
         }

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -161,7 +161,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
             int index = ctors.findCachedFunction(cx, args);
             if (index < 0) {
                 String sig = NativeJavaMethod.scriptSignature(args);
-                throw Context.reportRuntimeError2(
+                throw Context.reportRuntimeErrorById(
                     "msg.no.java.ctor", classObject.getName(), sig);
             }
 
@@ -169,7 +169,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
             return constructSpecific(cx, scope, args, ctors.methods[index]);
         }
         if (args.length == 0) {
-            throw Context.reportRuntimeError0("msg.adapter.zero.args");
+            throw Context.reportRuntimeErrorById("msg.adapter.zero.args");
         }
         Scriptable topLevel = ScriptableObject.getTopLevelScope(this);
         String msg = "";
@@ -197,7 +197,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
             if (m != null)
                 msg = m;
         }
-        throw Context.reportRuntimeError2(
+        throw Context.reportRuntimeErrorById(
             "msg.cant.instantiate", msg, classObject.getName());
     }
 

--- a/src/org/mozilla/javascript/NativeJavaMethod.java
+++ b/src/org/mozilla/javascript/NativeJavaMethod.java
@@ -142,7 +142,7 @@ public class NativeJavaMethod extends BaseFunction
             Class<?> c = methods[0].method().getDeclaringClass();
             String sig = c.getName() + '.' + getFunctionName() + '(' +
                          scriptSignature(args) + ')';
-            throw Context.reportRuntimeError1("msg.java.no_such_method", sig);
+            throw Context.reportRuntimeErrorById("msg.java.no_such_method", sig);
         }
 
         MemberBox meth = methods[index];
@@ -206,7 +206,7 @@ public class NativeJavaMethod extends BaseFunction
             Class<?> c = meth.getDeclaringClass();
             for (;;) {
                 if (o == null) {
-                    throw Context.reportRuntimeError3(
+                    throw Context.reportRuntimeErrorById(
                         "msg.nonjava.method", getFunctionName(),
                         ScriptRuntime.toString(thisObj), c.getName());
                 }
@@ -453,11 +453,11 @@ public class NativeJavaMethod extends BaseFunction
         String memberClass = firstFitMember.getDeclaringClass().getName();
 
         if (methodsOrCtors[0].isCtor()) {
-            throw Context.reportRuntimeError3(
+            throw Context.reportRuntimeErrorById(
                 "msg.constructor.ambiguous",
                 memberName, scriptSignature(args), buf.toString());
         }
-        throw Context.reportRuntimeError4(
+        throw Context.reportRuntimeErrorById(
             "msg.method.ambiguous", memberClass,
             memberName, scriptSignature(args), buf.toString());
     }

--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -230,7 +230,7 @@ public class NativeJavaObject
             } else if (hint == ScriptRuntime.NumberClass) {
                 converterName = "doubleValue";
             } else {
-                throw Context.reportRuntimeError0("msg.default.value");
+                throw Context.reportRuntimeErrorById("msg.default.value");
             }
             Object converterObject = get(converterName, this);
             if (converterObject instanceof Function) {
@@ -900,7 +900,7 @@ public class NativeJavaObject
     {
         // It uses String.valueOf(value), not value.toString() since
         // value can be null, bug 282447.
-        throw Context.reportRuntimeError2(
+        throw Context.reportRuntimeErrorById(
             "msg.conversion.not.allowed",
             String.valueOf(value),
             JavaMembers.javaSignature(type));

--- a/src/org/mozilla/javascript/NativeJavaPackage.java
+++ b/src/org/mozilla/javascript/NativeJavaPackage.java
@@ -76,7 +76,7 @@ public class NativeJavaPackage extends ScriptableObject
 
     @Override
     public void put(int index, Scriptable start, Object value) {
-        throw Context.reportRuntimeError0("msg.pkg.int");
+        throw Context.reportRuntimeErrorById("msg.pkg.int");
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeJavaTopPackage.java
+++ b/src/org/mozilla/javascript/NativeJavaTopPackage.java
@@ -63,7 +63,7 @@ public class NativeJavaTopPackage
             }
         }
         if (loader == null) {
-            Context.reportRuntimeError0("msg.not.classloader");
+            Context.reportRuntimeErrorById("msg.not.classloader");
             return null;
         }
         NativeJavaPackage pkg = new NativeJavaPackage(true, "", loader);
@@ -148,7 +148,7 @@ public class NativeJavaTopPackage
                 offset = index+1;
             }
         }
-        throw Context.reportRuntimeError0("msg.not.java.obj");
+        throw Context.reportRuntimeErrorById("msg.not.java.obj");
     }
 
     private static final Object FTAG = "JavaTopPackage";

--- a/src/org/mozilla/javascript/NativeMap.java
+++ b/src/org/mozilla/javascript/NativeMap.java
@@ -57,7 +57,7 @@ public class NativeMap extends IdScriptableObject {
                     }
                     return nm;
                 }
-                throw ScriptRuntime.typeError1("msg.no.new", "Map");
+                throw ScriptRuntime.typeErrorById("msg.no.new", "Map");
             case Id_set:
                 return realThis(thisObj, f).js_set(
                     args.length > 0 ? args[0] : Undefined.instance,
@@ -143,7 +143,7 @@ public class NativeMap extends IdScriptableObject {
     private Object js_forEach(Context cx, Scriptable scope, Object arg1, Object arg2)
     {
         if (!(arg1 instanceof Callable)) {
-            throw ScriptRuntime.typeError2("msg.isnt.function", arg1, ScriptRuntime.typeof(arg1));
+            throw ScriptRuntime.typeErrorById("msg.isnt.function", arg1, ScriptRuntime.typeof(arg1));
         }
         final Callable f = (Callable)arg1;
 
@@ -201,7 +201,7 @@ public class NativeMap extends IdScriptableObject {
             for (Object val : it) {
                 Scriptable sVal = ScriptableObject.ensureScriptable(val);
                 if (sVal instanceof Symbol) {
-                    throw ScriptRuntime.typeError1("msg.arg.not.object", ScriptRuntime.typeof(sVal));
+                    throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(sVal));
                 }
                 Object finalKey = sVal.get(0, sVal);
                 if (finalKey == NOT_FOUND) {
@@ -221,7 +221,7 @@ public class NativeMap extends IdScriptableObject {
         final NativeMap nm = ensureType(thisObj, NativeMap.class, f);
         if (!nm.instanceOfMap) {
             // Check for "Map internal data tag"
-            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", f.getFunctionName());
         }
 
         return nm;

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -255,7 +255,7 @@ final class NativeNumber extends IdScriptableObject
                ECMA requires; this is permitted by ECMA. */
             double p = ScriptRuntime.toInteger(args[0]);
             if (p < precisionMin || p > MAX_PRECISION) {
-                String msg = ScriptRuntime.getMessage1(
+                String msg = ScriptRuntime.getMessageById(
                     "msg.bad.precision", ScriptRuntime.toString(args[0]));
                 throw ScriptRuntime.rangeError(msg);
             }

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -164,13 +164,13 @@ public class NativeObject extends IdScriptableObject implements Map
 
           case Id_valueOf:
               if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                  throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
               }
             return thisObj;
 
           case Id_hasOwnProperty: {
               if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                  throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
               }
               boolean result;
               Object arg = args.length < 1 ? Undefined.instance : args[0];
@@ -189,7 +189,7 @@ public class NativeObject extends IdScriptableObject implements Map
 
           case Id_propertyIsEnumerable: {
               if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                  throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                  throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
               }
 
             boolean result;
@@ -236,7 +236,7 @@ public class NativeObject extends IdScriptableObject implements Map
 
           case Id_isPrototypeOf: {
             if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                throw ScriptRuntime.typeError0("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
             }
 
             boolean result = false;
@@ -328,11 +328,11 @@ public class NativeObject extends IdScriptableObject implements Map
           case ConstructorId_setPrototypeOf:
               {
                 if (args.length < 2) {
-                    throw ScriptRuntime.typeError3("msg.method.missing.parameter", "Object.setPrototypeOf", "2", Integer.toString(args.length));
+                    throw ScriptRuntime.typeErrorById("msg.method.missing.parameter", "Object.setPrototypeOf", "2", Integer.toString(args.length));
                 }
                 Scriptable proto = (args[1] == null) ? null : ensureScriptable(args[1]);
                 if (proto instanceof Symbol) {
-                    throw ScriptRuntime.typeError1("msg.arg.not.object", ScriptRuntime.typeof(proto));
+                    throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(proto));
                 }
 
                 final Object arg0 = args[0];
@@ -344,14 +344,14 @@ public class NativeObject extends IdScriptableObject implements Map
                 }
                 ScriptableObject obj = (ScriptableObject) arg0;
                 if (!obj.isExtensible()) {
-                    throw ScriptRuntime.typeError0("msg.not.extensible");
+                    throw ScriptRuntime.typeErrorById("msg.not.extensible");
                 }
 
                 // cycle detection
                 Scriptable prototypeProto = proto;
                 while (prototypeProto != null) {
                     if (prototypeProto == obj) {
-                        throw ScriptRuntime.typeError1("msg.object.cyclic.prototype", obj.getClass().getSimpleName());
+                        throw ScriptRuntime.typeErrorById("msg.object.cyclic.prototype", obj.getClass().getSimpleName());
                     }
                     prototypeProto = prototypeProto.getPrototype();
                 }

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -223,7 +223,7 @@ public class NativeObject extends IdScriptableObject implements Map
                         }
                     }
                 } catch (EvaluatorException ee) {
-                    if (ee.getMessage().startsWith(ScriptRuntime.getMessage1("msg.prop.not.found",
+                    if (ee.getMessage().startsWith(ScriptRuntime.getMessageById("msg.prop.not.found",
                                                         s.stringId == null ? Integer.toString(s.index) : s.stringId))) {
                         result = false;
                     } else {

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -264,7 +264,7 @@ public class NativeObject extends IdScriptableObject implements Map
                     throw ScriptRuntime.notFunctionError(badArg);
                 }
                 if (!(thisObj instanceof ScriptableObject)) {
-                    throw Context.reportRuntimeError2(
+                    throw Context.reportRuntimeErrorById(
                         "msg.extend.scriptable",
                         thisObj == null ? "null" : thisObj.getClass().getName(),
                         String.valueOf(args[0]));

--- a/src/org/mozilla/javascript/NativeScript.java
+++ b/src/org/mozilla/javascript/NativeScript.java
@@ -59,7 +59,7 @@ class NativeScript extends BaseFunction
     @Override
     public Scriptable construct(Context cx, Scriptable scope, Object[] args)
     {
-        throw Context.reportRuntimeError0("msg.script.is.not.constructor");
+        throw Context.reportRuntimeErrorById("msg.script.is.not.constructor");
     }
 
     @Override
@@ -125,7 +125,7 @@ class NativeScript extends BaseFunction
           }
 
           case Id_exec: {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.cant.call.indirect", "exec");
           }
 

--- a/src/org/mozilla/javascript/NativeSet.java
+++ b/src/org/mozilla/javascript/NativeSet.java
@@ -58,7 +58,7 @@ public class NativeSet extends IdScriptableObject {
                     }
                     return ns;
                 } else {
-                    throw ScriptRuntime.typeError1("msg.no.new", "Set");
+                    throw ScriptRuntime.typeErrorById("msg.no.new", "Set");
                 }
             case Id_add:
                 return realThis(thisObj, f).js_add(args.length > 0 ? args[0] : Undefined.instance);
@@ -187,7 +187,7 @@ public class NativeSet extends IdScriptableObject {
         final NativeSet ns = ensureType(thisObj, NativeSet.class, f);
         if (!ns.instanceOfSet) {
             // If we get here, then this object doesn't have the "Set internal data slot."
-            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", f.getFunctionName());
         }
 
         return ns;

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -320,7 +320,7 @@ final class NativeString extends IdScriptableObject
                 case Id_endsWith:
                     String thisString = ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, f));
                     if (args.length > 0 && args[0] instanceof NativeRegExp) {
-                        throw ScriptRuntime.typeError2("msg.first.arg.not.regexp", String.class.getSimpleName(), f.getFunctionName());
+                        throw ScriptRuntime.typeErrorById("msg.first.arg.not.regexp", String.class.getSimpleName(), f.getFunctionName());
                     }
 
                     int idx = js_indexOf(id, thisString, args);

--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -195,7 +195,7 @@ public class NativeSymbol
             if (thisObj == null) {
                 if (cx.getThreadLocal(CONSTRUCTOR_SLOT) == null) {
                     // We should never get to this via "new".
-                    throw ScriptRuntime.typeError0("msg.no.symbol.new");
+                    throw ScriptRuntime.typeErrorById("msg.no.symbol.new");
                 }
                 // Unless we are being called by our own internal "new"
                 return js_constructor(args);
@@ -216,7 +216,7 @@ public class NativeSymbol
         try {
             return (NativeSymbol)thisObj;
         } catch (ClassCastException cce) {
-            throw ScriptRuntime.typeError1("msg.invalid.type", thisObj.getClass().getName());
+            throw ScriptRuntime.typeErrorById("msg.invalid.type", thisObj.getClass().getName());
         }
     }
 
@@ -291,7 +291,7 @@ public class NativeSymbol
         if (!isSymbol()) {
             super.put(name, start, value);
         } else if (isStrictMode()) {
-            throw ScriptRuntime.typeError0("msg.no.assign.symbol.strict");
+            throw ScriptRuntime.typeErrorById("msg.no.assign.symbol.strict");
         }
     }
 
@@ -301,7 +301,7 @@ public class NativeSymbol
         if (!isSymbol()) {
             super.put(index, start, value);
         } else if (isStrictMode()) {
-            throw ScriptRuntime.typeError0("msg.no.assign.symbol.strict");
+            throw ScriptRuntime.typeErrorById("msg.no.assign.symbol.strict");
         }
     }
 
@@ -311,7 +311,7 @@ public class NativeSymbol
         if (!isSymbol()) {
             super.put(key, start, value);
         } else if (isStrictMode()) {
-            throw ScriptRuntime.typeError0("msg.no.assign.symbol.strict");
+            throw ScriptRuntime.typeErrorById("msg.no.assign.symbol.strict");
         }
     }
 

--- a/src/org/mozilla/javascript/NativeWeakMap.java
+++ b/src/org/mozilla/javascript/NativeWeakMap.java
@@ -57,7 +57,7 @@ public class NativeWeakMap extends IdScriptableObject {
                     }
                     return nm;
                 }
-                throw ScriptRuntime.typeError1("msg.no.new", "WeakMap");
+                throw ScriptRuntime.typeErrorById("msg.no.new", "WeakMap");
             case Id_delete:
                 return realThis(thisObj, f).js_delete(args.length > 0 ? args[0] : Undefined.instance);
             case Id_get:
@@ -105,7 +105,7 @@ public class NativeWeakMap extends IdScriptableObject {
         // equals or hashCode, which means that in effect we are only keying on object identity.
         // This is all correct according to the ECMAscript spec.
         if (!ScriptRuntime.isObject(key)) {
-            throw ScriptRuntime.typeError1("msg.arg.not.object", ScriptRuntime.typeof(key));
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(key));
         }
         // Map.get() does not distinguish between "not found" and a null value. So,
         // replace true null here with a marker so that we can re-convert in "get".
@@ -118,7 +118,7 @@ public class NativeWeakMap extends IdScriptableObject {
         final NativeWeakMap nm = ensureType(thisObj, NativeWeakMap.class, f);
         if (!nm.instanceOfWeakMap) {
             // Check for "Map internal data tag"
-            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", f.getFunctionName());
         }
 
         return nm;

--- a/src/org/mozilla/javascript/NativeWeakSet.java
+++ b/src/org/mozilla/javascript/NativeWeakSet.java
@@ -54,7 +54,7 @@ public class NativeWeakSet extends IdScriptableObject {
                     }
                     return ns;
                 }
-                throw ScriptRuntime.typeError1("msg.no.new", "WeakSet");
+                throw ScriptRuntime.typeErrorById("msg.no.new", "WeakSet");
             case Id_add:
                 return realThis(thisObj, f).js_add(args.length > 0 ? args[0] : Undefined.instance);
             case Id_delete:
@@ -71,7 +71,7 @@ public class NativeWeakSet extends IdScriptableObject {
         // equals or hashCode, which means that in effect we are only keying on object identity.
         // This is all correct according to the ECMAscript spec.
         if (!ScriptRuntime.isObject(key)) {
-            throw ScriptRuntime.typeError1("msg.arg.not.object", ScriptRuntime.typeof(key));
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(key));
         }
         // Add a value to the map, but don't make it the key -- otherwise the WeakHashMap
         // will never GC anything.
@@ -97,7 +97,7 @@ public class NativeWeakSet extends IdScriptableObject {
         final NativeWeakSet ns = ensureType(thisObj, NativeWeakSet.class, f);
         if (!ns.instanceOfWeakSet) {
             // Check for "Set internal data tag"
-            throw ScriptRuntime.typeError1("msg.incompat.call", f.getFunctionName());
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", f.getFunctionName());
         }
 
         return ns;

--- a/src/org/mozilla/javascript/NativeWith.java
+++ b/src/org/mozilla/javascript/NativeWith.java
@@ -194,7 +194,7 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
     {
         if (f.hasTag(FTAG)) {
             if (f.methodId() == Id_constructor) {
-                throw Context.reportRuntimeError1("msg.cant.call.indirect", "With");
+                throw Context.reportRuntimeErrorById("msg.cant.call.indirect", "With");
             }
         }
         throw f.unknown();

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -298,8 +298,8 @@ public class Parser
 
     String lookupMessage(String messageId, String messageArg) {
         return messageArg == null
-            ? ScriptRuntime.getMessage0(messageId)
-            : ScriptRuntime.getMessage1(messageId, messageArg);
+            ? ScriptRuntime.getMessageById(messageId)
+            : ScriptRuntime.getMessageById(messageId, messageArg);
     }
 
     void reportError(String messageId) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -56,7 +56,7 @@ public class ScriptRuntime {
 
           @Override
           public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-            throw typeError0("msg.op.not.allowed");
+            throw typeErrorById("msg.op.not.allowed");
           }
           @Override
           public int getLength() {
@@ -437,7 +437,7 @@ public class ScriptRuntime {
             if (val instanceof Boolean)
                 return ((Boolean) val).booleanValue() ? 1 : +0.0;
             if (val instanceof Symbol)
-                throw typeError0("msg.not.a.number");
+                throw typeErrorById("msg.not.a.number");
             if (val instanceof Scriptable) {
                 val = ((Scriptable) val).getDefaultValue(NumberClass);
                 if ((val instanceof Scriptable) && !isSymbol(val))
@@ -865,7 +865,7 @@ public class ScriptRuntime {
                 return numberToString(((Number)val).doubleValue(), 10);
             }
             if (val instanceof Symbol) {
-                throw typeError0("msg.not.a.string");
+                throw typeErrorById("msg.not.a.string");
             }
             if (val instanceof Scriptable) {
                 val = ((Scriptable) val).getDefaultValue(StringClass);
@@ -1100,10 +1100,10 @@ public class ScriptRuntime {
     public static Scriptable toObject(Context cx, Scriptable scope, Object val)
     {
         if (val == null) {
-            throw typeError0("msg.null.to.object");
+            throw typeErrorById("msg.null.to.object");
         }
         if (Undefined.isUndefined(val)) {
-            throw typeError0("msg.undef.to.object");
+            throw typeErrorById("msg.undef.to.object");
         }
 
         if (isSymbol(val)) {
@@ -2203,14 +2203,14 @@ public class ScriptRuntime {
             Object v = ScriptableObject.getProperty(obj,
                 NativeIterator.ITERATOR_PROPERTY_NAME);
             if (!(v instanceof Callable)) {
-               throw typeError0("msg.invalid.iterator");
+               throw typeErrorById("msg.invalid.iterator");
             }
             Callable f = (Callable) v;
             Object[] args = new Object[] { keyOnly ? Boolean.TRUE
                                                    : Boolean.FALSE };
             v = f.call(cx, scope, obj, args);
             if (!(v instanceof Scriptable)) {
-                throw typeError0("msg.iterator.primitive");
+                throw typeErrorById("msg.iterator.primitive");
             }
             return (Scriptable) v;
         }
@@ -2282,19 +2282,19 @@ public class ScriptRuntime {
 
     private static Object enumInitInOrder(Context cx, IdEnumeration x) {
         if (!(x.obj instanceof SymbolScriptable) || !ScriptableObject.hasProperty(x.obj, SymbolKey.ITERATOR)) {
-            throw typeError1("msg.not.iterable", toString(x.obj));
+            throw typeErrorById("msg.not.iterable", toString(x.obj));
         }
 
         Object iterator = ScriptableObject.getProperty(x.obj, SymbolKey.ITERATOR);
         if (!(iterator instanceof Callable)) {
-            throw typeError1("msg.not.iterable", toString(x.obj));
+            throw typeErrorById("msg.not.iterable", toString(x.obj));
         }
         Callable f = (Callable) iterator;
         Scriptable scope = x.obj.getParentScope();
         Object[] args = new Object[] {};
         Object v = f.call(cx, scope, x.obj, args);
         if (!(v instanceof Scriptable)) {
-            throw typeError1("msg.not.iterable", toString(x.obj));
+            throw typeErrorById("msg.not.iterable", toString(x.obj));
         }
         x.iterator = (Scriptable) v;
         return x;
@@ -2719,7 +2719,7 @@ public class ScriptRuntime {
     {
         if (callType == Node.SPECIALCALL_EVAL) {
             if (NativeGlobal.isEvalFunction(fun)) {
-                throw typeError1("msg.not.ctor", "eval");
+                throw typeErrorById("msg.not.ctor", "eval");
             }
         } else if (callType == Node.SPECIALCALL_WITH) {
             if (NativeWith.isWithFunction(fun)) {
@@ -2795,7 +2795,7 @@ public class ScriptRuntime {
         } else if( arg1 instanceof ScriptableObject ) {
             return ScriptRuntime.emptyArgs;
         } else {
-            throw ScriptRuntime.typeError0("msg.arg.isnt.array");
+            throw ScriptRuntime.typeErrorById("msg.arg.isnt.array");
         }
     }
 
@@ -2949,7 +2949,7 @@ public class ScriptRuntime {
             }
         }
         if ((val1 instanceof Symbol) || (val2 instanceof Symbol)) {
-            throw typeError0("msg.not.a.number");
+            throw typeErrorById("msg.not.a.number");
         }
         if (val1 instanceof Scriptable)
             val1 = ((Scriptable) val1).getDefaultValue(null);
@@ -3168,7 +3168,7 @@ public class ScriptRuntime {
         Scriptable s = (Scriptable)val;
         Object result = s.getDefaultValue(typeHint);
         if ((result instanceof Scriptable) && !isSymbol(result))
-            throw typeError0("msg.bad.default.value");
+            throw typeErrorById("msg.bad.default.value");
         return result;
     }
 
@@ -3416,7 +3416,7 @@ public class ScriptRuntime {
     {
         // Check RHS is an object
         if (! (b instanceof Scriptable)) {
-            throw typeError0("msg.instanceof.not.object");
+            throw typeErrorById("msg.instanceof.not.object");
         }
 
         // for primitive values on LHS, return false
@@ -3459,7 +3459,7 @@ public class ScriptRuntime {
     public static boolean in(Object a, Object b, Context cx)
     {
         if (!(b instanceof Scriptable)) {
-            throw typeError0("msg.in.not.object");
+            throw typeErrorById("msg.in.not.object");
         }
 
         return hasObjectElem((Scriptable)b, a, cx);
@@ -3473,7 +3473,7 @@ public class ScriptRuntime {
             d2 = ((Number)val2).doubleValue();
         } else {
             if ((val1 instanceof Symbol) || (val2 instanceof Symbol)) {
-                throw typeError0("msg.compare.symbol");
+                throw typeErrorById("msg.compare.symbol");
             }
             if (val1 instanceof Scriptable)
                 val1 = ((Scriptable) val1).getDefaultValue(NumberClass);
@@ -3496,7 +3496,7 @@ public class ScriptRuntime {
             d2 = ((Number)val2).doubleValue();
         } else {
             if ((val1 instanceof Symbol) || (val2 instanceof Symbol)) {
-                throw typeError0("msg.compare.symbol");
+                throw typeErrorById("msg.compare.symbol");
             }
             if (val1 instanceof Scriptable)
                 val1 = ((Scriptable) val1).getDefaultValue(NumberClass);
@@ -3921,7 +3921,7 @@ public class ScriptRuntime {
     {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
-            throw typeError1("msg.undef.with", toString(obj));
+            throw typeErrorById("msg.undef.with", toString(obj));
         }
         if (sobj instanceof XMLObject) {
             XMLObject xmlObject = (XMLObject)sobj;
@@ -4296,18 +4296,36 @@ public class ScriptRuntime {
         return constructError("TypeError", message);
     }
 
+    public static EcmaError typeErrorById(String messageId, Object... args)
+    {
+        String msg = getMessageById(messageId, args);
+        return typeError(msg);
+    }
+
+    /**
+     * @deprecated Use {@link #typeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static EcmaError typeError0(String messageId)
     {
         String msg = getMessage0(messageId);
         return typeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #typeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static EcmaError typeError1(String messageId, Object arg1)
     {
         String msg = getMessage1(messageId, arg1);
         return typeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #typeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static EcmaError typeError2(String messageId, Object arg1,
                                        Object arg2)
     {
@@ -4315,6 +4333,10 @@ public class ScriptRuntime {
         return typeError(msg);
     }
 
+    /**
+     * @deprecated Use {@link #typeErrorById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static EcmaError typeError3(String messageId, String arg1,
                                        String arg2, String arg3)
     {
@@ -4324,25 +4346,25 @@ public class ScriptRuntime {
 
     public static RuntimeException undefReadError(Object object, Object id)
     {
-        return typeError2("msg.undef.prop.read", toString(object), toString(id));
+        return typeErrorById("msg.undef.prop.read", toString(object), toString(id));
     }
 
     public static RuntimeException undefCallError(Object object, Object id)
     {
-        return typeError2("msg.undef.method.call", toString(object), toString(id));
+        return typeErrorById("msg.undef.method.call", toString(object), toString(id));
     }
 
     public static RuntimeException undefWriteError(Object object,
                                                    Object id,
                                                    Object value)
     {
-        return typeError3("msg.undef.prop.write", toString(object), toString(id),
+        return typeErrorById("msg.undef.prop.write", toString(object), toString(id),
                           toString(value));
     }
 
     private static RuntimeException undefDeleteError(Object object, Object id)
     {
-        throw typeError2("msg.undef.prop.delete", toString(object), toString(id));
+        throw typeErrorById("msg.undef.prop.delete", toString(object), toString(id));
     }
 
     public static RuntimeException notFoundError(Scriptable object,
@@ -4365,9 +4387,9 @@ public class ScriptRuntime {
         String msg = (messageHelper == null)
                      ? "null" : messageHelper.toString();
         if (value == Scriptable.NOT_FOUND) {
-            return typeError1("msg.function.not.found", msg);
+            return typeErrorById("msg.function.not.found", msg);
         }
-        return typeError2("msg.isnt.function", msg, typeof(value));
+        return typeErrorById("msg.isnt.function", msg, typeof(value));
     }
 
     public static RuntimeException notFunctionError(Object obj, Object value,
@@ -4384,16 +4406,16 @@ public class ScriptRuntime {
             }
         }
         if (value == Scriptable.NOT_FOUND) {
-            return typeError2("msg.function.not.found.in", propertyName,
+            return typeErrorById("msg.function.not.found.in", propertyName,
                     objString);
         }
-        return typeError3("msg.isnt.function.in", propertyName, objString,
+        return typeErrorById("msg.isnt.function.in", propertyName, objString,
                           typeof(value));
     }
 
     private static RuntimeException notXmlError(Object value)
     {
-        throw typeError1("msg.isnt.xml.object", toString(value));
+        throw typeErrorById("msg.isnt.xml.object", toString(value));
     }
 
     private static void warnAboutNonJSObject(Object nonJSObject)

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4217,6 +4217,11 @@ public class ScriptRuntime {
         return messageProvider.getMessage(messageId, arguments);
     }
 
+    public static String getMessageById(String messageId, Object... args)
+    {
+        return messageProvider.getMessage(messageId, args);
+    }
+
     /* OPT there's a noticable delay for the first error!  Maybe it'd
      * make sense to use a ListResourceBundle instead of a properties
      * file to avoid (synchronized) text parsing.

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -901,7 +901,7 @@ public class ScriptRuntime {
 
     public static String numberToString(double d, int base) {
         if ((base < 2) || (base > 36)) {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.bad.radix", Integer.toString(base));
         }
 
@@ -1336,10 +1336,10 @@ public class ScriptRuntime {
             return (Function)ctorVal;
         }
         if (ctorVal == Scriptable.NOT_FOUND) {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                 "msg.ctor.not.found", constructorName);
         }
-        throw Context.reportRuntimeError1("msg.not.ctor", constructorName);
+        throw Context.reportRuntimeErrorById("msg.not.ctor", constructorName);
     }
 
     /**
@@ -2703,7 +2703,7 @@ public class ScriptRuntime {
             }
         } else if (callType == Node.SPECIALCALL_WITH) {
             if (NativeWith.isWithFunction(fun)) {
-                throw Context.reportRuntimeError1("msg.only.from.new",
+                throw Context.reportRuntimeErrorById("msg.only.from.new",
                                                   "With");
             }
         } else {
@@ -2830,7 +2830,7 @@ public class ScriptRuntime {
             if (cx.hasFeature(Context.FEATURE_STRICT_MODE) ||
                 cx.hasFeature(Context.FEATURE_STRICT_EVAL))
             {
-                throw Context.reportRuntimeError0("msg.eval.nonstring.strict");
+                throw Context.reportRuntimeErrorById("msg.eval.nonstring.strict");
             }
             String message = ScriptRuntime.getMessageById("msg.eval.nonstring");
             Context.reportWarning(message);
@@ -4468,7 +4468,7 @@ public class ScriptRuntime {
     {
         RegExpProxy result = getRegExpProxy(cx);
         if (result == null) {
-            throw Context.reportRuntimeError0("msg.no.regexp");
+            throw Context.reportRuntimeErrorById("msg.no.regexp");
         }
         return result;
     }
@@ -4610,7 +4610,7 @@ public class ScriptRuntime {
 
     private static RuntimeException errorWithClassName(String msg, Object val)
     {
-        return Context.reportRuntimeError1(msg, val.getClass().getName());
+        return Context.reportRuntimeErrorById(msg, val.getClass().getName());
     }
 
     /**

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -1596,7 +1596,7 @@ public class ScriptRuntime {
         Object result = ScriptableObject.getProperty(obj, property);
         if (result == Scriptable.NOT_FOUND) {
             if (cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
-                Context.reportWarning(ScriptRuntime.getMessage1(
+                Context.reportWarning(ScriptRuntime.getMessageById(
                     "msg.ref.undefined.prop", property));
             }
             result = Undefined.instance;
@@ -2121,7 +2121,7 @@ public class ScriptRuntime {
                 cx.hasFeature(Context.FEATURE_STRICT_VARS))
             {
                 Context.reportWarning(
-                    ScriptRuntime.getMessage1("msg.assn.create.strict", id));
+                    ScriptRuntime.getMessageById("msg.assn.create.strict", id));
             }
             // Find the top scope by walking up the scope chain.
             bound = ScriptableObject.getTopLevelScope(scope);
@@ -2670,7 +2670,7 @@ public class ScriptRuntime {
             return ref;
         }
         // No runtime support for now
-        String msg = getMessage1("msg.no.ref.from.function",
+        String msg = getMessageById("msg.no.ref.from.function",
                                  toString(function));
         throw constructError("ReferenceError", msg);
     }
@@ -2832,7 +2832,7 @@ public class ScriptRuntime {
             {
                 throw Context.reportRuntimeError0("msg.eval.nonstring.strict");
             }
-            String message = ScriptRuntime.getMessage0("msg.eval.nonstring");
+            String message = ScriptRuntime.getMessageById("msg.eval.nonstring");
             Context.reportWarning(message);
             return x;
         }
@@ -4152,7 +4152,7 @@ public class ScriptRuntime {
     static void checkDeprecated(Context cx, String name) {
         int version = cx.getLanguageVersion();
         if (version >= Context.VERSION_1_4 || version == Context.VERSION_DEFAULT) {
-            String msg = getMessage1("msg.deprec.ctor", name);
+            String msg = getMessageById("msg.deprec.ctor", name);
             if (version == Context.VERSION_DEFAULT)
                 Context.reportWarning(msg);
             else
@@ -4160,17 +4160,29 @@ public class ScriptRuntime {
         }
     }
 
+    /**
+     * @deprecated Use {@link #getMessageById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static String getMessage0(String messageId)
     {
         return getMessage(messageId, null);
     }
 
+    /**
+     * @deprecated Use {@link #getMessageById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static String getMessage1(String messageId, Object arg1)
     {
         Object[] arguments = {arg1};
         return getMessage(messageId, arguments);
     }
 
+    /**
+     * @deprecated Use {@link #getMessageById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static String getMessage2(
         String messageId, Object arg1, Object arg2)
     {
@@ -4178,6 +4190,10 @@ public class ScriptRuntime {
         return getMessage(messageId, arguments);
     }
 
+    /**
+     * @deprecated Use {@link #getMessageById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static String getMessage3(
         String messageId, Object arg1, Object arg2, Object arg3)
     {
@@ -4185,6 +4201,10 @@ public class ScriptRuntime {
         return getMessage(messageId, arguments);
     }
 
+    /**
+     * @deprecated Use {@link #getMessageById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static String getMessage4(
         String messageId, Object arg1, Object arg2, Object arg3, Object arg4)
     {
@@ -4212,6 +4232,10 @@ public class ScriptRuntime {
 
     public static final MessageProvider messageProvider = new DefaultMessageProvider();
 
+    /**
+     * @deprecated Use {@link #getMessageById(String messageId, Object... args)} instead
+     */
+    @Deprecated
     public static String getMessage(String messageId, Object[] arguments)
     {
         return messageProvider.getMessage(messageId, arguments);
@@ -4371,7 +4395,7 @@ public class ScriptRuntime {
                                                  String property)
     {
         // XXX: use object to improve the error message
-        String msg = getMessage1("msg.is.not.defined", property);
+        String msg = getMessageById("msg.is.not.defined", property);
         throw constructError("ReferenceError", msg);
     }
 
@@ -4420,9 +4444,9 @@ public class ScriptRuntime {
 
     private static void warnAboutNonJSObject(Object nonJSObject)
     {
-        final String omitParam = ScriptRuntime.getMessage0("params.omit.non.js.object.warning");
+        final String omitParam = ScriptRuntime.getMessageById("params.omit.non.js.object.warning");
         if (!"true".equals(omitParam)) {
-            String message = ScriptRuntime.getMessage2("msg.non.js.object.warning",nonJSObject,nonJSObject.getClass().getName());
+            String message = ScriptRuntime.getMessageById("msg.non.js.object.warning",nonJSObject,nonJSObject.getClass().getName());
             Context.reportWarning(message);
             // Just to be sure that it would be noticed
             System.err.println(message);

--- a/src/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/src/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -10,7 +10,7 @@ public class ScriptRuntimeES6 {
 
     public static Object requireObjectCoercible(Context cx, Object val, IdFunctionObject idFuncObj) {
         if (val == null || Undefined.isUndefined(val)) {
-            throw ScriptRuntime.typeError2("msg.called.null.or.undefined", idFuncObj.getTag(), idFuncObj.getFunctionName());
+            throw ScriptRuntime.typeErrorById("msg.called.null.or.undefined", idFuncObj.getTag(), idFuncObj.getFunctionName());
         }
         return val;
     }

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -175,7 +175,7 @@ public abstract class ScriptableObject implements Scriptable,
         boolean setValue(Object value, Scriptable owner, Scriptable start) {
             if ((attributes & READONLY) != 0) {
                 if (Context.getContext().isStrictMode()) {
-                    throw ScriptRuntime.typeError1("msg.modify.readonly", name);
+                    throw ScriptRuntime.typeErrorById("msg.modify.readonly", name);
                 }
                 return true;
             }
@@ -282,7 +282,7 @@ public abstract class ScriptableObject implements Scriptable,
                         if (name != null) {
                             prop = "[" + start.getClassName() + "]." + name;
                         }
-                        throw ScriptRuntime.typeError2("msg.set.prop.no.setter", prop, Context.toString(value));
+                        throw ScriptRuntime.typeErrorById("msg.set.prop.no.setter", prop, Context.toString(value));
                     }
                     // Assignment to a property with only a getter defined. The
                     // assignment is ignored. See bug 478047.
@@ -1079,7 +1079,7 @@ public abstract class ScriptableObject implements Scriptable,
         }
         // fall through to error
         String arg = (typeHint == null) ? "undefined" : typeHint.getName();
-        throw ScriptRuntime.typeError1("msg.default.value", arg);
+        throw ScriptRuntime.typeErrorById("msg.default.value", arg);
     }
 
     /**
@@ -1975,21 +1975,21 @@ public abstract class ScriptableObject implements Scriptable,
             throw ScriptRuntime.notFunctionError(setter);
         }
         if (isDataDescriptor(desc) && isAccessorDescriptor(desc)) {
-            throw ScriptRuntime.typeError0("msg.both.data.and.accessor.desc");
+            throw ScriptRuntime.typeErrorById("msg.both.data.and.accessor.desc");
         }
     }
 
     protected void checkPropertyChange(Object id, ScriptableObject current,
                                        ScriptableObject desc) {
         if (current == null) { // new property
-            if (!isExtensible()) throw ScriptRuntime.typeError0("msg.not.extensible");
+            if (!isExtensible()) throw ScriptRuntime.typeErrorById("msg.not.extensible");
         } else {
             if (isFalse(current.get("configurable", current))) {
                 if (isTrue(getProperty(desc, "configurable")))
-                    throw ScriptRuntime.typeError1(
+                    throw ScriptRuntime.typeErrorById(
                         "msg.change.configurable.false.to.true", id);
                 if (isTrue(current.get("enumerable", current)) != isTrue(getProperty(desc, "enumerable")))
-                    throw ScriptRuntime.typeError1(
+                    throw ScriptRuntime.typeErrorById(
                         "msg.change.enumerable.with.configurable.false", id);
                 boolean isData = isDataDescriptor(desc);
                 boolean isAccessor = isAccessorDescriptor(desc);
@@ -1998,26 +1998,26 @@ public abstract class ScriptableObject implements Scriptable,
                 } else if (isData && isDataDescriptor(current)) {
                     if (isFalse(current.get("writable", current))) {
                         if (isTrue(getProperty(desc, "writable")))
-                            throw ScriptRuntime.typeError1(
+                            throw ScriptRuntime.typeErrorById(
                                 "msg.change.writable.false.to.true.with.configurable.false", id);
 
                         if (!sameValue(getProperty(desc, "value"), current.get("value", current)))
-                            throw ScriptRuntime.typeError1(
+                            throw ScriptRuntime.typeErrorById(
                                 "msg.change.value.with.writable.false", id);
                     }
                 } else if (isAccessor && isAccessorDescriptor(current)) {
                     if (!sameValue(getProperty(desc, "set"), current.get("set", current)))
-                        throw ScriptRuntime.typeError1(
+                        throw ScriptRuntime.typeErrorById(
                             "msg.change.setter.with.configurable.false", id);
 
                     if (!sameValue(getProperty(desc, "get"), current.get("get", current)))
-                        throw ScriptRuntime.typeError1(
+                        throw ScriptRuntime.typeErrorById(
                             "msg.change.getter.with.configurable.false", id);
                 } else {
                     if (isDataDescriptor(current))
-                        throw ScriptRuntime.typeError1(
+                        throw ScriptRuntime.typeErrorById(
                             "msg.change.property.data.to.accessor.with.configurable.false", id);
-                    throw ScriptRuntime.typeError1(
+                    throw ScriptRuntime.typeErrorById(
                         "msg.change.property.accessor.to.data.with.configurable.false", id);
                 }
             }
@@ -2114,19 +2114,19 @@ public abstract class ScriptableObject implements Scriptable,
 
     protected static Scriptable ensureScriptable(Object arg) {
         if ( !(arg instanceof Scriptable) )
-            throw ScriptRuntime.typeError1("msg.arg.not.object", ScriptRuntime.typeof(arg));
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(arg));
         return (Scriptable) arg;
     }
 
     protected static SymbolScriptable ensureSymbolScriptable(Object arg) {
         if ( !(arg instanceof SymbolScriptable) )
-            throw ScriptRuntime.typeError1("msg.object.not.symbolscriptable", ScriptRuntime.typeof(arg));
+            throw ScriptRuntime.typeErrorById("msg.object.not.symbolscriptable", ScriptRuntime.typeof(arg));
         return (SymbolScriptable) arg;
     }
 
     protected static ScriptableObject ensureScriptableObject(Object arg) {
         if ( !(arg instanceof ScriptableObject) )
-            throw ScriptRuntime.typeError1("msg.arg.not.object", ScriptRuntime.typeof(arg));
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(arg));
         return (ScriptableObject) arg;
     }
 
@@ -2458,10 +2458,10 @@ public abstract class ScriptableObject implements Scriptable,
             ConstProperties cp = (ConstProperties)base;
 
             if (cp.isConst(name))
-                throw ScriptRuntime.typeError1("msg.const.redecl", name);
+                throw ScriptRuntime.typeErrorById("msg.const.redecl", name);
         }
         if (isConst)
-            throw ScriptRuntime.typeError1("msg.var.redecl", name);
+            throw ScriptRuntime.typeErrorById("msg.var.redecl", name);
     }
     /**
      * Returns whether an indexed property is defined in an object or any object
@@ -2815,7 +2815,7 @@ public abstract class ScriptableObject implements Scriptable,
                         || (!(slot instanceof GetterSlot)
                                 && (slot.getAttributes() & READONLY) != 0))
                     && Context.getContext().isStrictMode()) {
-                throw ScriptRuntime.typeError0("msg.not.extensible");
+                throw ScriptRuntime.typeErrorById("msg.not.extensible");
             }
             if (slot == null) {
                 return false;
@@ -2825,7 +2825,7 @@ public abstract class ScriptableObject implements Scriptable,
             if((slot == null
                         || (!(slot instanceof GetterSlot) && (slot.getAttributes() & READONLY) != 0))
                     && Context.getContext().isStrictMode()) {
-                throw ScriptRuntime.typeError0("msg.not.extensible");
+                throw ScriptRuntime.typeErrorById("msg.not.extensible");
             }
             if (slot == null) {
                 return true;
@@ -2858,7 +2858,7 @@ public abstract class ScriptableObject implements Scriptable,
         if (!isExtensible) {
             Context cx = Context.getContext();
             if (cx.isStrictMode()) {
-                throw ScriptRuntime.typeError0("msg.not.extensible");
+                throw ScriptRuntime.typeErrorById("msg.not.extensible");
             }
         }
         Slot slot;

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -835,7 +835,7 @@ public abstract class ScriptableObject implements Scriptable,
         if (!force) {
             int attributes = gslot.getAttributes();
             if ((attributes & READONLY) != 0) {
-                throw Context.reportRuntimeError1("msg.modify.readonly", name);
+                throw Context.reportRuntimeErrorById("msg.modify.readonly", name);
             }
         }
         if (isSetter) {
@@ -1355,7 +1355,7 @@ public abstract class ScriptableObject implements Scriptable,
             }
         }
         if (protoCtor == null) {
-            throw Context.reportRuntimeError1(
+            throw Context.reportRuntimeErrorById(
                       "msg.zero.arg.ctor", clazz.getName());
         }
 
@@ -1419,14 +1419,14 @@ public abstract class ScriptableObject implements Scriptable,
                     ctorMember = ctors[0];
             }
             if (ctorMember == null) {
-                throw Context.reportRuntimeError1(
+                throw Context.reportRuntimeErrorById(
                           "msg.ctor.multiple.parms", clazz.getName());
             }
         }
 
         FunctionObject ctor = new FunctionObject(className, ctorMember, scope);
         if (ctor.isVarArgsMethod()) {
-            throw Context.reportRuntimeError1
+            throw Context.reportRuntimeErrorById
                 ("msg.varargs.ctor", ctorMember.getName());
         }
         ctor.initAsConstructor(scope, proto);
@@ -1488,7 +1488,7 @@ public abstract class ScriptableObject implements Scriptable,
             HashSet<String> names = isStatic ? staticNames : instanceNames;
             String propName = getPropertyName(name, prefix, annotation);
             if (names.contains(propName)) {
-                throw Context.reportRuntimeError2("duplicate.defineClass.name",
+                throw Context.reportRuntimeErrorById("duplicate.defineClass.name",
                         name, propName);
             }
             names.add(propName);
@@ -1496,7 +1496,7 @@ public abstract class ScriptableObject implements Scriptable,
 
             if (annotation instanceof JSGetter || prefix == getterPrefix) {
                 if (!(proto instanceof ScriptableObject)) {
-                    throw Context.reportRuntimeError2(
+                    throw Context.reportRuntimeErrorById(
                         "msg.extend.scriptable",
                         proto.getClass().toString(), name);
                 }
@@ -1518,7 +1518,7 @@ public abstract class ScriptableObject implements Scriptable,
 
             FunctionObject f = new FunctionObject(name, method, proto);
             if (f.isVarArgsConstructor()) {
-                throw Context.reportRuntimeError1
+                throw Context.reportRuntimeErrorById
                     ("msg.varargs.fun", ctorMember.getName());
             }
             defineProperty(isStatic ? ctor : proto, name, f, DONTENUM);
@@ -1812,14 +1812,14 @@ public abstract class ScriptableObject implements Scriptable,
                 errorId = "msg.bad.getter.parms";
             }
             if (errorId != null) {
-                throw Context.reportRuntimeError1(errorId, getter.toString());
+                throw Context.reportRuntimeErrorById(errorId, getter.toString());
             }
         }
 
         MemberBox setterBox = null;
         if (setter != null) {
             if (setter.getReturnType() != Void.TYPE)
-                throw Context.reportRuntimeError1("msg.setter.return",
+                throw Context.reportRuntimeErrorById("msg.setter.return",
                                                   setter.toString());
 
             setterBox = new MemberBox(setter);
@@ -1855,7 +1855,7 @@ public abstract class ScriptableObject implements Scriptable,
                 errorId = "msg.setter.parms";
             }
             if (errorId != null) {
-                throw Context.reportRuntimeError1(errorId, setter.toString());
+                throw Context.reportRuntimeErrorById(errorId, setter.toString());
             }
         }
 
@@ -2151,7 +2151,7 @@ public abstract class ScriptableObject implements Scriptable,
             String name = names[i];
             Method m = FunctionObject.findSingleMethod(methods, name);
             if (m == null) {
-                throw Context.reportRuntimeError2(
+                throw Context.reportRuntimeErrorById(
                     "msg.method.not.found", name, clazz.getName());
             }
             FunctionObject f = new FunctionObject(name, m, this);
@@ -2300,7 +2300,7 @@ public abstract class ScriptableObject implements Scriptable,
             return;
 
         String str = (key != null) ? key.toString() : Integer.toString(index);
-        throw Context.reportRuntimeError1("msg.modify.sealed", str);
+        throw Context.reportRuntimeErrorById("msg.modify.sealed", str);
     }
 
     /**
@@ -2878,7 +2878,7 @@ public abstract class ScriptableObject implements Scriptable,
             slot = slotMap.get(name, index, SlotAccess.MODIFY_CONST);
             int attr = slot.getAttributes();
             if ((attr & READONLY) == 0)
-                throw Context.reportRuntimeError1("msg.var.redecl", name);
+                throw Context.reportRuntimeErrorById("msg.var.redecl", name);
             if ((attr & UNINITIALIZED_CONST) != 0) {
                 slot.value = value;
                 // clear the bit on const initialization
@@ -2895,7 +2895,7 @@ public abstract class ScriptableObject implements Scriptable,
         Slot slot = slotMap.get(name, index, accessType);
         if (slot == null) {
             String str = (name != null ? name : Integer.toString(index));
-            throw Context.reportRuntimeError1("msg.prop.not.found", str);
+            throw Context.reportRuntimeErrorById("msg.prop.not.found", str);
         }
         return slot;
     }
@@ -2904,7 +2904,7 @@ public abstract class ScriptableObject implements Scriptable,
     {
         Slot slot = slotMap.get(key, 0, accessType);
         if (slot == null) {
-            throw Context.reportRuntimeError1("msg.prop.not.found", key);
+            throw Context.reportRuntimeErrorById("msg.prop.not.found", key);
         }
         return slot;
     }

--- a/src/org/mozilla/javascript/SpecialRef.java
+++ b/src/org/mozilla/javascript/SpecialRef.java
@@ -101,7 +101,7 @@ class SpecialRef extends Ref
                     if (target instanceof ScriptableObject
                             && !((ScriptableObject)target).isExtensible()
                             && cx.getLanguageVersion() >= Context.VERSION_1_8) {
-                        throw ScriptRuntime.typeError0("msg.not.extensible");
+                        throw ScriptRuntime.typeErrorById("msg.not.extensible");
                     }
 
                     if (cx.getLanguageVersion() >= Context.VERSION_ES6) {

--- a/src/org/mozilla/javascript/SpecialRef.java
+++ b/src/org/mozilla/javascript/SpecialRef.java
@@ -87,7 +87,7 @@ class SpecialRef extends Ref
                     Scriptable search = obj;
                     do {
                         if (search == target) {
-                            throw Context.reportRuntimeError1(
+                            throw Context.reportRuntimeErrorById(
                                 "msg.cyclic.value", name);
                         }
                         if (type == SPECIAL_PROTO) {

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2542,14 +2542,14 @@ public class NativeRegExp extends IdScriptableObject
     private static void reportWarning(Context cx, String messageId, String arg)
     {
         if (cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
-            String msg = ScriptRuntime.getMessage1(messageId, arg);
+            String msg = ScriptRuntime.getMessageById(messageId, arg);
             Context.reportWarning(msg);
         }
     }
 
     private static void reportError(String messageId, String arg)
     {
-        String msg = ScriptRuntime.getMessage1(messageId, arg);
+        String msg = ScriptRuntime.getMessageById(messageId, arg);
         throw ScriptRuntime.constructError("SyntaxError", msg);
     }
 

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -166,7 +166,7 @@ public class NativeRegExp extends IdScriptableObject
         if (args.length > 0 && args[0] instanceof NativeRegExp) {
             if (args.length > 1 && args[1] != Undefined.instance) {
                 // report error
-                throw ScriptRuntime.typeError0("msg.bad.regexp.compile");
+                throw ScriptRuntime.typeErrorById("msg.bad.regexp.compile");
             }
             NativeRegExp thatObj = (NativeRegExp) args[0];
             this.re = thatObj.re;
@@ -2646,7 +2646,7 @@ public class NativeRegExp extends IdScriptableObject
 
     private void setLastIndex(Object value) {
         if ((lastIndexAttr & READONLY) != 0) {
-            throw ScriptRuntime.typeError1("msg.modify.readonly", "lastIndex");
+            throw ScriptRuntime.typeErrorById("msg.modify.readonly", "lastIndex");
         }
         lastIndex = value;
     }

--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -275,7 +275,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView impl
         switch (id) {
         case Id_constructor:
             if (thisObj != null && cx.getLanguageVersion() >= Context.VERSION_ES6) {
-                throw ScriptRuntime.typeError1("msg.only.from.new", getClassName());
+                throw ScriptRuntime.typeErrorById("msg.only.from.new", getClassName());
             }
             return js_constructor(cx, scope, args);
 

--- a/src/org/mozilla/javascript/xml/XMLLib.java
+++ b/src/org/mozilla/javascript/xml/XMLLib.java
@@ -60,7 +60,7 @@ public abstract class XMLLib
         if (lib != null) {
             return lib;
         }
-        String msg = ScriptRuntime.getMessage0("msg.XML.not.available");
+        String msg = ScriptRuntime.getMessageById("msg.XML.not.available");
         throw Context.reportRuntimeError(msg);
     }
 

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -720,7 +720,7 @@ class XMLList extends XMLObjectImpl implements Function {
         String methodName = isApply ? "apply" : "call";
         if(!(thisObj instanceof XMLList) ||
             ((XMLList)thisObj).targetProperty == null)
-            throw ScriptRuntime.typeError1("msg.isnt.function",
+            throw ScriptRuntime.typeErrorById("msg.isnt.function",
                 methodName);
 
         return ScriptRuntime.applyOrCall(isApply, cx, scope, thisObj, args);
@@ -767,7 +767,7 @@ class XMLList extends XMLObjectImpl implements Function {
             return applyOrCall(isApply, cx, scope, thisObj, args);
 
         if (!(thisObj instanceof XMLObject)) {
-            throw ScriptRuntime.typeError1("msg.incompat.call", methodName);
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", methodName);
         }
         Object func = null;
         Scriptable sobj = thisObj;
@@ -794,7 +794,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
-        throw ScriptRuntime.typeError1("msg.not.ctor", "XMLList");
+        throw ScriptRuntime.typeErrorById("msg.not.ctor", "XMLList");
     }
 }
 


### PR DESCRIPTION
Before
```java
    public static String getMessage0(String messageId)
    public static String getMessage1(String messageId, Object arg1)
    public static String getMessage2(String messageId, Object arg1, Object arg2)
```
After
```java
   // use variadic of JDK1.5
    public static String getMessage(String messageId, Object... args)
```
If there was a code to pass `Object[]` to `getMessage1`, It may be incompatible.