### PR TITLE
Fixed a broken StackMapTable.

### DIFF
--- a/src/org/mozilla/classfile/ClassFileWriter.java
+++ b/src/org/mozilla/classfile/ClassFileWriter.java
@@ -2176,8 +2176,12 @@ public class ClassFileWriter {
                         if (tag == TypeInfo.UNINITIALIZED_VARIABLE(0) ||
                             tag == TypeInfo.UNINITIALIZED_THIS) {
                             if ("<init>".equals(methodName)) {
-                                int newType =
-                                    TypeInfo.OBJECT(itsThisClassIndex);
+                                int newType;
+                                if (tag == TypeInfo.UNINITIALIZED_VARIABLE(0)) {
+                                    newType = TypeInfo.OBJECT(m.getClassName(), itsConstantPool);
+                                } else {
+                                    newType = TypeInfo.OBJECT(itsThisClassIndex);
+                                }
                                 initializeTypeInfo(instType, newType);
                             } else {
                                 throw new IllegalStateException("bad instance");

--- a/testsrc/org/mozilla/classfile/tests/ClassFileWriterTest.java
+++ b/testsrc/org/mozilla/classfile/tests/ClassFileWriterTest.java
@@ -1,0 +1,61 @@
+package org.mozilla.javascript.classfile.tests;
+
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+
+import org.junit.Test;
+import org.mozilla.classfile.ByteCode;
+import org.mozilla.classfile.ClassFileWriter;
+import org.mozilla.javascript.DefiningClassLoader;
+import static org.mozilla.classfile.ClassFileWriter.ACC_PUBLIC;
+import static org.mozilla.classfile.ClassFileWriter.ACC_STATIC;
+
+import static org.junit.Assert.*;
+
+public class ClassFileWriterTest {
+    @Test
+    public void testStackMapTable() throws Exception {
+        final String CLASS_NAME = "TestStackMapTable";
+        final String METHOD_NAME = "returnObject";
+
+        ClassFileWriter cfw = new ClassFileWriter(CLASS_NAME,
+                                                  "java/lang/Object",
+                                                  "ClassFileWriterTest.java");;
+
+        // public static Object returnObject()
+        cfw.startMethod(METHOD_NAME, "()Ljava/lang/Object;", (short)(ACC_PUBLIC | ACC_STATIC));
+
+        cfw.add(ByteCode.NEW, "java/math/BigInteger");
+        cfw.add(ByteCode.DUP);
+
+        // new byte[]{ 123 }
+        cfw.addPush(1);
+        cfw.add(ByteCode.NEWARRAY, ByteCode.T_BYTE);
+        cfw.add(ByteCode.DUP);
+        cfw.addPush(0);
+        cfw.add(ByteCode.BIPUSH, 123);
+        cfw.add(ByteCode.BASTORE);
+
+        // new java.math.BigInteger(bytes)
+        cfw.addInvoke(ByteCode.INVOKESPECIAL, "java/math/BigInteger", "<init>", "([B)V");
+
+        // generate StackMapTable
+        cfw.add(ByteCode.DUP);
+        int target = cfw.acquireLabel();
+        cfw.add(ByteCode.IFNULL, target);
+        cfw.markLabel(target);
+
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short)0);
+
+        byte[] bytecode = cfw.toByteArray();
+        DefiningClassLoader loader = new DefiningClassLoader();
+        Class cl = loader.defineClass(CLASS_NAME, bytecode);
+
+        Method method = cl.getMethod(METHOD_NAME);
+        Object ret = method.invoke(cl);
+
+        assertTrue(ret instanceof BigInteger);
+        assertEquals(ret, new BigInteger(new byte[]{ 123 }));
+    }
+}


### PR DESCRIPTION
Before the fix, I got this error when I ran the test.
```
org.mozilla.javascript.classfile.tests.ClassFileWriterTest > testStackMapTable FAILED
    java.lang.VerifyError: Inconsistent stackmap frames at branch target 34
    Exception Details:
      Location:
        TestStackMapTable.returnObject()Ljava/lang/Object; @34: aload_0
      Reason:
        Type 'java/math/BigInteger' (current frame, stack[0]) is not assignable to 'TestStackMapTable' (stack map, stack[0])
      Current Frame:
        bci: @27
        flags: { }
        locals: { '[Z' }
        stack: { 'java/math/BigInteger' }
      Stackmap Frame:
        bci: @34
        flags: { }
        locals: { '[Z' }
        stack: { 'TestStackMapTable' }
      Bytecode:
        0x0000000: b800 164b bb00 0959 04bc 0859 0310 7b54
        0x0000010: b700 0d59 c700 0a2a 0304 54a7 0007 2a04
        0x0000020: 0454 2a05 0454 b0                      
      Stackmap Table:
        full_frame(@30,{Object[#24]},{Object[#9]})
        same_locals_1_stack_item_frame(@34,Object[#2])
        at java.lang.Class.getDeclaredMethods0(Native Method)
        at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
        at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
        at java.lang.Class.getMethod0(Class.java:3018)
        at java.lang.Class.getMethod(Class.java:1784)
        at org.mozilla.javascript.classfile.tests.ClassFileWriterTest.testStackMapTable(ClassFileWriterTest.java:55)
```
---
https://github.com/mozilla/rhino/blob/1f45c8f28e139d9cd5d291f5d8e33c2f3031e7c4/src/org/mozilla/classfile/ClassFileWriter.java#L2176-L2181

### UNINITIALIZED_THIS
example:
```java
// constructor
public TestClass() {
    super();
```
It is correct to rewrite the `UNINITIALIZED_THIS` type with `this.getClass()`  in this case.

### UNINITIALIZED_VARIABLE(0)
example:
```java
    o = new BigInteger(bytes);
```
It is probably correct to rewrite it with `BigInteger` instead of `this.getClass()` in this case.

I'm not familiar with Java bytecode, so could you please check if the pull request is correct?