### PR TITLE
Add a sanity check for DocumentBuilder's resettability

### DIFF
--- a/testsrc/org/mozilla/javascript/xmlimpl/NonResettableDocumentBuilder.java
+++ b/testsrc/org/mozilla/javascript/xmlimpl/NonResettableDocumentBuilder.java
@@ -1,0 +1,61 @@
+package org.mozilla.javascript.xmlimpl;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.io.IOException;
+
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class NonResettableDocumentBuilder extends DocumentBuilder {
+    private DocumentBuilder delegateBuilder;
+    private final DocumentBuilder delegateBuilderAfterReset;
+
+    public NonResettableDocumentBuilder(DocumentBuilder delegateBuilderBeforeReset, DocumentBuilder delegateBuilderAfterReset) {
+        this.delegateBuilder = delegateBuilderBeforeReset;
+        this.delegateBuilderAfterReset = delegateBuilderAfterReset;
+    }
+
+    @Override
+    public Document parse(InputSource is) throws SAXException, IOException {
+        return delegateBuilder.parse(is);
+    }
+
+    @Override
+    public boolean isNamespaceAware() {
+        return delegateBuilder.isNamespaceAware();
+    }
+
+    @Override
+    public boolean isValidating() {
+        return delegateBuilder.isNamespaceAware();
+    }
+
+    @Override
+    public void setEntityResolver(EntityResolver er) {
+        delegateBuilder.setEntityResolver(er);
+    }
+
+    @Override
+    public void setErrorHandler(ErrorHandler eh) {
+        delegateBuilder.setErrorHandler(eh);
+    }
+
+    @Override
+    public Document newDocument() {
+        return delegateBuilder.newDocument();
+    }
+
+    @Override
+    public DOMImplementation getDOMImplementation() {
+        return delegateBuilder.getDOMImplementation();
+    }
+
+    @Override
+    public void reset() {
+        delegateBuilder = delegateBuilderAfterReset;
+    }
+}

--- a/testsrc/org/mozilla/javascript/xmlimpl/NonResettableDocumentBuilderFactory.java
+++ b/testsrc/org/mozilla/javascript/xmlimpl/NonResettableDocumentBuilderFactory.java
@@ -1,0 +1,81 @@
+package org.mozilla.javascript.xmlimpl;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.util.Properties;
+
+public class NonResettableDocumentBuilderFactory extends DocumentBuilderFactory {
+    private static final String XML_PROPERTY = "javax.xml.parsers.DocumentBuilderFactory";
+    private final DocumentBuilderFactory delegateFactory;
+    private final DocumentBuilder delegateBuilderAfterReset;
+
+    public NonResettableDocumentBuilderFactory() throws ParserConfigurationException {
+        Properties systemProperties = System.getProperties();
+        String oldValue = systemProperties.getProperty(XML_PROPERTY);
+        systemProperties.remove(XML_PROPERTY);
+        System.setProperties(systemProperties);
+        delegateFactory = DocumentBuilderFactory.newInstance();
+        delegateBuilderAfterReset = delegateFactory.newDocumentBuilder();
+        System.setProperty(XML_PROPERTY, oldValue);
+    }
+
+    @Override
+    public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        return new NonResettableDocumentBuilder(delegateFactory.newDocumentBuilder(), delegateBuilderAfterReset);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) throws IllegalArgumentException {
+    }
+
+    @Override
+    public Object getAttribute(String name) throws IllegalArgumentException {
+        return null;
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) {
+    }
+
+    @Override
+    public boolean getFeature(String name) {
+        return false;
+    }
+
+    @Override
+    public void setNamespaceAware(boolean awareness) {
+        super.setNamespaceAware(awareness);
+        delegateFactory.setNamespaceAware(awareness);
+    }
+
+    @Override
+    public void setValidating(boolean validating) {
+        super.setValidating(validating);
+        delegateFactory.setValidating(validating);
+    }
+
+    @Override
+    public void setIgnoringElementContentWhitespace(boolean whitespace) {
+        super.setIgnoringElementContentWhitespace(whitespace);
+        delegateFactory.setIgnoringElementContentWhitespace(whitespace);
+    }
+
+    @Override
+    public void setExpandEntityReferences(boolean expandEntityRef) {
+        super.setExpandEntityReferences(expandEntityRef);
+        delegateFactory.setExpandEntityReferences(expandEntityRef);
+    }
+
+    @Override
+    public void setIgnoringComments(boolean ignoreComments) {
+        super.setIgnoringComments(ignoreComments);
+        delegateFactory.setIgnoringComments(ignoreComments);
+    }
+
+    @Override
+    public void setCoalescing(boolean coalescing) {
+        super.setCoalescing(coalescing);
+        delegateFactory.setCoalescing(coalescing);
+    }
+}

--- a/testsrc/org/mozilla/javascript/xmlimpl/XmlNonResettableDocumentBuilderTest.java
+++ b/testsrc/org/mozilla/javascript/xmlimpl/XmlNonResettableDocumentBuilderTest.java
@@ -1,0 +1,43 @@
+package org.mozilla.javascript.xmlimpl;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
+
+public class XmlNonResettableDocumentBuilderTest {
+    private static final String XML_PROPERTY = "javax.xml.parsers.DocumentBuilderFactory";
+    private final String originalDocumentBuilderFactory = System.getProperty(XML_PROPERTY);
+
+    @Before
+    public void setUp() {
+        System.setProperty(XML_PROPERTY, NonResettableDocumentBuilderFactory.class.getName());
+    }
+
+    @After
+    public void tearDown() {
+        if (originalDocumentBuilderFactory == null) {
+            System.clearProperty(XML_PROPERTY);
+        } else {
+            System.setProperty(XML_PROPERTY, originalDocumentBuilderFactory);
+        }
+    }
+
+    @Test
+    public void testNonResettableDocumentBuilder() {
+        Context cx = new ContextFactory().enterContext();
+        try {
+            Scriptable scope = cx.initStandardObjects();
+            Object result = cx.evaluateString(scope,
+                    "var employees = new XML('<employees><employee><name>John</name></employee></employees>');" +
+                    "employees.employee.name;",
+                    "source", 1, null);
+            Assert.assertEquals("John", String.valueOf(result));
+        } finally {
+            Context.exit();
+        }
+    }
+}

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlProcessor.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlProcessor.java
@@ -247,6 +247,11 @@ class XmlProcessor implements Serializable {
     private void returnDocumentBuilderToPool(DocumentBuilder db) {
         try {
             db.reset();
+            // DocumentBuilders are supposed to be namespace-aware.
+            // This is a sanity check for DocumentBuilder's resettability (a known bug in Android).
+            if (!db.isNamespaceAware()) {
+                return;
+            }
             documentBuilderPool.offerFirst(db);
         } catch (UnsupportedOperationException e) {
             // document builders that don't support reset() can't be pooled


### PR DESCRIPTION
Some DocumentBuilder.reset implementations do not work as expected,
and do not restore the builder to the original state (when it was
created with DcoumentBuilderFactory.newDocument). An example of
such implementation is Android - see https://issuetracker.google.com/issues/176560895

This change adds a sanity check which treats such implementations
as non-resettable.
