### PR TITLE
ref. #783 target set not writable in Object.assign

### DIFF
--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -567,6 +567,12 @@ public class NativeObject extends IdScriptableObject implements Map
               Scriptable sourceObj = ScriptRuntime.toObject(cx, thisObj, args[i]);
               Object[] ids = sourceObj.getIds();
               for (Object key : ids) {
+                if (targetObj instanceof ScriptableObject) {
+                  ScriptableObject desc = ((ScriptableObject) targetObj).getOwnPropertyDescriptor(cx, key);
+                  if (desc != null && isDataDescriptor(desc) && isFalse(desc.get("writable"))) {
+                      throw ScriptRuntime.typeErrorById("msg.change.value.with.writable.false", key);
+                  }
+                }
                 if (key instanceof String) {
                   Object val = sourceObj.get((String) key, sourceObj);
                   if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -690,7 +690,6 @@ built-ins/Number
     ! parseInt.js
 
 built-ins/Object
-    ! assign/target-set-not-writable.js
     ! create/15.2.3.5-4-311.js
     ! defineProperties/15.2.3.7-6-a-112.js
     ! defineProperties/15.2.3.7-6-a-113.js


### PR DESCRIPTION
ref. #783

https://www.ecma-international.org/ecma-262/11.0/index.html#sec-object.assign
> Perform ? Set(to, nextKey, propValue, true).

https://www.ecma-international.org/ecma-262/11.0/index.html#sec-set-o-p-v-throw
> Let success be ? O.[[Set]](P, V, O).
> If success is false and Throw is true, throw a TypeError exception.

https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver
https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ordinaryset
https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ordinarysetwithowndescriptor
> If IsDataDescriptor(ownDesc) is true, then
> If ownDesc.[[Writable]] is false, return false.