### PR TITLE
Can't convert function to interface of all default methods.

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/InterfaceAdapterTest.java
+++ b/testsrc/org/mozilla/javascript/tests/InterfaceAdapterTest.java
@@ -10,10 +10,13 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.junit.Test;
+import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Wrapper;
 
 import junit.framework.TestCase;
+
+import static org.junit.Assert.*;
 
 /*
  * This testcase tests the support of converting javascript functions to
@@ -85,4 +88,140 @@ public class InterfaceAdapterTest extends TestCase {
         testIt(js, Arrays.asList("bar", "foo"));
     }
 
+    public interface EmptyInterface {
+    }
+
+    public static void receiveEmptyInterface(EmptyInterface i) {
+    }
+
+    @Test
+    public void testFunctionAsEmptyInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveEmptyInterface(a => a);\n"
+                + "list";
+        assertThrows(EvaluatorException.class, () -> testIt(js, Arrays.asList("foo", "bar")));
+    }
+
+    public interface OneMethodInterface {
+        String a();
+    }
+
+    public static String receiveOneMethodInterface(OneMethodInterface i) {
+        return i.a();
+    }
+
+    @Test
+    public void testFunctionAsOneMethodInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveOneMethodInterface(() => 'ok');";
+        testIt(js, "ok");
+    }
+
+    public interface TwoMethodsInterface {
+        void a();
+        void b();
+    }
+
+    public static void receiveTwoMethodsInterface(TwoMethodsInterface i) {
+    }
+
+    @Test
+    public void testFunctionAsTwoMethodsInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveTwoMethodsInterface(a => a);\n"
+                + "list";
+        assertThrows(EvaluatorException.class, () -> testIt(js, Arrays.asList("foo", "bar")));
+    }
+
+    public interface TwoMethodsWithExtendsInterface extends OneMethodInterface {
+        void b();
+    }
+
+    public static void receiveTwoMethodsWithExtendsInterface(TwoMethodsWithExtendsInterface i) {
+    }
+
+    @Test
+    public void testFunctionAsTwoMethodsWithExtendsInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveTwoMethodsWithExtendsInterface(a => a);\n"
+                + "list";
+        assertThrows(EvaluatorException.class, () -> testIt(js, Arrays.asList("foo", "bar")));
+    }
+
+    public interface OneDefaultMethodInterface {
+        default String a() {
+            return "ng";
+        }
+    }
+
+    public static String receiveOneDefaultMethodInterface(OneDefaultMethodInterface i) {
+        return i.a();
+    }
+
+    @Test
+    public void testFunctionAsOneDefaultMethodInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveOneDefaultMethodInterface(() => 'ok');";
+        testIt(js, "ok");
+    }
+
+    public interface TwoDefaultMethodsInterface {
+        default void a() {}
+        default void b() {}
+    }
+
+    public static void receiveTwoDefaultMethodsInterface(TwoDefaultMethodsInterface i) {
+    }
+
+    @Test
+    public void testFunctionAsTwoDefaultMethodsInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveTwoDefaultMethodsInterface(a => a);\n"
+                + "list";
+        assertThrows(EvaluatorException.class, () -> testIt(js, Arrays.asList("foo", "bar")));
+    }
+
+    public interface TwoSameNameDefaultMethodsInterface {
+        default String a(int i) {
+            return "ng";
+        }
+        default String a(String s) {
+            return "ng";
+        }
+    }
+
+    public static String receiveTwoSameNameDefaultMethodsInterface(TwoSameNameDefaultMethodsInterface i) {
+        return i.a(1);
+    }
+
+    @Test
+    public void testFunctionAsTwoSameNameDefaultMethodsInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveTwoSameNameDefaultMethodsInterface(i => 'ok,' + i);";
+        testIt(js, "ok,1");
+    }
+
+    public interface OneAbstructOneDefaultSameNameMethodInterface {
+        String a(int i);
+        default String a(String s) {
+            return "ng";
+        }
+    }
+
+    public static String receiveOneAbstructOneDefaultSameNameMethodInterface(OneAbstructOneDefaultSameNameMethodInterface i) {
+        return i.a(2);
+    }
+
+    @Test
+    public void testFunctionAsOneAbstructOneDefaultSameNameMethodInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveOneAbstructOneDefaultSameNameMethodInterface(i => 'ok,' + i);";
+        testIt(js, "ok,2");
+    }
+
+    public interface AddDefaultMethodWithExtendsInterface extends OneMethodInterface {
+        default void b() {}
+    }
+
+    public static String receiveAddDefaultMethodWithExtendsInterface(AddDefaultMethodWithExtendsInterface i) {
+        return i.a();
+    }
+
+    @Test
+    public void testFunctionAsAddDefaultMethodWithExtendsInterface() {
+        String js = "org.mozilla.javascript.tests.InterfaceAdapterTest.receiveAddDefaultMethodWithExtendsInterface(() => 'ok');";
+        testIt(js, "ok");
+    }
 }


### PR DESCRIPTION
Cannot convert function to interface with no methods.
```java
    public interface EmptyInterface {}
    public static void receiveEmptyInterface(EmptyInterface i) {}
```
```js
// org.mozilla.javascript.EvaluatorException: Cannot convert function to interface org.mozilla.javascript.tests.InterfaceAdapterTest$EmptyInterface with no methods (testNativeFunction.js#1)
a.receiveEmptyInterface(a => a)
```
But in interface case of all default methods, can convert.
```java
    public interface AllDefaultMethodInterface {
        default void a() {}
        default void b() {}
    }
    public static void receiveAllDefaultMethodInterface(AllDefaultMethodInterface i) {}
```
```js
// no errors
a.receiveAllDefaultMethodInterface(a => a)
```
I think it should be handled as if there were no methods.