### PR TITLE
Disable Java Map accessing by properties

### DIFF
--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -349,6 +349,26 @@ public class Context
      */
     public static final int FEATURE_ENABLE_XML_SECURE_PARSING = 20;
 
+    /**
+     * Configure whether the entries in a Java Map can be accessed by properties.
+     *
+     * WARNING: This feature is similar to the one in Nashorn, but incomplete.
+     *
+     * 1. A entry has priority over method.
+     *
+     *   map.put("put", "abc");
+     *   map.put;  // abc
+     *   map.put("put", "efg"); // ERROR
+     *
+     * 2. The distinction between numeric keys and string keys is ambiguous.
+     *
+     *   map.put('1', 123);
+     *   map['1']; // Not found. This means `map[1]`.
+     *
+     * @since 1.7 Release 14
+     */
+    public static final int FEATURE_ENABLE_JAVA_MAP_ACCESS = 21;
+
     public static final String languageVersionProperty = "language version";
     public static final String errorReporterProperty   = "error reporter";
 

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -352,6 +352,18 @@ public class Context
     /**
      * Configure whether the entries in a Java Map can be accessed by properties.
      *
+     * Not enabled:
+     *
+     *   var map = new java.util.HashMap();
+     *   map.put('foo', 1);
+     *   map.foo; // undefined
+     *
+     * Enabled:
+     *
+     *   var map = new java.util.HashMap();
+     *   map.put('foo', 1);
+     *   map.foo; // 1
+     *
      * WARNING: This feature is similar to the one in Nashorn, but incomplete.
      *
      * 1. A entry has priority over method.

--- a/src/org/mozilla/javascript/ContextFactory.java
+++ b/src/org/mozilla/javascript/ContextFactory.java
@@ -301,6 +301,9 @@ public class ContextFactory
 
           case Context.FEATURE_ENABLE_XML_SECURE_PARSING:
               return true;
+
+        case Context.FEATURE_ENABLE_JAVA_MAP_ACCESS:
+              return false;
         }
         // It is a bug to call the method with unknown featureIndex
         throw new IllegalArgumentException(String.valueOf(featureIndex));

--- a/src/org/mozilla/javascript/NativeJavaList.java
+++ b/src/org/mozilla/javascript/NativeJavaList.java
@@ -59,9 +59,12 @@ public class NativeJavaList extends NativeJavaObject {
     @Override
     public Object get(int index, Scriptable start) {
         if (isWithValidIndex(index)) {
-            Context cx = Context.getContext();
+            Context cx = Context.getCurrentContext();
             Object obj = list.get(index);
-            return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+            if (cx != null) {
+                return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+            }
+            return obj;
         }
         return Undefined.instance;
     }

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -27,8 +27,8 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public boolean has(String name, Scriptable start) {
-        Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        Context cx = Context.getCurrentContext();
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(name)) {
                 return true;
             }
@@ -38,8 +38,8 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public boolean has(int index, Scriptable start) {
-        Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        Context cx = Context.getCurrentContext();
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(Integer.valueOf(index))) {
                 return true;
             }
@@ -49,8 +49,8 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public Object get(String name, Scriptable start) {
-        Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        Context cx = Context.getCurrentContext();
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(name)) {
                 Object obj = map.get(name);
                 return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
@@ -61,8 +61,8 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public Object get(int index, Scriptable start) {
-        Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        Context cx = Context.getCurrentContext();
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(Integer.valueOf(index))) {
                 Object obj = map.get(Integer.valueOf(index));
                 return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
@@ -73,8 +73,8 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public void put(String name, Scriptable start, Object value) {
-        Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        Context cx = Context.getCurrentContext();
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             map.put(name, Context.jsToJava(value, Object.class));
         } else {
             super.put(name, start, value);
@@ -84,7 +84,7 @@ public class NativeJavaMap extends NativeJavaObject {
     @Override
     public void put(int index, Scriptable start, Object value) {
         Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             map.put(Integer.valueOf(index), Context.jsToJava(value, Object.class));
         } else {
             super.put(index, start, value);
@@ -93,8 +93,8 @@ public class NativeJavaMap extends NativeJavaObject {
 
     @Override
     public Object[] getIds() {
-        Context cx = Context.getContext();
-        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+        Context cx = Context.getCurrentContext();
+        if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             List<Object> ids = new ArrayList<>(map.size());
             for (Object key : map.keySet()) {
                 if (key instanceof Integer) {

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -25,63 +25,86 @@ public class NativeJavaMap extends NativeJavaObject {
         return "JavaMap";
     }
 
-
     @Override
     public boolean has(String name, Scriptable start) {
-        if (map.containsKey(name)) {
-            return true;
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            if (map.containsKey(name)) {
+                return true;
+            }
         }
         return super.has(name, start);
     }
 
     @Override
     public boolean has(int index, Scriptable start) {
-        if (map.containsKey(Integer.valueOf(index))) {
-            return true;
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            if (map.containsKey(Integer.valueOf(index))) {
+                return true;
+            }
         }
         return super.has(index, start);
     }
 
     @Override
     public Object get(String name, Scriptable start) {
-        if (map.containsKey(name)) {
-            Context cx = Context.getContext();
-            Object obj = map.get(name);
-            return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            if (map.containsKey(name)) {
+                Object obj = map.get(name);
+                return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+            }
         }
         return super.get(name, start);
     }
 
     @Override
     public Object get(int index, Scriptable start) {
-        if (map.containsKey(Integer.valueOf(index))) {
-            Context cx = Context.getContext();
-            Object obj = map.get(Integer.valueOf(index));
-            return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            if (map.containsKey(Integer.valueOf(index))) {
+                Object obj = map.get(Integer.valueOf(index));
+                return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+            }
         }
         return super.get(index, start);
     }
 
     @Override
     public void put(String name, Scriptable start, Object value) {
-        map.put(name, Context.jsToJava(value, Object.class));
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            map.put(name, Context.jsToJava(value, Object.class));
+        } else {
+            super.put(name, start, value);
+        }
     }
 
     @Override
     public void put(int index, Scriptable start, Object value) {
-        map.put(Integer.valueOf(index), Context.jsToJava(value, Object.class));
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            map.put(Integer.valueOf(index), Context.jsToJava(value, Object.class));
+        } else {
+            super.put(index, start, value);
+        }
     }
 
     @Override
     public Object[] getIds() {
-        List<Object> ids = new ArrayList<>(map.size());
-        for (Object key : map.keySet()) {
-            if (key instanceof Integer) {
-                ids.add((Integer)key);
-            } else {
-                ids.add(ScriptRuntime.toString(key));
+        Context cx = Context.getContext();
+        if (cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
+            List<Object> ids = new ArrayList<>(map.size());
+            for (Object key : map.keySet()) {
+                if (key instanceof Integer) {
+                    ids.add((Integer)key);
+                } else {
+                    ids.add(ScriptRuntime.toString(key));
+                }
             }
+            return ids.toArray();
         }
-        return ids.toArray();
+        return super.getIds();
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -9,7 +9,9 @@ package org.mozilla.javascript.tests;
 import junit.framework.TestCase;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.NativeArray;
+import org.mozilla.javascript.NativeJavaMethod;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -17,16 +19,26 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.junit.Assert.*;
+
 /**
  * From @makusuko (Markus Sunela), imported from PR https://github.com/mozilla/rhino/pull/561
  */
 public class NativeJavaMapTest extends TestCase {
     protected final Global global = new Global();
+    private final ContextFactory contextFactoryWithMapAccess = new ContextFactory() {
+        @Override
+        protected boolean hasFeature(Context cx, int featureIndex) {
+            if (featureIndex == Context.FEATURE_ENABLE_JAVA_MAP_ACCESS) {
+                return true;
+            }
+            return super.hasFeature(cx, featureIndex);
+        }
+    };
 
     public NativeJavaMapTest() {
         global.init(ContextFactory.getGlobal());
     }
-
 
     public void testAccessingJavaMapIntegerValues() {
         Map<Number, Number> map = new HashMap<>();
@@ -34,8 +46,8 @@ public class NativeJavaMapTest extends TestCase {
         map.put(1, 2);
         map.put(2, 3);
 
-        assertEquals(2, runScriptAsInt("value[1]", map));
-        assertEquals(3, runScriptAsInt("value[2]", map));
+        assertEquals(2, runScriptAsInt("value[1]", map, true));
+        assertEquals(3, runScriptAsInt("value[2]", map, true));
     }
 
     public void testJavaMethodCalls() {
@@ -43,9 +55,9 @@ public class NativeJavaMapTest extends TestCase {
         map.put("a", 1);
         map.put("b", 2);
         map.put("c", 3);
-        assertEquals(3, runScriptAsInt("value.size()", map));
-        assertEquals(1, runScriptAsInt("value.get('a')", map));
-        assertEquals(4, runScriptAsInt("value.put('d', 4);value.size()", map));
+        assertEquals(3, runScriptAsInt("value.size()", map, true));
+        assertEquals(1, runScriptAsInt("value.get('a')", map, true));
+        assertEquals(4, runScriptAsInt("value.put('d', 4);value.size()", map, true));
     }
 
     public void testUpdatingJavaMapIntegerValues() {
@@ -54,8 +66,8 @@ public class NativeJavaMapTest extends TestCase {
         map.put(1,2);
         map.put(2,3);
 
-        assertEquals(2, runScriptAsInt("value[1]", map));
-        assertEquals(5, runScriptAsInt("value[1]=5;value[1]", map));
+        assertEquals(2, runScriptAsInt("value[1]", map, true));
+        assertEquals(5, runScriptAsInt("value[1]=5;value[1]", map, true));
         assertEquals(5, map.get(1).intValue());
     }
 
@@ -65,10 +77,10 @@ public class NativeJavaMapTest extends TestCase {
         map.put("b", "b");
         map.put("c", "c");
 
-        assertEquals("b", runScriptAsString("value['b']", map));
-        assertEquals("c", runScriptAsString("value['c']", map));
-        assertEquals("b", runScriptAsString("value.b", map));
-        assertEquals("c", runScriptAsString("value.c", map));
+        assertEquals("b", runScriptAsString("value['b']", map, true));
+        assertEquals("c", runScriptAsString("value['c']", map, true));
+        assertEquals("b", runScriptAsString("value.b", map, true));
+        assertEquals("c", runScriptAsString("value.c", map, true));
     }
 
     public void testUpdatingJavaMapStringValues() {
@@ -77,11 +89,11 @@ public class NativeJavaMapTest extends TestCase {
         map.put("b", "b");
         map.put("c", "c");
 
-        assertEquals("b", runScriptAsString("value['b']", map));
-        assertEquals("b", runScriptAsString("value.b", map));
-        assertEquals("f", runScriptAsString("value['b']=\"f\";value['b']", map));
+        assertEquals("b", runScriptAsString("value['b']", map, true));
+        assertEquals("b", runScriptAsString("value.b", map, true));
+        assertEquals("f", runScriptAsString("value['b']=\"f\";value['b']", map, true));
         assertEquals("f", map.get("b"));
-        assertEquals("g", runScriptAsString("value.b=\"g\";value.b", map));
+        assertEquals("g", runScriptAsString("value.b=\"g\";value.b", map, true));
     }
 
     public void testAccessMapInMap() {
@@ -89,8 +101,8 @@ public class NativeJavaMapTest extends TestCase {
         map.put("a", new HashMap<>());
         map.get("a").put("a", "a");
 
-        assertEquals("a", runScriptAsString("value['a']['a']", map));
-        assertEquals("a", runScriptAsString("value.a.a", map));
+        assertEquals("a", runScriptAsString("value['a']['a']", map, true));
+        assertEquals("a", runScriptAsString("value.a.a", map, true));
     }
 
     public void testUpdatingMapInMap() {
@@ -98,21 +110,21 @@ public class NativeJavaMapTest extends TestCase {
         map.put("a", new HashMap<>());
         map.get("a").put("a", "a");
 
-        assertEquals("a", runScriptAsString("value['a']['a']", map));
-        assertEquals("a", runScriptAsString("value.a.a", map));
-        assertEquals("b", runScriptAsString("value.a.a = 'b';value.a.a", map));
+        assertEquals("a", runScriptAsString("value['a']['a']", map, true));
+        assertEquals("a", runScriptAsString("value.a.a", map, true));
+        assertEquals("b", runScriptAsString("value.a.a = 'b';value.a.a", map, true));
     }
 
     public void testKeys() {
         Map<String, String> map = new HashMap<>();
-        NativeArray resEmpty = (NativeArray) runScript("Object.keys(value)", map, Function.identity());
+        NativeArray resEmpty = (NativeArray) runScript("Object.keys(value)", map, true);
         assertEquals(0, resEmpty.size());
 
         map.put("a", "a");
         map.put("b", "b");
         map.put("c", "c");
 
-        NativeArray res = (NativeArray) runScript("Object.keys(value)", map, Function.identity());
+        NativeArray res = (NativeArray) runScript("Object.keys(value)", map, true);
         assertEquals(3, res.size());
         assertTrue(res.contains("a"));
         assertTrue(res.contains("b"));
@@ -120,23 +132,44 @@ public class NativeJavaMapTest extends TestCase {
 
         Map<Integer, String> mapInt = new HashMap<>();
         mapInt.put(42, "test");
-        NativeArray resInt = (NativeArray) runScript("Object.keys(value)", mapInt, Function.identity());
+        NativeArray resInt = (NativeArray) runScript("Object.keys(value)", mapInt, true);
         assertTrue(resInt.contains("42")); // Object.keys always return Strings as key
     }
 
-    private int runScriptAsInt(String scriptSourceText, Object value) {
-        return runScript(scriptSourceText, value, Context::toNumber).intValue();
+    public void testJavaMapWithoutAccessEntries() {
+        Map<Object, Object> map = new HashMap<>();
+        map.put(0, 1);
+        map.put("put", "method");
+        map.put("a", "abc");
+
+        assertThrows(EvaluatorException.class, () -> runScript("value[0]", map, false));
+        assertTrue(runScript("value.put", map, false) instanceof NativeJavaMethod);
+        assertThrows(EvaluatorException.class, () -> runScript("value['a'] = 0", map, false));
+        assertEquals(false, runScript("'a' in value", map, false));
+        assertEquals(true, runScript("Object.keys(value).includes('getClass')", map, false));
     }
 
-    private String runScriptAsString(String scriptSourceText, Object value) {
-        return runScript(scriptSourceText, value, Context::toString);
+    private int runScriptAsInt(String scriptSourceText, Object value, boolean enableJavaMapAccess) {
+        return runScript(scriptSourceText, value, Context::toNumber, enableJavaMapAccess).intValue();
     }
 
-    private <T> T runScript(String scriptSourceText, Object value, Function<Object, T> convert) {
-        return ContextFactory.getGlobal().call(context -> {
+    private String runScriptAsString(String scriptSourceText, Object value, boolean enableJavaMapAccess) {
+        return runScript(scriptSourceText, value, Context::toString, enableJavaMapAccess);
+    }
+
+    private Object runScript(String scriptSourceText, Object value, boolean enableJavaMapAccess) {
+        return runScript(scriptSourceText, value, Function.identity(), enableJavaMapAccess);
+    }
+
+    private <T> T runScript(String scriptSourceText, Object value, Function<Object, T> convert, boolean enableJavaMapAccess) {
+        return getContextFactory(enableJavaMapAccess).call(context -> {
             Scriptable scope = context.initStandardObjects(global);
             scope.put("value", scope, Context.javaToJS(value, scope));
             return convert.apply(context.evaluateString(scope, scriptSourceText, "", 1, null));
         });
+    }
+
+    private ContextFactory getContextFactory(boolean enableJavaMapAccess) {
+         return enableJavaMapAccess ? contextFactoryWithMapAccess : ContextFactory.getGlobal();
     }
 }


### PR DESCRIPTION
ref. #820
This will have an impact on these Pull Requests. #824, #827
___
#713 had compatibility issues because entry access by properties took precedence over Java methods. If Java methods are prioritized, compatibility issues will probably disappear.
But here's what happens.
```java
// Java
public Map getMap() {
    return new TreeMap();
}
```
```js
// Rhino
var m = Foo.getMap();
m.firstKey();  // TreeMap method
```
`getMap` returns `java.util.Map`, but an instance of it is `java.util.TreeMap`, so you can use the `java.util.TreeMap` method. If Java methods are prioritized, in order to access it by property, you need to avoid the `TreeMap` method instead of `Map`. You always need to know what the instance is. Also, if `getMap` returns a different Map implementation, your existing code may not work.
___
Nashorn has probably extended the use of indirect-eval-call to distinguish between property access and method invocation. I'm also checking for behavior such as the distinction between `m[0]` and `m['0']`, and that Java methods are not JavaScript Functions.