### PR TITLE
make compileImpl protected

### DIFF
--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -2481,7 +2481,7 @@ public class Context
         return cx;
     }
 
-    private Object compileImpl(Scriptable scope,
+    protected Object compileImpl(Scriptable scope,
                                String sourceString, String sourceName, int lineno,
                                Object securityDomain, boolean returnFunction,
                                Evaluator compiler,


### PR DESCRIPTION
We want to implement a caching mechanism, so the same script should not be compiled again

To do this, I would have the compileImpl to be protected, so that we can overwrite this in our "MyContext extends Context".
Currently we overwrite the compileImpl this way:
```
    @Override
    protected Object compileImpl(
            final Scriptable scope,
            final String sourceString,
            final String sourceName,
            final int lineno,
            final Object securityDomain,
            final boolean returnFunction,
            final Evaluator compiler,
            final ErrorReporter compilationErrorReporter) throws IOException {

        CacheKey key = new CacheKey(scope,
                sourceString,
                sourceName,
                lineno,
                securityDomain,
                returnFunction,
                compiler,
                compilationErrorReporter);
        return cache.computeIfAbsent(key, this::compileImpl);

    }

    @SneakyThrows
    private Object compileImpl(final CacheKey key) {
        return super.compileImpl(key.getScope(),
                key.getSourceString(),
                key.getSourceName(),
                key.getLineno(),
                key.getSecurityDomain(),
                key.isReturnFunction(),
                key.getCompiler(),
                key.getCompilationErrorReporter());
    }
```
