### PR TITLE
ES2020 BigInt

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -15,9 +15,7 @@ import org.mozilla.javascript.ast.Scope;
 import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.ast.VariableInitializer;
 
-/**
- * Generates bytecode for the Interpreter.
- */
+/** Generates bytecode for the Interpreter. */
 class CodeGenerator extends Icode {
 
     private static final int MIN_LABEL_TABLE_SIZE = 32;
@@ -51,11 +49,11 @@ class CodeGenerator extends Icode {
     // ECF_ or Expression Context Flags constants: for now only TAIL
     private static final int ECF_TAIL = 1 << 0;
 
-    public InterpreterData compile(CompilerEnvirons compilerEnv,
-                                   ScriptNode tree,
-                                   String encodedSource,
-                                   boolean returnFunction)
-    {
+    public InterpreterData compile(
+            CompilerEnvirons compilerEnv,
+            ScriptNode tree,
+            String encodedSource,
+            boolean returnFunction) {
         this.compilerEnv = compilerEnv;
 
         if (Token.printTrees) {
@@ -76,10 +74,12 @@ class CodeGenerator extends Icode {
             scriptOrFn = tree;
         }
 
-        itsData = new InterpreterData(compilerEnv.getLanguageVersion(),
-                                      scriptOrFn.getSourceName(),
-                                      encodedSource,
-                                      scriptOrFn.isInStrictMode());
+        itsData =
+                new InterpreterData(
+                        compilerEnv.getLanguageVersion(),
+                        scriptOrFn.getSourceName(),
+                        encodedSource,
+                        scriptOrFn.isInStrictMode());
         itsData.topLevel = true;
 
         if (returnFunction) {
@@ -90,11 +90,10 @@ class CodeGenerator extends Icode {
         return itsData;
     }
 
-    private void generateFunctionICode()
-    {
+    private void generateFunctionICode() {
         itsInFunctionFlag = true;
 
-        FunctionNode theFunction = (FunctionNode)scriptOrFn;
+        FunctionNode theFunction = (FunctionNode) scriptOrFn;
 
         itsData.itsFunctionType = theFunction.getFunctionType();
         itsData.itsNeedsActivation = theFunction.requiresActivation();
@@ -102,8 +101,8 @@ class CodeGenerator extends Icode {
             itsData.itsName = theFunction.getName();
         }
         if (theFunction.isGenerator()) {
-          addIcode(Icode_GENERATOR);
-          addUint16(theFunction.getBaseLineno() & 0xFFFF);
+            addIcode(Icode_GENERATOR);
+            addUint16(theFunction.getBaseLineno() & 0xFFFF);
         }
         if (theFunction.isInStrictMode()) {
             itsData.isStrict = true;
@@ -117,8 +116,7 @@ class CodeGenerator extends Icode {
         generateICodeFromTree(theFunction.getLastChild());
     }
 
-    private void generateICodeFromTree(Node tree)
-    {
+    private void generateICodeFromTree(Node tree) {
         generateNestedFunctions();
 
         generateRegExpLiterals();
@@ -143,7 +141,7 @@ class CodeGenerator extends Icode {
             itsData.itsStringTable = new String[strings.size()];
             ObjToIntMap.Iterator iter = strings.newIterator();
             for (iter.start(); !iter.done(); iter.next()) {
-                String str = (String)iter.getKey();
+                String str = (String) iter.getKey();
                 int index = iter.getValue();
                 if (itsData.itsStringTable[index] != null) Kit.codeBug();
                 itsData.itsStringTable[index] = str;
@@ -153,25 +151,19 @@ class CodeGenerator extends Icode {
             itsData.itsDoubleTable = null;
         } else if (itsData.itsDoubleTable.length != doubleTableTop) {
             double[] tmp = new double[doubleTableTop];
-            System.arraycopy(itsData.itsDoubleTable, 0, tmp, 0,
-                             doubleTableTop);
+            System.arraycopy(itsData.itsDoubleTable, 0, tmp, 0, doubleTableTop);
             itsData.itsDoubleTable = tmp;
         }
-        if (exceptionTableTop != 0
-            && itsData.itsExceptionTable.length != exceptionTableTop)
-        {
+        if (exceptionTableTop != 0 && itsData.itsExceptionTable.length != exceptionTableTop) {
             int[] tmp = new int[exceptionTableTop];
-            System.arraycopy(itsData.itsExceptionTable, 0, tmp, 0,
-                             exceptionTableTop);
+            System.arraycopy(itsData.itsExceptionTable, 0, tmp, 0, exceptionTableTop);
             itsData.itsExceptionTable = tmp;
         }
 
         itsData.itsMaxVars = scriptOrFn.getParamAndVarCount();
         // itsMaxFrameArray: interpret method needs this amount for its
         // stack and sDbl arrays
-        itsData.itsMaxFrameArray = itsData.itsMaxVars
-                                   + itsData.itsMaxLocals
-                                   + itsData.itsMaxStack;
+        itsData.itsMaxFrameArray = itsData.itsMaxVars + itsData.itsMaxLocals + itsData.itsMaxStack;
 
         itsData.argNames = scriptOrFn.getParamAndVarNames();
         itsData.argIsConst = scriptOrFn.getParamAndVarConst();
@@ -187,8 +179,7 @@ class CodeGenerator extends Icode {
         if (Token.printICode) Interpreter.dumpICode(itsData);
     }
 
-    private void generateNestedFunctions()
-    {
+    private void generateNestedFunctions() {
         int functionCount = scriptOrFn.getFunctionCount();
         if (functionCount == 0) return;
 
@@ -206,14 +197,13 @@ class CodeGenerator extends Icode {
             if (!(fnParent instanceof AstRoot
                     || fnParent instanceof Scope
                     || fnParent instanceof Block)) {
-                        gen.itsData.declaredAsFunctionExpression = true;
+                gen.itsData.declaredAsFunctionExpression = true;
             }
         }
         itsData.itsNestedFunctions = array;
     }
 
-    private void generateRegExpLiterals()
-    {
+    private void generateRegExpLiterals() {
         int N = scriptOrFn.getRegexpCount();
         if (N == 0) return;
 
@@ -228,8 +218,7 @@ class CodeGenerator extends Icode {
         itsData.itsRegExpLiterals = array;
     }
 
-    private void updateLineNumber(Node node)
-    {
+    private void updateLineNumber(Node node) {
         int lineno = node.getLineno();
         if (lineno != lineNumber && lineno >= 0) {
             if (itsData.firstLinePC < 0) {
@@ -241,283 +230,283 @@ class CodeGenerator extends Icode {
         }
     }
 
-    private static RuntimeException badTree(Node node)
-    {
+    private static RuntimeException badTree(Node node) {
         throw new RuntimeException(node.toString());
     }
 
-    private void visitStatement(Node node, int initialStackDepth)
-    {
+    private void visitStatement(Node node, int initialStackDepth) {
         int type = node.getType();
         Node child = node.getFirstChild();
         switch (type) {
-
-          case Token.FUNCTION:
-            {
-                int fnIndex = node.getExistingIntProp(Node.FUNCTION_PROP);
-                int fnType = scriptOrFn.getFunctionNode(fnIndex).
-                                 getFunctionType();
-                // Only function expressions or function expression
-                // statements need closure code creating new function
-                // object on stack as function statements are initialized
-                // at script/function start.
-                // In addition, function expressions can not be present here
-                // at statement level, they must only be present as expressions.
-                if (fnType == FunctionNode.FUNCTION_EXPRESSION_STATEMENT) {
-                    addIndexOp(Icode_CLOSURE_STMT, fnIndex);
-                } else {
-                    if (fnType != FunctionNode.FUNCTION_STATEMENT) {
-                        throw Kit.codeBug();
+            case Token.FUNCTION:
+                {
+                    int fnIndex = node.getExistingIntProp(Node.FUNCTION_PROP);
+                    int fnType = scriptOrFn.getFunctionNode(fnIndex).getFunctionType();
+                    // Only function expressions or function expression
+                    // statements need closure code creating new function
+                    // object on stack as function statements are initialized
+                    // at script/function start.
+                    // In addition, function expressions can not be present here
+                    // at statement level, they must only be present as expressions.
+                    if (fnType == FunctionNode.FUNCTION_EXPRESSION_STATEMENT) {
+                        addIndexOp(Icode_CLOSURE_STMT, fnIndex);
+                    } else {
+                        if (fnType != FunctionNode.FUNCTION_STATEMENT) {
+                            throw Kit.codeBug();
+                        }
+                    }
+                    // For function statements or function expression statements
+                    // in scripts, we need to ensure that the result of the script
+                    // is the function if it is the last statement in the script.
+                    // For example, eval("function () {}") should return a
+                    // function, not undefined.
+                    if (!itsInFunctionFlag) {
+                        addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
+                        stackChange(1);
+                        addIcode(Icode_POP_RESULT);
+                        stackChange(-1);
                     }
                 }
-                // For function statements or function expression statements
-                // in scripts, we need to ensure that the result of the script
-                // is the function if it is the last statement in the script.
-                // For example, eval("function () {}") should return a
-                // function, not undefined.
-                if (!itsInFunctionFlag) {
-                    addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
-                    stackChange(1);
-                    addIcode(Icode_POP_RESULT);
-                    stackChange(-1);
-                }
-            }
-            break;
+                break;
 
-          case Token.LABEL:
-          case Token.LOOP:
-          case Token.BLOCK:
-          case Token.EMPTY:
-          case Token.WITH:
-            updateLineNumber(node);
-            // fall through
-          case Token.SCRIPT:
-            while (child != null) {
-                visitStatement(child, initialStackDepth);
-                child = child.getNext();
-            }
-            break;
-
-          case Token.ENTERWITH:
-            visitExpression(child, 0);
-            addToken(Token.ENTERWITH);
-            stackChange(-1);
-            break;
-
-          case Token.LEAVEWITH:
-            addToken(Token.LEAVEWITH);
-            break;
-
-          case Token.LOCAL_BLOCK:
-            {
-                int local = allocLocal();
-                node.putIntProp(Node.LOCAL_PROP, local);
+            case Token.LABEL:
+            case Token.LOOP:
+            case Token.BLOCK:
+            case Token.EMPTY:
+            case Token.WITH:
                 updateLineNumber(node);
+                // fall through
+            case Token.SCRIPT:
                 while (child != null) {
                     visitStatement(child, initialStackDepth);
                     child = child.getNext();
                 }
-                addIndexOp(Icode_LOCAL_CLEAR, local);
-                releaseLocal(local);
-            }
-            break;
+                break;
 
-          case Token.DEBUGGER:
-            addIcode(Icode_DEBUGGER);
-            break;
-
-          case Token.SWITCH:
-            updateLineNumber(node);
-            // See comments in IRFactory.createSwitch() for description
-            // of SWITCH node
-            {
+            case Token.ENTERWITH:
                 visitExpression(child, 0);
-                for (Jump caseNode = (Jump)child.getNext();
-                     caseNode != null;
-                     caseNode = (Jump)caseNode.getNext())
+                addToken(Token.ENTERWITH);
+                stackChange(-1);
+                break;
+
+            case Token.LEAVEWITH:
+                addToken(Token.LEAVEWITH);
+                break;
+
+            case Token.LOCAL_BLOCK:
                 {
-                    if (caseNode.getType() != Token.CASE)
-                        throw badTree(caseNode);
-                    Node test = caseNode.getFirstChild();
-                    addIcode(Icode_DUP);
+                    int local = allocLocal();
+                    node.putIntProp(Node.LOCAL_PROP, local);
+                    updateLineNumber(node);
+                    while (child != null) {
+                        visitStatement(child, initialStackDepth);
+                        child = child.getNext();
+                    }
+                    addIndexOp(Icode_LOCAL_CLEAR, local);
+                    releaseLocal(local);
+                }
+                break;
+
+            case Token.DEBUGGER:
+                addIcode(Icode_DEBUGGER);
+                break;
+
+            case Token.SWITCH:
+                updateLineNumber(node);
+                // See comments in IRFactory.createSwitch() for description
+                // of SWITCH node
+                {
+                    visitExpression(child, 0);
+                    for (Jump caseNode = (Jump) child.getNext();
+                            caseNode != null;
+                            caseNode = (Jump) caseNode.getNext()) {
+                        if (caseNode.getType() != Token.CASE) throw badTree(caseNode);
+                        Node test = caseNode.getFirstChild();
+                        addIcode(Icode_DUP);
+                        stackChange(1);
+                        visitExpression(test, 0);
+                        addToken(Token.SHEQ);
+                        stackChange(-1);
+                        // If true, Icode_IFEQ_POP will jump and remove case
+                        // value from stack
+                        addGoto(caseNode.target, Icode_IFEQ_POP);
+                        stackChange(-1);
+                    }
+                    addIcode(Icode_POP);
+                    stackChange(-1);
+                }
+                break;
+
+            case Token.TARGET:
+                markTargetLabel(node);
+                break;
+
+            case Token.IFEQ:
+            case Token.IFNE:
+                {
+                    Node target = ((Jump) node).target;
+                    visitExpression(child, 0);
+                    addGoto(target, type);
+                    stackChange(-1);
+                }
+                break;
+
+            case Token.GOTO:
+                {
+                    Node target = ((Jump) node).target;
+                    addGoto(target, type);
+                }
+                break;
+
+            case Token.JSR:
+                {
+                    Node target = ((Jump) node).target;
+                    addGoto(target, Icode_GOSUB);
+                }
+                break;
+
+            case Token.FINALLY:
+                {
+                    // Account for incomming GOTOSUB address
                     stackChange(1);
-                    visitExpression(test, 0);
-                    addToken(Token.SHEQ);
+                    int finallyRegister = getLocalBlockRef(node);
+                    addIndexOp(Icode_STARTSUB, finallyRegister);
                     stackChange(-1);
-                    // If true, Icode_IFEQ_POP will jump and remove case
-                    // value from stack
-                    addGoto(caseNode.target, Icode_IFEQ_POP);
-                    stackChange(-1);
+                    while (child != null) {
+                        visitStatement(child, initialStackDepth);
+                        child = child.getNext();
+                    }
+                    addIndexOp(Icode_RETSUB, finallyRegister);
                 }
-                addIcode(Icode_POP);
-                stackChange(-1);
-            }
-            break;
+                break;
 
-          case Token.TARGET:
-            markTargetLabel(node);
-            break;
-
-          case Token.IFEQ :
-          case Token.IFNE :
-            {
-                Node target = ((Jump)node).target;
+            case Token.EXPR_VOID:
+            case Token.EXPR_RESULT:
+                updateLineNumber(node);
                 visitExpression(child, 0);
-                addGoto(target, type);
+                addIcode((type == Token.EXPR_VOID) ? Icode_POP : Icode_POP_RESULT);
                 stackChange(-1);
-            }
-            break;
+                break;
 
-          case Token.GOTO:
-            {
-                Node target = ((Jump)node).target;
-                addGoto(target, type);
-            }
-            break;
+            case Token.TRY:
+                {
+                    Jump tryNode = (Jump) node;
+                    int exceptionObjectLocal = getLocalBlockRef(tryNode);
+                    int scopeLocal = allocLocal();
 
-          case Token.JSR:
-            {
-                Node target = ((Jump)node).target;
-                addGoto(target, Icode_GOSUB);
-            }
-            break;
+                    addIndexOp(Icode_SCOPE_SAVE, scopeLocal);
 
-          case Token.FINALLY:
-            {
-                // Account for incomming GOTOSUB address
-                stackChange(1);
-                int finallyRegister = getLocalBlockRef(node);
-                addIndexOp(Icode_STARTSUB, finallyRegister);
-                stackChange(-1);
-                while (child != null) {
-                    visitStatement(child, initialStackDepth);
+                    int tryStart = iCodeTop;
+                    boolean savedFlag = itsInTryFlag;
+                    itsInTryFlag = true;
+                    while (child != null) {
+                        visitStatement(child, initialStackDepth);
+                        child = child.getNext();
+                    }
+                    itsInTryFlag = savedFlag;
+
+                    Node catchTarget = tryNode.target;
+                    if (catchTarget != null) {
+                        int catchStartPC = labelTable[getTargetLabel(catchTarget)];
+                        addExceptionHandler(
+                                tryStart,
+                                catchStartPC,
+                                catchStartPC,
+                                false,
+                                exceptionObjectLocal,
+                                scopeLocal);
+                    }
+                    Node finallyTarget = tryNode.getFinally();
+                    if (finallyTarget != null) {
+                        int finallyStartPC = labelTable[getTargetLabel(finallyTarget)];
+                        addExceptionHandler(
+                                tryStart,
+                                finallyStartPC,
+                                finallyStartPC,
+                                true,
+                                exceptionObjectLocal,
+                                scopeLocal);
+                    }
+
+                    addIndexOp(Icode_LOCAL_CLEAR, scopeLocal);
+                    releaseLocal(scopeLocal);
+                }
+                break;
+
+            case Token.CATCH_SCOPE:
+                {
+                    int localIndex = getLocalBlockRef(node);
+                    int scopeIndex = node.getExistingIntProp(Node.CATCH_SCOPE_PROP);
+                    String name = child.getString();
                     child = child.getNext();
-                }
-                addIndexOp(Icode_RETSUB, finallyRegister);
-            }
-            break;
-
-          case Token.EXPR_VOID:
-          case Token.EXPR_RESULT:
-            updateLineNumber(node);
-            visitExpression(child, 0);
-            addIcode((type == Token.EXPR_VOID) ? Icode_POP : Icode_POP_RESULT);
-            stackChange(-1);
-            break;
-
-          case Token.TRY:
-            {
-                Jump tryNode = (Jump)node;
-                int exceptionObjectLocal = getLocalBlockRef(tryNode);
-                int scopeLocal = allocLocal();
-
-                addIndexOp(Icode_SCOPE_SAVE, scopeLocal);
-
-                int tryStart = iCodeTop;
-                boolean savedFlag = itsInTryFlag;
-                itsInTryFlag = true;
-                while (child != null) {
-                    visitStatement(child, initialStackDepth);
-                    child = child.getNext();
-                }
-                itsInTryFlag = savedFlag;
-
-                Node catchTarget = tryNode.target;
-                if (catchTarget != null) {
-                    int catchStartPC
-                        = labelTable[getTargetLabel(catchTarget)];
-                    addExceptionHandler(
-                        tryStart, catchStartPC, catchStartPC,
-                        false, exceptionObjectLocal, scopeLocal);
-                }
-                Node finallyTarget = tryNode.getFinally();
-                if (finallyTarget != null) {
-                    int finallyStartPC
-                        = labelTable[getTargetLabel(finallyTarget)];
-                    addExceptionHandler(
-                        tryStart, finallyStartPC, finallyStartPC,
-                        true, exceptionObjectLocal, scopeLocal);
-                }
-
-                addIndexOp(Icode_LOCAL_CLEAR, scopeLocal);
-                releaseLocal(scopeLocal);
-            }
-            break;
-
-          case Token.CATCH_SCOPE:
-            {
-                int localIndex = getLocalBlockRef(node);
-                int scopeIndex = node.getExistingIntProp(Node.CATCH_SCOPE_PROP);
-                String name = child.getString();
-                child = child.getNext();
-                visitExpression(child, 0); // load expression object
-                addStringPrefix(name);
-                addIndexPrefix(localIndex);
-                addToken(Token.CATCH_SCOPE);
-                addUint8(scopeIndex != 0 ? 1 : 0);
-                stackChange(-1);
-            }
-            break;
-
-          case Token.THROW:
-            updateLineNumber(node);
-            visitExpression(child, 0);
-            addToken(Token.THROW);
-            addUint16(lineNumber & 0xFFFF);
-            stackChange(-1);
-            break;
-
-          case Token.RETHROW:
-            updateLineNumber(node);
-            addIndexOp(Token.RETHROW, getLocalBlockRef(node));
-            break;
-
-          case Token.RETURN:
-            updateLineNumber(node);
-            if (node.getIntProp(Node.GENERATOR_END_PROP, 0) != 0) {
-                if ((child == null) ||
-                    (compilerEnv.getLanguageVersion() < Context.VERSION_ES6)) {
-                    // End generator function with no result, or old language version
-                    // in which generators never return a result.
-                    addIcode(Icode_GENERATOR_END);
-                    addUint16(lineNumber & 0xFFFF);
-                } else {
-                    visitExpression(child, ECF_TAIL);
-                    addIcode(Icode_GENERATOR_RETURN);
-                    addUint16(lineNumber & 0xFFFF);
+                    visitExpression(child, 0); // load expression object
+                    addStringPrefix(name);
+                    addIndexPrefix(localIndex);
+                    addToken(Token.CATCH_SCOPE);
+                    addUint8(scopeIndex != 0 ? 1 : 0);
                     stackChange(-1);
                 }
+                break;
 
-            } else {
-                if (child == null) {
-                    addIcode(Icode_RETUNDEF);
+            case Token.THROW:
+                updateLineNumber(node);
+                visitExpression(child, 0);
+                addToken(Token.THROW);
+                addUint16(lineNumber & 0xFFFF);
+                stackChange(-1);
+                break;
+
+            case Token.RETHROW:
+                updateLineNumber(node);
+                addIndexOp(Token.RETHROW, getLocalBlockRef(node));
+                break;
+
+            case Token.RETURN:
+                updateLineNumber(node);
+                if (node.getIntProp(Node.GENERATOR_END_PROP, 0) != 0) {
+                    if ((child == null)
+                            || (compilerEnv.getLanguageVersion() < Context.VERSION_ES6)) {
+                        // End generator function with no result, or old language version
+                        // in which generators never return a result.
+                        addIcode(Icode_GENERATOR_END);
+                        addUint16(lineNumber & 0xFFFF);
+                    } else {
+                        visitExpression(child, ECF_TAIL);
+                        addIcode(Icode_GENERATOR_RETURN);
+                        addUint16(lineNumber & 0xFFFF);
+                        stackChange(-1);
+                    }
+
                 } else {
-                    visitExpression(child, ECF_TAIL);
-                    addToken(Token.RETURN);
-                    stackChange(-1);
+                    if (child == null) {
+                        addIcode(Icode_RETUNDEF);
+                    } else {
+                        visitExpression(child, ECF_TAIL);
+                        addToken(Token.RETURN);
+                        stackChange(-1);
+                    }
                 }
-            }
-            break;
+                break;
 
-          case Token.RETURN_RESULT:
-            updateLineNumber(node);
-            addToken(Token.RETURN_RESULT);
-            break;
+            case Token.RETURN_RESULT:
+                updateLineNumber(node);
+                addToken(Token.RETURN_RESULT);
+                break;
 
-          case Token.ENUM_INIT_KEYS:
-          case Token.ENUM_INIT_VALUES:
-          case Token.ENUM_INIT_ARRAY:
-          case Token.ENUM_INIT_VALUES_IN_ORDER:
-            visitExpression(child, 0);
-            addIndexOp(type, getLocalBlockRef(node));
-            stackChange(-1);
-            break;
+            case Token.ENUM_INIT_KEYS:
+            case Token.ENUM_INIT_VALUES:
+            case Token.ENUM_INIT_ARRAY:
+            case Token.ENUM_INIT_VALUES_IN_ORDER:
+                visitExpression(child, 0);
+                addIndexOp(type, getLocalBlockRef(node));
+                stackChange(-1);
+                break;
 
-          case Icode_GENERATOR:
-            break;
+            case Icode_GENERATOR:
+                break;
 
-          default:
-            throw badTree(node);
+            default:
+                throw badTree(node);
         }
 
         if (stackDepth != initialStackDepth) {
@@ -525,583 +514,586 @@ class CodeGenerator extends Icode {
         }
     }
 
-    private void visitExpression(Node node, int contextFlags)
-    {
+    private void visitExpression(Node node, int contextFlags) {
         int type = node.getType();
         Node child = node.getFirstChild();
         int savedStackDepth = stackDepth;
         switch (type) {
-
-          case Token.FUNCTION:
-            {
-                int fnIndex = node.getExistingIntProp(Node.FUNCTION_PROP);
-                FunctionNode fn = scriptOrFn.getFunctionNode(fnIndex);
-                // See comments in visitStatement for Token.FUNCTION case
-                if (fn.getFunctionType() != FunctionNode.FUNCTION_EXPRESSION &&
-                    fn.getFunctionType() != FunctionNode.ARROW_FUNCTION) {
-                    throw Kit.codeBug();
+            case Token.FUNCTION:
+                {
+                    int fnIndex = node.getExistingIntProp(Node.FUNCTION_PROP);
+                    FunctionNode fn = scriptOrFn.getFunctionNode(fnIndex);
+                    // See comments in visitStatement for Token.FUNCTION case
+                    if (fn.getFunctionType() != FunctionNode.FUNCTION_EXPRESSION
+                            && fn.getFunctionType() != FunctionNode.ARROW_FUNCTION) {
+                        throw Kit.codeBug();
+                    }
+                    addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
+                    stackChange(1);
                 }
-                addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
-                stackChange(1);
-            }
-            break;
+                break;
 
-          case Token.LOCAL_LOAD:
-            {
-                int localIndex = getLocalBlockRef(node);
-                addIndexOp(Token.LOCAL_LOAD, localIndex);
-                stackChange(1);
-            }
-            break;
+            case Token.LOCAL_LOAD:
+                {
+                    int localIndex = getLocalBlockRef(node);
+                    addIndexOp(Token.LOCAL_LOAD, localIndex);
+                    stackChange(1);
+                }
+                break;
 
-          case Token.COMMA:
-            {
-                Node lastChild = node.getLastChild();
-                while (child != lastChild) {
+            case Token.COMMA:
+                {
+                    Node lastChild = node.getLastChild();
+                    while (child != lastChild) {
+                        visitExpression(child, 0);
+                        addIcode(Icode_POP);
+                        stackChange(-1);
+                        child = child.getNext();
+                    }
+                    // Preserve tail context flag if any
+                    visitExpression(child, contextFlags & ECF_TAIL);
+                }
+                break;
+
+            case Token.USE_STACK:
+                // Indicates that stack was modified externally,
+                // like placed catch object
+                stackChange(1);
+                break;
+
+            case Token.REF_CALL:
+            case Token.CALL:
+            case Token.NEW:
+                {
+                    if (type == Token.NEW) {
+                        visitExpression(child, 0);
+                    } else {
+                        generateCallFunAndThis(child);
+                    }
+                    int argCount = 0;
+                    while ((child = child.getNext()) != null) {
+                        visitExpression(child, 0);
+                        ++argCount;
+                    }
+                    int callType = node.getIntProp(Node.SPECIALCALL_PROP, Node.NON_SPECIALCALL);
+                    if (type != Token.REF_CALL && callType != Node.NON_SPECIALCALL) {
+                        // embed line number and source filename
+                        addIndexOp(Icode_CALLSPECIAL, argCount);
+                        addUint8(callType);
+                        addUint8(type == Token.NEW ? 1 : 0);
+                        addUint16(lineNumber & 0xFFFF);
+                    } else {
+                        // Only use the tail call optimization if we're not in a try
+                        // or we're not generating debug info (since the
+                        // optimization will confuse the debugger)
+                        if (type == Token.CALL
+                                && (contextFlags & ECF_TAIL) != 0
+                                && !compilerEnv.isGenerateDebugInfo()
+                                && !itsInTryFlag) {
+                            type = Icode_TAIL_CALL;
+                        }
+                        addIndexOp(type, argCount);
+                    }
+                    // adjust stack
+                    if (type == Token.NEW) {
+                        // new: f, args -> result
+                        stackChange(-argCount);
+                    } else {
+                        // call: f, thisObj, args -> result
+                        // ref_call: f, thisObj, args -> ref
+                        stackChange(-1 - argCount);
+                    }
+                    if (argCount > itsData.itsMaxCalleeArgs) {
+                        itsData.itsMaxCalleeArgs = argCount;
+                    }
+                }
+                break;
+
+            case Token.AND:
+            case Token.OR:
+                {
                     visitExpression(child, 0);
+                    addIcode(Icode_DUP);
+                    stackChange(1);
+                    int afterSecondJumpStart = iCodeTop;
+                    int jump = (type == Token.AND) ? Token.IFNE : Token.IFEQ;
+                    addGotoOp(jump);
+                    stackChange(-1);
                     addIcode(Icode_POP);
                     stackChange(-1);
                     child = child.getNext();
+                    // Preserve tail context flag if any
+                    visitExpression(child, contextFlags & ECF_TAIL);
+                    resolveForwardGoto(afterSecondJumpStart);
                 }
-                // Preserve tail context flag if any
-                visitExpression(child, contextFlags & ECF_TAIL);
-            }
-            break;
+                break;
 
-          case Token.USE_STACK:
-            // Indicates that stack was modified externally,
-            // like placed catch object
-            stackChange(1);
-            break;
-
-          case Token.REF_CALL:
-          case Token.CALL:
-          case Token.NEW:
-            {
-                if (type == Token.NEW) {
+            case Token.HOOK:
+                {
+                    Node ifThen = child.getNext();
+                    Node ifElse = ifThen.getNext();
                     visitExpression(child, 0);
-                } else {
-                    generateCallFunAndThis(child);
+                    int elseJumpStart = iCodeTop;
+                    addGotoOp(Token.IFNE);
+                    stackChange(-1);
+                    // Preserve tail context flag if any
+                    visitExpression(ifThen, contextFlags & ECF_TAIL);
+                    int afterElseJumpStart = iCodeTop;
+                    addGotoOp(Token.GOTO);
+                    resolveForwardGoto(elseJumpStart);
+                    stackDepth = savedStackDepth;
+                    // Preserve tail context flag if any
+                    visitExpression(ifElse, contextFlags & ECF_TAIL);
+                    resolveForwardGoto(afterElseJumpStart);
                 }
-                int argCount = 0;
-                while ((child = child.getNext()) != null) {
-                    visitExpression(child, 0);
-                    ++argCount;
-                }
-                int callType = node.getIntProp(Node.SPECIALCALL_PROP,
-                                               Node.NON_SPECIALCALL);
-                if (type != Token.REF_CALL && callType != Node.NON_SPECIALCALL) {
-                    // embed line number and source filename
-                    addIndexOp(Icode_CALLSPECIAL, argCount);
-                    addUint8(callType);
-                    addUint8(type == Token.NEW ? 1 : 0);
-                    addUint16(lineNumber & 0xFFFF);
-                } else {
-                    // Only use the tail call optimization if we're not in a try
-                    // or we're not generating debug info (since the
-                    // optimization will confuse the debugger)
-                    if (type == Token.CALL && (contextFlags & ECF_TAIL) != 0 &&
-                        !compilerEnv.isGenerateDebugInfo() && !itsInTryFlag)
-                    {
-                        type = Icode_TAIL_CALL;
-                    }
-                    addIndexOp(type, argCount);
-                }
-                // adjust stack
-                if (type == Token.NEW) {
-                    // new: f, args -> result
-                    stackChange(-argCount);
-                } else {
-                    // call: f, thisObj, args -> result
-                    // ref_call: f, thisObj, args -> ref
-                    stackChange(-1 - argCount);
-                }
-                if (argCount > itsData.itsMaxCalleeArgs) {
-                    itsData.itsMaxCalleeArgs = argCount;
-                }
-            }
-            break;
+                break;
 
-          case Token.AND:
-          case Token.OR:
-            {
+            case Token.GETPROP:
+            case Token.GETPROPNOWARN:
                 visitExpression(child, 0);
-                addIcode(Icode_DUP);
-                stackChange(1);
-                int afterSecondJumpStart = iCodeTop;
-                int jump = (type == Token.AND) ? Token.IFNE : Token.IFEQ;
-                addGotoOp(jump);
-                stackChange(-1);
-                addIcode(Icode_POP);
-                stackChange(-1);
                 child = child.getNext();
-                // Preserve tail context flag if any
-                visitExpression(child, contextFlags & ECF_TAIL);
-                resolveForwardGoto(afterSecondJumpStart);
-            }
-            break;
+                addStringOp(type, child.getString());
+                break;
 
-          case Token.HOOK:
-            {
-                Node ifThen = child.getNext();
-                Node ifElse = ifThen.getNext();
+            case Token.DELPROP:
+                boolean isName = child.getType() == Token.BINDNAME;
                 visitExpression(child, 0);
-                int elseJumpStart = iCodeTop;
-                addGotoOp(Token.IFNE);
+                child = child.getNext();
+                visitExpression(child, 0);
+                if (isName) {
+                    // special handling for delete name
+                    addIcode(Icode_DELNAME);
+                } else {
+                    addToken(Token.DELPROP);
+                }
                 stackChange(-1);
-                // Preserve tail context flag if any
-                visitExpression(ifThen, contextFlags & ECF_TAIL);
-                int afterElseJumpStart = iCodeTop;
-                addGotoOp(Token.GOTO);
-                resolveForwardGoto(elseJumpStart);
-                stackDepth = savedStackDepth;
-                // Preserve tail context flag if any
-                visitExpression(ifElse, contextFlags & ECF_TAIL);
-                resolveForwardGoto(afterElseJumpStart);
-            }
-            break;
+                break;
 
-          case Token.GETPROP:
-          case Token.GETPROPNOWARN:
-            visitExpression(child, 0);
-            child = child.getNext();
-            addStringOp(type, child.getString());
-            break;
-
-          case Token.DELPROP:
-            boolean isName = child.getType() == Token.BINDNAME;
-            visitExpression(child, 0);
-            child = child.getNext();
-            visitExpression(child, 0);
-            if (isName) {
-                // special handling for delete name
-                addIcode(Icode_DELNAME);
-            } else {
-                addToken(Token.DELPROP);
-            }
-            stackChange(-1);
-            break;
-
-          case Token.GETELEM:
-          case Token.BITAND:
-          case Token.BITOR:
-          case Token.BITXOR:
-          case Token.LSH:
-          case Token.RSH:
-          case Token.URSH:
-          case Token.ADD:
-          case Token.SUB:
-          case Token.MOD:
-          case Token.DIV:
-          case Token.MUL:
-          case Token.EXP:
-          case Token.EQ:
-          case Token.NE:
-          case Token.SHEQ:
-          case Token.SHNE:
-          case Token.IN:
-          case Token.INSTANCEOF:
-          case Token.LE:
-          case Token.LT:
-          case Token.GE:
-          case Token.GT:
-            visitExpression(child, 0);
-            child = child.getNext();
-            visitExpression(child, 0);
-            addToken(type);
-            stackChange(-1);
-            break;
-
-          case Token.POS:
-          case Token.NEG:
-          case Token.NOT:
-          case Token.BITNOT:
-          case Token.TYPEOF:
-          case Token.VOID:
-            visitExpression(child, 0);
-            if (type == Token.VOID) {
-                addIcode(Icode_POP);
-                addIcode(Icode_UNDEF);
-            } else {
+            case Token.GETELEM:
+            case Token.BITAND:
+            case Token.BITOR:
+            case Token.BITXOR:
+            case Token.LSH:
+            case Token.RSH:
+            case Token.URSH:
+            case Token.ADD:
+            case Token.SUB:
+            case Token.MOD:
+            case Token.DIV:
+            case Token.MUL:
+            case Token.EXP:
+            case Token.EQ:
+            case Token.NE:
+            case Token.SHEQ:
+            case Token.SHNE:
+            case Token.IN:
+            case Token.INSTANCEOF:
+            case Token.LE:
+            case Token.LT:
+            case Token.GE:
+            case Token.GT:
+                visitExpression(child, 0);
+                child = child.getNext();
+                visitExpression(child, 0);
                 addToken(type);
-            }
-            break;
+                stackChange(-1);
+                break;
 
-          case Token.GET_REF:
-          case Token.DEL_REF:
-            visitExpression(child, 0);
-            addToken(type);
-            break;
+            case Token.POS:
+            case Token.NEG:
+            case Token.NOT:
+            case Token.BITNOT:
+            case Token.TYPEOF:
+            case Token.VOID:
+                visitExpression(child, 0);
+                if (type == Token.VOID) {
+                    addIcode(Icode_POP);
+                    addIcode(Icode_UNDEF);
+                } else {
+                    addToken(type);
+                }
+                break;
 
-          case Token.SETPROP:
-          case Token.SETPROP_OP:
-            {
+            case Token.GET_REF:
+            case Token.DEL_REF:
+                visitExpression(child, 0);
+                addToken(type);
+                break;
+
+            case Token.SETPROP:
+            case Token.SETPROP_OP:
+                {
+                    visitExpression(child, 0);
+                    child = child.getNext();
+                    String property = child.getString();
+                    child = child.getNext();
+                    if (type == Token.SETPROP_OP) {
+                        addIcode(Icode_DUP);
+                        stackChange(1);
+                        addStringOp(Token.GETPROP, property);
+                        // Compensate for the following USE_STACK
+                        stackChange(-1);
+                    }
+                    visitExpression(child, 0);
+                    addStringOp(Token.SETPROP, property);
+                    stackChange(-1);
+                }
+                break;
+
+            case Token.SETELEM:
+            case Token.SETELEM_OP:
                 visitExpression(child, 0);
                 child = child.getNext();
-                String property = child.getString();
+                visitExpression(child, 0);
                 child = child.getNext();
-                if (type == Token.SETPROP_OP) {
-                    addIcode(Icode_DUP);
-                    stackChange(1);
-                    addStringOp(Token.GETPROP, property);
+                if (type == Token.SETELEM_OP) {
+                    addIcode(Icode_DUP2);
+                    stackChange(2);
+                    addToken(Token.GETELEM);
+                    stackChange(-1);
                     // Compensate for the following USE_STACK
                     stackChange(-1);
                 }
                 visitExpression(child, 0);
-                addStringOp(Token.SETPROP, property);
-                stackChange(-1);
-            }
-            break;
+                addToken(Token.SETELEM);
+                stackChange(-2);
+                break;
 
-          case Token.SETELEM:
-          case Token.SETELEM_OP:
-            visitExpression(child, 0);
-            child = child.getNext();
-            visitExpression(child, 0);
-            child = child.getNext();
-            if (type == Token.SETELEM_OP) {
-                addIcode(Icode_DUP2);
-                stackChange(2);
-                addToken(Token.GETELEM);
-                stackChange(-1);
-                // Compensate for the following USE_STACK
-                stackChange(-1);
-            }
-            visitExpression(child, 0);
-            addToken(Token.SETELEM);
-            stackChange(-2);
-            break;
-
-          case Token.SET_REF:
-          case Token.SET_REF_OP:
-            visitExpression(child, 0);
-            child = child.getNext();
-            if (type == Token.SET_REF_OP) {
-                addIcode(Icode_DUP);
-                stackChange(1);
-                addToken(Token.GET_REF);
-                // Compensate for the following USE_STACK
-                stackChange(-1);
-            }
-            visitExpression(child, 0);
-            addToken(Token.SET_REF);
-            stackChange(-1);
-            break;
-
-          case Token.STRICT_SETNAME:
-          case Token.SETNAME:
-            {
-                String name = child.getString();
+            case Token.SET_REF:
+            case Token.SET_REF_OP:
                 visitExpression(child, 0);
                 child = child.getNext();
-                visitExpression(child, 0);
-                addStringOp(type, name);
-                stackChange(-1);
-            }
-            break;
-
-          case Token.SETCONST:
-            {
-                String name = child.getString();
-                visitExpression(child, 0);
-                child = child.getNext();
-                visitExpression(child, 0);
-                addStringOp(Icode_SETCONST, name);
-                stackChange(-1);
-            }
-            break;
-
-          case Token.TYPEOFNAME:
-            {
-                int index = -1;
-                // use typeofname if an activation frame exists
-                // since the vars all exist there instead of in jregs
-                if (itsInFunctionFlag && !itsData.itsNeedsActivation)
-                    index = scriptOrFn.getIndexForNameNode(node);
-                if (index == -1) {
-                    addStringOp(Icode_TYPEOFNAME, node.getString());
+                if (type == Token.SET_REF_OP) {
+                    addIcode(Icode_DUP);
                     stackChange(1);
-                } else {
+                    addToken(Token.GET_REF);
+                    // Compensate for the following USE_STACK
+                    stackChange(-1);
+                }
+                visitExpression(child, 0);
+                addToken(Token.SET_REF);
+                stackChange(-1);
+                break;
+
+            case Token.STRICT_SETNAME:
+            case Token.SETNAME:
+                {
+                    String name = child.getString();
+                    visitExpression(child, 0);
+                    child = child.getNext();
+                    visitExpression(child, 0);
+                    addStringOp(type, name);
+                    stackChange(-1);
+                }
+                break;
+
+            case Token.SETCONST:
+                {
+                    String name = child.getString();
+                    visitExpression(child, 0);
+                    child = child.getNext();
+                    visitExpression(child, 0);
+                    addStringOp(Icode_SETCONST, name);
+                    stackChange(-1);
+                }
+                break;
+
+            case Token.TYPEOFNAME:
+                {
+                    int index = -1;
+                    // use typeofname if an activation frame exists
+                    // since the vars all exist there instead of in jregs
+                    if (itsInFunctionFlag && !itsData.itsNeedsActivation)
+                        index = scriptOrFn.getIndexForNameNode(node);
+                    if (index == -1) {
+                        addStringOp(Icode_TYPEOFNAME, node.getString());
+                        stackChange(1);
+                    } else {
+                        addVarOp(Token.GETVAR, index);
+                        stackChange(1);
+                        addToken(Token.TYPEOF);
+                    }
+                }
+                break;
+
+            case Token.BINDNAME:
+            case Token.NAME:
+            case Token.STRING:
+                addStringOp(type, node.getString());
+                stackChange(1);
+                break;
+
+            case Token.INC:
+            case Token.DEC:
+                visitIncDec(node, child);
+                break;
+
+            case Token.NUMBER:
+                {
+                    double num = node.getDouble();
+                    int inum = (int) num;
+                    if (inum == num) {
+                        if (inum == 0) {
+                            addIcode(Icode_ZERO);
+                            // Check for negative zero
+                            if (1.0 / num < 0.0) {
+                                addToken(Token.NEG);
+                            }
+                        } else if (inum == 1) {
+                            addIcode(Icode_ONE);
+                        } else if ((short) inum == inum) {
+                            addIcode(Icode_SHORTNUMBER);
+                            // write short as uin16 bit pattern
+                            addUint16(inum & 0xFFFF);
+                        } else {
+                            addIcode(Icode_INTNUMBER);
+                            addInt(inum);
+                        }
+                    } else {
+                        int index = getDoubleIndex(num);
+                        addIndexOp(Token.NUMBER, index);
+                    }
+                    stackChange(1);
+                }
+                break;
+
+            case Token.GETVAR:
+                {
+                    if (itsData.itsNeedsActivation) Kit.codeBug();
+                    int index = scriptOrFn.getIndexForNameNode(node);
                     addVarOp(Token.GETVAR, index);
                     stackChange(1);
-                    addToken(Token.TYPEOF);
                 }
-            }
-            break;
+                break;
 
-          case Token.BINDNAME:
-          case Token.NAME:
-          case Token.STRING:
-            addStringOp(type, node.getString());
-            stackChange(1);
-            break;
-
-          case Token.INC:
-          case Token.DEC:
-            visitIncDec(node, child);
-            break;
-
-          case Token.NUMBER:
-            {
-                double num = node.getDouble();
-                int inum = (int)num;
-                if (inum == num) {
-                    if (inum == 0) {
-                        addIcode(Icode_ZERO);
-                        // Check for negative zero
-                        if (1.0 / num < 0.0) {
-                            addToken(Token.NEG);
-                        }
-                    } else if (inum == 1) {
-                        addIcode(Icode_ONE);
-                    } else if ((short)inum == inum) {
-                        addIcode(Icode_SHORTNUMBER);
-                        // write short as uin16 bit pattern
-                        addUint16(inum & 0xFFFF);
-                    } else {
-                        addIcode(Icode_INTNUMBER);
-                        addInt(inum);
-                    }
-                } else {
-                    int index = getDoubleIndex(num);
-                    addIndexOp(Token.NUMBER, index);
-                }
-                stackChange(1);
-            }
-            break;
-
-          case Token.GETVAR:
-            {
-                if (itsData.itsNeedsActivation) Kit.codeBug();
-                int index = scriptOrFn.getIndexForNameNode(node);
-                addVarOp(Token.GETVAR, index);
-                stackChange(1);
-            }
-            break;
-
-          case Token.SETVAR:
-            {
-                if (itsData.itsNeedsActivation) Kit.codeBug();
-                int index = scriptOrFn.getIndexForNameNode(child);
-                child = child.getNext();
-                visitExpression(child, 0);
-                addVarOp(Token.SETVAR, index);
-            }
-            break;
-
-          case Token.SETCONSTVAR:
-            {
-                if (itsData.itsNeedsActivation) Kit.codeBug();
-                int index = scriptOrFn.getIndexForNameNode(child);
-                child = child.getNext();
-                visitExpression(child, 0);
-                addVarOp(Token.SETCONSTVAR, index);
-            }
-            break;
-
-          case Token.NULL:
-          case Token.THIS:
-          case Token.THISFN:
-          case Token.FALSE:
-          case Token.TRUE:
-            addToken(type);
-            stackChange(1);
-            break;
-
-          case Token.ENUM_NEXT:
-          case Token.ENUM_ID:
-            addIndexOp(type, getLocalBlockRef(node));
-            stackChange(1);
-            break;
-
-          case Token.REGEXP:
-            {
-                int index = node.getExistingIntProp(Node.REGEXP_PROP);
-                addIndexOp(Token.REGEXP, index);
-                stackChange(1);
-            }
-            break;
-
-          case Token.ARRAYLIT:
-          case Token.OBJECTLIT:
-            visitLiteral(node, child);
-            break;
-
-          case Token.ARRAYCOMP:
-            visitArrayComprehension(node, child, child.getNext());
-            break;
-
-          case Token.REF_SPECIAL:
-            visitExpression(child, 0);
-            addStringOp(type, (String)node.getProp(Node.NAME_PROP));
-            break;
-
-          case Token.REF_MEMBER:
-          case Token.REF_NS_MEMBER:
-          case Token.REF_NAME:
-          case Token.REF_NS_NAME:
-            {
-                int memberTypeFlags = node.getIntProp(Node.MEMBER_TYPE_PROP, 0);
-                // generate possible target, possible namespace and member
-                int childCount = 0;
-                do {
-                    visitExpression(child, 0);
-                    ++childCount;
+            case Token.SETVAR:
+                {
+                    if (itsData.itsNeedsActivation) Kit.codeBug();
+                    int index = scriptOrFn.getIndexForNameNode(child);
                     child = child.getNext();
-                } while (child != null);
-                addIndexOp(type, memberTypeFlags);
-                stackChange(1 - childCount);
-            }
-            break;
+                    visitExpression(child, 0);
+                    addVarOp(Token.SETVAR, index);
+                }
+                break;
 
-          case Token.DOTQUERY:
-            {
-                int queryPC;
-                updateLineNumber(node);
-                visitExpression(child, 0);
-                addIcode(Icode_ENTERDQ);
-                stackChange(-1);
-                queryPC = iCodeTop;
-                visitExpression(child.getNext(), 0);
-                addBackwardGoto(Icode_LEAVEDQ, queryPC);
-            }
-            break;
+            case Token.SETCONSTVAR:
+                {
+                    if (itsData.itsNeedsActivation) Kit.codeBug();
+                    int index = scriptOrFn.getIndexForNameNode(child);
+                    child = child.getNext();
+                    visitExpression(child, 0);
+                    addVarOp(Token.SETCONSTVAR, index);
+                }
+                break;
 
-          case Token.DEFAULTNAMESPACE :
-          case Token.ESCXMLATTR :
-          case Token.ESCXMLTEXT :
-            visitExpression(child, 0);
-            addToken(type);
-            break;
-
-          case Token.YIELD:
-          case Token.YIELD_STAR:
-            if (child != null) {
-                visitExpression(child, 0);
-            } else {
-                addIcode(Icode_UNDEF);
+            case Token.NULL:
+            case Token.THIS:
+            case Token.THISFN:
+            case Token.FALSE:
+            case Token.TRUE:
+                addToken(type);
                 stackChange(1);
-            }
-            if (type == Token.YIELD) {
-                addToken(Token.YIELD);
-            } else {
-                addIcode(Icode_YIELD_STAR);
-            }
-            addUint16(node.getLineno() & 0xFFFF);
-            break;
+                break;
 
-          case Token.WITHEXPR: {
-            Node enterWith = node.getFirstChild();
-            Node with = enterWith.getNext();
-            visitExpression(enterWith.getFirstChild(), 0);
-            addToken(Token.ENTERWITH);
-            stackChange(-1);
-            visitExpression(with.getFirstChild(), 0);
-            addToken(Token.LEAVEWITH);
-            break;
-          }
+            case Token.ENUM_NEXT:
+            case Token.ENUM_ID:
+                addIndexOp(type, getLocalBlockRef(node));
+                stackChange(1);
+                break;
 
-          default:
-            throw badTree(node);
+            case Token.REGEXP:
+                {
+                    int index = node.getExistingIntProp(Node.REGEXP_PROP);
+                    addIndexOp(Token.REGEXP, index);
+                    stackChange(1);
+                }
+                break;
+
+            case Token.ARRAYLIT:
+            case Token.OBJECTLIT:
+                visitLiteral(node, child);
+                break;
+
+            case Token.ARRAYCOMP:
+                visitArrayComprehension(node, child, child.getNext());
+                break;
+
+            case Token.REF_SPECIAL:
+                visitExpression(child, 0);
+                addStringOp(type, (String) node.getProp(Node.NAME_PROP));
+                break;
+
+            case Token.REF_MEMBER:
+            case Token.REF_NS_MEMBER:
+            case Token.REF_NAME:
+            case Token.REF_NS_NAME:
+                {
+                    int memberTypeFlags = node.getIntProp(Node.MEMBER_TYPE_PROP, 0);
+                    // generate possible target, possible namespace and member
+                    int childCount = 0;
+                    do {
+                        visitExpression(child, 0);
+                        ++childCount;
+                        child = child.getNext();
+                    } while (child != null);
+                    addIndexOp(type, memberTypeFlags);
+                    stackChange(1 - childCount);
+                }
+                break;
+
+            case Token.DOTQUERY:
+                {
+                    int queryPC;
+                    updateLineNumber(node);
+                    visitExpression(child, 0);
+                    addIcode(Icode_ENTERDQ);
+                    stackChange(-1);
+                    queryPC = iCodeTop;
+                    visitExpression(child.getNext(), 0);
+                    addBackwardGoto(Icode_LEAVEDQ, queryPC);
+                }
+                break;
+
+            case Token.DEFAULTNAMESPACE:
+            case Token.ESCXMLATTR:
+            case Token.ESCXMLTEXT:
+                visitExpression(child, 0);
+                addToken(type);
+                break;
+
+            case Token.YIELD:
+            case Token.YIELD_STAR:
+                if (child != null) {
+                    visitExpression(child, 0);
+                } else {
+                    addIcode(Icode_UNDEF);
+                    stackChange(1);
+                }
+                if (type == Token.YIELD) {
+                    addToken(Token.YIELD);
+                } else {
+                    addIcode(Icode_YIELD_STAR);
+                }
+                addUint16(node.getLineno() & 0xFFFF);
+                break;
+
+            case Token.WITHEXPR:
+                {
+                    Node enterWith = node.getFirstChild();
+                    Node with = enterWith.getNext();
+                    visitExpression(enterWith.getFirstChild(), 0);
+                    addToken(Token.ENTERWITH);
+                    stackChange(-1);
+                    visitExpression(with.getFirstChild(), 0);
+                    addToken(Token.LEAVEWITH);
+                    break;
+                }
+
+            default:
+                throw badTree(node);
         }
         if (savedStackDepth + 1 != stackDepth) {
             Kit.codeBug();
         }
     }
 
-    private void generateCallFunAndThis(Node left)
-    {
+    private void generateCallFunAndThis(Node left) {
         // Generate code to place on stack function and thisObj
         int type = left.getType();
         switch (type) {
-          case Token.NAME: {
-            String name = left.getString();
-            // stack: ... -> ... function thisObj
-            addStringOp(Icode_NAME_AND_THIS, name);
-            stackChange(2);
-            break;
-          }
-          case Token.GETPROP:
-          case Token.GETELEM: {
-            Node target = left.getFirstChild();
-            visitExpression(target, 0);
-            Node id = target.getNext();
-            if (type == Token.GETPROP) {
-                String property = id.getString();
-                // stack: ... target -> ... function thisObj
-                addStringOp(Icode_PROP_AND_THIS, property);
+            case Token.NAME:
+                {
+                    String name = left.getString();
+                    // stack: ... -> ... function thisObj
+                    addStringOp(Icode_NAME_AND_THIS, name);
+                    stackChange(2);
+                    break;
+                }
+            case Token.GETPROP:
+            case Token.GETELEM:
+                {
+                    Node target = left.getFirstChild();
+                    visitExpression(target, 0);
+                    Node id = target.getNext();
+                    if (type == Token.GETPROP) {
+                        String property = id.getString();
+                        // stack: ... target -> ... function thisObj
+                        addStringOp(Icode_PROP_AND_THIS, property);
+                        stackChange(1);
+                    } else {
+                        visitExpression(id, 0);
+                        // stack: ... target id -> ... function thisObj
+                        addIcode(Icode_ELEM_AND_THIS);
+                    }
+                    break;
+                }
+            default:
+                // Including Token.GETVAR
+                visitExpression(left, 0);
+                // stack: ... value -> ... function thisObj
+                addIcode(Icode_VALUE_AND_THIS);
                 stackChange(1);
-            } else {
-                visitExpression(id, 0);
-                // stack: ... target id -> ... function thisObj
-                addIcode(Icode_ELEM_AND_THIS);
-            }
-            break;
-          }
-          default:
-            // Including Token.GETVAR
-            visitExpression(left, 0);
-            // stack: ... value -> ... function thisObj
-            addIcode(Icode_VALUE_AND_THIS);
-            stackChange(1);
-            break;
+                break;
         }
     }
 
-
-    private void visitIncDec(Node node, Node child)
-    {
+    private void visitIncDec(Node node, Node child) {
         int incrDecrMask = node.getExistingIntProp(Node.INCRDECR_PROP);
         int childType = child.getType();
         switch (childType) {
-          case Token.GETVAR : {
-            if (itsData.itsNeedsActivation) Kit.codeBug();
-            int i = scriptOrFn.getIndexForNameNode(child);
-            addVarOp(Icode_VAR_INC_DEC, i);
-            addUint8(incrDecrMask);
-            stackChange(1);
-            break;
-          }
-          case Token.NAME : {
-            String name = child.getString();
-            addStringOp(Icode_NAME_INC_DEC, name);
-            addUint8(incrDecrMask);
-            stackChange(1);
-            break;
-          }
-          case Token.GETPROP : {
-            Node object = child.getFirstChild();
-            visitExpression(object, 0);
-            String property = object.getNext().getString();
-            addStringOp(Icode_PROP_INC_DEC, property);
-            addUint8(incrDecrMask);
-            break;
-          }
-          case Token.GETELEM : {
-            Node object = child.getFirstChild();
-            visitExpression(object, 0);
-            Node index = object.getNext();
-            visitExpression(index, 0);
-            addIcode(Icode_ELEM_INC_DEC);
-            addUint8(incrDecrMask);
-            stackChange(-1);
-            break;
-          }
-          case Token.GET_REF : {
-            Node ref = child.getFirstChild();
-            visitExpression(ref, 0);
-            addIcode(Icode_REF_INC_DEC);
-            addUint8(incrDecrMask);
-            break;
-          }
-          default : {
-            throw badTree(node);
-          }
+            case Token.GETVAR:
+                {
+                    if (itsData.itsNeedsActivation) Kit.codeBug();
+                    int i = scriptOrFn.getIndexForNameNode(child);
+                    addVarOp(Icode_VAR_INC_DEC, i);
+                    addUint8(incrDecrMask);
+                    stackChange(1);
+                    break;
+                }
+            case Token.NAME:
+                {
+                    String name = child.getString();
+                    addStringOp(Icode_NAME_INC_DEC, name);
+                    addUint8(incrDecrMask);
+                    stackChange(1);
+                    break;
+                }
+            case Token.GETPROP:
+                {
+                    Node object = child.getFirstChild();
+                    visitExpression(object, 0);
+                    String property = object.getNext().getString();
+                    addStringOp(Icode_PROP_INC_DEC, property);
+                    addUint8(incrDecrMask);
+                    break;
+                }
+            case Token.GETELEM:
+                {
+                    Node object = child.getFirstChild();
+                    visitExpression(object, 0);
+                    Node index = object.getNext();
+                    visitExpression(index, 0);
+                    addIcode(Icode_ELEM_INC_DEC);
+                    addUint8(incrDecrMask);
+                    stackChange(-1);
+                    break;
+                }
+            case Token.GET_REF:
+                {
+                    Node ref = child.getFirstChild();
+                    visitExpression(ref, 0);
+                    addIcode(Icode_REF_INC_DEC);
+                    addUint8(incrDecrMask);
+                    break;
+                }
+            default:
+                {
+                    throw badTree(node);
+                }
         }
     }
 
-    private void visitLiteral(Node node, Node child)
-    {
+    private void visitLiteral(Node node, Node child) {
         int type = node.getType();
         int count;
         Object[] propertyIds = null;
@@ -1111,7 +1103,7 @@ class CodeGenerator extends Icode {
                 ++count;
             }
         } else if (type == Token.OBJECTLIT) {
-            propertyIds = (Object[])node.getProp(Node.OBJECT_IDS_PROP);
+            propertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
             count = propertyIds.length;
         } else {
             throw badTree(node);
@@ -1137,7 +1129,7 @@ class CodeGenerator extends Icode {
             child = child.getNext();
         }
         if (type == Token.ARRAYLIT) {
-            int[] skipIndexes = (int[])node.getProp(Node.SKIP_INDEXES_PROP);
+            int[] skipIndexes = (int[]) node.getProp(Node.SKIP_INDEXES_PROP);
             if (skipIndexes == null) {
                 addToken(Token.ARRAYLIT);
             } else {
@@ -1153,8 +1145,7 @@ class CodeGenerator extends Icode {
         stackChange(-1);
     }
 
-    private void visitArrayComprehension(Node node, Node initStmt, Node expr)
-    {
+    private void visitArrayComprehension(Node node, Node initStmt, Node expr) {
         // A bit of a hack: array comprehensions are implemented using
         // statement nodes for the iteration, yet they appear in an
         // expression context. So we pass the current stack depth to
@@ -1164,14 +1155,12 @@ class CodeGenerator extends Icode {
         visitExpression(expr, 0);
     }
 
-    private static int getLocalBlockRef(Node node)
-    {
-        Node localBlock = (Node)node.getProp(Node.LOCAL_BLOCK_PROP);
+    private static int getLocalBlockRef(Node node) {
+        Node localBlock = (Node) node.getProp(Node.LOCAL_BLOCK_PROP);
         return localBlock.getExistingIntProp(Node.LOCAL_PROP);
     }
 
-    private int getTargetLabel(Node target)
-    {
+    private int getTargetLabel(Node target) {
         int label = target.labelId();
         if (label != -1) {
             return label;
@@ -1180,7 +1169,7 @@ class CodeGenerator extends Icode {
         if (labelTable == null || label == labelTable.length) {
             if (labelTable == null) {
                 labelTable = new int[MIN_LABEL_TABLE_SIZE];
-            }else {
+            } else {
                 int[] tmp = new int[labelTable.length * 2];
                 System.arraycopy(labelTable, 0, tmp, 0, label);
                 labelTable = tmp;
@@ -1193,8 +1182,7 @@ class CodeGenerator extends Icode {
         return label;
     }
 
-    private void markTargetLabel(Node target)
-    {
+    private void markTargetLabel(Node target) {
         int label = getTargetLabel(target);
         if (labelTable[label] != -1) {
             // Can mark label only once
@@ -1203,8 +1191,7 @@ class CodeGenerator extends Icode {
         labelTable[label] = iCodeTop;
     }
 
-    private void addGoto(Node target, int gotoOp)
-    {
+    private void addGoto(Node target, int gotoOp) {
         int label = getTargetLabel(target);
         if (!(label < labelTableTop)) Kit.codeBug();
         int targetPC = labelTable[label];
@@ -1225,16 +1212,15 @@ class CodeGenerator extends Icode {
                 }
             }
             fixupTableTop = top + 1;
-            fixupTable[top] = ((long)label << 32) | gotoPC;
+            fixupTable[top] = ((long) label << 32) | gotoPC;
         }
     }
 
-    private void fixLabelGotos()
-    {
+    private void fixLabelGotos() {
         for (int i = 0; i < fixupTableTop; i++) {
             long fixup = fixupTable[i];
-            int label = (int)(fixup >> 32);
-            int jumpSource = (int)fixup;
+            int label = (int) (fixup >> 32);
+            int jumpSource = (int) fixup;
             int pc = labelTable[label];
             if (pc == -1) {
                 // Unlocated label
@@ -1245,8 +1231,7 @@ class CodeGenerator extends Icode {
         fixupTableTop = 0;
     }
 
-    private void addBackwardGoto(int gotoOp, int jumpPC)
-    {
+    private void addBackwardGoto(int gotoOp, int jumpPC) {
         int fromPC = iCodeTop;
         // Ensure that this is a jump backward
         if (fromPC <= jumpPC) throw Kit.codeBug();
@@ -1254,20 +1239,18 @@ class CodeGenerator extends Icode {
         resolveGoto(fromPC, jumpPC);
     }
 
-    private void resolveForwardGoto(int fromPC)
-    {
+    private void resolveForwardGoto(int fromPC) {
         // Ensure that forward jump skips at least self bytecode
         if (iCodeTop < fromPC + 3) throw Kit.codeBug();
         resolveGoto(fromPC, iCodeTop);
     }
 
-    private void resolveGoto(int fromPC, int jumpPC)
-    {
+    private void resolveGoto(int fromPC, int jumpPC) {
         int offset = jumpPC - fromPC;
         // Ensure that jumps do not overlap
         if (0 <= offset && offset <= 2) throw Kit.codeBug();
         int offsetSite = fromPC + 1;
-        if (offset != (short)offset) {
+        if (offset != (short) offset) {
             if (itsData.longJumps == null) {
                 itsData.longJumps = new UintMap();
             }
@@ -1275,64 +1258,58 @@ class CodeGenerator extends Icode {
             offset = 0;
         }
         byte[] array = itsData.itsICode;
-        array[offsetSite] = (byte)(offset >> 8);
-        array[offsetSite + 1] = (byte)offset;
+        array[offsetSite] = (byte) (offset >> 8);
+        array[offsetSite + 1] = (byte) offset;
     }
 
-    private void addToken(int token)
-    {
+    private void addToken(int token) {
         if (!Icode.validTokenCode(token)) throw Kit.codeBug();
         addUint8(token);
     }
 
-    private void addIcode(int icode)
-    {
+    private void addIcode(int icode) {
         if (!Icode.validIcode(icode)) throw Kit.codeBug();
         // Write negative icode as uint8 bits
         addUint8(icode & 0xFF);
     }
 
-    private void addUint8(int value)
-    {
+    private void addUint8(int value) {
         if ((value & ~0xFF) != 0) throw Kit.codeBug();
         byte[] array = itsData.itsICode;
         int top = iCodeTop;
         if (top == array.length) {
             array = increaseICodeCapacity(1);
         }
-        array[top] = (byte)value;
+        array[top] = (byte) value;
         iCodeTop = top + 1;
     }
 
-    private void addUint16(int value)
-    {
+    private void addUint16(int value) {
         if ((value & ~0xFFFF) != 0) throw Kit.codeBug();
         byte[] array = itsData.itsICode;
         int top = iCodeTop;
         if (top + 2 > array.length) {
             array = increaseICodeCapacity(2);
         }
-        array[top] = (byte)(value >>> 8);
-        array[top + 1] = (byte)value;
+        array[top] = (byte) (value >>> 8);
+        array[top + 1] = (byte) value;
         iCodeTop = top + 2;
     }
 
-    private void addInt(int i)
-    {
+    private void addInt(int i) {
         byte[] array = itsData.itsICode;
         int top = iCodeTop;
         if (top + 4 > array.length) {
             array = increaseICodeCapacity(4);
         }
-        array[top] = (byte)(i >>> 24);
-        array[top + 1] = (byte)(i >>> 16);
-        array[top + 2] = (byte)(i >>> 8);
-        array[top + 3] = (byte)i;
+        array[top] = (byte) (i >>> 24);
+        array[top + 1] = (byte) (i >>> 16);
+        array[top + 2] = (byte) (i >>> 8);
+        array[top + 3] = (byte) i;
         iCodeTop = top + 4;
     }
 
-    private int getDoubleIndex(double num)
-    {
+    private int getDoubleIndex(double num) {
         int index = doubleTableTop;
         if (index == 0) {
             itsData.itsDoubleTable = new double[64];
@@ -1346,46 +1323,43 @@ class CodeGenerator extends Icode {
         return index;
     }
 
-    private void addGotoOp(int gotoOp)
-    {
+    private void addGotoOp(int gotoOp) {
         byte[] array = itsData.itsICode;
         int top = iCodeTop;
         if (top + 3 > array.length) {
             array = increaseICodeCapacity(3);
         }
-        array[top] = (byte)gotoOp;
+        array[top] = (byte) gotoOp;
         // Offset would written later
         iCodeTop = top + 1 + 2;
     }
 
-    private void addVarOp(int op, int varIndex)
-    {
+    private void addVarOp(int op, int varIndex) {
         switch (op) {
-          case Token.SETCONSTVAR:
-            if (varIndex < 128) {
-                addIcode(Icode_SETCONSTVAR1);
-                addUint8(varIndex);
+            case Token.SETCONSTVAR:
+                if (varIndex < 128) {
+                    addIcode(Icode_SETCONSTVAR1);
+                    addUint8(varIndex);
+                    return;
+                }
+                addIndexOp(Icode_SETCONSTVAR, varIndex);
                 return;
-            }
-            addIndexOp(Icode_SETCONSTVAR, varIndex);
-            return;
-          case Token.GETVAR:
-          case Token.SETVAR:
-            if (varIndex < 128) {
-                addIcode(op == Token.GETVAR ? Icode_GETVAR1 : Icode_SETVAR1);
-                addUint8(varIndex);
+            case Token.GETVAR:
+            case Token.SETVAR:
+                if (varIndex < 128) {
+                    addIcode(op == Token.GETVAR ? Icode_GETVAR1 : Icode_SETVAR1);
+                    addUint8(varIndex);
+                    return;
+                }
+                // fallthrough
+            case Icode_VAR_INC_DEC:
+                addIndexOp(op, varIndex);
                 return;
-            }
-            // fallthrough
-          case Icode_VAR_INC_DEC:
-            addIndexOp(op, varIndex);
-            return;
         }
         throw Kit.codeBug();
     }
 
-    private void addStringOp(int op, String str)
-    {
+    private void addStringOp(int op, String str) {
         addStringPrefix(str);
         if (Icode.validIcode(op)) {
             addIcode(op);
@@ -1394,8 +1368,7 @@ class CodeGenerator extends Icode {
         }
     }
 
-    private void addIndexOp(int op, int index)
-    {
+    private void addIndexOp(int op, int index) {
         addIndexPrefix(index);
         if (Icode.validIcode(op)) {
             addIcode(op);
@@ -1404,8 +1377,7 @@ class CodeGenerator extends Icode {
         }
     }
 
-    private void addStringPrefix(String str)
-    {
+    private void addStringPrefix(String str) {
         int index = strings.get(str, -1);
         if (index == -1) {
             index = strings.size();
@@ -1416,36 +1388,38 @@ class CodeGenerator extends Icode {
         } else if (index <= 0xFF) {
             addIcode(Icode_REG_STR1);
             addUint8(index);
-         } else if (index <= 0xFFFF) {
+        } else if (index <= 0xFFFF) {
             addIcode(Icode_REG_STR2);
             addUint16(index);
-         } else {
+        } else {
             addIcode(Icode_REG_STR4);
             addInt(index);
         }
     }
 
-    private void addIndexPrefix(int index)
-    {
+    private void addIndexPrefix(int index) {
         if (index < 0) Kit.codeBug();
         if (index < 6) {
             addIcode(Icode_REG_IND_C0 - index);
         } else if (index <= 0xFF) {
             addIcode(Icode_REG_IND1);
             addUint8(index);
-         } else if (index <= 0xFFFF) {
+        } else if (index <= 0xFFFF) {
             addIcode(Icode_REG_IND2);
             addUint16(index);
-         } else {
+        } else {
             addIcode(Icode_REG_IND4);
             addInt(index);
         }
     }
 
-    private void addExceptionHandler(int icodeStart, int icodeEnd,
-                                     int handlerStart, boolean isFinally,
-                                     int exceptionObjectLocal, int scopeLocal)
-    {
+    private void addExceptionHandler(
+            int icodeStart,
+            int icodeEnd,
+            int handlerStart,
+            boolean isFinally,
+            int exceptionObjectLocal,
+            int scopeLocal) {
         int top = exceptionTableTop;
         int[] table = itsData.itsExceptionTable;
         if (table == null) {
@@ -1457,18 +1431,17 @@ class CodeGenerator extends Icode {
             System.arraycopy(itsData.itsExceptionTable, 0, table, 0, top);
             itsData.itsExceptionTable = table;
         }
-        table[top + Interpreter.EXCEPTION_TRY_START_SLOT]  = icodeStart;
-        table[top + Interpreter.EXCEPTION_TRY_END_SLOT]    = icodeEnd;
-        table[top + Interpreter.EXCEPTION_HANDLER_SLOT]    = handlerStart;
-        table[top + Interpreter.EXCEPTION_TYPE_SLOT]     = isFinally ? 1 : 0;
-        table[top + Interpreter.EXCEPTION_LOCAL_SLOT]    = exceptionObjectLocal;
-        table[top + Interpreter.EXCEPTION_SCOPE_SLOT]    = scopeLocal;
+        table[top + Interpreter.EXCEPTION_TRY_START_SLOT] = icodeStart;
+        table[top + Interpreter.EXCEPTION_TRY_END_SLOT] = icodeEnd;
+        table[top + Interpreter.EXCEPTION_HANDLER_SLOT] = handlerStart;
+        table[top + Interpreter.EXCEPTION_TYPE_SLOT] = isFinally ? 1 : 0;
+        table[top + Interpreter.EXCEPTION_LOCAL_SLOT] = exceptionObjectLocal;
+        table[top + Interpreter.EXCEPTION_SCOPE_SLOT] = scopeLocal;
 
         exceptionTableTop = top + Interpreter.EXCEPTION_SLOT_SIZE;
     }
 
-    private byte[] increaseICodeCapacity(int extraSize)
-    {
+    private byte[] increaseICodeCapacity(int extraSize) {
         int capacity = itsData.itsICode.length;
         int top = iCodeTop;
         if (top + extraSize <= capacity) throw Kit.codeBug();
@@ -1482,8 +1455,7 @@ class CodeGenerator extends Icode {
         return array;
     }
 
-    private void stackChange(int change)
-    {
+    private void stackChange(int change) {
         if (change <= 0) {
             stackDepth += change;
         } else {
@@ -1495,8 +1467,7 @@ class CodeGenerator extends Icode {
         }
     }
 
-    private int allocLocal()
-    {
+    private int allocLocal() {
         int localSlot = localTop;
         ++localTop;
         if (localTop > itsData.itsMaxLocals) {
@@ -1505,8 +1476,7 @@ class CodeGenerator extends Icode {
         return localSlot;
     }
 
-    private void releaseLocal(int localSlot)
-    {
+    private void releaseLocal(int localSlot) {
         --localTop;
         if (localSlot != localTop) Kit.codeBug();
     }

--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -6,6 +6,7 @@
 
 package org.mozilla.javascript;
 
+import java.math.BigInteger;
 import org.mozilla.javascript.ast.FunctionNode;
 
 /**
@@ -154,6 +155,11 @@ public class Decompiler {
                 append((char) lbits);
             }
         }
+    }
+
+    void addBigInt(BigInteger n) {
+        addToken(Token.BIGINT);
+        appendString(n.toString());
     }
 
     private void appendString(String str) {
@@ -305,6 +311,10 @@ public class Decompiler {
 
                 case Token.NUMBER:
                     i = printSourceNumber(source, i + 1, result);
+                    continue;
+
+                case Token.BIGINT:
+                    i = printSourceBigInt(source, i + 1, result);
                     continue;
 
                 case Token.TRUE:
@@ -835,6 +845,24 @@ public class Decompiler {
             sb.append(ScriptRuntime.numberToString(number, 10));
         }
         return offset;
+    }
+
+    /**
+     * @see #printSourceString(String source, int offset, boolean asQuotedString, StringBuilder sb)
+     */
+    private static int printSourceBigInt(String source, int offset, StringBuilder sb) {
+        int length = source.charAt(offset);
+        ++offset;
+        if ((0x8000 & length) != 0) {
+            length = ((0x7FFF & length) << 16) | source.charAt(offset);
+            ++offset;
+        }
+        if (sb != null) {
+            String str = source.substring(offset, offset + length);
+            sb.append(str);
+            sb.append('n');
+        }
+        return offset + length;
     }
 
     private char[] sourceBuffer = new char[128];

--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -9,187 +9,154 @@ package org.mozilla.javascript;
 import org.mozilla.javascript.ast.FunctionNode;
 
 /**
- * The following class save decompilation information about the source.
- * Source information is returned from the parser as a String
- * associated with function nodes and with the toplevel script.  When
- * saved in the constant pool of a class, this string will be UTF-8
- * encoded, and token values will occupy a single byte.
-
- * Source is saved (mostly) as token numbers.  The tokens saved pretty
- * much correspond to the token stream of a 'canonical' representation
- * of the input program, as directed by the parser.  (There were a few
- * cases where tokens could have been left out where decompiler could
- * easily reconstruct them, but I left them in for clarity).  (I also
- * looked adding source collection to TokenStream instead, where I
- * could have limited the changes to a few lines in getToken... but
- * this wouldn't have saved any space in the resulting source
- * representation, and would have meant that I'd have to duplicate
- * parser logic in the decompiler to disambiguate situations where
- * newlines are important.)  The function decompile expands the
- * tokens back into their string representations, using simple
- * lookahead to correct spacing and indentation.
+ * The following class save decompilation information about the source. Source information is
+ * returned from the parser as a String associated with function nodes and with the toplevel script.
+ * When saved in the constant pool of a class, this string will be UTF-8 encoded, and token values
+ * will occupy a single byte.
  *
- * Assignments are saved as two-token pairs (Token.ASSIGN, op). Number tokens
- * are stored inline, as a NUMBER token, a character representing the type, and
- * either 1 or 4 characters representing the bit-encoding of the number.  String
- * types NAME, STRING and OBJECT are currently stored as a token type,
- * followed by a character giving the length of the string (assumed to
- * be less than 2^16), followed by the characters of the string
- * inlined into the source string.  Changing this to some reference to
- * to the string in the compiled class' constant pool would probably
- * save a lot of space... but would require some method of deriving
- * the final constant pool entry from information available at parse
- * time.
+ * <p>Source is saved (mostly) as token numbers. The tokens saved pretty much correspond to the
+ * token stream of a 'canonical' representation of the input program, as directed by the parser.
+ * (There were a few cases where tokens could have been left out where decompiler could easily
+ * reconstruct them, but I left them in for clarity). (I also looked adding source collection to
+ * TokenStream instead, where I could have limited the changes to a few lines in getToken... but
+ * this wouldn't have saved any space in the resulting source representation, and would have meant
+ * that I'd have to duplicate parser logic in the decompiler to disambiguate situations where
+ * newlines are important.) The function decompile expands the tokens back into their string
+ * representations, using simple lookahead to correct spacing and indentation.
+ *
+ * <p>Assignments are saved as two-token pairs (Token.ASSIGN, op). Number tokens are stored inline,
+ * as a NUMBER token, a character representing the type, and either 1 or 4 characters representing
+ * the bit-encoding of the number. String types NAME, STRING and OBJECT are currently stored as a
+ * token type, followed by a character giving the length of the string (assumed to be less than
+ * 2^16), followed by the characters of the string inlined into the source string. Changing this to
+ * some reference to to the string in the compiled class' constant pool would probably save a lot of
+ * space... but would require some method of deriving the final constant pool entry from information
+ * available at parse time.
  */
-public class Decompiler
-{
+public class Decompiler {
     /**
-     * Flag to indicate that the decompilation should omit the
-     * function header and trailing brace.
+     * Flag to indicate that the decompilation should omit the function header and trailing brace.
      */
     public static final int ONLY_BODY_FLAG = 1 << 0;
 
-    /**
-     * Flag to indicate that the decompilation generates toSource result.
-     */
+    /** Flag to indicate that the decompilation generates toSource result. */
     public static final int TO_SOURCE_FLAG = 1 << 1;
 
-    /**
-     * Decompilation property to specify initial ident value.
-     */
+    /** Decompilation property to specify initial ident value. */
     public static final int INITIAL_INDENT_PROP = 1;
 
-    /**
-     * Decompilation property to specify default identation offset.
-     */
+    /** Decompilation property to specify default identation offset. */
     public static final int INDENT_GAP_PROP = 2;
 
-    /**
-     * Decompilation property to specify identation offset for case labels.
-     */
+    /** Decompilation property to specify identation offset for case labels. */
     public static final int CASE_GAP_PROP = 3;
 
     // Marker to denote the last RC of function so it can be distinguished from
     // the last RC of object literals in case of function expressions
     private static final int FUNCTION_END = Token.LAST_TOKEN + 1;
 
-    String getEncodedSource()
-    {
+    String getEncodedSource() {
         return sourceToString(0);
     }
 
-    int getCurrentOffset()
-    {
+    int getCurrentOffset() {
         return sourceTop;
     }
 
-    int markFunctionStart(int functionType)
-    {
+    int markFunctionStart(int functionType) {
         int savedOffset = getCurrentOffset();
         if (functionType != FunctionNode.ARROW_FUNCTION) {
             addToken(Token.FUNCTION);
-            append((char)functionType);
+            append((char) functionType);
         }
         return savedOffset;
     }
 
-    int markFunctionEnd(int functionStart)
-    {
+    int markFunctionEnd(int functionStart) {
         int offset = getCurrentOffset();
-        append((char)FUNCTION_END);
+        append((char) FUNCTION_END);
         return offset;
     }
 
-    void addToken(int token)
-    {
-        if (!(0 <= token && token <= Token.LAST_TOKEN))
-            throw new IllegalArgumentException();
+    void addToken(int token) {
+        if (!(0 <= token && token <= Token.LAST_TOKEN)) throw new IllegalArgumentException();
 
-        append((char)token);
+        append((char) token);
     }
 
-    void addEOL(int token)
-    {
-        if (!(0 <= token && token <= Token.LAST_TOKEN))
-            throw new IllegalArgumentException();
+    void addEOL(int token) {
+        if (!(0 <= token && token <= Token.LAST_TOKEN)) throw new IllegalArgumentException();
 
-        append((char)token);
-        append((char)Token.EOL);
+        append((char) token);
+        append((char) Token.EOL);
     }
 
-    void addName(String str)
-    {
+    void addName(String str) {
         addToken(Token.NAME);
         appendString(str);
     }
 
-    void addString(String str)
-    {
+    void addString(String str) {
         addToken(Token.STRING);
         appendString(str);
     }
 
-    void addRegexp(String regexp, String flags)
-    {
+    void addRegexp(String regexp, String flags) {
         addToken(Token.REGEXP);
         appendString('/' + regexp + '/' + flags);
     }
 
-    void addNumber(double n)
-    {
+    void addNumber(double n) {
         addToken(Token.NUMBER);
 
         /* encode the number in the source stream.
-         * Save as NUMBER type (char | char char char char)
-         * where type is
-         * 'D' - double, 'S' - short, 'J' - long.
+        * Save as NUMBER type (char | char char char char)
+        * where type is
+        * 'D' - double, 'S' - short, 'J' - long.
 
-         * We need to retain float vs. integer type info to keep the
-         * behavior of liveconnect type-guessing the same after
-         * decompilation.  (Liveconnect tries to present 1.0 to Java
-         * as a float/double)
-         * OPT: This is no longer true. We could compress the format.
+        * We need to retain float vs. integer type info to keep the
+        * behavior of liveconnect type-guessing the same after
+        * decompilation.  (Liveconnect tries to present 1.0 to Java
+        * as a float/double)
+        * OPT: This is no longer true. We could compress the format.
 
-         * This may not be the most space-efficient encoding;
-         * the chars created below may take up to 3 bytes in
-         * constant pool UTF-8 encoding, so a Double could take
-         * up to 12 bytes.
-         */
+        * This may not be the most space-efficient encoding;
+        * the chars created below may take up to 3 bytes in
+        * constant pool UTF-8 encoding, so a Double could take
+        * up to 12 bytes.
+        */
 
-        long lbits = (long)n;
+        long lbits = (long) n;
         if (lbits != n) {
             // if it's floating point, save as a Double bit pattern.
             // (12/15/97 our scanner only returns Double for f.p.)
             lbits = Double.doubleToLongBits(n);
             append('D');
-            append((char)(lbits >> 48));
-            append((char)(lbits >> 32));
-            append((char)(lbits >> 16));
-            append((char)lbits);
-        }
-        else {
+            append((char) (lbits >> 48));
+            append((char) (lbits >> 32));
+            append((char) (lbits >> 16));
+            append((char) lbits);
+        } else {
             // we can ignore negative values, bc they're already prefixed
             // by NEG
-               if (lbits < 0) Kit.codeBug();
+            if (lbits < 0) Kit.codeBug();
 
             // will it fit in a char?
             // this gives a short encoding for integer values up to 2^16.
             if (lbits <= Character.MAX_VALUE) {
                 append('S');
-                append((char)lbits);
-            }
-            else { // Integral, but won't fit in a char. Store as a long.
+                append((char) lbits);
+            } else { // Integral, but won't fit in a char. Store as a long.
                 append('J');
-                append((char)(lbits >> 48));
-                append((char)(lbits >> 32));
-                append((char)(lbits >> 16));
-                append((char)lbits);
+                append((char) (lbits >> 48));
+                append((char) (lbits >> 32));
+                append((char) (lbits >> 16));
+                append((char) lbits);
             }
         }
     }
 
-    private void appendString(String str)
-    {
+    private void appendString(String str) {
         int L = str.length();
         int lengthEncodingSize = 1;
         if (L >= 0x8000) {
@@ -202,17 +169,16 @@ public class Decompiler
         if (L >= 0x8000) {
             // Use 2 chars to encode strings exceeding 32K, were the highest
             // bit in the first char indicates presence of the next byte
-            sourceBuffer[sourceTop] = (char)(0x8000 | (L >>> 16));
+            sourceBuffer[sourceTop] = (char) (0x8000 | (L >>> 16));
             ++sourceTop;
         }
-        sourceBuffer[sourceTop] = (char)L;
+        sourceBuffer[sourceTop] = (char) L;
         ++sourceTop;
         str.getChars(0, L, sourceBuffer, sourceTop);
         sourceTop = nextTop;
     }
 
-    private void append(char c)
-    {
+    private void append(char c) {
         if (sourceTop == sourceBuffer.length) {
             increaseSourceCapacity(sourceTop + 1);
         }
@@ -220,8 +186,7 @@ public class Decompiler
         ++sourceTop;
     }
 
-    private void increaseSourceCapacity(int minimalCapacity)
-    {
+    private void increaseSourceCapacity(int minimalCapacity) {
         // Call this only when capacity increase is must
         if (minimalCapacity <= sourceBuffer.length) Kit.codeBug();
         int newCapacity = sourceBuffer.length * 2;
@@ -233,33 +198,27 @@ public class Decompiler
         sourceBuffer = tmp;
     }
 
-    private String sourceToString(int offset)
-    {
+    private String sourceToString(int offset) {
         if (offset < 0 || sourceTop < offset) Kit.codeBug();
         return new String(sourceBuffer, offset, sourceTop - offset);
     }
 
     /**
-     * Decompile the source information associated with this js
-     * function/script back into a string.  For the most part, this
-     * just means translating tokens back to their string
-     * representations; there's a little bit of lookahead logic to
-     * decide the proper spacing/indentation.  Most of the work in
-     * mapping the original source to the prettyprinted decompiled
-     * version is done by the parser.
+     * Decompile the source information associated with this js function/script back into a string.
+     * For the most part, this just means translating tokens back to their string representations;
+     * there's a little bit of lookahead logic to decide the proper spacing/indentation. Most of the
+     * work in mapping the original source to the prettyprinted decompiled version is done by the
+     * parser.
      *
      * @param source encoded source tree presentation
-     *
      * @param flags flags to select output format
-     *
      * @param properties indentation properties
-     *
      */
-    public static String decompile(String source, int flags,
-                                   UintMap properties)
-    {
+    public static String decompile(String source, int flags, UintMap properties) {
         int length = source.length();
-        if (length == 0) { return ""; }
+        if (length == 0) {
+            return "";
+        }
 
         int indent = properties.getInt(INITIAL_INDENT_PROP, 0);
         if (indent < 0) throw new IllegalArgumentException();
@@ -286,15 +245,14 @@ public class Decompiler
                 if (tokenname == null) {
                     tokenname = "---";
                 }
-                String pad = tokenname.length() > 7
-                    ? "\t"
-                    : "\t\t";
-                System.err.println
-                    (tokenname
-                     + pad + (int)source.charAt(i)
-                     + "\t'" + ScriptRuntime.escapeString
-                     (source.substring(i, i+1))
-                     + "'");
+                String pad = tokenname.length() > 7 ? "\t" : "\t\t";
+                System.err.println(
+                        tokenname
+                                + pad
+                                + (int) source.charAt(i)
+                                + "\t'"
+                                + ScriptRuntime.escapeString(source.substring(i, i + 1))
+                                + "'");
             }
             System.err.println();
         }
@@ -313,8 +271,7 @@ public class Decompiler
         if (!toSource) {
             // add an initial newline to exactly match js.
             result.append('\n');
-            for (int j = 0; j < indent; j++)
-                result.append(' ');
+            for (int j = 0; j < indent; j++) result.append(' ');
         } else {
             if (topFunctionType == FunctionNode.FUNCTION_EXPRESSION) {
                 result.append('(');
@@ -322,502 +279,492 @@ public class Decompiler
         }
 
         while (i < length) {
-            switch(source.charAt(i)) {
-            case Token.GET:
-            case Token.SET:
-            case Token.METHOD:
-                if (source.charAt(i) == Token.GET) {
-                    result.append("get ");
-                } else if (source.charAt(i) == Token.SET) {
-                    result.append("set ");
-                }
-                ++i;
-                i = printSourceString(source, i + 1, false, result);
-                // Now increment one more to get past the FUNCTION token
-                ++i;
-                break;
-
-            case Token.NAME:
-            case Token.REGEXP:  // re-wrapped in '/'s in parser...
-                i = printSourceString(source, i + 1, false, result);
-                continue;
-
-            case Token.STRING:
-                i = printSourceString(source, i + 1, true, result);
-                continue;
-
-            case Token.NUMBER:
-                i = printSourceNumber(source, i + 1, result);
-                continue;
-
-            case Token.TRUE:
-                result.append("true");
-                break;
-
-            case Token.FALSE:
-                result.append("false");
-                break;
-
-            case Token.NULL:
-                result.append("null");
-                break;
-
-            case Token.THIS:
-                result.append("this");
-                break;
-
-            case Token.FUNCTION:
-                ++i; // skip function type
-                result.append("function ");
-                break;
-
-            case FUNCTION_END:
-                // Do nothing
-                break;
-
-            case Token.COMMA:
-                result.append(", ");
-                break;
-
-            case Token.LC:
-                ++braceNesting;
-                if (Token.EOL == getNext(source, length, i))
-                    indent += indentGap;
-                result.append('{');
-                break;
-
-            case Token.RC: {
-                --braceNesting;
-                /* don't print the closing RC if it closes the
-                 * toplevel function and we're called from
-                 * decompileFunctionBody.
-                 */
-                if (justFunctionBody && braceNesting == 0)
+            switch (source.charAt(i)) {
+                case Token.GET:
+                case Token.SET:
+                case Token.METHOD:
+                    if (source.charAt(i) == Token.GET) {
+                        result.append("get ");
+                    } else if (source.charAt(i) == Token.SET) {
+                        result.append("set ");
+                    }
+                    ++i;
+                    i = printSourceString(source, i + 1, false, result);
+                    // Now increment one more to get past the FUNCTION token
+                    ++i;
                     break;
 
-                result.append('}');
-                switch (getNext(source, length, i)) {
-                    case Token.EOL:
-                    case FUNCTION_END:
-                        indent -= indentGap;
-                        break;
-                    case Token.WHILE:
-                    case Token.ELSE:
-                        indent -= indentGap;
-                        result.append(' ');
-                        break;
-                }
-                break;
-            }
-            case Token.LP:
-                result.append('(');
-                break;
+                case Token.NAME:
+                case Token.REGEXP: // re-wrapped in '/'s in parser...
+                    i = printSourceString(source, i + 1, false, result);
+                    continue;
 
-            case Token.RP:
-                result.append(')');
-                if (Token.LC == getNext(source, length, i))
-                    result.append(' ');
-                break;
+                case Token.STRING:
+                    i = printSourceString(source, i + 1, true, result);
+                    continue;
 
-            case Token.LB:
-                result.append('[');
-                break;
+                case Token.NUMBER:
+                    i = printSourceNumber(source, i + 1, result);
+                    continue;
 
-            case Token.RB:
-                result.append(']');
-                break;
+                case Token.TRUE:
+                    result.append("true");
+                    break;
 
-            case Token.EOL: {
-                if (toSource) break;
-                boolean newLine = true;
-                if (!afterFirstEOL) {
-                    afterFirstEOL = true;
-                    if (justFunctionBody) {
-                        /* throw away just added 'function name(...) {'
-                         * and restore the original indent
-                         */
-                        result.setLength(0);
-                        indent -= indentGap;
-                        newLine = false;
-                    }
-                }
-                if (newLine) {
-                    result.append('\n');
-                }
+                case Token.FALSE:
+                    result.append("false");
+                    break;
 
-                /* add indent if any tokens remain,
-                 * less setback if next token is
-                 * a label, case or default.
-                 */
-                if (i + 1 < length) {
-                    int less = 0;
-                    int nextToken = source.charAt(i + 1);
-                    if (nextToken == Token.CASE
-                        || nextToken == Token.DEFAULT)
+                case Token.NULL:
+                    result.append("null");
+                    break;
+
+                case Token.THIS:
+                    result.append("this");
+                    break;
+
+                case Token.FUNCTION:
+                    ++i; // skip function type
+                    result.append("function ");
+                    break;
+
+                case FUNCTION_END:
+                    // Do nothing
+                    break;
+
+                case Token.COMMA:
+                    result.append(", ");
+                    break;
+
+                case Token.LC:
+                    ++braceNesting;
+                    if (Token.EOL == getNext(source, length, i)) indent += indentGap;
+                    result.append('{');
+                    break;
+
+                case Token.RC:
                     {
-                        less = indentGap - caseGap;
-                    } else if (nextToken == Token.RC) {
-                        less = indentGap;
-                    }
+                        --braceNesting;
+                        /* don't print the closing RC if it closes the
+                         * toplevel function and we're called from
+                         * decompileFunctionBody.
+                         */
+                        if (justFunctionBody && braceNesting == 0) break;
 
-                    /* elaborate check against label... skip past a
-                     * following inlined NAME and look for a COLON.
-                     */
-                    else if (nextToken == Token.NAME) {
-                        int afterName = getSourceStringEnd(source, i + 2);
-                        if (source.charAt(afterName) == Token.COLON)
-                            less = indentGap;
+                        result.append('}');
+                        switch (getNext(source, length, i)) {
+                            case Token.EOL:
+                            case FUNCTION_END:
+                                indent -= indentGap;
+                                break;
+                            case Token.WHILE:
+                            case Token.ELSE:
+                                indent -= indentGap;
+                                result.append(' ');
+                                break;
+                        }
+                        break;
                     }
+                case Token.LP:
+                    result.append('(');
+                    break;
 
-                    for (; less < indent; less++)
+                case Token.RP:
+                    result.append(')');
+                    if (Token.LC == getNext(source, length, i)) result.append(' ');
+                    break;
+
+                case Token.LB:
+                    result.append('[');
+                    break;
+
+                case Token.RB:
+                    result.append(']');
+                    break;
+
+                case Token.EOL:
+                    {
+                        if (toSource) break;
+                        boolean newLine = true;
+                        if (!afterFirstEOL) {
+                            afterFirstEOL = true;
+                            if (justFunctionBody) {
+                                /* throw away just added 'function name(...) {'
+                                 * and restore the original indent
+                                 */
+                                result.setLength(0);
+                                indent -= indentGap;
+                                newLine = false;
+                            }
+                        }
+                        if (newLine) {
+                            result.append('\n');
+                        }
+
+                        /* add indent if any tokens remain,
+                         * less setback if next token is
+                         * a label, case or default.
+                         */
+                        if (i + 1 < length) {
+                            int less = 0;
+                            int nextToken = source.charAt(i + 1);
+                            if (nextToken == Token.CASE || nextToken == Token.DEFAULT) {
+                                less = indentGap - caseGap;
+                            } else if (nextToken == Token.RC) {
+                                less = indentGap;
+                            }
+
+                            /* elaborate check against label... skip past a
+                             * following inlined NAME and look for a COLON.
+                             */
+                            else if (nextToken == Token.NAME) {
+                                int afterName = getSourceStringEnd(source, i + 2);
+                                if (source.charAt(afterName) == Token.COLON) less = indentGap;
+                            }
+
+                            for (; less < indent; less++) result.append(' ');
+                        }
+                        break;
+                    }
+                case Token.DOT:
+                    result.append('.');
+                    break;
+
+                case Token.NEW:
+                    result.append("new ");
+                    break;
+
+                case Token.DELPROP:
+                    result.append("delete ");
+                    break;
+
+                case Token.IF:
+                    result.append("if ");
+                    break;
+
+                case Token.ELSE:
+                    result.append("else ");
+                    break;
+
+                case Token.FOR:
+                    result.append("for ");
+                    break;
+
+                case Token.IN:
+                    result.append(" in ");
+                    break;
+
+                case Token.WITH:
+                    result.append("with ");
+                    break;
+
+                case Token.WHILE:
+                    result.append("while ");
+                    break;
+
+                case Token.DO:
+                    result.append("do ");
+                    break;
+
+                case Token.TRY:
+                    result.append("try ");
+                    break;
+
+                case Token.CATCH:
+                    result.append("catch ");
+                    break;
+
+                case Token.FINALLY:
+                    result.append("finally ");
+                    break;
+
+                case Token.THROW:
+                    result.append("throw ");
+                    break;
+
+                case Token.SWITCH:
+                    result.append("switch ");
+                    break;
+
+                case Token.BREAK:
+                    result.append("break");
+                    if (Token.NAME == getNext(source, length, i)) result.append(' ');
+                    break;
+
+                case Token.CONTINUE:
+                    result.append("continue");
+                    if (Token.NAME == getNext(source, length, i)) result.append(' ');
+                    break;
+
+                case Token.CASE:
+                    result.append("case ");
+                    break;
+
+                case Token.DEFAULT:
+                    result.append("default");
+                    break;
+
+                case Token.RETURN:
+                    result.append("return");
+                    if (Token.SEMI != getNext(source, length, i)) result.append(' ');
+                    break;
+
+                case Token.VAR:
+                    result.append("var ");
+                    break;
+
+                case Token.LET:
+                    result.append("let ");
+                    break;
+
+                case Token.SEMI:
+                    result.append(';');
+                    if (Token.EOL != getNext(source, length, i)) {
+                        // separators in FOR
                         result.append(' ');
-                }
-                break;
-            }
-            case Token.DOT:
-                result.append('.');
-                break;
-
-            case Token.NEW:
-                result.append("new ");
-                break;
-
-            case Token.DELPROP:
-                result.append("delete ");
-                break;
-
-            case Token.IF:
-                result.append("if ");
-                break;
-
-            case Token.ELSE:
-                result.append("else ");
-                break;
-
-            case Token.FOR:
-                result.append("for ");
-                break;
-
-            case Token.IN:
-                result.append(" in ");
-                break;
-
-            case Token.WITH:
-                result.append("with ");
-                break;
-
-            case Token.WHILE:
-                result.append("while ");
-                break;
-
-            case Token.DO:
-                result.append("do ");
-                break;
-
-            case Token.TRY:
-                result.append("try ");
-                break;
-
-            case Token.CATCH:
-                result.append("catch ");
-                break;
-
-            case Token.FINALLY:
-                result.append("finally ");
-                break;
-
-            case Token.THROW:
-                result.append("throw ");
-                break;
-
-            case Token.SWITCH:
-                result.append("switch ");
-                break;
-
-            case Token.BREAK:
-                result.append("break");
-                if (Token.NAME == getNext(source, length, i))
-                    result.append(' ');
-                break;
-
-            case Token.CONTINUE:
-                result.append("continue");
-                if (Token.NAME == getNext(source, length, i))
-                    result.append(' ');
-                break;
-
-            case Token.CASE:
-                result.append("case ");
-                break;
-
-            case Token.DEFAULT:
-                result.append("default");
-                break;
-
-            case Token.RETURN:
-                result.append("return");
-                if (Token.SEMI != getNext(source, length, i))
-                    result.append(' ');
-                break;
-
-            case Token.VAR:
-                result.append("var ");
-                break;
-
-            case Token.LET:
-              result.append("let ");
-              break;
-
-            case Token.SEMI:
-                result.append(';');
-                if (Token.EOL != getNext(source, length, i)) {
-                    // separators in FOR
-                    result.append(' ');
-                }
-                break;
-
-            case Token.ASSIGN:
-                result.append(" = ");
-                break;
-
-            case Token.ASSIGN_ADD:
-                result.append(" += ");
-                break;
-
-            case Token.ASSIGN_SUB:
-                result.append(" -= ");
-                break;
-
-            case Token.ASSIGN_MUL:
-                result.append(" *= ");
-                break;
-
-            case Token.ASSIGN_DIV:
-                result.append(" /= ");
-                break;
-
-            case Token.ASSIGN_MOD:
-                result.append(" %= ");
-                break;
-
-            case Token.ASSIGN_BITOR:
-                result.append(" |= ");
-                break;
-
-            case Token.ASSIGN_BITXOR:
-                result.append(" ^= ");
-                break;
-
-            case Token.ASSIGN_BITAND:
-                result.append(" &= ");
-                break;
-
-            case Token.ASSIGN_LSH:
-                result.append(" <<= ");
-                break;
-
-            case Token.ASSIGN_RSH:
-                result.append(" >>= ");
-                break;
-
-            case Token.ASSIGN_URSH:
-                result.append(" >>>= ");
-                break;
-
-            case Token.HOOK:
-                result.append(" ? ");
-                break;
-
-            case Token.OBJECTLIT:
-                // pun OBJECTLIT to mean colon in objlit property
-                // initialization.
-                // This needs to be distinct from COLON in the general case
-                // to distinguish from the colon in a ternary... which needs
-                // different spacing.
-                result.append(": ");
-                break;
-
-            case Token.COLON:
-                if (Token.EOL == getNext(source, length, i))
-                    // it's the end of a label
-                    result.append(':');
-                else
-                    // it's the middle part of a ternary
-                    result.append(" : ");
-                break;
-
-            case Token.OR:
-                result.append(" || ");
-                break;
-
-            case Token.AND:
-                result.append(" && ");
-                break;
-
-            case Token.BITOR:
-                result.append(" | ");
-                break;
-
-            case Token.BITXOR:
-                result.append(" ^ ");
-                break;
-
-            case Token.BITAND:
-                result.append(" & ");
-                break;
-
-            case Token.SHEQ:
-                result.append(" === ");
-                break;
-
-            case Token.SHNE:
-                result.append(" !== ");
-                break;
-
-            case Token.EQ:
-                result.append(" == ");
-                break;
-
-            case Token.NE:
-                result.append(" != ");
-                break;
-
-            case Token.LE:
-                result.append(" <= ");
-                break;
-
-            case Token.LT:
-                result.append(" < ");
-                break;
-
-            case Token.GE:
-                result.append(" >= ");
-                break;
-
-            case Token.GT:
-                result.append(" > ");
-                break;
-
-            case Token.INSTANCEOF:
-                result.append(" instanceof ");
-                break;
-
-            case Token.LSH:
-                result.append(" << ");
-                break;
-
-            case Token.RSH:
-                result.append(" >> ");
-                break;
-
-            case Token.URSH:
-                result.append(" >>> ");
-                break;
-
-            case Token.TYPEOF:
-                result.append("typeof ");
-                break;
-
-            case Token.VOID:
-                result.append("void ");
-                break;
-
-            case Token.CONST:
-                result.append("const ");
-                break;
-
-            case Token.YIELD:
-                result.append("yield ");
-                break;
-            
-            case Token.YIELD_STAR:
-                result.append("yield *");
-                break;
-
-            case Token.NOT:
-                result.append('!');
-                break;
-
-            case Token.BITNOT:
-                result.append('~');
-                break;
-
-            case Token.POS:
-                result.append('+');
-                break;
-
-            case Token.NEG:
-                result.append('-');
-                break;
-
-            case Token.INC:
-                result.append("++");
-                break;
-
-            case Token.DEC:
-                result.append("--");
-                break;
-
-            case Token.ADD:
-                result.append(" + ");
-                break;
-
-            case Token.SUB:
-                result.append(" - ");
-                break;
-
-            case Token.MUL:
-                result.append(" * ");
-                break;
-
-            case Token.DIV:
-                result.append(" / ");
-                break;
-
-            case Token.MOD:
-                result.append(" % ");
-                break;
-
-            case Token.EXP:
-                result.append(" ** ");
-                break;
-
-            case Token.COLONCOLON:
-                result.append("::");
-                break;
-
-            case Token.DOTDOT:
-                result.append("..");
-                break;
-
-            case Token.DOTQUERY:
-                result.append(".(");
-                break;
-
-            case Token.XMLATTR:
-                result.append('@');
-                break;
-
-            case Token.DEBUGGER:
-                result.append("debugger;\n");
-                break;
-
-            case Token.ARROW:
-                result.append(" => ");
-                break;
-
-            default:
-                // If we don't know how to decompile it, raise an exception.
-                throw new RuntimeException("Token: " +
-                                               Token.name(source.charAt(i)));
+                    }
+                    break;
+
+                case Token.ASSIGN:
+                    result.append(" = ");
+                    break;
+
+                case Token.ASSIGN_ADD:
+                    result.append(" += ");
+                    break;
+
+                case Token.ASSIGN_SUB:
+                    result.append(" -= ");
+                    break;
+
+                case Token.ASSIGN_MUL:
+                    result.append(" *= ");
+                    break;
+
+                case Token.ASSIGN_DIV:
+                    result.append(" /= ");
+                    break;
+
+                case Token.ASSIGN_MOD:
+                    result.append(" %= ");
+                    break;
+
+                case Token.ASSIGN_BITOR:
+                    result.append(" |= ");
+                    break;
+
+                case Token.ASSIGN_BITXOR:
+                    result.append(" ^= ");
+                    break;
+
+                case Token.ASSIGN_BITAND:
+                    result.append(" &= ");
+                    break;
+
+                case Token.ASSIGN_LSH:
+                    result.append(" <<= ");
+                    break;
+
+                case Token.ASSIGN_RSH:
+                    result.append(" >>= ");
+                    break;
+
+                case Token.ASSIGN_URSH:
+                    result.append(" >>>= ");
+                    break;
+
+                case Token.HOOK:
+                    result.append(" ? ");
+                    break;
+
+                case Token.OBJECTLIT:
+                    // pun OBJECTLIT to mean colon in objlit property
+                    // initialization.
+                    // This needs to be distinct from COLON in the general case
+                    // to distinguish from the colon in a ternary... which needs
+                    // different spacing.
+                    result.append(": ");
+                    break;
+
+                case Token.COLON:
+                    if (Token.EOL == getNext(source, length, i))
+                        // it's the end of a label
+                        result.append(':');
+                    else
+                        // it's the middle part of a ternary
+                        result.append(" : ");
+                    break;
+
+                case Token.OR:
+                    result.append(" || ");
+                    break;
+
+                case Token.AND:
+                    result.append(" && ");
+                    break;
+
+                case Token.BITOR:
+                    result.append(" | ");
+                    break;
+
+                case Token.BITXOR:
+                    result.append(" ^ ");
+                    break;
+
+                case Token.BITAND:
+                    result.append(" & ");
+                    break;
+
+                case Token.SHEQ:
+                    result.append(" === ");
+                    break;
+
+                case Token.SHNE:
+                    result.append(" !== ");
+                    break;
+
+                case Token.EQ:
+                    result.append(" == ");
+                    break;
+
+                case Token.NE:
+                    result.append(" != ");
+                    break;
+
+                case Token.LE:
+                    result.append(" <= ");
+                    break;
+
+                case Token.LT:
+                    result.append(" < ");
+                    break;
+
+                case Token.GE:
+                    result.append(" >= ");
+                    break;
+
+                case Token.GT:
+                    result.append(" > ");
+                    break;
+
+                case Token.INSTANCEOF:
+                    result.append(" instanceof ");
+                    break;
+
+                case Token.LSH:
+                    result.append(" << ");
+                    break;
+
+                case Token.RSH:
+                    result.append(" >> ");
+                    break;
+
+                case Token.URSH:
+                    result.append(" >>> ");
+                    break;
+
+                case Token.TYPEOF:
+                    result.append("typeof ");
+                    break;
+
+                case Token.VOID:
+                    result.append("void ");
+                    break;
+
+                case Token.CONST:
+                    result.append("const ");
+                    break;
+
+                case Token.YIELD:
+                    result.append("yield ");
+                    break;
+
+                case Token.YIELD_STAR:
+                    result.append("yield *");
+                    break;
+
+                case Token.NOT:
+                    result.append('!');
+                    break;
+
+                case Token.BITNOT:
+                    result.append('~');
+                    break;
+
+                case Token.POS:
+                    result.append('+');
+                    break;
+
+                case Token.NEG:
+                    result.append('-');
+                    break;
+
+                case Token.INC:
+                    result.append("++");
+                    break;
+
+                case Token.DEC:
+                    result.append("--");
+                    break;
+
+                case Token.ADD:
+                    result.append(" + ");
+                    break;
+
+                case Token.SUB:
+                    result.append(" - ");
+                    break;
+
+                case Token.MUL:
+                    result.append(" * ");
+                    break;
+
+                case Token.DIV:
+                    result.append(" / ");
+                    break;
+
+                case Token.MOD:
+                    result.append(" % ");
+                    break;
+
+                case Token.EXP:
+                    result.append(" ** ");
+                    break;
+
+                case Token.COLONCOLON:
+                    result.append("::");
+                    break;
+
+                case Token.DOTDOT:
+                    result.append("..");
+                    break;
+
+                case Token.DOTQUERY:
+                    result.append(".(");
+                    break;
+
+                case Token.XMLATTR:
+                    result.append('@');
+                    break;
+
+                case Token.DEBUGGER:
+                    result.append("debugger;\n");
+                    break;
+
+                case Token.ARROW:
+                    result.append(" => ");
+                    break;
+
+                default:
+                    // If we don't know how to decompile it, raise an exception.
+                    throw new RuntimeException("Token: " + Token.name(source.charAt(i)));
             }
             ++i;
         }
 
         if (!toSource) {
             // add that trailing newline if it's an outermost function.
-            if (!justFunctionBody)
-                result.append('\n');
+            if (!justFunctionBody) result.append('\n');
         } else {
             if (topFunctionType == FunctionNode.FUNCTION_EXPRESSION) {
                 result.append(')');
@@ -827,20 +774,16 @@ public class Decompiler
         return result.toString();
     }
 
-    private static int getNext(String source, int length, int i)
-    {
+    private static int getNext(String source, int length, int i) {
         return (i + 1 < length) ? source.charAt(i + 1) : Token.EOF;
     }
 
-    private static int getSourceStringEnd(String source, int offset)
-    {
+    private static int getSourceStringEnd(String source, int offset) {
         return printSourceString(source, offset, false, null);
     }
 
-    private static int printSourceString(String source, int offset,
-                                         boolean asQuotedString,
-                                         StringBuilder sb)
-    {
+    private static int printSourceString(
+            String source, int offset, boolean asQuotedString, StringBuilder sb) {
         int length = source.charAt(offset);
         ++offset;
         if ((0x8000 & length) != 0) {
@@ -860,9 +803,7 @@ public class Decompiler
         return offset + length;
     }
 
-    private static int printSourceNumber(String source, int offset,
-                                         StringBuilder sb)
-    {
+    private static int printSourceNumber(String source, int offset, StringBuilder sb) {
         double number = 0.0;
         char type = source.charAt(offset);
         ++offset;
@@ -875,9 +816,9 @@ public class Decompiler
         } else if (type == 'J' || type == 'D') {
             if (sb != null) {
                 long lbits;
-                lbits = (long)source.charAt(offset) << 48;
-                lbits |= (long)source.charAt(offset + 1) << 32;
-                lbits |= (long)source.charAt(offset + 2) << 16;
+                lbits = (long) source.charAt(offset) << 48;
+                lbits |= (long) source.charAt(offset + 1) << 32;
+                lbits |= (long) source.charAt(offset + 2) << 16;
                 lbits |= source.charAt(offset + 3);
                 if (type == 'J') {
                     number = lbits;
@@ -898,11 +839,10 @@ public class Decompiler
 
     private char[] sourceBuffer = new char[128];
 
-// Per script/function source buffer top: parent source does not include a
-// nested functions source and uses function index as a reference instead.
+    // Per script/function source buffer top: parent source does not include a
+    // nested functions source and uses function index as a reference instead.
     private int sourceTop;
 
-// whether to do a debug print of the source information, when decompiling.
+    // whether to do a debug print of the source information, when decompiling.
     private static final boolean printSource = false;
-
 }

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -8,7 +8,6 @@ package org.mozilla.javascript;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.mozilla.javascript.ast.ArrayComprehension;
 import org.mozilla.javascript.ast.ArrayComprehensionLoop;
 import org.mozilla.javascript.ast.ArrayLiteral;
@@ -80,11 +79,10 @@ import org.mozilla.javascript.ast.Yield;
  * @author Mike McCabe
  * @author Norris Boyd
  */
-public final class IRFactory extends Parser
-{
+public final class IRFactory extends Parser {
     private static final int LOOP_DO_WHILE = 0;
-    private static final int LOOP_WHILE    = 1;
-    private static final int LOOP_FOR      = 2;
+    private static final int LOOP_WHILE = 1;
+    private static final int LOOP_FOR = 2;
 
     private static final int ALWAYS_TRUE_BOOLEAN = 1;
     private static final int ALWAYS_FALSE_BOOLEAN = -1;
@@ -104,8 +102,8 @@ public final class IRFactory extends Parser
     }
 
     /**
-     * Transforms the tree into a lower-level IR suitable for codegen.
-     * Optionally generates the encoded source.
+     * Transforms the tree into a lower-level IR suitable for codegen. Optionally generates the
+     * encoded source.
      */
     public ScriptNode transformTree(AstRoot root) {
         currentScriptOrFn = root;
@@ -116,11 +114,10 @@ public final class IRFactory extends Parser
             System.out.println("IRFactory.transformTree");
             System.out.println(root.debugPrint());
         }
-        ScriptNode script = (ScriptNode)transform(root);
+        ScriptNode script = (ScriptNode) transform(root);
 
         int sourceEndOffset = decompiler.getCurrentOffset();
-        script.setEncodedSourceBounds(sourceStartOffset,
-                                      sourceEndOffset);
+        script.setEncodedSourceBounds(sourceStartOffset, sourceEndOffset);
 
         if (compilerEnv.isGeneratingSource()) {
             script.setEncodedSource(decompiler.getEncodedSource());
@@ -136,115 +133,115 @@ public final class IRFactory extends Parser
     // Another possibility:  create AstTransformer interface and adapter.
     public Node transform(AstNode node) {
         switch (node.getType()) {
-          case Token.ARRAYCOMP:
-              return transformArrayComp((ArrayComprehension)node);
-          case Token.ARRAYLIT:
-              return transformArrayLiteral((ArrayLiteral)node);
-          case Token.BLOCK:
-              return transformBlock(node);
-          case Token.BREAK:
-              return transformBreak((BreakStatement)node);
-          case Token.CALL:
-              return transformFunctionCall((FunctionCall)node);
-          case Token.CONTINUE:
-              return transformContinue((ContinueStatement)node);
-          case Token.DO:
-              return transformDoLoop((DoLoop)node);
-          case Token.EMPTY:
-          case Token.COMMENT:
-              return node;
-          case Token.FOR:
-              if (node instanceof ForInLoop) {
-                  return transformForInLoop((ForInLoop)node);
-              }
-              return transformForLoop((ForLoop)node);
-          case Token.FUNCTION:
-              return transformFunction((FunctionNode)node);
-          case Token.GENEXPR:
-              return transformGenExpr((GeneratorExpression)node);
-          case Token.GETELEM:
-              return transformElementGet((ElementGet)node);
-          case Token.GETPROP:
-              return transformPropertyGet((PropertyGet)node);
-          case Token.HOOK:
-              return transformCondExpr((ConditionalExpression)node);
-          case Token.IF:
-              return transformIf((IfStatement)node);
+            case Token.ARRAYCOMP:
+                return transformArrayComp((ArrayComprehension) node);
+            case Token.ARRAYLIT:
+                return transformArrayLiteral((ArrayLiteral) node);
+            case Token.BLOCK:
+                return transformBlock(node);
+            case Token.BREAK:
+                return transformBreak((BreakStatement) node);
+            case Token.CALL:
+                return transformFunctionCall((FunctionCall) node);
+            case Token.CONTINUE:
+                return transformContinue((ContinueStatement) node);
+            case Token.DO:
+                return transformDoLoop((DoLoop) node);
+            case Token.EMPTY:
+            case Token.COMMENT:
+                return node;
+            case Token.FOR:
+                if (node instanceof ForInLoop) {
+                    return transformForInLoop((ForInLoop) node);
+                }
+                return transformForLoop((ForLoop) node);
+            case Token.FUNCTION:
+                return transformFunction((FunctionNode) node);
+            case Token.GENEXPR:
+                return transformGenExpr((GeneratorExpression) node);
+            case Token.GETELEM:
+                return transformElementGet((ElementGet) node);
+            case Token.GETPROP:
+                return transformPropertyGet((PropertyGet) node);
+            case Token.HOOK:
+                return transformCondExpr((ConditionalExpression) node);
+            case Token.IF:
+                return transformIf((IfStatement) node);
 
-          case Token.TRUE:
-          case Token.FALSE:
-          case Token.THIS:
-          case Token.NULL:
-          case Token.DEBUGGER:
-              return transformLiteral(node);
+            case Token.TRUE:
+            case Token.FALSE:
+            case Token.THIS:
+            case Token.NULL:
+            case Token.DEBUGGER:
+                return transformLiteral(node);
 
-          case Token.NAME:
-              return transformName((Name)node);
-          case Token.NUMBER:
-              return transformNumber((NumberLiteral)node);
-          case Token.NEW:
-              return transformNewExpr((NewExpression)node);
-          case Token.OBJECTLIT:
-              return transformObjectLiteral((ObjectLiteral)node);
-          case Token.REGEXP:
-              return transformRegExp((RegExpLiteral)node);
-          case Token.RETURN:
-              return transformReturn((ReturnStatement)node);
-          case Token.SCRIPT:
-              return transformScript((ScriptNode)node);
-          case Token.STRING:
-              return transformString((StringLiteral)node);
-          case Token.SWITCH:
-              return transformSwitch((SwitchStatement)node);
-          case Token.THROW:
-              return transformThrow((ThrowStatement)node);
-          case Token.TRY:
-              return transformTry((TryStatement)node);
-          case Token.WHILE:
-              return transformWhileLoop((WhileLoop)node);
-          case Token.WITH:
-              return transformWith((WithStatement)node);
-          case Token.YIELD:
-          case Token.YIELD_STAR:
-              return transformYield((Yield)node);
-          default:
-              if (node instanceof ExpressionStatement) {
-                  return transformExprStmt((ExpressionStatement)node);
-              }
-              if (node instanceof Assignment) {
-                  return transformAssignment((Assignment)node);
-              }
-              if (node instanceof UnaryExpression) {
-                  return transformUnary((UnaryExpression)node);
-              }
-              if (node instanceof UpdateExpression) {
-                  return transformUpdate((UpdateExpression)node);
-              }
-              if (node instanceof XmlMemberGet) {
-                  return transformXmlMemberGet((XmlMemberGet)node);
-              }
-              if (node instanceof InfixExpression) {
-                  return transformInfix((InfixExpression)node);
-              }
-              if (node instanceof VariableDeclaration) {
-                  return transformVariables((VariableDeclaration)node);
-              }
-              if (node instanceof ParenthesizedExpression) {
-                  return transformParenExpr((ParenthesizedExpression)node);
-              }
-              if (node instanceof LabeledStatement) {
-                  return transformLabeledStatement((LabeledStatement)node);
-              }
-              if (node instanceof LetNode) {
-                  return transformLetNode((LetNode)node);
-              }
-              if (node instanceof XmlRef) {
-                  return transformXmlRef((XmlRef)node);
-              }
-              if (node instanceof XmlLiteral) {
-                  return transformXmlLiteral((XmlLiteral)node);
-              }
-              throw new IllegalArgumentException("Can't transform: " + node);
+            case Token.NAME:
+                return transformName((Name) node);
+            case Token.NUMBER:
+                return transformNumber((NumberLiteral) node);
+            case Token.NEW:
+                return transformNewExpr((NewExpression) node);
+            case Token.OBJECTLIT:
+                return transformObjectLiteral((ObjectLiteral) node);
+            case Token.REGEXP:
+                return transformRegExp((RegExpLiteral) node);
+            case Token.RETURN:
+                return transformReturn((ReturnStatement) node);
+            case Token.SCRIPT:
+                return transformScript((ScriptNode) node);
+            case Token.STRING:
+                return transformString((StringLiteral) node);
+            case Token.SWITCH:
+                return transformSwitch((SwitchStatement) node);
+            case Token.THROW:
+                return transformThrow((ThrowStatement) node);
+            case Token.TRY:
+                return transformTry((TryStatement) node);
+            case Token.WHILE:
+                return transformWhileLoop((WhileLoop) node);
+            case Token.WITH:
+                return transformWith((WithStatement) node);
+            case Token.YIELD:
+            case Token.YIELD_STAR:
+                return transformYield((Yield) node);
+            default:
+                if (node instanceof ExpressionStatement) {
+                    return transformExprStmt((ExpressionStatement) node);
+                }
+                if (node instanceof Assignment) {
+                    return transformAssignment((Assignment) node);
+                }
+                if (node instanceof UnaryExpression) {
+                    return transformUnary((UnaryExpression) node);
+                }
+                if (node instanceof UpdateExpression) {
+                    return transformUpdate((UpdateExpression) node);
+                }
+                if (node instanceof XmlMemberGet) {
+                    return transformXmlMemberGet((XmlMemberGet) node);
+                }
+                if (node instanceof InfixExpression) {
+                    return transformInfix((InfixExpression) node);
+                }
+                if (node instanceof VariableDeclaration) {
+                    return transformVariables((VariableDeclaration) node);
+                }
+                if (node instanceof ParenthesizedExpression) {
+                    return transformParenExpr((ParenthesizedExpression) node);
+                }
+                if (node instanceof LabeledStatement) {
+                    return transformLabeledStatement((LabeledStatement) node);
+                }
+                if (node instanceof LetNode) {
+                    return transformLetNode((LetNode) node);
+                }
+                if (node instanceof XmlRef) {
+                    return transformXmlRef((XmlRef) node);
+                }
+                if (node instanceof XmlLiteral) {
+                    return transformXmlLiteral((XmlLiteral) node);
+                }
+                throw new IllegalArgumentException("Can't transform: " + node);
         }
     }
 
@@ -277,11 +274,11 @@ public final class IRFactory extends Parser
             defineSymbol(Token.LET, arrayName, false);
             Node block = new Node(Token.BLOCK, lineno);
             Node newArray = createCallOrNew(Token.NEW, createName("Array"));
-            Node init = new Node(Token.EXPR_VOID,
-                                 createAssignment(Token.ASSIGN,
-                                                  createName(arrayName),
-                                                  newArray),
-                                 lineno);
+            Node init =
+                    new Node(
+                            Token.EXPR_VOID,
+                            createAssignment(Token.ASSIGN, createName(arrayName), newArray),
+                            lineno);
             block.addChildToBack(init);
             block.addChildToBack(arrayCompTransformHelper(node, arrayName));
             scopeNode.addChildToBack(block);
@@ -292,8 +289,7 @@ public final class IRFactory extends Parser
         }
     }
 
-    private Node arrayCompTransformHelper(ArrayComprehension node,
-                                          String arrayName) {
+    private Node arrayCompTransformHelper(ArrayComprehension node, String arrayName) {
         decompiler.addToken(Token.LB);
         int lineno = node.getLineno();
         Node expr = transform(node.getResult());
@@ -324,11 +320,11 @@ public final class IRFactory extends Parser
                 decompile(iter);
                 name = currentScriptOrFn.getNextTempName();
                 defineSymbol(Token.LP, name, false);
-                expr = createBinary(Token.COMMA,
-                                    createAssignment(Token.ASSIGN,
-                                                     iter,
-                                                     createName(name)),
-                                    expr);
+                expr =
+                        createBinary(
+                                Token.COMMA,
+                                createAssignment(Token.ASSIGN, iter, createName(name)),
+                                expr);
             }
             Node init = createName(name);
             // Define as a let since we want the scope of the variable to
@@ -346,10 +342,9 @@ public final class IRFactory extends Parser
         }
 
         // generate code for tmpArray.push(body)
-        Node call = createCallOrNew(Token.CALL,
-                                    createPropertyGet(createName(arrayName),
-                                                      null,
-                                                      "push", 0));
+        Node call =
+                createCallOrNew(
+                        Token.CALL, createPropertyGet(createName(arrayName), null, "push", 0));
 
         Node body = new Node(Token.EXPR_VOID, call, lineno);
 
@@ -364,19 +359,23 @@ public final class IRFactory extends Parser
         // Now walk loops in reverse to build up the body statement.
         int pushed = 0;
         try {
-            for (int i = numLoops-1; i >= 0; i--) {
+            for (int i = numLoops - 1; i >= 0; i--) {
                 ArrayComprehensionLoop acl = loops.get(i);
-                Scope loop = createLoopNode(null,  // no label
-                                            acl.getLineno());
+                Scope loop =
+                        createLoopNode(
+                                null, // no label
+                                acl.getLineno());
                 pushScope(loop);
                 pushed++;
-                body = createForIn(Token.LET,
-                                   loop,
-                                   iterators[i],
-                                   iteratedObjs[i],
-                                   body,
-                                   acl.isForEach(),
-                                   acl.isForOf());
+                body =
+                        createForIn(
+                                Token.LET,
+                                loop,
+                                iterators[i],
+                                iteratedObjs[i],
+                                body,
+                                acl.isForEach(),
+                                acl.isForOf());
             }
         } finally {
             for (int i = 0; i < pushed; i++) {
@@ -410,16 +409,13 @@ public final class IRFactory extends Parser
                 }
                 skipIndexes.add(Integer.valueOf(i));
             }
-            if (i < elems.size() - 1)
-                decompiler.addToken(Token.COMMA);
+            if (i < elems.size() - 1) decompiler.addToken(Token.COMMA);
         }
         decompiler.addToken(Token.RB);
-        array.putIntProp(Node.DESTRUCTURING_ARRAY_LENGTH,
-                         node.getDestructuringLength());
+        array.putIntProp(Node.DESTRUCTURING_ARRAY_LENGTH, node.getDestructuringLength());
         if (skipIndexes != null) {
             int[] skips = new int[skipIndexes.size()];
-            for (int i = 0; i < skipIndexes.size(); i++)
-                skips[i] = skipIndexes.get(i).intValue();
+            for (int i = 0; i < skipIndexes.size(); i++) skips[i] = skipIndexes.get(i).intValue();
             array.putProp(Node.SKIP_INDEXES_PROP, skips);
         }
         return array;
@@ -443,8 +439,10 @@ public final class IRFactory extends Parser
     }
 
     private AstNode transformAssignmentLeft(Assignment node, AstNode left, AstNode right) {
-        if (right.getType() == Token.NULL && node.getType() == Token.ASSIGN
-                && left instanceof Name && right instanceof KeywordLiteral) {
+        if (right.getType() == Token.NULL
+                && node.getType() == Token.ASSIGN
+                && left instanceof Name
+                && right instanceof KeywordLiteral) {
 
             String identifier = ((Name) left).getIdentifier();
             for (AstNode p = node.getParent(); p != null; p = p.getParent()) {
@@ -467,12 +465,12 @@ public final class IRFactory extends Parser
 
     private Node transformBlock(AstNode node) {
         if (node instanceof Scope) {
-            pushScope((Scope)node);
+            pushScope((Scope) node);
         }
         try {
             List<Node> kids = new ArrayList<Node>();
             for (Node kid : node) {
-                kids.add(transform((AstNode)kid));
+                kids.add(transform((AstNode) kid));
             }
             node.removeChildren();
             for (Node kid : kids) {
@@ -526,8 +524,7 @@ public final class IRFactory extends Parser
             Node cond = transform(loop.getCondition());
             decompiler.addToken(Token.RP);
             decompiler.addEOL(Token.SEMI);
-            return createLoop(loop, LOOP_DO_WHILE,
-                              body, cond, null, null);
+            return createLoop(loop, LOOP_DO_WHILE, body, cond, null, null);
         } finally {
             popScope();
         }
@@ -551,8 +548,7 @@ public final class IRFactory extends Parser
 
     private Node transformForInLoop(ForInLoop loop) {
         decompiler.addToken(Token.FOR);
-        if (loop.isForEach())
-            decompiler.addName("each ");
+        if (loop.isForEach()) decompiler.addName("each ");
         decompiler.addToken(Token.LP);
 
         loop.setType(Token.LOOP);
@@ -561,7 +557,7 @@ public final class IRFactory extends Parser
             int declType = -1;
             AstNode iter = loop.getIterator();
             if (iter instanceof VariableDeclaration) {
-                declType = ((VariableDeclaration)iter).getType();
+                declType = ((VariableDeclaration) iter).getType();
             }
             Node lhs = transform(iter);
             if (loop.isForOf()) {
@@ -574,8 +570,7 @@ public final class IRFactory extends Parser
             decompiler.addEOL(Token.LC);
             Node body = transform(loop.getBody());
             decompiler.addEOL(Token.RC);
-            return createForIn(declType, loop, lhs, obj, body,
-                               loop.isForEach(), loop.isForOf());
+            return createForIn(declType, loop, lhs, obj, body, loop.isForEach(), loop.isForOf());
         } finally {
             popScope();
         }
@@ -615,11 +610,11 @@ public final class IRFactory extends Parser
         try {
             // If we start needing to record much more codegen metadata during
             // function parsing, we should lump it all into a helper class.
-            Node destructuring = (Node)fn.getProp(Node.DESTRUCTURING_PARAMS);
+            Node destructuring = (Node) fn.getProp(Node.DESTRUCTURING_PARAMS);
             fn.removeProp(Node.DESTRUCTURING_PARAMS);
 
             int lineno = fn.getBody().getLineno();
-            ++nestingOfFunction;  // only for body, not params
+            ++nestingOfFunction; // only for body, not params
             Node body = transform(fn.getBody());
 
             if (!fn.isExpressionClosure()) {
@@ -634,8 +629,7 @@ public final class IRFactory extends Parser
             }
 
             if (destructuring != null) {
-                body.addChildToFront(new Node(Token.EXPR_VOID,
-                                              destructuring, lineno));
+                body.addChildToFront(new Node(Token.EXPR_VOID, destructuring, lineno));
             }
 
             int syntheticType = fn.getFunctionType();
@@ -688,11 +682,11 @@ public final class IRFactory extends Parser
         try {
             // If we start needing to record much more codegen metadata during
             // function parsing, we should lump it all into a helper class.
-            Node destructuring = (Node)fn.getProp(Node.DESTRUCTURING_PARAMS);
+            Node destructuring = (Node) fn.getProp(Node.DESTRUCTURING_PARAMS);
             fn.removeProp(Node.DESTRUCTURING_PARAMS);
 
             int lineno = node.lineno;
-            ++nestingOfFunction;  // only for body, not params
+            ++nestingOfFunction; // only for body, not params
             Node body = genExprTransformHelper(node);
 
             if (!fn.isExpressionClosure()) {
@@ -707,8 +701,7 @@ public final class IRFactory extends Parser
             }
 
             if (destructuring != null) {
-                body.addChildToFront(new Node(Token.EXPR_VOID,
-                                              destructuring, lineno));
+                body.addChildToFront(new Node(Token.EXPR_VOID, destructuring, lineno));
             }
 
             int syntheticType = fn.getFunctionType();
@@ -759,11 +752,11 @@ public final class IRFactory extends Parser
                 decompile(iter);
                 name = currentScriptOrFn.getNextTempName();
                 defineSymbol(Token.LP, name, false);
-                expr = createBinary(Token.COMMA,
-                                    createAssignment(Token.ASSIGN,
-                                                     iter,
-                                                     createName(name)),
-                                    expr);
+                expr =
+                        createBinary(
+                                Token.COMMA,
+                                createAssignment(Token.ASSIGN, iter, createName(name)),
+                                expr);
             }
             Node init = createName(name);
             // Define as a let since we want the scope of the variable to
@@ -796,19 +789,23 @@ public final class IRFactory extends Parser
         // Now walk loops in reverse to build up the body statement.
         int pushed = 0;
         try {
-            for (int i = numLoops-1; i >= 0; i--) {
+            for (int i = numLoops - 1; i >= 0; i--) {
                 GeneratorExpressionLoop acl = loops.get(i);
-                Scope loop = createLoopNode(null,  // no label
-                                            acl.getLineno());
+                Scope loop =
+                        createLoopNode(
+                                null, // no label
+                                acl.getLineno());
                 pushScope(loop);
                 pushed++;
-                body = createForIn(Token.LET,
-                                   loop,
-                                   iterators[i],
-                                   iteratedObjs[i],
-                                   body,
-                                   acl.isForEach(),
-                                   acl.isForOf());
+                body =
+                        createForIn(
+                                Token.LET,
+                                loop,
+                                iterators[i],
+                                iteratedObjs[i],
+                                body,
+                                acl.isForEach(),
+                                acl.isForOf());
             }
         } finally {
             for (int i = 0; i < pushed; i++) {
@@ -998,15 +995,15 @@ public final class IRFactory extends Parser
     private Object getPropKey(Node id) {
         Object key;
         if (id instanceof Name) {
-            String s = ((Name)id).getIdentifier();
+            String s = ((Name) id).getIdentifier();
             decompiler.addName(s);
             key = ScriptRuntime.getIndexObject(s);
         } else if (id instanceof StringLiteral) {
-            String s = ((StringLiteral)id).getValue();
+            String s = ((StringLiteral) id).getValue();
             decompiler.addString(s);
             key = ScriptRuntime.getIndexObject(s);
         } else if (id instanceof NumberLiteral) {
-            double n = ((NumberLiteral)id).getNumber();
+            double n = ((NumberLiteral) id).getNumber();
             decompiler.addNumber(n);
             key = ScriptRuntime.getIndexObject(n);
         } else {
@@ -1022,7 +1019,7 @@ public final class IRFactory extends Parser
         while (expr instanceof ParenthesizedExpression) {
             decompiler.addToken(Token.LP);
             count++;
-            expr = ((ParenthesizedExpression)expr).getExpression();
+            expr = ((ParenthesizedExpression) expr).getExpression();
         }
         Node result = transform(expr);
         for (int i = 0; i < count; i++) {
@@ -1060,8 +1057,8 @@ public final class IRFactory extends Parser
         Node value = rv == null ? null : transform(rv);
         if (!expClosure) decompiler.addEOL(Token.SEMI);
         return rv == null
-            ? new Node(Token.RETURN, node.getLineno())
-            : new Node(Token.RETURN, value, node.getLineno());
+                ? new Node(Token.RETURN, node.getLineno())
+                : new Node(Token.RETURN, value, node.getLineno());
     }
 
     private Node transformScript(ScriptNode node) {
@@ -1070,7 +1067,7 @@ public final class IRFactory extends Parser
         currentScope = node;
         Node body = new Node(Token.BLOCK);
         for (Node kid : node) {
-            body.addChildToBack(transform((AstNode)kid));
+            body.addChildToBack(transform((AstNode) kid));
         }
         node.removeChildren();
         Node children = body.getFirstChild();
@@ -1196,8 +1193,7 @@ public final class IRFactory extends Parser
             Node body = transform(cc.getBody());
             decompiler.addEOL(Token.RC);
 
-            catchBlocks.addChildToBack(createCatch(varName, catchCond,
-                                                   body, cc.getLineno()));
+            catchBlocks.addChildToBack(createCatch(varName, catchCond, body, cc.getLineno()));
         }
         Node finallyBlock = null;
         if (node.getFinallyBlock() != null) {
@@ -1206,8 +1202,7 @@ public final class IRFactory extends Parser
             finallyBlock = transform(node.getFinallyBlock());
             decompiler.addEOL(Token.RC);
         }
-        return createTryCatchFinally(tryBlock, catchBlocks,
-                                     finallyBlock, node.getLineno());
+        return createTryCatchFinally(tryBlock, catchBlocks, finallyBlock, node.getLineno());
     }
 
     private Node transformUnary(UnaryExpression node) {
@@ -1240,8 +1235,7 @@ public final class IRFactory extends Parser
         // Might be most robust to have parser record whether it was
         // a variable declaration statement, possibly as a node property.
         AstNode parent = node.getParent();
-        if (!(parent instanceof Loop)
-            && !(parent instanceof LetNode)) {
+        if (!(parent instanceof Loop) && !(parent instanceof LetNode)) {
             decompiler.addEOL(Token.SEMI);
         }
         return node;
@@ -1256,7 +1250,7 @@ public final class IRFactory extends Parser
 
             Node left = null;
             if (var.isDestructuring()) {
-                decompile(target);  // decompile but don't transform
+                decompile(target); // decompile but don't transform
                 left = target;
             } else {
                 left = transform(target);
@@ -1269,11 +1263,10 @@ public final class IRFactory extends Parser
             }
 
             if (var.isDestructuring()) {
-                if (right == null) {  // TODO:  should this ever happen?
+                if (right == null) { // TODO:  should this ever happen?
                     node.addChildToBack(left);
                 } else {
-                    Node d = createDestructuringAssignment(node.getType(),
-                                                           left, right);
+                    Node d = createDestructuringAssignment(node.getType(), left, right);
                     node.addChildToBack(d);
                 }
             } else {
@@ -1282,7 +1275,7 @@ public final class IRFactory extends Parser
                 }
                 node.addChildToBack(left);
             }
-            if (i++ < size-1) {
+            if (i++ < size - 1) {
                 decompiler.addToken(Token.COMMA);
             }
         }
@@ -1320,8 +1313,7 @@ public final class IRFactory extends Parser
     private Node transformYield(Yield node) {
         decompiler.addToken(node.getType());
         Node kid = node.getValue() == null ? null : transform(node.getValue());
-        if (kid != null)
-            return new Node(node.getType(), kid, node.getLineno());
+        if (kid != null) return new Node(node.getType(), kid, node.getLineno());
         return new Node(node.getType(), node.getLineno());
     }
 
@@ -1332,14 +1324,14 @@ public final class IRFactory extends Parser
         Node pnXML = new Node(Token.NEW, node.getLineno());
         List<XmlFragment> frags = node.getFragments();
 
-        XmlString first = (XmlString)frags.get(0);
+        XmlString first = (XmlString) frags.get(0);
         boolean anon = first.getXml().trim().startsWith("<>");
         pnXML.addChildToBack(createName(anon ? "XMLList" : "XML"));
 
         Node pn = null;
         for (XmlFragment frag : frags) {
             if (frag instanceof XmlString) {
-                String xml = ((XmlString)frag).getXml();
+                String xml = ((XmlString) frag).getXml();
                 decompiler.addName(xml);
                 if (pn == null) {
                     pn = createString(xml);
@@ -1347,7 +1339,7 @@ public final class IRFactory extends Parser
                     pn = createBinary(Token.ADD, pn, createString(xml));
                 }
             } else {
-                XmlExpression xexpr = (XmlExpression)frag;
+                XmlExpression xexpr = (XmlExpression) frag;
                 boolean isXmlAttr = xexpr.isXmlAttribute();
                 Node expr;
                 decompiler.addToken(Token.LC);
@@ -1360,12 +1352,8 @@ public final class IRFactory extends Parser
                 if (isXmlAttr) {
                     // Need to put the result in double quotes
                     expr = createUnary(Token.ESCXMLATTR, expr);
-                    Node prepend = createBinary(Token.ADD,
-                                                createString("\""),
-                                                expr);
-                    expr = createBinary(Token.ADD,
-                                        prepend,
-                                        createString("\""));
+                    Node prepend = createBinary(Token.ADD, createString("\""), expr);
+                    expr = createBinary(Token.ADD, prepend, createString("\""));
                 } else {
                     expr = createUnary(Token.ESCXMLTEXT, expr);
                 }
@@ -1392,14 +1380,12 @@ public final class IRFactory extends Parser
 
     // We get here if we weren't a child of a . or .. infix node
     private Node transformXmlRef(XmlRef node) {
-        int memberTypeFlags = node.isAttributeAccess()
-            ? Node.ATTRIBUTE_FLAG : 0;
+        int memberTypeFlags = node.isAttributeAccess() ? Node.ATTRIBUTE_FLAG : 0;
         return transformXmlRef(null, node, memberTypeFlags);
     }
 
     private Node transformXmlRef(Node pn, XmlRef node, int memberTypeFlags) {
-        if ((memberTypeFlags & Node.ATTRIBUTE_FLAG) != 0)
-            decompiler.addToken(Token.XMLATTR);
+        if ((memberTypeFlags & Node.ATTRIBUTE_FLAG) != 0) decompiler.addToken(Token.XMLATTR);
         Name namespace = node.getNamespace();
         String ns = namespace != null ? namespace.getIdentifier() : null;
         if (ns != null) {
@@ -1407,12 +1393,12 @@ public final class IRFactory extends Parser
             decompiler.addToken(Token.COLONCOLON);
         }
         if (node instanceof XmlPropRef) {
-            String name = ((XmlPropRef)node).getPropName().getIdentifier();
+            String name = ((XmlPropRef) node).getPropName().getIdentifier();
             decompiler.addName(name);
             return createPropertyGet(pn, ns, name, memberTypeFlags);
         }
         decompiler.addToken(Token.LB);
-        Node expr = transform(((XmlElemRef)node).getExpression());
+        Node expr = transform(((XmlElemRef) node).getExpression());
         decompiler.addToken(Token.RB);
         return createElementGet(pn, ns, expr, memberTypeFlags);
     }
@@ -1426,14 +1412,10 @@ public final class IRFactory extends Parser
         return createUnary(Token.DEFAULTNAMESPACE, child);
     }
 
-    /**
-     * If caseExpression argument is null it indicates a default label.
-     */
-    private static void addSwitchCase(Node switchBlock, Node caseExpression,
-                               Node statements)
-    {
+    /** If caseExpression argument is null it indicates a default label. */
+    private static void addSwitchCase(Node switchBlock, Node caseExpression, Node statements) {
         if (switchBlock.getType() != Token.BLOCK) throw Kit.codeBug();
-        Jump switchNode = (Jump)switchBlock.getFirstChild();
+        Jump switchNode = (Jump) switchBlock.getFirstChild();
         if (switchNode.getType() != Token.SWITCH) throw Kit.codeBug();
 
         Node gotoTarget = Node.newTarget();
@@ -1448,10 +1430,9 @@ public final class IRFactory extends Parser
         switchBlock.addChildToBack(statements);
     }
 
-    private static void closeSwitch(Node switchBlock)
-    {
+    private static void closeSwitch(Node switchBlock) {
         if (switchBlock.getType() != Token.BLOCK) throw Kit.codeBug();
-        Jump switchNode = (Jump)switchBlock.getFirstChild();
+        Jump switchNode = (Jump) switchBlock.getFirstChild();
         if (switchNode.getType() != Token.SWITCH) throw Kit.codeBug();
 
         Node switchBreakTarget = Node.newTarget();
@@ -1464,8 +1445,7 @@ public final class IRFactory extends Parser
             defaultTarget = switchBreakTarget;
         }
 
-        switchBlock.addChildAfter(makeJump(Token.GOTO, defaultTarget),
-                                  switchNode);
+        switchBlock.addChildAfter(makeJump(Token.GOTO, defaultTarget), switchNode);
         switchBlock.addChildToBack(switchBreakTarget);
     }
 
@@ -1479,23 +1459,22 @@ public final class IRFactory extends Parser
 
     /**
      * Catch clause of try/catch/finally
+     *
      * @param varName the name of the variable to bind to the exception
-     * @param catchCond the condition under which to catch the exception.
-     *                  May be null if no condition is given.
+     * @param catchCond the condition under which to catch the exception. May be null if no
+     *     condition is given.
      * @param stmts the statements in the catch clause
      * @param lineno the starting line number of the catch clause
      */
-    private Node createCatch(String varName, Node catchCond, Node stmts,
-                             int lineno) {
+    private Node createCatch(String varName, Node catchCond, Node stmts, int lineno) {
         if (catchCond == null) {
             catchCond = new Node(Token.EMPTY);
         }
-        return new Node(Token.CATCH, createName(varName),
-                        catchCond, stmts, lineno);
+        return new Node(Token.CATCH, createName(varName), catchCond, stmts, lineno);
     }
 
-    private static Node initFunction(FunctionNode fnNode, int functionIndex,
-                              Node statements, int functionType) {
+    private static Node initFunction(
+            FunctionNode fnNode, int functionIndex, Node statements, int functionType) {
         fnNode.setFunctionType(functionType);
         fnNode.addChildToBack(statements);
 
@@ -1507,7 +1486,8 @@ public final class IRFactory extends Parser
 
         if (functionType == FunctionNode.FUNCTION_EXPRESSION) {
             Name name = fnNode.getFunctionName();
-            if (name != null && name.length() != 0
+            if (name != null
+                    && name.length() != 0
                     && fnNode.getSymbol(name.getIdentifier()) == null) {
                 // A function expression needs to have its name as a
                 // variable (if it isn't already allocated as a variable).
@@ -1517,11 +1497,13 @@ public final class IRFactory extends Parser
                 // function doesn't already define a formal parameter, var,
                 // or nested function with the same name.
                 fnNode.putSymbol(new Symbol(Token.FUNCTION, name.getIdentifier()));
-                Node setFn = new Node(Token.EXPR_VOID,
-                                 new Node(Token.SETNAME,
-                                          Node.newString(Token.BINDNAME,
-                                                         name.getIdentifier()),
-                                     new Node(Token.THISFN)));
+                Node setFn =
+                        new Node(
+                                Token.EXPR_VOID,
+                                new Node(
+                                        Token.SETNAME,
+                                        Node.newString(Token.BINDNAME, name.getIdentifier()),
+                                        new Node(Token.THISFN)));
                 statements.addChildrenToFront(setFn);
             }
         }
@@ -1539,19 +1521,17 @@ public final class IRFactory extends Parser
 
     /**
      * Create loop node. The code generator will later call
-     * createWhile|createDoWhile|createFor|createForIn
-     * to finish loop generation.
+     * createWhile|createDoWhile|createFor|createForIn to finish loop generation.
      */
     private Scope createLoopNode(Node loopLabel, int lineno) {
         Scope result = createScopeNode(Token.LOOP, lineno);
         if (loopLabel != null) {
-            ((Jump)loopLabel).setLoop(result);
+            ((Jump) loopLabel).setLoop(result);
         }
         return result;
     }
 
-    private static Node createFor(Scope loop, Node init,
-                           Node test, Node incr, Node body) {
+    private static Node createFor(Scope loop, Node init, Node test, Node incr, Node body) {
         if (init.getType() == Token.LET) {
             // rewrite "for (let i=s; i < N; i++)..." as
             // "let (i=s) { for (; i < N; i++)..." so that "s" is evaluated
@@ -1559,16 +1539,14 @@ public final class IRFactory extends Parser
             Scope let = Scope.splitScope(loop);
             let.setType(Token.LET);
             let.addChildrenToBack(init);
-            let.addChildToBack(createLoop(loop, LOOP_FOR, body, test,
-                new Node(Token.EMPTY), incr));
+            let.addChildToBack(createLoop(loop, LOOP_FOR, body, test, new Node(Token.EMPTY), incr));
             return let;
         }
         return createLoop(loop, LOOP_FOR, body, test, init, incr);
     }
 
-    private static Node createLoop(Jump loop, int loopType, Node body,
-                            Node cond, Node init, Node incr)
-    {
+    private static Node createLoop(
+            Jump loop, int loopType, Node body, Node cond, Node init, Node incr) {
         Node bodyTarget = Node.newTarget();
         Node condTarget = Node.newTarget();
         if (loopType == LOOP_FOR && cond.getType() == Token.EMPTY) {
@@ -1617,12 +1595,15 @@ public final class IRFactory extends Parser
         return loop;
     }
 
-    /**
-     * Generate IR for a for..in loop.
-     */
-    private Node createForIn(int declType, Node loop, Node lhs,
-                             Node obj, Node body, boolean isForEach, boolean isForOf)
-    {
+    /** Generate IR for a for..in loop. */
+    private Node createForIn(
+            int declType,
+            Node loop,
+            Node lhs,
+            Node obj,
+            Node body,
+            boolean isForEach,
+            boolean isForOf) {
         int destructuring = -1;
         int destructuringLen = 0;
         Node lvalue;
@@ -1630,8 +1611,7 @@ public final class IRFactory extends Parser
         if (type == Token.VAR || type == Token.LET) {
             Node kid = lhs.getLastChild();
             int kidType = kid.getType();
-            if (kidType == Token.ARRAYLIT || kidType == Token.OBJECTLIT)
-            {
+            if (kidType == Token.ARRAYLIT || kidType == Token.OBJECTLIT) {
                 type = destructuring = kidType;
                 lvalue = kid;
                 destructuringLen = 0;
@@ -1658,11 +1638,14 @@ public final class IRFactory extends Parser
         }
 
         Node localBlock = new Node(Token.LOCAL_BLOCK);
-        int initType = isForEach ? Token.ENUM_INIT_VALUES
-                       : isForOf ? Token.ENUM_INIT_VALUES_IN_ORDER
-                                 : (destructuring != -1
-                                    ? Token.ENUM_INIT_ARRAY
-                                    : Token.ENUM_INIT_KEYS);
+        int initType =
+                isForEach
+                        ? Token.ENUM_INIT_VALUES
+                        : isForOf
+                                ? Token.ENUM_INIT_VALUES_IN_ORDER
+                                : (destructuring != -1
+                                        ? Token.ENUM_INIT_ARRAY
+                                        : Token.ENUM_INIT_KEYS);
         Node init = new Node(initType, obj);
         init.putProp(Node.LOCAL_BLOCK_PROP, localBlock);
         Node cond = new Node(Token.ENUM_NEXT);
@@ -1674,10 +1657,9 @@ public final class IRFactory extends Parser
         Node assign;
         if (destructuring != -1) {
             assign = createDestructuringAssignment(declType, lvalue, id);
-            if (!isForEach && !isForOf &&
-                (destructuring == Token.OBJECTLIT ||
-                 destructuringLen != 2))
-            {
+            if (!isForEach
+                    && !isForOf
+                    && (destructuring == Token.OBJECTLIT || destructuringLen != 2)) {
                 // destructuring assignment is only allowed in for..each or
                 // with an array type of length 2 (to hold key and value)
                 reportError("msg.bad.for.in.destruct");
@@ -1688,10 +1670,9 @@ public final class IRFactory extends Parser
         newBody.addChildToBack(new Node(Token.EXPR_VOID, assign));
         newBody.addChildToBack(body);
 
-        loop = createLoop((Jump)loop, LOOP_WHILE, newBody, cond, null, null);
+        loop = createLoop((Jump) loop, LOOP_WHILE, newBody, cond, null, null);
         loop.addChildToFront(init);
-        if (type == Token.VAR || type == Token.LET)
-            loop.addChildToFront(lhs);
+        if (type == Token.VAR || type == Token.LET) loop.addChildToFront(lhs);
         localBlock.addChildToBack(loop);
 
         return localBlock;
@@ -1700,41 +1681,37 @@ public final class IRFactory extends Parser
     /**
      * Try/Catch/Finally
      *
-     * The IRFactory tries to express as much as possible in the tree;
-     * the responsibilities remaining for Codegen are to add the Java
-     * handlers: (Either (but not both) of TARGET and FINALLY might not
-     * be defined)
+     * <p>The IRFactory tries to express as much as possible in the tree; the responsibilities
+     * remaining for Codegen are to add the Java handlers: (Either (but not both) of TARGET and
+     * FINALLY might not be defined)
      *
-     * - a catch handler for javascript exceptions that unwraps the
-     * exception onto the stack and GOTOes to the catch target
+     * <p>- a catch handler for javascript exceptions that unwraps the exception onto the stack and
+     * GOTOes to the catch target
      *
-     * - a finally handler
+     * <p>- a finally handler
      *
-     * ... and a goto to GOTO around these handlers.
+     * <p>... and a goto to GOTO around these handlers.
      */
-    private Node createTryCatchFinally(Node tryBlock, Node catchBlocks,
-                                       Node finallyBlock, int lineno)
-    {
-        boolean hasFinally = (finallyBlock != null)
-                             && (finallyBlock.getType() != Token.BLOCK
-                                 || finallyBlock.hasChildren());
+    private Node createTryCatchFinally(
+            Node tryBlock, Node catchBlocks, Node finallyBlock, int lineno) {
+        boolean hasFinally =
+                (finallyBlock != null)
+                        && (finallyBlock.getType() != Token.BLOCK || finallyBlock.hasChildren());
 
         // short circuit
-        if (tryBlock.getType() == Token.BLOCK && !tryBlock.hasChildren()
-            && !hasFinally)
-        {
+        if (tryBlock.getType() == Token.BLOCK && !tryBlock.hasChildren() && !hasFinally) {
             return tryBlock;
         }
 
         boolean hasCatch = catchBlocks.hasChildren();
 
         // short circuit
-        if (!hasFinally && !hasCatch)  {
+        if (!hasFinally && !hasCatch) {
             // bc finally might be an empty block...
             return tryBlock;
         }
 
-        Node handlerBlock  = new Node(Token.LOCAL_BLOCK);
+        Node handlerBlock = new Node(Token.LOCAL_BLOCK);
         Jump pn = new Jump(Token.TRY, tryBlock, lineno);
         pn.putProp(Node.LOCAL_BLOCK_PROP, handlerBlock);
 
@@ -1826,22 +1803,19 @@ public final class IRFactory extends Parser
                     condStmt = catchStatement;
                     hasDefault = true;
                 } else {
-                    condStmt = createIf(cond, catchStatement, null,
-                                        catchLineNo);
+                    condStmt = createIf(cond, catchStatement, null, catchLineNo);
                 }
 
                 // Generate code to create the scope object and store
                 // it in catchScopeBlock register
-                Node catchScope = new Node(Token.CATCH_SCOPE, name,
-                                           createUseLocal(handlerBlock));
+                Node catchScope = new Node(Token.CATCH_SCOPE, name, createUseLocal(handlerBlock));
                 catchScope.putProp(Node.LOCAL_BLOCK_PROP, catchScopeBlock);
                 catchScope.putIntProp(Node.CATCH_SCOPE_PROP, scopeIndex);
                 catchScopeBlock.addChildToBack(catchScope);
 
                 // Add with statement based on catch scope object
                 catchScopeBlock.addChildToBack(
-                    createWith(createUseLocal(catchScopeBlock), condStmt,
-                               catchLineNo));
+                        createWith(createUseLocal(catchScopeBlock), condStmt, catchLineNo));
 
                 // move to next cb
                 cb = cb.getNext();
@@ -1890,8 +1864,7 @@ public final class IRFactory extends Parser
         return result;
     }
 
-    private static Node createIf(Node cond, Node ifTrue, Node ifFalse, int lineno)
-    {
+    private static Node createIf(Node cond, Node ifTrue, Node ifFalse, int lineno) {
         int condStatus = isAlwaysDefinedBoolean(cond);
         if (condStatus == ALWAYS_TRUE_BOOLEAN) {
             return ifTrue;
@@ -1934,73 +1907,72 @@ public final class IRFactory extends Parser
         return new Node(Token.HOOK, cond, ifTrue, ifFalse);
     }
 
-    private static Node createUnary(int nodeType, Node child)
-    {
+    private static Node createUnary(int nodeType, Node child) {
         int childType = child.getType();
         switch (nodeType) {
-          case Token.DELPROP: {
-            Node n;
-            if (childType == Token.NAME) {
-                // Transform Delete(Name "a")
-                //  to Delete(Bind("a"), String("a"))
-                child.setType(Token.BINDNAME);
-                Node left = child;
-                Node right = Node.newString(child.getString());
-                n = new Node(nodeType, left, right);
-            } else if (childType == Token.GETPROP ||
-                       childType == Token.GETELEM)
-            {
-                Node left = child.getFirstChild();
-                Node right = child.getLastChild();
-                child.removeChild(left);
-                child.removeChild(right);
-                n = new Node(nodeType, left, right);
-            } else if (childType == Token.GET_REF) {
-                Node ref = child.getFirstChild();
-                child.removeChild(ref);
-                n = new Node(Token.DEL_REF, ref);
-            } else {
-                // Always evaluate delete operand, see ES5 11.4.1 & bug #726121
-                n = new Node(nodeType, new Node(Token.TRUE), child);
-            }
-            return n;
-          }
-          case Token.TYPEOF:
-            if (childType == Token.NAME) {
-                child.setType(Token.TYPEOFNAME);
-                return child;
-            }
-            break;
-          case Token.BITNOT:
-            if (childType == Token.NUMBER) {
-                int value = ScriptRuntime.toInt32(child.getDouble());
-                child.setDouble(~value);
-                return child;
-            }
-            break;
-          case Token.NEG:
-            if (childType == Token.NUMBER) {
-                child.setDouble(-child.getDouble());
-                return child;
-            }
-            break;
-          case Token.NOT: {
-            int status = isAlwaysDefinedBoolean(child);
-            if (status != 0) {
-                int type;
-                if (status == ALWAYS_TRUE_BOOLEAN) {
-                    type = Token.FALSE;
-                } else {
-                    type = Token.TRUE;
+            case Token.DELPROP:
+                {
+                    Node n;
+                    if (childType == Token.NAME) {
+                        // Transform Delete(Name "a")
+                        //  to Delete(Bind("a"), String("a"))
+                        child.setType(Token.BINDNAME);
+                        Node left = child;
+                        Node right = Node.newString(child.getString());
+                        n = new Node(nodeType, left, right);
+                    } else if (childType == Token.GETPROP || childType == Token.GETELEM) {
+                        Node left = child.getFirstChild();
+                        Node right = child.getLastChild();
+                        child.removeChild(left);
+                        child.removeChild(right);
+                        n = new Node(nodeType, left, right);
+                    } else if (childType == Token.GET_REF) {
+                        Node ref = child.getFirstChild();
+                        child.removeChild(ref);
+                        n = new Node(Token.DEL_REF, ref);
+                    } else {
+                        // Always evaluate delete operand, see ES5 11.4.1 & bug #726121
+                        n = new Node(nodeType, new Node(Token.TRUE), child);
+                    }
+                    return n;
                 }
-                if (childType == Token.TRUE || childType == Token.FALSE) {
-                    child.setType(type);
+            case Token.TYPEOF:
+                if (childType == Token.NAME) {
+                    child.setType(Token.TYPEOFNAME);
                     return child;
                 }
-                return new Node(type);
-            }
-            break;
-          }
+                break;
+            case Token.BITNOT:
+                if (childType == Token.NUMBER) {
+                    int value = ScriptRuntime.toInt32(child.getDouble());
+                    child.setDouble(~value);
+                    return child;
+                }
+                break;
+            case Token.NEG:
+                if (childType == Token.NUMBER) {
+                    child.setDouble(-child.getDouble());
+                    return child;
+                }
+                break;
+            case Token.NOT:
+                {
+                    int status = isAlwaysDefinedBoolean(child);
+                    if (status != 0) {
+                        int type;
+                        if (status == ALWAYS_TRUE_BOOLEAN) {
+                            type = Token.FALSE;
+                        } else {
+                            type = Token.TRUE;
+                        }
+                        if (childType == Token.TRUE || childType == Token.FALSE) {
+                            child.setType(type);
+                            return child;
+                        }
+                        return new Node(type);
+                    }
+                    break;
+                }
         }
         return new Node(nodeType, child);
     }
@@ -2029,34 +2001,33 @@ public final class IRFactory extends Parser
         return node;
     }
 
-    private static Node createIncDec(int nodeType, boolean post, Node child)
-    {
+    private static Node createIncDec(int nodeType, boolean post, Node child) {
         child = makeReference(child);
         int childType = child.getType();
 
         switch (childType) {
-          case Token.NAME:
-          case Token.GETPROP:
-          case Token.GETELEM:
-          case Token.GET_REF: {
-            Node n = new Node(nodeType, child);
-            int incrDecrMask = 0;
-            if (nodeType == Token.DEC) {
-                incrDecrMask |= Node.DECR_FLAG;
-            }
-            if (post) {
-                incrDecrMask |= Node.POST_FLAG;
-            }
-            n.putIntProp(Node.INCRDECR_PROP, incrDecrMask);
-            return n;
-          }
+            case Token.NAME:
+            case Token.GETPROP:
+            case Token.GETELEM:
+            case Token.GET_REF:
+                {
+                    Node n = new Node(nodeType, child);
+                    int incrDecrMask = 0;
+                    if (nodeType == Token.DEC) {
+                        incrDecrMask |= Node.DECR_FLAG;
+                    }
+                    if (post) {
+                        incrDecrMask |= Node.POST_FLAG;
+                    }
+                    n.putIntProp(Node.INCRDECR_PROP, incrDecrMask);
+                    return n;
+                }
         }
         throw Kit.codeBug();
     }
 
-    private Node createPropertyGet(Node target, String namespace, String name,
-                                   int memberTypeFlags)
-    {
+    private Node createPropertyGet(
+            Node target, String namespace, String name, int memberTypeFlags) {
         if (namespace == null && memberTypeFlags == 0) {
             if (target == null) {
                 return createName(name);
@@ -2080,9 +2051,7 @@ public final class IRFactory extends Parser
      * @param elem the node in the brackets
      * @param memberTypeFlags E4X flags
      */
-    private Node createElementGet(Node target, String namespace, Node elem,
-                                  int memberTypeFlags)
-    {
+    private Node createElementGet(Node target, String namespace, Node elem, int memberTypeFlags) {
         // OPT: could optimize to createPropertyGet
         // iff elem is string that can not be number
         if (namespace == null && memberTypeFlags == 0) {
@@ -2094,9 +2063,7 @@ public final class IRFactory extends Parser
         return createMemberRefGet(target, namespace, elem, memberTypeFlags);
     }
 
-    private Node createMemberRefGet(Node target, String namespace, Node elem,
-                                    int memberTypeFlags)
-    {
+    private Node createMemberRefGet(Node target, String namespace, Node elem, int memberTypeFlags) {
         Node nsNode = null;
         if (namespace != null) {
             // See 11.1.2 in ECMA 357
@@ -2128,140 +2095,138 @@ public final class IRFactory extends Parser
 
     private static Node createBinary(int nodeType, Node left, Node right) {
         switch (nodeType) {
+            case Token.ADD:
+                // numerical addition and string concatenation
+                if (left.type == Token.STRING) {
+                    String s2;
+                    if (right.type == Token.STRING) {
+                        s2 = right.getString();
+                    } else if (right.type == Token.NUMBER) {
+                        s2 = ScriptRuntime.numberToString(right.getDouble(), 10);
+                    } else {
+                        break;
+                    }
+                    String s1 = left.getString();
+                    left.setString(s1.concat(s2));
+                    return left;
+                } else if (left.type == Token.NUMBER) {
+                    if (right.type == Token.NUMBER) {
+                        left.setDouble(left.getDouble() + right.getDouble());
+                        return left;
+                    } else if (right.type == Token.STRING) {
+                        String s1, s2;
+                        s1 = ScriptRuntime.numberToString(left.getDouble(), 10);
+                        s2 = right.getString();
+                        right.setString(s1.concat(s2));
+                        return right;
+                    }
+                }
+                // can't do anything if we don't know  both types - since
+                // 0 + object is supposed to call toString on the object and do
+                // string concantenation rather than addition
+                break;
 
-          case Token.ADD:
-            // numerical addition and string concatenation
-            if (left.type == Token.STRING) {
-                String s2;
-                if (right.type == Token.STRING) {
-                    s2 = right.getString();
+            case Token.SUB:
+                // numerical subtraction
+                if (left.type == Token.NUMBER) {
+                    double ld = left.getDouble();
+                    if (right.type == Token.NUMBER) {
+                        // both numbers
+                        left.setDouble(ld - right.getDouble());
+                        return left;
+                    } else if (ld == 0.0) {
+                        // first 0: 0-x -> -x
+                        return new Node(Token.NEG, right);
+                    }
                 } else if (right.type == Token.NUMBER) {
-                    s2 = ScriptRuntime.numberToString(right.getDouble(), 10);
-                } else {
+                    if (right.getDouble() == 0.0) {
+                        // second 0: x - 0 -> +x
+                        // can not make simply x because x - 0 must be number
+                        return new Node(Token.POS, left);
+                    }
+                }
+                break;
+
+            case Token.MUL:
+                // numerical multiplication
+                if (left.type == Token.NUMBER) {
+                    double ld = left.getDouble();
+                    if (right.type == Token.NUMBER) {
+                        // both numbers
+                        left.setDouble(ld * right.getDouble());
+                        return left;
+                    } else if (ld == 1.0) {
+                        // first 1: 1 *  x -> +x
+                        return new Node(Token.POS, right);
+                    }
+                } else if (right.type == Token.NUMBER) {
+                    if (right.getDouble() == 1.0) {
+                        // second 1: x * 1 -> +x
+                        // can not make simply x because x - 0 must be number
+                        return new Node(Token.POS, left);
+                    }
+                }
+                // can't do x*0: Infinity * 0 gives NaN, not 0
+                break;
+
+            case Token.DIV:
+                // number division
+                if (right.type == Token.NUMBER) {
+                    double rd = right.getDouble();
+                    if (left.type == Token.NUMBER) {
+                        // both constants -- just divide, trust Java to handle x/0
+                        left.setDouble(left.getDouble() / rd);
+                        return left;
+                    } else if (rd == 1.0) {
+                        // second 1: x/1 -> +x
+                        // not simply x to force number convertion
+                        return new Node(Token.POS, left);
+                    }
+                }
+                break;
+
+            case Token.AND:
+                {
+                    // Since x && y gives x, not false, when Boolean(x) is false,
+                    // and y, not Boolean(y), when Boolean(x) is true, x && y
+                    // can only be simplified if x is defined. See bug 309957.
+
+                    int leftStatus = isAlwaysDefinedBoolean(left);
+                    if (leftStatus == ALWAYS_FALSE_BOOLEAN) {
+                        // if the first one is false, just return it
+                        return left;
+                    } else if (leftStatus == ALWAYS_TRUE_BOOLEAN) {
+                        // if first is true, set to second
+                        return right;
+                    }
                     break;
                 }
-                String s1 = left.getString();
-                left.setString(s1.concat(s2));
-                return left;
-            } else if (left.type == Token.NUMBER) {
-                if (right.type == Token.NUMBER) {
-                    left.setDouble(left.getDouble() + right.getDouble());
-                    return left;
-                } else if (right.type == Token.STRING) {
-                    String s1, s2;
-                    s1 = ScriptRuntime.numberToString(left.getDouble(), 10);
-                    s2 = right.getString();
-                    right.setString(s1.concat(s2));
-                    return right;
+
+            case Token.OR:
+                {
+                    // Since x || y gives x, not true, when Boolean(x) is true,
+                    // and y, not Boolean(y), when Boolean(x) is false, x || y
+                    // can only be simplified if x is defined. See bug 309957.
+
+                    int leftStatus = isAlwaysDefinedBoolean(left);
+                    if (leftStatus == ALWAYS_TRUE_BOOLEAN) {
+                        // if the first one is true, just return it
+                        return left;
+                    } else if (leftStatus == ALWAYS_FALSE_BOOLEAN) {
+                        // if first is false, set to second
+                        return right;
+                    }
+                    break;
                 }
-            }
-            // can't do anything if we don't know  both types - since
-            // 0 + object is supposed to call toString on the object and do
-            // string concantenation rather than addition
-            break;
-
-          case Token.SUB:
-            // numerical subtraction
-            if (left.type == Token.NUMBER) {
-                double ld = left.getDouble();
-                if (right.type == Token.NUMBER) {
-                    //both numbers
-                    left.setDouble(ld - right.getDouble());
-                    return left;
-                } else if (ld == 0.0) {
-                    // first 0: 0-x -> -x
-                    return new Node(Token.NEG, right);
-                }
-            } else if (right.type == Token.NUMBER) {
-                if (right.getDouble() == 0.0) {
-                    //second 0: x - 0 -> +x
-                    // can not make simply x because x - 0 must be number
-                    return new Node(Token.POS, left);
-                }
-            }
-            break;
-
-          case Token.MUL:
-            // numerical multiplication
-            if (left.type == Token.NUMBER) {
-                double ld = left.getDouble();
-                if (right.type == Token.NUMBER) {
-                    //both numbers
-                    left.setDouble(ld * right.getDouble());
-                    return left;
-                } else if (ld == 1.0) {
-                    // first 1: 1 *  x -> +x
-                    return new Node(Token.POS, right);
-                }
-            } else if (right.type == Token.NUMBER) {
-                if (right.getDouble() == 1.0) {
-                    //second 1: x * 1 -> +x
-                    // can not make simply x because x - 0 must be number
-                    return new Node(Token.POS, left);
-                }
-            }
-            // can't do x*0: Infinity * 0 gives NaN, not 0
-            break;
-
-          case Token.DIV:
-            // number division
-            if (right.type == Token.NUMBER) {
-                double rd = right.getDouble();
-                if (left.type == Token.NUMBER) {
-                    // both constants -- just divide, trust Java to handle x/0
-                    left.setDouble(left.getDouble() / rd);
-                    return left;
-               } else if (rd == 1.0) {
-                    // second 1: x/1 -> +x
-                    // not simply x to force number convertion
-                    return new Node(Token.POS, left);
-                }
-            }
-            break;
-
-          case Token.AND: {
-            // Since x && y gives x, not false, when Boolean(x) is false,
-            // and y, not Boolean(y), when Boolean(x) is true, x && y
-            // can only be simplified if x is defined. See bug 309957.
-
-            int leftStatus = isAlwaysDefinedBoolean(left);
-            if (leftStatus == ALWAYS_FALSE_BOOLEAN) {
-                // if the first one is false, just return it
-                return left;
-            } else if (leftStatus == ALWAYS_TRUE_BOOLEAN) {
-                // if first is true, set to second
-                return right;
-            }
-            break;
-          }
-
-          case Token.OR: {
-            // Since x || y gives x, not true, when Boolean(x) is true,
-            // and y, not Boolean(y), when Boolean(x) is false, x || y
-            // can only be simplified if x is defined. See bug 309957.
-
-            int leftStatus = isAlwaysDefinedBoolean(left);
-            if (leftStatus == ALWAYS_TRUE_BOOLEAN) {
-                // if the first one is true, just return it
-                return left;
-            } else if (leftStatus == ALWAYS_FALSE_BOOLEAN) {
-                // if first is false, set to second
-                return right;
-            }
-            break;
-          }
         }
 
         return new Node(nodeType, left, right);
     }
 
-    private Node createAssignment(int assignType, Node left, Node right)
-    {
+    private Node createAssignment(int assignType, Node left, Node right) {
         Node ref = makeReference(left);
         if (ref == null) {
-            if (left.getType() == Token.ARRAYLIT ||
-                left.getType() == Token.OBJECTLIT)
-            {
+            if (left.getType() == Token.ARRAYLIT || left.getType() == Token.OBJECTLIT) {
                 if (assignType != Token.ASSIGN) {
                     reportError("msg.bad.destruct.op");
                     return right;
@@ -2275,50 +2240,76 @@ public final class IRFactory extends Parser
 
         int assignOp;
         switch (assignType) {
-          case Token.ASSIGN:
-            return simpleAssignment(left, right);
-          case Token.ASSIGN_BITOR:  assignOp = Token.BITOR;  break;
-          case Token.ASSIGN_BITXOR: assignOp = Token.BITXOR; break;
-          case Token.ASSIGN_BITAND: assignOp = Token.BITAND; break;
-          case Token.ASSIGN_LSH:    assignOp = Token.LSH;    break;
-          case Token.ASSIGN_RSH:    assignOp = Token.RSH;    break;
-          case Token.ASSIGN_URSH:   assignOp = Token.URSH;   break;
-          case Token.ASSIGN_ADD:    assignOp = Token.ADD;    break;
-          case Token.ASSIGN_SUB:    assignOp = Token.SUB;    break;
-          case Token.ASSIGN_MUL:    assignOp = Token.MUL;    break;
-          case Token.ASSIGN_DIV:    assignOp = Token.DIV;    break;
-          case Token.ASSIGN_MOD:    assignOp = Token.MOD;    break;
-          case Token.ASSIGN_EXP:    assignOp = Token.EXP;    break;
-          default: throw Kit.codeBug();
+            case Token.ASSIGN:
+                return simpleAssignment(left, right);
+            case Token.ASSIGN_BITOR:
+                assignOp = Token.BITOR;
+                break;
+            case Token.ASSIGN_BITXOR:
+                assignOp = Token.BITXOR;
+                break;
+            case Token.ASSIGN_BITAND:
+                assignOp = Token.BITAND;
+                break;
+            case Token.ASSIGN_LSH:
+                assignOp = Token.LSH;
+                break;
+            case Token.ASSIGN_RSH:
+                assignOp = Token.RSH;
+                break;
+            case Token.ASSIGN_URSH:
+                assignOp = Token.URSH;
+                break;
+            case Token.ASSIGN_ADD:
+                assignOp = Token.ADD;
+                break;
+            case Token.ASSIGN_SUB:
+                assignOp = Token.SUB;
+                break;
+            case Token.ASSIGN_MUL:
+                assignOp = Token.MUL;
+                break;
+            case Token.ASSIGN_DIV:
+                assignOp = Token.DIV;
+                break;
+            case Token.ASSIGN_MOD:
+                assignOp = Token.MOD;
+                break;
+            case Token.ASSIGN_EXP:
+                assignOp = Token.EXP;
+                break;
+            default:
+                throw Kit.codeBug();
         }
 
         int nodeType = left.getType();
         switch (nodeType) {
-          case Token.NAME: {
-            Node op = new Node(assignOp, left, right);
-            Node lvalueLeft = Node.newString(Token.BINDNAME, left.getString());
-            return new Node(Token.SETNAME, lvalueLeft, op);
-          }
-          case Token.GETPROP:
-          case Token.GETELEM: {
-            Node obj = left.getFirstChild();
-            Node id = left.getLastChild();
+            case Token.NAME:
+                {
+                    Node op = new Node(assignOp, left, right);
+                    Node lvalueLeft = Node.newString(Token.BINDNAME, left.getString());
+                    return new Node(Token.SETNAME, lvalueLeft, op);
+                }
+            case Token.GETPROP:
+            case Token.GETELEM:
+                {
+                    Node obj = left.getFirstChild();
+                    Node id = left.getLastChild();
 
-            int type = nodeType == Token.GETPROP
-                       ? Token.SETPROP_OP
-                       : Token.SETELEM_OP;
+                    int type = nodeType == Token.GETPROP ? Token.SETPROP_OP : Token.SETELEM_OP;
 
-            Node opLeft = new Node(Token.USE_STACK);
-            Node op = new Node(assignOp, opLeft, right);
-            return new Node(type, obj, id, op);
-          }
-          case Token.GET_REF: {
-            ref = left.getFirstChild();
-            checkMutableReference(ref);
-            Node opLeft = new Node(Token.USE_STACK);
-            Node op = new Node(assignOp, opLeft, right);
-            return new Node(Token.SET_REF_OP, ref, op);
-          }
+                    Node opLeft = new Node(Token.USE_STACK);
+                    Node op = new Node(assignOp, opLeft, right);
+                    return new Node(type, obj, id, op);
+                }
+            case Token.GET_REF:
+                {
+                    ref = left.getFirstChild();
+                    checkMutableReference(ref);
+                    Node opLeft = new Node(Token.USE_STACK);
+                    Node op = new Node(assignOp, opLeft, right);
+                    return new Node(Token.SET_REF_OP, ref, op);
+                }
         }
 
         throw Kit.codeBug();
@@ -2340,14 +2331,14 @@ public final class IRFactory extends Parser
     private static Node makeReference(Node node) {
         int type = node.getType();
         switch (type) {
-          case Token.NAME:
-          case Token.GETPROP:
-          case Token.GETELEM:
-          case Token.GET_REF:
-            return node;
-          case Token.CALL:
-            node.setType(Token.REF_CALL);
-            return new Node(Token.GET_REF, node);
+            case Token.NAME:
+            case Token.GETPROP:
+            case Token.GETELEM:
+            case Token.GET_REF:
+                return node;
+            case Token.CALL:
+                node.setType(Token.REF_CALL);
+                return new Node(Token.GET_REF, node);
         }
         // Signal caller to report error
         return null;
@@ -2356,26 +2347,26 @@ public final class IRFactory extends Parser
     // Check if Node always mean true or false in boolean context
     private static int isAlwaysDefinedBoolean(Node node) {
         switch (node.getType()) {
-          case Token.FALSE:
-          case Token.NULL:
-            return ALWAYS_FALSE_BOOLEAN;
-          case Token.TRUE:
-            return ALWAYS_TRUE_BOOLEAN;
-          case Token.NUMBER: {
-            double num = node.getDouble();
-            if (!Double.isNaN(num) && num != 0.0) {
+            case Token.FALSE:
+            case Token.NULL:
+                return ALWAYS_FALSE_BOOLEAN;
+            case Token.TRUE:
                 return ALWAYS_TRUE_BOOLEAN;
-            }
-            return ALWAYS_FALSE_BOOLEAN;
-          }
+            case Token.NUMBER:
+                {
+                    double num = node.getDouble();
+                    if (!Double.isNaN(num) && num != 0.0) {
+                        return ALWAYS_TRUE_BOOLEAN;
+                    }
+                    return ALWAYS_FALSE_BOOLEAN;
+                }
         }
         return 0;
     }
 
     // Check if node is the target of a destructuring bind.
     boolean isDestructuring(Node n) {
-        return n instanceof DestructuringForm
-            && ((DestructuringForm)n).isDestructuring();
+        return n instanceof DestructuringForm && ((DestructuringForm) n).isDestructuring();
     }
 
     Node decompileFunctionHeader(FunctionNode fn) {
@@ -2411,35 +2402,34 @@ public final class IRFactory extends Parser
 
     void decompile(AstNode node) {
         switch (node.getType()) {
-          case Token.ARRAYLIT:
-              decompileArrayLiteral((ArrayLiteral)node);
-              break;
-          case Token.OBJECTLIT:
-              decompileObjectLiteral((ObjectLiteral)node);
-              break;
-          case Token.STRING:
-              decompiler.addString(((StringLiteral)node).getValue());
-              break;
-          case Token.NAME:
-              decompiler.addName(((Name)node).getIdentifier());
-              break;
-          case Token.NUMBER:
-              decompiler.addNumber(((NumberLiteral)node).getNumber());
-              break;
-          case Token.GETPROP:
-              decompilePropertyGet((PropertyGet)node);
-              break;
-          case Token.EMPTY:
-              break;
-          case Token.GETELEM:
-              decompileElementGet((ElementGet) node);
-              break;
-          case Token.THIS:
-              decompiler.addToken(node.getType());
-              break;
-          default:
-              Kit.codeBug("unexpected token: "
-                          + Token.typeToName(node.getType()));
+            case Token.ARRAYLIT:
+                decompileArrayLiteral((ArrayLiteral) node);
+                break;
+            case Token.OBJECTLIT:
+                decompileObjectLiteral((ObjectLiteral) node);
+                break;
+            case Token.STRING:
+                decompiler.addString(((StringLiteral) node).getValue());
+                break;
+            case Token.NAME:
+                decompiler.addName(((Name) node).getIdentifier());
+                break;
+            case Token.NUMBER:
+                decompiler.addNumber(((NumberLiteral) node).getNumber());
+                break;
+            case Token.GETPROP:
+                decompilePropertyGet((PropertyGet) node);
+                break;
+            case Token.EMPTY:
+                break;
+            case Token.GETELEM:
+                decompileElementGet((ElementGet) node);
+                break;
+            case Token.THIS:
+                decompiler.addToken(node.getType());
+                break;
+            default:
+                Kit.codeBug("unexpected token: " + Token.typeToName(node.getType()));
         }
     }
 

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -14,6 +14,7 @@ import org.mozilla.javascript.ast.ArrayLiteral;
 import org.mozilla.javascript.ast.Assignment;
 import org.mozilla.javascript.ast.AstNode;
 import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.ast.BigIntLiteral;
 import org.mozilla.javascript.ast.Block;
 import org.mozilla.javascript.ast.BreakStatement;
 import org.mozilla.javascript.ast.CatchClause;
@@ -137,6 +138,8 @@ public final class IRFactory extends Parser {
                 return transformArrayComp((ArrayComprehension) node);
             case Token.ARRAYLIT:
                 return transformArrayLiteral((ArrayLiteral) node);
+            case Token.BIGINT:
+                return transformBigInt((BigIntLiteral) node);
             case Token.BLOCK:
                 return transformBlock(node);
             case Token.BREAK:
@@ -461,6 +464,11 @@ public final class IRFactory extends Parser {
             }
         }
         return left;
+    }
+
+    private Node transformBigInt(BigIntLiteral node) {
+        decompiler.addBigInt(node.getBigInt());
+        return node;
     }
 
     private Node transformBlock(AstNode node) {
@@ -2416,6 +2424,9 @@ public final class IRFactory extends Parser {
                 break;
             case Token.NUMBER:
                 decompiler.addNumber(((NumberLiteral) node).getNumber());
+                break;
+            case Token.BIGINT:
+                decompiler.addBigInt(((BigIntLiteral) node).getBigInt());
                 break;
             case Token.GETPROP:
                 decompilePropertyGet((PropertyGet) node);

--- a/src/org/mozilla/javascript/Icode.java
+++ b/src/org/mozilla/javascript/Icode.java
@@ -132,8 +132,17 @@ abstract class Icode {
             Icode_GENERATOR_RETURN = -65,
             Icode_YIELD_STAR = -66,
 
+            // Load BigInt register to prepare for the following BigInt operation
+            Icode_REG_BIGINT_C0 = -67,
+            Icode_REG_BIGINT_C1 = -68,
+            Icode_REG_BIGINT_C2 = -69,
+            Icode_REG_BIGINT_C3 = -70,
+            Icode_REG_BIGINT1 = -71,
+            Icode_REG_BIGINT2 = -72,
+            Icode_REG_BIGINT4 = -73,
+
             // Last icode
-            MIN_ICODE = -66;
+            MIN_ICODE = -73;
 
     static String bytecodeName(int bytecode) {
         if (!validBytecode(bytecode)) {
@@ -281,6 +290,20 @@ abstract class Icode {
                 return "GENERATOR_RETURN";
             case Icode_YIELD_STAR:
                 return "YIELD_STAR";
+            case Icode_REG_BIGINT_C0:
+                return "REG_BIGINT_C0";
+            case Icode_REG_BIGINT_C1:
+                return "REG_BIGINT_C1";
+            case Icode_REG_BIGINT_C2:
+                return "REG_BIGINT_C2";
+            case Icode_REG_BIGINT_C3:
+                return "REG_BIGINT_C3";
+            case Icode_REG_BIGINT1:
+                return "LOAD_BIGINT1";
+            case Icode_REG_BIGINT2:
+                return "LOAD_BIGINT2";
+            case Icode_REG_BIGINT4:
+                return "LOAD_BIGINT4";
         }
 
         // icode without name

--- a/src/org/mozilla/javascript/Icode.java
+++ b/src/org/mozilla/javascript/Icode.java
@@ -6,143 +6,136 @@
 
 package org.mozilla.javascript;
 
-/**
- * Additional interpreter-specific codes
- */
+/** Additional interpreter-specific codes */
 abstract class Icode {
 
     static final int
 
-    // delete operator used on a name
-        Icode_DELNAME                    = 0,
+            // delete operator used on a name
+            Icode_DELNAME = 0,
 
-    // Stack: ... value1 -> ... value1 value1
-        Icode_DUP                       = -1,
+            // Stack: ... value1 -> ... value1 value1
+            Icode_DUP = -1,
 
-    // Stack: ... value2 value1 -> ... value2 value1 value2 value1
-        Icode_DUP2                      = -2,
+            // Stack: ... value2 value1 -> ... value2 value1 value2 value1
+            Icode_DUP2 = -2,
 
-    // Stack: ... value2 value1 -> ... value1 value2
-        Icode_SWAP                      = -3,
+            // Stack: ... value2 value1 -> ... value1 value2
+            Icode_SWAP = -3,
 
-    // Stack: ... value1 -> ...
-        Icode_POP                       = -4,
+            // Stack: ... value1 -> ...
+            Icode_POP = -4,
 
-    // Store stack top into return register and then pop it
-        Icode_POP_RESULT                = -5,
+            // Store stack top into return register and then pop it
+            Icode_POP_RESULT = -5,
 
-    // To jump conditionally and pop additional stack value
-        Icode_IFEQ_POP                  = -6,
+            // To jump conditionally and pop additional stack value
+            Icode_IFEQ_POP = -6,
 
-    // various types of ++/--
-        Icode_VAR_INC_DEC               = -7,
-        Icode_NAME_INC_DEC              = -8,
-        Icode_PROP_INC_DEC              = -9,
-        Icode_ELEM_INC_DEC              = -10,
-        Icode_REF_INC_DEC               = -11,
+            // various types of ++/--
+            Icode_VAR_INC_DEC = -7,
+            Icode_NAME_INC_DEC = -8,
+            Icode_PROP_INC_DEC = -9,
+            Icode_ELEM_INC_DEC = -10,
+            Icode_REF_INC_DEC = -11,
 
-    // load/save scope from/to local
-        Icode_SCOPE_LOAD                = -12,
-        Icode_SCOPE_SAVE                = -13,
+            // load/save scope from/to local
+            Icode_SCOPE_LOAD = -12,
+            Icode_SCOPE_SAVE = -13,
+            Icode_TYPEOFNAME = -14,
 
-        Icode_TYPEOFNAME                = -14,
+            // helper for function calls
+            Icode_NAME_AND_THIS = -15,
+            Icode_PROP_AND_THIS = -16,
+            Icode_ELEM_AND_THIS = -17,
+            Icode_VALUE_AND_THIS = -18,
 
-    // helper for function calls
-        Icode_NAME_AND_THIS             = -15,
-        Icode_PROP_AND_THIS             = -16,
-        Icode_ELEM_AND_THIS             = -17,
-        Icode_VALUE_AND_THIS            = -18,
+            // Create closure object for nested functions
+            Icode_CLOSURE_EXPR = -19,
+            Icode_CLOSURE_STMT = -20,
 
-    // Create closure object for nested functions
-        Icode_CLOSURE_EXPR              = -19,
-        Icode_CLOSURE_STMT              = -20,
+            // Special calls
+            Icode_CALLSPECIAL = -21,
 
-    // Special calls
-        Icode_CALLSPECIAL               = -21,
+            // To return undefined value
+            Icode_RETUNDEF = -22,
 
-    // To return undefined value
-        Icode_RETUNDEF                  = -22,
+            // Exception handling implementation
+            Icode_GOSUB = -23,
+            Icode_STARTSUB = -24,
+            Icode_RETSUB = -25,
 
-    // Exception handling implementation
-        Icode_GOSUB                     = -23,
-        Icode_STARTSUB                  = -24,
-        Icode_RETSUB                    = -25,
+            // To indicating a line number change in icodes.
+            Icode_LINE = -26,
 
-    // To indicating a line number change in icodes.
-        Icode_LINE                      = -26,
+            // To store shorts and ints inline
+            Icode_SHORTNUMBER = -27,
+            Icode_INTNUMBER = -28,
 
-    // To store shorts and ints inline
-        Icode_SHORTNUMBER               = -27,
-        Icode_INTNUMBER                 = -28,
+            // To create and populate array to hold values for [] and {} literals
+            Icode_LITERAL_NEW = -29,
+            Icode_LITERAL_SET = -30,
 
-    // To create and populate array to hold values for [] and {} literals
-        Icode_LITERAL_NEW               = -29,
-        Icode_LITERAL_SET               = -30,
+            // Array literal with skipped index like [1,,2]
+            Icode_SPARE_ARRAYLIT = -31,
 
-    // Array literal with skipped index like [1,,2]
-        Icode_SPARE_ARRAYLIT            = -31,
+            // Load index register to prepare for the following index operation
+            Icode_REG_IND_C0 = -32,
+            Icode_REG_IND_C1 = -33,
+            Icode_REG_IND_C2 = -34,
+            Icode_REG_IND_C3 = -35,
+            Icode_REG_IND_C4 = -36,
+            Icode_REG_IND_C5 = -37,
+            Icode_REG_IND1 = -38,
+            Icode_REG_IND2 = -39,
+            Icode_REG_IND4 = -40,
 
-    // Load index register to prepare for the following index operation
-        Icode_REG_IND_C0                = -32,
-        Icode_REG_IND_C1                = -33,
-        Icode_REG_IND_C2                = -34,
-        Icode_REG_IND_C3                = -35,
-        Icode_REG_IND_C4                = -36,
-        Icode_REG_IND_C5                = -37,
-        Icode_REG_IND1                  = -38,
-        Icode_REG_IND2                  = -39,
-        Icode_REG_IND4                  = -40,
+            // Load string register to prepare for the following string operation
+            Icode_REG_STR_C0 = -41,
+            Icode_REG_STR_C1 = -42,
+            Icode_REG_STR_C2 = -43,
+            Icode_REG_STR_C3 = -44,
+            Icode_REG_STR1 = -45,
+            Icode_REG_STR2 = -46,
+            Icode_REG_STR4 = -47,
 
-    // Load string register to prepare for the following string operation
-        Icode_REG_STR_C0                = -41,
-        Icode_REG_STR_C1                = -42,
-        Icode_REG_STR_C2                = -43,
-        Icode_REG_STR_C3                = -44,
-        Icode_REG_STR1                  = -45,
-        Icode_REG_STR2                  = -46,
-        Icode_REG_STR4                  = -47,
+            // Version of getvar/setvar that read var index directly from bytecode
+            Icode_GETVAR1 = -48,
+            Icode_SETVAR1 = -49,
 
-    // Version of getvar/setvar that read var index directly from bytecode
-        Icode_GETVAR1                   = -48,
-        Icode_SETVAR1                   = -49,
+            // Load undefined
+            Icode_UNDEF = -50,
+            Icode_ZERO = -51,
+            Icode_ONE = -52,
 
-    // Load undefined
-        Icode_UNDEF                     = -50,
-        Icode_ZERO                      = -51,
-        Icode_ONE                       = -52,
+            // entrance and exit from .()
+            Icode_ENTERDQ = -53,
+            Icode_LEAVEDQ = -54,
+            Icode_TAIL_CALL = -55,
 
-    // entrance and exit from .()
-       Icode_ENTERDQ                    = -53,
-       Icode_LEAVEDQ                    = -54,
+            // Clear local to allow GC its context
+            Icode_LOCAL_CLEAR = -56,
 
-       Icode_TAIL_CALL                  = -55,
+            // Literal get/set
+            Icode_LITERAL_GETTER = -57,
+            Icode_LITERAL_SETTER = -58,
 
-    // Clear local to allow GC its context
-       Icode_LOCAL_CLEAR                = -56,
+            // const
+            Icode_SETCONST = -59,
+            Icode_SETCONSTVAR = -60,
+            Icode_SETCONSTVAR1 = -61,
 
-    // Literal get/set
-       Icode_LITERAL_GETTER             = -57,
-       Icode_LITERAL_SETTER             = -58,
+            // Generator opcodes (along with Token.YIELD)
+            Icode_GENERATOR = -62,
+            Icode_GENERATOR_END = -63,
+            Icode_DEBUGGER = -64,
+            Icode_GENERATOR_RETURN = -65,
+            Icode_YIELD_STAR = -66,
 
-    // const
-       Icode_SETCONST                   = -59,
-       Icode_SETCONSTVAR                = -60,
-       Icode_SETCONSTVAR1               = -61,
+            // Last icode
+            MIN_ICODE = -66;
 
-    // Generator opcodes (along with Token.YIELD)
-       Icode_GENERATOR                  = -62,
-       Icode_GENERATOR_END              = -63,
-
-       Icode_DEBUGGER                   = -64,
-
-       Icode_GENERATOR_RETURN           = -65,
-       Icode_YIELD_STAR                 = -66,
-
-       // Last icode
-        MIN_ICODE                       = -66;
-
-    static String bytecodeName(int bytecode)
-    {
+    static String bytecodeName(int bytecode) {
         if (!validBytecode(bytecode)) {
             throw new IllegalArgumentException(String.valueOf(bytecode));
         }
@@ -156,91 +149,153 @@ abstract class Icode {
         }
 
         switch (bytecode) {
-          case Icode_DUP:              return "DUP";
-          case Icode_DUP2:             return "DUP2";
-          case Icode_SWAP:             return "SWAP";
-          case Icode_POP:              return "POP";
-          case Icode_POP_RESULT:       return "POP_RESULT";
-          case Icode_IFEQ_POP:         return "IFEQ_POP";
-          case Icode_VAR_INC_DEC:      return "VAR_INC_DEC";
-          case Icode_NAME_INC_DEC:     return "NAME_INC_DEC";
-          case Icode_PROP_INC_DEC:     return "PROP_INC_DEC";
-          case Icode_ELEM_INC_DEC:     return "ELEM_INC_DEC";
-          case Icode_REF_INC_DEC:      return "REF_INC_DEC";
-          case Icode_SCOPE_LOAD:       return "SCOPE_LOAD";
-          case Icode_SCOPE_SAVE:       return "SCOPE_SAVE";
-          case Icode_TYPEOFNAME:       return "TYPEOFNAME";
-          case Icode_NAME_AND_THIS:    return "NAME_AND_THIS";
-          case Icode_PROP_AND_THIS:    return "PROP_AND_THIS";
-          case Icode_ELEM_AND_THIS:    return "ELEM_AND_THIS";
-          case Icode_VALUE_AND_THIS:   return "VALUE_AND_THIS";
-          case Icode_CLOSURE_EXPR:     return "CLOSURE_EXPR";
-          case Icode_CLOSURE_STMT:     return "CLOSURE_STMT";
-          case Icode_CALLSPECIAL:      return "CALLSPECIAL";
-          case Icode_RETUNDEF:         return "RETUNDEF";
-          case Icode_GOSUB:            return "GOSUB";
-          case Icode_STARTSUB:         return "STARTSUB";
-          case Icode_RETSUB:           return "RETSUB";
-          case Icode_LINE:             return "LINE";
-          case Icode_SHORTNUMBER:      return "SHORTNUMBER";
-          case Icode_INTNUMBER:        return "INTNUMBER";
-          case Icode_LITERAL_NEW:      return "LITERAL_NEW";
-          case Icode_LITERAL_SET:      return "LITERAL_SET";
-          case Icode_SPARE_ARRAYLIT:   return "SPARE_ARRAYLIT";
-          case Icode_REG_IND_C0:       return "REG_IND_C0";
-          case Icode_REG_IND_C1:       return "REG_IND_C1";
-          case Icode_REG_IND_C2:       return "REG_IND_C2";
-          case Icode_REG_IND_C3:       return "REG_IND_C3";
-          case Icode_REG_IND_C4:       return "REG_IND_C4";
-          case Icode_REG_IND_C5:       return "REG_IND_C5";
-          case Icode_REG_IND1:         return "LOAD_IND1";
-          case Icode_REG_IND2:         return "LOAD_IND2";
-          case Icode_REG_IND4:         return "LOAD_IND4";
-          case Icode_REG_STR_C0:       return "REG_STR_C0";
-          case Icode_REG_STR_C1:       return "REG_STR_C1";
-          case Icode_REG_STR_C2:       return "REG_STR_C2";
-          case Icode_REG_STR_C3:       return "REG_STR_C3";
-          case Icode_REG_STR1:         return "LOAD_STR1";
-          case Icode_REG_STR2:         return "LOAD_STR2";
-          case Icode_REG_STR4:         return "LOAD_STR4";
-          case Icode_GETVAR1:          return "GETVAR1";
-          case Icode_SETVAR1:          return "SETVAR1";
-          case Icode_UNDEF:            return "UNDEF";
-          case Icode_ZERO:             return "ZERO";
-          case Icode_ONE:              return "ONE";
-          case Icode_ENTERDQ:          return "ENTERDQ";
-          case Icode_LEAVEDQ:          return "LEAVEDQ";
-          case Icode_TAIL_CALL:        return "TAIL_CALL";
-          case Icode_LOCAL_CLEAR:      return "LOCAL_CLEAR";
-          case Icode_LITERAL_GETTER:   return "LITERAL_GETTER";
-          case Icode_LITERAL_SETTER:   return "LITERAL_SETTER";
-          case Icode_SETCONST:         return "SETCONST";
-          case Icode_SETCONSTVAR:      return "SETCONSTVAR";
-          case Icode_SETCONSTVAR1:     return "SETCONSTVAR1";
-          case Icode_GENERATOR:        return "GENERATOR";
-          case Icode_GENERATOR_END:    return "GENERATOR_END";
-          case Icode_DEBUGGER:         return "DEBUGGER";
-          case Icode_GENERATOR_RETURN: return "GENERATOR_RETURN";
-          case Icode_YIELD_STAR:       return "YIELD_STAR";
+            case Icode_DUP:
+                return "DUP";
+            case Icode_DUP2:
+                return "DUP2";
+            case Icode_SWAP:
+                return "SWAP";
+            case Icode_POP:
+                return "POP";
+            case Icode_POP_RESULT:
+                return "POP_RESULT";
+            case Icode_IFEQ_POP:
+                return "IFEQ_POP";
+            case Icode_VAR_INC_DEC:
+                return "VAR_INC_DEC";
+            case Icode_NAME_INC_DEC:
+                return "NAME_INC_DEC";
+            case Icode_PROP_INC_DEC:
+                return "PROP_INC_DEC";
+            case Icode_ELEM_INC_DEC:
+                return "ELEM_INC_DEC";
+            case Icode_REF_INC_DEC:
+                return "REF_INC_DEC";
+            case Icode_SCOPE_LOAD:
+                return "SCOPE_LOAD";
+            case Icode_SCOPE_SAVE:
+                return "SCOPE_SAVE";
+            case Icode_TYPEOFNAME:
+                return "TYPEOFNAME";
+            case Icode_NAME_AND_THIS:
+                return "NAME_AND_THIS";
+            case Icode_PROP_AND_THIS:
+                return "PROP_AND_THIS";
+            case Icode_ELEM_AND_THIS:
+                return "ELEM_AND_THIS";
+            case Icode_VALUE_AND_THIS:
+                return "VALUE_AND_THIS";
+            case Icode_CLOSURE_EXPR:
+                return "CLOSURE_EXPR";
+            case Icode_CLOSURE_STMT:
+                return "CLOSURE_STMT";
+            case Icode_CALLSPECIAL:
+                return "CALLSPECIAL";
+            case Icode_RETUNDEF:
+                return "RETUNDEF";
+            case Icode_GOSUB:
+                return "GOSUB";
+            case Icode_STARTSUB:
+                return "STARTSUB";
+            case Icode_RETSUB:
+                return "RETSUB";
+            case Icode_LINE:
+                return "LINE";
+            case Icode_SHORTNUMBER:
+                return "SHORTNUMBER";
+            case Icode_INTNUMBER:
+                return "INTNUMBER";
+            case Icode_LITERAL_NEW:
+                return "LITERAL_NEW";
+            case Icode_LITERAL_SET:
+                return "LITERAL_SET";
+            case Icode_SPARE_ARRAYLIT:
+                return "SPARE_ARRAYLIT";
+            case Icode_REG_IND_C0:
+                return "REG_IND_C0";
+            case Icode_REG_IND_C1:
+                return "REG_IND_C1";
+            case Icode_REG_IND_C2:
+                return "REG_IND_C2";
+            case Icode_REG_IND_C3:
+                return "REG_IND_C3";
+            case Icode_REG_IND_C4:
+                return "REG_IND_C4";
+            case Icode_REG_IND_C5:
+                return "REG_IND_C5";
+            case Icode_REG_IND1:
+                return "LOAD_IND1";
+            case Icode_REG_IND2:
+                return "LOAD_IND2";
+            case Icode_REG_IND4:
+                return "LOAD_IND4";
+            case Icode_REG_STR_C0:
+                return "REG_STR_C0";
+            case Icode_REG_STR_C1:
+                return "REG_STR_C1";
+            case Icode_REG_STR_C2:
+                return "REG_STR_C2";
+            case Icode_REG_STR_C3:
+                return "REG_STR_C3";
+            case Icode_REG_STR1:
+                return "LOAD_STR1";
+            case Icode_REG_STR2:
+                return "LOAD_STR2";
+            case Icode_REG_STR4:
+                return "LOAD_STR4";
+            case Icode_GETVAR1:
+                return "GETVAR1";
+            case Icode_SETVAR1:
+                return "SETVAR1";
+            case Icode_UNDEF:
+                return "UNDEF";
+            case Icode_ZERO:
+                return "ZERO";
+            case Icode_ONE:
+                return "ONE";
+            case Icode_ENTERDQ:
+                return "ENTERDQ";
+            case Icode_LEAVEDQ:
+                return "LEAVEDQ";
+            case Icode_TAIL_CALL:
+                return "TAIL_CALL";
+            case Icode_LOCAL_CLEAR:
+                return "LOCAL_CLEAR";
+            case Icode_LITERAL_GETTER:
+                return "LITERAL_GETTER";
+            case Icode_LITERAL_SETTER:
+                return "LITERAL_SETTER";
+            case Icode_SETCONST:
+                return "SETCONST";
+            case Icode_SETCONSTVAR:
+                return "SETCONSTVAR";
+            case Icode_SETCONSTVAR1:
+                return "SETCONSTVAR1";
+            case Icode_GENERATOR:
+                return "GENERATOR";
+            case Icode_GENERATOR_END:
+                return "GENERATOR_END";
+            case Icode_DEBUGGER:
+                return "DEBUGGER";
+            case Icode_GENERATOR_RETURN:
+                return "GENERATOR_RETURN";
+            case Icode_YIELD_STAR:
+                return "YIELD_STAR";
         }
 
         // icode without name
         throw new IllegalStateException(String.valueOf(bytecode));
     }
 
-    static boolean validIcode(int icode)
-    {
+    static boolean validIcode(int icode) {
         return MIN_ICODE <= icode && icode <= 0;
     }
 
-    static boolean validTokenCode(int token)
-    {
-        return Token.FIRST_BYTECODE_TOKEN <= token
-               && token <= Token.LAST_BYTECODE_TOKEN;
+    static boolean validTokenCode(int token) {
+        return Token.FIRST_BYTECODE_TOKEN <= token && token <= Token.LAST_BYTECODE_TOKEN;
     }
 
-    static boolean validBytecode(int bytecode)
-    {
+    static boolean validBytecode(int bytecode) {
         return validIcode(bytecode) || validTokenCode(bytecode);
     }
 }

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -3534,16 +3534,17 @@ public final class Interpreter extends Icode implements Evaluator {
                         new ConsString(ScriptRuntime.toCharSequence(lhs), (CharSequence) rhs);
 
             } else {
-                double lDbl =
-                        (lhs instanceof Number)
-                                ? ((Number) lhs).doubleValue()
-                                : ScriptRuntime.toNumber(lhs);
-                double rDbl =
-                        (rhs instanceof Number)
-                                ? ((Number) rhs).doubleValue()
-                                : ScriptRuntime.toNumber(rhs);
-                stack[stackTop] = DOUBLE_MARK;
-                sDbl[stackTop] = lDbl + rDbl;
+                Number lNum = (lhs instanceof Number) ? (Number) lhs : ScriptRuntime.toNumeric(lhs);
+                Number rNum = (rhs instanceof Number) ? (Number) rhs : ScriptRuntime.toNumeric(rhs);
+
+                if (lNum instanceof BigInteger && rNum instanceof BigInteger) {
+                    stack[stackTop] = ((BigInteger) lNum).add((BigInteger) rNum);
+                } else if (lNum instanceof BigInteger || rNum instanceof BigInteger) {
+                    throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+                } else {
+                    stack[stackTop] = DOUBLE_MARK;
+                    sDbl[stackTop] = lNum.doubleValue() + rNum.doubleValue();
+                }
             }
             return;
         }
@@ -3565,12 +3566,13 @@ public final class Interpreter extends Icode implements Evaluator {
                 stack[stackTop] = new ConsString(rstr, (CharSequence) lhs);
             }
         } else {
-            double lDbl =
-                    (lhs instanceof Number)
-                            ? ((Number) lhs).doubleValue()
-                            : ScriptRuntime.toNumber(lhs);
-            stack[stackTop] = DOUBLE_MARK;
-            sDbl[stackTop] = lDbl + d;
+            Number lNum = (lhs instanceof Number) ? (Number) lhs : ScriptRuntime.toNumeric(lhs);
+            if (lNum instanceof BigInteger) {
+                throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+            } else {
+                stack[stackTop] = DOUBLE_MARK;
+                sDbl[stackTop] = lNum.doubleValue() + d;
+            }
         }
     }
 

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -2647,27 +2647,35 @@ public final class Interpreter extends Icode implements Evaluator {
 
     private static int doBitOp(
             CallFrame frame, int op, Object[] stack, double[] sDbl, int stackTop) {
-        int lIntValue = stack_int32(frame, stackTop - 1);
-        int rIntValue = stack_int32(frame, stackTop);
-        stack[--stackTop] = DOUBLE_MARK;
+        Number lValue = stack_numeric(frame, stackTop - 1);
+        Number rValue = stack_numeric(frame, stackTop);
+        stackTop--;
+
+        Number result = null;
         switch (op) {
             case Token.BITAND:
-                lIntValue &= rIntValue;
+                result = ScriptRuntime.bitwiseAND(lValue, rValue);
                 break;
             case Token.BITOR:
-                lIntValue |= rIntValue;
+                result = ScriptRuntime.bitwiseOR(lValue, rValue);
                 break;
             case Token.BITXOR:
-                lIntValue ^= rIntValue;
+                result = ScriptRuntime.bitwiseXOR(lValue, rValue);
                 break;
             case Token.LSH:
-                lIntValue <<= rIntValue;
+                result = ScriptRuntime.leftShift(lValue, rValue);
                 break;
             case Token.RSH:
-                lIntValue >>= rIntValue;
+                result = ScriptRuntime.signedRightShift(lValue, rValue);
                 break;
         }
-        sDbl[stackTop] = lIntValue;
+
+        if (result instanceof BigInteger) {
+            stack[stackTop] = result;
+        } else {
+            stack[stackTop] = DOUBLE_MARK;
+            sDbl[stackTop] = result.doubleValue();
+        }
         return stackTop;
     }
 

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -1440,9 +1440,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                 break Loop;
                             case Token.BITNOT:
                                 {
-                                    int rIntValue = stack_int32(frame, stackTop);
-                                    stack[stackTop] = DBL_MRK;
-                                    sDbl[stackTop] = ~rIntValue;
+                                    stackTop = doBitNOT(frame, stack, sDbl, stackTop);
                                     continue Loop;
                                 }
                             case Token.BITAND:
@@ -2670,6 +2668,18 @@ public final class Interpreter extends Icode implements Evaluator {
                 break;
         }
 
+        if (result instanceof BigInteger) {
+            stack[stackTop] = result;
+        } else {
+            stack[stackTop] = DOUBLE_MARK;
+            sDbl[stackTop] = result.doubleValue();
+        }
+        return stackTop;
+    }
+
+    private static int doBitNOT(CallFrame frame, Object[] stack, double[] sDbl, int stackTop) {
+        Number value = stack_numeric(frame, stackTop);
+        Number result = ScriptRuntime.bitwiseNOT(value);
         if (result instanceof BigInteger) {
             stack[stackTop] = result;
         } else {

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -3494,6 +3494,8 @@ public final class Interpreter extends Icode implements Evaluator {
             return !Double.isNaN(d) && d != 0.0;
         } else if (x == null || x == Undefined.instance) {
             return false;
+        } else if (x instanceof BigInteger) {
+            return !((BigInteger) x).equals(BigInteger.ZERO);
         } else if (x instanceof Number) {
             double d = ((Number) x).doubleValue();
             return (!Double.isNaN(d) && d != 0.0);

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -3021,14 +3021,14 @@ public final class Interpreter extends Icode implements Evaluator {
             rdbl = sDbl[stackTop + 1];
             if (lhs == DBL_MRK) {
                 ldbl = sDbl[stackTop];
-            } else if (lhs instanceof Number) {
+            } else if (lhs instanceof Number && !(lhs instanceof BigInteger)) {
                 ldbl = ((Number) lhs).doubleValue();
             } else {
                 return false;
             }
         } else if (lhs == DBL_MRK) {
             ldbl = sDbl[stackTop];
-            if (rhs instanceof Number) {
+            if (rhs instanceof Number && !(rhs instanceof BigInteger)) {
                 rdbl = ((Number) rhs).doubleValue();
             } else {
                 return false;

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -3578,28 +3578,35 @@ public final class Interpreter extends Icode implements Evaluator {
 
     private static int doArithmetic(
             CallFrame frame, int op, Object[] stack, double[] sDbl, int stackTop) {
-        double lDbl = stack_double(frame, stackTop - 1);
-        double rDbl = stack_double(frame, stackTop);
+        Number lNum = stack_numeric(frame, stackTop - 1);
+        Number rNum = stack_numeric(frame, stackTop);
         --stackTop;
-        stack[stackTop] = DOUBLE_MARK;
+
+        Number result = null;
         switch (op) {
             case Token.SUB:
-                lDbl -= rDbl;
+                result = ScriptRuntime.subtract(lNum, rNum);
                 break;
             case Token.MUL:
-                lDbl *= rDbl;
+                result = ScriptRuntime.multiply(lNum, rNum);
                 break;
             case Token.DIV:
-                lDbl /= rDbl;
+                result = ScriptRuntime.divide(lNum, rNum);
                 break;
             case Token.MOD:
-                lDbl %= rDbl;
+                result = ScriptRuntime.remainder(lNum, rNum);
                 break;
             case Token.EXP:
-                lDbl = Math.pow(lDbl, rDbl);
+                result = ScriptRuntime.exponentiate(lNum, rNum);
                 break;
         }
-        sDbl[stackTop] = lDbl;
+
+        if (result instanceof BigInteger) {
+            stack[stackTop] = result;
+        } else {
+            stack[stackTop] = DOUBLE_MARK;
+            sDbl[stackTop] = result.doubleValue();
+        }
         return stackTop;
     }
 

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -1462,15 +1462,23 @@ public final class Interpreter extends Icode implements Evaluator {
                                     sDbl[stackTop] = ScriptRuntime.toUint32(lDbl) >>> rIntValue;
                                     continue Loop;
                                 }
-                            case Token.NEG:
                             case Token.POS:
                                 {
                                     double rDbl = stack_double(frame, stackTop);
                                     stack[stackTop] = DBL_MRK;
-                                    if (op == Token.NEG) {
-                                        rDbl = -rDbl;
-                                    }
                                     sDbl[stackTop] = rDbl;
+                                    continue Loop;
+                                }
+                            case Token.NEG:
+                                {
+                                    Number rNum = stack_numeric(frame, stackTop);
+                                    Number rNegNum = ScriptRuntime.negate(rNum);
+                                    if (rNegNum instanceof BigInteger) {
+                                        stack[stackTop] = rNegNum;
+                                    } else {
+                                        stack[stackTop] = DBL_MRK;
+                                        sDbl[stackTop] = rNegNum.doubleValue();
+                                    }
                                     continue Loop;
                                 }
                             case Token.ADD:
@@ -3430,6 +3438,14 @@ public final class Interpreter extends Icode implements Evaluator {
         Object x = frame.stack[i];
         if (x != UniqueTag.DOUBLE_MARK) {
             return ScriptRuntime.toNumber(x);
+        }
+        return frame.sDbl[i];
+    }
+
+    private static Number stack_numeric(CallFrame frame, int i) {
+        Object x = frame.stack[i];
+        if (x != UniqueTag.DOUBLE_MARK) {
+            return ScriptRuntime.toNumeric(x);
         }
         return frame.sDbl[i];
     }

--- a/src/org/mozilla/javascript/Interpreter.java
+++ b/src/org/mozilla/javascript/Interpreter.java
@@ -2626,32 +2626,18 @@ public final class Interpreter extends Icode implements Evaluator {
         {
             number_compare:
             {
-                double rDbl, lDbl;
+                Number rNum, lNum;
                 if (rhs == DOUBLE_MARK) {
-                    rDbl = sDbl[stackTop + 1];
-                    lDbl = stack_double(frame, stackTop);
+                    rNum = sDbl[stackTop + 1];
+                    lNum = stack_numeric(frame, stackTop);
                 } else if (lhs == DOUBLE_MARK) {
-                    rDbl = ScriptRuntime.toNumber(rhs);
-                    lDbl = sDbl[stackTop];
+                    rNum = ScriptRuntime.toNumeric(rhs);
+                    lNum = sDbl[stackTop];
                 } else {
                     break number_compare;
                 }
-                switch (op) {
-                    case Token.GE:
-                        valBln = (lDbl >= rDbl);
-                        break object_compare;
-                    case Token.LE:
-                        valBln = (lDbl <= rDbl);
-                        break object_compare;
-                    case Token.GT:
-                        valBln = (lDbl > rDbl);
-                        break object_compare;
-                    case Token.LT:
-                        valBln = (lDbl < rDbl);
-                        break object_compare;
-                    default:
-                        throw Kit.codeBug();
-                }
+                valBln = ScriptRuntime.compare(lNum, rNum, op);
+                break object_compare;
             }
             valBln = ScriptRuntime.compare(lhs, rhs, op);
         }

--- a/src/org/mozilla/javascript/InterpreterData.java
+++ b/src/org/mozilla/javascript/InterpreterData.java
@@ -8,20 +8,17 @@ package org.mozilla.javascript;
 
 import java.io.Serializable;
 import java.util.Arrays;
-
 import org.mozilla.javascript.debug.DebuggableScript;
 
-final class InterpreterData implements Serializable, DebuggableScript
-{
+final class InterpreterData implements Serializable, DebuggableScript {
     private static final long serialVersionUID = 5067677351589230234L;
 
     static final int INITIAL_MAX_ICODE_LENGTH = 1024;
     static final int INITIAL_STRINGTABLE_SIZE = 64;
     static final int INITIAL_NUMBERTABLE_SIZE = 64;
 
-    InterpreterData(int languageVersion, String sourceFile,
-                    String encodedSource, boolean isStrict)
-    {
+    InterpreterData(
+            int languageVersion, String sourceFile, String encodedSource, boolean isStrict) {
         this.languageVersion = languageVersion;
         this.itsSourceFile = sourceFile;
         this.encodedSource = encodedSource;
@@ -29,8 +26,7 @@ final class InterpreterData implements Serializable, DebuggableScript
         init();
     }
 
-    InterpreterData(InterpreterData parent)
-    {
+    InterpreterData(InterpreterData parent) {
         this.parentData = parent;
         this.languageVersion = parent.languageVersion;
         this.itsSourceFile = parent.itsSourceFile;
@@ -39,8 +35,7 @@ final class InterpreterData implements Serializable, DebuggableScript
         init();
     }
 
-    private void init()
-    {
+    private void init() {
         itsICode = new byte[INITIAL_MAX_ICODE_LENGTH];
         itsStringTable = new String[INITIAL_STRINGTABLE_SIZE];
     }
@@ -100,84 +95,70 @@ final class InterpreterData implements Serializable, DebuggableScript
     boolean declaredAsFunctionExpression;
 
     @Override
-    public boolean isTopLevel()
-    {
+    public boolean isTopLevel() {
         return topLevel;
     }
 
     @Override
-    public boolean isFunction()
-    {
+    public boolean isFunction() {
         return itsFunctionType != 0;
     }
 
     @Override
-    public String getFunctionName()
-    {
+    public String getFunctionName() {
         return itsName;
     }
 
     @Override
-    public int getParamCount()
-    {
+    public int getParamCount() {
         return argCount;
     }
 
     @Override
-    public int getParamAndVarCount()
-    {
+    public int getParamAndVarCount() {
         return argNames.length;
     }
 
     @Override
-    public String getParamOrVarName(int index)
-    {
+    public String getParamOrVarName(int index) {
         return argNames[index];
     }
 
-    public boolean getParamOrVarConst(int index)
-    {
+    public boolean getParamOrVarConst(int index) {
         return argIsConst[index];
     }
 
     @Override
-    public String getSourceName()
-    {
+    public String getSourceName() {
         return itsSourceFile;
     }
 
     @Override
-    public boolean isGeneratedScript()
-    {
+    public boolean isGeneratedScript() {
         return ScriptRuntime.isGeneratedScript(itsSourceFile);
     }
 
     @Override
-    public int[] getLineNumbers()
-    {
+    public int[] getLineNumbers() {
         return Interpreter.getLineNumbers(this);
     }
 
     @Override
-    public int getFunctionCount()
-    {
+    public int getFunctionCount() {
         return (itsNestedFunctions == null) ? 0 : itsNestedFunctions.length;
     }
 
     @Override
-    public DebuggableScript getFunction(int index)
-    {
+    public DebuggableScript getFunction(int index) {
         return itsNestedFunctions[index];
     }
 
     @Override
-    public DebuggableScript getParent()
-    {
-         return parentData;
+    public DebuggableScript getParent() {
+        return parentData;
     }
 
-    public int icodeHashCode()
-    {
+    public int icodeHashCode() {
         int h = icodeHashCode;
         if (h == 0) {
             icodeHashCode = h = Arrays.hashCode(itsICode);

--- a/src/org/mozilla/javascript/InterpreterData.java
+++ b/src/org/mozilla/javascript/InterpreterData.java
@@ -7,6 +7,7 @@
 package org.mozilla.javascript;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.util.Arrays;
 import org.mozilla.javascript.debug.DebuggableScript;
 
@@ -16,6 +17,7 @@ final class InterpreterData implements Serializable, DebuggableScript {
     static final int INITIAL_MAX_ICODE_LENGTH = 1024;
     static final int INITIAL_STRINGTABLE_SIZE = 64;
     static final int INITIAL_NUMBERTABLE_SIZE = 64;
+    static final int INITIAL_BIGINTTABLE_SIZE = 64;
 
     InterpreterData(
             int languageVersion, String sourceFile, String encodedSource, boolean isStrict) {
@@ -38,6 +40,7 @@ final class InterpreterData implements Serializable, DebuggableScript {
     private void init() {
         itsICode = new byte[INITIAL_MAX_ICODE_LENGTH];
         itsStringTable = new String[INITIAL_STRINGTABLE_SIZE];
+        itsBigIntTable = new BigInteger[INITIAL_BIGINTTABLE_SIZE];
     }
 
     String itsName;
@@ -47,6 +50,7 @@ final class InterpreterData implements Serializable, DebuggableScript {
 
     String[] itsStringTable;
     double[] itsDoubleTable;
+    BigInteger[] itsBigIntTable;
     InterpreterData[] itsNestedFunctions;
     Object[] itsRegExpLiterals;
 

--- a/src/org/mozilla/javascript/NativeBigInt.java
+++ b/src/org/mozilla/javascript/NativeBigInt.java
@@ -100,9 +100,7 @@ final class NativeBigInt extends IdScriptableObject {
                             (args.length == 0 || args[0] == Undefined.instance)
                                     ? 10
                                     : ScriptRuntime.toInt32(args[0]);
-                    // TODO
-                    // return ScriptRuntime.bigIntToString(value, base);
-                    return "";
+                    return ScriptRuntime.bigIntToString(value, base);
                 }
 
             case Id_toSource:
@@ -122,9 +120,7 @@ final class NativeBigInt extends IdScriptableObject {
 
     @Override
     public String toString() {
-        // TODO
-        // return ScriptRuntime.bigIntToString(bigIntValue, 10);
-        return "";
+        return ScriptRuntime.bigIntToString(bigIntValue, 10);
     }
 
     // #string_id_map#

--- a/src/org/mozilla/javascript/NativeBigInt.java
+++ b/src/org/mozilla/javascript/NativeBigInt.java
@@ -39,6 +39,15 @@ final class NativeBigInt extends IdScriptableObject {
 
     @Override
     protected void initPrototypeId(int id) {
+        if (id == SymbolId_toStringTag) {
+            initPrototypeValue(
+                    SymbolId_toStringTag,
+                    SymbolKey.TO_STRING_TAG,
+                    getClassName(),
+                    DONTENUM | READONLY);
+            return;
+        }
+
         String s;
         int arity;
         switch (id) {
@@ -123,7 +132,13 @@ final class NativeBigInt extends IdScriptableObject {
         return ScriptRuntime.bigIntToString(bigIntValue, 10);
     }
 
-    // #string_id_map#
+    @Override
+    protected int findPrototypeId(Symbol k) {
+        if (SymbolKey.TO_STRING_TAG.equals(k)) {
+            return SymbolId_toStringTag;
+        }
+        return 0;
+    }
 
     @Override
     protected int findPrototypeId(String s) {
@@ -156,7 +171,8 @@ final class NativeBigInt extends IdScriptableObject {
             Id_toLocaleString = 3,
             Id_toSource = 4,
             Id_valueOf = 5,
-            MAX_PROTOTYPE_ID = 5;
+            SymbolId_toStringTag = 6,
+            MAX_PROTOTYPE_ID = SymbolId_toStringTag;
 
     private BigInteger bigIntValue;
 }

--- a/src/org/mozilla/javascript/NativeBigInt.java
+++ b/src/org/mozilla/javascript/NativeBigInt.java
@@ -1,0 +1,170 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.math.BigInteger;
+
+/** This class implements the BigInt native object. */
+final class NativeBigInt extends IdScriptableObject {
+    private static final long serialVersionUID = 1335609231306775449L;
+
+    private static final Object BIG_INT_TAG = "BigInt";
+
+    static void init(Scriptable scope, boolean sealed) {
+        NativeBigInt obj = new NativeBigInt(BigInteger.ZERO);
+        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+    }
+
+    NativeBigInt(BigInteger bigInt) {
+        bigIntValue = bigInt;
+    }
+
+    @Override
+    public String getClassName() {
+        return "BigInt";
+    }
+
+    @Override
+    protected void fillConstructorProperties(IdFunctionObject ctor) {
+        // TODO
+        // addIdFunctionProperty(ctor, BIG_INT_TAG, ConstructorId_asIntN, "asIntN", 1);
+        // addIdFunctionProperty(ctor, BIG_INT_TAG, ConstructorId_asUintN, "asUintN", 1);
+
+        super.fillConstructorProperties(ctor);
+    }
+
+    @Override
+    protected void initPrototypeId(int id) {
+        String s;
+        int arity;
+        switch (id) {
+            case Id_constructor:
+                arity = 1;
+                s = "constructor";
+                break;
+            case Id_toString:
+                arity = 0;
+                s = "toString";
+                break;
+            case Id_toLocaleString:
+                arity = 0;
+                s = "toLocaleString";
+                break;
+            case Id_toSource:
+                arity = 0;
+                s = "toSource";
+                break;
+            case Id_valueOf:
+                arity = 0;
+                s = "valueOf";
+                break;
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
+        }
+        initPrototypeMethod(BIG_INT_TAG, id, s, arity);
+    }
+
+    @Override
+    public Object execIdCall(
+            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!f.hasTag(BIG_INT_TAG)) {
+            return super.execIdCall(f, cx, scope, thisObj, args);
+        }
+        int id = f.methodId();
+        if (id == Id_constructor) {
+            // TODO
+            // BigInteger val = (args.length >= 1)
+            //     ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
+            // if (thisObj == null) {
+            //     // new BigInt(val) creates a new BigInt object.
+            //     return new NativeBigInt(val);
+            // }
+            // // BigInt(val) converts val to a BigInt value.
+            // return ScriptRuntime.wrapBigInt(val);
+
+        } else if (id < Id_constructor) {
+            return execConstructorCall(id, args);
+        }
+
+        // The rest of BigInt.prototype methods require thisObj to be BigInt
+        BigInteger value = ensureType(thisObj, NativeBigInt.class, f).bigIntValue;
+
+        switch (id) {
+            case Id_toString:
+            case Id_toLocaleString:
+                {
+                    // toLocaleString is just an alias for toString for now
+                    int base =
+                            (args.length == 0 || args[0] == Undefined.instance)
+                                    ? 10
+                                    : ScriptRuntime.toInt32(args[0]);
+                    // TODO
+                    // return ScriptRuntime.bigIntToString(value, base);
+                    return "";
+                }
+
+            case Id_toSource:
+                return "(new BigInt(" + ScriptRuntime.toString(value) + "))";
+
+            case Id_valueOf:
+                // TODO
+                // return ScriptRuntime.wrapBigInt(value);
+                return ScriptRuntime.wrapNumber(0.0);
+
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
+        }
+    }
+
+    private static Object execConstructorCall(int id, Object[] args) {
+        throw new IllegalArgumentException(String.valueOf(id));
+    }
+
+    @Override
+    public String toString() {
+        // TODO
+        // return ScriptRuntime.bigIntToString(bigIntValue, 10);
+        return "";
+    }
+
+    // #string_id_map#
+
+    @Override
+    protected int findPrototypeId(String s) {
+        int id;
+        switch (s) {
+            case "constructor":
+                id = Id_constructor;
+                break;
+            case "toString":
+                id = Id_toString;
+                break;
+            case "toLocaleString":
+                id = Id_toLocaleString;
+                break;
+            case "toSource":
+                id = Id_toSource;
+                break;
+            case "valueOf":
+                id = Id_valueOf;
+                break;
+            default:
+                id = 0;
+                break;
+        }
+        return id;
+    }
+
+    private static final int Id_constructor = 1,
+            Id_toString = 2,
+            Id_toLocaleString = 3,
+            Id_toSource = 4,
+            Id_valueOf = 5,
+            MAX_PROTOTYPE_ID = 5;
+
+    private BigInteger bigIntValue;
+}

--- a/src/org/mozilla/javascript/NativeBigInt.java
+++ b/src/org/mozilla/javascript/NativeBigInt.java
@@ -76,15 +76,13 @@ final class NativeBigInt extends IdScriptableObject {
         }
         int id = f.methodId();
         if (id == Id_constructor) {
-            BigInteger val = (args.length >= 1) ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
             if (thisObj == null) {
-                // new BigInt(val) creates a new BigInt object.
-                return new NativeBigInt(val);
+                // new BigInt(val) throws TypeError.
+                throw ScriptRuntime.typeErrorById("msg.not.ctor", BIG_INT_TAG);
             }
-            // TODO
-            // // BigInt(val) converts val to a BigInt value.
-            // return ScriptRuntime.wrapBigInt(val);
-            return new NativeBigInt(val);
+            BigInteger val = (args.length >= 1) ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
+            // BigInt(val) converts val to a BigInteger value.
+            return val;
 
         } else if (id < Id_constructor) {
             return execConstructorCall(id, args);
@@ -111,9 +109,7 @@ final class NativeBigInt extends IdScriptableObject {
                 return "(new BigInt(" + ScriptRuntime.toString(value) + "))";
 
             case Id_valueOf:
-                // TODO
-                // return ScriptRuntime.wrapBigInt(value);
-                return ScriptRuntime.wrapNumber(0.0);
+                return value;
 
             default:
                 throw new IllegalArgumentException(String.valueOf(id));

--- a/src/org/mozilla/javascript/NativeBigInt.java
+++ b/src/org/mozilla/javascript/NativeBigInt.java
@@ -76,15 +76,15 @@ final class NativeBigInt extends IdScriptableObject {
         }
         int id = f.methodId();
         if (id == Id_constructor) {
+            BigInteger val = (args.length >= 1) ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
+            if (thisObj == null) {
+                // new BigInt(val) creates a new BigInt object.
+                return new NativeBigInt(val);
+            }
             // TODO
-            // BigInteger val = (args.length >= 1)
-            //     ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
-            // if (thisObj == null) {
-            //     // new BigInt(val) creates a new BigInt object.
-            //     return new NativeBigInt(val);
-            // }
             // // BigInt(val) converts val to a BigInt value.
             // return ScriptRuntime.wrapBigInt(val);
+            return new NativeBigInt(val);
 
         } else if (id < Id_constructor) {
             return execConstructorCall(id, args);

--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -305,7 +305,8 @@ public final class NativeJSON extends IdScriptableObject {
             value = ScriptRuntime.toString(value);
         } else if (value instanceof NativeBoolean) {
             value = ((NativeBoolean) value).getDefaultValue(ScriptRuntime.BooleanClass);
-        } else if (value instanceof NativeBigInt) {
+        } else if (state.cx.getLanguageVersion() >= Context.VERSION_ES6
+                && value instanceof NativeBigInt) {
             value = ((NativeBigInt) value).getDefaultValue(ScriptRuntime.BigIntegerClass);
         } else if (value instanceof NativeJavaObject) {
             unwrappedJavaValue = ((NativeJavaObject) value).unwrap();

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -114,7 +114,7 @@ final class NativeNumber extends IdScriptableObject {
         }
         int id = f.methodId();
         if (id == Id_constructor) {
-            double val = (args.length >= 1) ? ScriptRuntime.toNumber(args[0]) : 0.0;
+            double val = (args.length >= 1) ? ScriptRuntime.toNumeric(args[0]).doubleValue() : 0.0;
             if (thisObj == null) {
                 // new Number(val) creates a new Number object.
                 return new NativeNumber(val);

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -9,17 +9,14 @@ package org.mozilla.javascript;
 /**
  * This class implements the Number native object.
  *
- * See ECMA 15.7.
+ * <p>See ECMA 15.7.
  *
  * @author Norris Boyd
  */
-final class NativeNumber extends IdScriptableObject
-{
+final class NativeNumber extends IdScriptableObject {
     private static final long serialVersionUID = 3504516769741512101L;
 
-    /**
-     * @see https://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer
-     */
+    /** @see https://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer */
     public static final double MAX_SAFE_INTEGER = 9007199254740991.0; // Math.pow(2, 53) - 1
 
     private static final Object NUMBER_TAG = "Number";
@@ -27,49 +24,34 @@ final class NativeNumber extends IdScriptableObject
     private static final int MAX_PRECISION = 100;
     private static final double MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
 
-    static void init(Scriptable scope, boolean sealed)
-    {
+    static void init(Scriptable scope, boolean sealed) {
         NativeNumber obj = new NativeNumber(0.0);
         obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
     }
 
-    NativeNumber(double number)
-    {
+    NativeNumber(double number) {
         doubleValue = number;
     }
 
     @Override
-    public String getClassName()
-    {
+    public String getClassName() {
         return "Number";
     }
 
     @Override
-    protected void fillConstructorProperties(IdFunctionObject ctor)
-    {
-        final int attr = ScriptableObject.DONTENUM |
-                         ScriptableObject.PERMANENT |
-                         ScriptableObject.READONLY;
+    protected void fillConstructorProperties(IdFunctionObject ctor) {
+        final int attr =
+                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY;
 
         ctor.defineProperty("NaN", ScriptRuntime.NaNobj, attr);
-        ctor.defineProperty("POSITIVE_INFINITY",
-                            ScriptRuntime.wrapNumber(Double.POSITIVE_INFINITY),
-                            attr);
-        ctor.defineProperty("NEGATIVE_INFINITY",
-                            ScriptRuntime.wrapNumber(Double.NEGATIVE_INFINITY),
-                            attr);
-        ctor.defineProperty("MAX_VALUE",
-                            ScriptRuntime.wrapNumber(Double.MAX_VALUE),
-                            attr);
-        ctor.defineProperty("MIN_VALUE",
-                            ScriptRuntime.wrapNumber(Double.MIN_VALUE),
-                            attr);
-        ctor.defineProperty("MAX_SAFE_INTEGER",
-                            ScriptRuntime.wrapNumber(MAX_SAFE_INTEGER),
-                            attr);
-        ctor.defineProperty("MIN_SAFE_INTEGER",
-                            ScriptRuntime.wrapNumber(MIN_SAFE_INTEGER),
-                            attr);
+        ctor.defineProperty(
+                "POSITIVE_INFINITY", ScriptRuntime.wrapNumber(Double.POSITIVE_INFINITY), attr);
+        ctor.defineProperty(
+                "NEGATIVE_INFINITY", ScriptRuntime.wrapNumber(Double.NEGATIVE_INFINITY), attr);
+        ctor.defineProperty("MAX_VALUE", ScriptRuntime.wrapNumber(Double.MAX_VALUE), attr);
+        ctor.defineProperty("MIN_VALUE", ScriptRuntime.wrapNumber(Double.MIN_VALUE), attr);
+        ctor.defineProperty("MAX_SAFE_INTEGER", ScriptRuntime.wrapNumber(MAX_SAFE_INTEGER), attr);
+        ctor.defineProperty("MIN_SAFE_INTEGER", ScriptRuntime.wrapNumber(MIN_SAFE_INTEGER), attr);
 
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isFinite, "isFinite", 1);
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isNaN, "isNaN", 1);
@@ -82,35 +64,57 @@ final class NativeNumber extends IdScriptableObject
     }
 
     @Override
-    protected void initPrototypeId(int id)
-    {
+    protected void initPrototypeId(int id) {
         String s;
         int arity;
         switch (id) {
-          case Id_constructor:    arity=1; s="constructor";    break;
-          case Id_toString:       arity=1; s="toString";       break;
-          case Id_toLocaleString: arity=1; s="toLocaleString"; break;
-          case Id_toSource:       arity=0; s="toSource";       break;
-          case Id_valueOf:        arity=0; s="valueOf";        break;
-          case Id_toFixed:        arity=1; s="toFixed";        break;
-          case Id_toExponential:  arity=1; s="toExponential";  break;
-          case Id_toPrecision:    arity=1; s="toPrecision";    break;
-          default: throw new IllegalArgumentException(String.valueOf(id));
+            case Id_constructor:
+                arity = 1;
+                s = "constructor";
+                break;
+            case Id_toString:
+                arity = 1;
+                s = "toString";
+                break;
+            case Id_toLocaleString:
+                arity = 1;
+                s = "toLocaleString";
+                break;
+            case Id_toSource:
+                arity = 0;
+                s = "toSource";
+                break;
+            case Id_valueOf:
+                arity = 0;
+                s = "valueOf";
+                break;
+            case Id_toFixed:
+                arity = 1;
+                s = "toFixed";
+                break;
+            case Id_toExponential:
+                arity = 1;
+                s = "toExponential";
+                break;
+            case Id_toPrecision:
+                arity = 1;
+                s = "toPrecision";
+                break;
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
         }
         initPrototypeMethod(NUMBER_TAG, id, s, arity);
     }
 
     @Override
-    public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
-    {
+    public Object execIdCall(
+            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         if (!f.hasTag(NUMBER_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
         }
         int id = f.methodId();
         if (id == Id_constructor) {
-            double val = (args.length >= 1)
-                ? ScriptRuntime.toNumber(args[0]) : 0.0;
+            double val = (args.length >= 1) ? ScriptRuntime.toNumber(args[0]) : 0.0;
             if (thisObj == null) {
                 // new Number(val) creates a new Number object.
                 return new NativeNumber(val);
@@ -126,113 +130,120 @@ final class NativeNumber extends IdScriptableObject
         double value = ensureType(thisObj, NativeNumber.class, f).doubleValue;
 
         switch (id) {
+            case Id_toString:
+            case Id_toLocaleString:
+                {
+                    // toLocaleString is just an alias for toString for now
+                    int base =
+                            (args.length == 0 || args[0] == Undefined.instance)
+                                    ? 10
+                                    : ScriptRuntime.toInt32(args[0]);
+                    return ScriptRuntime.numberToString(value, base);
+                }
 
-          case Id_toString:
-          case Id_toLocaleString:
-            {
-                // toLocaleString is just an alias for toString for now
-                int base = (args.length == 0 || args[0] == Undefined.instance)
-                    ? 10 : ScriptRuntime.toInt32(args[0]);
-                return ScriptRuntime.numberToString(value, base);
-            }
+            case Id_toSource:
+                return "(new Number(" + ScriptRuntime.toString(value) + "))";
 
-          case Id_toSource:
-            return "(new Number("+ScriptRuntime.toString(value)+"))";
+            case Id_valueOf:
+                return ScriptRuntime.wrapNumber(value);
 
-          case Id_valueOf:
-            return ScriptRuntime.wrapNumber(value);
+            case Id_toFixed:
+                int precisionMin = cx.version < Context.VERSION_ES6 ? -20 : 0;
+                return num_to(value, args, DToA.DTOSTR_FIXED, DToA.DTOSTR_FIXED, precisionMin, 0);
 
-          case Id_toFixed:
-            int precisionMin = cx.version < Context.VERSION_ES6 ? -20 : 0;
-            return num_to(value, args, DToA.DTOSTR_FIXED, DToA.DTOSTR_FIXED, precisionMin, 0);
+            case Id_toExponential:
+                {
+                    // Handle special values before range check
+                    if (Double.isNaN(value)) {
+                        return "NaN";
+                    }
+                    if (Double.isInfinite(value)) {
+                        if (value >= 0) {
+                            return "Infinity";
+                        }
+                        return "-Infinity";
+                    }
+                    // General case
+                    return num_to(
+                            value,
+                            args,
+                            DToA.DTOSTR_STANDARD_EXPONENTIAL,
+                            DToA.DTOSTR_EXPONENTIAL,
+                            0,
+                            1);
+                }
 
-          case Id_toExponential: {
-              // Handle special values before range check
-              if(Double.isNaN(value)) {
-                  return "NaN";
-              }
-              if(Double.isInfinite(value)) {
-                  if(value >= 0) {
-                      return "Infinity";
-                  }
-                  return "-Infinity";
-              }
-              // General case
-              return num_to(value, args, DToA.DTOSTR_STANDARD_EXPONENTIAL,
-                      DToA.DTOSTR_EXPONENTIAL, 0, 1);
-          }
+            case Id_toPrecision:
+                {
+                    // Undefined precision, fall back to ToString()
+                    if (args.length == 0 || args[0] == Undefined.instance) {
+                        return ScriptRuntime.numberToString(value, 10);
+                    }
+                    // Handle special values before range check
+                    if (Double.isNaN(value)) {
+                        return "NaN";
+                    }
+                    if (Double.isInfinite(value)) {
+                        if (value >= 0) {
+                            return "Infinity";
+                        }
+                        return "-Infinity";
+                    }
+                    return num_to(value, args, DToA.DTOSTR_STANDARD, DToA.DTOSTR_PRECISION, 1, 0);
+                }
 
-          case Id_toPrecision: {
-              // Undefined precision, fall back to ToString()
-              if(args.length == 0 || args[0] == Undefined.instance) {
-                  return ScriptRuntime.numberToString(value, 10);
-              }
-              // Handle special values before range check
-              if(Double.isNaN(value)) {
-                  return "NaN";
-              }
-              if(Double.isInfinite(value)) {
-                  if(value >= 0) {
-                      return "Infinity";
-                  }
-                  return "-Infinity";
-              }
-              return num_to(value, args, DToA.DTOSTR_STANDARD,
-                      DToA.DTOSTR_PRECISION, 1, 0);
-          }
-
-          default: throw new IllegalArgumentException(String.valueOf(id));
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
         }
     }
 
-    private static Object execConstructorCall(int id, Object[] args)
-    {
+    private static Object execConstructorCall(int id, Object[] args) {
         switch (id) {
-        case ConstructorId_isFinite:
-            if ((args.length == 0) || (Undefined.instance == args[0])) {
+            case ConstructorId_isFinite:
+                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                    return Boolean.FALSE;
+                }
+                if (args[0] instanceof Number) {
+                    // Match ES6 polyfill, which only works for "number" types
+                    return isFinite(args[0]);
+                }
                 return Boolean.FALSE;
-            }
-            if (args[0] instanceof Number) {
-                // Match ES6 polyfill, which only works for "number" types
-                return isFinite(args[0]);
-            }
-            return Boolean.FALSE;
 
-        case ConstructorId_isNaN:
-            if ((args.length == 0) || (Undefined.instance == args[0])) {
+            case ConstructorId_isNaN:
+                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                    return Boolean.FALSE;
+                }
+                if (args[0] instanceof Number) {
+                    return isNaN((Number) args[0]);
+                }
                 return Boolean.FALSE;
-            }
-            if (args[0] instanceof Number) {
-                return isNaN((Number)args[0]);
-            }
-            return Boolean.FALSE;
 
-        case ConstructorId_isInteger:
-            if ((args.length == 0) || (Undefined.instance == args[0])) {
+            case ConstructorId_isInteger:
+                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                    return Boolean.FALSE;
+                }
+                if (args[0] instanceof Number) {
+                    return Boolean.valueOf(isInteger((Number) args[0]));
+                }
                 return Boolean.FALSE;
-            }
-            if (args[0] instanceof Number) {
-                return Boolean.valueOf(isInteger((Number)args[0]));
-            }
-            return Boolean.FALSE;
 
-        case ConstructorId_isSafeInteger:
-            if ((args.length == 0) || (Undefined.instance == args[0])) {
+            case ConstructorId_isSafeInteger:
+                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                    return Boolean.FALSE;
+                }
+                if (args[0] instanceof Number) {
+                    return Boolean.valueOf(isSafeInteger((Number) args[0]));
+                }
                 return Boolean.FALSE;
-            }
-            if (args[0] instanceof Number) {
-                return Boolean.valueOf(isSafeInteger((Number)args[0]));
-            }
-            return Boolean.FALSE;
 
-        case ConstructorId_parseFloat:
-            return NativeGlobal.js_parseFloat(args);
+            case ConstructorId_parseFloat:
+                return NativeGlobal.js_parseFloat(args);
 
-        case ConstructorId_parseInt:
-            return NativeGlobal.js_parseInt(args);
+            case ConstructorId_parseInt:
+                return NativeGlobal.js_parseInt(args);
 
-        default:
-            throw new IllegalArgumentException(String.valueOf(id));
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
         }
     }
 
@@ -241,22 +252,25 @@ final class NativeNumber extends IdScriptableObject
         return ScriptRuntime.numberToString(doubleValue, 10);
     }
 
-    private static String num_to(double val,
-                                 Object[] args,
-                                 int zeroArgMode, int oneArgMode,
-                                 int precisionMin, int precisionOffset)
-    {
+    private static String num_to(
+            double val,
+            Object[] args,
+            int zeroArgMode,
+            int oneArgMode,
+            int precisionMin,
+            int precisionOffset) {
         int precision;
         if (args.length == 0) {
             precision = 0;
             oneArgMode = zeroArgMode;
         } else {
             /* We allow a larger range of precision than
-               ECMA requires; this is permitted by ECMA. */
+            ECMA requires; this is permitted by ECMA. */
             double p = ScriptRuntime.toInteger(args[0]);
             if (p < precisionMin || p > MAX_PRECISION) {
-                String msg = ScriptRuntime.getMessageById(
-                    "msg.bad.precision", ScriptRuntime.toString(args[0]));
+                String msg =
+                        ScriptRuntime.getMessageById(
+                                "msg.bad.precision", ScriptRuntime.toString(args[0]));
                 throw ScriptRuntime.rangeError(msg);
             }
             precision = ScriptRuntime.toInt32(p);
@@ -266,125 +280,108 @@ final class NativeNumber extends IdScriptableObject
         return sb.toString();
     }
 
-    static Object isFinite(Object val)
-    {
+    static Object isFinite(Object val) {
         double d = ScriptRuntime.toNumber(val);
         Double nd = Double.valueOf(d);
         return ScriptRuntime.wrapBoolean(!nd.isInfinite() && !nd.isNaN());
     }
 
-    private static Boolean isNaN(Number val)
-    {
+    private static Boolean isNaN(Number val) {
         if (val instanceof Double) {
-            return Boolean.valueOf(((Double)val).isNaN());
+            return Boolean.valueOf(((Double) val).isNaN());
         }
 
         double d = val.doubleValue();
         return Boolean.valueOf(Double.isNaN(d));
     }
 
-    private static boolean isInteger(Number val)
-    {
+    private static boolean isInteger(Number val) {
         if (val instanceof Double) {
-            return isDoubleInteger((Double)val);
+            return isDoubleInteger((Double) val);
         }
         return isDoubleInteger(val.doubleValue());
     }
 
-    private static boolean isDoubleInteger(Double d)
-    {
-        return !d.isInfinite() &&
-                !d.isNaN() &&
-                (Math.floor(d.doubleValue()) == d.doubleValue());
+    private static boolean isDoubleInteger(Double d) {
+        return !d.isInfinite() && !d.isNaN() && (Math.floor(d.doubleValue()) == d.doubleValue());
     }
 
-    private static boolean isDoubleInteger(double d)
-    {
-        return !Double.isInfinite(d) &&
-                !Double.isNaN(d) &&
-                (Math.floor(d) == d);
+    private static boolean isDoubleInteger(double d) {
+        return !Double.isInfinite(d) && !Double.isNaN(d) && (Math.floor(d) == d);
     }
 
-    private static boolean isSafeInteger(Number val)
-    {
+    private static boolean isSafeInteger(Number val) {
         if (val instanceof Double) {
-            return isDoubleSafeInteger((Double)val);
+            return isDoubleSafeInteger((Double) val);
         }
         return isDoubleSafeInteger(val.doubleValue());
     }
 
-    private static boolean isDoubleSafeInteger(Double d)
-    {
-        return isDoubleInteger(d) &&
-                (d.doubleValue() <= MAX_SAFE_INTEGER) &&
-                (d.doubleValue() >= MIN_SAFE_INTEGER);
+    private static boolean isDoubleSafeInteger(Double d) {
+        return isDoubleInteger(d)
+                && (d.doubleValue() <= MAX_SAFE_INTEGER)
+                && (d.doubleValue() >= MIN_SAFE_INTEGER);
     }
 
-    private static boolean isDoubleSafeInteger(double d)
-    {
-        return isDoubleInteger(d) &&
-                (d <= MAX_SAFE_INTEGER) &&
-                (d >= MIN_SAFE_INTEGER);
+    private static boolean isDoubleSafeInteger(double d) {
+        return isDoubleInteger(d) && (d <= MAX_SAFE_INTEGER) && (d >= MIN_SAFE_INTEGER);
     }
-// #string_id_map#
+    // #string_id_map#
 
     @Override
-    protected int findPrototypeId(String s)
-    {
+    protected int findPrototypeId(String s) {
         int id;
-// #generated# Last update: 2021-03-21 09:51:08 MEZ
+        // #generated# Last update: 2021-03-21 09:51:08 MEZ
         switch (s) {
-        case "constructor":
-            id = Id_constructor;
-            break;
-        case "toString":
-            id = Id_toString;
-            break;
-        case "toLocaleString":
-            id = Id_toLocaleString;
-            break;
-        case "toSource":
-            id = Id_toSource;
-            break;
-        case "valueOf":
-            id = Id_valueOf;
-            break;
-        case "toFixed":
-            id = Id_toFixed;
-            break;
-        case "toExponential":
-            id = Id_toExponential;
-            break;
-        case "toPrecision":
-            id = Id_toPrecision;
-            break;
-        default:
-            id = 0;
-            break;
+            case "constructor":
+                id = Id_constructor;
+                break;
+            case "toString":
+                id = Id_toString;
+                break;
+            case "toLocaleString":
+                id = Id_toLocaleString;
+                break;
+            case "toSource":
+                id = Id_toSource;
+                break;
+            case "valueOf":
+                id = Id_valueOf;
+                break;
+            case "toFixed":
+                id = Id_toFixed;
+                break;
+            case "toExponential":
+                id = Id_toExponential;
+                break;
+            case "toPrecision":
+                id = Id_toPrecision;
+                break;
+            default:
+                id = 0;
+                break;
         }
-// #/generated#
+        // #/generated#
         return id;
     }
 
-    private static final int
-        ConstructorId_isFinite       = -1,
-        ConstructorId_isNaN          = -2,
-        ConstructorId_isInteger      = -3,
-        ConstructorId_isSafeInteger  = -4,
-        ConstructorId_parseFloat     = -5,
-        ConstructorId_parseInt       = -6,
+    private static final int ConstructorId_isFinite = -1,
+            ConstructorId_isNaN = -2,
+            ConstructorId_isInteger = -3,
+            ConstructorId_isSafeInteger = -4,
+            ConstructorId_parseFloat = -5,
+            ConstructorId_parseInt = -6,
+            Id_constructor = 1,
+            Id_toString = 2,
+            Id_toLocaleString = 3,
+            Id_toSource = 4,
+            Id_valueOf = 5,
+            Id_toFixed = 6,
+            Id_toExponential = 7,
+            Id_toPrecision = 8,
+            MAX_PROTOTYPE_ID = 8;
 
-        Id_constructor           = 1,
-        Id_toString              = 2,
-        Id_toLocaleString        = 3,
-        Id_toSource              = 4,
-        Id_valueOf               = 5,
-        Id_toFixed               = 6,
-        Id_toExponential         = 7,
-        Id_toPrecision           = 8,
-        MAX_PROTOTYPE_ID         = 8;
-
-// #/string_id_map#
+    // #/string_id_map#
 
     private double doubleValue;
 }

--- a/src/org/mozilla/javascript/Node.java
+++ b/src/org/mozilla/javascript/Node.java
@@ -6,6 +6,7 @@
 
 package org.mozilla.javascript;
 
+import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import org.mozilla.javascript.ast.Comment;
@@ -423,6 +424,8 @@ public class Node implements Iterable<Node> {
                     return "destructuring_names";
                 case DESTRUCTURING_PARAMS:
                     return "destructuring_params";
+                case EXPRESSION_CLOSURE_PROP:
+                    return "expression_closure_prop";
 
                 default:
                     Kit.codeBug();
@@ -527,6 +530,15 @@ public class Node implements Iterable<Node> {
 
     public final void setDouble(double number) {
         ((NumberLiteral) this).setNumber(number);
+    }
+
+    /** Can only be called when <code>getType() == Token.BIGINT</code> */
+    public BigInteger getBigInt() {
+        throw new UnsupportedOperationException("Can only be called when Token.BIGINT");
+    }
+
+    public void setBigInt(BigInteger bigInt) {
+        throw new UnsupportedOperationException("Can only be called when Token.BIGINT");
     }
 
     /** Can only be called when node has String context. */
@@ -1093,6 +1105,9 @@ public class Node implements Iterable<Node> {
             } else if (type == Token.NUMBER) {
                 sb.append(' ');
                 sb.append(getDouble());
+            } else if (type == Token.BIGINT) {
+                sb.append(' ');
+                sb.append(getBigInt().toString());
             } else if (type == Token.TARGET) {
                 sb.append(' ');
                 appendPrintId(this, printIds, sb);

--- a/src/org/mozilla/javascript/Node.java
+++ b/src/org/mozilla/javascript/Node.java
@@ -8,7 +8,6 @@ package org.mozilla.javascript;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
 import org.mozilla.javascript.ast.Comment;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
@@ -23,72 +22,63 @@ import org.mozilla.javascript.ast.ScriptNode;
  * @author Norris Boyd
  * @author Mike McCabe
  */
-public class Node implements Iterable<Node>
-{
-    public static final int
-        FUNCTION_PROP      =  1,
-        LOCAL_PROP         =  2,
-        LOCAL_BLOCK_PROP   =  3,
-        REGEXP_PROP        =  4,
-        CASEARRAY_PROP     =  5,
+public class Node implements Iterable<Node> {
+    public static final int FUNCTION_PROP = 1,
+            LOCAL_PROP = 2,
+            LOCAL_BLOCK_PROP = 3,
+            REGEXP_PROP = 4,
+            CASEARRAY_PROP = 5,
 
-    //  the following properties are defined and manipulated by the
-    //  optimizer -
-    //  TARGETBLOCK_PROP - the block referenced by a branch node
-    //  VARIABLE_PROP - the variable referenced by a BIND or NAME node
-    //  ISNUMBER_PROP - this node generates code on Number children and
-    //                  delivers a Number result (as opposed to Objects)
-    //  DIRECTCALL_PROP - this call node should emit code to test the function
-    //                    object against the known class and call direct if it
-    //                    matches.
+            //  the following properties are defined and manipulated by the
+            //  optimizer -
+            //  TARGETBLOCK_PROP - the block referenced by a branch node
+            //  VARIABLE_PROP - the variable referenced by a BIND or NAME node
+            //  ISNUMBER_PROP - this node generates code on Number children and
+            //                  delivers a Number result (as opposed to Objects)
+            //  DIRECTCALL_PROP - this call node should emit code to test the function
+            //                    object against the known class and call direct if it
+            //                    matches.
 
-        TARGETBLOCK_PROP     =  6,
-        VARIABLE_PROP        =  7,
-        ISNUMBER_PROP        =  8,
-        DIRECTCALL_PROP      =  9,
-        SPECIALCALL_PROP     = 10,
-        SKIP_INDEXES_PROP    = 11, // array of skipped indexes of array literal
-        OBJECT_IDS_PROP      = 12, // array of properties for object literal
-        INCRDECR_PROP        = 13, // pre or post type of increment/decrement
-        CATCH_SCOPE_PROP     = 14, // index of catch scope block in catch
-        LABEL_ID_PROP        = 15, // label id: code generation uses it
-        MEMBER_TYPE_PROP     = 16, // type of element access operation
-        NAME_PROP            = 17, // property name
-        CONTROL_BLOCK_PROP   = 18, // flags a control block that can drop off
-        PARENTHESIZED_PROP   = 19, // expression is parenthesized
-        GENERATOR_END_PROP   = 20,
-        DESTRUCTURING_ARRAY_LENGTH = 21,
-        DESTRUCTURING_NAMES  = 22,
-        DESTRUCTURING_PARAMS = 23,
-        JSDOC_PROP           = 24,
-        EXPRESSION_CLOSURE_PROP = 25, // JS 1.8 expression closure pseudo-return
-        SHORTHAND_PROPERTY_NAME = 26,
-        ARROW_FUNCTION_PROP  = 27,
-        LAST_PROP            = 27;
+            TARGETBLOCK_PROP = 6,
+            VARIABLE_PROP = 7,
+            ISNUMBER_PROP = 8,
+            DIRECTCALL_PROP = 9,
+            SPECIALCALL_PROP = 10,
+            SKIP_INDEXES_PROP = 11, // array of skipped indexes of array literal
+            OBJECT_IDS_PROP = 12, // array of properties for object literal
+            INCRDECR_PROP = 13, // pre or post type of increment/decrement
+            CATCH_SCOPE_PROP = 14, // index of catch scope block in catch
+            LABEL_ID_PROP = 15, // label id: code generation uses it
+            MEMBER_TYPE_PROP = 16, // type of element access operation
+            NAME_PROP = 17, // property name
+            CONTROL_BLOCK_PROP = 18, // flags a control block that can drop off
+            PARENTHESIZED_PROP = 19, // expression is parenthesized
+            GENERATOR_END_PROP = 20,
+            DESTRUCTURING_ARRAY_LENGTH = 21,
+            DESTRUCTURING_NAMES = 22,
+            DESTRUCTURING_PARAMS = 23,
+            JSDOC_PROP = 24,
+            EXPRESSION_CLOSURE_PROP = 25, // JS 1.8 expression closure pseudo-return
+            SHORTHAND_PROPERTY_NAME = 26,
+            ARROW_FUNCTION_PROP = 27,
+            LAST_PROP = 27;
 
     // values of ISNUMBER_PROP to specify
     // which of the children are Number types
-    public static final int
-        BOTH = 0,
-        LEFT = 1,
-        RIGHT = 2;
+    public static final int BOTH = 0, LEFT = 1, RIGHT = 2;
+    public static final int // values for SPECIALCALL_PROP
+            NON_SPECIALCALL = 0,
+            SPECIALCALL_EVAL = 1,
+            SPECIALCALL_WITH = 2;
+    public static final int // flags for INCRDECR_PROP
+            DECR_FLAG = 0x1,
+            POST_FLAG = 0x2;
+    public static final int // flags for MEMBER_TYPE_PROP
+            PROPERTY_FLAG = 0x1, // property access: element is valid name
+            ATTRIBUTE_FLAG = 0x2, // x.@y or x..@y
+            DESCENDANTS_FLAG = 0x4; // x..y or x..@i
 
-    public static final int    // values for SPECIALCALL_PROP
-        NON_SPECIALCALL  = 0,
-        SPECIALCALL_EVAL = 1,
-        SPECIALCALL_WITH = 2;
-
-    public static final int   // flags for INCRDECR_PROP
-        DECR_FLAG = 0x1,
-        POST_FLAG = 0x2;
-
-    public static final int   // flags for MEMBER_TYPE_PROP
-        PROPERTY_FLAG    = 0x1, // property access: element is valid name
-        ATTRIBUTE_FLAG   = 0x2, // x.@y or x..@y
-        DESCENDANTS_FLAG = 0x4; // x..y or x..@i
-
-    private static class PropListItem
-    {
+    private static class PropListItem {
         PropListItem next;
         int type;
         int intValue;
@@ -163,9 +153,7 @@ public class Node implements Iterable<Node>
         return type;
     }
 
-    /**
-     * Sets the node type and returns this node.
-     */
+    /** Sets the node type and returns this node. */
     public Node setType(int type) {
         this.type = type;
         return this;
@@ -173,29 +161,27 @@ public class Node implements Iterable<Node>
 
     /**
      * Gets the JsDoc comment string attached to this node.
-     * @return the comment string or {@code null} if no JsDoc is attached to
-     *     this node
+     *
+     * @return the comment string or {@code null} if no JsDoc is attached to this node
      */
     public String getJsDoc() {
         Comment comment = getJsDocNode();
         if (comment != null) {
-          return comment.getValue();
+            return comment.getValue();
         }
         return null;
     }
 
     /**
      * Gets the JsDoc Comment object attached to this node.
-     * @return the Comment or {@code null} if no JsDoc is attached to
-     *     this node
+     *
+     * @return the Comment or {@code null} if no JsDoc is attached to this node
      */
     public Comment getJsDocNode() {
         return (Comment) getProp(JSDOC_PROP);
     }
 
-    /**
-     * Sets the JsDoc comment string attached to this node.
-     */
+    /** Sets the JsDoc comment string attached to this node. */
     public void setJsDocNode(Comment jsdocNode) {
         putProp(JSDOC_PROP, jsdocNode);
     }
@@ -217,13 +203,11 @@ public class Node implements Iterable<Node>
     }
 
     public Node getChildBefore(Node child) {
-        if (child == first)
-            return null;
+        if (child == first) return null;
         Node n = first;
         while (n.next != child) {
             n = n.next;
-            if (n == null)
-                throw new RuntimeException("node is not a child");
+            if (n == null) throw new RuntimeException("node is not a child");
         }
         return n;
     }
@@ -273,13 +257,10 @@ public class Node implements Iterable<Node>
         }
     }
 
-    /**
-     * Add 'child' before 'node'.
-     */
+    /** Add 'child' before 'node'. */
     public void addChildBefore(Node newChild, Node node) {
         if (newChild.next != null)
-            throw new RuntimeException(
-                      "newChild had siblings in addChildBefore");
+            throw new RuntimeException("newChild had siblings in addChildBefore");
         if (first == node) {
             newChild.next = first;
             first = newChild;
@@ -289,25 +270,19 @@ public class Node implements Iterable<Node>
         addChildAfter(newChild, prev);
     }
 
-    /**
-     * Add 'child' after 'node'.
-     */
+    /** Add 'child' after 'node'. */
     public void addChildAfter(Node newChild, Node node) {
         if (newChild.next != null)
-            throw new RuntimeException(
-                      "newChild had siblings in addChildAfter");
+            throw new RuntimeException("newChild had siblings in addChildAfter");
         newChild.next = node.next;
         node.next = newChild;
-        if (last == node)
-            last = newChild;
+        if (last == node) last = newChild;
     }
 
     public void removeChild(Node child) {
         Node prev = getChildBefore(child);
-        if (prev == null)
-            first = first.next;
-        else
-            prev.next = child.next;
+        if (prev == null) first = first.next;
+        else prev.next = child.next;
         if (child == last) last = prev;
         child.next = null;
     }
@@ -320,8 +295,7 @@ public class Node implements Iterable<Node>
             Node prev = getChildBefore(child);
             prev.next = newChild;
         }
-        if (child == last)
-            last = newChild;
+        if (child == last) last = newChild;
         child.next = null;
     }
 
@@ -329,8 +303,7 @@ public class Node implements Iterable<Node>
         Node child = prevChild.next;
         newChild.next = child.next;
         prevChild.next = newChild;
-        if (child == last)
-            last = newChild;
+        if (child == last) last = newChild;
         child.next = null;
     }
 
@@ -341,12 +314,12 @@ public class Node implements Iterable<Node>
     private static final Node NOT_SET = new Node(Token.ERROR);
 
     /**
-     * Iterates over the children of this Node.  Supports child removal.  Not
-     * thread-safe.  If anyone changes the child list before the iterator
-     * finishes, the results are undefined and probably bad.
+     * Iterates over the children of this Node. Supports child removal. Not thread-safe. If anyone
+     * changes the child list before the iterator finishes, the results are undefined and probably
+     * bad.
      */
     public class NodeIterator implements Iterator<Node> {
-        private Node cursor;  // points to node to be returned next
+        private Node cursor; // points to node to be returned next
         private Node prev = NOT_SET;
         private Node prev2;
         private boolean removed = false;
@@ -378,8 +351,7 @@ public class Node implements Iterable<Node>
                 throw new IllegalStateException("next() has not been called");
             }
             if (removed) {
-                throw new IllegalStateException(
-                    "remove() already called for current element");
+                throw new IllegalStateException("remove() already called for current element");
             }
             if (prev == first) {
                 first = prev.next;
@@ -392,55 +364,74 @@ public class Node implements Iterable<Node>
         }
     }
 
-    /**
-     * Returns an {@link java.util.Iterator} over the node's children.
-     */
+    /** Returns an {@link java.util.Iterator} over the node's children. */
     @Override
     public Iterator<Node> iterator() {
         return new NodeIterator();
     }
 
-    private static final String propToString(int propType)
-    {
+    private static final String propToString(int propType) {
         if (Token.printTrees) {
             // If Context.printTrees is false, the compiler
             // can remove all these strings.
             switch (propType) {
-                case FUNCTION_PROP:        return "function";
-                case LOCAL_PROP:           return "local";
-                case LOCAL_BLOCK_PROP:     return "local_block";
-                case REGEXP_PROP:          return "regexp";
-                case CASEARRAY_PROP:       return "casearray";
+                case FUNCTION_PROP:
+                    return "function";
+                case LOCAL_PROP:
+                    return "local";
+                case LOCAL_BLOCK_PROP:
+                    return "local_block";
+                case REGEXP_PROP:
+                    return "regexp";
+                case CASEARRAY_PROP:
+                    return "casearray";
 
-                case TARGETBLOCK_PROP:     return "targetblock";
-                case VARIABLE_PROP:        return "variable";
-                case ISNUMBER_PROP:        return "isnumber";
-                case DIRECTCALL_PROP:      return "directcall";
+                case TARGETBLOCK_PROP:
+                    return "targetblock";
+                case VARIABLE_PROP:
+                    return "variable";
+                case ISNUMBER_PROP:
+                    return "isnumber";
+                case DIRECTCALL_PROP:
+                    return "directcall";
 
-                case SPECIALCALL_PROP:     return "specialcall";
-                case SKIP_INDEXES_PROP:    return "skip_indexes";
-                case OBJECT_IDS_PROP:      return "object_ids_prop";
-                case INCRDECR_PROP:        return "incrdecr_prop";
-                case CATCH_SCOPE_PROP:     return "catch_scope_prop";
-                case LABEL_ID_PROP:        return "label_id_prop";
-                case MEMBER_TYPE_PROP:     return "member_type_prop";
-                case NAME_PROP:            return "name_prop";
-                case CONTROL_BLOCK_PROP:   return "control_block_prop";
-                case PARENTHESIZED_PROP:   return "parenthesized_prop";
-                case GENERATOR_END_PROP:   return "generator_end";
+                case SPECIALCALL_PROP:
+                    return "specialcall";
+                case SKIP_INDEXES_PROP:
+                    return "skip_indexes";
+                case OBJECT_IDS_PROP:
+                    return "object_ids_prop";
+                case INCRDECR_PROP:
+                    return "incrdecr_prop";
+                case CATCH_SCOPE_PROP:
+                    return "catch_scope_prop";
+                case LABEL_ID_PROP:
+                    return "label_id_prop";
+                case MEMBER_TYPE_PROP:
+                    return "member_type_prop";
+                case NAME_PROP:
+                    return "name_prop";
+                case CONTROL_BLOCK_PROP:
+                    return "control_block_prop";
+                case PARENTHESIZED_PROP:
+                    return "parenthesized_prop";
+                case GENERATOR_END_PROP:
+                    return "generator_end";
                 case DESTRUCTURING_ARRAY_LENGTH:
-                                           return "destructuring_array_length";
-                case DESTRUCTURING_NAMES:  return "destructuring_names";
-                case DESTRUCTURING_PARAMS: return "destructuring_params";
+                    return "destructuring_array_length";
+                case DESTRUCTURING_NAMES:
+                    return "destructuring_names";
+                case DESTRUCTURING_PARAMS:
+                    return "destructuring_params";
 
-                default: Kit.codeBug();
+                default:
+                    Kit.codeBug();
             }
         }
         return null;
     }
 
-    private PropListItem lookupProperty(int propType)
-    {
+    private PropListItem lookupProperty(int propType) {
         PropListItem x = propListHead;
         while (x != null && propType != x.type) {
             x = x.next;
@@ -448,8 +439,7 @@ public class Node implements Iterable<Node>
         return x;
     }
 
-    private PropListItem ensureProperty(int propType)
-    {
+    private PropListItem ensureProperty(int propType) {
         PropListItem item = lookupProperty(propType);
         if (item == null) {
             item = new PropListItem();
@@ -460,15 +450,16 @@ public class Node implements Iterable<Node>
         return item;
     }
 
-    public void removeProp(int propType)
-    {
+    public void removeProp(int propType) {
         PropListItem x = propListHead;
         if (x != null) {
             PropListItem prev = null;
             while (x.type != propType) {
                 prev = x;
                 x = x.next;
-                if (x == null) { return; }
+                if (x == null) {
+                    return;
+                }
             }
             if (prev == null) {
                 propListHead = x.next;
@@ -478,29 +469,31 @@ public class Node implements Iterable<Node>
         }
     }
 
-    public Object getProp(int propType)
-    {
+    public Object getProp(int propType) {
         PropListItem item = lookupProperty(propType);
-        if (item == null) { return null; }
+        if (item == null) {
+            return null;
+        }
         return item.objectValue;
     }
 
-    public int getIntProp(int propType, int defaultValue)
-    {
+    public int getIntProp(int propType, int defaultValue) {
         PropListItem item = lookupProperty(propType);
-        if (item == null) { return defaultValue; }
+        if (item == null) {
+            return defaultValue;
+        }
         return item.intValue;
     }
 
-    public int getExistingIntProp(int propType)
-    {
+    public int getExistingIntProp(int propType) {
         PropListItem item = lookupProperty(propType);
-        if (item == null) { Kit.codeBug(); }
+        if (item == null) {
+            Kit.codeBug();
+        }
         return item.intValue;
     }
 
-    public void putProp(int propType, Object prop)
-    {
+    public void putProp(int propType, Object prop) {
         if (prop == null) {
             removeProp(propType);
         } else {
@@ -509,14 +502,14 @@ public class Node implements Iterable<Node>
         }
     }
 
-    public void putIntProp(int propType, int prop)
-    {
+    public void putIntProp(int propType, int prop) {
         PropListItem item = ensureProperty(propType);
         item.intValue = prop;
     }
 
     /**
      * Return the line number recorded for this node.
+     *
      * @return the line number
      */
     public int getLineno() {
@@ -529,27 +522,27 @@ public class Node implements Iterable<Node>
 
     /** Can only be called when <code>getType() == Token.NUMBER</code> */
     public final double getDouble() {
-        return ((NumberLiteral)this).getNumber();
+        return ((NumberLiteral) this).getNumber();
     }
 
     public final void setDouble(double number) {
-        ((NumberLiteral)this).setNumber(number);
+        ((NumberLiteral) this).setNumber(number);
     }
 
     /** Can only be called when node has String context. */
     public final String getString() {
-        return ((Name)this).getIdentifier();
+        return ((Name) this).getIdentifier();
     }
 
     /** Can only be called when node has String context. */
     public final void setString(String s) {
         if (s == null) Kit.codeBug();
-        ((Name)this).setIdentifier(s);
+        ((Name) this).setIdentifier(s);
     }
 
     /** Can only be called when node has String context. */
     public Scope getScope() {
-        return ((Name)this).getScope();
+        return ((Name) this).getScope();
     }
 
     /** Can only be called when node has String context. */
@@ -558,223 +551,207 @@ public class Node implements Iterable<Node>
         if (!(this instanceof Name)) {
             throw Kit.codeBug();
         }
-        ((Name)this).setScope(s);
+        ((Name) this).setScope(s);
     }
 
-    public static Node newTarget()
-    {
+    public static Node newTarget() {
         return new Node(Token.TARGET);
     }
 
-    public final int labelId()
-    {
+    public final int labelId() {
         if ((type != Token.TARGET) && (type != Token.YIELD) && (type != Token.YIELD_STAR)) {
             Kit.codeBug();
         }
         return getIntProp(LABEL_ID_PROP, -1);
     }
 
-    public void labelId(int labelId)
-    {
+    public void labelId(int labelId) {
         if ((type != Token.TARGET) && (type != Token.YIELD) && (type != Token.YIELD_STAR)) {
             Kit.codeBug();
         }
         putIntProp(LABEL_ID_PROP, labelId);
     }
 
-
     /**
-     * Does consistent-return analysis on the function body when strict mode is
-     * enabled.
+     * Does consistent-return analysis on the function body when strict mode is enabled.
      *
-     *   function (x) { return (x+1) }
-     * is ok, but
-     *   function (x) { if (x &lt; 0) return (x+1); }
-     * is not becuase the function can potentially return a value when the
-     * condition is satisfied and if not, the function does not explicitly
-     * return value.
+     * <p>function (x) { return (x+1) } is ok, but function (x) { if (x &lt; 0) return (x+1); } is
+     * not becuase the function can potentially return a value when the condition is satisfied and
+     * if not, the function does not explicitly return value.
      *
-     * This extends to checking mismatches such as "return" and "return <value>"
-     * used in the same function. Warnings are not emitted if inconsistent
-     * returns exist in code that can be statically shown to be unreachable.
-     * Ex.
+     * <p>This extends to checking mismatches such as "return" and "return <value>" used in the same
+     * function. Warnings are not emitted if inconsistent returns exist in code that can be
+     * statically shown to be unreachable. Ex.
+     *
      * <pre>function (x) { while (true) { ... if (..) { return value } ... } }
      * </pre>
-     * emits no warning. However if the loop had a break statement, then a
-     * warning would be emitted.
      *
-     * The consistency analysis looks at control structures such as loops, ifs,
-     * switch, try-catch-finally blocks, examines the reachable code paths and
-     * warns the user about an inconsistent set of termination possibilities.
+     * emits no warning. However if the loop had a break statement, then a warning would be emitted.
      *
-     * Caveat: Since the parser flattens many control structures into almost
-     * straight-line code with gotos, it makes such analysis hard. Hence this
-     * analyser is written to taken advantage of patterns of code generated by
-     * the parser (for loops, try blocks and such) and does not do a full
-     * control flow analysis of the gotos and break/continue statements.
-     * Future changes to the parser will affect this analysis.
+     * <p>The consistency analysis looks at control structures such as loops, ifs, switch,
+     * try-catch-finally blocks, examines the reachable code paths and warns the user about an
+     * inconsistent set of termination possibilities.
+     *
+     * <p>Caveat: Since the parser flattens many control structures into almost straight-line code
+     * with gotos, it makes such analysis hard. Hence this analyser is written to taken advantage of
+     * patterns of code generated by the parser (for loops, try blocks and such) and does not do a
+     * full control flow analysis of the gotos and break/continue statements. Future changes to the
+     * parser will affect this analysis.
      */
 
     /**
-     * These flags enumerate the possible ways a statement/function can
-     * terminate. These flags are used by endCheck() and by the Parser to
-     * detect inconsistent return usage.
+     * These flags enumerate the possible ways a statement/function can terminate. These flags are
+     * used by endCheck() and by the Parser to detect inconsistent return usage.
      *
-     * END_UNREACHED is reserved for code paths that are assumed to always be
-     * able to execute (example: throw, continue)
+     * <p>END_UNREACHED is reserved for code paths that are assumed to always be able to execute
+     * (example: throw, continue)
      *
-     * END_DROPS_OFF indicates if the statement can transfer control to the
-     * next one. Statement such as return dont. A compound statement may have
-     * some branch that drops off control to the next statement.
+     * <p>END_DROPS_OFF indicates if the statement can transfer control to the next one. Statement
+     * such as return dont. A compound statement may have some branch that drops off control to the
+     * next statement.
      *
-     * END_RETURNS indicates that the statement can return (without arguments)
-     * END_RETURNS_VALUE indicates that the statement can return a value.
+     * <p>END_RETURNS indicates that the statement can return (without arguments) END_RETURNS_VALUE
+     * indicates that the statement can return a value.
      *
-     * A compound statement such as
-     * if (condition) {
-     *   return value;
-     * }
-     * Will be detected as (END_DROPS_OFF | END_RETURN_VALUE) by endCheck()
+     * <p>A compound statement such as if (condition) { return value; } Will be detected as
+     * (END_DROPS_OFF | END_RETURN_VALUE) by endCheck()
      */
     public static final int END_UNREACHED = 0;
+
     public static final int END_DROPS_OFF = 1;
     public static final int END_RETURNS = 2;
     public static final int END_RETURNS_VALUE = 4;
     public static final int END_YIELDS = 8;
 
     /**
-     * Checks that every return usage in a function body is consistent with the
-     * requirements of strict-mode.
+     * Checks that every return usage in a function body is consistent with the requirements of
+     * strict-mode.
+     *
      * @return true if the function satisfies strict mode requirement.
      */
-    public boolean hasConsistentReturnUsage()
-    {
+    public boolean hasConsistentReturnUsage() {
         int n = endCheck();
-        return (n & END_RETURNS_VALUE) == 0 ||
-               (n & (END_DROPS_OFF|END_RETURNS|END_YIELDS)) == 0;
+        return (n & END_RETURNS_VALUE) == 0
+                || (n & (END_DROPS_OFF | END_RETURNS | END_YIELDS)) == 0;
     }
 
     /**
-     * Returns in the then and else blocks must be consistent with each other.
-     * If there is no else block, then the return statement can fall through.
+     * Returns in the then and else blocks must be consistent with each other. If there is no else
+     * block, then the return statement can fall through.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckIf()
-    {
+    private int endCheckIf() {
         Node th, el;
         int rv = END_UNREACHED;
 
         th = next;
-        el = ((Jump)this).target;
+        el = ((Jump) this).target;
 
         rv = th.endCheck();
 
-        if (el != null)
-            rv |= el.endCheck();
-        else
-            rv |= END_DROPS_OFF;
+        if (el != null) rv |= el.endCheck();
+        else rv |= END_DROPS_OFF;
 
         return rv;
     }
 
     /**
-     * Consistency of return statements is checked between the case statements.
-     * If there is no default, then the switch can fall through. If there is a
-     * default,we check to see if all code paths in the default return or if
-     * there is a code path that can fall through.
+     * Consistency of return statements is checked between the case statements. If there is no
+     * default, then the switch can fall through. If there is a default,we check to see if all code
+     * paths in the default return or if there is a code path that can fall through.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckSwitch()
-    {
+    private int endCheckSwitch() {
         int rv = END_UNREACHED;
 
         // examine the cases
-//         for (n = first.next; n != null; n = n.next)
-//         {
-//             if (n.type == Token.CASE) {
-//                 rv |= ((Jump)n).target.endCheck();
-//             } else
-//                 break;
-//         }
+        //         for (n = first.next; n != null; n = n.next)
+        //         {
+        //             if (n.type == Token.CASE) {
+        //                 rv |= ((Jump)n).target.endCheck();
+        //             } else
+        //                 break;
+        //         }
 
-//         // we don't care how the cases drop into each other
-//         rv &= ~END_DROPS_OFF;
+        //         // we don't care how the cases drop into each other
+        //         rv &= ~END_DROPS_OFF;
 
-//         // examine the default
-//         n = ((Jump)this).getDefault();
-//         if (n != null)
-//             rv |= n.endCheck();
-//         else
-//             rv |= END_DROPS_OFF;
+        //         // examine the default
+        //         n = ((Jump)this).getDefault();
+        //         if (n != null)
+        //             rv |= n.endCheck();
+        //         else
+        //             rv |= END_DROPS_OFF;
 
-//         // remove the switch block
-//         rv |= getIntProp(CONTROL_BLOCK_PROP, END_UNREACHED);
+        //         // remove the switch block
+        //         rv |= getIntProp(CONTROL_BLOCK_PROP, END_UNREACHED);
 
         return rv;
     }
 
     /**
-     * If the block has a finally, return consistency is checked in the
-     * finally block. If all code paths in the finally returns, then the
-     * returns in the try-catch blocks don't matter. If there is a code path
-     * that does not return or if there is no finally block, the returns
-     * of the try and catch blocks are checked for mismatch.
+     * If the block has a finally, return consistency is checked in the finally block. If all code
+     * paths in the finally returns, then the returns in the try-catch blocks don't matter. If there
+     * is a code path that does not return or if there is no finally block, the returns of the try
+     * and catch blocks are checked for mismatch.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckTry()
-    {
+    private int endCheckTry() {
         int rv = END_UNREACHED;
 
         // a TryStatement isn't a jump - needs rewriting
 
         // check the finally if it exists
-//         n = ((Jump)this).getFinally();
-//         if(n != null) {
-//             rv = n.next.first.endCheck();
-//         } else {
-//             rv = END_DROPS_OFF;
-//         }
+        //         n = ((Jump)this).getFinally();
+        //         if(n != null) {
+        //             rv = n.next.first.endCheck();
+        //         } else {
+        //             rv = END_DROPS_OFF;
+        //         }
 
-//         // if the finally block always returns, then none of the returns
-//         // in the try or catch blocks matter
-//         if ((rv & END_DROPS_OFF) != 0) {
-//             rv &= ~END_DROPS_OFF;
+        //         // if the finally block always returns, then none of the returns
+        //         // in the try or catch blocks matter
+        //         if ((rv & END_DROPS_OFF) != 0) {
+        //             rv &= ~END_DROPS_OFF;
 
-//             // examine the try block
-//             rv |= first.endCheck();
+        //             // examine the try block
+        //             rv |= first.endCheck();
 
-//             // check each catch block
-//             n = ((Jump)this).target;
-//             if (n != null)
-//             {
-//                 // point to the first catch_scope
-//                 for (n = n.next.first; n != null; n = n.next.next)
-//                 {
-//                     // check the block of user code in the catch_scope
-//                     rv |= n.next.first.next.first.endCheck();
-//                 }
-//             }
-//         }
+        //             // check each catch block
+        //             n = ((Jump)this).target;
+        //             if (n != null)
+        //             {
+        //                 // point to the first catch_scope
+        //                 for (n = n.next.first; n != null; n = n.next.next)
+        //                 {
+        //                     // check the block of user code in the catch_scope
+        //                     rv |= n.next.first.next.first.endCheck();
+        //                 }
+        //             }
+        //         }
 
         return rv;
     }
 
     /**
-     * Return statement in the loop body must be consistent. The default
-     * assumption for any kind of a loop is that it will eventually terminate.
-     * The only exception is a loop with a constant true condition. Code that
-     * follows such a loop is examined only if one can statically determine
-     * that there is a break out of the loop.
+     * Return statement in the loop body must be consistent. The default assumption for any kind of
+     * a loop is that it will eventually terminate. The only exception is a loop with a constant
+     * true condition. Code that follows such a loop is examined only if one can statically
+     * determine that there is a break out of the loop.
+     *
      * <pre>
      *  for(&lt;&gt; ; &lt;&gt;; &lt;&gt;) {}
      *  for(&lt;&gt; in &lt;&gt; ) {}
      *  while(&lt;&gt;) { }
      *  do { } while(&lt;&gt;)
      * </pre>
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckLoop()
-    {
+    private int endCheckLoop() {
         Node n;
         int rv = END_UNREACHED;
 
@@ -786,15 +763,13 @@ public class Node implements Iterable<Node>
         for (n = first; n.next != last; n = n.next) {
             /* skip */
         }
-        if (n.type != Token.IFEQ)
-            return END_DROPS_OFF;
+        if (n.type != Token.IFEQ) return END_DROPS_OFF;
 
         // The target's next is the loop body block
-        rv = ((Jump)n).target.next.endCheck();
+        rv = ((Jump) n).target.next.endCheck();
 
         // check to see if the loop condition is true
-        if (n.first.type == Token.TRUE)
-            rv &= ~END_DROPS_OFF;
+        if (n.first.type == Token.TRUE) rv &= ~END_DROPS_OFF;
 
         // look for effect of breaks
         rv |= getIntProp(CONTROL_BLOCK_PROP, END_UNREACHED);
@@ -803,20 +778,18 @@ public class Node implements Iterable<Node>
     }
 
     /**
-     * A general block of code is examined statement by statement. If any
-     * statement (even compound ones) returns in all branches, then subsequent
-     * statements are not examined.
+     * A general block of code is examined statement by statement. If any statement (even compound
+     * ones) returns in all branches, then subsequent statements are not examined.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckBlock()
-    {
+    private int endCheckBlock() {
         Node n;
         int rv = END_DROPS_OFF;
 
         // check each statment and if the statement can continue onto the next
         // one, then check the next statement
-        for (n=first; ((rv & END_DROPS_OFF) != 0) && n != null; n = n.next)
-        {
+        for (n = first; ((rv & END_DROPS_OFF) != 0) && n != null; n = n.next) {
             rv &= ~END_DROPS_OFF;
             rv |= n.endCheck();
         }
@@ -824,14 +797,13 @@ public class Node implements Iterable<Node>
     }
 
     /**
-     * A labelled statement implies that there maybe a break to the label. The
-     * function processes the labelled statement and then checks the
-     * CONTROL_BLOCK_PROP property to see if there is ever a break to the
-     * particular label.
+     * A labelled statement implies that there maybe a break to the label. The function processes
+     * the labelled statement and then checks the CONTROL_BLOCK_PROP property to see if there is
+     * ever a break to the particular label.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckLabel()
-    {
+    private int endCheckLabel() {
         int rv = END_UNREACHED;
 
         rv = next.endCheck();
@@ -841,36 +813,33 @@ public class Node implements Iterable<Node>
     }
 
     /**
-     * When a break is encountered annotate the statement being broken
-     * out of by setting its CONTROL_BLOCK_PROP property.
+     * When a break is encountered annotate the statement being broken out of by setting its
+     * CONTROL_BLOCK_PROP property.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheckBreak()
-    {
+    private int endCheckBreak() {
         Node n = ((Jump) this).getJumpStatement();
         n.putIntProp(CONTROL_BLOCK_PROP, END_DROPS_OFF);
         return END_UNREACHED;
     }
 
     /**
-     * endCheck() examines the body of a function, doing a basic reachability
-     * analysis and returns a combination of flags END_* flags that indicate
-     * how the function execution can terminate. These constitute only the
-     * pessimistic set of termination conditions. It is possible that at
-     * runtime certain code paths will never be actually taken. Hence this
-     * analysis will flag errors in cases where there may not be errors.
+     * endCheck() examines the body of a function, doing a basic reachability analysis and returns a
+     * combination of flags END_* flags that indicate how the function execution can terminate.
+     * These constitute only the pessimistic set of termination conditions. It is possible that at
+     * runtime certain code paths will never be actually taken. Hence this analysis will flag errors
+     * in cases where there may not be errors.
+     *
      * @return logical OR of END_* flags
      */
-    private int endCheck()
-    {
-        switch(type)
-        {
+    private int endCheck() {
+        switch (type) {
             case Token.BREAK:
                 return endCheckBreak();
 
             case Token.EXPR_VOID:
-                if (this.first != null)
-                    return first.endCheck();
+                if (this.first != null) return first.endCheck();
                 return END_DROPS_OFF;
 
             case Token.YIELD:
@@ -882,13 +851,11 @@ public class Node implements Iterable<Node>
                 return END_UNREACHED;
 
             case Token.RETURN:
-                if (this.first != null)
-                    return END_RETURNS_VALUE;
+                if (this.first != null) return END_RETURNS_VALUE;
                 return END_RETURNS;
 
             case Token.TARGET:
-                if (next != null)
-                    return next.endCheck();
+                if (next != null) return next.endCheck();
                 return END_DROPS_OFF;
 
             case Token.LOOP:
@@ -897,10 +864,9 @@ public class Node implements Iterable<Node>
             case Token.LOCAL_BLOCK:
             case Token.BLOCK:
                 // there are several special kinds of blocks
-                if (first == null)
-                    return END_DROPS_OFF;
+                if (first == null) return END_DROPS_OFF;
 
-                switch(first.type) {
+                switch (first.type) {
                     case Token.LABEL:
                         return first.endCheckLabel();
 
@@ -922,114 +888,106 @@ public class Node implements Iterable<Node>
         }
     }
 
-    public boolean hasSideEffects()
-    {
+    public boolean hasSideEffects() {
         switch (type) {
-          case Token.EXPR_VOID:
-          case Token.COMMA:
-            if (last != null)
-                return last.hasSideEffects();
-            return true;
+            case Token.EXPR_VOID:
+            case Token.COMMA:
+                if (last != null) return last.hasSideEffects();
+                return true;
 
-          case Token.HOOK:
-            if (first == null ||
-                first.next == null ||
-                first.next.next == null)
-                Kit.codeBug();
-            return first.next.hasSideEffects() &&
-                   first.next.next.hasSideEffects();
+            case Token.HOOK:
+                if (first == null || first.next == null || first.next.next == null) Kit.codeBug();
+                return first.next.hasSideEffects() && first.next.next.hasSideEffects();
 
-          case Token.AND:
-          case Token.OR:
-            if (first == null || last == null)
-                Kit.codeBug();
-            return first.hasSideEffects() || last.hasSideEffects();
+            case Token.AND:
+            case Token.OR:
+                if (first == null || last == null) Kit.codeBug();
+                return first.hasSideEffects() || last.hasSideEffects();
 
-          case Token.ERROR:         // Avoid cascaded error messages
-          case Token.EXPR_RESULT:
-          case Token.ASSIGN:
-          case Token.ASSIGN_ADD:
-          case Token.ASSIGN_SUB:
-          case Token.ASSIGN_MUL:
-          case Token.ASSIGN_DIV:
-          case Token.ASSIGN_MOD:
-          case Token.ASSIGN_BITOR:
-          case Token.ASSIGN_BITXOR:
-          case Token.ASSIGN_BITAND:
-          case Token.ASSIGN_LSH:
-          case Token.ASSIGN_RSH:
-          case Token.ASSIGN_URSH:
-          case Token.ENTERWITH:
-          case Token.LEAVEWITH:
-          case Token.RETURN:
-          case Token.GOTO:
-          case Token.IFEQ:
-          case Token.IFNE:
-          case Token.NEW:
-          case Token.DELPROP:
-          case Token.SETNAME:
-          case Token.SETPROP:
-          case Token.SETELEM:
-          case Token.CALL:
-          case Token.THROW:
-          case Token.RETHROW:
-          case Token.SETVAR:
-          case Token.CATCH_SCOPE:
-          case Token.RETURN_RESULT:
-          case Token.SET_REF:
-          case Token.DEL_REF:
-          case Token.REF_CALL:
-          case Token.TRY:
-          case Token.SEMI:
-          case Token.INC:
-          case Token.DEC:
-          case Token.IF:
-          case Token.ELSE:
-          case Token.SWITCH:
-          case Token.WHILE:
-          case Token.DO:
-          case Token.FOR:
-          case Token.BREAK:
-          case Token.CONTINUE:
-          case Token.VAR:
-          case Token.CONST:
-          case Token.LET:
-          case Token.LETEXPR:
-          case Token.WITH:
-          case Token.WITHEXPR:
-          case Token.CATCH:
-          case Token.FINALLY:
-          case Token.BLOCK:
-          case Token.LABEL:
-          case Token.TARGET:
-          case Token.LOOP:
-          case Token.JSR:
-          case Token.SETPROP_OP:
-          case Token.SETELEM_OP:
-          case Token.LOCAL_BLOCK:
-          case Token.SET_REF_OP:
-          case Token.YIELD:
-          case Token.YIELD_STAR:
-            return true;
+            case Token.ERROR: // Avoid cascaded error messages
+            case Token.EXPR_RESULT:
+            case Token.ASSIGN:
+            case Token.ASSIGN_ADD:
+            case Token.ASSIGN_SUB:
+            case Token.ASSIGN_MUL:
+            case Token.ASSIGN_DIV:
+            case Token.ASSIGN_MOD:
+            case Token.ASSIGN_BITOR:
+            case Token.ASSIGN_BITXOR:
+            case Token.ASSIGN_BITAND:
+            case Token.ASSIGN_LSH:
+            case Token.ASSIGN_RSH:
+            case Token.ASSIGN_URSH:
+            case Token.ENTERWITH:
+            case Token.LEAVEWITH:
+            case Token.RETURN:
+            case Token.GOTO:
+            case Token.IFEQ:
+            case Token.IFNE:
+            case Token.NEW:
+            case Token.DELPROP:
+            case Token.SETNAME:
+            case Token.SETPROP:
+            case Token.SETELEM:
+            case Token.CALL:
+            case Token.THROW:
+            case Token.RETHROW:
+            case Token.SETVAR:
+            case Token.CATCH_SCOPE:
+            case Token.RETURN_RESULT:
+            case Token.SET_REF:
+            case Token.DEL_REF:
+            case Token.REF_CALL:
+            case Token.TRY:
+            case Token.SEMI:
+            case Token.INC:
+            case Token.DEC:
+            case Token.IF:
+            case Token.ELSE:
+            case Token.SWITCH:
+            case Token.WHILE:
+            case Token.DO:
+            case Token.FOR:
+            case Token.BREAK:
+            case Token.CONTINUE:
+            case Token.VAR:
+            case Token.CONST:
+            case Token.LET:
+            case Token.LETEXPR:
+            case Token.WITH:
+            case Token.WITHEXPR:
+            case Token.CATCH:
+            case Token.FINALLY:
+            case Token.BLOCK:
+            case Token.LABEL:
+            case Token.TARGET:
+            case Token.LOOP:
+            case Token.JSR:
+            case Token.SETPROP_OP:
+            case Token.SETELEM_OP:
+            case Token.LOCAL_BLOCK:
+            case Token.SET_REF_OP:
+            case Token.YIELD:
+            case Token.YIELD_STAR:
+                return true;
 
-          default:
-            return false;
+            default:
+                return false;
         }
     }
 
     /**
      * Recursively unlabel every TARGET or YIELD node in the tree.
      *
-     * This is used and should only be used for inlining finally blocks where
-     * jsr instructions used to be. It is somewhat hackish, but implementing
-     * a clone() operation would take much, much more effort.
+     * <p>This is used and should only be used for inlining finally blocks where jsr instructions
+     * used to be. It is somewhat hackish, but implementing a clone() operation would take much,
+     * much more effort.
      *
-     * This solution works for inlining finally blocks because you should never
-     * be writing any given block to the class file simultaneously. Therefore,
-     * an unlabeling will never occur in the middle of a block.
+     * <p>This solution works for inlining finally blocks because you should never be writing any
+     * given block to the class file simultaneously. Therefore, an unlabeling will never occur in
+     * the middle of a block.
      */
-    public void resetTargets()
-    {
+    public void resetTargets() {
         if (type == Token.FINALLY) {
             resetTargets_r();
         } else {
@@ -1037,8 +995,7 @@ public class Node implements Iterable<Node>
         }
     }
 
-    private void resetTargets_r()
-    {
+    private void resetTargets_r() {
         if (type == Token.TARGET || type == Token.YIELD || type == Token.YIELD_STAR) {
             labelId(-1);
         }
@@ -1050,8 +1007,7 @@ public class Node implements Iterable<Node>
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         if (Token.printTrees) {
             StringBuilder sb = new StringBuilder();
             toString(new ObjToIntMap(), sb);
@@ -1060,8 +1016,7 @@ public class Node implements Iterable<Node>
         return String.valueOf(type);
     }
 
-    private void toString(ObjToIntMap printIds, StringBuilder sb)
-    {
+    private void toString(ObjToIntMap printIds, StringBuilder sb) {
         if (Token.printTrees) {
             sb.append(Token.name(type));
             if (this instanceof Name) {
@@ -1075,29 +1030,27 @@ public class Node implements Iterable<Node>
                 }
             } else if (this instanceof Scope) {
                 if (this instanceof ScriptNode) {
-                    ScriptNode sof = (ScriptNode)this;
+                    ScriptNode sof = (ScriptNode) this;
                     if (this instanceof FunctionNode) {
-                        FunctionNode fn = (FunctionNode)this;
+                        FunctionNode fn = (FunctionNode) this;
                         sb.append(' ');
                         sb.append(fn.getName());
                     }
                     sb.append(" [source name: ");
                     sb.append(sof.getSourceName());
                     sb.append("] [encoded source length: ");
-                    sb.append(sof.getEncodedSourceEnd()
-                              - sof.getEncodedSourceStart());
+                    sb.append(sof.getEncodedSourceEnd() - sof.getEncodedSourceStart());
                     sb.append("] [base line: ");
                     sb.append(sof.getBaseLineno());
                     sb.append("] [end line: ");
                     sb.append(sof.getEndLineno());
                     sb.append(']');
                 }
-                if (((Scope)this).getSymbolTable() != null) {
+                if (((Scope) this).getSymbolTable() != null) {
                     sb.append(" [scope ");
                     appendPrintId(this, printIds, sb);
                     sb.append(": ");
-                    Iterator<String> iter =
-                        ((Scope) this).getSymbolTable().keySet().iterator();
+                    Iterator<String> iter = ((Scope) this).getSymbolTable().keySet().iterator();
                     while (iter.hasNext()) {
                         sb.append(iter.next());
                         sb.append(" ");
@@ -1105,7 +1058,7 @@ public class Node implements Iterable<Node>
                     sb.append("]");
                 }
             } else if (this instanceof Jump) {
-                Jump jump = (Jump)this;
+                Jump jump = (Jump) this;
                 if (type == Token.BREAK || type == Token.CONTINUE) {
                     sb.append(" [label: ");
                     appendPrintId(jump.getJumpStatement(), printIds, sb);
@@ -1123,9 +1076,7 @@ public class Node implements Iterable<Node>
                         appendPrintId(finallyTarget, printIds, sb);
                         sb.append(']');
                     }
-                } else if (type == Token.LABEL || type == Token.LOOP
-                           || type == Token.SWITCH)
-                {
+                } else if (type == Token.LABEL || type == Token.LOOP || type == Token.SWITCH) {
                     sb.append(" [break: ");
                     appendPrintId(jump.target, printIds, sb);
                     sb.append(']');
@@ -1158,59 +1109,59 @@ public class Node implements Iterable<Node>
                 sb.append(": ");
                 String value;
                 switch (type) {
-                  case TARGETBLOCK_PROP : // can't add this as it recurses
-                    value = "target block property";
-                    break;
-                  case LOCAL_BLOCK_PROP :     // can't add this as it is dull
-                    value = "last local block";
-                    break;
-                  case ISNUMBER_PROP:
-                    switch (x.intValue) {
-                      case BOTH:
-                        value = "both";
+                    case TARGETBLOCK_PROP: // can't add this as it recurses
+                        value = "target block property";
                         break;
-                      case RIGHT:
-                        value = "right";
+                    case LOCAL_BLOCK_PROP: // can't add this as it is dull
+                        value = "last local block";
                         break;
-                      case LEFT:
-                        value = "left";
+                    case ISNUMBER_PROP:
+                        switch (x.intValue) {
+                            case BOTH:
+                                value = "both";
+                                break;
+                            case RIGHT:
+                                value = "right";
+                                break;
+                            case LEFT:
+                                value = "left";
+                                break;
+                            default:
+                                throw Kit.codeBug();
+                        }
                         break;
-                      default:
-                        throw Kit.codeBug();
-                    }
-                    break;
-                  case SPECIALCALL_PROP:
-                    switch (x.intValue) {
-                      case SPECIALCALL_EVAL:
-                        value = "eval";
+                    case SPECIALCALL_PROP:
+                        switch (x.intValue) {
+                            case SPECIALCALL_EVAL:
+                                value = "eval";
+                                break;
+                            case SPECIALCALL_WITH:
+                                value = "with";
+                                break;
+                            default:
+                                // NON_SPECIALCALL should not be stored
+                                throw Kit.codeBug();
+                        }
                         break;
-                      case SPECIALCALL_WITH:
-                        value = "with";
+                    case OBJECT_IDS_PROP:
+                        {
+                            Object[] a = (Object[]) x.objectValue;
+                            value = "[";
+                            for (int i = 0; i < a.length; i++) {
+                                value += a[i].toString();
+                                if (i + 1 < a.length) value += ", ";
+                            }
+                            value += "]";
+                            break;
+                        }
+                    default:
+                        Object obj = x.objectValue;
+                        if (obj != null) {
+                            value = obj.toString();
+                        } else {
+                            value = String.valueOf(x.intValue);
+                        }
                         break;
-                      default:
-                        // NON_SPECIALCALL should not be stored
-                        throw Kit.codeBug();
-                    }
-                    break;
-                  case OBJECT_IDS_PROP: {
-                    Object[] a = (Object[]) x.objectValue;
-                    value = "[";
-                    for (int i=0; i < a.length; i++) {
-                        value += a[i].toString();
-                        if (i+1 < a.length)
-                            value += ", ";
-                    }
-                    value += "]";
-                    break;
-                  }
-                  default :
-                    Object obj = x.objectValue;
-                    if (obj != null) {
-                        value = obj.toString();
-                    } else {
-                        value = String.valueOf(x.intValue);
-                    }
-                    break;
                 }
                 sb.append(value);
                 sb.append(']');
@@ -1227,10 +1178,8 @@ public class Node implements Iterable<Node>
         return null;
     }
 
-    private static void toStringTreeHelper(ScriptNode treeTop, Node n,
-                                           ObjToIntMap printIds,
-                                           int level, StringBuilder sb)
-    {
+    private static void toStringTreeHelper(
+            ScriptNode treeTop, Node n, ObjToIntMap printIds, int level, StringBuilder sb) {
         if (Token.printTrees) {
             if (printIds == null) {
                 printIds = new ObjToIntMap();
@@ -1241,35 +1190,28 @@ public class Node implements Iterable<Node>
             }
             n.toString(printIds, sb);
             sb.append('\n');
-            for (Node cursor = n.getFirstChild(); cursor != null;
-                 cursor = cursor.getNext())
-            {
+            for (Node cursor = n.getFirstChild(); cursor != null; cursor = cursor.getNext()) {
                 if (cursor.getType() == Token.FUNCTION) {
                     int fnIndex = cursor.getExistingIntProp(Node.FUNCTION_PROP);
                     FunctionNode fn = treeTop.getFunctionNode(fnIndex);
                     toStringTreeHelper(fn, fn, null, level + 1, sb);
                 } else {
-                    toStringTreeHelper(treeTop, cursor, printIds, level+1, sb);
+                    toStringTreeHelper(treeTop, cursor, printIds, level + 1, sb);
                 }
             }
         }
     }
 
-    private static void generatePrintIds(Node n, ObjToIntMap map)
-    {
+    private static void generatePrintIds(Node n, ObjToIntMap map) {
         if (Token.printTrees) {
             map.put(n, map.size());
-            for (Node cursor = n.getFirstChild(); cursor != null;
-                 cursor = cursor.getNext())
-            {
+            for (Node cursor = n.getFirstChild(); cursor != null; cursor = cursor.getNext()) {
                 generatePrintIds(cursor, map);
             }
         }
     }
 
-    private static void appendPrintId(Node n, ObjToIntMap printIds,
-                                      StringBuilder sb)
-    {
+    private static void appendPrintId(Node n, ObjToIntMap printIds, StringBuilder sb) {
         if (Token.printTrees) {
             if (n != null) {
                 int id = printIds.get(n, -1);
@@ -1284,16 +1226,15 @@ public class Node implements Iterable<Node>
     }
 
     protected int type = Token.ERROR; // type of the node, e.g. Token.NAME
-    protected Node next;             // next sibling
-    protected Node first;    // first element of a linked list of children
-    protected Node last;     // last element of a linked list of children
+    protected Node next; // next sibling
+    protected Node first; // first element of a linked list of children
+    protected Node last; // last element of a linked list of children
     protected int lineno = -1;
 
     /**
-     * Linked list of properties. Since vast majority of nodes would have
-     * no more then 2 properties, linked list saves memory and provides
-     * fast lookup. If this does not holds, propListHead can be replaced
-     * by UintMap.
+     * Linked list of properties. Since vast majority of nodes would have no more then 2 properties,
+     * linked list saves memory and provides fast lookup. If this does not holds, propListHead can
+     * be replaced by UintMap.
      */
     protected PropListItem propListHead;
 }

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.mozilla.javascript.ast.ArrayComprehension;
 import org.mozilla.javascript.ast.ArrayComprehensionLoop;
 import org.mozilla.javascript.ast.ArrayLiteral;
@@ -83,38 +82,32 @@ import org.mozilla.javascript.ast.XmlString;
 import org.mozilla.javascript.ast.Yield;
 
 /**
- * This class implements the JavaScript parser.<p>
+ * This class implements the JavaScript parser.
  *
- * It is based on the SpiderMonkey C source files jsparse.c and jsparse.h in the
- * jsref package.<p>
+ * <p>It is based on the SpiderMonkey C source files jsparse.c and jsparse.h in the jsref package.
  *
- * The parser generates an {@link AstRoot} parse tree representing the source
- * code.  No tree rewriting is permitted at this stage, so that the parse tree
- * is a faithful representation of the source for frontend processing tools and
- * IDEs.<p>
+ * <p>The parser generates an {@link AstRoot} parse tree representing the source code. No tree
+ * rewriting is permitted at this stage, so that the parse tree is a faithful representation of the
+ * source for frontend processing tools and IDEs.
  *
- * This parser implementation is not intended to be reused after a parse
- * finishes, and will throw an IllegalStateException() if invoked again.<p>
+ * <p>This parser implementation is not intended to be reused after a parse finishes, and will throw
+ * an IllegalStateException() if invoked again.
+ *
+ * <p>
  *
  * @see TokenStream
- *
  * @author Mike McCabe
  * @author Brendan Eich
  */
-public class Parser
-{
-    /**
-     * Maximum number of allowed function or constructor arguments,
-     * to follow SpiderMonkey.
-     */
+public class Parser {
+    /** Maximum number of allowed function or constructor arguments, to follow SpiderMonkey. */
     public static final int ARGC_LIMIT = 1 << 16;
 
     // TokenInformation flags : currentFlaggedToken stores them together
     // with token type
-    final static int
-        CLEAR_TI_MASK    = 0xFFFF,  // mask to clear token information bits
-        TI_AFTER_EOL     = 1 << 16, // first token of the source line
-        TI_CHECK_LABEL   = 1 << 17; // indicates to check for label
+    static final int CLEAR_TI_MASK = 0xFFFF, // mask to clear token information bits
+            TI_AFTER_EOL = 1 << 16, // first token of the source line
+            TI_CHECK_LABEL = 1 << 17; // indicates to check for label
 
     CompilerEnvirons compilerEnv;
     private ErrorReporter errorReporter;
@@ -122,8 +115,8 @@ public class Parser
     private String sourceURI;
     private char[] sourceChars;
 
-    boolean calledByCompileFunction;  // ugly - set directly by Context
-    private boolean parseFinished;  // set when finished to prevent reuse
+    boolean calledByCompileFunction; // ugly - set directly by Context
+    private boolean parseFinished; // set when finished to prevent reuse
 
     private TokenStream ts;
     private int currentFlaggedToken = Token.EOF;
@@ -143,8 +136,8 @@ public class Parser
     ScriptNode currentScriptOrFn;
     Scope currentScope;
     private int endFlags;
-    private boolean inForInit;  // bound temporarily during forStatement()
-    private Map<String,LabeledStatement> labelSet;
+    private boolean inForInit; // bound temporarily during forStatement()
+    private Map<String, LabeledStatement> labelSet;
     private List<Loop> loopSet;
     private List<Jump> loopAndSwitchSet;
     // end of per function variables
@@ -159,8 +152,7 @@ public class Parser
     private boolean defaultUseStrictDirective;
 
     // Exception to unwind
-    private static class ParserException extends RuntimeException
-    {
+    private static class ParserException extends RuntimeException {
         private static final long serialVersionUID = 5882582646773765630L;
     }
 
@@ -176,7 +168,7 @@ public class Parser
         this.compilerEnv = compilerEnv;
         this.errorReporter = errorReporter;
         if (errorReporter instanceof IdeErrorReporter) {
-            errorCollector = (IdeErrorReporter)errorReporter;
+            errorCollector = (IdeErrorReporter) errorReporter;
         }
     }
 
@@ -190,10 +182,8 @@ public class Parser
         addStrictWarning(messageId, messageArg, beg, end);
     }
 
-    void addStrictWarning(String messageId, String messageArg,
-                          int position, int length) {
-        if (compilerEnv.isStrictMode())
-            addWarning(messageId, messageArg, position, length);
+    void addStrictWarning(String messageId, String messageArg, int position, int length) {
+        if (compilerEnv.isStrictMode()) addWarning(messageId, messageArg, position, length);
     }
 
     void addWarning(String messageId, String messageArg) {
@@ -209,17 +199,14 @@ public class Parser
         addWarning(messageId, null, position, length);
     }
 
-    void addWarning(String messageId, String messageArg,
-                    int position, int length)
-    {
+    void addWarning(String messageId, String messageArg, int position, int length) {
         String message = lookupMessage(messageId, messageArg);
         if (compilerEnv.reportWarningAsError()) {
             addError(messageId, messageArg, position, length);
         } else if (errorCollector != null) {
             errorCollector.warning(message, sourceURI, position, length);
         } else {
-            errorReporter.warning(message, sourceURI, ts.getLineno(),
-                                  ts.getLine(), ts.getOffset());
+            errorReporter.warning(message, sourceURI, ts.getLineno(), ts.getLine(), ts.getOffset());
         }
     }
 
@@ -232,18 +219,15 @@ public class Parser
     }
 
     void addError(String messageId, String messageArg) {
-        addError(messageId, messageArg, ts.tokenBeg,
-                 ts.tokenEnd - ts.tokenBeg);
+        addError(messageId, messageArg, ts.tokenBeg, ts.tokenEnd - ts.tokenBeg);
     }
 
     void addError(String messageId, int c) {
-        String messageArg = Character.toString ((char) c);
-        addError(messageId, messageArg, ts.tokenBeg,
-                 ts.tokenEnd - ts.tokenBeg);
+        String messageArg = Character.toString((char) c);
+        addError(messageId, messageArg, ts.tokenBeg, ts.tokenEnd - ts.tokenBeg);
     }
 
-    void addError(String messageId, String messageArg, int position, int length)
-    {
+    void addError(String messageId, String messageArg, int position, int length) {
         ++syntaxErrorCount;
         String message = lookupMessage(messageId, messageArg);
         if (errorCollector != null) {
@@ -251,7 +235,7 @@ public class Parser
         } else {
             int lineno = 1, offset = 1;
             String line = "";
-            if (ts != null) {  // happens in some regression tests
+            if (ts != null) { // happens in some regression tests
                 lineno = ts.getLineno();
                 line = ts.getLine();
                 offset = ts.getOffset();
@@ -260,17 +244,27 @@ public class Parser
         }
     }
 
-    private void addStrictWarning(String messageId, String messageArg,
-                                  int position, int length,
-                                  int line, String lineSource, int lineOffset) {
+    private void addStrictWarning(
+            String messageId,
+            String messageArg,
+            int position,
+            int length,
+            int line,
+            String lineSource,
+            int lineOffset) {
         if (compilerEnv.isStrictMode()) {
             addWarning(messageId, messageArg, position, length, line, lineSource, lineOffset);
         }
     }
 
-    private void addWarning(String messageId, String messageArg,
-                            int position, int length,
-                            int line, String lineSource, int lineOffset) {
+    private void addWarning(
+            String messageId,
+            String messageArg,
+            int position,
+            int length,
+            int line,
+            String lineSource,
+            int lineOffset) {
         String message = lookupMessage(messageId, messageArg);
         if (compilerEnv.reportWarningAsError()) {
             addError(messageId, messageArg, position, length, line, lineSource, lineOffset);
@@ -281,9 +275,14 @@ public class Parser
         }
     }
 
-    private void addError(String messageId, String messageArg,
-                          int position, int length,
-                          int line, String lineSource, int lineOffset) {
+    private void addError(
+            String messageId,
+            String messageArg,
+            int position,
+            int length,
+            int line,
+            String lineSource,
+            int lineOffset) {
         ++syntaxErrorCount;
         String message = lookupMessage(messageId, messageArg);
         if (errorCollector != null) {
@@ -299,8 +298,8 @@ public class Parser
 
     String lookupMessage(String messageId, String messageArg) {
         return messageArg == null
-            ? ScriptRuntime.getMessageById(messageId)
-            : ScriptRuntime.getMessageById(messageId, messageArg);
+                ? ScriptRuntime.getMessageById(messageId)
+                : ScriptRuntime.getMessageById(messageId, messageArg);
     }
 
     void reportError(String messageId) {
@@ -308,22 +307,18 @@ public class Parser
     }
 
     void reportError(String messageId, String messageArg) {
-        if (ts == null) {  // happens in some regression tests
+        if (ts == null) { // happens in some regression tests
             reportError(messageId, messageArg, 1, 1);
         } else {
-            reportError(messageId, messageArg, ts.tokenBeg,
-                        ts.tokenEnd - ts.tokenBeg);
+            reportError(messageId, messageArg, ts.tokenBeg, ts.tokenEnd - ts.tokenBeg);
         }
     }
 
-    void reportError(String messageId, int position, int length)
-    {
+    void reportError(String messageId, int position, int length) {
         reportError(messageId, null, position, length);
     }
 
-    void reportError(String messageId, String messageArg, int position,
-                     int length)
-    {
+    void reportError(String messageId, String messageArg, int position, int length) {
         addError(messageId, messageArg, position, length);
 
         if (!compilerEnv.recoverFromErrors()) {
@@ -342,16 +337,12 @@ public class Parser
         if (scannedComments == null) {
             scannedComments = new ArrayList<Comment>();
         }
-        Comment commentNode = new Comment(ts.tokenBeg,
-                                          ts.getTokenLength(),
-                                          ts.commentType,
-                                          comment);
-        if (ts.commentType == Token.CommentType.JSDOC &&
-                compilerEnv.isRecordingLocalJsDocComments()) {
-            Comment jsDocCommentNode = new Comment(ts.tokenBeg,
-                    ts.getTokenLength(),
-                    ts.commentType,
-                    comment);
+        Comment commentNode =
+                new Comment(ts.tokenBeg, ts.getTokenLength(), ts.commentType, comment);
+        if (ts.commentType == Token.CommentType.JSDOC
+                && compilerEnv.isRecordingLocalJsDocComments()) {
+            Comment jsDocCommentNode =
+                    new Comment(ts.tokenBeg, ts.getTokenLength(), ts.commentType, comment);
             currentJsDocComment = jsDocCommentNode;
             currentJsDocComment.setLineno(lineno);
         }
@@ -364,7 +355,6 @@ public class Parser
         currentJsDocComment = null;
         return saved;
     }
-
 
     // Returns the next token without consuming it.
     // If previous token was consumed, calls scanner to get new token.
@@ -381,9 +371,7 @@ public class Parser
     //
     // Note that this function always returned the un-flagged token!
     // The flags, if any, are saved in currentFlaggedToken.
-    private int peekToken()
-        throws IOException
-    {
+    private int peekToken() throws IOException {
         // By far the most common case:  last token hasn't been consumed,
         // so return already-peeked token.
         if (currentFlaggedToken != Token.EOF) {
@@ -412,12 +400,10 @@ public class Parser
 
         currentToken = tt;
         currentFlaggedToken = tt | (sawEOL ? TI_AFTER_EOL : 0);
-        return currentToken;  // return unflagged token
+        return currentToken; // return unflagged token
     }
 
-    private int peekFlaggedToken()
-        throws IOException
-    {
+    private int peekFlaggedToken() throws IOException {
         peekToken();
         return currentFlaggedToken;
     }
@@ -426,19 +412,15 @@ public class Parser
         currentFlaggedToken = Token.EOF;
     }
 
-    private int nextToken()
-        throws IOException
-    {
+    private int nextToken() throws IOException {
         int tt = peekToken();
         consumeToken();
         return tt;
     }
 
-    private boolean matchToken(int toMatch, boolean ignoreComment)
-        throws IOException
-    {
+    private boolean matchToken(int toMatch, boolean ignoreComment) throws IOException {
         int tt = peekToken();
-        while(tt == Token.COMMENT && ignoreComment) {
+        while (tt == Token.COMMENT && ignoreComment) {
             consumeToken();
             tt = peekToken();
         }
@@ -454,9 +436,7 @@ public class Parser
     // token types valid if they are preceded by a newline.  One example is the
     // postfix ++ or -- operator, which has to be on the same line as its
     // operand.
-    private int peekTokenOrEOL()
-        throws IOException
-    {
+    private int peekTokenOrEOL() throws IOException {
         int tt = peekToken();
         // Check for last peeked token flags
         if ((currentFlaggedToken & TI_AFTER_EOL) != 0) {
@@ -466,15 +446,13 @@ public class Parser
     }
 
     private boolean mustMatchToken(int toMatch, String messageId, boolean ignoreComment)
-        throws IOException
-    {
-        return mustMatchToken(toMatch, messageId, ts.tokenBeg,
-                              ts.tokenEnd - ts.tokenBeg, ignoreComment);
+            throws IOException {
+        return mustMatchToken(
+                toMatch, messageId, ts.tokenBeg, ts.tokenEnd - ts.tokenBeg, ignoreComment);
     }
 
-    private boolean mustMatchToken(int toMatch, String msgId, int pos, int len, boolean ignoreComment)
-        throws IOException
-    {
+    private boolean mustMatchToken(
+            int toMatch, String msgId, int pos, int len, boolean ignoreComment) throws IOException {
         if (matchToken(toMatch, ignoreComment)) {
             return true;
         }
@@ -501,8 +479,7 @@ public class Parser
         // During codegen, parent scope chain may already be initialized,
         // in which case we just need to set currentScope variable.
         if (parent != null) {
-            if (parent != currentScope)
-                codeBug();
+            if (parent != currentScope) codeBug();
         } else {
             currentScope.addChildScope(scope);
         }
@@ -514,11 +491,9 @@ public class Parser
     }
 
     private void enterLoop(Loop loop) {
-        if (loopSet == null)
-            loopSet = new ArrayList<Loop>();
+        if (loopSet == null) loopSet = new ArrayList<Loop>();
         loopSet.add(loop);
-        if (loopAndSwitchSet == null)
-            loopAndSwitchSet = new ArrayList<Jump>();
+        if (loopAndSwitchSet == null) loopAndSwitchSet = new ArrayList<Jump>();
         loopAndSwitchSet.add(loop);
         pushScope(loop);
         if (currentLabel != null) {
@@ -541,14 +516,13 @@ public class Parser
     }
 
     private void restoreRelativeLoopPosition(Loop loop) {
-        if (loop.getParent() != null) {  // see comment in enterLoop
+        if (loop.getParent() != null) { // see comment in enterLoop
             loop.setRelative(loop.getParent().getPosition());
         }
     }
 
     private void enterSwitch(SwitchStatement node) {
-        if (loopAndSwitchSet == null)
-            loopAndSwitchSet = new ArrayList<Jump>();
+        if (loopAndSwitchSet == null) loopAndSwitchSet = new ArrayList<Jump>();
         loopAndSwitchSet.add(node);
     }
 
@@ -559,13 +533,11 @@ public class Parser
     /**
      * Builds a parse tree from the given source string.
      *
-     * @return an {@link AstRoot} object representing the parsed program.  If
-     * the parse fails, {@code null} will be returned.  (The parse failure will
-     * result in a call to the {@link ErrorReporter} from
-     * {@link CompilerEnvirons}.)
+     * @return an {@link AstRoot} object representing the parsed program. If the parse fails, {@code
+     *     null} will be returned. (The parse failure will result in a call to the {@link
+     *     ErrorReporter} from {@link CompilerEnvirons}.)
      */
-    public AstRoot parse(String sourceString, String sourceURI, int lineno)
-    {
+    public AstRoot parse(String sourceString, String sourceURI, int lineno) {
         if (parseFinished) throw new IllegalStateException("parser reused");
         this.sourceURI = sourceURI;
         if (compilerEnv.isIdeMode()) {
@@ -584,14 +556,13 @@ public class Parser
 
     /**
      * Builds a parse tree from the given sourcereader.
+     *
      * @see #parse(String,String,int)
      * @throws IOException if the {@link Reader} encounters an error
      * @deprecated use parse(String, String, int) instead
      */
-     @Deprecated
-    public AstRoot parse(Reader sourceReader, String sourceURI, int lineno)
-        throws IOException
-    {
+    @Deprecated
+    public AstRoot parse(Reader sourceReader, String sourceURI, int lineno) throws IOException {
         if (parseFinished) throw new IllegalStateException("parser reused");
         if (compilerEnv.isIdeMode()) {
             return parse(Kit.readReader(sourceReader), sourceURI, lineno);
@@ -605,14 +576,13 @@ public class Parser
         }
     }
 
-    private AstRoot parse() throws IOException
-    {
+    private AstRoot parse() throws IOException {
         int pos = 0;
         AstRoot root = new AstRoot(pos);
         currentScope = currentScriptOrFn = root;
 
-        int baseLineno = ts.lineno;  // line number where source starts
-        int end = pos;  // in case source is empty
+        int baseLineno = ts.lineno; // line number where source starts
+        int end = pos; // in case source is empty
 
         boolean inDirectivePrologue = true;
         boolean savedStrictMode = inUseStrictDirective;
@@ -623,7 +593,7 @@ public class Parser
         }
 
         try {
-            for (;;) {
+            for (; ; ) {
                 int tt = peekToken();
                 if (tt <= Token.EOF) {
                     break;
@@ -633,14 +603,16 @@ public class Parser
                 if (tt == Token.FUNCTION) {
                     consumeToken();
                     try {
-                        n = function(calledByCompileFunction
-                                     ? FunctionNode.FUNCTION_EXPRESSION
-                                     : FunctionNode.FUNCTION_STATEMENT);
+                        n =
+                                function(
+                                        calledByCompileFunction
+                                                ? FunctionNode.FUNCTION_EXPRESSION
+                                                : FunctionNode.FUNCTION_STATEMENT);
                     } catch (ParserException e) {
                         break;
                     }
-                } else if(tt == Token.COMMENT) {
-                    n = scannedComments.get(scannedComments.size()-1);
+                } else if (tt == Token.COMMENT) {
+                    n = scannedComments.get(scannedComments.size() - 1);
                     consumeToken();
                 } else {
                     n = statement();
@@ -661,8 +633,7 @@ public class Parser
         } catch (StackOverflowError ex) {
             String msg = lookupMessage("msg.too.deep.parser.recursion");
             if (!compilerEnv.isIdeMode())
-                throw Context.reportRuntimeError(msg, sourceURI,
-                                                 ts.lineno, null, 0);
+                throw Context.reportRuntimeError(msg, sourceURI, ts.lineno, null, 0);
         } finally {
             inUseStrictDirective = savedStrictMode;
         }
@@ -671,8 +642,7 @@ public class Parser
             String msg = String.valueOf(this.syntaxErrorCount);
             msg = lookupMessage("msg.got.syntax.errors", msg);
             if (!compilerEnv.isIdeMode())
-                throw errorReporter.runtimeError(msg, sourceURI, baseLineno,
-                                                 null, 0);
+                throw errorReporter.runtimeError(msg, sourceURI, baseLineno, null, 0);
         }
 
         // add comments to root in lexical order
@@ -693,12 +663,11 @@ public class Parser
         return root;
     }
 
-    private AstNode parseFunctionBody(int type, FunctionNode fnNode)
-        throws IOException
-    {
+    private AstNode parseFunctionBody(int type, FunctionNode fnNode) throws IOException {
         boolean isExpressionClosure = false;
         if (!matchToken(Token.LC, true)) {
-            if (compilerEnv.getLanguageVersion() < Context.VERSION_1_8 && type != FunctionNode.ARROW_FUNCTION) {
+            if (compilerEnv.getLanguageVersion() < Context.VERSION_1_8
+                    && type != FunctionNode.ARROW_FUNCTION) {
                 reportError("msg.no.brace.body");
             } else {
                 isExpressionClosure = true;
@@ -707,7 +676,7 @@ public class Parser
         boolean isArrow = type == FunctionNode.ARROW_FUNCTION;
         ++nestingOfFunction;
         int pos = ts.tokenBeg;
-        Block pn = new Block(pos);  // starts at LC position
+        Block pn = new Block(pos); // starts at LC position
 
         // Function code that is supplied as the arguments to the built-in
         // Function, Generator, and AsyncFunction constructors is strict mode code
@@ -721,7 +690,9 @@ public class Parser
         try {
             if (isExpressionClosure) {
                 AstNode returnValue = assignExpr();
-                ReturnStatement n = new ReturnStatement(returnValue.getPosition(), returnValue.getLength(), returnValue);
+                ReturnStatement n =
+                        new ReturnStatement(
+                                returnValue.getPosition(), returnValue.getLength(), returnValue);
                 // expression closure flag is required on both nodes
                 n.putProp(Node.EXPRESSION_CLOSURE_PROP, Boolean.TRUE);
                 pn.putProp(Node.EXPRESSION_CLOSURE_PROP, Boolean.TRUE);
@@ -730,7 +701,8 @@ public class Parser
                 }
                 pn.addStatement(n);
             } else {
-                bodyLoop: for (;;) {
+                bodyLoop:
+                for (; ; ) {
                     AstNode n;
                     int tt = peekToken();
                     switch (tt) {
@@ -740,7 +712,7 @@ public class Parser
                             break bodyLoop;
                         case Token.COMMENT:
                             consumeToken();
-                            n = scannedComments.get(scannedComments.size()-1);
+                            n = scannedComments.get(scannedComments.size() - 1);
                             break;
                         case Token.FUNCTION:
                             consumeToken();
@@ -790,9 +762,7 @@ public class Parser
         return null;
     }
 
-    private void  parseFunctionParams(FunctionNode fnNode)
-        throws IOException
-    {
+    private void parseFunctionParams(FunctionNode fnNode) throws IOException {
         if (matchToken(Token.RP, true)) {
             fnNode.setRp(ts.tokenBeg - fnNode.getPosition());
             return;
@@ -821,15 +791,13 @@ public class Parser
                     Name paramNameNode = createNameNode();
                     Comment jsdocNodeForName = getAndResetJsDoc();
                     if (jsdocNodeForName != null) {
-                      paramNameNode.setJsDocNode(jsdocNodeForName);
+                        paramNameNode.setJsDocNode(jsdocNodeForName);
                     }
                     fnNode.addParam(paramNameNode);
                     String paramName = ts.getString();
                     defineSymbol(Token.LP, paramName);
                     if (this.inUseStrictDirective) {
-                        if ("eval".equals(paramName) ||
-                            "arguments".equals(paramName))
-                        {
+                        if ("eval".equals(paramName) || "arguments".equals(paramName)) {
                             reportError("msg.bad.id.strict", paramName);
                         }
                         if (paramNames.contains(paramName))
@@ -845,11 +813,11 @@ public class Parser
         if (destructuring != null) {
             Node destructuringNode = new Node(Token.COMMA);
             // Add assignment helper for each destructuring parameter
-            for (Map.Entry<String, Node> param: destructuring.entrySet()) {
-                Node assign = createDestructuringAssignment(Token.VAR,
-                        param.getValue(), createName(param.getKey()));
+            for (Map.Entry<String, Node> param : destructuring.entrySet()) {
+                Node assign =
+                        createDestructuringAssignment(
+                                Token.VAR, param.getValue(), createName(param.getKey()));
                 destructuringNode.addChildToBack(assign);
-
             }
             fnNode.putProp(Node.DESTRUCTURING_PARAMS, destructuringNode);
         }
@@ -859,17 +827,14 @@ public class Parser
         }
     }
 
-    private FunctionNode function(int type)
-        throws IOException {
+    private FunctionNode function(int type) throws IOException {
         return function(type, false);
     }
 
-    private FunctionNode function(int type, boolean isGenerator)
-        throws IOException
-    {
+    private FunctionNode function(int type, boolean isGenerator) throws IOException {
         int syntheticType = type;
-        int baseLineno = ts.lineno;  // line number where source starts
-        int functionSourceStart = ts.tokenBeg;  // start of "function" kwd
+        int baseLineno = ts.lineno; // line number where source starts
+        int functionSourceStart = ts.tokenBeg; // start of "function" kwd
         Name name = null;
         AstNode memberExprNode = null;
 
@@ -877,7 +842,7 @@ public class Parser
             name = createNameNode(true, Token.NAME);
             if (inUseStrictDirective) {
                 String id = name.getIdentifier();
-                if ("eval".equals(id)|| "arguments".equals(id)) {
+                if ("eval".equals(id) || "arguments".equals(id)) {
                     reportError("msg.bad.id.strict", id);
                 }
             }
@@ -891,8 +856,8 @@ public class Parser
             }
         } else if (matchToken(Token.LP, true)) {
             // Anonymous function:  leave name as null
-        } else if (matchToken(Token.MUL, true) &&
-                   (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6)) {
+        } else if (matchToken(Token.MUL, true)
+                && (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6)) {
             // ES6 generator function
             return function(type, true);
         } else {
@@ -911,7 +876,8 @@ public class Parser
         }
 
         if (syntheticType != FunctionNode.FUNCTION_EXPRESSION
-            && name != null && name.length() > 0) {
+                && name != null
+                && name.length() > 0) {
             // Function statements define a symbol in the enclosing scope
             defineSymbol(Token.FUNCTION, name.getIdentifier());
         }
@@ -921,8 +887,7 @@ public class Parser
         if (isGenerator) {
             fnNode.setIsES6Generator();
         }
-        if (lpPos != -1)
-            fnNode.setLp(lpPos - functionSourceStart);
+        if (lpPos != -1) fnNode.setLp(lpPos - functionSourceStart);
 
         fnNode.setJsDocNode(getAndResetJsDoc());
 
@@ -933,11 +898,11 @@ public class Parser
             fnNode.setEncodedSourceBounds(functionSourceStart, ts.tokenEnd);
             fnNode.setLength(ts.tokenEnd - functionSourceStart);
 
-            if (compilerEnv.isStrictMode()
-                && !fnNode.getBody().hasConsistentReturnUsage()) {
-                String msg = (name != null && name.length() > 0)
-                           ? "msg.no.return.value"
-                           : "msg.anon.no.return.value";
+            if (compilerEnv.isStrictMode() && !fnNode.getBody().hasConsistentReturnUsage()) {
+                String msg =
+                        (name != null && name.length() > 0)
+                                ? "msg.no.return.value"
+                                : "msg.anon.no.return.value";
                 addStrictWarning(msg, name == null ? "" : name.getIdentifier());
             }
         } finally {
@@ -947,7 +912,7 @@ public class Parser
         if (memberExprNode != null) {
             // TODO(stevey): fix missing functionality
             Kit.codeBug();
-            fnNode.setMemberExprNode(memberExprNode);  // rewrite later
+            fnNode.setMemberExprNode(memberExprNode); // rewrite later
             /* old code:
             if (memberExprNode != null) {
                 pn = nf.createAssignment(Token.ASSIGN, memberExprNode, pn);
@@ -974,8 +939,9 @@ public class Parser
     }
 
     private AstNode arrowFunction(AstNode params) throws IOException {
-        int baseLineno = ts.lineno;  // line number where source starts
-        int functionSourceStart = params != null ? params.getPosition() : -1;  // start of "function" kwd
+        int baseLineno = ts.lineno; // line number where source starts
+        int functionSourceStart =
+                params != null ? params.getPosition() : -1; // start of "function" kwd
 
         FunctionNode fnNode = new FunctionNode(functionSourceStart);
         fnNode.setFunctionType(FunctionNode.ARROW_FUNCTION);
@@ -990,7 +956,7 @@ public class Parser
         try {
             if (params instanceof ParenthesizedExpression) {
                 fnNode.setParens(0, params.getLength());
-                AstNode p = ((ParenthesizedExpression)params).getExpression();
+                AstNode p = ((ParenthesizedExpression) params).getExpression();
                 if (!(p instanceof EmptyExpression)) {
                     arrowFunctionParams(fnNode, p, destructuring, paramNames);
                 }
@@ -1001,11 +967,11 @@ public class Parser
             if (!destructuring.isEmpty()) {
                 Node destructuringNode = new Node(Token.COMMA);
                 // Add assignment helper for each destructuring parameter
-                for (Map.Entry<String, Node> param: destructuring.entrySet()) {
-                    Node assign = createDestructuringAssignment(Token.VAR,
-                                                                param.getValue(), createName(param.getKey()));
+                for (Map.Entry<String, Node> param : destructuring.entrySet()) {
+                    Node assign =
+                            createDestructuringAssignment(
+                                    Token.VAR, param.getValue(), createName(param.getKey()));
                     destructuringNode.addChildToBack(assign);
-
                 }
                 fnNode.putProp(Node.DESTRUCTURING_PARAMS, destructuringNode);
             }
@@ -1029,7 +995,11 @@ public class Parser
         return fnNode;
     }
 
-    private void arrowFunctionParams(FunctionNode fnNode, AstNode params, Map<String, Node> destructuring, Set<String> paramNames) {
+    private void arrowFunctionParams(
+            FunctionNode fnNode,
+            AstNode params,
+            Map<String, Node> destructuring,
+            Set<String> paramNames) {
         if (params instanceof ArrayLiteral || params instanceof ObjectLiteral) {
             markDestructuring(params);
             fnNode.addParam(params);
@@ -1037,21 +1007,20 @@ public class Parser
             defineSymbol(Token.LP, pname, false);
             destructuring.put(pname, params);
         } else if (params instanceof InfixExpression && params.getType() == Token.COMMA) {
-            arrowFunctionParams(fnNode, ((InfixExpression)params).getLeft(), destructuring, paramNames);
-            arrowFunctionParams(fnNode, ((InfixExpression)params).getRight(), destructuring, paramNames);
+            arrowFunctionParams(
+                    fnNode, ((InfixExpression) params).getLeft(), destructuring, paramNames);
+            arrowFunctionParams(
+                    fnNode, ((InfixExpression) params).getRight(), destructuring, paramNames);
         } else if (params instanceof Name) {
             fnNode.addParam(params);
-            String paramName = ((Name)params).getIdentifier();
+            String paramName = ((Name) params).getIdentifier();
             defineSymbol(Token.LP, paramName);
 
             if (this.inUseStrictDirective) {
-                if ("eval".equals(paramName) ||
-                    "arguments".equals(paramName))
-                    {
-                        reportError("msg.bad.id.strict", paramName);
-                    }
-                if (paramNames.contains(paramName))
-                    addError("msg.dup.param.strict", paramName);
+                if ("eval".equals(paramName) || "arguments".equals(paramName)) {
+                    reportError("msg.bad.id.strict", paramName);
+                }
+                if (paramNames.contains(paramName)) addError("msg.dup.param.strict", paramName);
                 paramNames.add(paramName);
             }
         } else {
@@ -1069,8 +1038,8 @@ public class Parser
     // node are given relative start positions and correct lengths.
 
     private AstNode statements(AstNode parent) throws IOException {
-        if (currentToken != Token.LC  // assertion can be invalid in bad code
-            && !compilerEnv.isIdeMode()) codeBug();
+        if (currentToken != Token.LC // assertion can be invalid in bad code
+                && !compilerEnv.isIdeMode()) codeBug();
         int pos = ts.tokenBeg;
         AstNode block = parent != null ? parent : new Block(pos);
         block.setLineno(ts.lineno);
@@ -1094,32 +1063,28 @@ public class Parser
     }
 
     // parse and return a parenthesized expression
-    private ConditionData condition()
-        throws IOException
-    {
+    private ConditionData condition() throws IOException {
         ConditionData data = new ConditionData();
 
-        if (mustMatchToken(Token.LP, "msg.no.paren.cond", true))
-            data.lp = ts.tokenBeg;
+        if (mustMatchToken(Token.LP, "msg.no.paren.cond", true)) data.lp = ts.tokenBeg;
 
         data.condition = expr();
 
-        if (mustMatchToken(Token.RP, "msg.no.paren.after.cond", true))
-            data.rp = ts.tokenBeg;
+        if (mustMatchToken(Token.RP, "msg.no.paren.after.cond", true)) data.rp = ts.tokenBeg;
 
         // Report strict warning on code like "if (a = 7) ...". Suppress the
         // warning if the condition is parenthesized, like "if ((a = 7)) ...".
         if (data.condition instanceof Assignment) {
-            addStrictWarning("msg.equal.as.assign", "",
-                             data.condition.getPosition(),
-                             data.condition.getLength());
+            addStrictWarning(
+                    "msg.equal.as.assign",
+                    "",
+                    data.condition.getPosition(),
+                    data.condition.getLength());
         }
         return data;
     }
 
-    private AstNode statement()
-        throws IOException
-    {
+    private AstNode statement() throws IOException {
         int pos = ts.tokenBeg;
         try {
             AstNode pn = statementHelper();
@@ -1127,14 +1092,19 @@ public class Parser
                 if (compilerEnv.isStrictMode() && !pn.hasSideEffects()) {
                     int beg = pn.getPosition();
                     beg = Math.max(beg, lineBeginningFor(beg));
-                    addStrictWarning(pn instanceof EmptyStatement
-                                     ? "msg.extra.trailing.semi"
-                                     : "msg.no.side.effects",
-                                     "", beg, nodeEnd(pn) - beg);
+                    addStrictWarning(
+                            pn instanceof EmptyStatement
+                                    ? "msg.extra.trailing.semi"
+                                    : "msg.no.side.effects",
+                            "",
+                            beg,
+                            nodeEnd(pn) - beg);
                 }
                 int ntt = peekToken();
-                if(ntt == Token.COMMENT && pn.getLineno() == scannedComments.get(scannedComments.size()-1).getLineno()) {
-                    pn.setInlineComment(scannedComments.get(scannedComments.size()-1));
+                if (ntt == Token.COMMENT
+                        && pn.getLineno()
+                                == scannedComments.get(scannedComments.size() - 1).getLineno()) {
+                    pn.setInlineComment(scannedComments.get(scannedComments.size() - 1));
                     consumeToken();
                 }
                 return pn;
@@ -1144,15 +1114,16 @@ public class Parser
         }
 
         // error:  skip ahead to a probable statement boundary
-        guessingStatementEnd: for (;;) {
+        guessingStatementEnd:
+        for (; ; ) {
             int tt = peekTokenOrEOL();
             consumeToken();
             switch (tt) {
-              case Token.ERROR:
-              case Token.EOF:
-              case Token.EOL:
-              case Token.SEMI:
-                break guessingStatementEnd;
+                case Token.ERROR:
+                case Token.EOF:
+                case Token.EOL:
+                case Token.SEMI:
+                    break guessingStatementEnd;
             }
         }
         // We don't make error nodes explicitly part of the tree;
@@ -1161,116 +1132,109 @@ public class Parser
         return new EmptyStatement(pos, ts.tokenBeg - pos);
     }
 
-    private AstNode statementHelper()
-        throws IOException
-    {
+    private AstNode statementHelper() throws IOException {
         // If the statement is set, then it's been told its label by now.
-        if (currentLabel != null && currentLabel.getStatement() != null)
-            currentLabel = null;
+        if (currentLabel != null && currentLabel.getStatement() != null) currentLabel = null;
 
         AstNode pn = null;
         int tt = peekToken(), pos = ts.tokenBeg;
 
         switch (tt) {
-          case Token.IF:
-              return ifStatement();
+            case Token.IF:
+                return ifStatement();
 
-          case Token.SWITCH:
-              return switchStatement();
+            case Token.SWITCH:
+                return switchStatement();
 
-          case Token.WHILE:
-              return whileLoop();
+            case Token.WHILE:
+                return whileLoop();
 
-          case Token.DO:
-              return doLoop();
+            case Token.DO:
+                return doLoop();
 
-          case Token.FOR:
-              return forLoop();
+            case Token.FOR:
+                return forLoop();
 
-          case Token.TRY:
-              return tryStatement();
+            case Token.TRY:
+                return tryStatement();
 
-          case Token.THROW:
-              pn = throwStatement();
-              break;
+            case Token.THROW:
+                pn = throwStatement();
+                break;
 
-          case Token.BREAK:
-              pn = breakStatement();
-              break;
+            case Token.BREAK:
+                pn = breakStatement();
+                break;
 
-          case Token.CONTINUE:
-              pn = continueStatement();
-              break;
+            case Token.CONTINUE:
+                pn = continueStatement();
+                break;
 
-          case Token.WITH:
-              if (this.inUseStrictDirective) {
-                  reportError("msg.no.with.strict");
-              }
-              return withStatement();
+            case Token.WITH:
+                if (this.inUseStrictDirective) {
+                    reportError("msg.no.with.strict");
+                }
+                return withStatement();
 
-          case Token.CONST:
-          case Token.VAR:
-              consumeToken();
-              int lineno = ts.lineno;
-              pn = variables(currentToken, ts.tokenBeg, true);
-              pn.setLineno(lineno);
-              break;
+            case Token.CONST:
+            case Token.VAR:
+                consumeToken();
+                int lineno = ts.lineno;
+                pn = variables(currentToken, ts.tokenBeg, true);
+                pn.setLineno(lineno);
+                break;
 
-          case Token.LET:
-              pn = letStatement();
-              if (pn instanceof VariableDeclaration
-                  && peekToken() == Token.SEMI)
-                  break;
-              return pn;
+            case Token.LET:
+                pn = letStatement();
+                if (pn instanceof VariableDeclaration && peekToken() == Token.SEMI) break;
+                return pn;
 
-          case Token.RETURN:
-          case Token.YIELD:
-              pn = returnOrYield(tt, false);
-              break;
+            case Token.RETURN:
+            case Token.YIELD:
+                pn = returnOrYield(tt, false);
+                break;
 
-          case Token.DEBUGGER:
-              consumeToken();
-              pn = new KeywordLiteral(ts.tokenBeg,
-                                      ts.tokenEnd - ts.tokenBeg, tt);
-              pn.setLineno(ts.lineno);
-              break;
+            case Token.DEBUGGER:
+                consumeToken();
+                pn = new KeywordLiteral(ts.tokenBeg, ts.tokenEnd - ts.tokenBeg, tt);
+                pn.setLineno(ts.lineno);
+                break;
 
-          case Token.LC:
-              return block();
+            case Token.LC:
+                return block();
 
-          case Token.ERROR:
-              consumeToken();
-              return makeErrorNode();
+            case Token.ERROR:
+                consumeToken();
+                return makeErrorNode();
 
-          case Token.SEMI:
-              consumeToken();
-              pos = ts.tokenBeg;
-              pn = new EmptyStatement(pos, ts.tokenEnd - pos);
-              pn.setLineno(ts.lineno);
-              return pn;
+            case Token.SEMI:
+                consumeToken();
+                pos = ts.tokenBeg;
+                pn = new EmptyStatement(pos, ts.tokenEnd - pos);
+                pn.setLineno(ts.lineno);
+                return pn;
 
-          case Token.FUNCTION:
-              consumeToken();
-              return function(FunctionNode.FUNCTION_EXPRESSION_STATEMENT);
+            case Token.FUNCTION:
+                consumeToken();
+                return function(FunctionNode.FUNCTION_EXPRESSION_STATEMENT);
 
-          case Token.DEFAULT :
-              pn = defaultXmlNamespace();
-              break;
+            case Token.DEFAULT:
+                pn = defaultXmlNamespace();
+                break;
 
-          case Token.NAME:
-              pn = nameOrLabel();
-              if (pn instanceof ExpressionStatement)
-                  break;
-              return pn;  // LabeledStatement
-          case Token.COMMENT:
-              //Do not consume token here
-              pn = scannedComments.get(scannedComments.size()-1);
-              return pn;
-          default:
-              lineno = ts.lineno;
-              pn = new ExpressionStatement(expr(), !insideFunction());
-              pn.setLineno(lineno);
-              break;
+            case Token.NAME:
+                pn = nameOrLabel();
+                if (pn instanceof ExpressionStatement) break;
+                return pn; // LabeledStatement
+            case Token.COMMENT:
+                // Do not consume token here
+                pn = scannedComments.get(scannedComments.size() - 1);
+                return pn;
+            default:
+                lineno = ts.lineno;
+                pn = new ExpressionStatement(expr(), !insideFunction());
+                pn.setLineno(lineno);
+                break;
         }
 
         autoInsertSemicolon(pn);
@@ -1281,34 +1245,32 @@ public class Parser
         int ttFlagged = peekFlaggedToken();
         int pos = pn.getPosition();
         switch (ttFlagged & CLEAR_TI_MASK) {
-          case Token.SEMI:
-              // Consume ';' as a part of expression
-              consumeToken();
-              // extend the node bounds to include the semicolon.
-              pn.setLength(ts.tokenEnd - pos);
-              break;
-          case Token.ERROR:
-          case Token.EOF:
-          case Token.RC:
-              // Autoinsert ;
-              // Token.EOF can have negative length and negative nodeEnd(pn).
-              // So, make the end position at least pos+1.
-              warnMissingSemi(pos, Math.max(pos + 1, nodeEnd(pn)));
-              break;
-          default:
-              if ((ttFlagged & TI_AFTER_EOL) == 0) {
-                  // Report error if no EOL or autoinsert ; otherwise
-                  reportError("msg.no.semi.stmt");
-              } else {
-                  warnMissingSemi(pos, nodeEnd(pn));
-              }
-              break;
+            case Token.SEMI:
+                // Consume ';' as a part of expression
+                consumeToken();
+                // extend the node bounds to include the semicolon.
+                pn.setLength(ts.tokenEnd - pos);
+                break;
+            case Token.ERROR:
+            case Token.EOF:
+            case Token.RC:
+                // Autoinsert ;
+                // Token.EOF can have negative length and negative nodeEnd(pn).
+                // So, make the end position at least pos+1.
+                warnMissingSemi(pos, Math.max(pos + 1, nodeEnd(pn)));
+                break;
+            default:
+                if ((ttFlagged & TI_AFTER_EOL) == 0) {
+                    // Report error if no EOL or autoinsert ; otherwise
+                    reportError("msg.no.semi.stmt");
+                } else {
+                    warnMissingSemi(pos, nodeEnd(pn));
+                }
+                break;
         }
     }
 
-    private IfStatement ifStatement()
-        throws IOException
-    {
+    private IfStatement ifStatement() throws IOException {
         if (currentToken != Token.IF) codeBug();
         consumeToken();
         int pos = ts.tokenBeg, lineno = ts.lineno, elsePos = -1;
@@ -1317,8 +1279,8 @@ public class Parser
         AstNode ifTrue = getNextStatementAfterInlineComments(pn), ifFalse = null;
         if (matchToken(Token.ELSE, true)) {
             int tt = peekToken();
-            if(tt == Token.COMMENT) {
-                pn.setElseKeyWordInlineComment(scannedComments.get(scannedComments.size()-1));
+            if (tt == Token.COMMENT) {
+                pn.setElseKeyWordInlineComment(scannedComments.get(scannedComments.size() - 1));
                 consumeToken();
             }
             elsePos = ts.tokenBeg - pos;
@@ -1335,16 +1297,13 @@ public class Parser
         return pn;
     }
 
-    private SwitchStatement switchStatement()
-        throws IOException
-    {
+    private SwitchStatement switchStatement() throws IOException {
         if (currentToken != Token.SWITCH) codeBug();
         consumeToken();
         int pos = ts.tokenBeg;
 
         SwitchStatement pn = new SwitchStatement(pos);
-        if (mustMatchToken(Token.LP, "msg.no.paren.switch", true))
-            pn.setLp(ts.tokenBeg - pos);
+        if (mustMatchToken(Token.LP, "msg.no.paren.switch", true)) pn.setLp(ts.tokenBeg - pos);
         pn.setLineno(ts.lineno);
 
         AstNode discriminant = expr();
@@ -1359,7 +1318,8 @@ public class Parser
 
             boolean hasDefault = false;
             int tt;
-            switchLoop: for (;;) {
+            switchLoop:
+            for (; ; ) {
                 tt = nextToken();
                 int casePos = ts.tokenBeg;
                 int caseLineno = ts.lineno;
@@ -1382,7 +1342,7 @@ public class Parser
                         mustMatchToken(Token.COLON, "msg.no.colon.case", true);
                         break;
                     case Token.COMMENT:
-                        AstNode n = scannedComments.get(scannedComments.size()-1);
+                        AstNode n = scannedComments.get(scannedComments.size() - 1);
                         pn.addChild(n);
                         continue switchLoop;
                     default:
@@ -1392,17 +1352,17 @@ public class Parser
 
                 SwitchCase caseNode = new SwitchCase(casePos);
                 caseNode.setExpression(caseExpression);
-                caseNode.setLength(ts.tokenEnd - pos);  // include colon
+                caseNode.setLength(ts.tokenEnd - pos); // include colon
                 caseNode.setLineno(caseLineno);
 
                 while ((tt = peekToken()) != Token.RC
-                       && tt != Token.CASE
-                       && tt != Token.DEFAULT
-                       && tt != Token.EOF)
-                {
-                    if(tt == Token.COMMENT) {
+                        && tt != Token.CASE
+                        && tt != Token.DEFAULT
+                        && tt != Token.EOF) {
+                    if (tt == Token.COMMENT) {
                         Comment inlineComment = scannedComments.get(scannedComments.size() - 1);
-                        if (caseNode.getInlineComment() == null && inlineComment.getLineno() == caseNode.getLineno()) {
+                        if (caseNode.getInlineComment() == null
+                                && inlineComment.getLineno() == caseNode.getLineno()) {
                             caseNode.setInlineComment(inlineComment);
                         } else {
                             caseNode.addStatement(inlineComment);
@@ -1411,7 +1371,7 @@ public class Parser
                         continue;
                     }
                     AstNode nextStmt = statement();
-                    caseNode.addStatement(nextStmt);  // updates length
+                    caseNode.addStatement(nextStmt); // updates length
                 }
                 pn.addCase(caseNode);
             }
@@ -1421,9 +1381,7 @@ public class Parser
         return pn;
     }
 
-    private WhileLoop whileLoop()
-        throws IOException
-    {
+    private WhileLoop whileLoop() throws IOException {
         if (currentToken != Token.WHILE) codeBug();
         consumeToken();
         int pos = ts.tokenBeg;
@@ -1444,9 +1402,7 @@ public class Parser
         return pn;
     }
 
-    private DoLoop doLoop()
-        throws IOException
-    {
+    private DoLoop doLoop() throws IOException {
         if (currentToken != Token.DO) codeBug();
         consumeToken();
         int pos = ts.tokenBeg, end;
@@ -1498,21 +1454,19 @@ public class Parser
         return body;
     }
 
-    private Loop forLoop()
-        throws IOException
-    {
+    private Loop forLoop() throws IOException {
         if (currentToken != Token.FOR) codeBug();
         consumeToken();
         int forPos = ts.tokenBeg, lineno = ts.lineno;
         boolean isForEach = false, isForIn = false, isForOf = false;
         int eachPos = -1, inPos = -1, lp = -1, rp = -1;
-        AstNode init = null;  // init is also foo in 'foo in object'
-        AstNode cond = null;  // cond is also object in 'foo in object'
+        AstNode init = null; // init is also foo in 'foo in object'
+        AstNode cond = null; // cond is also object in 'foo in object'
         AstNode incr = null;
         Loop pn = null;
 
         Scope tempScope = new Scope();
-        pushScope(tempScope);  // decide below what AST class to use
+        pushScope(tempScope); // decide below what AST class to use
         try {
             // See if this is a for each () instead of just a for ()
             if (matchToken(Token.NAME, true)) {
@@ -1524,8 +1478,7 @@ public class Parser
                 }
             }
 
-            if (mustMatchToken(Token.LP, "msg.no.paren.for", true))
-                lp = ts.tokenBeg - forPos;
+            if (mustMatchToken(Token.LP, "msg.no.paren.for", true)) lp = ts.tokenBeg - forPos;
             int tt = peekToken();
 
             init = forLoopInit(tt);
@@ -1533,14 +1486,15 @@ public class Parser
                 isForIn = true;
                 inPos = ts.tokenBeg - forPos;
                 markDestructuring(init);
-                cond = expr();  // object over which we're iterating
-            } else if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6 &&
-                       matchToken(Token.NAME, true) && "of".equals(ts.getString())) {
+                cond = expr(); // object over which we're iterating
+            } else if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6
+                    && matchToken(Token.NAME, true)
+                    && "of".equals(ts.getString())) {
                 isForOf = true;
                 inPos = ts.tokenBeg - forPos;
                 markDestructuring(init);
-                cond = expr();  // object over which we're iterating
-            } else {  // ordinary for-loop
+                cond = expr(); // object over which we're iterating
+            } else { // ordinary for-loop
                 mustMatchToken(Token.SEMI, "msg.no.semi.for", true);
                 if (peekToken() == Token.SEMI) {
                     // no loop condition
@@ -1560,14 +1514,13 @@ public class Parser
                 }
             }
 
-            if (mustMatchToken(Token.RP, "msg.no.paren.for.ctrl", true))
-                rp = ts.tokenBeg - forPos;
+            if (mustMatchToken(Token.RP, "msg.no.paren.for.ctrl", true)) rp = ts.tokenBeg - forPos;
 
             if (isForIn || isForOf) {
                 ForInLoop fis = new ForInLoop(forPos);
                 if (init instanceof VariableDeclaration) {
                     // check that there was only one variable given
-                    if (((VariableDeclaration)init).getVariables().size() > 1) {
+                    if (((VariableDeclaration) init).getVariables().size() > 1) {
                         reportError("msg.mult.index");
                     }
                 }
@@ -1618,7 +1571,7 @@ public class Parser
 
     private AstNode forLoopInit(int tt) throws IOException {
         try {
-            inForInit = true;  // checked by variables() and relExpr()
+            inForInit = true; // checked by variables() and relExpr()
             AstNode init = null;
             if (tt == Token.SEMI) {
                 init = new EmptyExpression(ts.tokenBeg, 1);
@@ -1635,9 +1588,7 @@ public class Parser
         }
     }
 
-    private TryStatement tryStatement()
-        throws IOException
-    {
+    private TryStatement tryStatement() throws IOException {
         if (currentToken != Token.TRY) codeBug();
         consumeToken();
 
@@ -1647,10 +1598,10 @@ public class Parser
         int tryPos = ts.tokenBeg, lineno = ts.lineno, finallyPos = -1;
 
         TryStatement pn = new TryStatement(tryPos);
-        //Hnadled comment here because there should not be try without LC
+        // Hnadled comment here because there should not be try without LC
         int lctt = peekToken();
-        while(lctt == Token.COMMENT) {
-            Comment commentNode = scannedComments.get(scannedComments.size()-1);
+        while (lctt == Token.COMMENT) {
+            Comment commentNode = scannedComments.get(scannedComments.size() - 1);
             pn.setInlineComment(commentNode);
             consumeToken();
             lctt = peekToken();
@@ -1665,8 +1616,8 @@ public class Parser
 
         boolean sawDefaultCatch = false;
         int peek = peekToken();
-        while(peek == Token.COMMENT) {
-            Comment commentNode = scannedComments.get(scannedComments.size()-1);
+        while (peek == Token.COMMENT) {
+            Comment commentNode = scannedComments.get(scannedComments.size() - 1);
             pn.setInlineComment(commentNode);
             consumeToken();
             peek = peekToken();
@@ -1678,21 +1629,18 @@ public class Parser
                     reportError("msg.catch.unreachable");
                 }
                 int catchPos = ts.tokenBeg, lp = -1, rp = -1, guardPos = -1;
-                if (mustMatchToken(Token.LP, "msg.no.paren.catch", true))
-                    lp = ts.tokenBeg;
+                if (mustMatchToken(Token.LP, "msg.no.paren.catch", true)) lp = ts.tokenBeg;
 
                 mustMatchToken(Token.NAME, "msg.bad.catchcond", true);
 
                 Name varName = createNameNode();
                 Comment jsdocNodeForName = getAndResetJsDoc();
                 if (jsdocNodeForName != null) {
-                  varName.setJsDocNode(jsdocNodeForName);
+                    varName.setJsDocNode(jsdocNodeForName);
                 }
                 String varNameString = varName.getIdentifier();
                 if (inUseStrictDirective) {
-                    if ("eval".equals(varNameString) ||
-                        "arguments".equals(varNameString))
-                    {
+                    if ("eval".equals(varNameString) || "arguments".equals(varNameString)) {
                         reportError("msg.bad.id.strict", varNameString);
                     }
                 }
@@ -1705,11 +1653,10 @@ public class Parser
                     sawDefaultCatch = true;
                 }
 
-                if (mustMatchToken(Token.RP, "msg.bad.catchcond", true))
-                    rp = ts.tokenBeg;
+                if (mustMatchToken(Token.RP, "msg.bad.catchcond", true)) rp = ts.tokenBeg;
                 mustMatchToken(Token.LC, "msg.no.brace.catchblock", true);
 
-                Block catchBlock = (Block)statements();
+                Block catchBlock = (Block) statements();
                 tryEnd = getNodeEnd(catchBlock);
                 CatchClause catchNode = new CatchClause(catchPos);
                 catchNode.setVarName(varName);
@@ -1721,11 +1668,9 @@ public class Parser
                 catchNode.setParens(lp, rp);
                 catchNode.setLineno(catchLineNum);
 
-                if (mustMatchToken(Token.RC, "msg.no.brace.after.body", true))
-                    tryEnd = ts.tokenEnd;
+                if (mustMatchToken(Token.RC, "msg.no.brace.after.body", true)) tryEnd = ts.tokenEnd;
                 catchNode.setLength(tryEnd - catchPos);
-                if (clauses == null)
-                    clauses = new ArrayList<CatchClause>();
+                if (clauses == null) clauses = new ArrayList<CatchClause>();
                 clauses.add(catchNode);
             }
         } else if (peek != Token.FINALLY) {
@@ -1755,9 +1700,7 @@ public class Parser
         return pn;
     }
 
-    private ThrowStatement throwStatement()
-        throws IOException
-    {
+    private ThrowStatement throwStatement() throws IOException {
         if (currentToken != Token.THROW) codeBug();
         consumeToken();
         int pos = ts.tokenBeg, lineno = ts.lineno;
@@ -1778,9 +1721,7 @@ public class Parser
     // the peeked token was not a name.  Side effect:  sets scanner token
     // information for the label identifier (tokenBeg, tokenEnd, etc.)
 
-    private LabeledStatement matchJumpLabelName()
-        throws IOException
-    {
+    private LabeledStatement matchJumpLabelName() throws IOException {
         LabeledStatement label = null;
 
         if (peekTokenOrEOL() == Token.NAME) {
@@ -1796,9 +1737,7 @@ public class Parser
         return label;
     }
 
-    private BreakStatement breakStatement()
-        throws IOException
-    {
+    private BreakStatement breakStatement() throws IOException {
         if (currentToken != Token.BREAK) codeBug();
         consumeToken();
         int lineno = ts.lineno, pos = ts.tokenBeg, end = ts.tokenEnd;
@@ -1824,15 +1763,12 @@ public class Parser
         BreakStatement pn = new BreakStatement(pos, end - pos);
         pn.setBreakLabel(breakLabel);
         // can be null if it's a bad break in error-recovery mode
-        if (breakTarget != null)
-            pn.setBreakTarget(breakTarget);
+        if (breakTarget != null) pn.setBreakTarget(breakTarget);
         pn.setLineno(lineno);
         return pn;
     }
 
-    private ContinueStatement continueStatement()
-        throws IOException
-    {
+    private ContinueStatement continueStatement() throws IOException {
         if (currentToken != Token.CONTINUE) codeBug();
         consumeToken();
         int lineno = ts.lineno, pos = ts.tokenBeg, end = ts.tokenEnd;
@@ -1855,33 +1791,29 @@ public class Parser
             if (labels == null || !(labels.getStatement() instanceof Loop)) {
                 reportError("msg.continue.nonloop", pos, end - pos);
             }
-            target = labels == null ? null : (Loop)labels.getStatement();
+            target = labels == null ? null : (Loop) labels.getStatement();
         }
 
         ContinueStatement pn = new ContinueStatement(pos, end - pos);
-        if (target != null)  // can be null in error-recovery mode
-            pn.setTarget(target);
+        if (target != null) // can be null in error-recovery mode
+        pn.setTarget(target);
         pn.setLabel(label);
         pn.setLineno(lineno);
         return pn;
     }
 
-    private WithStatement withStatement()
-        throws IOException
-    {
+    private WithStatement withStatement() throws IOException {
         if (currentToken != Token.WITH) codeBug();
         consumeToken();
 
         Comment withComment = getAndResetJsDoc();
 
         int lineno = ts.lineno, pos = ts.tokenBeg, lp = -1, rp = -1;
-        if (mustMatchToken(Token.LP, "msg.no.paren.with", true))
-            lp = ts.tokenBeg;
+        if (mustMatchToken(Token.LP, "msg.no.paren.with", true)) lp = ts.tokenBeg;
 
         AstNode obj = expr();
 
-        if (mustMatchToken(Token.RP, "msg.no.paren.after.with", true))
-            rp = ts.tokenBeg;
+        if (mustMatchToken(Token.RP, "msg.no.paren.after.with", true)) rp = ts.tokenBeg;
 
         WithStatement pn = new WithStatement(pos);
         AstNode body = getNextStatementAfterInlineComments(pn);
@@ -1894,9 +1826,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode letStatement()
-        throws IOException
-    {
+    private AstNode letStatement() throws IOException {
         if (currentToken != Token.LET) codeBug();
         consumeToken();
         int lineno = ts.lineno, pos = ts.tokenBeg;
@@ -1904,7 +1834,7 @@ public class Parser
         if (peekToken() == Token.LP) {
             pn = let(true, pos);
         } else {
-            pn = variables(Token.LET, pos, true);  // else, e.g.: let x=6, y=7;
+            pn = variables(Token.LET, pos, true); // else, e.g.: let x=6, y=7;
         }
         pn.setLineno(lineno);
         return pn;
@@ -1912,49 +1842,51 @@ public class Parser
 
     /**
      * Returns whether or not the bits in the mask have changed to all set.
+     *
      * @param before bits before change
      * @param after bits after change
      * @param mask mask for bits
-     * @return {@code true} if all the bits in the mask are set in "after"
-     *          but not in "before"
+     * @return {@code true} if all the bits in the mask are set in "after" but not in "before"
      */
     private static final boolean nowAllSet(int before, int after, int mask) {
         return ((before & mask) != mask) && ((after & mask) == mask);
     }
 
-    private AstNode returnOrYield(int tt, boolean exprContext)
-        throws IOException
-    {
+    private AstNode returnOrYield(int tt, boolean exprContext) throws IOException {
         if (!insideFunction()) {
-            reportError(tt == Token.RETURN ? "msg.bad.return"
-                                           : "msg.bad.yield");
+            reportError(tt == Token.RETURN ? "msg.bad.return" : "msg.bad.yield");
         }
         consumeToken();
         int lineno = ts.lineno, pos = ts.tokenBeg, end = ts.tokenEnd;
 
         boolean yieldStar = false;
-        if ((tt == Token.YIELD) &&
-            (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) &&
-            (peekToken() == Token.MUL)) {
-          yieldStar = true;
-          consumeToken();
+        if ((tt == Token.YIELD)
+                && (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6)
+                && (peekToken() == Token.MUL)) {
+            yieldStar = true;
+            consumeToken();
         }
 
         AstNode e = null;
         // This is ugly, but we don't want to require a semicolon.
         switch (peekTokenOrEOL()) {
-          case Token.SEMI: case Token.RC:  case Token.RB:    case Token.RP:
-          case Token.EOF:  case Token.EOL: case Token.ERROR:
-            break;
-          case Token.YIELD:
-            if (compilerEnv.getLanguageVersion() < Context.VERSION_ES6) {
-                // Take extra care to preserve language compatibility
+            case Token.SEMI:
+            case Token.RC:
+            case Token.RB:
+            case Token.RP:
+            case Token.EOF:
+            case Token.EOL:
+            case Token.ERROR:
                 break;
-            }
-            // fallthrough
-          default:
-            e = expr();
-            end = getNodeEnd(e);
+            case Token.YIELD:
+                if (compilerEnv.getLanguageVersion() < Context.VERSION_ES6) {
+                    // Take extra care to preserve language compatibility
+                    break;
+                }
+                // fallthrough
+            default:
+                e = expr();
+                end = getNodeEnd(e);
         }
 
         int before = endFlags;
@@ -1965,12 +1897,10 @@ public class Parser
             ret = new ReturnStatement(pos, end - pos, e);
 
             // see if we need a strict mode warning
-            if (nowAllSet(before, endFlags,
-                    Node.END_RETURNS|Node.END_RETURNS_VALUE))
+            if (nowAllSet(before, endFlags, Node.END_RETURNS | Node.END_RETURNS_VALUE))
                 addStrictWarning("msg.return.inconsistent", "", pos, end - pos);
         } else {
-            if (!insideFunction())
-                reportError("msg.bad.yield");
+            if (!insideFunction()) reportError("msg.bad.yield");
             endFlags |= Node.END_YIELDS;
             ret = new Yield(pos, end - pos, e, yieldStar);
             setRequiresActivation();
@@ -1982,11 +1912,10 @@ public class Parser
 
         // see if we are mixing yields and value returns.
         if (insideFunction()
-            && nowAllSet(before, endFlags,
-                    Node.END_YIELDS|Node.END_RETURNS_VALUE)) {
-            FunctionNode fn = (FunctionNode)currentScriptOrFn;
+                && nowAllSet(before, endFlags, Node.END_YIELDS | Node.END_RETURNS_VALUE)) {
+            FunctionNode fn = (FunctionNode) currentScriptOrFn;
             if (!fn.isES6Generator()) {
-                Name name = ((FunctionNode)currentScriptOrFn).getFunctionName();
+                Name name = ((FunctionNode) currentScriptOrFn).getFunctionName();
                 if (name == null || name.length() == 0) {
                     addError("msg.anon.generator.returns", "");
                 } else {
@@ -1999,9 +1928,7 @@ public class Parser
         return ret;
     }
 
-    private AstNode block()
-        throws IOException
-    {
+    private AstNode block() throws IOException {
         if (currentToken != Token.LC) codeBug();
         consumeToken();
         int pos = ts.tokenBeg;
@@ -2018,9 +1945,7 @@ public class Parser
         }
     }
 
-    private AstNode defaultXmlNamespace()
-        throws IOException
-    {
+    private AstNode defaultXmlNamespace() throws IOException {
         if (currentToken != Token.DEFAULT) codeBug();
         consumeToken();
         mustHaveXML();
@@ -2047,25 +1972,21 @@ public class Parser
         return es;
     }
 
-    private void recordLabel(Label label, LabeledStatement bundle)
-        throws IOException
-    {
+    private void recordLabel(Label label, LabeledStatement bundle) throws IOException {
         // current token should be colon that primaryExpr left untouched
         if (peekToken() != Token.COLON) codeBug();
         consumeToken();
         String name = label.getName();
         if (labelSet == null) {
-            labelSet = new HashMap<String,LabeledStatement>();
+            labelSet = new HashMap<String, LabeledStatement>();
         } else {
             LabeledStatement ls = labelSet.get(name);
             if (ls != null) {
                 if (compilerEnv.isIdeMode()) {
                     Label dup = ls.getLabelByName(name);
-                    reportError("msg.dup.label",
-                                dup.getAbsolutePosition(), dup.getLength());
+                    reportError("msg.dup.label", dup.getAbsolutePosition(), dup.getLength());
                 }
-                reportError("msg.dup.label",
-                            label.getPosition(), label.getLength());
+                reportError("msg.dup.label", label.getPosition(), label.getLength());
             }
         }
         bundle.addLabel(label);
@@ -2073,14 +1994,11 @@ public class Parser
     }
 
     /**
-     * Found a name in a statement context.  If it's a label, we gather
-     * up any following labels and the next non-label statement into a
-     * {@link LabeledStatement} "bundle" and return that.  Otherwise we parse
-     * an expression and return it wrapped in an {@link ExpressionStatement}.
+     * Found a name in a statement context. If it's a label, we gather up any following labels and
+     * the next non-label statement into a {@link LabeledStatement} "bundle" and return that.
+     * Otherwise we parse an expression and return it wrapped in an {@link ExpressionStatement}.
      */
-    private AstNode nameOrLabel()
-        throws IOException
-    {
+    private AstNode nameOrLabel() throws IOException {
         if (currentToken != Token.NAME) throw codeBug();
         int pos = ts.tokenBeg;
 
@@ -2095,7 +2013,7 @@ public class Parser
         }
 
         LabeledStatement bundle = new LabeledStatement(pos);
-        recordLabel((Label)expr, bundle);
+        recordLabel((Label) expr, bundle);
         bundle.setLineno(ts.lineno);
         // look for more labels
         AstNode stmt = null;
@@ -2107,7 +2025,7 @@ public class Parser
                 autoInsertSemicolon(stmt);
                 break;
             }
-            recordLabel((Label)expr, bundle);
+            recordLabel((Label) expr, bundle);
         }
 
         // no more labels; now parse the labeled statement
@@ -2116,7 +2034,9 @@ public class Parser
             if (stmt == null) {
                 stmt = statementHelper();
                 int ntt = peekToken();
-                if(ntt == Token.COMMENT && stmt.getLineno() == scannedComments.get(scannedComments.size()-1).getLineno()) {
+                if (ntt == Token.COMMENT
+                        && stmt.getLineno()
+                                == scannedComments.get(scannedComments.size() - 1).getLineno()) {
                     stmt.setInlineComment(scannedComments.get(scannedComments.size() - 1));
                     consumeToken();
                 }
@@ -2131,26 +2051,22 @@ public class Parser
 
         // If stmt has parent assigned its position already is relative
         // (See bug #710225)
-        bundle.setLength(stmt.getParent() == null
-                     ? getNodeEnd(stmt) - pos
-                     : getNodeEnd(stmt));
+        bundle.setLength(stmt.getParent() == null ? getNodeEnd(stmt) - pos : getNodeEnd(stmt));
         bundle.setStatement(stmt);
         return bundle;
     }
 
     /**
-     * Parse a 'var' or 'const' statement, or a 'var' init list in a for
-     * statement.
-     * @param declType A token value: either VAR, CONST, or LET depending on
-     * context.
-     * @param pos the position where the node should start.  It's sometimes
-     * the var/const/let keyword, and other times the beginning of the first
-     * token in the first variable declaration.
+     * Parse a 'var' or 'const' statement, or a 'var' init list in a for statement.
+     *
+     * @param declType A token value: either VAR, CONST, or LET depending on context.
+     * @param pos the position where the node should start. It's sometimes the var/const/let
+     *     keyword, and other times the beginning of the first token in the first variable
+     *     declaration.
      * @return the parsed variable list
      */
     private VariableDeclaration variables(int declType, int pos, boolean isStatement)
-        throws IOException
-    {
+            throws IOException {
         int end;
         VariableDeclaration pn = new VariableDeclaration(pos);
         pn.setType(declType);
@@ -2162,7 +2078,7 @@ public class Parser
         // Example:
         // var foo = {a: 1, b: 2}, bar = [3, 4];
         // var {b: s2, a: s1} = foo, x = 6, y, [s3, s4] = bar;
-        for (;;) {
+        for (; ; ) {
             AstNode destructuring = null;
             Name name = null;
             int tt = peekToken(), kidPos = ts.tokenBeg;
@@ -2182,8 +2098,7 @@ public class Parser
                 name.setLineno(ts.getLineno());
                 if (inUseStrictDirective) {
                     String id = ts.getString();
-                    if ("eval".equals(id) || "arguments".equals(ts.getString()))
-                    {
+                    if ("eval".equals(id) || "arguments".equals(ts.getString())) {
                         reportError("msg.bad.id.strict", id);
                     }
                 }
@@ -2215,8 +2130,7 @@ public class Parser
             vi.setLineno(lineno);
             pn.addVariable(vi);
 
-            if (!matchToken(Token.COMMA, true))
-                break;
+            if (!matchToken(Token.COMMA, true)) break;
         }
         pn.setLength(end - pos);
         pn.setIsStatement(isStatement);
@@ -2224,13 +2138,10 @@ public class Parser
     }
 
     // have to pass in 'let' kwd position to compute kid offsets properly
-    private AstNode let(boolean isStatement, int pos)
-        throws IOException
-    {
+    private AstNode let(boolean isStatement, int pos) throws IOException {
         LetNode pn = new LetNode(pos);
         pn.setLineno(ts.lineno);
-        if (mustMatchToken(Token.LP, "msg.no.paren.after.let", true))
-            pn.setLp(ts.tokenBeg - pos);
+        if (mustMatchToken(Token.LP, "msg.no.paren.after.let", true)) pn.setLp(ts.tokenBeg - pos);
         pushScope(pn);
         try {
             VariableDeclaration vars = variables(Token.LET, ts.tokenBeg, isStatement);
@@ -2241,7 +2152,7 @@ public class Parser
             if (isStatement && peekToken() == Token.LC) {
                 // let statement
                 consumeToken();
-                int beg = ts.tokenBeg;  // position stmt at LC
+                int beg = ts.tokenBeg; // position stmt at LC
                 AstNode stmt = statements();
                 mustMatchToken(Token.RC, "msg.no.curly.let", true);
                 stmt.setLength(ts.tokenEnd - beg);
@@ -2255,8 +2166,7 @@ public class Parser
                 pn.setBody(expr);
                 if (isStatement) {
                     // let expression in statement context
-                    ExpressionStatement es =
-                            new ExpressionStatement(pn, !insideFunction());
+                    ExpressionStatement es = new ExpressionStatement(pn, !insideFunction());
                     es.setLineno(pn.getLineno());
                     return es;
                 }
@@ -2273,87 +2183,82 @@ public class Parser
 
     void defineSymbol(int declType, String name, boolean ignoreNotInBlock) {
         if (name == null) {
-            if (compilerEnv.isIdeMode()) {  // be robust in IDE-mode
+            if (compilerEnv.isIdeMode()) { // be robust in IDE-mode
                 return;
             }
             codeBug();
         }
         Scope definingScope = currentScope.getDefiningScope(name);
-        Symbol symbol = definingScope != null
-                        ? definingScope.getSymbol(name)
-                        : null;
+        Symbol symbol = definingScope != null ? definingScope.getSymbol(name) : null;
         int symDeclType = symbol != null ? symbol.getDeclType() : -1;
         if (symbol != null
-            && (symDeclType == Token.CONST
-                || declType == Token.CONST
-                || (definingScope == currentScope && symDeclType == Token.LET)))
-        {
-            addError(symDeclType == Token.CONST ? "msg.const.redecl" :
-                     symDeclType == Token.LET ? "msg.let.redecl" :
-                     symDeclType == Token.VAR ? "msg.var.redecl" :
-                     symDeclType == Token.FUNCTION ? "msg.fn.redecl" :
-                     "msg.parm.redecl", name);
+                && (symDeclType == Token.CONST
+                        || declType == Token.CONST
+                        || (definingScope == currentScope && symDeclType == Token.LET))) {
+            addError(
+                    symDeclType == Token.CONST
+                            ? "msg.const.redecl"
+                            : symDeclType == Token.LET
+                                    ? "msg.let.redecl"
+                                    : symDeclType == Token.VAR
+                                            ? "msg.var.redecl"
+                                            : symDeclType == Token.FUNCTION
+                                                    ? "msg.fn.redecl"
+                                                    : "msg.parm.redecl",
+                    name);
             return;
         }
         switch (declType) {
-          case Token.LET:
-              if (!ignoreNotInBlock &&
-                  ((currentScope.getType() == Token.IF) ||
-                   currentScope instanceof Loop)) {
-                  addError("msg.let.decl.not.in.block");
-                  return;
-              }
-              currentScope.putSymbol(new Symbol(declType, name));
-              return;
+            case Token.LET:
+                if (!ignoreNotInBlock
+                        && ((currentScope.getType() == Token.IF) || currentScope instanceof Loop)) {
+                    addError("msg.let.decl.not.in.block");
+                    return;
+                }
+                currentScope.putSymbol(new Symbol(declType, name));
+                return;
 
-          case Token.VAR:
-          case Token.CONST:
-          case Token.FUNCTION:
-              if (symbol != null) {
-                  if (symDeclType == Token.VAR)
-                      addStrictWarning("msg.var.redecl", name);
-                  else if (symDeclType == Token.LP) {
-                      addStrictWarning("msg.var.hides.arg", name);
-                  }
-              } else {
-                  currentScriptOrFn.putSymbol(new Symbol(declType, name));
-              }
-              return;
+            case Token.VAR:
+            case Token.CONST:
+            case Token.FUNCTION:
+                if (symbol != null) {
+                    if (symDeclType == Token.VAR) addStrictWarning("msg.var.redecl", name);
+                    else if (symDeclType == Token.LP) {
+                        addStrictWarning("msg.var.hides.arg", name);
+                    }
+                } else {
+                    currentScriptOrFn.putSymbol(new Symbol(declType, name));
+                }
+                return;
 
-          case Token.LP:
-              if (symbol != null) {
-                  // must be duplicate parameter. Second parameter hides the
-                  // first, so go ahead and add the second parameter
-                  addWarning("msg.dup.parms", name);
-              }
-              currentScriptOrFn.putSymbol(new Symbol(declType, name));
-              return;
+            case Token.LP:
+                if (symbol != null) {
+                    // must be duplicate parameter. Second parameter hides the
+                    // first, so go ahead and add the second parameter
+                    addWarning("msg.dup.parms", name);
+                }
+                currentScriptOrFn.putSymbol(new Symbol(declType, name));
+                return;
 
-          default:
-              throw codeBug();
+            default:
+                throw codeBug();
         }
     }
 
-    private AstNode expr()
-        throws IOException
-    {
+    private AstNode expr() throws IOException {
         AstNode pn = assignExpr();
         int pos = pn.getPosition();
         while (matchToken(Token.COMMA, true)) {
             int opPos = ts.tokenBeg;
             if (compilerEnv.isStrictMode() && !pn.hasSideEffects())
-                addStrictWarning("msg.no.side.effects", "",
-                                 pos, nodeEnd(pn) - pos);
-            if (peekToken() == Token.YIELD)
-                reportError("msg.yield.parenthesized");
+                addStrictWarning("msg.no.side.effects", "", pos, nodeEnd(pn) - pos);
+            if (peekToken() == Token.YIELD) reportError("msg.yield.parenthesized");
             pn = new InfixExpression(Token.COMMA, pn, assignExpr(), opPos);
         }
         return pn;
     }
 
-    private AstNode assignExpr()
-        throws IOException
-    {
+    private AstNode assignExpr() throws IOException {
         int tt = peekToken();
         if (tt == Token.YIELD) {
             return returnOrYield(tt, true);
@@ -2399,9 +2304,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode condExpr()
-        throws IOException
-    {
+    private AstNode condExpr() throws IOException {
         AstNode pn = orExpr();
         if (matchToken(Token.HOOK, true)) {
             int line = ts.lineno;
@@ -2419,8 +2322,7 @@ public class Parser
             } finally {
                 inForInit = wasInForInit;
             }
-            if (mustMatchToken(Token.COLON, "msg.no.colon.cond", true))
-                colonPos = ts.tokenBeg;
+            if (mustMatchToken(Token.COLON, "msg.no.colon.cond", true)) colonPos = ts.tokenBeg;
             AstNode ifFalse = assignExpr();
             int beg = pn.getPosition(), len = getNodeEnd(ifFalse) - beg;
             ConditionalExpression ce = new ConditionalExpression(beg, len);
@@ -2435,9 +2337,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode orExpr()
-        throws IOException
-    {
+    private AstNode orExpr() throws IOException {
         AstNode pn = andExpr();
         if (matchToken(Token.OR, true)) {
             int opPos = ts.tokenBeg;
@@ -2446,9 +2346,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode andExpr()
-        throws IOException
-    {
+    private AstNode andExpr() throws IOException {
         AstNode pn = bitOrExpr();
         if (matchToken(Token.AND, true)) {
             int opPos = ts.tokenBeg;
@@ -2457,9 +2355,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode bitOrExpr()
-        throws IOException
-    {
+    private AstNode bitOrExpr() throws IOException {
         AstNode pn = bitXorExpr();
         while (matchToken(Token.BITOR, true)) {
             int opPos = ts.tokenBeg;
@@ -2468,9 +2364,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode bitXorExpr()
-        throws IOException
-    {
+    private AstNode bitXorExpr() throws IOException {
         AstNode pn = bitAndExpr();
         while (matchToken(Token.BITXOR, true)) {
             int opPos = ts.tokenBeg;
@@ -2479,9 +2373,7 @@ public class Parser
         return pn;
     }
 
-    private AstNode bitAndExpr()
-        throws IOException
-    {
+    private AstNode bitAndExpr() throws IOException {
         AstNode pn = eqExpr();
         while (matchToken(Token.BITAND, true)) {
             int opPos = ts.tokenBeg;
@@ -2490,83 +2382,72 @@ public class Parser
         return pn;
     }
 
-    private AstNode eqExpr()
-        throws IOException
-    {
+    private AstNode eqExpr() throws IOException {
         AstNode pn = relExpr();
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken(), opPos = ts.tokenBeg;
             switch (tt) {
-              case Token.EQ:
-              case Token.NE:
-              case Token.SHEQ:
-              case Token.SHNE:
-                consumeToken();
-                int parseToken = tt;
-                if (compilerEnv.getLanguageVersion() == Context.VERSION_1_2) {
-                    // JavaScript 1.2 uses shallow equality for == and != .
-                    if (tt == Token.EQ)
-                        parseToken = Token.SHEQ;
-                    else if (tt == Token.NE)
-                        parseToken = Token.SHNE;
-                }
-                pn = new InfixExpression(parseToken, pn, relExpr(), opPos);
-                continue;
+                case Token.EQ:
+                case Token.NE:
+                case Token.SHEQ:
+                case Token.SHNE:
+                    consumeToken();
+                    int parseToken = tt;
+                    if (compilerEnv.getLanguageVersion() == Context.VERSION_1_2) {
+                        // JavaScript 1.2 uses shallow equality for == and != .
+                        if (tt == Token.EQ) parseToken = Token.SHEQ;
+                        else if (tt == Token.NE) parseToken = Token.SHNE;
+                    }
+                    pn = new InfixExpression(parseToken, pn, relExpr(), opPos);
+                    continue;
             }
             break;
         }
         return pn;
     }
 
-    private AstNode relExpr()
-        throws IOException
-    {
+    private AstNode relExpr() throws IOException {
         AstNode pn = shiftExpr();
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken(), opPos = ts.tokenBeg;
             switch (tt) {
-              case Token.IN:
-                if (inForInit)
-                    break;
-                // fall through
-              case Token.INSTANCEOF:
-              case Token.LE:
-              case Token.LT:
-              case Token.GE:
-              case Token.GT:
-                consumeToken();
-                pn = new InfixExpression(tt, pn, shiftExpr(), opPos);
-                continue;
+                case Token.IN:
+                    if (inForInit) break;
+                    // fall through
+                case Token.INSTANCEOF:
+                case Token.LE:
+                case Token.LT:
+                case Token.GE:
+                case Token.GT:
+                    consumeToken();
+                    pn = new InfixExpression(tt, pn, shiftExpr(), opPos);
+                    continue;
             }
             break;
         }
         return pn;
     }
 
-    private AstNode shiftExpr()
-        throws IOException
-    {
+    private AstNode shiftExpr() throws IOException {
         AstNode pn = addExpr();
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken(), opPos = ts.tokenBeg;
             switch (tt) {
-              case Token.LSH:
-              case Token.URSH:
-              case Token.RSH:
-                consumeToken();
-                pn = new InfixExpression(tt, pn, addExpr(), opPos);
-                continue;
+                case Token.LSH:
+                case Token.URSH:
+                case Token.RSH:
+                    consumeToken();
+                    pn = new InfixExpression(tt, pn, addExpr(), opPos);
+                    continue;
             }
             break;
         }
         return pn;
     }
 
-    private AstNode addExpr()
-        throws IOException
-    {
+    private AstNode addExpr() throws IOException {
         AstNode pn = mulExpr();
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken(), opPos = ts.tokenBeg;
             if (tt == Token.ADD || tt == Token.SUB) {
                 consumeToken();
@@ -2578,49 +2459,45 @@ public class Parser
         return pn;
     }
 
-    private AstNode mulExpr()
-        throws IOException
-    {
+    private AstNode mulExpr() throws IOException {
         AstNode pn = expExpr();
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken(), opPos = ts.tokenBeg;
             switch (tt) {
-              case Token.MUL:
-              case Token.DIV:
-              case Token.MOD:
-                consumeToken();
-                pn = new InfixExpression(tt, pn, expExpr(), opPos);
-                continue;
+                case Token.MUL:
+                case Token.DIV:
+                case Token.MOD:
+                    consumeToken();
+                    pn = new InfixExpression(tt, pn, expExpr(), opPos);
+                    continue;
             }
             break;
         }
         return pn;
     }
 
-    private AstNode expExpr()
-        throws IOException
-    {
+    private AstNode expExpr() throws IOException {
         AstNode pn = unaryExpr();
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken(), opPos = ts.tokenBeg;
             switch (tt) {
-            case Token.EXP:
-                if (pn instanceof UnaryExpression) {
-                    reportError("msg.no.unary.expr.on.left.exp", AstNode.operatorToString(pn.getType()));
-                    return makeErrorNode();
-                }
-                consumeToken();
-                pn = new InfixExpression(tt, pn, expExpr(), opPos);
-                continue;
+                case Token.EXP:
+                    if (pn instanceof UnaryExpression) {
+                        reportError(
+                                "msg.no.unary.expr.on.left.exp",
+                                AstNode.operatorToString(pn.getType()));
+                        return makeErrorNode();
+                    }
+                    consumeToken();
+                    pn = new InfixExpression(tt, pn, expExpr(), opPos);
+                    continue;
             }
             break;
         }
         return pn;
     }
 
-    private AstNode unaryExpr()
-        throws IOException
-    {
+    private AstNode unaryExpr() throws IOException {
         AstNode node;
         int tt = peekToken();
         if (tt == Token.COMMENT) {
@@ -2629,76 +2506,72 @@ public class Parser
         }
         int line = ts.lineno;
 
-        switch(tt) {
-          case Token.VOID:
-          case Token.NOT:
-          case Token.BITNOT:
-          case Token.TYPEOF:
-              consumeToken();
-              node = new UnaryExpression(tt, ts.tokenBeg, unaryExpr());
-              node.setLineno(line);
-              return node;
+        switch (tt) {
+            case Token.VOID:
+            case Token.NOT:
+            case Token.BITNOT:
+            case Token.TYPEOF:
+                consumeToken();
+                node = new UnaryExpression(tt, ts.tokenBeg, unaryExpr());
+                node.setLineno(line);
+                return node;
 
-          case Token.ADD:
-              consumeToken();
-              // Convert to special POS token in parse tree
-              node = new UnaryExpression(Token.POS, ts.tokenBeg, unaryExpr());
-              node.setLineno(line);
-              return node;
+            case Token.ADD:
+                consumeToken();
+                // Convert to special POS token in parse tree
+                node = new UnaryExpression(Token.POS, ts.tokenBeg, unaryExpr());
+                node.setLineno(line);
+                return node;
 
-          case Token.SUB:
-              consumeToken();
-              // Convert to special NEG token in parse tree
-              node = new UnaryExpression(Token.NEG, ts.tokenBeg, unaryExpr());
-              node.setLineno(line);
-              return node;
+            case Token.SUB:
+                consumeToken();
+                // Convert to special NEG token in parse tree
+                node = new UnaryExpression(Token.NEG, ts.tokenBeg, unaryExpr());
+                node.setLineno(line);
+                return node;
 
-          case Token.INC:
-          case Token.DEC:
-              consumeToken();
-              UpdateExpression expr = new UpdateExpression(tt, ts.tokenBeg,
-                                                           memberExpr(true));
-              expr.setLineno(line);
-              checkBadIncDec(expr);
-              return expr;
+            case Token.INC:
+            case Token.DEC:
+                consumeToken();
+                UpdateExpression expr = new UpdateExpression(tt, ts.tokenBeg, memberExpr(true));
+                expr.setLineno(line);
+                checkBadIncDec(expr);
+                return expr;
 
-          case Token.DELPROP:
-              consumeToken();
-              node = new UnaryExpression(tt, ts.tokenBeg, unaryExpr());
-              node.setLineno(line);
-              return node;
+            case Token.DELPROP:
+                consumeToken();
+                node = new UnaryExpression(tt, ts.tokenBeg, unaryExpr());
+                node.setLineno(line);
+                return node;
 
-          case Token.ERROR:
-              consumeToken();
-              return makeErrorNode();
-          case Token.LT:
-              // XML stream encountered in expression.
-              if (compilerEnv.isXmlAvailable()) {
-                  consumeToken();
-                  return memberExprTail(true, xmlInitializer());
-              }
-              // Fall thru to the default handling of RELOP
-              // fall through
+            case Token.ERROR:
+                consumeToken();
+                return makeErrorNode();
+            case Token.LT:
+                // XML stream encountered in expression.
+                if (compilerEnv.isXmlAvailable()) {
+                    consumeToken();
+                    return memberExprTail(true, xmlInitializer());
+                }
+                // Fall thru to the default handling of RELOP
+                // fall through
 
-          default:
-              AstNode pn = memberExpr(true);
-              // Don't look across a newline boundary for a postfix incop.
-              tt = peekTokenOrEOL();
-              if (!(tt == Token.INC || tt == Token.DEC)) {
-                  return pn;
-              }
-              consumeToken();
-              UpdateExpression uexpr =
-                      new UpdateExpression(tt, ts.tokenBeg, pn, true);
-              uexpr.setLineno(line);
-              checkBadIncDec(uexpr);
-              return uexpr;
+            default:
+                AstNode pn = memberExpr(true);
+                // Don't look across a newline boundary for a postfix incop.
+                tt = peekTokenOrEOL();
+                if (!(tt == Token.INC || tt == Token.DEC)) {
+                    return pn;
+                }
+                consumeToken();
+                UpdateExpression uexpr = new UpdateExpression(tt, ts.tokenBeg, pn, true);
+                uexpr.setLineno(line);
+                checkBadIncDec(uexpr);
+                return uexpr;
         }
     }
 
-    private AstNode xmlInitializer()
-        throws IOException
-    {
+    private AstNode xmlInitializer() throws IOException {
         if (currentToken != Token.LT) codeBug();
         int pos = ts.tokenBeg, tt = ts.getFirstXMLToken();
         if (tt != Token.XML && tt != Token.XMLEND) {
@@ -2709,46 +2582,44 @@ public class Parser
         XmlLiteral pn = new XmlLiteral(pos);
         pn.setLineno(ts.lineno);
 
-        for (;;tt = ts.getNextXMLToken()) {
+        for (; ; tt = ts.getNextXMLToken()) {
             switch (tt) {
-              case Token.XML:
-                  pn.addFragment(new XmlString(ts.tokenBeg, ts.getString()));
-                  mustMatchToken(Token.LC, "msg.syntax", true);
-                  int beg = ts.tokenBeg;
-                  AstNode expr = (peekToken() == Token.RC)
-                                 ? new EmptyExpression(beg, ts.tokenEnd - beg)
-                                 : expr();
-                  mustMatchToken(Token.RC, "msg.syntax", true);
-                  XmlExpression xexpr = new XmlExpression(beg, expr);
-                  xexpr.setIsXmlAttribute(ts.isXMLAttribute());
-                  xexpr.setLength(ts.tokenEnd - beg);
-                  pn.addFragment(xexpr);
-                  break;
+                case Token.XML:
+                    pn.addFragment(new XmlString(ts.tokenBeg, ts.getString()));
+                    mustMatchToken(Token.LC, "msg.syntax", true);
+                    int beg = ts.tokenBeg;
+                    AstNode expr =
+                            (peekToken() == Token.RC)
+                                    ? new EmptyExpression(beg, ts.tokenEnd - beg)
+                                    : expr();
+                    mustMatchToken(Token.RC, "msg.syntax", true);
+                    XmlExpression xexpr = new XmlExpression(beg, expr);
+                    xexpr.setIsXmlAttribute(ts.isXMLAttribute());
+                    xexpr.setLength(ts.tokenEnd - beg);
+                    pn.addFragment(xexpr);
+                    break;
 
-              case Token.XMLEND:
-                  pn.addFragment(new XmlString(ts.tokenBeg, ts.getString()));
-                  return pn;
+                case Token.XMLEND:
+                    pn.addFragment(new XmlString(ts.tokenBeg, ts.getString()));
+                    return pn;
 
-              default:
-                  reportError("msg.syntax");
-                  return makeErrorNode();
+                default:
+                    reportError("msg.syntax");
+                    return makeErrorNode();
             }
         }
     }
 
-    private List<AstNode> argumentList()
-        throws IOException
-    {
-        if (matchToken(Token.RP, true))
-            return null;
+    private List<AstNode> argumentList() throws IOException {
+        if (matchToken(Token.RP, true)) return null;
 
         List<AstNode> result = new ArrayList<AstNode>();
         boolean wasInForInit = inForInit;
         inForInit = false;
         try {
             do {
-                if(peekToken() == Token.RP) {
-                    //Quick fix to handle scenario like f1(a,); but not f1(a,b
+                if (peekToken() == Token.RP) {
+                    // Quick fix to handle scenario like f1(a,); but not f1(a,b
                     break;
                 }
                 if (peekToken() == Token.YIELD) {
@@ -2758,12 +2629,10 @@ public class Parser
                 if (peekToken() == Token.FOR) {
                     try {
                         result.add(generatorExpression(en, 0, true));
-                    }
-                    catch(IOException ex) {
+                    } catch (IOException ex) {
                         // #TODO
                     }
-                }
-                else {
+                } else {
                     result.add(en);
                 }
             } while (matchToken(Token.COMMA, true));
@@ -2776,13 +2645,11 @@ public class Parser
     }
 
     /**
-     * Parse a new-expression, or if next token isn't {@link Token#NEW},
-     * a primary expression.
+     * Parse a new-expression, or if next token isn't {@link Token#NEW}, a primary expression.
+     *
      * @param allowCallSyntax passed down to {@link #memberExprTail}
      */
-    private AstNode memberExpr(boolean allowCallSyntax)
-        throws IOException
-    {
+    private AstNode memberExpr(boolean allowCallSyntax) throws IOException {
         int tt = peekToken(), lineno = ts.lineno;
         AstNode pn;
 
@@ -2805,8 +2672,7 @@ public class Parser
                     reportError("msg.too.many.constructor.args");
                 int rp = ts.tokenBeg;
                 end = ts.tokenEnd;
-                if (args != null)
-                    nx.setArguments(args);
+                if (args != null) nx.setArguments(args);
                 nx.setParens(lp - pos, rp - pos);
             }
 
@@ -2828,98 +2694,101 @@ public class Parser
     }
 
     /**
-     * Parse any number of "(expr)", "[expr]" ".expr", "..expr",
-     * or ".(expr)" constructs trailing the passed expression.
+     * Parse any number of "(expr)", "[expr]" ".expr", "..expr", or ".(expr)" constructs trailing
+     * the passed expression.
+     *
      * @param pn the non-null parent node
-     * @return the outermost (lexically last occurring) expression,
-     * which will have the passed parent node as a descendant
+     * @return the outermost (lexically last occurring) expression, which will have the passed
+     *     parent node as a descendant
      */
-    private AstNode memberExprTail(boolean allowCallSyntax, AstNode pn)
-        throws IOException
-    {
+    private AstNode memberExprTail(boolean allowCallSyntax, AstNode pn) throws IOException {
         // we no longer return null for errors, so this won't be null
         if (pn == null) codeBug();
         int pos = pn.getPosition();
         int lineno;
-      tailLoop:
-        for (;;) {
+        tailLoop:
+        for (; ; ) {
             int tt = peekToken();
             switch (tt) {
-              case Token.DOT:
-              case Token.DOTDOT:
-                  lineno = ts.lineno;
-                  pn = propertyAccess(tt, pn);
-                  pn.setLineno(lineno);
-                  break;
+                case Token.DOT:
+                case Token.DOTDOT:
+                    lineno = ts.lineno;
+                    pn = propertyAccess(tt, pn);
+                    pn.setLineno(lineno);
+                    break;
 
-              case Token.DOTQUERY:
-                  consumeToken();
-                  int opPos = ts.tokenBeg, rp = -1;
-                  lineno = ts.lineno;
-                  mustHaveXML();
-                  setRequiresActivation();
-                  AstNode filter = expr();
-                  int end = getNodeEnd(filter);
-                  if (mustMatchToken(Token.RP, "msg.no.paren", true)) {
-                      rp = ts.tokenBeg;
-                      end = ts.tokenEnd;
-                  }
-                  XmlDotQuery q = new XmlDotQuery(pos, end - pos);
-                  q.setLeft(pn);
-                  q.setRight(filter);
-                  q.setOperatorPosition(opPos);
-                  q.setRp(rp - pos);
-                  q.setLineno(lineno);
-                  pn = q;
-                  break;
+                case Token.DOTQUERY:
+                    consumeToken();
+                    int opPos = ts.tokenBeg, rp = -1;
+                    lineno = ts.lineno;
+                    mustHaveXML();
+                    setRequiresActivation();
+                    AstNode filter = expr();
+                    int end = getNodeEnd(filter);
+                    if (mustMatchToken(Token.RP, "msg.no.paren", true)) {
+                        rp = ts.tokenBeg;
+                        end = ts.tokenEnd;
+                    }
+                    XmlDotQuery q = new XmlDotQuery(pos, end - pos);
+                    q.setLeft(pn);
+                    q.setRight(filter);
+                    q.setOperatorPosition(opPos);
+                    q.setRp(rp - pos);
+                    q.setLineno(lineno);
+                    pn = q;
+                    break;
 
-              case Token.LB:
-                  consumeToken();
-                  int lb = ts.tokenBeg, rb = -1;
-                  lineno = ts.lineno;
-                  AstNode expr = expr();
-                  end = getNodeEnd(expr);
-                  if (mustMatchToken(Token.RB, "msg.no.bracket.index", true)) {
-                      rb = ts.tokenBeg;
-                      end = ts.tokenEnd;
-                  }
-                  ElementGet g = new ElementGet(pos, end - pos);
-                  g.setTarget(pn);
-                  g.setElement(expr);
-                  g.setParens(lb, rb);
-                  g.setLineno(lineno);
-                  pn = g;
-                  break;
+                case Token.LB:
+                    consumeToken();
+                    int lb = ts.tokenBeg, rb = -1;
+                    lineno = ts.lineno;
+                    AstNode expr = expr();
+                    end = getNodeEnd(expr);
+                    if (mustMatchToken(Token.RB, "msg.no.bracket.index", true)) {
+                        rb = ts.tokenBeg;
+                        end = ts.tokenEnd;
+                    }
+                    ElementGet g = new ElementGet(pos, end - pos);
+                    g.setTarget(pn);
+                    g.setElement(expr);
+                    g.setParens(lb, rb);
+                    g.setLineno(lineno);
+                    pn = g;
+                    break;
 
-              case Token.LP:
-                  if (!allowCallSyntax) {
-                      break tailLoop;
-                  }
-                  lineno = ts.lineno;
-                  consumeToken();
-                  checkCallRequiresActivation(pn);
-                  FunctionCall f = new FunctionCall(pos);
-                  f.setTarget(pn);
-                  // Assign the line number for the function call to where
-                  // the paren appeared, not where the name expression started.
-                  f.setLineno(lineno);
-                  f.setLp(ts.tokenBeg - pos);
-                  List<AstNode> args = argumentList();
-                  if (args != null && args.size() > ARGC_LIMIT)
-                      reportError("msg.too.many.function.args");
-                  f.setArguments(args);
-                  f.setRp(ts.tokenBeg - pos);
-                  f.setLength(ts.tokenEnd - pos);
-                  pn = f;
-                  break;
-              case Token.COMMENT:
-                  //Ignoring all the comments, because previous statement may not be terminated properly.
-                  int currentFlagTOken = currentFlaggedToken;
-                  peekUntilNonComment(tt);
-                  currentFlaggedToken = (currentFlaggedToken & TI_AFTER_EOL) != 0 ? currentFlaggedToken : currentFlagTOken;
-                  break;
-              default:
-                  break tailLoop;
+                case Token.LP:
+                    if (!allowCallSyntax) {
+                        break tailLoop;
+                    }
+                    lineno = ts.lineno;
+                    consumeToken();
+                    checkCallRequiresActivation(pn);
+                    FunctionCall f = new FunctionCall(pos);
+                    f.setTarget(pn);
+                    // Assign the line number for the function call to where
+                    // the paren appeared, not where the name expression started.
+                    f.setLineno(lineno);
+                    f.setLp(ts.tokenBeg - pos);
+                    List<AstNode> args = argumentList();
+                    if (args != null && args.size() > ARGC_LIMIT)
+                        reportError("msg.too.many.function.args");
+                    f.setArguments(args);
+                    f.setRp(ts.tokenBeg - pos);
+                    f.setLength(ts.tokenEnd - pos);
+                    pn = f;
+                    break;
+                case Token.COMMENT:
+                    // Ignoring all the comments, because previous statement may not be terminated
+                    // properly.
+                    int currentFlagTOken = currentFlaggedToken;
+                    peekUntilNonComment(tt);
+                    currentFlaggedToken =
+                            (currentFlaggedToken & TI_AFTER_EOL) != 0
+                                    ? currentFlaggedToken
+                                    : currentFlagTOken;
+                    break;
+                default:
+                    break tailLoop;
             }
         }
         return pn;
@@ -2927,12 +2796,11 @@ public class Parser
 
     /**
      * Handles any construct following a "." or ".." operator.
-     * @param pn the left-hand side (target) of the operator.  Never null.
+     *
+     * @param pn the left-hand side (target) of the operator. Never null.
      * @return a PropertyGet, XmlMemberGet, or ErrorNode
      */
-    private AstNode propertyAccess(int tt, AstNode pn)
-            throws IOException
-    {
+    private AstNode propertyAccess(int tt, AstNode pn) throws IOException {
         if (pn == null) codeBug();
         int memberTypeFlags = 0, lineno = ts.lineno, dotPos = ts.tokenBeg;
         consumeToken();
@@ -2946,8 +2814,11 @@ public class Parser
             int maybeName = nextToken();
             if (maybeName != Token.NAME
                     && !(compilerEnv.isReservedKeywordAsIdentifier()
-                    && TokenStream.isKeyword(ts.getString(), compilerEnv.getLanguageVersion(), inUseStrictDirective))) {
-              reportError("msg.no.name.after.dot");
+                            && TokenStream.isKeyword(
+                                    ts.getString(),
+                                    compilerEnv.getLanguageVersion(),
+                                    inUseStrictDirective))) {
+                reportError("msg.no.name.after.dot");
             }
 
             Name name = createNameNode(true, Token.GETPROP);
@@ -2956,97 +2827,96 @@ public class Parser
             return pg;
         }
 
-        AstNode ref = null;  // right side of . or .. operator
+        AstNode ref = null; // right side of . or .. operator
 
         int token = nextToken();
         switch (token) {
-          case Token.THROW:
-              // needed for generator.throw();
-              saveNameTokenData(ts.tokenBeg, "throw", ts.lineno);
-              ref = propertyName(-1, memberTypeFlags);
-              break;
+            case Token.THROW:
+                // needed for generator.throw();
+                saveNameTokenData(ts.tokenBeg, "throw", ts.lineno);
+                ref = propertyName(-1, memberTypeFlags);
+                break;
 
-          case Token.NAME:
-              // handles: name, ns::name, ns::*, ns::[expr]
-              ref = propertyName(-1, memberTypeFlags);
-              break;
+            case Token.NAME:
+                // handles: name, ns::name, ns::*, ns::[expr]
+                ref = propertyName(-1, memberTypeFlags);
+                break;
 
-          case Token.MUL:
-              // handles: *, *::name, *::*, *::[expr]
-              saveNameTokenData(ts.tokenBeg, "*", ts.lineno);
-              ref = propertyName(-1, memberTypeFlags);
-              break;
+            case Token.MUL:
+                // handles: *, *::name, *::*, *::[expr]
+                saveNameTokenData(ts.tokenBeg, "*", ts.lineno);
+                ref = propertyName(-1, memberTypeFlags);
+                break;
 
-          case Token.XMLATTR:
-              // handles: '@attr', '@ns::attr', '@ns::*', '@ns::*',
-              //          '@::attr', '@::*', '@*', '@*::attr', '@*::*'
-              ref = attributeAccess();
-              break;
+            case Token.XMLATTR:
+                // handles: '@attr', '@ns::attr', '@ns::*', '@ns::*',
+                //          '@::attr', '@::*', '@*', '@*::attr', '@*::*'
+                ref = attributeAccess();
+                break;
 
-          case Token.RESERVED: {
-              String name = ts.getString();
-              saveNameTokenData(ts.tokenBeg, name, ts.lineno);
-              ref = propertyName(-1, memberTypeFlags);
-              break;
-          }
+            case Token.RESERVED:
+                {
+                    String name = ts.getString();
+                    saveNameTokenData(ts.tokenBeg, name, ts.lineno);
+                    ref = propertyName(-1, memberTypeFlags);
+                    break;
+                }
 
-          default:
-              if (compilerEnv.isReservedKeywordAsIdentifier()) {
-                  // allow keywords as property names, e.g. ({if: 1})
-                  String name = Token.keywordToName(token);
-                  if (name != null) {
-                      saveNameTokenData(ts.tokenBeg, name, ts.lineno);
-                      ref = propertyName(-1, memberTypeFlags);
-                      break;
-                  }
-              }
-              reportError("msg.no.name.after.dot");
-              return makeErrorNode();
+            default:
+                if (compilerEnv.isReservedKeywordAsIdentifier()) {
+                    // allow keywords as property names, e.g. ({if: 1})
+                    String name = Token.keywordToName(token);
+                    if (name != null) {
+                        saveNameTokenData(ts.tokenBeg, name, ts.lineno);
+                        ref = propertyName(-1, memberTypeFlags);
+                        break;
+                    }
+                }
+                reportError("msg.no.name.after.dot");
+                return makeErrorNode();
         }
 
         boolean xml = ref instanceof XmlRef;
         InfixExpression result = xml ? new XmlMemberGet() : new PropertyGet();
-        if (xml && tt == Token.DOT)
-            result.setType(Token.DOT);
+        if (xml && tt == Token.DOT) result.setType(Token.DOT);
         int pos = pn.getPosition();
         result.setPosition(pos);
         result.setLength(getNodeEnd(ref) - pos);
         result.setOperatorPosition(dotPos - pos);
         result.setLineno(pn.getLineno());
-        result.setLeft(pn);  // do this after setting position
+        result.setLeft(pn); // do this after setting position
         result.setRight(ref);
         return result;
     }
 
     /**
-     * Xml attribute expression:<p>
-     *   {@code @attr}, {@code @ns::attr}, {@code @ns::*}, {@code @ns::*},
-     *   {@code @*}, {@code @*::attr}, {@code @*::*}, {@code @ns::[expr]},
-     *   {@code @*::[expr]}, {@code @[expr]} <p>
-     * Called if we peeked an '@' token.
+     * Xml attribute expression:
+     *
+     * <p>{@code @attr}, {@code @ns::attr}, {@code @ns::*}, {@code @ns::*}, {@code @*},
+     * {@code @*::attr}, {@code @*::*}, {@code @ns::[expr]}, {@code @*::[expr]}, {@code @[expr]}
+     *
+     * <p>Called if we peeked an '@' token.
      */
-    private AstNode attributeAccess()
-        throws IOException
-    {
+    private AstNode attributeAccess() throws IOException {
         int tt = nextToken(), atPos = ts.tokenBeg;
 
         switch (tt) {
-          // handles: @name, @ns::name, @ns::*, @ns::[expr]
-          case Token.NAME:
-              return propertyName(atPos, 0);
+                // handles: @name, @ns::name, @ns::*, @ns::[expr]
+            case Token.NAME:
+                return propertyName(atPos, 0);
 
-          // handles: @*, @*::name, @*::*, @*::[expr]
-          case Token.MUL:
-              saveNameTokenData(ts.tokenBeg, "*", ts.lineno);
-              return propertyName(atPos, 0);
+                // handles: @*, @*::name, @*::*, @*::[expr]
+            case Token.MUL:
+                saveNameTokenData(ts.tokenBeg, "*", ts.lineno);
+                return propertyName(atPos, 0);
 
-          // handles @[expr]
-          case Token.LB:
-              return xmlElemRef(atPos, null, -1);
+                // handles @[expr]
+            case Token.LB:
+                return xmlElemRef(atPos, null, -1);
 
-          default:
-              reportError("msg.no.name.after.xmlAttr");
-              return makeErrorNode();
+            default:
+                reportError("msg.no.name.after.xmlAttr");
+                return makeErrorNode();
         }
     }
 
@@ -3054,20 +2924,13 @@ public class Parser
      * Check if :: follows name in which case it becomes a qualified name.
      *
      * @param atPos a natural number if we just read an '@' token, else -1
-     *
-     * @param s the name or string that was matched (an identifier, "throw" or
-     * "*").
-     *
+     * @param s the name or string that was matched (an identifier, "throw" or "*").
      * @param memberTypeFlags flags tracking whether we're a '.' or '..' child
-     *
-     * @return an XmlRef node if it's an attribute access, a child of a
-     * '..' operator, or the name is followed by ::.  For a plain name,
-     * returns a Name node.  Returns an ErrorNode for malformed XML
-     * expressions.  (For now - might change to return a partial XmlRef.)
+     * @return an XmlRef node if it's an attribute access, a child of a '..' operator, or the name
+     *     is followed by ::. For a plain name, returns a Name node. Returns an ErrorNode for
+     *     malformed XML expressions. (For now - might change to return a partial XmlRef.)
      */
-    private AstNode propertyName(int atPos, int memberTypeFlags)
-        throws IOException
-    {
+    private AstNode propertyName(int atPos, int memberTypeFlags) throws IOException {
         int pos = atPos != -1 ? atPos : ts.tokenBeg, lineno = ts.lineno;
         int colonPos = -1;
         Name name = createNameNode(true, currentToken);
@@ -3078,24 +2941,24 @@ public class Parser
             colonPos = ts.tokenBeg;
 
             switch (nextToken()) {
-              // handles name::name
-              case Token.NAME:
-                  name = createNameNode();
-                  break;
+                    // handles name::name
+                case Token.NAME:
+                    name = createNameNode();
+                    break;
 
-              // handles name::*
-              case Token.MUL:
-                  saveNameTokenData(ts.tokenBeg, "*", ts.lineno);
-                  name = createNameNode(false, -1);
-                  break;
+                    // handles name::*
+                case Token.MUL:
+                    saveNameTokenData(ts.tokenBeg, "*", ts.lineno);
+                    name = createNameNode(false, -1);
+                    break;
 
-              // handles name::[expr] or *::[expr]
-              case Token.LB:
-                  return xmlElemRef(atPos, ns, colonPos);
+                    // handles name::[expr] or *::[expr]
+                case Token.LB:
+                    return xmlElemRef(atPos, ns, colonPos);
 
-              default:
-                  reportError("msg.no.name.after.coloncolon");
-                  return makeErrorNode();
+                default:
+                    reportError("msg.no.name.after.coloncolon");
+                    return makeErrorNode();
             }
         }
 
@@ -3113,12 +2976,10 @@ public class Parser
     }
 
     /**
-     * Parse the [expr] portion of an xml element reference, e.g.
-     * @[expr], @*::[expr], or ns::[expr].
+     * Parse the [expr] portion of an xml element reference, e.g. @[expr], @*::[expr], or
+     * ns::[expr].
      */
-    private XmlElemRef xmlElemRef(int atPos, Name namespace, int colonPos)
-        throws IOException
-    {
+    private XmlElemRef xmlElemRef(int atPos, Name namespace, int colonPos) throws IOException {
         int lb = ts.tokenBeg, rb = -1, pos = atPos != -1 ? atPos : lb;
         AstNode expr = expr();
         int end = getNodeEnd(expr);
@@ -3135,9 +2996,7 @@ public class Parser
         return ref;
     }
 
-    private AstNode destructuringPrimaryExpr()
-        throws IOException, ParserException
-    {
+    private AstNode destructuringPrimaryExpr() throws IOException, ParserException {
         try {
             inDestructuringAssignment = true;
             return primaryExpr();
@@ -3146,89 +3005,89 @@ public class Parser
         }
     }
 
-    private AstNode primaryExpr()
-        throws IOException
-    {
+    private AstNode primaryExpr() throws IOException {
         int ttFlagged = peekFlaggedToken();
         int tt = ttFlagged & CLEAR_TI_MASK;
 
-        switch(tt) {
-          case Token.FUNCTION:
-              consumeToken();
-              return function(FunctionNode.FUNCTION_EXPRESSION);
+        switch (tt) {
+            case Token.FUNCTION:
+                consumeToken();
+                return function(FunctionNode.FUNCTION_EXPRESSION);
 
-          case Token.LB:
-              consumeToken();
-              return arrayLiteral();
+            case Token.LB:
+                consumeToken();
+                return arrayLiteral();
 
-          case Token.LC:
-              consumeToken();
-              return objectLiteral();
+            case Token.LC:
+                consumeToken();
+                return objectLiteral();
 
-          case Token.LET:
-              consumeToken();
-              return let(false, ts.tokenBeg);
+            case Token.LET:
+                consumeToken();
+                return let(false, ts.tokenBeg);
 
-          case Token.LP:
-              consumeToken();
-              return parenExpr();
+            case Token.LP:
+                consumeToken();
+                return parenExpr();
 
-          case Token.XMLATTR:
-              consumeToken();
-              mustHaveXML();
-              return attributeAccess();
+            case Token.XMLATTR:
+                consumeToken();
+                mustHaveXML();
+                return attributeAccess();
 
-          case Token.NAME:
-              consumeToken();
-              return name(ttFlagged, tt);
+            case Token.NAME:
+                consumeToken();
+                return name(ttFlagged, tt);
 
-          case Token.NUMBER: {
-              consumeToken();
-              return createNumberLiteral(false);
-          }
+            case Token.NUMBER:
+                {
+                    consumeToken();
+                    return createNumberLiteral(false);
+                }
 
-          case Token.STRING:
-              consumeToken();
-              return createStringLiteral();
+            case Token.STRING:
+                consumeToken();
+                return createStringLiteral();
 
-          case Token.DIV:
-          case Token.ASSIGN_DIV:
-              consumeToken();
-              // Got / or /= which in this context means a regexp
-              ts.readRegExp(tt);
-              int pos = ts.tokenBeg, end = ts.tokenEnd;
-              RegExpLiteral re = new RegExpLiteral(pos, end - pos);
-              re.setValue(ts.getString());
-              re.setFlags(ts.readAndClearRegExpFlags());
-              return re;
+            case Token.DIV:
+            case Token.ASSIGN_DIV:
+                consumeToken();
+                // Got / or /= which in this context means a regexp
+                ts.readRegExp(tt);
+                int pos = ts.tokenBeg, end = ts.tokenEnd;
+                RegExpLiteral re = new RegExpLiteral(pos, end - pos);
+                re.setValue(ts.getString());
+                re.setFlags(ts.readAndClearRegExpFlags());
+                return re;
 
-          case Token.NULL:
-          case Token.THIS:
-          case Token.FALSE:
-          case Token.TRUE:
-              consumeToken();
-              pos = ts.tokenBeg; end = ts.tokenEnd;
-              return new KeywordLiteral(pos, end - pos, tt);
+            case Token.NULL:
+            case Token.THIS:
+            case Token.FALSE:
+            case Token.TRUE:
+                consumeToken();
+                pos = ts.tokenBeg;
+                end = ts.tokenEnd;
+                return new KeywordLiteral(pos, end - pos, tt);
 
-          case Token.RESERVED:
-              consumeToken();
-              reportError("msg.reserved.id", ts.getString());
-              break;
+            case Token.RESERVED:
+                consumeToken();
+                reportError("msg.reserved.id", ts.getString());
+                break;
 
-          case Token.ERROR:
-              consumeToken();
-              // the scanner or one of its subroutines reported the error.
-              break;
+            case Token.ERROR:
+                consumeToken();
+                // the scanner or one of its subroutines reported the error.
+                break;
 
-          case Token.EOF:
-              consumeToken();
-              reportError("msg.unexpected.eof");
-              break;
+            case Token.EOF:
+                consumeToken();
+                reportError("msg.unexpected.eof");
+                break;
 
-          default:
-              consumeToken();
-              reportError("msg.syntax");
-              break;
+            default:
+                consumeToken();
+                reportError("msg.syntax");
+                break;
         }
         // should only be reachable in IDE/error-recovery mode
         consumeToken();
@@ -3248,8 +3107,8 @@ public class Parser
             }
             mustMatchToken(Token.RP, "msg.no.paren", true);
             if (e.getType() == Token.EMPTY && peekToken() != Token.ARROW) {
-              reportError("msg.syntax");
-              return makeErrorNode();
+                reportError("msg.syntax");
+                return makeErrorNode();
             }
             int length = ts.tokenEnd - begin;
             ParenthesizedExpression pn = new ParenthesizedExpression(begin, length, e);
@@ -3288,12 +3147,8 @@ public class Parser
         return createNameNode(true, Token.NAME);
     }
 
-    /**
-     * May return an {@link ArrayLiteral} or {@link ArrayComprehension}.
-     */
-    private AstNode arrayLiteral()
-        throws IOException
-    {
+    /** May return an {@link ArrayLiteral} or {@link ArrayComprehension}. */
+    private AstNode arrayLiteral() throws IOException {
         if (currentToken != Token.LB) codeBug();
         int pos = ts.tokenBeg, end = ts.tokenEnd;
         List<AstNode> elements = new ArrayList<AstNode>();
@@ -3301,7 +3156,7 @@ public class Parser
         boolean after_lb_or_comma = true;
         int afterComma = -1;
         int skipCount = 0;
-        for (;;) {
+        for (; ; ) {
             int tt = peekToken();
             if (tt == Token.COMMA) {
                 consumeToken();
@@ -3312,7 +3167,7 @@ public class Parser
                     elements.add(new EmptyExpression(ts.tokenBeg, 1));
                     skipCount++;
                 }
-            } else if(tt == Token.COMMENT) {
+            } else if (tt == Token.COMMENT) {
                 consumeToken();
             } else if (tt == Token.RB) {
                 consumeToken();
@@ -3322,14 +3177,11 @@ public class Parser
                 // array literal contexts. So we calculate a special
                 // length value just for destructuring assignment.
                 end = ts.tokenEnd;
-                pn.setDestructuringLength(elements.size() +
-                                          (after_lb_or_comma ? 1 : 0));
+                pn.setDestructuringLength(elements.size() + (after_lb_or_comma ? 1 : 0));
                 pn.setSkipCount(skipCount);
-                if (afterComma != -1)
-                    warnTrailingComma(pos, elements, afterComma);
+                if (afterComma != -1) warnTrailingComma(pos, elements, afterComma);
                 break;
-            } else if (tt == Token.FOR && !after_lb_or_comma
-                       && elements.size() == 1) {
+            } else if (tt == Token.FOR && !after_lb_or_comma && elements.size() == 1) {
                 return arrayComprehension(elements.get(0), pos);
             } else if (tt == Token.EOF) {
                 reportError("msg.no.bracket.arg");
@@ -3352,15 +3204,13 @@ public class Parser
 
     /**
      * Parse a JavaScript 1.7 Array comprehension.
+     *
      * @param result the first expression after the opening left-bracket
      * @param pos start of LB token that begins the array comprehension
      * @return the array comprehension or an error node
      */
-    private AstNode arrayComprehension(AstNode result, int pos)
-        throws IOException
-    {
-        List<ArrayComprehensionLoop> loops =
-                new ArrayList<ArrayComprehensionLoop>();
+    private AstNode arrayComprehension(AstNode result, int pos) throws IOException {
+        List<ArrayComprehensionLoop> loops = new ArrayList<ArrayComprehensionLoop>();
         while (peekToken() == Token.FOR) {
             loops.add(arrayComprehensionLoop());
         }
@@ -3384,9 +3234,7 @@ public class Parser
         return pn;
     }
 
-    private ArrayComprehensionLoop arrayComprehensionLoop()
-        throws IOException
-    {
+    private ArrayComprehensionLoop arrayComprehensionLoop() throws IOException {
         if (nextToken() != Token.FOR) codeBug();
         int pos = ts.tokenBeg;
         int eachPos = -1, lp = -1, rp = -1, inPos = -1;
@@ -3408,18 +3256,18 @@ public class Parser
 
             AstNode iter = null;
             switch (peekToken()) {
-              case Token.LB:
-              case Token.LC:
-                  // handle destructuring assignment
-                  iter = destructuringPrimaryExpr();
-                  markDestructuring(iter);
-                  break;
-              case Token.NAME:
-                  consumeToken();
-                  iter = createNameNode();
-                  break;
-              default:
-                  reportError("msg.bad.var");
+                case Token.LB:
+                case Token.LC:
+                    // handle destructuring assignment
+                    iter = destructuringPrimaryExpr();
+                    markDestructuring(iter);
+                    break;
+                case Token.NAME:
+                    consumeToken();
+                    iter = createNameNode();
+                    break;
+                default:
+                    reportError("msg.bad.var");
             }
 
             // Define as a let since we want the scope of the variable to
@@ -3429,25 +3277,24 @@ public class Parser
             }
 
             switch (nextToken()) {
-            case Token.IN:
-                inPos = ts.tokenBeg - pos;
-                break;
-            case Token.NAME:
-                if ("of".equals(ts.getString())) {
-                    if (eachPos != -1) {
-                        reportError("msg.invalid.for.each");
-                    }
+                case Token.IN:
                     inPos = ts.tokenBeg - pos;
-                    isForOf = true;
                     break;
-                }
-                // fall through
-            default:
-                reportError("msg.in.after.for.name");
+                case Token.NAME:
+                    if ("of".equals(ts.getString())) {
+                        if (eachPos != -1) {
+                            reportError("msg.invalid.for.each");
+                        }
+                        inPos = ts.tokenBeg - pos;
+                        isForOf = true;
+                        break;
+                    }
+                    // fall through
+                default:
+                    reportError("msg.in.after.for.name");
             }
             AstNode obj = expr();
-            if (mustMatchToken(Token.RP, "msg.no.paren.for.ctrl", true))
-                rp = ts.tokenBeg - pos;
+            if (mustMatchToken(Token.RP, "msg.no.paren.for.ctrl", true)) rp = ts.tokenBeg - pos;
 
             pn.setLength(ts.tokenEnd - pos);
             pn.setIterator(iter);
@@ -3463,18 +3310,14 @@ public class Parser
         }
     }
 
-    private AstNode generatorExpression(AstNode result, int pos)
-        throws IOException
-    {
+    private AstNode generatorExpression(AstNode result, int pos) throws IOException {
         return generatorExpression(result, pos, false);
     }
 
     private AstNode generatorExpression(AstNode result, int pos, boolean inFunctionParams)
-        throws IOException
-    {
+            throws IOException {
 
-        List<GeneratorExpressionLoop> loops =
-                new ArrayList<GeneratorExpressionLoop>();
+        List<GeneratorExpressionLoop> loops = new ArrayList<GeneratorExpressionLoop>();
         while (peekToken() == Token.FOR) {
             loops.add(generatorExpressionLoop());
         }
@@ -3485,7 +3328,7 @@ public class Parser
             ifPos = ts.tokenBeg - pos;
             data = condition();
         }
-        if(!inFunctionParams) {
+        if (!inFunctionParams) {
             mustMatchToken(Token.RP, "msg.no.paren.let", true);
         }
         GeneratorExpression pn = new GeneratorExpression(pos, ts.tokenEnd - pos);
@@ -3500,9 +3343,7 @@ public class Parser
         return pn;
     }
 
-    private GeneratorExpressionLoop generatorExpressionLoop()
-        throws IOException
-    {
+    private GeneratorExpressionLoop generatorExpressionLoop() throws IOException {
         if (nextToken() != Token.FOR) codeBug();
         int pos = ts.tokenBeg;
         int lp = -1, rp = -1, inPos = -1;
@@ -3516,18 +3357,18 @@ public class Parser
 
             AstNode iter = null;
             switch (peekToken()) {
-              case Token.LB:
-              case Token.LC:
-                  // handle destructuring assignment
-                  iter = destructuringPrimaryExpr();
-                  markDestructuring(iter);
-                  break;
-              case Token.NAME:
-                  consumeToken();
-                  iter = createNameNode();
-                  break;
-              default:
-                  reportError("msg.bad.var");
+                case Token.LB:
+                case Token.LC:
+                    // handle destructuring assignment
+                    iter = destructuringPrimaryExpr();
+                    markDestructuring(iter);
+                    break;
+                case Token.NAME:
+                    consumeToken();
+                    iter = createNameNode();
+                    break;
+                default:
+                    reportError("msg.bad.var");
             }
 
             // Define as a let since we want the scope of the variable to
@@ -3536,11 +3377,9 @@ public class Parser
                 defineSymbol(Token.LET, ts.getString(), true);
             }
 
-            if (mustMatchToken(Token.IN, "msg.in.after.for.name", true))
-                inPos = ts.tokenBeg - pos;
+            if (mustMatchToken(Token.IN, "msg.in.after.for.name", true)) inPos = ts.tokenBeg - pos;
             AstNode obj = expr();
-            if (mustMatchToken(Token.RP, "msg.no.paren.for.ctrl", true))
-                rp = ts.tokenBeg - pos;
+            if (mustMatchToken(Token.RP, "msg.no.paren.for.ctrl", true)) rp = ts.tokenBeg - pos;
 
             pn.setLength(ts.tokenEnd - pos);
             pn.setIterator(iter);
@@ -3553,14 +3392,12 @@ public class Parser
         }
     }
 
-    private static final int PROP_ENTRY   = 1;
-    private static final int GET_ENTRY    = 2;
-    private static final int SET_ENTRY    = 4;
+    private static final int PROP_ENTRY = 1;
+    private static final int GET_ENTRY = 2;
+    private static final int SET_ENTRY = 4;
     private static final int METHOD_ENTRY = 8;
 
-    private ObjectLiteral objectLiteral()
-        throws IOException
-    {
+    private ObjectLiteral objectLiteral() throws IOException {
         int pos = ts.tokenBeg, lineno = ts.lineno;
         int afterComma = -1;
         List<ObjectProperty> elems = new ArrayList<ObjectProperty>();
@@ -3572,19 +3409,18 @@ public class Parser
         }
         Comment objJsdocNode = getAndResetJsDoc();
 
-      commaLoop:
-        for (;;) {
+        commaLoop:
+        for (; ; ) {
             String propertyName = null;
             int entryKind = PROP_ENTRY;
             int tt = peekToken();
             Comment jsdocNode = getAndResetJsDoc();
-            if(tt == Token.COMMENT) {
+            if (tt == Token.COMMENT) {
                 consumeToken();
                 tt = peekUntilNonComment(tt);
             }
             if (tt == Token.RC) {
-                if (afterComma != -1)
-                    warnTrailingComma(pos, elems, afterComma);
+                if (afterComma != -1) warnTrailingComma(pos, elems, afterComma);
                 break commaLoop;
             }
             AstNode pname = objliteralProperty();
@@ -3604,10 +3440,7 @@ public class Parser
                 // first case. (Because of keywords, the second case may be
                 // many tokens.)
                 int peeked = peekToken();
-                if (peeked != Token.COMMA
-                        && peeked != Token.COLON
-                        && peeked != Token.RC)
-                {
+                if (peeked != Token.COMMA && peeked != Token.COLON && peeked != Token.RC) {
                     if (peeked == Token.LP) {
                         entryKind = METHOD_ENTRY;
                     } else if (pname.getType() == Token.NAME) {
@@ -3628,8 +3461,7 @@ public class Parser
                         propertyName = null;
                     } else {
                         propertyName = ts.getString();
-                        ObjectProperty objectProp = methodDefinition(
-                                ppos, pname, entryKind);
+                        ObjectProperty objectProp = methodDefinition(ppos, pname, entryKind);
                         pname.setJsDocNode(jsdocNode);
                         elems.add(objectProp);
                     }
@@ -3641,27 +3473,27 @@ public class Parser
 
             if (this.inUseStrictDirective && propertyName != null) {
                 switch (entryKind) {
-                case PROP_ENTRY:
-                case METHOD_ENTRY:
-                    if (getterNames.contains(propertyName)
-                            || setterNames.contains(propertyName)) {
-                        addError("msg.dup.obj.lit.prop.strict", propertyName);
-                    }
-                    getterNames.add(propertyName);
-                    setterNames.add(propertyName);
-                    break;
-                case GET_ENTRY:
-                    if (getterNames.contains(propertyName)) {
-                        addError("msg.dup.obj.lit.prop.strict", propertyName);
-                    }
-                    getterNames.add(propertyName);
-                    break;
-                case SET_ENTRY:
-                    if (setterNames.contains(propertyName)) {
-                        addError("msg.dup.obj.lit.prop.strict", propertyName);
-                    }
-                    setterNames.add(propertyName);
-                    break;
+                    case PROP_ENTRY:
+                    case METHOD_ENTRY:
+                        if (getterNames.contains(propertyName)
+                                || setterNames.contains(propertyName)) {
+                            addError("msg.dup.obj.lit.prop.strict", propertyName);
+                        }
+                        getterNames.add(propertyName);
+                        setterNames.add(propertyName);
+                        break;
+                    case GET_ENTRY:
+                        if (getterNames.contains(propertyName)) {
+                            addError("msg.dup.obj.lit.prop.strict", propertyName);
+                        }
+                        getterNames.add(propertyName);
+                        break;
+                    case SET_ENTRY:
+                        if (setterNames.contains(propertyName)) {
+                            addError("msg.dup.obj.lit.prop.strict", propertyName);
+                        }
+                        setterNames.add(propertyName);
+                        break;
                 }
             }
 
@@ -3688,41 +3520,44 @@ public class Parser
     private AstNode objliteralProperty() throws IOException {
         AstNode pname;
         int tt = peekToken();
-        switch(tt) {
-          case Token.NAME:
-              pname = createNameNode();
-              break;
+        switch (tt) {
+            case Token.NAME:
+                pname = createNameNode();
+                break;
 
-          case Token.STRING:
-              pname = createStringLiteral();
-              break;
+            case Token.STRING:
+                pname = createStringLiteral();
+                break;
 
-          case Token.NUMBER:
-              pname = createNumberLiteral(true);
-              break;
+            case Token.NUMBER:
+                pname = createNumberLiteral(true);
+                break;
 
-          default:
-              if (compilerEnv.isReservedKeywordAsIdentifier()
-                      && TokenStream.isKeyword(ts.getString(), compilerEnv.getLanguageVersion(), inUseStrictDirective)) {
-                  // convert keyword to property name, e.g. ({if: 1})
-                  pname = createNameNode();
-                  break;
-              }
-              return null;
+            default:
+                if (compilerEnv.isReservedKeywordAsIdentifier()
+                        && TokenStream.isKeyword(
+                                ts.getString(),
+                                compilerEnv.getLanguageVersion(),
+                                inUseStrictDirective)) {
+                    // convert keyword to property name, e.g. ({if: 1})
+                    pname = createNameNode();
+                    break;
+                }
+                return null;
         }
 
         return pname;
     }
 
-    private ObjectProperty plainProperty(AstNode property, int ptt)
-        throws IOException
-    {
+    private ObjectProperty plainProperty(AstNode property, int ptt) throws IOException {
         // Support, e.g., |var {x, y} = o| as destructuring shorthand
         // for |var {x: x, y: y} = o|, as implemented in spidermonkey JS 1.8.
         int tt = peekToken();
-        if ((tt == Token.COMMA || tt == Token.RC) && ptt == Token.NAME
+        if ((tt == Token.COMMA || tt == Token.RC)
+                && ptt == Token.NAME
                 && compilerEnv.getLanguageVersion() >= Context.VERSION_1_8) {
-            if (!inDestructuringAssignment && compilerEnv.getLanguageVersion() < Context.VERSION_ES6) {
+            if (!inDestructuringAssignment
+                    && compilerEnv.getLanguageVersion() < Context.VERSION_ES6) {
                 reportError("msg.bad.object.init");
             }
             AstNode nn = new Name(property.getPosition(), property.getString());
@@ -3739,8 +3574,7 @@ public class Parser
     }
 
     private ObjectProperty methodDefinition(int pos, AstNode propName, int entryKind)
-        throws IOException
-    {
+            throws IOException {
         FunctionNode fn = function(FunctionNode.FUNCTION_EXPRESSION);
         // We've already parsed the function name, so fn should be anonymous.
         Name name = fn.getFunctionName();
@@ -3749,18 +3583,18 @@ public class Parser
         }
         ObjectProperty pn = new ObjectProperty(pos);
         switch (entryKind) {
-        case GET_ENTRY:
-            pn.setIsGetterMethod();
-            fn.setFunctionIsGetterMethod();
-            break;
-        case SET_ENTRY:
-            pn.setIsSetterMethod();
-            fn.setFunctionIsSetterMethod();
-            break;
-        case METHOD_ENTRY:
-            pn.setIsNormalMethod();
-            fn.setFunctionIsNormalMethod();
-            break;
+            case GET_ENTRY:
+                pn.setIsGetterMethod();
+                fn.setFunctionIsGetterMethod();
+                break;
+            case SET_ENTRY:
+                pn.setIsSetterMethod();
+                fn.setFunctionIsSetterMethod();
+                break;
+            case METHOD_ENTRY:
+                pn.setIsNormalMethod();
+                fn.setFunctionIsNormalMethod();
+                break;
         }
         int end = getNodeEnd(fn);
         pn.setLeft(propName);
@@ -3774,11 +3608,10 @@ public class Parser
     }
 
     /**
-     * Create a {@code Name} node using the token info from the
-     * last scanned name.  In some cases we need to either synthesize
-     * a name node, or we lost the name token information by peeking.
-     * If the {@code token} parameter is not {@link Token#NAME}, then
-     * we use token info saved in instance vars.
+     * Create a {@code Name} node using the token info from the last scanned name. In some cases we
+     * need to either synthesize a name node, or we lost the name token information by peeking. If
+     * the {@code token} parameter is not {@link Token#NAME}, then we use token info saved in
+     * instance vars.
      */
     private Name createNameNode(boolean checkActivation, int token) {
         int beg = ts.tokenBeg;
@@ -3825,18 +3658,16 @@ public class Parser
         }
         if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6 || !isProperty) {
             if (ts.isNumberBinary()) {
-                s = "0b"+s;
+                s = "0b" + s;
             } else if (ts.isNumberOldOctal()) {
-                s = "0"+s;
+                s = "0" + s;
             } else if (ts.isNumberOctal()) {
-                s = "0o"+s;
+                s = "0o" + s;
             } else if (ts.isNumberHex()) {
-                s = "0x"+s;
+                s = "0x" + s;
             }
         }
-        return new NumberLiteral(ts.tokenBeg,
-                                 s,
-                                 ts.getNumber());
+        return new NumberLiteral(ts.tokenBeg, s, ts.getNumber());
     }
 
     protected void checkActivationName(String name, int token) {
@@ -3844,17 +3675,17 @@ public class Parser
             return;
         }
         boolean activation = false;
-        if ("arguments".equals(name) &&
-            // An arrow function not generate arguments. So it not need activation.
-            ((FunctionNode)currentScriptOrFn).getFunctionType() != FunctionNode.ARROW_FUNCTION) {
+        if ("arguments".equals(name)
+                &&
+                // An arrow function not generate arguments. So it not need activation.
+                ((FunctionNode) currentScriptOrFn).getFunctionType()
+                        != FunctionNode.ARROW_FUNCTION) {
             activation = true;
         } else if (compilerEnv.getActivationNames() != null
                 && compilerEnv.getActivationNames().contains(name)) {
             activation = true;
         } else if ("length".equals(name)) {
-            if (token == Token.GETPROP
-                && compilerEnv.getLanguageVersion() == Context.VERSION_1_2)
-            {
+            if (token == Token.GETPROP && compilerEnv.getLanguageVersion() == Context.VERSION_1_2) {
                 // Use of "length" in 1.2 requires an activation object.
                 activation = true;
             }
@@ -3866,21 +3697,20 @@ public class Parser
 
     protected void setRequiresActivation() {
         if (insideFunction()) {
-            ((FunctionNode)currentScriptOrFn).setRequiresActivation();
+            ((FunctionNode) currentScriptOrFn).setRequiresActivation();
         }
     }
 
     private void checkCallRequiresActivation(AstNode pn) {
-        if ((pn.getType() == Token.NAME
-             && "eval".equals(((Name)pn).getIdentifier()))
-            || (pn.getType() == Token.GETPROP &&
-                "eval".equals(((PropertyGet)pn).getProperty().getIdentifier())))
+        if ((pn.getType() == Token.NAME && "eval".equals(((Name) pn).getIdentifier()))
+                || (pn.getType() == Token.GETPROP
+                        && "eval".equals(((PropertyGet) pn).getProperty().getIdentifier())))
             setRequiresActivation();
     }
 
     protected void setIsGenerator() {
         if (insideFunction()) {
-            ((FunctionNode)currentScriptOrFn).setIsGenerator();
+            ((FunctionNode) currentScriptOrFn).setIsGenerator();
         }
     }
 
@@ -3888,13 +3718,11 @@ public class Parser
         AstNode op = removeParens(expr.getOperand());
         int tt = op.getType();
         if (!(tt == Token.NAME
-              || tt == Token.GETPROP
-              || tt == Token.GETELEM
-              || tt == Token.GET_REF
-              || tt == Token.CALL))
-            reportError(expr.getType() == Token.INC
-                        ? "msg.bad.incr"
-                        : "msg.bad.decr");
+                || tt == Token.GETPROP
+                || tt == Token.GETELEM
+                || tt == Token.GET_REF
+                || tt == Token.CALL))
+            reportError(expr.getType() == Token.INC ? "msg.bad.incr" : "msg.bad.decr");
     }
 
     private ErrorNode makeErrorNode() {
@@ -3915,17 +3743,14 @@ public class Parser
     }
 
     /**
-     * Return the file offset of the beginning of the input source line
-     * containing the passed position.
+     * Return the file offset of the beginning of the input source line containing the passed
+     * position.
      *
-     * @param pos an offset into the input source stream.  If the offset
-     * is negative, it's converted to 0, and if it's beyond the end of
-     * the source buffer, the last source position is used.
-     *
-     * @return the offset of the beginning of the line containing pos
-     * (i.e. 1+ the offset of the first preceding newline).  Returns -1
-     * if the {@link CompilerEnvirons} is not set to ide-mode,
-     * and {@link #parse(java.io.Reader,String,int)} was used.
+     * @param pos an offset into the input source stream. If the offset is negative, it's converted
+     *     to 0, and if it's beyond the end of the source buffer, the last source position is used.
+     * @return the offset of the beginning of the line containing pos (i.e. 1+ the offset of the
+     *     first preceding newline). Returns -1 if the {@link CompilerEnvirons} is not set to
+     *     ide-mode, and {@link #parse(java.io.Reader,String,int)} was used.
      */
     private int lineBeginningFor(int pos) {
         if (sourceChars == null) {
@@ -3957,12 +3782,9 @@ public class Parser
             // this code originally called lineBeginningFor() and in order to
             // preserve its different line-offset handling, we need to special
             // case ide-mode here
-            int beg = compilerEnv.isIdeMode()
-                      ? Math.max(pos, end - linep[1])
-                      : pos;
+            int beg = compilerEnv.isIdeMode() ? Math.max(pos, end - linep[1]) : pos;
             if (line != null) {
-                addStrictWarning("msg.missing.semi", "", beg, end - beg,
-                                 linep[0], line, linep[1]);
+                addStrictWarning("msg.missing.semi", "", beg, end - beg, linep[0], line, linep[1]);
             } else {
                 // no line information available, report warning at current line
                 addStrictWarning("msg.missing.semi", "", beg, end - beg);
@@ -3974,7 +3796,7 @@ public class Parser
         if (compilerEnv.getWarnTrailingComma()) {
             // back up from comma to beginning of line or array/objlit
             if (!elems.isEmpty()) {
-                pos = ((AstNode)elems.get(0)).getPosition();
+                pos = ((AstNode) elems.get(0)).getPosition();
             }
             pos = Math.max(pos, lineBeginningFor(commaPos));
             addWarning("msg.extra.trailing.comma", pos, commaPos - pos);
@@ -3982,13 +3804,12 @@ public class Parser
     }
 
     // helps reduce clutter in the already-large function() method
-    protected class PerFunctionVariables
-    {
+    protected class PerFunctionVariables {
         private ScriptNode savedCurrentScriptOrFn;
         private Scope savedCurrentScope;
         private int savedEndFlags;
         private boolean savedInForInit;
-        private Map<String,LabeledStatement> savedLabelSet;
+        private Map<String, LabeledStatement> savedLabelSet;
         private List<Loop> savedLoopSet;
         private List<Jump> savedLoopAndSwitchSet;
 
@@ -4027,33 +3848,26 @@ public class Parser
     }
 
     /**
-     * Given a destructuring assignment with a left hand side parsed
-     * as an array or object literal and a right hand side expression,
-     * rewrite as a series of assignments to the variables defined in
-     * left from property accesses to the expression on the right.
+     * Given a destructuring assignment with a left hand side parsed as an array or object literal
+     * and a right hand side expression, rewrite as a series of assignments to the variables defined
+     * in left from property accesses to the expression on the right.
+     *
      * @param type declaration type: Token.VAR or Token.LET or -1
-     * @param left array or object literal containing NAME nodes for
-     *        variables to assign
+     * @param left array or object literal containing NAME nodes for variables to assign
      * @param right expression to assign from
-     * @return expression that performs a series of assignments to
-     *         the variables defined in left
+     * @return expression that performs a series of assignments to the variables defined in left
      */
-    Node createDestructuringAssignment(int type, Node left, Node right)
-    {
+    Node createDestructuringAssignment(int type, Node left, Node right) {
         String tempName = currentScriptOrFn.getNextTempName();
-        Node result = destructuringAssignmentHelper(type, left, right,
-            tempName);
+        Node result = destructuringAssignmentHelper(type, left, right, tempName);
         Node comma = result.getLastChild();
         comma.addChildToBack(createName(tempName));
         return result;
     }
 
-    Node destructuringAssignmentHelper(int variableType, Node left,
-                                       Node right, String tempName)
-    {
+    Node destructuringAssignmentHelper(int variableType, Node left, Node right, String tempName) {
         Scope result = createScopeNode(Token.LETEXPR, left.getLineno());
-        result.addChildToFront(new Node(Token.LET,
-            createName(Token.NAME, tempName, right)));
+        result.addChildToFront(new Node(Token.LET, createName(Token.NAME, tempName, right)));
         try {
             pushScope(result);
             defineSymbol(Token.LET, tempName, true);
@@ -4065,28 +3879,36 @@ public class Parser
         List<String> destructuringNames = new ArrayList<String>();
         boolean empty = true;
         switch (left.getType()) {
-          case Token.ARRAYLIT:
-              empty = destructuringArray((ArrayLiteral)left,
-                                         variableType, tempName, comma,
-                                         destructuringNames);
-              break;
-          case Token.OBJECTLIT:
-              empty = destructuringObject((ObjectLiteral)left,
-                                          variableType, tempName, comma,
-                                          destructuringNames);
-              break;
-          case Token.GETPROP:
-          case Token.GETELEM:
-              switch (variableType) {
-                  case Token.CONST:
-                  case Token.LET:
-                  case Token.VAR:
-                      reportError("msg.bad.assign.left");
-              }
-              comma.addChildToBack(simpleAssignment(left, createName(tempName)));
-              break;
-          default:
-              reportError("msg.bad.assign.left");
+            case Token.ARRAYLIT:
+                empty =
+                        destructuringArray(
+                                (ArrayLiteral) left,
+                                variableType,
+                                tempName,
+                                comma,
+                                destructuringNames);
+                break;
+            case Token.OBJECTLIT:
+                empty =
+                        destructuringObject(
+                                (ObjectLiteral) left,
+                                variableType,
+                                tempName,
+                                comma,
+                                destructuringNames);
+                break;
+            case Token.GETPROP:
+            case Token.GETELEM:
+                switch (variableType) {
+                    case Token.CONST:
+                    case Token.LET:
+                    case Token.VAR:
+                        reportError("msg.bad.assign.left");
+                }
+                comma.addChildToBack(simpleAssignment(left, createName(tempName)));
+                break;
+            default:
+                reportError("msg.bad.assign.left");
         }
         if (empty) {
             // Don't want a COMMA node with no children. Just add a zero.
@@ -4096,40 +3918,33 @@ public class Parser
         return result;
     }
 
-    boolean destructuringArray(ArrayLiteral array,
-                               int variableType,
-                               String tempName,
-                               Node parent,
-                               List<String> destructuringNames)
-    {
+    boolean destructuringArray(
+            ArrayLiteral array,
+            int variableType,
+            String tempName,
+            Node parent,
+            List<String> destructuringNames) {
         boolean empty = true;
-        int setOp = variableType == Token.CONST
-            ? Token.SETCONST : Token.SETNAME;
+        int setOp = variableType == Token.CONST ? Token.SETCONST : Token.SETNAME;
         int index = 0;
         for (AstNode n : array.getElements()) {
             if (n.getType() == Token.EMPTY) {
                 index++;
                 continue;
             }
-            Node rightElem = new Node(Token.GETELEM,
-                                      createName(tempName),
-                                      createNumber(index));
+            Node rightElem = new Node(Token.GETELEM, createName(tempName), createNumber(index));
             if (n.getType() == Token.NAME) {
                 String name = n.getString();
-                parent.addChildToBack(new Node(setOp,
-                                              createName(Token.BINDNAME,
-                                                         name, null),
-                                              rightElem));
+                parent.addChildToBack(
+                        new Node(setOp, createName(Token.BINDNAME, name, null), rightElem));
                 if (variableType != -1) {
                     defineSymbol(variableType, name, true);
                     destructuringNames.add(name);
                 }
             } else {
-                parent.addChildToBack
-                    (destructuringAssignmentHelper
-                     (variableType, n,
-                      rightElem,
-                      currentScriptOrFn.getNextTempName()));
+                parent.addChildToBack(
+                        destructuringAssignmentHelper(
+                                variableType, n, rightElem, currentScriptOrFn.getNextTempName()));
             }
             index++;
             empty = false;
@@ -4137,15 +3952,14 @@ public class Parser
         return empty;
     }
 
-    boolean destructuringObject(ObjectLiteral node,
-                                int variableType,
-                                String tempName,
-                                Node parent,
-                                List<String> destructuringNames)
-    {
+    boolean destructuringObject(
+            ObjectLiteral node,
+            int variableType,
+            String tempName,
+            Node parent,
+            List<String> destructuringNames) {
         boolean empty = true;
-        int setOp = variableType == Token.CONST
-            ? Token.SETCONST : Token.SETNAME;
+        int setOp = variableType == Token.CONST ? Token.SETCONST : Token.SETNAME;
 
         for (ObjectProperty prop : node.getElements()) {
             int lineno = 0;
@@ -4153,18 +3967,18 @@ public class Parser
             // when executing regression tests, and in those cases the
             // tokenStream isn't set.  Deal with it.
             if (ts != null) {
-              lineno = ts.lineno;
+                lineno = ts.lineno;
             }
             AstNode id = prop.getLeft();
             Node rightElem = null;
             if (id instanceof Name) {
-                Node s = Node.newString(((Name)id).getIdentifier());
+                Node s = Node.newString(((Name) id).getIdentifier());
                 rightElem = new Node(Token.GETPROP, createName(tempName), s);
             } else if (id instanceof StringLiteral) {
-                Node s = Node.newString(((StringLiteral)id).getValue());
+                Node s = Node.newString(((StringLiteral) id).getValue());
                 rightElem = new Node(Token.GETPROP, createName(tempName), s);
             } else if (id instanceof NumberLiteral) {
-                Node s = createNumber((int)((NumberLiteral)id).getNumber());
+                Node s = createNumber((int) ((NumberLiteral) id).getNumber());
                 rightElem = new Node(Token.GETELEM, createName(tempName), s);
             } else {
                 throw codeBug();
@@ -4172,20 +3986,20 @@ public class Parser
             rightElem.setLineno(lineno);
             AstNode value = prop.getRight();
             if (value.getType() == Token.NAME) {
-                String name = ((Name)value).getIdentifier();
-                parent.addChildToBack(new Node(setOp,
-                                              createName(Token.BINDNAME,
-                                                         name, null),
-                                              rightElem));
+                String name = ((Name) value).getIdentifier();
+                parent.addChildToBack(
+                        new Node(setOp, createName(Token.BINDNAME, name, null), rightElem));
                 if (variableType != -1) {
                     defineSymbol(variableType, name, true);
                     destructuringNames.add(name);
                 }
             } else {
-                parent.addChildToBack
-                    (destructuringAssignmentHelper
-                     (variableType, value, rightElem,
-                      currentScriptOrFn.getNextTempName()));
+                parent.addChildToBack(
+                        destructuringAssignmentHelper(
+                                variableType,
+                                value,
+                                rightElem,
+                                currentScriptOrFn.getNextTempName()));
             }
             empty = false;
         }
@@ -4200,8 +4014,7 @@ public class Parser
     protected Node createName(int type, String name, Node child) {
         Node result = createName(name);
         result.setType(type);
-        if (child != null)
-            result.addChildToBack(child);
+        if (child != null) result.addChildToBack(child);
         return result;
     }
 
@@ -4210,15 +4023,15 @@ public class Parser
     }
 
     /**
-     * Create a node that can be used to hold lexically scoped variable
-     * definitions (via let declarations).
+     * Create a node that can be used to hold lexically scoped variable definitions (via let
+     * declarations).
      *
      * @param token the token of the node to create
      * @param lineno line number of source
      * @return the created node
      */
     protected Scope createScopeNode(int token, int lineno) {
-        Scope scope =new Scope();
+        Scope scope = new Scope();
         scope.setType(token);
         scope.setLineno(lineno);
         return scope;
@@ -4249,53 +4062,55 @@ public class Parser
     protected Node simpleAssignment(Node left, Node right) {
         int nodeType = left.getType();
         switch (nodeType) {
-          case Token.NAME:
-              String name = ((Name) left).getIdentifier();
-              if (inUseStrictDirective &&
-                  ("eval".equals(name) || "arguments".equals(name)))
-              {
-                  reportError("msg.bad.id.strict", name);
-              }
-              left.setType(Token.BINDNAME);
-              return new Node(Token.SETNAME, left, right);
+            case Token.NAME:
+                String name = ((Name) left).getIdentifier();
+                if (inUseStrictDirective && ("eval".equals(name) || "arguments".equals(name))) {
+                    reportError("msg.bad.id.strict", name);
+                }
+                left.setType(Token.BINDNAME);
+                return new Node(Token.SETNAME, left, right);
 
-          case Token.GETPROP:
-          case Token.GETELEM: {
-              Node obj, id;
-              // If it's a PropertyGet or ElementGet, we're in the parse pass.
-              // We could alternately have PropertyGet and ElementGet
-              // override getFirstChild/getLastChild and return the appropriate
-              // field, but that seems just as ugly as this casting.
-              if (left instanceof PropertyGet) {
-                  obj = ((PropertyGet)left).getTarget();
-                  id = ((PropertyGet)left).getProperty();
-              } else if (left instanceof ElementGet) {
-                  obj = ((ElementGet)left).getTarget();
-                  id = ((ElementGet)left).getElement();
-              } else {
-                  // This branch is called during IRFactory transform pass.
-                  obj = left.getFirstChild();
-                  id = left.getLastChild();
-              }
-              int type;
-              if (nodeType == Token.GETPROP) {
-                  type = Token.SETPROP;
-                  // TODO(stevey) - see https://bugzilla.mozilla.org/show_bug.cgi?id=492036
-                  // The new AST code generates NAME tokens for GETPROP ids where the old parser
-                  // generated STRING nodes. If we don't set the type to STRING below, this will
-                  // cause java.lang.VerifyError in codegen for code like
-                  // "var obj={p:3};[obj.p]=[9];"
-                  id.setType(Token.STRING);
-              } else {
-                  type = Token.SETELEM;
-              }
-              return new Node(type, obj, id, right);
-          }
-          case Token.GET_REF: {
-              Node ref = left.getFirstChild();
-              checkMutableReference(ref);
-              return new Node(Token.SET_REF, ref, right);
-          }
+            case Token.GETPROP:
+            case Token.GETELEM:
+                {
+                    Node obj, id;
+                    // If it's a PropertyGet or ElementGet, we're in the parse pass.
+                    // We could alternately have PropertyGet and ElementGet
+                    // override getFirstChild/getLastChild and return the appropriate
+                    // field, but that seems just as ugly as this casting.
+                    if (left instanceof PropertyGet) {
+                        obj = ((PropertyGet) left).getTarget();
+                        id = ((PropertyGet) left).getProperty();
+                    } else if (left instanceof ElementGet) {
+                        obj = ((ElementGet) left).getTarget();
+                        id = ((ElementGet) left).getElement();
+                    } else {
+                        // This branch is called during IRFactory transform pass.
+                        obj = left.getFirstChild();
+                        id = left.getLastChild();
+                    }
+                    int type;
+                    if (nodeType == Token.GETPROP) {
+                        type = Token.SETPROP;
+                        // TODO(stevey) - see https://bugzilla.mozilla.org/show_bug.cgi?id=492036
+                        // The new AST code generates NAME tokens for GETPROP ids where the old
+                        // parser
+                        // generated STRING nodes. If we don't set the type to STRING below, this
+                        // will
+                        // cause java.lang.VerifyError in codegen for code like
+                        // "var obj={p:3};[obj.p]=[9];"
+                        id.setType(Token.STRING);
+                    } else {
+                        type = Token.SETELEM;
+                    }
+                    return new Node(type, obj, id, right);
+                }
+            case Token.GET_REF:
+                {
+                    Node ref = left.getFirstChild();
+                    checkMutableReference(ref);
+                    return new Node(Token.SET_REF, ref, right);
+                }
         }
 
         throw codeBug();
@@ -4311,26 +4126,28 @@ public class Parser
     // remove any ParenthesizedExpression wrappers
     protected AstNode removeParens(AstNode node) {
         while (node instanceof ParenthesizedExpression) {
-            node = ((ParenthesizedExpression)node).getExpression();
+            node = ((ParenthesizedExpression) node).getExpression();
         }
         return node;
     }
 
     void markDestructuring(AstNode node) {
         if (node instanceof DestructuringForm) {
-            ((DestructuringForm)node).setIsDestructuring(true);
+            ((DestructuringForm) node).setIsDestructuring(true);
         } else if (node instanceof ParenthesizedExpression) {
-            markDestructuring(((ParenthesizedExpression)node).getExpression());
+            markDestructuring(((ParenthesizedExpression) node).getExpression());
         }
     }
 
     // throw a failed-assertion with some helpful debugging info
-    private RuntimeException codeBug()
-        throws RuntimeException
-    {
-        throw Kit.codeBug("ts.cursor=" + ts.cursor
-                          + ", ts.tokenBeg=" + ts.tokenBeg
-                          + ", currentToken=" + currentToken);
+    private RuntimeException codeBug() throws RuntimeException {
+        throw Kit.codeBug(
+                "ts.cursor="
+                        + ts.cursor
+                        + ", ts.tokenBeg="
+                        + ts.tokenBeg
+                        + ", currentToken="
+                        + currentToken);
     }
 
     public void setDefaultUseStrictDirective(boolean useStrict) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -164,6 +164,7 @@ public class ScriptRuntime {
         NativeString.init(scope, sealed);
         NativeBoolean.init(scope, sealed);
         NativeNumber.init(scope, sealed);
+        NativeBigInt.init(scope, sealed);
         NativeDate.init(scope, sealed);
         NativeMath.init(scope, sealed);
         NativeJSON.init(scope, sealed);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2958,6 +2958,63 @@ public class ScriptRuntime {
         }
     }
 
+    public static Number bitwiseAND(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            return ((BigInteger) val1).and((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            int result = toInt32(val1.doubleValue()) & toInt32(val2.doubleValue());
+            return Double.valueOf(result);
+        }
+    }
+
+    public static Number bitwiseOR(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            return ((BigInteger) val1).or((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            int result = toInt32(val1.doubleValue()) | toInt32(val2.doubleValue());
+            return Double.valueOf(result);
+        }
+    }
+
+    public static Number bitwiseXOR(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            return ((BigInteger) val1).xor((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            int result = toInt32(val1.doubleValue()) ^ toInt32(val2.doubleValue());
+            return Double.valueOf(result);
+        }
+    }
+
+    public static Number leftShift(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            // TODO: val2 is supported only in the range of 32-bit integer.
+            return ((BigInteger) val1).shiftLeft(val2.intValue());
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            int result = toInt32(val1.doubleValue()) << toInt32(val2.doubleValue());
+            return Double.valueOf(result);
+        }
+    }
+
+    public static Number signedRightShift(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            // TODO: val2 is supported only in the range of 32-bit integer.
+            return ((BigInteger) val1).shiftRight(val2.intValue());
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            int result = toInt32(val1.doubleValue()) >> toInt32(val2.doubleValue());
+            return Double.valueOf(result);
+        }
+    }
+
     /**
      * The method is only present for compatibility.
      *

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2968,8 +2968,14 @@ public class ScriptRuntime {
             if (((BigInteger) val2).signum() == -1) {
                 throw ScriptRuntime.rangeErrorById("msg.bigint.negative.exponent");
             }
-            // TODO: val2 is supported only in the range of 32-bit integer.
-            return ((BigInteger) val1).pow(val2.intValue());
+
+            try {
+                int intVal2 = ((BigInteger) val2).intValueExact();
+                return ((BigInteger) val1).pow(intVal2);
+            } catch (ArithmeticException e) {
+                // This is outside the scope of the ECMA262 specification.
+                throw ScriptRuntime.rangeErrorById("msg.bigint.out.of.range.arithmetic");
+            }
         } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
             throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
         } else {
@@ -3012,8 +3018,13 @@ public class ScriptRuntime {
 
     public static Number leftShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
-            // TODO: val2 is supported only in the range of 32-bit integer.
-            return ((BigInteger) val1).shiftLeft(val2.intValue());
+            try {
+                int intVal2 = ((BigInteger) val2).intValueExact();
+                return ((BigInteger) val1).shiftLeft(intVal2);
+            } catch (ArithmeticException e) {
+                // This is outside the scope of the ECMA262 specification.
+                throw ScriptRuntime.rangeErrorById("msg.bigint.out.of.range.arithmetic");
+            }
         } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
             throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
         } else {
@@ -3024,8 +3035,13 @@ public class ScriptRuntime {
 
     public static Number signedRightShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
-            // TODO: val2 is supported only in the range of 32-bit integer.
-            return ((BigInteger) val1).shiftRight(val2.intValue());
+            try {
+                int intVal2 = ((BigInteger) val2).intValueExact();
+                return ((BigInteger) val1).shiftRight(intVal2);
+            } catch (ArithmeticException e) {
+                // This is outside the scope of the ECMA262 specification.
+                throw ScriptRuntime.rangeErrorById("msg.bigint.out.of.range.arithmetic");
+            }
         } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
             throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
         } else {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3015,6 +3015,15 @@ public class ScriptRuntime {
         }
     }
 
+    public static Number bitwiseNOT(Number val) {
+        if (val instanceof BigInteger) {
+            return ((BigInteger) val).not();
+        } else {
+            int result = ~toInt32(val.doubleValue());
+            return Double.valueOf(result);
+        }
+    }
+
     /**
      * The method is only present for compatibility.
      *

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -1194,6 +1194,11 @@ public class ScriptRuntime {
             setBuiltinProtoAndParent(result, scope, TopLevel.Builtins.String);
             return result;
         }
+        if (val instanceof BigInteger) {
+            NativeBigInt result = new NativeBigInt(((BigInteger) val));
+            setBuiltinProtoAndParent(result, scope, TopLevel.Builtins.BigInt);
+            return result;
+        }
         if (val instanceof Number) {
             NativeNumber result = new NativeNumber(((Number) val).doubleValue());
             setBuiltinProtoAndParent(result, scope, TopLevel.Builtins.Number);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2898,6 +2898,66 @@ public class ScriptRuntime {
         return new ConsString(toCharSequence(val1), val2);
     }
 
+    public static Number subtract(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            return ((BigInteger) val1).subtract((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            return val1.doubleValue() - val2.doubleValue();
+        }
+    }
+
+    public static Number multiply(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            return ((BigInteger) val1).multiply((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            return val1.doubleValue() * val2.doubleValue();
+        }
+    }
+
+    public static Number divide(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            if (val2.equals(BigInteger.ZERO)) {
+                throw ScriptRuntime.rangeErrorById("msg.division.zero");
+            }
+            return ((BigInteger) val1).divide((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            return val1.doubleValue() / val2.doubleValue();
+        }
+    }
+
+    public static Number remainder(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            if (val2.equals(BigInteger.ZERO)) {
+                throw ScriptRuntime.rangeErrorById("msg.division.zero");
+            }
+            return ((BigInteger) val1).remainder((BigInteger) val2);
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            return val1.doubleValue() % val2.doubleValue();
+        }
+    }
+
+    public static Number exponentiate(Number val1, Number val2) {
+        if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
+            if (((BigInteger) val2).signum() == -1) {
+                throw ScriptRuntime.rangeErrorById("msg.bigint.negative.exponent");
+            }
+            // TODO: val2 is supported only in the range of 32-bit integer.
+            return ((BigInteger) val1).pow(val2.intValue());
+        } else if (val1 instanceof BigInteger || val2 instanceof BigInteger) {
+            throw ScriptRuntime.typeErrorById("msg.cant.convert.to.number", "BigInt");
+        } else {
+            return Math.pow(val1.doubleValue(), val2.doubleValue());
+        }
+    }
+
     /**
      * The method is only present for compatibility.
      *

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -831,6 +831,22 @@ public class ScriptRuntime {
         return toNumber(val);
     }
 
+    public static int toIndex(Object val) {
+        if (Undefined.isUndefined(val)) {
+            return 0;
+        }
+        double integerIndex = toInteger(val);
+        if (integerIndex < 0) {
+            throw rangeError("index out of range");
+        }
+        // ToLength
+        double index = Math.min(integerIndex, NativeNumber.MAX_SAFE_INTEGER);
+        if (integerIndex != index) {
+            throw rangeError("index out of range");
+        }
+        return (int) index;
+    }
+
     /**
      * Helper function for builtin objects that use the varargs form. ECMA function formal arguments
      * are undefined if not supplied; this function pads the argument array out to the expected

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -818,6 +818,13 @@ public class ScriptRuntime {
         }
     }
 
+    public static Number toNumeric(Object val) {
+        if (val instanceof BigInteger) {
+            return (BigInteger) val;
+        }
+        return toNumber(val);
+    }
+
     /**
      * Helper function for builtin objects that use the varargs form. ECMA function formal arguments
      * are undefined if not supplied; this function pads the argument array out to the expected
@@ -3034,6 +3041,13 @@ public class ScriptRuntime {
             return value;
         }
         return result;
+    }
+
+    public static Number negate(Number val) {
+        if (val instanceof BigInteger) {
+            return ((BigInteger) val).negate();
+        }
+        return -val.doubleValue();
     }
 
     public static Object toPrimitive(Object val) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -415,6 +415,9 @@ public class ScriptRuntime {
      */
     public static double toNumber(Object val) {
         for (; ; ) {
+            if (val instanceof BigInteger) {
+                throw typeErrorById("msg.cant.convert.to.number", "BigInt");
+            }
             if (val instanceof Number) return ((Number) val).doubleValue();
             if (val == null) return +0.0;
             if (val == Undefined.instance) return NaN;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3067,6 +3067,8 @@ public class ScriptRuntime {
                 }
             }
             return false;
+        } else if (x instanceof BigInteger) {
+            return eqBigInt((BigInteger) x, y);
         } else if (x instanceof Number) {
             return eqNumber(((Number) x).doubleValue(), y);
         } else if (x == y) {
@@ -3119,6 +3121,8 @@ public class ScriptRuntime {
                 }
                 double d = ((Boolean) y).booleanValue() ? 1.0 : 0.0;
                 return eqNumber(d, x);
+            } else if (y instanceof BigInteger) {
+                return eqBigInt((BigInteger) y, x);
             } else if (y instanceof Number) {
                 return eqNumber(((Number) y).doubleValue(), x);
             } else if (y instanceof CharSequence) {
@@ -3153,6 +3157,9 @@ public class ScriptRuntime {
     public static boolean sameZero(Object x, Object y) {
         if (!typeof(x).equals(typeof(y))) {
             return false;
+        }
+        if (x instanceof BigInteger) {
+            return x.equals(y);
         }
         if (x instanceof Number) {
             if (isNaN(x) && isNaN(y)) {
@@ -3192,6 +3199,8 @@ public class ScriptRuntime {
         for (; ; ) {
             if (y == null || y == Undefined.instance) {
                 return false;
+            } else if (y instanceof BigInteger) {
+                return eqBigInt((BigInteger) y, x);
             } else if (y instanceof Number) {
                 return x == ((Number) y).doubleValue();
             } else if (y instanceof CharSequence) {
@@ -3216,6 +3225,57 @@ public class ScriptRuntime {
         }
     }
 
+    static boolean eqBigInt(BigInteger x, Object y) {
+        for (; ; ) {
+            if (y == null || y == Undefined.instance) {
+                return false;
+            } else if (y instanceof BigInteger) {
+                return x.equals(y);
+            } else if (y instanceof Number) {
+                return eqBigInt(x, ((Number) y).doubleValue());
+            } else if (y instanceof CharSequence) {
+                BigInteger biy;
+                try {
+                    biy = toBigInt(y);
+                } catch (EcmaError e) {
+                    return false;
+                }
+                return x.equals(biy);
+            } else if (y instanceof Boolean) {
+                BigInteger biy = ((Boolean) y).booleanValue() ? BigInteger.ONE : BigInteger.ZERO;
+                return x.equals(biy);
+            } else if (isSymbol(y)) {
+                return false;
+            } else if (y instanceof Scriptable) {
+                if (y instanceof ScriptableObject) {
+                    Object test = ((ScriptableObject) y).equivalentValues(x);
+                    if (test != Scriptable.NOT_FOUND) {
+                        return ((Boolean) test).booleanValue();
+                    }
+                }
+                y = toPrimitive(y);
+            } else {
+                warnAboutNonJSObject(y);
+                return false;
+            }
+        }
+    }
+
+    private static boolean eqBigInt(BigInteger x, double y) {
+        if (Double.isNaN(y) || Double.isInfinite(y)) {
+            return false;
+        }
+
+        double d = Math.ceil(y);
+        if (d != y) {
+            return false;
+        }
+
+        BigDecimal bdx = new BigDecimal(x);
+        BigDecimal bdy = new BigDecimal(d, MathContext.UNLIMITED);
+        return bdx.compareTo(bdy) == 0;
+    }
+
     private static boolean eqString(CharSequence x, Object y) {
         for (; ; ) {
             if (y == null || y == Undefined.instance) {
@@ -3223,6 +3283,14 @@ public class ScriptRuntime {
             } else if (y instanceof CharSequence) {
                 CharSequence c = (CharSequence) y;
                 return x.length() == c.length() && x.toString().equals(c.toString());
+            } else if (y instanceof BigInteger) {
+                BigInteger bix;
+                try {
+                    bix = toBigInt(x);
+                } catch (EcmaError e) {
+                    return false;
+                }
+                return bix.equals(y);
             } else if (y instanceof Number) {
                 return toNumber(x.toString()) == ((Number) y).doubleValue();
             } else if (y instanceof Boolean) {
@@ -3259,8 +3327,12 @@ public class ScriptRuntime {
                     || (x == Undefined.SCRIPTABLE_UNDEFINED && y == Undefined.instance))
                 return true;
             return false;
-        } else if (x instanceof Number) {
-            if (y instanceof Number) {
+        } else if (x instanceof BigInteger) {
+            if (y instanceof BigInteger) {
+                return x.equals(y);
+            }
+        } else if (x instanceof Number && !(x instanceof BigInteger)) {
+            if (y instanceof Number && !(y instanceof BigInteger)) {
                 return ((Number) x).doubleValue() == ((Number) y).doubleValue();
             }
         } else if (x instanceof CharSequence) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2958,25 +2958,32 @@ public class ScriptRuntime {
             Object value,
             int incrDecrMask) {
         final boolean post = (incrDecrMask & Node.POST_FLAG) != 0;
-        double number;
+
+        Number number;
         if (value instanceof Number) {
-            number = ((Number) value).doubleValue();
+            number = (Number) value;
         } else {
-            number = toNumber(value);
-            if (post) {
-                // convert result to number
-                value = wrapNumber(number);
+            number = toNumeric(value);
+        }
+
+        Number result;
+        if (number instanceof BigInteger) {
+            if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                result = ((BigInteger) number).add(BigInteger.ONE);
+            } else {
+                result = ((BigInteger) number).subtract(BigInteger.ONE);
+            }
+        } else {
+            if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                result = number.doubleValue() + 1.0;
+            } else {
+                result = number.doubleValue() - 1.0;
             }
         }
-        if ((incrDecrMask & Node.DECR_FLAG) == 0) {
-            ++number;
-        } else {
-            --number;
-        }
-        Number result = wrapNumber(number);
+
         target.put(id, protoChainStart, result);
         if (post) {
-            return value;
+            return number;
         }
         return result;
     }
@@ -2991,25 +2998,32 @@ public class ScriptRuntime {
             Object obj, Object index, Context cx, Scriptable scope, int incrDecrMask) {
         Object value = getObjectElem(obj, index, cx, scope);
         final boolean post = (incrDecrMask & Node.POST_FLAG) != 0;
-        double number;
+
+        Number number;
         if (value instanceof Number) {
-            number = ((Number) value).doubleValue();
+            number = (Number) value;
         } else {
-            number = toNumber(value);
-            if (post) {
-                // convert result to number
-                value = wrapNumber(number);
+            number = toNumeric(value);
+        }
+
+        Number result;
+        if (number instanceof BigInteger) {
+            if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                result = ((BigInteger) number).add(BigInteger.ONE);
+            } else {
+                result = ((BigInteger) number).subtract(BigInteger.ONE);
+            }
+        } else {
+            if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                result = number.doubleValue() + 1.0;
+            } else {
+                result = number.doubleValue() - 1.0;
             }
         }
-        if ((incrDecrMask & Node.DECR_FLAG) == 0) {
-            ++number;
-        } else {
-            --number;
-        }
-        Number result = wrapNumber(number);
+
         setObjectElem(obj, index, result, cx, scope);
         if (post) {
-            return value;
+            return number;
         }
         return result;
     }
@@ -3023,25 +3037,32 @@ public class ScriptRuntime {
     public static Object refIncrDecr(Ref ref, Context cx, Scriptable scope, int incrDecrMask) {
         Object value = ref.get(cx);
         boolean post = ((incrDecrMask & Node.POST_FLAG) != 0);
-        double number;
+
+        Number number;
         if (value instanceof Number) {
-            number = ((Number) value).doubleValue();
+            number = (Number) value;
         } else {
-            number = toNumber(value);
-            if (post) {
-                // convert result to number
-                value = wrapNumber(number);
+            number = toNumeric(value);
+        }
+
+        Number result;
+        if (number instanceof BigInteger) {
+            if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                result = ((BigInteger) number).add(BigInteger.ONE);
+            } else {
+                result = ((BigInteger) number).subtract(BigInteger.ONE);
+            }
+        } else {
+            if ((incrDecrMask & Node.DECR_FLAG) == 0) {
+                result = number.doubleValue() + 1.0;
+            } else {
+                result = number.doubleValue() - 1.0;
             }
         }
-        if ((incrDecrMask & Node.DECR_FLAG) == 0) {
-            ++number;
-        } else {
-            --number;
-        }
-        Number result = wrapNumber(number);
+
         ref.set(cx, scope, result);
         if (post) {
-            return value;
+            return number;
         }
         return result;
     }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -168,7 +168,6 @@ public class ScriptRuntime {
         NativeString.init(scope, sealed);
         NativeBoolean.init(scope, sealed);
         NativeNumber.init(scope, sealed);
-        NativeBigInt.init(scope, sealed);
         NativeDate.init(scope, sealed);
         NativeMath.init(scope, sealed);
         NativeJSON.init(scope, sealed);
@@ -281,6 +280,7 @@ public class ScriptRuntime {
             NativeSet.init(cx, scope, sealed);
             NativeWeakMap.init(scope, sealed);
             NativeWeakSet.init(scope, sealed);
+            NativeBigInt.init(scope, sealed);
         }
 
         if (scope instanceof TopLevel) {
@@ -1226,7 +1226,7 @@ public class ScriptRuntime {
             setBuiltinProtoAndParent(result, scope, TopLevel.Builtins.String);
             return result;
         }
-        if (val instanceof BigInteger) {
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6 && val instanceof BigInteger) {
             NativeBigInt result = new NativeBigInt(((BigInteger) val));
             setBuiltinProtoAndParent(result, scope, TopLevel.Builtins.BigInt);
             return result;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -384,6 +384,9 @@ public class ScriptRuntime {
             if (val instanceof Boolean) return ((Boolean) val).booleanValue();
             if (val == null || val == Undefined.instance) return false;
             if (val instanceof CharSequence) return ((CharSequence) val).length() != 0;
+            if (val instanceof BigInteger) {
+                return !((BigInteger) val).equals(BigInteger.ZERO);
+            }
             if (val instanceof Number) {
                 double d = ((Number) val).doubleValue();
                 return (!Double.isNaN(d) && d != 0.0);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2771,6 +2771,7 @@ public class ScriptRuntime {
         if (value instanceof ScriptableObject) return ((ScriptableObject) value).getTypeOf();
         if (value instanceof Scriptable) return (value instanceof Callable) ? "function" : "object";
         if (value instanceof CharSequence) return "string";
+        if (value instanceof BigInteger) return "bigint";
         if (value instanceof Number) return "number";
         if (value instanceof Boolean) return "boolean";
         throw errorWithClassName("msg.invalid.type", value);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -8,6 +8,9 @@ package org.mozilla.javascript;
 
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Locale;
@@ -111,7 +114,8 @@ public class ScriptRuntime {
             ObjectClass = Kit.classOrNull("java.lang.Object"),
             ShortClass = Kit.classOrNull("java.lang.Short"),
             StringClass = Kit.classOrNull("java.lang.String"),
-            DateClass = Kit.classOrNull("java.util.Date");
+            DateClass = Kit.classOrNull("java.util.Date"),
+            BigIntegerClass = Kit.classOrNull("java.math.BigInteger");
     public static final Class<?> ContextClass = Kit.classOrNull("org.mozilla.javascript.Context"),
             ContextFactoryClass = Kit.classOrNull("org.mozilla.javascript.ContextFactory"),
             FunctionClass = Kit.classOrNull("org.mozilla.javascript.Function"),
@@ -689,6 +693,128 @@ public class ScriptRuntime {
             return Double.parseDouble(sub);
         } catch (NumberFormatException ex) {
             return NaN;
+        }
+    }
+
+    /** Convert the value to a BigInt. */
+    public static BigInteger toBigInt(Object val) {
+        for (; ; ) {
+            if (val instanceof BigInteger) {
+                return (BigInteger) val;
+            }
+            if (val instanceof BigDecimal) {
+                return ((BigDecimal) val).toBigInteger();
+            }
+            if (val instanceof Number) {
+                if (val instanceof Long) {
+                    return BigInteger.valueOf(((Long) val));
+                } else {
+                    double d = ((Number) val).doubleValue();
+                    if (Double.isNaN(d) || Double.isInfinite(d)) {
+                        throw rangeErrorById(
+                                "msg.cant.convert.to.bigint.isnt.integer", toString(val));
+                    }
+                    BigDecimal bd = new BigDecimal(d, MathContext.UNLIMITED);
+                    try {
+                        return bd.toBigIntegerExact();
+                    } catch (ArithmeticException e) {
+                        throw rangeErrorById(
+                                "msg.cant.convert.to.bigint.isnt.integer", toString(val));
+                    }
+                }
+            }
+            if (val == null || val == Undefined.instance) {
+                throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
+            }
+            if (val instanceof String) {
+                return toBigInt((String) val);
+            }
+            if (val instanceof CharSequence) {
+                return toBigInt(val.toString());
+            }
+            if (val instanceof Boolean) {
+                return ((Boolean) val).booleanValue() ? BigInteger.ONE : BigInteger.ZERO;
+            }
+            if (val instanceof Symbol) {
+                throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
+            }
+            if (val instanceof Scriptable) {
+                val = ((Scriptable) val).getDefaultValue(BigIntegerClass);
+                if ((val instanceof Scriptable) && !isSymbol(val)) {
+                    throw errorWithClassName("msg.primitive.expected", val);
+                }
+                continue;
+            }
+            warnAboutNonJSObject(val);
+            return BigInteger.ZERO;
+        }
+    }
+
+    /** ToBigInt applied to the String type */
+    public static BigInteger toBigInt(String s) {
+        final int len = s.length();
+
+        // Skip whitespace at the start
+        int start = 0;
+        char startChar;
+        for (; ; ) {
+            if (start == len) {
+                // empty or contains only whitespace
+                return BigInteger.ZERO;
+            }
+            startChar = s.charAt(start);
+            if (!ScriptRuntime.isStrWhiteSpaceChar(startChar)) {
+                // found first non-whitespace character
+                break;
+            }
+            start++;
+        }
+
+        // Skip whitespace at the end
+        int end = len - 1;
+        while (ScriptRuntime.isStrWhiteSpaceChar(s.charAt(end))) {
+            end--;
+        }
+
+        // Handle non-base10 numbers
+        if (startChar == '0') {
+            if (start + 2 <= end) {
+                final char radixC = s.charAt(start + 1);
+                int radix = -1;
+                if (radixC == 'x' || radixC == 'X') {
+                    radix = 16;
+                } else if (radixC == 'o' || radixC == 'O') {
+                    radix = 8;
+                } else if (radixC == 'b' || radixC == 'B') {
+                    radix = 2;
+                }
+                if (radix != -1) {
+                    try {
+                        return new BigInteger(s.substring(start + 2, end + 1), radix);
+                    } catch (NumberFormatException ex) {
+                        throw syntaxErrorById("msg.bigint.bad.form");
+                    }
+                }
+            }
+        }
+
+        // A base10, non-infinity bigint:
+        // just try a normal biginteger conversion
+        String sub = s.substring(start, end + 1);
+        for (int i = sub.length() - 1; i >= 0; i--) {
+            char c = sub.charAt(i);
+            if (i == 0 && (c == '+' || c == '-')) {
+                continue;
+            }
+            if ('0' <= c && c <= '9') {
+                continue;
+            }
+            throw syntaxErrorById("msg.bigint.bad.form");
+        }
+        try {
+            return new BigInteger(sub);
+        } catch (NumberFormatException ex) {
+            throw syntaxErrorById("msg.bigint.bad.form");
         }
     }
 
@@ -3988,6 +4114,11 @@ public class ScriptRuntime {
         return constructError("RangeError", message);
     }
 
+    public static EcmaError rangeErrorById(String messageId, Object... args) {
+        String msg = getMessageById(messageId, args);
+        return rangeError(msg);
+    }
+
     public static EcmaError typeError(String message) {
         return constructError("TypeError", message);
     }
@@ -4080,6 +4211,15 @@ public class ScriptRuntime {
 
     private static RuntimeException notXmlError(Object value) {
         throw typeErrorById("msg.isnt.xml.object", toString(value));
+    }
+
+    public static EcmaError syntaxError(String message) {
+        return constructError("SyntaxError", message);
+    }
+
+    public static EcmaError syntaxErrorById(String messageId, Object... args) {
+        String msg = getMessageById(messageId, args);
+        return syntaxError(msg);
     }
 
     private static void warnAboutNonJSObject(Object nonJSObject) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -1012,6 +1012,14 @@ public class ScriptRuntime {
         return buffer.toString();
     }
 
+    public static String bigIntToString(BigInteger n, int base) {
+        if ((base < 2) || (base > 36)) {
+            throw rangeErrorById("msg.bad.radix", Integer.toString(base));
+        }
+
+        return n.toString(base);
+    }
+
     static String uneval(Context cx, Scriptable scope, Object value) {
         if (value == null) {
             return "null";

--- a/src/org/mozilla/javascript/Token.java
+++ b/src/org/mozilla/javascript/Token.java
@@ -119,108 +119,109 @@ public class Token {
             REF_MEMBER = 79, // Reference for x.@y, x..y etc.
             REF_NS_MEMBER = 80, // Reference for x.ns::y, x..ns::y etc.
             REF_NAME = 81, // Reference for @y, @[y] etc.
-            REF_NS_NAME = 82; // Reference for ns::y, @ns::y@[y] etc.
+            REF_NS_NAME = 82, // Reference for ns::y, @ns::y@[y] etc.
+            BIGINT = 83; // ES2020 BigInt
 
     // End of interpreter bytecodes
-    public static final int LAST_BYTECODE_TOKEN = REF_NS_NAME,
-            TRY = 83,
-            SEMI = 84, // semicolon
-            LB = 85, // left and right brackets
-            RB = 86,
-            LC = 87, // left and right curlies (braces)
-            RC = 88,
-            LP = 89, // left and right parentheses
-            RP = 90,
-            COMMA = 91, // comma operator
-            ASSIGN = 92, // simple assignment  (=)
-            ASSIGN_BITOR = 93, // |=
-            ASSIGN_BITXOR = 94, // ^=
-            ASSIGN_BITAND = 95, // |=
-            ASSIGN_LSH = 96, // <<=
-            ASSIGN_RSH = 97, // >>=
-            ASSIGN_URSH = 98, // >>>=
-            ASSIGN_ADD = 99, // +=
-            ASSIGN_SUB = 100, // -=
-            ASSIGN_MUL = 101, // *=
-            ASSIGN_DIV = 102, // /=
-            ASSIGN_MOD = 103, // %=
-            ASSIGN_EXP = 104; // **=
+    public static final int LAST_BYTECODE_TOKEN = BIGINT,
+            TRY = 84,
+            SEMI = 85, // semicolon
+            LB = 86, // left and right brackets
+            RB = 87,
+            LC = 88, // left and right curlies (braces)
+            RC = 89,
+            LP = 90, // left and right parentheses
+            RP = 91,
+            COMMA = 92, // comma operator
+            ASSIGN = 93, // simple assignment  (=)
+            ASSIGN_BITOR = 94, // |=
+            ASSIGN_BITXOR = 95, // ^=
+            ASSIGN_BITAND = 96, // |=
+            ASSIGN_LSH = 97, // <<=
+            ASSIGN_RSH = 98, // >>=
+            ASSIGN_URSH = 99, // >>>=
+            ASSIGN_ADD = 100, // +=
+            ASSIGN_SUB = 101, // -=
+            ASSIGN_MUL = 102, // *=
+            ASSIGN_DIV = 103, // /=
+            ASSIGN_MOD = 104, // %=
+            ASSIGN_EXP = 105; // **=
     public static final int FIRST_ASSIGN = ASSIGN,
             LAST_ASSIGN = ASSIGN_EXP,
-            HOOK = 105, // conditional (?:)
-            COLON = 106,
-            OR = 107, // logical or (||)
-            AND = 108, // logical and (&&)
-            INC = 109, // increment/decrement (++ --)
-            DEC = 110,
-            DOT = 111, // member operator (.)
-            FUNCTION = 112, // function keyword
-            EXPORT = 113, // export keyword
-            IMPORT = 114, // import keyword
-            IF = 115, // if keyword
-            ELSE = 116, // else keyword
-            SWITCH = 117, // switch keyword
-            CASE = 118, // case keyword
-            DEFAULT = 119, // default keyword
-            WHILE = 120, // while keyword
-            DO = 121, // do keyword
-            FOR = 122, // for keyword
-            BREAK = 123, // break keyword
-            CONTINUE = 124, // continue keyword
-            VAR = 125, // var keyword
-            WITH = 126, // with keyword
-            CATCH = 127, // catch keyword
-            FINALLY = 128, // finally keyword
-            VOID = 129, // void keyword
-            RESERVED = 130, // reserved keywords
-            EMPTY = 131,
+            HOOK = 106, // conditional (?:)
+            COLON = 107,
+            OR = 108, // logical or (||)
+            AND = 109, // logical and (&&)
+            INC = 110, // increment/decrement (++ --)
+            DEC = 111,
+            DOT = 112, // member operator (.)
+            FUNCTION = 113, // function keyword
+            EXPORT = 114, // export keyword
+            IMPORT = 115, // import keyword
+            IF = 116, // if keyword
+            ELSE = 117, // else keyword
+            SWITCH = 118, // switch keyword
+            CASE = 119, // case keyword
+            DEFAULT = 120, // default keyword
+            WHILE = 121, // while keyword
+            DO = 122, // do keyword
+            FOR = 123, // for keyword
+            BREAK = 124, // break keyword
+            CONTINUE = 125, // continue keyword
+            VAR = 126, // var keyword
+            WITH = 127, // with keyword
+            CATCH = 128, // catch keyword
+            FINALLY = 129, // finally keyword
+            VOID = 130, // void keyword
+            RESERVED = 131, // reserved keywords
+            EMPTY = 132,
 
             /* types used for the parse tree - these never get returned
              * by the scanner.
              */
 
-            BLOCK = 132, // statement block
-            LABEL = 133, // label
-            TARGET = 134,
-            LOOP = 135,
-            EXPR_VOID = 136, // expression statement in functions
-            EXPR_RESULT = 137, // expression statement in scripts
-            JSR = 138,
-            SCRIPT = 139, // top-level node for entire script
-            TYPEOFNAME = 140, // for typeof(simple-name)
-            USE_STACK = 141,
-            SETPROP_OP = 142, // x.y op= something
-            SETELEM_OP = 143, // x[y] op= something
-            LOCAL_BLOCK = 144,
-            SET_REF_OP = 145, // *reference op= something
+            BLOCK = 133, // statement block
+            LABEL = 134, // label
+            TARGET = 135,
+            LOOP = 136,
+            EXPR_VOID = 137, // expression statement in functions
+            EXPR_RESULT = 138, // expression statement in scripts
+            JSR = 139,
+            SCRIPT = 140, // top-level node for entire script
+            TYPEOFNAME = 141, // for typeof(simple-name)
+            USE_STACK = 142,
+            SETPROP_OP = 143, // x.y op= something
+            SETELEM_OP = 144, // x[y] op= something
+            LOCAL_BLOCK = 145,
+            SET_REF_OP = 146, // *reference op= something
 
             // For XML support:
-            DOTDOT = 146, // member operator (..)
-            COLONCOLON = 147, // namespace::name
-            XML = 148, // XML type
-            DOTQUERY = 149, // .() -- e.g., x.emps.emp.(name == "terry")
-            XMLATTR = 150, // @
-            XMLEND = 151,
+            DOTDOT = 147, // member operator (..)
+            COLONCOLON = 148, // namespace::name
+            XML = 149, // XML type
+            DOTQUERY = 150, // .() -- e.g., x.emps.emp.(name == "terry")
+            XMLATTR = 151, // @
+            XMLEND = 152,
 
             // Optimizer-only-tokens
-            TO_OBJECT = 152,
-            TO_DOUBLE = 153,
-            GET = 154, // JS 1.5 get pseudo keyword
-            SET = 155, // JS 1.5 set pseudo keyword
-            LET = 156, // JS 1.7 let pseudo keyword
-            CONST = 157,
-            SETCONST = 158,
-            SETCONSTVAR = 159,
-            ARRAYCOMP = 160, // array comprehension
-            LETEXPR = 161,
-            WITHEXPR = 162,
-            DEBUGGER = 163,
-            COMMENT = 164,
-            GENEXPR = 165,
-            METHOD = 166, // ES6 MethodDefinition
-            ARROW = 167, // ES6 ArrowFunction
-            YIELD_STAR = 168, // ES6 "yield *", a specialization of yield
-            LAST_TOKEN = 169;
+            TO_OBJECT = 153,
+            TO_DOUBLE = 154,
+            GET = 155, // JS 1.5 get pseudo keyword
+            SET = 156, // JS 1.5 set pseudo keyword
+            LET = 157, // JS 1.7 let pseudo keyword
+            CONST = 158,
+            SETCONST = 159,
+            SETCONSTVAR = 160,
+            ARRAYCOMP = 161, // array comprehension
+            LETEXPR = 162,
+            WITHEXPR = 163,
+            DEBUGGER = 164,
+            COMMENT = 165,
+            GENEXPR = 166,
+            METHOD = 167, // ES6 MethodDefinition
+            ARROW = 168, // ES6 ArrowFunction
+            YIELD_STAR = 169, // ES6 "yield *", a specialization of yield
+            LAST_TOKEN = 170;
 
     /**
      * Returns a name for the token. If Rhino is compiled with certain hardcoded debugging flags in
@@ -579,6 +580,8 @@ public class Token {
                 return "ARROW";
             case YIELD_STAR:
                 return "YIELD_STAR";
+            case BIGINT:
+                return "BIGINT";
         }
 
         // Token without name

--- a/src/org/mozilla/javascript/Token.java
+++ b/src/org/mozilla/javascript/Token.java
@@ -9,19 +9,18 @@ package org.mozilla.javascript;
 /**
  * This class implements the JavaScript scanner.
  *
- * It is based on the C source files jsscan.c and jsscan.h
- * in the jsref package.
+ * <p>It is based on the C source files jsscan.c and jsscan.h in the jsref package.
  *
  * @see org.mozilla.javascript.Parser
- *
  * @author Mike McCabe
  * @author Brendan Eich
  */
-
-public class Token
-{
+public class Token {
     public static enum CommentType {
-        LINE, BLOCK_COMMENT, JSDOC, HTML
+        LINE,
+        BLOCK_COMMENT,
+        JSDOC,
+        HTML
     }
 
     // debug flags
@@ -29,221 +28,206 @@ public class Token
     static final boolean printICode = false;
     static final boolean printNames = printTrees || printICode;
 
-    /**
-     * Token types.  These values correspond to JSTokenType values in
-     * jsscan.c.
-     */
+    /** Token types. These values correspond to JSTokenType values in jsscan.c. */
+    public static final int
+            // start enum
+            ERROR = -1, // well-known as the only code < EOF
+            EOF = 0, // end of file token - (not EOF_CHAR)
+            EOL = 1, // end of line
 
-    public final static int
-    // start enum
-        ERROR          = -1, // well-known as the only code < EOF
-        EOF            = 0,  // end of file token - (not EOF_CHAR)
-        EOL            = 1,  // end of line
+            // Interpreter reuses the following as bytecodes
+            FIRST_BYTECODE_TOKEN = 2,
+            ENTERWITH = 2,
+            LEAVEWITH = 3,
+            RETURN = 4,
+            GOTO = 5,
+            IFEQ = 6,
+            IFNE = 7,
+            SETNAME = 8,
+            BITOR = 9,
+            BITXOR = 10,
+            BITAND = 11,
+            EQ = 12,
+            NE = 13,
+            LT = 14,
+            LE = 15,
+            GT = 16,
+            GE = 17,
+            LSH = 18,
+            RSH = 19,
+            URSH = 20,
+            ADD = 21,
+            SUB = 22,
+            MUL = 23,
+            DIV = 24,
+            MOD = 25,
+            NOT = 26,
+            BITNOT = 27,
+            POS = 28,
+            NEG = 29,
+            NEW = 30,
+            DELPROP = 31,
+            TYPEOF = 32,
+            GETPROP = 33,
+            GETPROPNOWARN = 34,
+            SETPROP = 35,
+            GETELEM = 36,
+            SETELEM = 37,
+            CALL = 38,
+            NAME = 39,
+            NUMBER = 40,
+            STRING = 41,
+            NULL = 42,
+            THIS = 43,
+            FALSE = 44,
+            TRUE = 45,
+            SHEQ = 46, // shallow equality (===)
+            SHNE = 47, // shallow inequality (!==)
+            REGEXP = 48,
+            BINDNAME = 49,
+            THROW = 50,
+            RETHROW = 51, // rethrow caught exception: catch (e if ) use it
+            IN = 52,
+            INSTANCEOF = 53,
+            LOCAL_LOAD = 54,
+            GETVAR = 55,
+            SETVAR = 56,
+            CATCH_SCOPE = 57,
+            ENUM_INIT_KEYS = 58,
+            ENUM_INIT_VALUES = 59,
+            ENUM_INIT_ARRAY = 60,
+            ENUM_INIT_VALUES_IN_ORDER = 61,
+            ENUM_NEXT = 62,
+            ENUM_ID = 63,
+            THISFN = 64,
+            RETURN_RESULT = 65, // to return previously stored return result
+            ARRAYLIT = 66, // array literal
+            OBJECTLIT = 67, // object literal
+            GET_REF = 68, // *reference
+            SET_REF = 69, // *reference    = something
+            DEL_REF = 70, // delete reference
+            REF_CALL = 71, // f(args)    = something or f(args)++
+            REF_SPECIAL = 72, // reference for special properties like __proto
+            YIELD = 73, // JS 1.7 yield pseudo keyword
+            STRICT_SETNAME = 74,
+            EXP = 75, // Exponentiation Operator
 
-        // Interpreter reuses the following as bytecodes
-        FIRST_BYTECODE_TOKEN    = 2,
+            // For XML support:
+            DEFAULTNAMESPACE = 76, // default xml namespace =
+            ESCXMLATTR = 77,
+            ESCXMLTEXT = 78,
+            REF_MEMBER = 79, // Reference for x.@y, x..y etc.
+            REF_NS_MEMBER = 80, // Reference for x.ns::y, x..ns::y etc.
+            REF_NAME = 81, // Reference for @y, @[y] etc.
+            REF_NS_NAME = 82; // Reference for ns::y, @ns::y@[y] etc.
 
-        ENTERWITH      = 2,
-        LEAVEWITH      = 3,
-        RETURN         = 4,
-        GOTO           = 5,
-        IFEQ           = 6,
-        IFNE           = 7,
-        SETNAME        = 8,
-        BITOR          = 9,
-        BITXOR         = 10,
-        BITAND         = 11,
-        EQ             = 12,
-        NE             = 13,
-        LT             = 14,
-        LE             = 15,
-        GT             = 16,
-        GE             = 17,
-        LSH            = 18,
-        RSH            = 19,
-        URSH           = 20,
-        ADD            = 21,
-        SUB            = 22,
-        MUL            = 23,
-        DIV            = 24,
-        MOD            = 25,
-        NOT            = 26,
-        BITNOT         = 27,
-        POS            = 28,
-        NEG            = 29,
-        NEW            = 30,
-        DELPROP        = 31,
-        TYPEOF         = 32,
-        GETPROP        = 33,
-        GETPROPNOWARN  = 34,
-        SETPROP        = 35,
-        GETELEM        = 36,
-        SETELEM        = 37,
-        CALL           = 38,
-        NAME           = 39,
-        NUMBER         = 40,
-        STRING         = 41,
-        NULL           = 42,
-        THIS           = 43,
-        FALSE          = 44,
-        TRUE           = 45,
-        SHEQ           = 46,   // shallow equality (===)
-        SHNE           = 47,   // shallow inequality (!==)
-        REGEXP         = 48,
-        BINDNAME       = 49,
-        THROW          = 50,
-        RETHROW        = 51, // rethrow caught exception: catch (e if ) use it
-        IN             = 52,
-        INSTANCEOF     = 53,
-        LOCAL_LOAD     = 54,
-        GETVAR         = 55,
-        SETVAR         = 56,
-        CATCH_SCOPE    = 57,
-        ENUM_INIT_KEYS = 58,
-        ENUM_INIT_VALUES = 59,
-        ENUM_INIT_ARRAY= 60,
-        ENUM_INIT_VALUES_IN_ORDER = 61,
-        ENUM_NEXT      = 62,
-        ENUM_ID        = 63,
-        THISFN         = 64,
-        RETURN_RESULT  = 65, // to return previously stored return result
-        ARRAYLIT       = 66, // array literal
-        OBJECTLIT      = 67, // object literal
-        GET_REF        = 68, // *reference
-        SET_REF        = 69, // *reference    = something
-        DEL_REF        = 70, // delete reference
-        REF_CALL       = 71, // f(args)    = something or f(args)++
-        REF_SPECIAL    = 72, // reference for special properties like __proto
-        YIELD          = 73,  // JS 1.7 yield pseudo keyword
-        STRICT_SETNAME = 74,
-        EXP            = 75,  // Exponentiation Operator
+    // End of interpreter bytecodes
+    public static final int LAST_BYTECODE_TOKEN = REF_NS_NAME,
+            TRY = 83,
+            SEMI = 84, // semicolon
+            LB = 85, // left and right brackets
+            RB = 86,
+            LC = 87, // left and right curlies (braces)
+            RC = 88,
+            LP = 89, // left and right parentheses
+            RP = 90,
+            COMMA = 91, // comma operator
+            ASSIGN = 92, // simple assignment  (=)
+            ASSIGN_BITOR = 93, // |=
+            ASSIGN_BITXOR = 94, // ^=
+            ASSIGN_BITAND = 95, // |=
+            ASSIGN_LSH = 96, // <<=
+            ASSIGN_RSH = 97, // >>=
+            ASSIGN_URSH = 98, // >>>=
+            ASSIGN_ADD = 99, // +=
+            ASSIGN_SUB = 100, // -=
+            ASSIGN_MUL = 101, // *=
+            ASSIGN_DIV = 102, // /=
+            ASSIGN_MOD = 103, // %=
+            ASSIGN_EXP = 104; // **=
+    public static final int FIRST_ASSIGN = ASSIGN,
+            LAST_ASSIGN = ASSIGN_EXP,
+            HOOK = 105, // conditional (?:)
+            COLON = 106,
+            OR = 107, // logical or (||)
+            AND = 108, // logical and (&&)
+            INC = 109, // increment/decrement (++ --)
+            DEC = 110,
+            DOT = 111, // member operator (.)
+            FUNCTION = 112, // function keyword
+            EXPORT = 113, // export keyword
+            IMPORT = 114, // import keyword
+            IF = 115, // if keyword
+            ELSE = 116, // else keyword
+            SWITCH = 117, // switch keyword
+            CASE = 118, // case keyword
+            DEFAULT = 119, // default keyword
+            WHILE = 120, // while keyword
+            DO = 121, // do keyword
+            FOR = 122, // for keyword
+            BREAK = 123, // break keyword
+            CONTINUE = 124, // continue keyword
+            VAR = 125, // var keyword
+            WITH = 126, // with keyword
+            CATCH = 127, // catch keyword
+            FINALLY = 128, // finally keyword
+            VOID = 129, // void keyword
+            RESERVED = 130, // reserved keywords
+            EMPTY = 131,
 
-        // For XML support:
-        DEFAULTNAMESPACE = 76, // default xml namespace =
-        ESCXMLATTR     = 77,
-        ESCXMLTEXT     = 78,
-        REF_MEMBER     = 79, // Reference for x.@y, x..y etc.
-        REF_NS_MEMBER  = 80, // Reference for x.ns::y, x..ns::y etc.
-        REF_NAME       = 81, // Reference for @y, @[y] etc.
-        REF_NS_NAME    = 82; // Reference for ns::y, @ns::y@[y] etc.
+            /* types used for the parse tree - these never get returned
+             * by the scanner.
+             */
 
-        // End of interpreter bytecodes
-    public final static int
-        LAST_BYTECODE_TOKEN    = REF_NS_NAME,
+            BLOCK = 132, // statement block
+            LABEL = 133, // label
+            TARGET = 134,
+            LOOP = 135,
+            EXPR_VOID = 136, // expression statement in functions
+            EXPR_RESULT = 137, // expression statement in scripts
+            JSR = 138,
+            SCRIPT = 139, // top-level node for entire script
+            TYPEOFNAME = 140, // for typeof(simple-name)
+            USE_STACK = 141,
+            SETPROP_OP = 142, // x.y op= something
+            SETELEM_OP = 143, // x[y] op= something
+            LOCAL_BLOCK = 144,
+            SET_REF_OP = 145, // *reference op= something
 
-        TRY            = 83,
-        SEMI           = 84,  // semicolon
-        LB             = 85,  // left and right brackets
-        RB             = 86,
-        LC             = 87,  // left and right curlies (braces)
-        RC             = 88,
-        LP             = 89,  // left and right parentheses
-        RP             = 90,
-        COMMA          = 91,  // comma operator
+            // For XML support:
+            DOTDOT = 146, // member operator (..)
+            COLONCOLON = 147, // namespace::name
+            XML = 148, // XML type
+            DOTQUERY = 149, // .() -- e.g., x.emps.emp.(name == "terry")
+            XMLATTR = 150, // @
+            XMLEND = 151,
 
-        ASSIGN         = 92,  // simple assignment  (=)
-        ASSIGN_BITOR   = 93,  // |=
-        ASSIGN_BITXOR  = 94,  // ^=
-        ASSIGN_BITAND  = 95,  // |=
-        ASSIGN_LSH     = 96,  // <<=
-        ASSIGN_RSH     = 97,  // >>=
-        ASSIGN_URSH    = 98,  // >>>=
-        ASSIGN_ADD     = 99,  // +=
-        ASSIGN_SUB     = 100, // -=
-        ASSIGN_MUL     = 101, // *=
-        ASSIGN_DIV     = 102, // /=
-        ASSIGN_MOD     = 103, // %=
-        ASSIGN_EXP     = 104; // **=
-
-    public final static int
-        FIRST_ASSIGN   = ASSIGN,
-        LAST_ASSIGN    = ASSIGN_EXP,
-
-        HOOK           = 105, // conditional (?:)
-        COLON          = 106,
-        OR             = 107, // logical or (||)
-        AND            = 108, // logical and (&&)
-        INC            = 109, // increment/decrement (++ --)
-        DEC            = 110,
-        DOT            = 111, // member operator (.)
-        FUNCTION       = 112, // function keyword
-        EXPORT         = 113, // export keyword
-        IMPORT         = 114, // import keyword
-        IF             = 115, // if keyword
-        ELSE           = 116, // else keyword
-        SWITCH         = 117, // switch keyword
-        CASE           = 118, // case keyword
-        DEFAULT        = 119, // default keyword
-        WHILE          = 120, // while keyword
-        DO             = 121, // do keyword
-        FOR            = 122, // for keyword
-        BREAK          = 123, // break keyword
-        CONTINUE       = 124, // continue keyword
-        VAR            = 125, // var keyword
-        WITH           = 126, // with keyword
-        CATCH          = 127, // catch keyword
-        FINALLY        = 128, // finally keyword
-        VOID           = 129, // void keyword
-        RESERVED       = 130, // reserved keywords
-
-        EMPTY          = 131,
-
-        /* types used for the parse tree - these never get returned
-         * by the scanner.
-         */
-
-        BLOCK          = 132, // statement block
-        LABEL          = 133, // label
-        TARGET         = 134,
-        LOOP           = 135,
-        EXPR_VOID      = 136, // expression statement in functions
-        EXPR_RESULT    = 137, // expression statement in scripts
-        JSR            = 138,
-        SCRIPT         = 139, // top-level node for entire script
-        TYPEOFNAME     = 140, // for typeof(simple-name)
-        USE_STACK      = 141,
-        SETPROP_OP     = 142, // x.y op= something
-        SETELEM_OP     = 143, // x[y] op= something
-        LOCAL_BLOCK    = 144,
-        SET_REF_OP     = 145, // *reference op= something
-
-        // For XML support:
-        DOTDOT         = 146,  // member operator (..)
-        COLONCOLON     = 147,  // namespace::name
-        XML            = 148,  // XML type
-        DOTQUERY       = 149,  // .() -- e.g., x.emps.emp.(name == "terry")
-        XMLATTR        = 150,  // @
-        XMLEND         = 151,
-
-        // Optimizer-only-tokens
-        TO_OBJECT      = 152,
-        TO_DOUBLE      = 153,
-
-        GET            = 154,  // JS 1.5 get pseudo keyword
-        SET            = 155,  // JS 1.5 set pseudo keyword
-        LET            = 156,  // JS 1.7 let pseudo keyword
-        CONST          = 157,
-        SETCONST       = 158,
-        SETCONSTVAR    = 159,
-        ARRAYCOMP      = 160,  // array comprehension
-        LETEXPR        = 161,
-        WITHEXPR       = 162,
-        DEBUGGER       = 163,
-        COMMENT        = 164,
-        GENEXPR        = 165,
-        METHOD         = 166,  // ES6 MethodDefinition
-        ARROW          = 167,  // ES6 ArrowFunction
-        YIELD_STAR     = 168,  // ES6 "yield *", a specialization of yield
-        LAST_TOKEN     = 169;
-        
+            // Optimizer-only-tokens
+            TO_OBJECT = 152,
+            TO_DOUBLE = 153,
+            GET = 154, // JS 1.5 get pseudo keyword
+            SET = 155, // JS 1.5 set pseudo keyword
+            LET = 156, // JS 1.7 let pseudo keyword
+            CONST = 157,
+            SETCONST = 158,
+            SETCONSTVAR = 159,
+            ARRAYCOMP = 160, // array comprehension
+            LETEXPR = 161,
+            WITHEXPR = 162,
+            DEBUGGER = 163,
+            COMMENT = 164,
+            GENEXPR = 165,
+            METHOD = 166, // ES6 MethodDefinition
+            ARROW = 167, // ES6 ArrowFunction
+            YIELD_STAR = 168, // ES6 "yield *", a specialization of yield
+            LAST_TOKEN = 169;
 
     /**
-     * Returns a name for the token.  If Rhino is compiled with certain
-     * hardcoded debugging flags in this file, it calls {@code #typeToName};
-     * otherwise it returns a string whose value is the token number.
+     * Returns a name for the token. If Rhino is compiled with certain hardcoded debugging flags in
+     * this file, it calls {@code #typeToName}; otherwise it returns a string whose value is the
+     * token number.
      */
-    public static String name(int token)
-    {
+    public static String name(int token) {
         if (!printNames) {
             return String.valueOf(token);
         }
@@ -251,181 +235,350 @@ public class Token
     }
 
     /**
-     * Always returns a human-readable string for the token name.
-     * For instance, {@link #FINALLY} has the name "FINALLY".
+     * Always returns a human-readable string for the token name. For instance, {@link #FINALLY} has
+     * the name "FINALLY".
+     *
      * @param token the token code
      * @return the actual name for the token code
      */
     public static String typeToName(int token) {
         switch (token) {
-          case ERROR:           return "ERROR";
-          case EOF:             return "EOF";
-          case EOL:             return "EOL";
-          case ENTERWITH:       return "ENTERWITH";
-          case LEAVEWITH:       return "LEAVEWITH";
-          case RETURN:          return "RETURN";
-          case GOTO:            return "GOTO";
-          case IFEQ:            return "IFEQ";
-          case IFNE:            return "IFNE";
-          case SETNAME:         return "SETNAME";
-          case BITOR:           return "BITOR";
-          case BITXOR:          return "BITXOR";
-          case BITAND:          return "BITAND";
-          case EQ:              return "EQ";
-          case NE:              return "NE";
-          case LT:              return "LT";
-          case LE:              return "LE";
-          case GT:              return "GT";
-          case GE:              return "GE";
-          case LSH:             return "LSH";
-          case RSH:             return "RSH";
-          case URSH:            return "URSH";
-          case ADD:             return "ADD";
-          case SUB:             return "SUB";
-          case MUL:             return "MUL";
-          case DIV:             return "DIV";
-          case MOD:             return "MOD";
-          case NOT:             return "NOT";
-          case BITNOT:          return "BITNOT";
-          case POS:             return "POS";
-          case NEG:             return "NEG";
-          case NEW:             return "NEW";
-          case DELPROP:         return "DELPROP";
-          case TYPEOF:          return "TYPEOF";
-          case GETPROP:         return "GETPROP";
-          case GETPROPNOWARN:   return "GETPROPNOWARN";
-          case SETPROP:         return "SETPROP";
-          case GETELEM:         return "GETELEM";
-          case SETELEM:         return "SETELEM";
-          case CALL:            return "CALL";
-          case NAME:            return "NAME";
-          case NUMBER:          return "NUMBER";
-          case STRING:          return "STRING";
-          case NULL:            return "NULL";
-          case THIS:            return "THIS";
-          case FALSE:           return "FALSE";
-          case TRUE:            return "TRUE";
-          case SHEQ:            return "SHEQ";
-          case SHNE:            return "SHNE";
-          case REGEXP:          return "REGEXP";
-          case BINDNAME:        return "BINDNAME";
-          case THROW:           return "THROW";
-          case RETHROW:         return "RETHROW";
-          case IN:              return "IN";
-          case INSTANCEOF:      return "INSTANCEOF";
-          case LOCAL_LOAD:      return "LOCAL_LOAD";
-          case GETVAR:          return "GETVAR";
-          case SETVAR:          return "SETVAR";
-          case CATCH_SCOPE:     return "CATCH_SCOPE";
-          case ENUM_INIT_KEYS:  return "ENUM_INIT_KEYS";
-          case ENUM_INIT_VALUES:return "ENUM_INIT_VALUES";
-          case ENUM_INIT_ARRAY: return "ENUM_INIT_ARRAY";
-          case ENUM_INIT_VALUES_IN_ORDER: return "ENUM_INIT_VALUES_IN_ORDER";
-          case ENUM_NEXT:       return "ENUM_NEXT";
-          case ENUM_ID:         return "ENUM_ID";
-          case THISFN:          return "THISFN";
-          case RETURN_RESULT:   return "RETURN_RESULT";
-          case ARRAYLIT:        return "ARRAYLIT";
-          case OBJECTLIT:       return "OBJECTLIT";
-          case GET_REF:         return "GET_REF";
-          case SET_REF:         return "SET_REF";
-          case DEL_REF:         return "DEL_REF";
-          case REF_CALL:        return "REF_CALL";
-          case REF_SPECIAL:     return "REF_SPECIAL";
-          case DEFAULTNAMESPACE:return "DEFAULTNAMESPACE";
-          case ESCXMLTEXT:      return "ESCXMLTEXT";
-          case ESCXMLATTR:      return "ESCXMLATTR";
-          case REF_MEMBER:      return "REF_MEMBER";
-          case REF_NS_MEMBER:   return "REF_NS_MEMBER";
-          case REF_NAME:        return "REF_NAME";
-          case REF_NS_NAME:     return "REF_NS_NAME";
-          case TRY:             return "TRY";
-          case SEMI:            return "SEMI";
-          case LB:              return "LB";
-          case RB:              return "RB";
-          case LC:              return "LC";
-          case RC:              return "RC";
-          case LP:              return "LP";
-          case RP:              return "RP";
-          case COMMA:           return "COMMA";
-          case ASSIGN:          return "ASSIGN";
-          case ASSIGN_BITOR:    return "ASSIGN_BITOR";
-          case ASSIGN_BITXOR:   return "ASSIGN_BITXOR";
-          case ASSIGN_BITAND:   return "ASSIGN_BITAND";
-          case ASSIGN_LSH:      return "ASSIGN_LSH";
-          case ASSIGN_RSH:      return "ASSIGN_RSH";
-          case ASSIGN_URSH:     return "ASSIGN_URSH";
-          case ASSIGN_ADD:      return "ASSIGN_ADD";
-          case ASSIGN_SUB:      return "ASSIGN_SUB";
-          case ASSIGN_MUL:      return "ASSIGN_MUL";
-          case ASSIGN_DIV:      return "ASSIGN_DIV";
-          case ASSIGN_MOD:      return "ASSIGN_MOD";
-          case ASSIGN_EXP:      return "ASSIGN_EXP";
-          case HOOK:            return "HOOK";
-          case COLON:           return "COLON";
-          case OR:              return "OR";
-          case AND:             return "AND";
-          case INC:             return "INC";
-          case DEC:             return "DEC";
-          case DOT:             return "DOT";
-          case FUNCTION:        return "FUNCTION";
-          case EXPORT:          return "EXPORT";
-          case IMPORT:          return "IMPORT";
-          case IF:              return "IF";
-          case ELSE:            return "ELSE";
-          case SWITCH:          return "SWITCH";
-          case CASE:            return "CASE";
-          case DEFAULT:         return "DEFAULT";
-          case WHILE:           return "WHILE";
-          case DO:              return "DO";
-          case FOR:             return "FOR";
-          case BREAK:           return "BREAK";
-          case CONTINUE:        return "CONTINUE";
-          case VAR:             return "VAR";
-          case WITH:            return "WITH";
-          case CATCH:           return "CATCH";
-          case FINALLY:         return "FINALLY";
-          case VOID:            return "VOID";
-          case RESERVED:        return "RESERVED";
-          case EMPTY:           return "EMPTY";
-          case BLOCK:           return "BLOCK";
-          case LABEL:           return "LABEL";
-          case TARGET:          return "TARGET";
-          case LOOP:            return "LOOP";
-          case EXPR_VOID:       return "EXPR_VOID";
-          case EXPR_RESULT:     return "EXPR_RESULT";
-          case JSR:             return "JSR";
-          case SCRIPT:          return "SCRIPT";
-          case TYPEOFNAME:      return "TYPEOFNAME";
-          case USE_STACK:       return "USE_STACK";
-          case SETPROP_OP:      return "SETPROP_OP";
-          case SETELEM_OP:      return "SETELEM_OP";
-          case LOCAL_BLOCK:     return "LOCAL_BLOCK";
-          case SET_REF_OP:      return "SET_REF_OP";
-          case DOTDOT:          return "DOTDOT";
-          case COLONCOLON:      return "COLONCOLON";
-          case XML:             return "XML";
-          case DOTQUERY:        return "DOTQUERY";
-          case XMLATTR:         return "XMLATTR";
-          case XMLEND:          return "XMLEND";
-          case TO_OBJECT:       return "TO_OBJECT";
-          case TO_DOUBLE:       return "TO_DOUBLE";
-          case GET:             return "GET";
-          case SET:             return "SET";
-          case LET:             return "LET";
-          case YIELD:           return "YIELD";
-          case EXP:             return "EXP";
-          case CONST:           return "CONST";
-          case SETCONST:        return "SETCONST";
-          case ARRAYCOMP:       return "ARRAYCOMP";
-          case WITHEXPR:        return "WITHEXPR";
-          case LETEXPR:         return "LETEXPR";
-          case DEBUGGER:        return "DEBUGGER";
-          case COMMENT:         return "COMMENT";
-          case GENEXPR:         return "GENEXPR";
-          case METHOD:          return "METHOD";
-          case ARROW:           return "ARROW";
-          case YIELD_STAR:      return "YIELD_STAR";
+            case ERROR:
+                return "ERROR";
+            case EOF:
+                return "EOF";
+            case EOL:
+                return "EOL";
+            case ENTERWITH:
+                return "ENTERWITH";
+            case LEAVEWITH:
+                return "LEAVEWITH";
+            case RETURN:
+                return "RETURN";
+            case GOTO:
+                return "GOTO";
+            case IFEQ:
+                return "IFEQ";
+            case IFNE:
+                return "IFNE";
+            case SETNAME:
+                return "SETNAME";
+            case BITOR:
+                return "BITOR";
+            case BITXOR:
+                return "BITXOR";
+            case BITAND:
+                return "BITAND";
+            case EQ:
+                return "EQ";
+            case NE:
+                return "NE";
+            case LT:
+                return "LT";
+            case LE:
+                return "LE";
+            case GT:
+                return "GT";
+            case GE:
+                return "GE";
+            case LSH:
+                return "LSH";
+            case RSH:
+                return "RSH";
+            case URSH:
+                return "URSH";
+            case ADD:
+                return "ADD";
+            case SUB:
+                return "SUB";
+            case MUL:
+                return "MUL";
+            case DIV:
+                return "DIV";
+            case MOD:
+                return "MOD";
+            case NOT:
+                return "NOT";
+            case BITNOT:
+                return "BITNOT";
+            case POS:
+                return "POS";
+            case NEG:
+                return "NEG";
+            case NEW:
+                return "NEW";
+            case DELPROP:
+                return "DELPROP";
+            case TYPEOF:
+                return "TYPEOF";
+            case GETPROP:
+                return "GETPROP";
+            case GETPROPNOWARN:
+                return "GETPROPNOWARN";
+            case SETPROP:
+                return "SETPROP";
+            case GETELEM:
+                return "GETELEM";
+            case SETELEM:
+                return "SETELEM";
+            case CALL:
+                return "CALL";
+            case NAME:
+                return "NAME";
+            case NUMBER:
+                return "NUMBER";
+            case STRING:
+                return "STRING";
+            case NULL:
+                return "NULL";
+            case THIS:
+                return "THIS";
+            case FALSE:
+                return "FALSE";
+            case TRUE:
+                return "TRUE";
+            case SHEQ:
+                return "SHEQ";
+            case SHNE:
+                return "SHNE";
+            case REGEXP:
+                return "REGEXP";
+            case BINDNAME:
+                return "BINDNAME";
+            case THROW:
+                return "THROW";
+            case RETHROW:
+                return "RETHROW";
+            case IN:
+                return "IN";
+            case INSTANCEOF:
+                return "INSTANCEOF";
+            case LOCAL_LOAD:
+                return "LOCAL_LOAD";
+            case GETVAR:
+                return "GETVAR";
+            case SETVAR:
+                return "SETVAR";
+            case CATCH_SCOPE:
+                return "CATCH_SCOPE";
+            case ENUM_INIT_KEYS:
+                return "ENUM_INIT_KEYS";
+            case ENUM_INIT_VALUES:
+                return "ENUM_INIT_VALUES";
+            case ENUM_INIT_ARRAY:
+                return "ENUM_INIT_ARRAY";
+            case ENUM_INIT_VALUES_IN_ORDER:
+                return "ENUM_INIT_VALUES_IN_ORDER";
+            case ENUM_NEXT:
+                return "ENUM_NEXT";
+            case ENUM_ID:
+                return "ENUM_ID";
+            case THISFN:
+                return "THISFN";
+            case RETURN_RESULT:
+                return "RETURN_RESULT";
+            case ARRAYLIT:
+                return "ARRAYLIT";
+            case OBJECTLIT:
+                return "OBJECTLIT";
+            case GET_REF:
+                return "GET_REF";
+            case SET_REF:
+                return "SET_REF";
+            case DEL_REF:
+                return "DEL_REF";
+            case REF_CALL:
+                return "REF_CALL";
+            case REF_SPECIAL:
+                return "REF_SPECIAL";
+            case DEFAULTNAMESPACE:
+                return "DEFAULTNAMESPACE";
+            case ESCXMLTEXT:
+                return "ESCXMLTEXT";
+            case ESCXMLATTR:
+                return "ESCXMLATTR";
+            case REF_MEMBER:
+                return "REF_MEMBER";
+            case REF_NS_MEMBER:
+                return "REF_NS_MEMBER";
+            case REF_NAME:
+                return "REF_NAME";
+            case REF_NS_NAME:
+                return "REF_NS_NAME";
+            case TRY:
+                return "TRY";
+            case SEMI:
+                return "SEMI";
+            case LB:
+                return "LB";
+            case RB:
+                return "RB";
+            case LC:
+                return "LC";
+            case RC:
+                return "RC";
+            case LP:
+                return "LP";
+            case RP:
+                return "RP";
+            case COMMA:
+                return "COMMA";
+            case ASSIGN:
+                return "ASSIGN";
+            case ASSIGN_BITOR:
+                return "ASSIGN_BITOR";
+            case ASSIGN_BITXOR:
+                return "ASSIGN_BITXOR";
+            case ASSIGN_BITAND:
+                return "ASSIGN_BITAND";
+            case ASSIGN_LSH:
+                return "ASSIGN_LSH";
+            case ASSIGN_RSH:
+                return "ASSIGN_RSH";
+            case ASSIGN_URSH:
+                return "ASSIGN_URSH";
+            case ASSIGN_ADD:
+                return "ASSIGN_ADD";
+            case ASSIGN_SUB:
+                return "ASSIGN_SUB";
+            case ASSIGN_MUL:
+                return "ASSIGN_MUL";
+            case ASSIGN_DIV:
+                return "ASSIGN_DIV";
+            case ASSIGN_MOD:
+                return "ASSIGN_MOD";
+            case ASSIGN_EXP:
+                return "ASSIGN_EXP";
+            case HOOK:
+                return "HOOK";
+            case COLON:
+                return "COLON";
+            case OR:
+                return "OR";
+            case AND:
+                return "AND";
+            case INC:
+                return "INC";
+            case DEC:
+                return "DEC";
+            case DOT:
+                return "DOT";
+            case FUNCTION:
+                return "FUNCTION";
+            case EXPORT:
+                return "EXPORT";
+            case IMPORT:
+                return "IMPORT";
+            case IF:
+                return "IF";
+            case ELSE:
+                return "ELSE";
+            case SWITCH:
+                return "SWITCH";
+            case CASE:
+                return "CASE";
+            case DEFAULT:
+                return "DEFAULT";
+            case WHILE:
+                return "WHILE";
+            case DO:
+                return "DO";
+            case FOR:
+                return "FOR";
+            case BREAK:
+                return "BREAK";
+            case CONTINUE:
+                return "CONTINUE";
+            case VAR:
+                return "VAR";
+            case WITH:
+                return "WITH";
+            case CATCH:
+                return "CATCH";
+            case FINALLY:
+                return "FINALLY";
+            case VOID:
+                return "VOID";
+            case RESERVED:
+                return "RESERVED";
+            case EMPTY:
+                return "EMPTY";
+            case BLOCK:
+                return "BLOCK";
+            case LABEL:
+                return "LABEL";
+            case TARGET:
+                return "TARGET";
+            case LOOP:
+                return "LOOP";
+            case EXPR_VOID:
+                return "EXPR_VOID";
+            case EXPR_RESULT:
+                return "EXPR_RESULT";
+            case JSR:
+                return "JSR";
+            case SCRIPT:
+                return "SCRIPT";
+            case TYPEOFNAME:
+                return "TYPEOFNAME";
+            case USE_STACK:
+                return "USE_STACK";
+            case SETPROP_OP:
+                return "SETPROP_OP";
+            case SETELEM_OP:
+                return "SETELEM_OP";
+            case LOCAL_BLOCK:
+                return "LOCAL_BLOCK";
+            case SET_REF_OP:
+                return "SET_REF_OP";
+            case DOTDOT:
+                return "DOTDOT";
+            case COLONCOLON:
+                return "COLONCOLON";
+            case XML:
+                return "XML";
+            case DOTQUERY:
+                return "DOTQUERY";
+            case XMLATTR:
+                return "XMLATTR";
+            case XMLEND:
+                return "XMLEND";
+            case TO_OBJECT:
+                return "TO_OBJECT";
+            case TO_DOUBLE:
+                return "TO_DOUBLE";
+            case GET:
+                return "GET";
+            case SET:
+                return "SET";
+            case LET:
+                return "LET";
+            case YIELD:
+                return "YIELD";
+            case EXP:
+                return "EXP";
+            case CONST:
+                return "CONST";
+            case SETCONST:
+                return "SETCONST";
+            case ARRAYCOMP:
+                return "ARRAYCOMP";
+            case WITHEXPR:
+                return "WITHEXPR";
+            case LETEXPR:
+                return "LETEXPR";
+            case DEBUGGER:
+                return "DEBUGGER";
+            case COMMENT:
+                return "COMMENT";
+            case GENEXPR:
+                return "GENEXPR";
+            case METHOD:
+                return "METHOD";
+            case ARROW:
+                return "ARROW";
+            case YIELD_STAR:
+                return "YIELD_STAR";
         }
 
         // Token without name
@@ -433,56 +586,90 @@ public class Token
     }
 
     /**
-     * Convert a keyword token to a name string for use with the
-     * {@link Context#FEATURE_RESERVED_KEYWORD_AS_IDENTIFIER} feature.
+     * Convert a keyword token to a name string for use with the {@link
+     * Context#FEATURE_RESERVED_KEYWORD_AS_IDENTIFIER} feature.
+     *
      * @param token A token
      * @return the corresponding name string
      */
     public static String keywordToName(int token) {
         switch (token) {
-            case Token.BREAK:      return "break";
-            case Token.CASE:       return "case";
-            case Token.CONTINUE:   return "continue";
-            case Token.DEFAULT:    return "default";
-            case Token.DELPROP:    return "delete";
-            case Token.DO:         return "do";
-            case Token.ELSE:       return "else";
-            case Token.FALSE:      return "false";
-            case Token.FOR:        return "for";
-            case Token.FUNCTION:   return "function";
-            case Token.IF:         return "if";
-            case Token.IN:         return "in";
-            case Token.LET:        return "let";
-            case Token.NEW:        return "new";
-            case Token.NULL:       return "null";
-            case Token.RETURN:     return "return";
-            case Token.SWITCH:     return "switch";
-            case Token.THIS:       return "this";
-            case Token.TRUE:       return "true";
-            case Token.TYPEOF:     return "typeof";
-            case Token.VAR:        return "var";
-            case Token.VOID:       return "void";
-            case Token.WHILE:      return "while";
-            case Token.WITH:       return "with";
-            case Token.YIELD:      return "yield";
-            case Token.CATCH:      return "catch";
-            case Token.CONST:      return "const";
-            case Token.DEBUGGER:   return "debugger";
-            case Token.FINALLY:    return "finally";
-            case Token.INSTANCEOF: return "instanceof";
-            case Token.THROW:      return "throw";
-            case Token.TRY:        return "try";
-            default:               return null;
+            case Token.BREAK:
+                return "break";
+            case Token.CASE:
+                return "case";
+            case Token.CONTINUE:
+                return "continue";
+            case Token.DEFAULT:
+                return "default";
+            case Token.DELPROP:
+                return "delete";
+            case Token.DO:
+                return "do";
+            case Token.ELSE:
+                return "else";
+            case Token.FALSE:
+                return "false";
+            case Token.FOR:
+                return "for";
+            case Token.FUNCTION:
+                return "function";
+            case Token.IF:
+                return "if";
+            case Token.IN:
+                return "in";
+            case Token.LET:
+                return "let";
+            case Token.NEW:
+                return "new";
+            case Token.NULL:
+                return "null";
+            case Token.RETURN:
+                return "return";
+            case Token.SWITCH:
+                return "switch";
+            case Token.THIS:
+                return "this";
+            case Token.TRUE:
+                return "true";
+            case Token.TYPEOF:
+                return "typeof";
+            case Token.VAR:
+                return "var";
+            case Token.VOID:
+                return "void";
+            case Token.WHILE:
+                return "while";
+            case Token.WITH:
+                return "with";
+            case Token.YIELD:
+                return "yield";
+            case Token.CATCH:
+                return "catch";
+            case Token.CONST:
+                return "const";
+            case Token.DEBUGGER:
+                return "debugger";
+            case Token.FINALLY:
+                return "finally";
+            case Token.INSTANCEOF:
+                return "instanceof";
+            case Token.THROW:
+                return "throw";
+            case Token.TRY:
+                return "try";
+            default:
+                return null;
         }
     }
 
     /**
      * Return true if the passed code is a valid Token constant.
+     *
      * @param code a potential token code
      * @return true if it's a known token
      */
     public static boolean isValidToken(int code) {
-        return code >= ERROR
-                && code <= LAST_TOKEN;
+        return code >= ERROR && code <= LAST_TOKEN;
     }
 }

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -8,6 +8,7 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.math.BigInteger;
 
 /**
  * This class implements the JavaScript scanner.
@@ -67,6 +68,9 @@ class TokenStream {
 
                 case Token.NUMBER:
                     return "NUMBER " + this.number;
+
+                case Token.BIGINT:
+                    return "BIGINT " + this.bigInt.toString();
             }
 
             return name;
@@ -602,19 +606,23 @@ class TokenStream {
         return number;
     }
 
-    final boolean isNumberBinary() {
+    final BigInteger getBigInt() {
+        return bigInt;
+    }
+
+    final boolean isNumericBinary() {
         return isBinary;
     }
 
-    final boolean isNumberOldOctal() {
+    final boolean isNumericOldOctal() {
         return isOldOctal;
     }
 
-    final boolean isNumberOctal() {
+    final boolean isNumericOctal() {
         return isOctal;
     }
 
-    final boolean isNumberHex() {
+    final boolean isNumericHex() {
         return isHex;
     }
 
@@ -830,8 +838,13 @@ class TokenStream {
                 }
 
                 boolean isInteger = true;
+                boolean isBigInt = false;
 
-                if (base == 10) {
+                if (c == 'n') {
+                    isBigInt = true;
+                    c = getChar();
+                } else if (base == 10 && (c == '.' || c == 'e' || c == 'E')) {
+                    isInteger = false;
                     if (c == '.') {
                         isInteger = false;
                         addToString(c);
@@ -875,6 +888,11 @@ class TokenStream {
                         }
                     }
                     numString = new String(chars, 0, pos);
+                }
+
+                if (isBigInt) {
+                    this.bigInt = new BigInteger(numString, base);
+                    return Token.BIGINT;
                 }
 
                 double dval;
@@ -2033,6 +2051,7 @@ class TokenStream {
     // code.
     private String string = "";
     private double number;
+    private BigInteger bigInt;
     private boolean isBinary;
     private boolean isOldOctal;
     private boolean isOctal;

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -840,7 +840,7 @@ class TokenStream {
                 boolean isInteger = true;
                 boolean isBigInt = false;
 
-                if (c == 'n') {
+                if (es6 && c == 'n') {
                     isBigInt = true;
                     c = getChar();
                 } else if (base == 10 && (c == '.' || c == 'e' || c == 'E')) {

--- a/src/org/mozilla/javascript/TopLevel.java
+++ b/src/org/mozilla/javascript/TopLevel.java
@@ -54,7 +54,9 @@ public class TopLevel extends IdScriptableObject {
         /** The built-in Symbol type. */
         Symbol,
         /** The built-in GeneratorFunction type. */
-        GeneratorFunction
+        GeneratorFunction,
+        /** The built-in BigInt type. */
+        BigInt
     }
 
     /** An enumeration of built-in native errors. [ECMAScript 5 - 15.11.6] */

--- a/src/org/mozilla/javascript/TopLevel.java
+++ b/src/org/mozilla/javascript/TopLevel.java
@@ -4,44 +4,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- package org.mozilla.javascript;
+package org.mozilla.javascript;
 
 import java.util.EnumMap;
 
 /**
- * A top-level scope object that provides special means to cache and preserve
- * the initial values of the built-in constructor properties for better
- * ECMAScript compliance.
+ * A top-level scope object that provides special means to cache and preserve the initial values of
+ * the built-in constructor properties for better ECMAScript compliance.
  *
- * <p>ECMA 262 requires that most constructors used internally construct
- * objects with the original prototype object as value of their [[Prototype]]
- * internal property. Since built-in global constructors are defined as
- * writable and deletable, this means they should be cached to protect against
- * redefinition at runtime.</p>
+ * <p>ECMA 262 requires that most constructors used internally construct objects with the original
+ * prototype object as value of their [[Prototype]] internal property. Since built-in global
+ * constructors are defined as writable and deletable, this means they should be cached to protect
+ * against redefinition at runtime.
  *
- * <p>In order to implement this efficiently, this class provides a mechanism
- * to access the original built-in global constructors and their prototypes
- * via numeric class-ids. To make use of this, the new
- * {@link ScriptRuntime#newBuiltinObject ScriptRuntime.newBuiltinObject} and
- * {@link ScriptRuntime#setBuiltinProtoAndParent ScriptRuntime.setBuiltinProtoAndParent}
- * methods should be used to create and initialize objects of built-in classes
- * instead of their generic counterparts.</p>
+ * <p>In order to implement this efficiently, this class provides a mechanism to access the original
+ * built-in global constructors and their prototypes via numeric class-ids. To make use of this, the
+ * new {@link ScriptRuntime#newBuiltinObject ScriptRuntime.newBuiltinObject} and {@link
+ * ScriptRuntime#setBuiltinProtoAndParent ScriptRuntime.setBuiltinProtoAndParent} methods should be
+ * used to create and initialize objects of built-in classes instead of their generic counterparts.
  *
- * <p>Calling {@link org.mozilla.javascript.Context#initStandardObjects()}
- * with an instance of this class as argument will automatically cache
- * built-in classes after initialization. For other setups involving
- * top-level scopes that inherit global properties from their proptotypes
- * (e.g. with dynamic scopes) embeddings should explicitly call
- * {@link #cacheBuiltins(Scriptable, boolean)} to initialize the class cache for each top-level
- * scope.</p>
+ * <p>Calling {@link org.mozilla.javascript.Context#initStandardObjects()} with an instance of this
+ * class as argument will automatically cache built-in classes after initialization. For other
+ * setups involving top-level scopes that inherit global properties from their proptotypes (e.g.
+ * with dynamic scopes) embeddings should explicitly call {@link #cacheBuiltins(Scriptable,
+ * boolean)} to initialize the class cache for each top-level scope.
  */
 public class TopLevel extends IdScriptableObject {
 
     private static final long serialVersionUID = -4648046356662472260L;
 
-    /**
-     * An enumeration of built-in ECMAScript objects.
-     */
+    /** An enumeration of built-in ECMAScript objects. */
     public enum Builtins {
         /** The built-in Object type. */
         Object,
@@ -65,9 +57,7 @@ public class TopLevel extends IdScriptableObject {
         GeneratorFunction
     }
 
-    /**
-     * An enumeration of built-in native errors. [ECMAScript 5 - 15.11.6]
-     */
+    /** An enumeration of built-in native errors. [ECMAScript 5 - 15.11.6] */
     enum NativeErrors {
         /** Basic Error */
         Error,
@@ -98,52 +88,50 @@ public class TopLevel extends IdScriptableObject {
     }
 
     /**
-     * Cache the built-in ECMAScript objects to protect them against
-     * modifications by the script. This method is called automatically by
-     * {@link ScriptRuntime#initStandardObjects ScriptRuntime.initStandardObjects}
-     * if the scope argument is an instance of this class. It only has to be
-     * called by the embedding if a top-level scope is not initialized through
-     * <code>initStandardObjects()</code>.
+     * Cache the built-in ECMAScript objects to protect them against modifications by the script.
+     * This method is called automatically by {@link ScriptRuntime#initStandardObjects
+     * ScriptRuntime.initStandardObjects} if the scope argument is an instance of this class. It
+     * only has to be called by the embedding if a top-level scope is not initialized through <code>
+     * initStandardObjects()</code>.
      */
     public void cacheBuiltins(Scriptable scope, boolean sealed) {
         ctors = new EnumMap<Builtins, BaseFunction>(Builtins.class);
         for (Builtins builtin : Builtins.values()) {
             Object value = ScriptableObject.getProperty(this, builtin.name());
             if (value instanceof BaseFunction) {
-                ctors.put(builtin, (BaseFunction)value);
+                ctors.put(builtin, (BaseFunction) value);
             } else if (builtin == Builtins.GeneratorFunction) {
                 // Handle weird situation of "GeneratorFunction" being a real constructor
                 // which is never registered in the top-level scope
-                ctors.put(builtin, (BaseFunction)BaseFunction.initAsGeneratorFunction(scope, sealed));
+                ctors.put(
+                        builtin,
+                        (BaseFunction) BaseFunction.initAsGeneratorFunction(scope, sealed));
             }
         }
         errors = new EnumMap<NativeErrors, BaseFunction>(NativeErrors.class);
         for (NativeErrors error : NativeErrors.values()) {
             Object value = ScriptableObject.getProperty(this, error.name());
             if (value instanceof BaseFunction) {
-                errors.put(error, (BaseFunction)value);
+                errors.put(error, (BaseFunction) value);
             }
         }
     }
 
     /**
-     * Static helper method to get a built-in object constructor with the given
-     * <code>type</code> from the given <code>scope</code>. If the scope is not
-     * an instance of this class or does have a cache of built-ins,
-     * the constructor is looked up via normal property lookup.
+     * Static helper method to get a built-in object constructor with the given <code>type</code>
+     * from the given <code>scope</code>. If the scope is not an instance of this class or does have
+     * a cache of built-ins, the constructor is looked up via normal property lookup.
      *
      * @param cx the current Context
      * @param scope the top-level scope
      * @param type the built-in type
      * @return the built-in constructor
      */
-    public static Function getBuiltinCtor(Context cx,
-                                          Scriptable scope,
-                                          Builtins type) {
+    public static Function getBuiltinCtor(Context cx, Scriptable scope, Builtins type) {
         // must be called with top level scope
         assert scope.getParentScope() == null;
         if (scope instanceof TopLevel) {
-            Function result = ((TopLevel)scope).getBuiltinCtor(type);
+            Function result = ((TopLevel) scope).getBuiltinCtor(type);
             if (result != null) {
                 return result;
             }
@@ -162,22 +150,20 @@ public class TopLevel extends IdScriptableObject {
     }
 
     /**
-     * Static helper method to get a native error constructor with the given
-     * <code>type</code> from the given <code>scope</code>. If the scope is not
-     * an instance of this class or does have a cache of native errors,
-     * the constructor is looked up via normal property lookup.
+     * Static helper method to get a native error constructor with the given <code>type</code> from
+     * the given <code>scope</code>. If the scope is not an instance of this class or does have a
+     * cache of native errors, the constructor is looked up via normal property lookup.
      *
      * @param cx the current Context
      * @param scope the top-level scope
      * @param type the native error type
      * @return the native error constructor
      */
-    static Function getNativeErrorCtor(Context cx, Scriptable scope,
-                                       NativeErrors type) {
+    static Function getNativeErrorCtor(Context cx, Scriptable scope, NativeErrors type) {
         // must be called with top level scope
         assert scope.getParentScope() == null;
         if (scope instanceof TopLevel) {
-            Function result = ((TopLevel)scope).getNativeErrorCtor(type);
+            Function result = ((TopLevel) scope).getNativeErrorCtor(type);
             if (result != null) {
                 return result;
             }
@@ -187,22 +173,19 @@ public class TopLevel extends IdScriptableObject {
     }
 
     /**
-     * Static helper method to get a built-in object prototype with the given
-     * <code>type</code> from the given <code>scope</code>. If the scope is not
-     * an instance of this class or does have a cache of built-ins,
-     * the prototype is looked up via normal property lookup.
+     * Static helper method to get a built-in object prototype with the given <code>type</code> from
+     * the given <code>scope</code>. If the scope is not an instance of this class or does have a
+     * cache of built-ins, the prototype is looked up via normal property lookup.
      *
      * @param scope the top-level scope
      * @param type the built-in type
      * @return the built-in prototype
      */
-    public static Scriptable getBuiltinPrototype(Scriptable scope,
-                                                 Builtins type) {
+    public static Scriptable getBuiltinPrototype(Scriptable scope, Builtins type) {
         // must be called with top level scope
         assert scope.getParentScope() == null;
         if (scope instanceof TopLevel) {
-            Scriptable result = ((TopLevel)scope)
-                    .getBuiltinPrototype(type);
+            Scriptable result = ((TopLevel) scope).getBuiltinPrototype(type);
             if (result != null) {
                 return result;
             }
@@ -221,9 +204,10 @@ public class TopLevel extends IdScriptableObject {
     }
 
     /**
-     * Get the cached built-in object constructor from this scope with the
-     * given <code>type</code>. Returns null if {@link #cacheBuiltins(Scriptable, boolean)} has not
-     * been called on this object.
+     * Get the cached built-in object constructor from this scope with the given <code>type</code>.
+     * Returns null if {@link #cacheBuiltins(Scriptable, boolean)} has not been called on this
+     * object.
+     *
      * @param type the built-in type
      * @return the built-in constructor
      */
@@ -232,9 +216,9 @@ public class TopLevel extends IdScriptableObject {
     }
 
     /**
-     * Get the cached native error constructor from this scope with the
-     * given <code>type</code>. Returns null if {@link #cacheBuiltins()} has not
-     * been called on this object.
+     * Get the cached native error constructor from this scope with the given <code>type</code>.
+     * Returns null if {@link #cacheBuiltins()} has not been called on this object.
+     *
      * @param type the native error type
      * @return the native error constructor
      */
@@ -243,9 +227,10 @@ public class TopLevel extends IdScriptableObject {
     }
 
     /**
-     * Get the cached built-in object prototype from this scope with the
-     * given <code>type</code>. Returns null if {@link #cacheBuiltins(Scriptable, boolean)} has not
-     * been called on this object.
+     * Get the cached built-in object prototype from this scope with the given <code>type</code>.
+     * Returns null if {@link #cacheBuiltins(Scriptable, boolean)} has not been called on this
+     * object.
+     *
      * @param type the built-in type
      * @return the built-in prototype
      */
@@ -254,5 +239,4 @@ public class TopLevel extends IdScriptableObject {
         Object proto = func != null ? func.getPrototypeProperty() : null;
         return proto instanceof Scriptable ? (Scriptable) proto : null;
     }
-
 }

--- a/src/org/mozilla/javascript/WrapFactory.java
+++ b/src/org/mozilla/javascript/WrapFactory.java
@@ -8,6 +8,7 @@
 
 package org.mozilla.javascript;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +60,8 @@ public class WrapFactory {
                     || obj instanceof Short
                     || obj instanceof Long
                     || obj instanceof Float
-                    || obj instanceof Double) {
+                    || obj instanceof Double
+                    || obj instanceof BigInteger) {
                 return obj;
             } else if (obj instanceof Character) {
                 return String.valueOf(((Character) obj).charValue());

--- a/src/org/mozilla/javascript/WrapFactory.java
+++ b/src/org/mozilla/javascript/WrapFactory.java
@@ -12,65 +12,57 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Embeddings that wish to provide their own custom wrappings for Java
- * objects may extend this class and call
- * {@link Context#setWrapFactory(WrapFactory)}
- * Once an instance of this class or an extension of this class is enabled
- * for a given context (by calling setWrapFactory on that context), Rhino
- * will call the methods of this class whenever it needs to wrap a value
- * resulting from a call to a Java method or an access to a Java field.
+ * Embeddings that wish to provide their own custom wrappings for Java objects may extend this class
+ * and call {@link Context#setWrapFactory(WrapFactory)} Once an instance of this class or an
+ * extension of this class is enabled for a given context (by calling setWrapFactory on that
+ * context), Rhino will call the methods of this class whenever it needs to wrap a value resulting
+ * from a call to a Java method or an access to a Java field.
  *
  * @see org.mozilla.javascript.Context#setWrapFactory(WrapFactory)
  * @since 1.5 Release 4
  */
-public class WrapFactory
-{
+public class WrapFactory {
     /**
      * Wrap the object.
-     * <p>
-     * The value returned must be one of
+     *
+     * <p>The value returned must be one of
+     *
      * <UL>
-     * <LI>java.lang.Boolean</LI>
-     * <LI>java.lang.String</LI>
-     * <LI>java.lang.Number</LI>
-     * <LI>org.mozilla.javascript.Scriptable objects</LI>
-     * <LI>The value returned by Context.getUndefinedValue()</LI>
-     * <LI>null</LI>
+     *   <LI>java.lang.Boolean
+     *   <LI>java.lang.String
+     *   <LI>java.lang.Number
+     *   <LI>org.mozilla.javascript.Scriptable objects
+     *   <LI>The value returned by Context.getUndefinedValue()
+     *   <LI>null
      * </UL>
+     *
      * @param cx the current Context for this thread
      * @param scope the scope of the executing script
      * @param obj the object to be wrapped. Note it can be null.
-     * @param staticType type hint. If security restrictions prevent to wrap
-              object based on its class, staticType will be used instead.
+     * @param staticType type hint. If security restrictions prevent to wrap object based on its
+     *     class, staticType will be used instead.
      * @return the wrapped value.
      */
-    public Object wrap(Context cx, Scriptable scope,
-                       Object obj, Class<?> staticType)
-    {
-        if (obj == null || obj == Undefined.instance
-            || obj instanceof Scriptable)
-        {
+    public Object wrap(Context cx, Scriptable scope, Object obj, Class<?> staticType) {
+        if (obj == null || obj == Undefined.instance || obj instanceof Scriptable) {
             return obj;
         }
         if (staticType != null && staticType.isPrimitive()) {
-            if (staticType == Void.TYPE)
-                return Undefined.instance;
-            if (staticType == Character.TYPE)
-                return Integer.valueOf(((Character) obj).charValue());
+            if (staticType == Void.TYPE) return Undefined.instance;
+            if (staticType == Character.TYPE) return Integer.valueOf(((Character) obj).charValue());
             return obj;
         }
         if (!isJavaPrimitiveWrap()) {
-            if (obj instanceof String ||
-                obj instanceof Boolean ||
-                obj instanceof Integer ||
-                obj instanceof Short ||
-                obj instanceof Long ||
-                obj instanceof Float ||
-                obj instanceof Double)
-            {
+            if (obj instanceof String
+                    || obj instanceof Boolean
+                    || obj instanceof Integer
+                    || obj instanceof Short
+                    || obj instanceof Long
+                    || obj instanceof Float
+                    || obj instanceof Double) {
                 return obj;
             } else if (obj instanceof Character) {
-                return String.valueOf(((Character)obj).charValue());
+                return String.valueOf(((Character) obj).charValue());
             }
         }
         Class<?> cls = obj.getClass();
@@ -82,15 +74,15 @@ public class WrapFactory
 
     /**
      * Wrap an object newly created by a constructor call.
+     *
      * @param cx the current Context for this thread
      * @param scope the scope of the executing script
      * @param obj the object to be wrapped
      * @return the wrapped value.
      */
-    public Scriptable wrapNewObject(Context cx, Scriptable scope, Object obj)
-    {
+    public Scriptable wrapNewObject(Context cx, Scriptable scope, Object obj) {
         if (obj instanceof Scriptable) {
-            return (Scriptable)obj;
+            return (Scriptable) obj;
         }
         Class<?> cls = obj.getClass();
         if (cls.isArray()) {
@@ -100,26 +92,24 @@ public class WrapFactory
     }
 
     /**
-     * Wrap Java object as Scriptable instance to allow full access to its
-     * methods and fields from JavaScript.
-     * <p>
-     * {@link #wrap(Context, Scriptable, Object, Class)} and
-     * {@link #wrapNewObject(Context, Scriptable, Object)} call this method
-     * when they can not convert <code>javaObject</code> to JavaScript primitive
-     * value or JavaScript array.
-     * <p>
-     * Subclasses can override the method to provide custom wrappers
-     * for Java objects.
+     * Wrap Java object as Scriptable instance to allow full access to its methods and fields from
+     * JavaScript.
+     *
+     * <p>{@link #wrap(Context, Scriptable, Object, Class)} and {@link #wrapNewObject(Context,
+     * Scriptable, Object)} call this method when they can not convert <code>javaObject</code> to
+     * JavaScript primitive value or JavaScript array.
+     *
+     * <p>Subclasses can override the method to provide custom wrappers for Java objects.
+     *
      * @param cx the current Context for this thread
      * @param scope the scope of the executing script
      * @param javaObject the object to be wrapped
-     * @param staticType type hint. If security restrictions prevent to wrap
-                object based on its class, staticType will be used instead.
+     * @param staticType type hint. If security restrictions prevent to wrap object based on its
+     *     class, staticType will be used instead.
      * @return the wrapped value which shall not be null
      */
-    public Scriptable wrapAsJavaObject(Context cx, Scriptable scope,
-                                       Object javaObject, Class<?> staticType)
-    {
+    public Scriptable wrapAsJavaObject(
+            Context cx, Scriptable scope, Object javaObject, Class<?> staticType) {
         if (List.class.isAssignableFrom(javaObject.getClass())) {
             return new NativeJavaList(scope, javaObject);
         } else if (Map.class.isAssignableFrom(javaObject.getClass())) {
@@ -129,11 +119,10 @@ public class WrapFactory
     }
 
     /**
-     * Wrap a Java class as Scriptable instance to allow access to its static
-     * members and fields and use as constructor from JavaScript.
-     * <p>
-     * Subclasses can override this method to provide custom wrappers for
-     * Java classes.
+     * Wrap a Java class as Scriptable instance to allow access to its static members and fields and
+     * use as constructor from JavaScript.
+     *
+     * <p>Subclasses can override this method to provide custom wrappers for Java classes.
      *
      * @param cx the current Context for this thread
      * @param scope the scope of the executing script
@@ -141,33 +130,24 @@ public class WrapFactory
      * @return the wrapped value which shall not be null
      * @since 1.7R3
      */
-    public Scriptable wrapJavaClass(Context cx, Scriptable scope,
-                                    Class<?> javaClass)
-    {
+    public Scriptable wrapJavaClass(Context cx, Scriptable scope, Class<?> javaClass) {
         return new NativeJavaClass(scope, javaClass);
     }
 
     /**
-     * Return <code>false</code> if result of Java method, which is instance of
-     * <code>String</code>, <code>Number</code>, <code>Boolean</code> and
-     * <code>Character</code>, should be used directly as JavaScript primitive
-     * type.
-     * By default the method returns true to indicate that instances of
-     * <code>String</code>, <code>Number</code>, <code>Boolean</code> and
-     * <code>Character</code> should be wrapped as any other Java object and
-     * scripts can access any Java method available in these objects.
-     * Use {@link #setJavaPrimitiveWrap(boolean)} to change this.
+     * Return <code>false</code> if result of Java method, which is instance of <code>String</code>,
+     * <code>Number</code>, <code>Boolean</code> and <code>Character</code>, should be used directly
+     * as JavaScript primitive type. By default the method returns true to indicate that instances
+     * of <code>String</code>, <code>Number</code>, <code>Boolean</code> and <code>Character</code>
+     * should be wrapped as any other Java object and scripts can access any Java method available
+     * in these objects. Use {@link #setJavaPrimitiveWrap(boolean)} to change this.
      */
-    public final boolean isJavaPrimitiveWrap()
-    {
+    public final boolean isJavaPrimitiveWrap() {
         return javaPrimitiveWrap;
     }
 
-    /**
-     * @see #isJavaPrimitiveWrap()
-     */
-    public final void setJavaPrimitiveWrap(boolean value)
-    {
+    /** @see #isJavaPrimitiveWrap() */
+    public final void setJavaPrimitiveWrap(boolean value) {
         Context cx = Context.getCurrentContext();
         if (cx != null && cx.isSealed()) {
             Context.onSealedMutation();
@@ -176,5 +156,4 @@ public class WrapFactory
     }
 
     private boolean javaPrimitiveWrap = true;
-
 }

--- a/src/org/mozilla/javascript/ast/BigIntLiteral.java
+++ b/src/org/mozilla/javascript/ast/BigIntLiteral.java
@@ -1,0 +1,82 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import java.math.BigInteger;
+import org.mozilla.javascript.Token;
+
+/** AST node for a BigInt literal. Node type is {@link Token#BIGINT}. */
+public class BigIntLiteral extends AstNode {
+
+    private String value;
+    private BigInteger bigInt;
+
+    {
+        type = Token.BIGINT;
+    }
+
+    public BigIntLiteral() {}
+
+    public BigIntLiteral(int pos) {
+        super(pos);
+    }
+
+    public BigIntLiteral(int pos, int len) {
+        super(pos, len);
+    }
+
+    /** Constructor. Sets the length to the length of the {@code value} string. */
+    public BigIntLiteral(int pos, String value) {
+        super(pos);
+        setValue(value);
+        setLength(value.length());
+    }
+
+    /** Constructor. Sets the length to the length of the {@code value} string. */
+    public BigIntLiteral(int pos, String value, BigInteger bigInt) {
+        this(pos, value);
+        setBigInt(bigInt);
+    }
+
+    /** Returns the node's string value (the original source token) */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the node's value
+     *
+     * @throws IllegalArgumentException} if value is {@code null}
+     */
+    public void setValue(String value) {
+        assertNotNull(value);
+        this.value = value;
+    }
+
+    /** Gets the {@code BigInteger} value. */
+    @Override
+    public BigInteger getBigInt() {
+        return bigInt;
+    }
+
+    /** Sets the node's {@code BigInteger} value. */
+    @Override
+    public void setBigInt(BigInteger value) {
+        bigInt = value;
+    }
+
+    @Override
+    public String toSource(int depth) {
+        return makeIndent(depth) + (bigInt == null ? "<null>" : bigInt.toString());
+    }
+
+    /** Visits this node. There are no children to visit. */
+    @Override
+    public void visit(NodeVisitor v) {
+        v.visit(this);
+    }
+}

--- a/src/org/mozilla/javascript/ast/ObjectProperty.java
+++ b/src/org/mozilla/javascript/ast/ObjectProperty.java
@@ -9,19 +9,14 @@ package org.mozilla.javascript.ast;
 import org.mozilla.javascript.Token;
 
 /**
- * AST node for a single name:value entry in an Object literal.
- * For simple entries, the node type is {@link Token#COLON}, and
- * the name (left side expression) is either a {@link Name}, a
- * {@link StringLiteral} or a {@link NumberLiteral}.
+ * AST node for a single name:value entry in an Object literal. For simple entries, the node type is
+ * {@link Token#COLON}, and the name (left side expression) is either a {@link Name}, a {@link
+ * StringLiteral} or a {@link NumberLiteral}.
  *
- * <p>This node type is also used for getter/setter properties in object
- * literals.  In this case the node bounds include the "get" or "set"
- * keyword.  The left-hand expression in this case is always a
- * {@link Name}, and the overall node type is {@link Token#GET} or
- * {@link Token#SET}, as appropriate.</p>
- *
- * The {@code operatorPosition} field is meaningless if the node is
- * a getter or setter.
+ * <p>This node type is also used for getter/setter properties in object literals. In this case the
+ * node bounds include the "get" or "set" keyword. The left-hand expression in this case is always a
+ * {@link Name}, and the overall node type is {@link Token#GET} or {@link Token#SET}, as
+ * appropriate. The {@code operatorPosition} field is meaningless if the node is a getter or setter.
  *
  * <pre><i>ObjectProperty</i> :
  *       PropertyName <b>:</b> AssignmentExpression
@@ -37,22 +32,21 @@ public class ObjectProperty extends InfixExpression {
     }
 
     /**
-     * Sets the node type.  Must be one of
-     * {@link Token#COLON}, {@link Token#GET}, or {@link Token#SET}.
+     * Sets the node type. Must be one of {@link Token#COLON}, {@link Token#GET}, or {@link
+     * Token#SET}.
+     *
      * @throws IllegalArgumentException if {@code nodeType} is invalid
      */
     public void setNodeType(int nodeType) {
         if (nodeType != Token.COLON
-            && nodeType != Token.GET
-            && nodeType != Token.SET
-            && nodeType != Token.METHOD)
-            throw new IllegalArgumentException("invalid node type: "
-                                               + nodeType);
+                && nodeType != Token.GET
+                && nodeType != Token.SET
+                && nodeType != Token.METHOD)
+            throw new IllegalArgumentException("invalid node type: " + nodeType);
         setType(nodeType);
     }
 
-    public ObjectProperty() {
-    }
+    public ObjectProperty() {}
 
     public ObjectProperty(int pos) {
         super(pos);
@@ -62,30 +56,22 @@ public class ObjectProperty extends InfixExpression {
         super(pos, len);
     }
 
-    /**
-     * Marks this node as a "getter" property.
-     */
+    /** Marks this node as a "getter" property. */
     public void setIsGetterMethod() {
         type = Token.GET;
     }
 
-    /**
-     * Returns true if this is a getter function.
-     */
+    /** Returns true if this is a getter function. */
     public boolean isGetterMethod() {
         return type == Token.GET;
     }
 
-    /**
-     * Marks this node as a "setter" property.
-     */
+    /** Marks this node as a "setter" property. */
     public void setIsSetterMethod() {
         type = Token.SET;
     }
 
-    /**
-     * Returns true if this is a setter function.
-     */
+    /** Returns true if this is a setter function. */
     public boolean isSetterMethod() {
         return type == Token.SET;
     }
@@ -106,17 +92,17 @@ public class ObjectProperty extends InfixExpression {
     public String toSource(int depth) {
         StringBuilder sb = new StringBuilder();
         sb.append("\n");
-        sb.append(makeIndent(depth+1));
+        sb.append(makeIndent(depth + 1));
         if (isGetterMethod()) {
             sb.append("get ");
         } else if (isSetterMethod()) {
             sb.append("set ");
         }
-        sb.append(left.toSource(getType()==Token.COLON ? 0 : depth));
+        sb.append(left.toSource(getType() == Token.COLON ? 0 : depth));
         if (type == Token.COLON) {
             sb.append(": ");
         }
-        sb.append(right.toSource(getType()==Token.COLON ? 0 : depth+1));
+        sb.append(right.toSource(getType() == Token.COLON ? 0 : depth + 1));
         return sb.toString();
     }
 }

--- a/src/org/mozilla/javascript/ast/ObjectProperty.java
+++ b/src/org/mozilla/javascript/ast/ObjectProperty.java
@@ -11,7 +11,7 @@ import org.mozilla.javascript.Token;
 /**
  * AST node for a single name:value entry in an Object literal. For simple entries, the node type is
  * {@link Token#COLON}, and the name (left side expression) is either a {@link Name}, a {@link
- * StringLiteral} or a {@link NumberLiteral}.
+ * StringLiteral}, a {@link NumberLiteral} or a {@link BigIntLiteral}.
  *
  * <p>This node type is also used for getter/setter properties in object literals. In this case the
  * node bounds include the "get" or "set" keyword. The left-hand expression in this case is always a
@@ -23,7 +23,8 @@ import org.mozilla.javascript.Token;
  * <i>PropertyName</i> :
  *       Identifier
  *       StringLiteral
- *       NumberLiteral</pre>
+ *       NumberLiteral
+ *       BigIntLiteral</pre>
  */
 public class ObjectProperty extends InfixExpression {
 

--- a/src/org/mozilla/javascript/optimizer/Block.java
+++ b/src/org/mozilla/javascript/optimizer/Block.java
@@ -526,6 +526,7 @@ class Block {
             case Token.ARRAYCOMP:
             case Token.ARRAYLIT:
             case Token.OBJECTLIT:
+            case Token.BIGINT:
                 return Optimizer.AnyType; // XXX: actually, we know it's not
                 // number, but no type yet for that
 

--- a/src/org/mozilla/javascript/optimizer/Block.java
+++ b/src/org/mozilla/javascript/optimizer/Block.java
@@ -9,39 +9,45 @@ import java.io.StringWriter;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.ObjArray;
 import org.mozilla.javascript.ObjToIntMap;
 import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.Jump;
 
-class Block
-{
+class Block {
 
-    private static class FatBlock
-    {
+    private static class FatBlock {
 
-        private static Block[] reduceToArray(ObjToIntMap map)
-        {
+        private static Block[] reduceToArray(ObjToIntMap map) {
             Block[] result = null;
             if (!map.isEmpty()) {
                 result = new Block[map.size()];
                 int i = 0;
                 ObjToIntMap.Iterator iter = map.newIterator();
                 for (iter.start(); !iter.done(); iter.next()) {
-                    FatBlock fb = (FatBlock)(iter.getKey());
+                    FatBlock fb = (FatBlock) (iter.getKey());
                     result[i++] = fb.realBlock;
                 }
             }
             return result;
         }
 
-        void addSuccessor(FatBlock b)  { successors.put(b, 0); }
-        void addPredecessor(FatBlock b)  { predecessors.put(b, 0); }
+        void addSuccessor(FatBlock b) {
+            successors.put(b, 0);
+        }
 
-        Block[] getSuccessors() { return reduceToArray(successors); }
-        Block[] getPredecessors() { return reduceToArray(predecessors); }
+        void addPredecessor(FatBlock b) {
+            predecessors.put(b, 0);
+        }
+
+        Block[] getSuccessors() {
+            return reduceToArray(successors);
+        }
+
+        Block[] getPredecessors() {
+            return reduceToArray(predecessors);
+        }
 
         // all the Blocks that come immediately after this
         private ObjToIntMap successors = new ObjToIntMap();
@@ -51,14 +57,12 @@ class Block
         Block realBlock;
     }
 
-    Block(int startNodeIndex, int endNodeIndex)
-    {
+    Block(int startNodeIndex, int endNodeIndex) {
         itsStartNodeIndex = startNodeIndex;
         itsEndNodeIndex = endNodeIndex;
     }
 
-    static void runFlowAnalyzes(OptFunctionNode fn, Node[] statementNodes)
-    {
+    static void runFlowAnalyzes(OptFunctionNode fn, Node[] statementNodes) {
         int paramCount = fn.fnode.getParamCount();
         int varCount = fn.fnode.getParamAndVarCount();
         int[] varTypes = new int[varCount];
@@ -76,7 +80,12 @@ class Block
 
         if (DEBUG) {
             ++debug_blockCount;
-            System.out.println("-------------------"+fn.fnode.getFunctionName()+"  "+debug_blockCount+"--------");
+            System.out.println(
+                    "-------------------"
+                            + fn.fnode.getFunctionName()
+                            + "  "
+                            + debug_blockCount
+                            + "--------");
             System.out.println(fn.fnode.toStringTree(fn.fnode));
             System.out.println(toString(theBlocks, statementNodes));
         }
@@ -91,7 +100,7 @@ class Block
             }
             System.out.println("Variable Table, size = " + varCount);
             for (int i = 0; i != varCount; i++) {
-                System.out.println("["+i+"] type: "+varTypes[i]);
+                System.out.println("[" + i + "] type: " + varTypes[i]);
             }
         }
 
@@ -100,13 +109,11 @@ class Block
                 fn.setIsNumberVar(i);
             }
         }
-
     }
 
-    private static Block[] buildBlocks(Node[] statementNodes)
-    {
+    private static Block[] buildBlocks(Node[] statementNodes) {
         // a mapping from each target node to the block it begins
-        Map<Node,FatBlock> theTargetBlocks = new HashMap<Node,FatBlock>();
+        Map<Node, FatBlock> theTargetBlocks = new HashMap<Node, FatBlock>();
         ObjArray theBlocks = new ObjArray();
 
         // there's a block that starts at index 0
@@ -114,32 +121,32 @@ class Block
 
         for (int i = 0; i < statementNodes.length; i++) {
             switch (statementNodes[i].getType()) {
-                case Token.TARGET :
-                {
-                    if (i != beginNodeIndex) {
-                        FatBlock fb = newFatBlock(beginNodeIndex, i - 1);
+                case Token.TARGET:
+                    {
+                        if (i != beginNodeIndex) {
+                            FatBlock fb = newFatBlock(beginNodeIndex, i - 1);
+                            if (statementNodes[beginNodeIndex].getType() == Token.TARGET) {
+                                theTargetBlocks.put(statementNodes[beginNodeIndex], fb);
+                            }
+                            theBlocks.add(fb);
+                            // start the next block at this node
+                            beginNodeIndex = i;
+                        }
+                    }
+                    break;
+                case Token.IFNE:
+                case Token.IFEQ:
+                case Token.GOTO:
+                    {
+                        FatBlock fb = newFatBlock(beginNodeIndex, i);
                         if (statementNodes[beginNodeIndex].getType() == Token.TARGET) {
                             theTargetBlocks.put(statementNodes[beginNodeIndex], fb);
                         }
                         theBlocks.add(fb);
-                        // start the next block at this node
-                        beginNodeIndex = i;
+                        // start the next block at the next node
+                        beginNodeIndex = i + 1;
                     }
-                }
-                break;
-                case Token.IFNE :
-                case Token.IFEQ :
-                case Token.GOTO :
-                {
-                    FatBlock fb = newFatBlock(beginNodeIndex, i);
-                    if (statementNodes[beginNodeIndex].getType() == Token.TARGET) {
-                        theTargetBlocks.put(statementNodes[beginNodeIndex], fb);
-                    }
-                    theBlocks.add(fb);
-                    // start the next block at the next node
-                    beginNodeIndex = i + 1;
-                }
-                break;
+                    break;
             }
         }
 
@@ -154,22 +161,21 @@ class Block
         // build successor and predecessor links
 
         for (int i = 0; i < theBlocks.size(); i++) {
-            FatBlock fb = (FatBlock)(theBlocks.get(i));
+            FatBlock fb = (FatBlock) (theBlocks.get(i));
 
             Node blockEndNode = statementNodes[fb.realBlock.itsEndNodeIndex];
             int blockEndNodeType = blockEndNode.getType();
 
             if ((blockEndNodeType != Token.GOTO) && (i < (theBlocks.size() - 1))) {
-                FatBlock fallThruTarget = (FatBlock)(theBlocks.get(i + 1));
+                FatBlock fallThruTarget = (FatBlock) (theBlocks.get(i + 1));
                 fb.addSuccessor(fallThruTarget);
                 fallThruTarget.addPredecessor(fb);
             }
 
-
-            if ( (blockEndNodeType == Token.IFNE)
+            if ((blockEndNodeType == Token.IFNE)
                     || (blockEndNodeType == Token.IFEQ)
-                    || (blockEndNodeType == Token.GOTO) ) {
-                Node target = ((Jump)blockEndNode).target;
+                    || (blockEndNodeType == Token.GOTO)) {
+                Node target = ((Jump) blockEndNode).target;
                 FatBlock branchTargetBlock = theTargetBlocks.get(target);
                 target.putProp(Node.TARGETBLOCK_PROP, branchTargetBlock.realBlock);
                 fb.addSuccessor(branchTargetBlock);
@@ -180,7 +186,7 @@ class Block
         Block[] result = new Block[theBlocks.size()];
 
         for (int i = 0; i < theBlocks.size(); i++) {
-            FatBlock fb = (FatBlock)(theBlocks.get(i));
+            FatBlock fb = (FatBlock) (theBlocks.get(i));
             Block b = fb.realBlock;
             b.itsSuccessors = fb.getSuccessors();
             b.itsPredecessors = fb.getPredecessors();
@@ -191,15 +197,13 @@ class Block
         return result;
     }
 
-    private static FatBlock newFatBlock(int startNodeIndex, int endNodeIndex)
-    {
+    private static FatBlock newFatBlock(int startNodeIndex, int endNodeIndex) {
         FatBlock fb = new FatBlock();
         fb.realBlock = new Block(startNodeIndex, endNodeIndex);
         return fb;
     }
 
-    private static String toString(Block[] blockList, Node[] statementNodes)
-    {
+    private static String toString(Block[] blockList, Node[] statementNodes) {
         if (!DEBUG) return null;
 
         StringWriter sw = new StringWriter();
@@ -209,12 +213,16 @@ class Block
         for (int i = 0; i < blockList.length; i++) {
             Block b = blockList[i];
             pw.println("#" + b.itsBlockID);
-            pw.println("from " + b.itsStartNodeIndex
-                    + " "
-                    + statementNodes[b.itsStartNodeIndex].toString());
-            pw.println("thru " + b.itsEndNodeIndex
-                    + " "
-                    + statementNodes[b.itsEndNodeIndex].toString());
+            pw.println(
+                    "from "
+                            + b.itsStartNodeIndex
+                            + " "
+                            + statementNodes[b.itsStartNodeIndex].toString());
+            pw.println(
+                    "thru "
+                            + b.itsEndNodeIndex
+                            + " "
+                            + statementNodes[b.itsEndNodeIndex].toString());
             pw.print("Predecessors ");
             if (b.itsPredecessors != null) {
                 for (int j = 0; j < b.itsPredecessors.length; j++) {
@@ -237,22 +245,21 @@ class Block
         return sw.toString();
     }
 
-    private static void reachingDefDataFlow(OptFunctionNode fn, Node[] statementNodes,
-                                            Block theBlocks[], int[] varTypes)
-    {
-/*
-    initialize the liveOnEntry and liveOnExit sets, then discover the variables
-    that are def'd by each function, and those that are used before being def'd
-    (hence liveOnEntry)
-*/
+    private static void reachingDefDataFlow(
+            OptFunctionNode fn, Node[] statementNodes, Block theBlocks[], int[] varTypes) {
+        /*
+            initialize the liveOnEntry and liveOnExit sets, then discover the variables
+            that are def'd by each function, and those that are used before being def'd
+            (hence liveOnEntry)
+        */
         for (int i = 0; i < theBlocks.length; i++) {
             theBlocks[i].initLiveOnEntrySets(fn, statementNodes);
         }
-/*
-    this visits every block starting at the last, re-adding the predecessors of
-    any block whose inputs change as a result of the dataflow.
-    REMIND, better would be to visit in CFG postorder
-*/
+        /*
+            this visits every block starting at the last, re-adding the predecessors of
+            any block whose inputs change as a result of the dataflow.
+            REMIND, better would be to visit in CFG postorder
+        */
         boolean visit[] = new boolean[theBlocks.length];
         boolean doneOnce[] = new boolean[theBlocks.length];
         int vIndex = theBlocks.length - 1;
@@ -284,18 +291,17 @@ class Block
                 vIndex--;
             }
         }
-/*
-        if any variable is live on entry to block 0, we have to mark it as
-        not jRegable - since it means that someone is trying to access the
-        'undefined'-ness of that variable.
-*/
+        /*
+                if any variable is live on entry to block 0, we have to mark it as
+                not jRegable - since it means that someone is trying to access the
+                'undefined'-ness of that variable.
+        */
 
         theBlocks[0].markAnyTypeVariables(varTypes);
     }
 
-    private static void typeFlow(OptFunctionNode fn, Node[] statementNodes,
-                                 Block theBlocks[], int[] varTypes)
-    {
+    private static void typeFlow(
+            OptFunctionNode fn, Node[] statementNodes, Block theBlocks[], int[] varTypes) {
         boolean visit[] = new boolean[theBlocks.length];
         boolean doneOnce[] = new boolean[theBlocks.length];
         int vIndex = 0;
@@ -305,8 +311,7 @@ class Block
             if (visit[vIndex] || !doneOnce[vIndex]) {
                 doneOnce[vIndex] = true;
                 visit[vIndex] = false;
-                if (theBlocks[vIndex].doTypeFlow(fn, statementNodes, varTypes))
-                {
+                if (theBlocks[vIndex].doTypeFlow(fn, statementNodes, varTypes)) {
                     Block succ[] = theBlocks[vIndex].itsSuccessors;
                     if (succ != null) {
                         for (int i = 0; i < succ.length; i++) {
@@ -330,20 +335,17 @@ class Block
         }
     }
 
-    private static boolean assignType(int[] varTypes, int index, int type)
-    {
+    private static boolean assignType(int[] varTypes, int index, int type) {
         int prev = varTypes[index];
         return prev != (varTypes[index] |= type);
     }
 
-    private void markAnyTypeVariables(int[] varTypes)
-    {
+    private void markAnyTypeVariables(int[] varTypes) {
         for (int i = 0; i != varTypes.length; i++) {
             if (itsLiveOnEntrySet.get(i)) {
                 assignType(varTypes, i, Optimizer.AnyType);
             }
         }
-
     }
 
     /*
@@ -354,49 +356,46 @@ class Block
         The itsNotDefSet is built reversed then flipped later.
 
     */
-    private void lookForVariableAccess(OptFunctionNode fn, Node n)
-    {
+    private void lookForVariableAccess(OptFunctionNode fn, Node n) {
         switch (n.getType()) {
             case Token.TYPEOFNAME:
-            {
-                // TYPEOFNAME may be used with undefined names, which is why
-                // this is handled separately from GETVAR above.
-                int varIndex = fn.fnode.getIndexForNameNode(n);
-                if (varIndex > -1 && !itsNotDefSet.get(varIndex))
-                    itsUseBeforeDefSet.set(varIndex);
-            }
-            break;
-            case Token.DEC :
-            case Token.INC :
-            {
-                Node child = n.getFirstChild();
-                if (child.getType() == Token.GETVAR) {
-                    int varIndex = fn.getVarIndex(child);
-                    if (!itsNotDefSet.get(varIndex))
+                {
+                    // TYPEOFNAME may be used with undefined names, which is why
+                    // this is handled separately from GETVAR above.
+                    int varIndex = fn.fnode.getIndexForNameNode(n);
+                    if (varIndex > -1 && !itsNotDefSet.get(varIndex))
                         itsUseBeforeDefSet.set(varIndex);
-                    itsNotDefSet.set(varIndex);
-                } else {
-                    lookForVariableAccess(fn, child);
                 }
-            }
-            break;
-            case Token.SETVAR :
-            case Token.SETCONSTVAR :
-            {
-                Node lhs = n.getFirstChild();
-                Node rhs = lhs.getNext();
-                lookForVariableAccess(fn, rhs);
-                itsNotDefSet.set(fn.getVarIndex(n));
-            }
-            break;
-            case Token.GETVAR :
-            {
-                int varIndex = fn.getVarIndex(n);
-                if (!itsNotDefSet.get(varIndex))
-                    itsUseBeforeDefSet.set(varIndex);
-            }
-            break;
-            default :
+                break;
+            case Token.DEC:
+            case Token.INC:
+                {
+                    Node child = n.getFirstChild();
+                    if (child.getType() == Token.GETVAR) {
+                        int varIndex = fn.getVarIndex(child);
+                        if (!itsNotDefSet.get(varIndex)) itsUseBeforeDefSet.set(varIndex);
+                        itsNotDefSet.set(varIndex);
+                    } else {
+                        lookForVariableAccess(fn, child);
+                    }
+                }
+                break;
+            case Token.SETVAR:
+            case Token.SETCONSTVAR:
+                {
+                    Node lhs = n.getFirstChild();
+                    Node rhs = lhs.getNext();
+                    lookForVariableAccess(fn, rhs);
+                    itsNotDefSet.set(fn.getVarIndex(n));
+                }
+                break;
+            case Token.GETVAR:
+                {
+                    int varIndex = fn.getVarIndex(n);
+                    if (!itsNotDefSet.get(varIndex)) itsUseBeforeDefSet.set(varIndex);
+                }
+                break;
+            default:
                 Node child = n.getFirstChild();
                 while (child != null) {
                     lookForVariableAccess(fn, child);
@@ -411,8 +410,7 @@ class Block
         Then walk the trees looking for defs/uses of variables
         and build the def and useBeforeDef sets.
     */
-    private void initLiveOnEntrySets(OptFunctionNode fn, Node[] statementNodes)
-    {
+    private void initLiveOnEntrySets(OptFunctionNode fn, Node[] statementNodes) {
         int listLength = fn.getVarCount();
         itsUseBeforeDefSet = new BitSet(listLength);
         itsNotDefSet = new BitSet(listLength);
@@ -422,7 +420,7 @@ class Block
             Node n = statementNodes[i];
             lookForVariableAccess(fn, n);
         }
-        itsNotDefSet.flip(0, listLength);         // truth in advertising
+        itsNotDefSet.flip(0, listLength); // truth in advertising
     }
 
     /*
@@ -431,20 +429,20 @@ class Block
         liveOnEntry = liveOnExit - defsInThisBlock + useBeforeDefsInThisBlock
 
     */
-    private boolean doReachedUseDataFlow()
-    {
+    private boolean doReachedUseDataFlow() {
         itsLiveOnExitSet.clear();
         if (itsSuccessors != null) {
             for (int i = 0; i < itsSuccessors.length; i++) {
                 itsLiveOnExitSet.or(itsSuccessors[i].itsLiveOnEntrySet);
             }
         }
-        return updateEntrySet(itsLiveOnEntrySet, itsLiveOnExitSet,
-                              itsUseBeforeDefSet, itsNotDefSet);
+        return updateEntrySet(
+                itsLiveOnEntrySet, itsLiveOnExitSet,
+                itsUseBeforeDefSet, itsNotDefSet);
     }
 
-    private static boolean updateEntrySet(BitSet entrySet, BitSet exitSet,
-                                   BitSet useBeforeDef, BitSet notDef) {
+    private static boolean updateEntrySet(
+            BitSet entrySet, BitSet exitSet, BitSet useBeforeDef, BitSet notDef) {
         int card = entrySet.cardinality();
         entrySet.or(exitSet);
         entrySet.and(notDef);
@@ -458,9 +456,7 @@ class Block
             Literals,
             Arithmetic operations - always return a Number
     */
-    private static int findExpressionType(OptFunctionNode fn, Node n,
-                                          int[] varTypes)
-    {
+    private static int findExpressionType(OptFunctionNode fn, Node n, int[] varTypes) {
         switch (n.getType()) {
             case Token.NUMBER:
                 return Optimizer.NumberType;
@@ -531,24 +527,26 @@ class Block
             case Token.ARRAYLIT:
             case Token.OBJECTLIT:
                 return Optimizer.AnyType; // XXX: actually, we know it's not
-            // number, but no type yet for that
+                // number, but no type yet for that
 
-            case Token.ADD: {
-                // if the lhs & rhs are known to be numbers, we can be sure that's
-                // the result, otherwise it could be a string.
-                Node child = n.getFirstChild();
-                int lType = findExpressionType(fn, child, varTypes);
-                int rType = findExpressionType(fn, child.getNext(), varTypes);
-                return lType | rType;    // we're not distinguishing strings yet
-            }
+            case Token.ADD:
+                {
+                    // if the lhs & rhs are known to be numbers, we can be sure that's
+                    // the result, otherwise it could be a string.
+                    Node child = n.getFirstChild();
+                    int lType = findExpressionType(fn, child, varTypes);
+                    int rType = findExpressionType(fn, child.getNext(), varTypes);
+                    return lType | rType; // we're not distinguishing strings yet
+                }
 
-            case Token.HOOK: {
-                Node ifTrue = n.getFirstChild().getNext();
-                Node ifFalse = ifTrue.getNext();
-                int ifTrueType = findExpressionType(fn, ifTrue, varTypes);
-                int ifFalseType = findExpressionType(fn, ifFalse, varTypes);
-                return ifTrueType | ifFalseType;
-            }
+            case Token.HOOK:
+                {
+                    Node ifTrue = n.getFirstChild().getNext();
+                    Node ifFalse = ifTrue.getNext();
+                    int ifTrueType = findExpressionType(fn, ifTrue, varTypes);
+                    int ifFalseType = findExpressionType(fn, ifFalse, varTypes);
+                    return ifTrueType | ifFalseType;
+                }
 
             case Token.COMMA:
             case Token.SETVAR:
@@ -559,28 +557,27 @@ class Block
                 return findExpressionType(fn, n.getLastChild(), varTypes);
 
             case Token.AND:
-            case Token.OR: {
-                Node child = n.getFirstChild();
-                int lType = findExpressionType(fn, child, varTypes);
-                int rType = findExpressionType(fn, child.getNext(), varTypes);
-                return lType | rType;
-            }
+            case Token.OR:
+                {
+                    Node child = n.getFirstChild();
+                    int lType = findExpressionType(fn, child, varTypes);
+                    int rType = findExpressionType(fn, child.getNext(), varTypes);
+                    return lType | rType;
+                }
         }
 
         return Optimizer.AnyType;
     }
 
-    private static boolean findDefPoints(OptFunctionNode fn, Node n,
-                                         int[] varTypes)
-    {
+    private static boolean findDefPoints(OptFunctionNode fn, Node n, int[] varTypes) {
         boolean result = false;
         Node first = n.getFirstChild();
         for (Node next = first; next != null; next = next.getNext()) {
             result |= findDefPoints(fn, next, varTypes);
         }
         switch (n.getType()) {
-            case Token.DEC :
-            case Token.INC :
+            case Token.DEC:
+            case Token.INC:
                 if (first.getType() == Token.GETVAR) {
                     // theVar is a Number now
                     int i = fn.getVarIndex(first);
@@ -589,24 +586,22 @@ class Block
                     }
                 }
                 break;
-            case Token.SETVAR :
-            case Token.SETCONSTVAR : {
-                Node rValue = first.getNext();
-                int theType = findExpressionType(fn, rValue, varTypes);
-                int i = fn.getVarIndex(n);
-                if (!(n.getType() == Token.SETVAR
-                        && fn.fnode.getParamAndVarConst()[i])) {
-                    result |= assignType(varTypes, i, theType);
+            case Token.SETVAR:
+            case Token.SETCONSTVAR:
+                {
+                    Node rValue = first.getNext();
+                    int theType = findExpressionType(fn, rValue, varTypes);
+                    int i = fn.getVarIndex(n);
+                    if (!(n.getType() == Token.SETVAR && fn.fnode.getParamAndVarConst()[i])) {
+                        result |= assignType(varTypes, i, theType);
+                    }
+                    break;
                 }
-                break;
-            }
         }
         return result;
     }
 
-    private boolean doTypeFlow(OptFunctionNode fn, Node[] statementNodes,
-                               int[] varTypes)
-    {
+    private boolean doTypeFlow(OptFunctionNode fn, Node[] statementNodes, int[] varTypes) {
         boolean changed = false;
 
         for (int i = itsStartNodeIndex; i <= itsEndNodeIndex; i++) {
@@ -619,19 +614,14 @@ class Block
         return changed;
     }
 
-    private void printLiveOnEntrySet(OptFunctionNode fn)
-    {
+    private void printLiveOnEntrySet(OptFunctionNode fn) {
         if (DEBUG) {
             for (int i = 0; i < fn.getVarCount(); i++) {
                 String name = fn.fnode.getParamOrVarName(i);
-                if (itsUseBeforeDefSet.get(i))
-                    System.out.println(name + " is used before def'd");
-                if (itsNotDefSet.get(i))
-                    System.out.println(name + " is not def'd");
-                if (itsLiveOnEntrySet.get(i))
-                    System.out.println(name + " is live on entry");
-                if (itsLiveOnExitSet.get(i))
-                    System.out.println(name + " is live on exit");
+                if (itsUseBeforeDefSet.get(i)) System.out.println(name + " is used before def'd");
+                if (itsNotDefSet.get(i)) System.out.println(name + " is not def'd");
+                if (itsLiveOnEntrySet.get(i)) System.out.println(name + " is live on entry");
+                if (itsLiveOnExitSet.get(i)) System.out.println(name + " is live on exit");
             }
         }
     }
@@ -641,10 +631,10 @@ class Block
     // all the Blocks that come immediately before this
     private Block[] itsPredecessors;
 
-    private int itsStartNodeIndex;       // the Node at the start of the block
-    private int itsEndNodeIndex;         // the Node at the end of the block
+    private int itsStartNodeIndex; // the Node at the start of the block
+    private int itsEndNodeIndex; // the Node at the end of the block
 
-    private int itsBlockID;               // a unique index for each block
+    private int itsBlockID; // a unique index for each block
 
     // reaching def bit sets -
     private BitSet itsLiveOnEntrySet;
@@ -654,6 +644,4 @@ class Block
 
     static final boolean DEBUG = false;
     private static int debug_blockCount;
-
 }
-

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1240,13 +1240,15 @@ class BodyCodegen {
                 break;
 
             case Token.POS:
-            case Token.NEG:
                 generateExpression(child, node);
                 addObjectToDouble();
-                if (type == Token.NEG) {
-                    cfw.add(ByteCode.DNEG);
-                }
                 addDoubleWrap();
+                break;
+
+            case Token.NEG:
+                generateExpression(child, node);
+                addObjectToNumeric();
+                addScriptRuntimeInvoke("negate", "(Ljava/lang/Number;" + ")Ljava/lang/Number;");
                 break;
 
             case Token.TO_DOUBLE:
@@ -4094,6 +4096,10 @@ class BodyCodegen {
 
     private void addObjectToDouble() {
         addScriptRuntimeInvoke("toNumber", "(Ljava/lang/Object;)D");
+    }
+
+    private void addObjectToNumeric() {
+        addScriptRuntimeInvoke("toNumeric", "(Ljava/lang/Object;)Ljava/lang/Number;");
     }
 
     private void addNewObjectArray(int size) {

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -3472,36 +3472,64 @@ class BodyCodegen {
             return;
         }
         if (childNumberFlag == -1) {
-            addScriptRuntimeInvoke("toInt32", "(Ljava/lang/Object;)I");
+            addObjectToNumeric();
             generateExpression(child.getNext(), node);
-            addScriptRuntimeInvoke("toInt32", "(Ljava/lang/Object;)I");
+            addObjectToNumeric();
+
+            switch (type) {
+                case Token.BITOR:
+                    addScriptRuntimeInvoke(
+                            "bitwiseOR",
+                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    break;
+                case Token.BITXOR:
+                    addScriptRuntimeInvoke(
+                            "bitwiseXOR",
+                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    break;
+                case Token.BITAND:
+                    addScriptRuntimeInvoke(
+                            "bitwiseAND",
+                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    break;
+                case Token.RSH:
+                    addScriptRuntimeInvoke(
+                            "signedRightShift",
+                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    break;
+                case Token.LSH:
+                    addScriptRuntimeInvoke(
+                            "leftShift",
+                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    break;
+                default:
+                    throw Kit.codeBug(Token.typeToName(type));
+            }
         } else {
             addScriptRuntimeInvoke("toInt32", "(D)I");
             generateExpression(child.getNext(), node);
             addScriptRuntimeInvoke("toInt32", "(D)I");
-        }
-        switch (type) {
-            case Token.BITOR:
-                cfw.add(ByteCode.IOR);
-                break;
-            case Token.BITXOR:
-                cfw.add(ByteCode.IXOR);
-                break;
-            case Token.BITAND:
-                cfw.add(ByteCode.IAND);
-                break;
-            case Token.RSH:
-                cfw.add(ByteCode.ISHR);
-                break;
-            case Token.LSH:
-                cfw.add(ByteCode.ISHL);
-                break;
-            default:
-                throw Codegen.badTree();
-        }
-        cfw.add(ByteCode.I2D);
-        if (childNumberFlag == -1) {
-            addDoubleWrap();
+
+            switch (type) {
+                case Token.BITOR:
+                    cfw.add(ByteCode.IOR);
+                    break;
+                case Token.BITXOR:
+                    cfw.add(ByteCode.IXOR);
+                    break;
+                case Token.BITAND:
+                    cfw.add(ByteCode.IAND);
+                    break;
+                case Token.RSH:
+                    cfw.add(ByteCode.ISHR);
+                    break;
+                case Token.LSH:
+                    cfw.add(ByteCode.ISHL);
+                    break;
+                default:
+                    throw Kit.codeBug(Token.typeToName(type));
+            }
+            cfw.add(ByteCode.I2D);
         }
     }
 

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1004,6 +1004,24 @@ class BodyCodegen {
                 }
                 break;
 
+            case Token.BIGINT:
+                {
+                    byte[] bytes = node.getBigInt().toByteArray();
+                    cfw.add(ByteCode.NEW, "java/math/BigInteger");
+                    cfw.add(ByteCode.DUP);
+                    cfw.addPush(bytes.length);
+                    cfw.add(ByteCode.NEWARRAY, ByteCode.T_BYTE);
+                    for (int i = 0; i < bytes.length; i++) {
+                        cfw.add(ByteCode.DUP);
+                        cfw.addPush(i);
+                        cfw.add(ByteCode.BIPUSH, bytes[i]);
+                        cfw.add(ByteCode.BASTORE);
+                    }
+                    cfw.addInvoke(
+                            ByteCode.INVOKESPECIAL, "java/math/BigInteger", "<init>", "([B)V");
+                }
+                break;
+
             case Token.STRING:
                 cfw.addPush(node.getString());
                 break;

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -3439,15 +3439,13 @@ class BodyCodegen {
         int childNumberFlag = node.getIntProp(Node.ISNUMBER_PROP, -1);
         generateExpression(child, node);
         if (childNumberFlag == -1) {
-            addScriptRuntimeInvoke("toInt32", "(Ljava/lang/Object;)I");
+            addObjectToNumeric();
+            addScriptRuntimeInvoke("bitwiseNOT", "(Ljava/lang/Number;)Ljava/lang/Number;");
         } else {
             addScriptRuntimeInvoke("toInt32", "(D)I");
-        }
-        cfw.addPush(-1); // implement ~a as (a ^ -1)
-        cfw.add(ByteCode.IXOR);
-        cfw.add(ByteCode.I2D);
-        if (childNumberFlag == -1) {
-            addDoubleWrap();
+            cfw.addPush(-1); // implement ~a as (a ^ -1)
+            cfw.add(ByteCode.IXOR);
+            cfw.add(ByteCode.I2D);
         }
     }
 

--- a/src/org/mozilla/javascript/optimizer/Optimizer.java
+++ b/src/org/mozilla/javascript/optimizer/Optimizer.java
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
-
 package org.mozilla.javascript.optimizer;
 
 import org.mozilla.javascript.Node;
@@ -11,8 +9,7 @@ import org.mozilla.javascript.ObjArray;
 import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.ScriptNode;
 
-class Optimizer
-{
+class Optimizer {
 
     static final int NoType = 0;
     static final int NumberType = 1;
@@ -20,8 +17,7 @@ class Optimizer
 
     // It is assumed that (NumberType | AnyType) == AnyType
 
-    void optimize(ScriptNode scriptOrFn)
-    {
+    void optimize(ScriptNode scriptOrFn) {
         //  run on one function at a time for now
         int functionCount = scriptOrFn.getFunctionCount();
         for (int i = 0; i != functionCount; ++i) {
@@ -30,8 +26,7 @@ class Optimizer
         }
     }
 
-    private void optimizeFunction(OptFunctionNode theFunction)
-    {
+    private void optimizeFunction(OptFunctionNode theFunction) {
         if (theFunction.fnode.requiresActivation()) return;
 
         inDirectCallFunction = theFunction.isTargetOfDirectCall();
@@ -58,43 +53,39 @@ class Optimizer
             }
             theFunction.setParameterNumberContext(parameterUsedInNumberContext);
         }
-
     }
 
+    /*
+            Each directCall parameter is passed as a pair of values - an object
+            and a double. The value passed depends on the type of value available at
+            the call site. If a double is available, the object in java/lang/Void.TYPE
+            is passed as the object value, and if an object value is available, then
+            0.0 is passed as the double value.
 
-/*
-        Each directCall parameter is passed as a pair of values - an object
-        and a double. The value passed depends on the type of value available at
-        the call site. If a double is available, the object in java/lang/Void.TYPE
-        is passed as the object value, and if an object value is available, then
-        0.0 is passed as the double value.
+            The receiving routine always tests the object value before proceeding.
+            If the parameter is being accessed in a 'Number Context' then the code
+            sequence is :
+            if ("parameter_objectValue" == java/lang/Void.TYPE)
+                ...fine..., use the parameter_doubleValue
+            else
+                toNumber(parameter_objectValue)
 
-        The receiving routine always tests the object value before proceeding.
-        If the parameter is being accessed in a 'Number Context' then the code
-        sequence is :
-        if ("parameter_objectValue" == java/lang/Void.TYPE)
-            ...fine..., use the parameter_doubleValue
-        else
-            toNumber(parameter_objectValue)
+            and if the parameter is being referenced in an Object context, the code is
+            if ("parameter_objectValue" == java/lang/Void.TYPE)
+                new Double(parameter_doubleValue)
+            else
+                ...fine..., use the parameter_objectValue
 
-        and if the parameter is being referenced in an Object context, the code is
-        if ("parameter_objectValue" == java/lang/Void.TYPE)
-            new Double(parameter_doubleValue)
-        else
-            ...fine..., use the parameter_objectValue
+            If the receiving code never uses the doubleValue, it is converted on
+            entry to a Double instead.
+    */
 
-        If the receiving code never uses the doubleValue, it is converted on
-        entry to a Double instead.
-*/
-
-
-/*
-        We're referencing a node in a Number context (i.e. we'd prefer it
-        was a double value). If the node is a parameter in a directCall
-        function, mark it as being referenced in this context.
-*/
-    private void markDCPNumberContext(Node n)
-    {
+    /*
+            We're referencing a node in a Number context (i.e. we'd prefer it
+            was a double value). If the node is a parameter in a directCall
+            function, mark it as being referenced in this context.
+    */
+    private void markDCPNumberContext(Node n) {
         if (inDirectCallFunction && n.getType() == Token.GETVAR) {
             int varIndex = theFunction.getVarIndex(n);
             if (theFunction.isParameter(varIndex)) {
@@ -103,8 +94,7 @@ class Optimizer
         }
     }
 
-    private boolean convertParameter(Node n)
-    {
+    private boolean convertParameter(Node n) {
         if (inDirectCallFunction && n.getType() == Token.GETVAR) {
             int varIndex = theFunction.getVarIndex(n);
             if (theFunction.isParameter(varIndex)) {
@@ -115,65 +105,60 @@ class Optimizer
         return false;
     }
 
-    private int rewriteForNumberVariables(Node n, int desired)
-    {
+    private int rewriteForNumberVariables(Node n, int desired) {
         switch (n.getType()) {
-            case Token.EXPR_VOID : {
+            case Token.EXPR_VOID:
+                {
                     Node child = n.getFirstChild();
                     int type = rewriteForNumberVariables(child, NumberType);
-                    if (type == NumberType)
-                        n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
-                     return NoType;
+                    if (type == NumberType) n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
+                    return NoType;
                 }
-            case Token.NUMBER :
+            case Token.NUMBER:
                 n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                 return NumberType;
 
-            case Token.GETVAR :
+            case Token.GETVAR:
                 {
                     int varIndex = theFunction.getVarIndex(n);
                     if (inDirectCallFunction
-                        && theFunction.isParameter(varIndex)
-                        && desired == NumberType)
-                    {
+                            && theFunction.isParameter(varIndex)
+                            && desired == NumberType) {
                         n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                         return NumberType;
-                    }
-                    else if (theFunction.isNumberVar(varIndex)) {
+                    } else if (theFunction.isNumberVar(varIndex)) {
                         n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                         return NumberType;
                     }
                     return NoType;
                 }
 
-            case Token.INC :
-            case Token.DEC : {
+            case Token.INC:
+            case Token.DEC:
+                {
                     Node child = n.getFirstChild();
                     int type = rewriteForNumberVariables(child, NumberType);
                     if (child.getType() == Token.GETVAR) {
-                        if (type == NumberType && !convertParameter(child))
-                        {
+                        if (type == NumberType && !convertParameter(child)) {
                             n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                             markDCPNumberContext(child);
                             return NumberType;
                         }
                         return NoType;
-                    }
-                    else if (child.getType() == Token.GETELEM
+                    } else if (child.getType() == Token.GETELEM
                             || child.getType() == Token.GETPROP) {
                         return type;
                     }
                     return NoType;
                 }
-            case Token.SETVAR :
-            case Token.SETCONSTVAR : {
+            case Token.SETVAR:
+            case Token.SETCONSTVAR:
+                {
                     Node lChild = n.getFirstChild();
                     Node rChild = lChild.getNext();
                     int rType = rewriteForNumberVariables(rChild, NumberType);
                     int varIndex = theFunction.getVarIndex(n);
-                    if (inDirectCallFunction
-                        && theFunction.isParameter(varIndex))
-                    {
+                    if (inDirectCallFunction && theFunction.isParameter(varIndex)) {
                         if (rType == NumberType) {
                             if (!convertParameter(rChild)) {
                                 n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
@@ -183,32 +168,29 @@ class Optimizer
                             return NoType;
                         }
                         return rType;
-                    }
-                    else if (theFunction.isNumberVar(varIndex)) {
+                    } else if (theFunction.isNumberVar(varIndex)) {
                         if (rType != NumberType) {
                             n.removeChild(rChild);
-                            n.addChildToBack(
-                                new Node(Token.TO_DOUBLE, rChild));
+                            n.addChildToBack(new Node(Token.TO_DOUBLE, rChild));
                         }
                         n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                         markDCPNumberContext(rChild);
                         return NumberType;
-                    }
-                    else {
+                    } else {
                         if (rType == NumberType) {
                             if (!convertParameter(rChild)) {
                                 n.removeChild(rChild);
-                                n.addChildToBack(
-                                    new Node(Token.TO_OBJECT, rChild));
+                                n.addChildToBack(new Node(Token.TO_OBJECT, rChild));
                             }
                         }
                         return NoType;
                     }
                 }
-            case Token.LE :
-            case Token.LT :
-            case Token.GE :
-            case Token.GT : {
+            case Token.LE:
+            case Token.LT:
+            case Token.GE:
+            case Token.GT:
+                {
                     Node lChild = n.getFirstChild();
                     Node rChild = lChild.getNext();
                     int lType = rewriteForNumberVariables(lChild, NumberType);
@@ -222,22 +204,18 @@ class Optimizer
                         } else if (rType == NumberType) {
                             n.putIntProp(Node.ISNUMBER_PROP, Node.RIGHT);
                         }
-                    }
-                    else if (convertParameter(rChild)) {
+                    } else if (convertParameter(rChild)) {
                         if (lType == NumberType) {
                             n.putIntProp(Node.ISNUMBER_PROP, Node.LEFT);
                         }
-                    }
-                    else {
+                    } else {
                         if (lType == NumberType) {
                             if (rType == NumberType) {
                                 n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
-                            }
-                            else {
+                            } else {
                                 n.putIntProp(Node.ISNUMBER_PROP, Node.LEFT);
                             }
-                        }
-                        else {
+                        } else {
                             if (rType == NumberType) {
                                 n.putIntProp(Node.ISNUMBER_PROP, Node.RIGHT);
                             }
@@ -247,12 +225,12 @@ class Optimizer
                     return NoType;
                 }
 
-            case Token.ADD : {
+            case Token.ADD:
+                {
                     Node lChild = n.getFirstChild();
                     Node rChild = lChild.getNext();
                     int lType = rewriteForNumberVariables(lChild, NumberType);
                     int rType = rewriteForNumberVariables(rChild, NumberType);
-
 
                     if (convertParameter(lChild)) {
                         if (convertParameter(rChild)) {
@@ -261,25 +239,21 @@ class Optimizer
                         if (rType == NumberType) {
                             n.putIntProp(Node.ISNUMBER_PROP, Node.RIGHT);
                         }
-                    }
-                    else {
+                    } else {
                         if (convertParameter(rChild)) {
                             if (lType == NumberType) {
                                 n.putIntProp(Node.ISNUMBER_PROP, Node.LEFT);
                             }
-                        }
-                        else {
+                        } else {
                             if (lType == NumberType) {
                                 if (rType == NumberType) {
                                     n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                                     return NumberType;
                                 }
                                 n.putIntProp(Node.ISNUMBER_PROP, Node.LEFT);
-                            }
-                            else {
+                            } else {
                                 if (rType == NumberType) {
-                                    n.putIntProp(Node.ISNUMBER_PROP,
-                                                 Node.RIGHT);
+                                    n.putIntProp(Node.ISNUMBER_PROP, Node.RIGHT);
                                 }
                             }
                         }
@@ -287,16 +261,17 @@ class Optimizer
                     return NoType;
                 }
 
-            case Token.BITXOR :
-            case Token.BITOR :
-            case Token.BITAND :
-            case Token.RSH :
-            case Token.LSH :
-            case Token.SUB :
-            case Token.MUL :
-            case Token.DIV :
-            case Token.MOD :
-            case Token.EXP : {
+            case Token.BITXOR:
+            case Token.BITOR:
+            case Token.BITAND:
+            case Token.RSH:
+            case Token.LSH:
+            case Token.SUB:
+            case Token.MUL:
+            case Token.DIV:
+            case Token.MOD:
+            case Token.EXP:
+                {
                     Node lChild = n.getFirstChild();
                     Node rChild = lChild.getNext();
                     int lType = rewriteForNumberVariables(lChild, NumberType);
@@ -310,8 +285,7 @@ class Optimizer
                         }
                         if (!convertParameter(rChild)) {
                             n.removeChild(rChild);
-                            n.addChildToBack(
-                                new Node(Token.TO_DOUBLE, rChild));
+                            n.addChildToBack(new Node(Token.TO_DOUBLE, rChild));
                             n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                         }
                         return NumberType;
@@ -319,27 +293,25 @@ class Optimizer
                     if (rType == NumberType) {
                         if (!convertParameter(lChild)) {
                             n.removeChild(lChild);
-                            n.addChildToFront(
-                                new Node(Token.TO_DOUBLE, lChild));
+                            n.addChildToFront(new Node(Token.TO_DOUBLE, lChild));
                             n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                         }
                         return NumberType;
                     }
                     if (!convertParameter(lChild)) {
                         n.removeChild(lChild);
-                        n.addChildToFront(
-                            new Node(Token.TO_DOUBLE, lChild));
+                        n.addChildToFront(new Node(Token.TO_DOUBLE, lChild));
                     }
                     if (!convertParameter(rChild)) {
                         n.removeChild(rChild);
-                        n.addChildToBack(
-                            new Node(Token.TO_DOUBLE, rChild));
+                        n.addChildToBack(new Node(Token.TO_DOUBLE, rChild));
                     }
                     n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                     return NumberType;
                 }
 
-            case Token.BITNOT : {
+            case Token.BITNOT:
+                {
                     Node child = n.getFirstChild();
                     int type = rewriteForNumberVariables(child, NumberType);
                     if (type == NumberType && !convertParameter(child)) {
@@ -350,8 +322,9 @@ class Optimizer
                     return NoType;
                 }
 
-            case Token.SETELEM :
-            case Token.SETELEM_OP : {
+            case Token.SETELEM:
+            case Token.SETELEM_OP:
+                {
                     Node arrayBase = n.getFirstChild();
                     Node arrayIndex = arrayBase.getNext();
                     Node rValue = arrayIndex.getNext();
@@ -359,8 +332,7 @@ class Optimizer
                     if (baseType == NumberType) {
                         if (!convertParameter(arrayBase)) {
                             n.removeChild(arrayBase);
-                            n.addChildToFront(
-                                new Node(Token.TO_OBJECT, arrayBase));
+                            n.addChildToFront(new Node(Token.TO_OBJECT, arrayBase));
                         }
                     }
                     int indexType = rewriteForNumberVariables(arrayIndex, NumberType);
@@ -376,21 +348,20 @@ class Optimizer
                     if (rValueType == NumberType) {
                         if (!convertParameter(rValue)) {
                             n.removeChild(rValue);
-                            n.addChildToBack(
-                                new Node(Token.TO_OBJECT, rValue));
+                            n.addChildToBack(new Node(Token.TO_OBJECT, rValue));
                         }
                     }
                     return NoType;
                 }
-            case Token.GETELEM : {
+            case Token.GETELEM:
+                {
                     Node arrayBase = n.getFirstChild();
                     Node arrayIndex = arrayBase.getNext();
                     int baseType = rewriteForNumberVariables(arrayBase, NumberType);
                     if (baseType == NumberType) {
                         if (!convertParameter(arrayBase)) {
                             n.removeChild(arrayBase);
-                            n.addChildToFront(
-                                new Node(Token.TO_OBJECT, arrayBase));
+                            n.addChildToFront(new Node(Token.TO_OBJECT, arrayBase));
                         }
                     }
                     int indexType = rewriteForNumberVariables(arrayIndex, NumberType);
@@ -404,20 +375,19 @@ class Optimizer
                     }
                     return NoType;
                 }
-            case Token.CALL :
+            case Token.CALL:
                 {
                     Node child = n.getFirstChild(); // the function node
                     // must be an object
                     rewriteAsObjectChildren(child, child.getFirstChild());
                     child = child.getNext(); // the first arg
 
-                    OptFunctionNode target
-                            = (OptFunctionNode)n.getProp(Node.DIRECTCALL_PROP);
+                    OptFunctionNode target = (OptFunctionNode) n.getProp(Node.DIRECTCALL_PROP);
                     if (target != null) {
-/*
-    we leave each child as a Number if it can be. The codegen will
-    handle moving the pairs of parameters.
-*/
+                        /*
+                            we leave each child as a Number if it can be. The codegen will
+                            handle moving the pairs of parameters.
+                        */
                         while (child != null) {
                             int type = rewriteForNumberVariables(child, NumberType);
                             if (type == NumberType) {
@@ -430,15 +400,15 @@ class Optimizer
                     }
                     return NoType;
                 }
-            default : {
+            default:
+                {
                     rewriteAsObjectChildren(n, n.getFirstChild());
                     return NoType;
                 }
         }
     }
 
-    private void rewriteAsObjectChildren(Node n, Node child)
-    {
+    private void rewriteAsObjectChildren(Node n, Node child) {
         // Force optimized children to be objects
         while (child != null) {
             Node nextChild = child.getNext();
@@ -447,24 +417,20 @@ class Optimizer
                 if (!convertParameter(child)) {
                     n.removeChild(child);
                     Node nuChild = new Node(Token.TO_OBJECT, child);
-                    if (nextChild == null)
-                        n.addChildToBack(nuChild);
-                    else
-                        n.addChildBefore(nuChild, nextChild);
+                    if (nextChild == null) n.addChildToBack(nuChild);
+                    else n.addChildBefore(nuChild, nextChild);
                 }
             }
             child = nextChild;
         }
     }
 
-    private static void buildStatementList_r(Node node, ObjArray statements)
-    {
+    private static void buildStatementList_r(Node node, ObjArray statements) {
         int type = node.getType();
         if (type == Token.BLOCK
-            || type == Token.LOCAL_BLOCK
-            || type == Token.LOOP
-            || type == Token.FUNCTION)
-        {
+                || type == Token.LOCAL_BLOCK
+                || type == Token.LOOP
+                || type == Token.FUNCTION) {
             Node child = node.getFirstChild();
             while (child != null) {
                 buildStatementList_r(child, statements);

--- a/src/org/mozilla/javascript/optimizer/Optimizer.java
+++ b/src/org/mozilla/javascript/optimizer/Optimizer.java
@@ -298,16 +298,8 @@ class Optimizer {
                         }
                         return NumberType;
                     }
-                    if (!convertParameter(lChild)) {
-                        n.removeChild(lChild);
-                        n.addChildToFront(new Node(Token.TO_DOUBLE, lChild));
-                    }
-                    if (!convertParameter(rChild)) {
-                        n.removeChild(rChild);
-                        n.addChildToBack(new Node(Token.TO_DOUBLE, rChild));
-                    }
-                    n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
-                    return NumberType;
+                    // Numeric Type (Number or BigInt)
+                    return AnyType;
                 }
 
             case Token.BITNOT:

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -912,6 +912,9 @@ msg.not.a.string =\
 msg.not.a.number =\
   The object is not a number
 
+msg.cant.convert.to.number =\
+  Cannot convert {0} to a number
+
 msg.no.symbol.new =\
   Symbol objects may not be constructed using \"new\"
 

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -519,6 +519,9 @@ msg.destruct.default.vals =\
 msg.no.old.octal.strict =\
     Old octal numbers prohibited in strict mode.
 
+msg.no.old.octal.bigint =\
+    Old octal numbers prohibited in BigInt.
+
 msg.dup.obj.lit.prop.strict =\
     Property "{0}" already defined in this object literal.
 

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -659,6 +659,9 @@ msg.division.zero = \
 msg.bigint.negative.exponent = \
     BigInt negative exponent.
 
+msg.bigint.out.of.range.arithmetic = \
+    BigInt is too large.
+
 # ScriptableObject
 msg.default.value =\
     Cannot find default value for object.

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -580,6 +580,15 @@ msg.null.to.object =\
 msg.undef.to.object =\
     Cannot convert undefined to an object.
 
+msg.cant.convert.to.bigint =\
+    Cannot convert {0} to an BigInt.
+
+msg.cant.convert.to.bigint.isnt.integer =\
+    Cannot convert {0} to an BigInt. It isn\'t an integer.
+
+msg.bigint.bad.form =\
+    illegally formed BigInt syntax
+
 msg.cyclic.value =\
     Cyclic {0} value not allowed.
 

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -653,6 +653,12 @@ msg.in.not.object = \
 msg.bad.radix = \
     illegal radix {0}.
 
+msg.division.zero = \
+    Division by zero.
+
+msg.bigint.negative.exponent = \
+    BigInt negative exponent.
+
 # ScriptableObject
 msg.default.value =\
     Cannot find default value for object.

--- a/testsrc/jstests/es2020/bigint.js
+++ b/testsrc/jstests/es2020/bigint.js
@@ -18,4 +18,27 @@ assertEquals(1n, (() => 1n & one)());
 assertEquals(2n, (() => 1n << one)());
 assertEquals(0n, (() => 1n >> one)());
 
+// Out of range check for BigInt
+const MAX_INT = 2n ** 31n - 1n;
+assertEquals(1n, 1n ** MAX_INT);
+assertThrows(() => {
+  2n ** MAX_INT;
+}, RangeError);
+assertThrows(() => {
+  1n ** (MAX_INT + 1n);
+}, RangeError);
+
+assertEquals(0n, 0n << MAX_INT);
+assertThrows(() => {
+  1n << MAX_INT;
+}, RangeError);
+assertThrows(() => {
+  1n << (MAX_INT + 1n);
+}, RangeError);
+
+assertEquals(0n, 1n >> MAX_INT);
+assertThrows(() => {
+  1n >> (MAX_INT + 1n);
+}, RangeError);
+
 "success";

--- a/testsrc/jstests/es2020/bigint.js
+++ b/testsrc/jstests/es2020/bigint.js
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+// optimizer test
+const one = 1n;
+assertEquals(2n, (() => 1n + one)());
+assertEquals(0n, (() => 1n - one)());
+assertEquals(1n, (() => 1n * one)());
+assertEquals(1n, (() => 1n / one)());
+assertEquals(0n, (() => 1n % one)());
+assertEquals(1n, (() => 1n ** one)());
+assertEquals(0n, (() => 1n ^ one)());
+assertEquals(1n, (() => 1n | one)());
+assertEquals(1n, (() => 1n & one)());
+assertEquals(2n, (() => 1n << one)());
+assertEquals(0n, (() => 1n >> one)());
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/DecompileTest.java
+++ b/testsrc/org/mozilla/javascript/tests/DecompileTest.java
@@ -38,6 +38,7 @@ public class DecompileTest {
         final String source = "var x = 123n;";
         Utils.runWithAllOptimizationLevels(
                 cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
                     final Script script = cx.compileString(source, "my script", 0, null);
                     Assert.assertEquals(source, cx.decompileScript(script, 4).trim());
                     return null;

--- a/testsrc/org/mozilla/javascript/tests/DecompileTest.java
+++ b/testsrc/org/mozilla/javascript/tests/DecompileTest.java
@@ -32,4 +32,15 @@ public class DecompileTest {
                     return null;
                 });
     }
+
+    @Test
+    public void bigInt() {
+        final String source = "var x = 123n;";
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Script script = cx.compileString(source, "my script", 0, null);
+                    Assert.assertEquals(source, cx.decompileScript(script, 4).trim());
+                    return null;
+                });
+    }
 }

--- a/testsrc/org/mozilla/javascript/tests/DecompileTest.java
+++ b/testsrc/org/mozilla/javascript/tests/DecompileTest.java
@@ -4,7 +4,6 @@
 
 package org.mozilla.javascript.tests;
 
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
@@ -12,22 +11,25 @@ import org.mozilla.javascript.Script;
 
 /**
  * Test for {@link Context#decompileScript(Script, int)}.
+ *
  * @author Marc Guillemot
  */
 public class DecompileTest {
 
     /**
-     * As of head of trunk on 30.09.09, decompile of "new Date()" returns "new Date" without parentheses.
+     * As of head of trunk on 30.09.09, decompile of "new Date()" returns "new Date" without
+     * parentheses.
+     *
      * @see <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=519692">Bug 519692</a>
      */
     @Test
-    public void newObject0Arg()
-    {
+    public void newObject0Arg() {
         final String source = "var x = new Date().getTime();";
-        Utils.runWithAllOptimizationLevels(cx -> {
-            final Script script = cx.compileString(source, "my script", 0, null);
-            Assert.assertEquals(source, cx.decompileScript(script, 4).trim());
-            return null;
-        });
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Script script = cx.compileString(source, "my script", 0, null);
+                    Assert.assertEquals(source, cx.decompileScript(script, 4).trim());
+                    return null;
+                });
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -195,13 +195,15 @@ public class Test262SuiteTest {
             }
 
             String str = testCase.source;
+            int line = 1;
             if (useStrict) {
                 str = "\"use strict\";\n" + str;
+                line--;
             }
 
             boolean failedEarly = true;
             try {
-                Script caseScript = cx.compileString(str, testFilePath, 0, null);
+                Script caseScript = cx.compileString(str, testFilePath, line, null);
 
                 failedEarly = false; // not after this line
                 caseScript.exec(cx, scope);

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -62,7 +62,6 @@ public class Test262SuiteTest {
             new HashSet<>(
                     Arrays.asList(
                             "Atomics",
-                            "BigInt",
                             "IsHTMLDDA",
                             "Promise.prototype.finally",
                             "Proxy",

--- a/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
+++ b/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
@@ -28,7 +28,7 @@ public class WrapFactoryTest {
         test(true, Boolean.FALSE, "boolean", "object", "object");
         test(true, new Integer(1), "number", "object", "object");
         test(true, new Long(2L), "number", "object", "object");
-        test(true, new BigInteger("3"), "number", "object", "object");
+        test(true, new BigInteger("3"), "bigint", "object", "object"); // TODO: compatibility issue
         test(true, new BigDecimal("4.0"), "number", "object", "object");
     }
 
@@ -41,7 +41,12 @@ public class WrapFactoryTest {
         test(false, new Long(2L), "number", "number", "number");
 
         // I want to treat BigInteger / BigDecimal as BigInteger / BigDecimal. But fails.
-        test(false, new BigInteger("30"), "number", "object", "object");
+        test(
+                false,
+                new BigInteger("30"),
+                "bigint",
+                "object",
+                "object"); // TODO: compatibility issue
         test(false, new BigDecimal("4.0"), "number", "object", "object");
 
         // This is the best. I want not to convert to number.

--- a/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
+++ b/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
@@ -28,7 +28,7 @@ public class WrapFactoryTest {
         test(true, Boolean.FALSE, "boolean", "object", "object");
         test(true, new Integer(1), "number", "object", "object");
         test(true, new Long(2L), "number", "object", "object");
-        test(true, new BigInteger("3"), "bigint", "object", "object"); // TODO: compatibility issue
+        test(true, new BigInteger("3"), "bigint", "object", "object");
         test(true, new BigDecimal("4.0"), "number", "object", "object");
     }
 
@@ -40,17 +40,12 @@ public class WrapFactoryTest {
         test(false, new Integer(1), "number", "number", "number");
         test(false, new Long(2L), "number", "number", "number");
 
-        // I want to treat BigInteger / BigDecimal as BigInteger / BigDecimal. But fails.
-        test(
-                false,
-                new BigInteger("30"),
-                "bigint",
-                "object",
-                "object"); // TODO: compatibility issue
+        test(false, new BigInteger("30"), "bigint", "bigint", "bigint");
+
+        // I want to treat BigDecimal as BigDecimal. But fails.
         test(false, new BigDecimal("4.0"), "number", "object", "object");
 
         // This is the best. I want not to convert to number.
-        // test(false, new BigInteger("30"), "object", "object", "object");
         // test(false, new BigDecimal("4.0"), "object", "object", "object");
     }
 

--- a/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
+++ b/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
@@ -7,88 +7,82 @@ import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 
-/**
- *
- * @author hatanaka
- */
+/** @author hatanaka */
 public class WrapFactoryTest {
-  /** javascript code */
-  private static String script = "var result = typeof test;" //
-      + "var mapResult = typeof map.get('test');" //
-      + "var getResult = typeof object.get();";
+    /** javascript code */
+    private static String script =
+            "var result = typeof test;" //
+                    + "var mapResult = typeof map.get('test');" //
+                    + "var getResult = typeof object.get();";
 
-  /**
-   * for your reference
-   * default setting (javaPrimitiveWrap = true)
-   */
-  @Test
-  public void primitiveWrapTrue() {
-    test(true, "text", "string", "object", "object");
-    test(true, Boolean.FALSE, "boolean", "object", "object");
-    test(true, new Integer(1), "number", "object", "object");
-    test(true, new Long(2L), "number", "object", "object");
-    test(true, new BigInteger("3"), "number", "object", "object");
-    test(true, new BigDecimal("4.0"), "number", "object", "object");
-  }
-
-  /**
-   * javaPrimitiveWrap = false
-   */
-  @Test
-  public void primitiveWrapFalse() {
-    test(false, "text", "string", "string", "string"); // Great! I want to do this.
-    test(false, Boolean.FALSE, "boolean", "boolean", "boolean");
-    test(false, new Integer(1), "number", "number", "number");
-    test(false, new Long(2L), "number", "number", "number");
-
-    // I want to treat BigInteger / BigDecimal as BigInteger / BigDecimal. But fails.
-    test(false, new BigInteger("30"), "number", "object", "object");
-    test(false, new BigDecimal("4.0"), "number", "object", "object");
-
-    // This is the best. I want not to convert to number.
-    //test(false, new BigInteger("30"), "object", "object", "object");
-    //test(false, new BigDecimal("4.0"), "object", "object", "object");
-  }
-
-  /**
-   * @param javaPrimitiveWrap
-   * @param object
-   * @param result typeof value
-   * @param mapResult typeof map value
-   * @param getResult typeof getter value
-   */
-  private void test(boolean javaPrimitiveWrap, Object object, String result,
-      String mapResult, String getResult) {
-    Context cx = Context.enter();
-    try {
-      cx.getWrapFactory().setJavaPrimitiveWrap(javaPrimitiveWrap);
-      Scriptable scope = cx.initStandardObjects(new ImporterTopLevel(cx));
-
-      //register object
-      Map<String, Object> map = new LinkedHashMap<>();
-      map.put("test", object);
-      ScriptableObject.putProperty(scope, "map", map);
-      ScriptableObject.putProperty(scope, "object", Optional.of(object));
-      ScriptableObject.putProperty(scope, "test", object);
-
-      //execute script
-      cx.evaluateString(scope, script, "", 1, null);
-
-      //evaluate result
-      assertEquals(result, ScriptableObject.getProperty(scope, "result"));
-      assertEquals(mapResult,
-          ScriptableObject.getProperty(scope, "mapResult"));
-      assertEquals(getResult,
-          ScriptableObject.getProperty(scope, "getResult"));
-    } finally {
-      Context.exit();
+    /** for your reference default setting (javaPrimitiveWrap = true) */
+    @Test
+    public void primitiveWrapTrue() {
+        test(true, "text", "string", "object", "object");
+        test(true, Boolean.FALSE, "boolean", "object", "object");
+        test(true, new Integer(1), "number", "object", "object");
+        test(true, new Long(2L), "number", "object", "object");
+        test(true, new BigInteger("3"), "number", "object", "object");
+        test(true, new BigDecimal("4.0"), "number", "object", "object");
     }
-  }
+
+    /** javaPrimitiveWrap = false */
+    @Test
+    public void primitiveWrapFalse() {
+        test(false, "text", "string", "string", "string"); // Great! I want to do this.
+        test(false, Boolean.FALSE, "boolean", "boolean", "boolean");
+        test(false, new Integer(1), "number", "number", "number");
+        test(false, new Long(2L), "number", "number", "number");
+
+        // I want to treat BigInteger / BigDecimal as BigInteger / BigDecimal. But fails.
+        test(false, new BigInteger("30"), "number", "object", "object");
+        test(false, new BigDecimal("4.0"), "number", "object", "object");
+
+        // This is the best. I want not to convert to number.
+        // test(false, new BigInteger("30"), "object", "object", "object");
+        // test(false, new BigDecimal("4.0"), "object", "object", "object");
+    }
+
+    /**
+     * @param javaPrimitiveWrap
+     * @param object
+     * @param result typeof value
+     * @param mapResult typeof map value
+     * @param getResult typeof getter value
+     */
+    private void test(
+            boolean javaPrimitiveWrap,
+            Object object,
+            String result,
+            String mapResult,
+            String getResult) {
+        Context cx = Context.enter();
+        try {
+            cx.getWrapFactory().setJavaPrimitiveWrap(javaPrimitiveWrap);
+            Scriptable scope = cx.initStandardObjects(new ImporterTopLevel(cx));
+
+            // register object
+            Map<String, Object> map = new LinkedHashMap<>();
+            map.put("test", object);
+            ScriptableObject.putProperty(scope, "map", map);
+            ScriptableObject.putProperty(scope, "object", Optional.of(object));
+            ScriptableObject.putProperty(scope, "test", object);
+
+            // execute script
+            cx.evaluateString(scope, script, "", 1, null);
+
+            // evaluate result
+            assertEquals(result, ScriptableObject.getProperty(scope, "result"));
+            assertEquals(mapResult, ScriptableObject.getProperty(scope, "mapResult"));
+            assertEquals(getResult, ScriptableObject.getProperty(scope, "getResult"));
+        } finally {
+            Context.exit();
+        }
+    }
 }

--- a/testsrc/org/mozilla/javascript/tests/es2020/NativeBigIntTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es2020/NativeBigIntTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2020;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2020/bigint.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class NativeBigIntTest extends ScriptTestsBase {}

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3010,21 +3010,18 @@ language/expressions/arrow-function
 
 language/expressions/bitwise-and
     ! bigint-non-primitive.js
-    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/bitwise-not
-    ! bigint.js
     ! bigint-non-primitive.js
+    ! bigint.js
 
 language/expressions/bitwise-or
     ! bigint-non-primitive.js
-    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/bitwise-xor
     ! bigint-non-primitive.js
-    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/call
@@ -3437,7 +3434,6 @@ language/expressions/instanceof
 
 language/expressions/left-shift
     ! bigint-non-primitive.js
-    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/less-than
@@ -3787,7 +3783,6 @@ language/expressions/relational
 
 language/expressions/right-shift
     ! bigint-non-primitive.js
-    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/strict-does-not-equals

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -2773,6 +2773,7 @@ language/eval-code
 language/export
 
 language/expressions/addition
+    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! coerce-bigint-to-string.js
     ! coerce-symbol-to-prim-err.js
@@ -3431,11 +3432,13 @@ language/expressions/greater-than-or-equal
     ! bigint-and-bigint.js
     ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
+    ! bigint-and-number.js
 
 language/expressions/greater-than-or-equal
     ! bigint-and-bigint.js
     ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
+    ! bigint-and-number.js
 
 language/expressions/grouping
 
@@ -3459,11 +3462,13 @@ language/expressions/less-than
     ! bigint-and-bigint.js
     ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
+    ! bigint-and-number.js
 
 language/expressions/less-than-or-equal
     ! bigint-and-bigint.js
     ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
+    ! bigint-and-number.js
 
 language/expressions/logical-and
 
@@ -3765,7 +3770,6 @@ language/expressions/postfix-decrement
     ! S11.3.2_A6_T1.js
     ! S11.3.2_A6_T2.js
     ! S11.3.2_A6_T3.js
-    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3778,7 +3782,6 @@ language/expressions/postfix-increment
     ! S11.3.1_A6_T1.js
     ! S11.3.1_A6_T2.js
     ! S11.3.1_A6_T3.js
-    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3791,7 +3794,6 @@ language/expressions/prefix-decrement
     ! S11.4.5_A6_T1.js
     ! S11.4.5_A6_T2.js
     ! S11.4.5_A6_T3.js
-    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3803,7 +3805,6 @@ language/expressions/prefix-increment
     ! S11.4.4_A6_T1.js
     ! S11.4.4_A6_T2.js
     ! S11.4.4_A6_T3.js
-    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3186,8 +3186,6 @@ language/expressions/delete
     ! identifier-strict.js
 
 language/expressions/division
-    ! bigint-arithmetic.js
-    ! bigint-complex-infinity.js
     ! order-of-evaluation.js
 
 language/expressions/does-not-equals
@@ -3201,9 +3199,6 @@ language/expressions/equals
     ! to-prim-hint.js
 
 language/expressions/exponentiation
-    ! bigint-arithmetic.js
-    ! bigint-exp-operator-negative-throws.js
-    ! bigint-zero-base-zero-exponent.js
     ! order-of-evaluation.js
 
 language/expressions/function
@@ -3474,12 +3469,9 @@ language/expressions/logical-not
 language/expressions/logical-or
 
 language/expressions/modulus
-    ! bigint-arithmetic.js
-    ! bigint-modulo-zero.js
     ! order-of-evaluation.js
 
 language/expressions/multiplication
-    ! bigint-arithmetic.js
     ! order-of-evaluation.js
 
 language/expressions/object
@@ -3821,7 +3813,6 @@ language/expressions/strict-does-not-equals
 language/expressions/strict-equals
 
 language/expressions/subtraction
-    ! bigint-arithmetic.js
     ! order-of-evaluation.js
 
 language/expressions/super

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -623,7 +623,6 @@ built-ins/JSON
     ! Symbol.toStringTag.js
     ! parse/S15.12.2_A1.js
     ! stringify/bigint-order.js
-    ! stringify/bigint-replacer.js
     ! stringify/bigint-tojson.js
     ! stringify/bigint.js
 
@@ -3937,7 +3936,6 @@ language/expressions/this
     ! S11.1.1_A1.js
 
 language/expressions/typeof
-    ! bigint.js
     ! built-in-ordinary-objects-no-call.js
 
 language/expressions/unary-minus

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -2468,7 +2468,6 @@ built-ins/TypedArrayConstructors
     ! internals/Set/BigInt/symbol-tobigint.js
     ! internals/Set/BigInt/tonumber-value-throws.js
     ! internals/Set/BigInt/undefined-tobigint.js
-    ! internals/Set/bigint-tonumber.js
     ! internals/Set/detached-buffer-key-is-not-numeric-index.js
     ! internals/Set/detached-buffer-key-is-symbol.js
     ! internals/Set/detached-buffer-realm.js
@@ -2774,7 +2773,6 @@ language/eval-code
 language/export
 
 language/expressions/addition
-    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! coerce-bigint-to-string.js
     ! coerce-symbol-to-prim-err.js
@@ -3013,7 +3011,6 @@ language/expressions/arrow-function
     ! syntax/early-errors/use-strict-with-non-simple-param.js
 
 language/expressions/bitwise-and
-    ! bigint-and-number.js
     ! bigint-non-primitive.js
     ! bigint.js
     ! order-of-evaluation.js
@@ -3023,13 +3020,11 @@ language/expressions/bitwise-not
     ! bigint-non-primitive.js
 
 language/expressions/bitwise-or
-    ! bigint-and-number.js
     ! bigint-non-primitive.js
     ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/bitwise-xor
-    ! bigint-and-number.js
     ! bigint-non-primitive.js
     ! bigint.js
     ! order-of-evaluation.js
@@ -3193,7 +3188,6 @@ language/expressions/delete
     ! identifier-strict.js
 
 language/expressions/division
-    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! bigint-complex-infinity.js
     ! order-of-evaluation.js
@@ -3209,7 +3203,6 @@ language/expressions/equals
     ! to-prim-hint.js
 
 language/expressions/exponentiation
-    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! bigint-exp-operator-negative-throws.js
     ! bigint-zero-base-zero-exponent.js
@@ -3436,10 +3429,12 @@ language/expressions/greater-than
 
 language/expressions/greater-than-or-equal
     ! bigint-and-bigint.js
+    ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
 
 language/expressions/greater-than-or-equal
     ! bigint-and-bigint.js
+    ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
 
 language/expressions/grouping
@@ -3456,17 +3451,18 @@ language/expressions/instanceof
     ! symbol-hasinstance-to-boolean.js
 
 language/expressions/left-shift
-    ! bigint-and-number.js
     ! bigint-non-primitive.js
     ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/less-than
     ! bigint-and-bigint.js
+    ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
 
 language/expressions/less-than-or-equal
     ! bigint-and-bigint.js
+    ! bigint-and-non-finite.js
     ! bigint-and-number-extremes.js
 
 language/expressions/logical-and
@@ -3476,13 +3472,11 @@ language/expressions/logical-not
 language/expressions/logical-or
 
 language/expressions/modulus
-    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! bigint-modulo-zero.js
     ! order-of-evaluation.js
 
 language/expressions/multiplication
-    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! order-of-evaluation.js
 
@@ -3820,7 +3814,6 @@ language/expressions/property-accessors
 language/expressions/relational
 
 language/expressions/right-shift
-    ! bigint-and-number.js
     ! bigint-non-primitive.js
     ! bigint.js
     ! order-of-evaluation.js
@@ -3830,7 +3823,6 @@ language/expressions/strict-does-not-equals
 language/expressions/strict-equals
 
 language/expressions/subtraction
-    ! bigint-and-number.js
     ! bigint-arithmetic.js
     ! order-of-evaluation.js
 
@@ -3932,13 +3924,10 @@ language/expressions/unary-minus
     ! bigint-non-primitive.js
 
 language/expressions/unary-plus
-    ! bigint-throws.js
 
 language/expressions/unsigned-right-shift
-    ! bigint-and-number.js
     ! bigint-non-primitive.js
     ! bigint-toprimitive.js
-    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/void

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3421,16 +3421,6 @@ language/expressions/generators
 language/expressions/greater-than
 
 language/expressions/greater-than-or-equal
-    ! bigint-and-bigint.js
-    ! bigint-and-non-finite.js
-    ! bigint-and-number-extremes.js
-    ! bigint-and-number.js
-
-language/expressions/greater-than-or-equal
-    ! bigint-and-bigint.js
-    ! bigint-and-non-finite.js
-    ! bigint-and-number-extremes.js
-    ! bigint-and-number.js
 
 language/expressions/grouping
 
@@ -3451,16 +3441,8 @@ language/expressions/left-shift
     ! order-of-evaluation.js
 
 language/expressions/less-than
-    ! bigint-and-bigint.js
-    ! bigint-and-non-finite.js
-    ! bigint-and-number-extremes.js
-    ! bigint-and-number.js
 
 language/expressions/less-than-or-equal
-    ! bigint-and-bigint.js
-    ! bigint-and-non-finite.js
-    ! bigint-and-number-extremes.js
-    ! bigint-and-number.js
 
 language/expressions/logical-and
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -2773,9 +2773,6 @@ language/eval-code
 language/export
 
 language/expressions/addition
-    ! bigint-and-number.js
-    ! bigint-arithmetic.js
-    ! coerce-bigint-to-string.js
     ! coerce-symbol-to-prim-err.js
     ! coerce-symbol-to-prim-invocation.js
     ! coerce-symbol-to-prim-return-obj.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -131,20 +131,6 @@ built-ins/ArrayIteratorPrototype
 # built-ins/Atomics
 
 built-ins/BigInt
-    ! asIntN/arithmetic.js
-    ! asIntN/asIntN.js
-    ! asIntN/bigint-tobigint.js
-    ! asIntN/bits-toindex.js
-    ! asIntN/length.js
-    ! asIntN/name.js
-    ! asIntN/order-of-steps.js
-    ! asUintN/arithmetic.js
-    ! asUintN/asUintN.js
-    ! asUintN/bigint-tobigint.js
-    ! asUintN/bits-toindex.js
-    ! asUintN/length.js
-    ! asUintN/name.js
-    ! asUintN/order-of-steps.js
     # Check IsInteger in ES2020, not IsSafeInteger
     # https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     ! out-of-bounds-integer-rangeerror.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -2637,8 +2637,6 @@ language/block-scope
     ! shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
     ! syntax/for-in/disallow-initialization-assignment.js
     ! syntax/for-in/mixed-values-in-iteration.js
-    ! syntax/for-in/disallow-initialization-assignment.js
-    ! syntax/for-in/mixed-values-in-iteration.js
     ! syntax/function-declarations/in-statement-position-do-statement-while-expression.js
     ! syntax/function-declarations/in-statement-position-for-statement.js
     ! syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -130,7 +130,33 @@ built-ins/ArrayIteratorPrototype
 
 # built-ins/Atomics
 
-# built-ins/BigInt
+built-ins/BigInt
+    ! asIntN/arithmetic.js
+    ! asIntN/asIntN.js
+    ! asIntN/bigint-tobigint.js
+    ! asIntN/bits-toindex.js
+    ! asIntN/length.js
+    ! asIntN/name.js
+    ! asIntN/order-of-steps.js
+    ! asUintN/arithmetic.js
+    ! asUintN/asUintN.js
+    ! asUintN/bigint-tobigint.js
+    ! asUintN/bits-toindex.js
+    ! asUintN/length.js
+    ! asUintN/name.js
+    ! asUintN/order-of-steps.js
+    ! constructor-from-decimal-string.js
+    ! constructor-trailing-leading-spaces.js
+    ! issafeinteger-true.js
+    # Check IsInteger in ES2020, not IsSafeInteger
+    # https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
+    ! out-of-bounds-integer-rangeerror.js
+    # Can not rewrite BigInt.prototype[Symbol.toStringTag]
+    ! prototype/Symbol.toStringTag.js
+    ! prototype/toString/prototype-call.js
+    ! prototype/toString/radix-err.js
+    # Computed property is not support
+    ! prototype/toString/thisbigintvalue-not-valid-throws.js
 
 built-ins/Boolean
 
@@ -596,8 +622,12 @@ built-ins/IteratorPrototype
     ! Symbol.iterator/return-val.js
 
 built-ins/JSON
-    ! parse/S15.12.2_A1.js
     ! Symbol.toStringTag.js
+    ! parse/S15.12.2_A1.js
+    ! stringify/bigint-order.js
+    ! stringify/bigint-replacer.js
+    ! stringify/bigint-tojson.js
+    ! stringify/bigint.js
 
 built-ins/Map
     ! iterator-is-undefined-throws.js
@@ -773,7 +803,6 @@ built-ins/Object
     ! prototype/valueOf/S15.2.4.4_A15.js
     ! seal/symbol-object-contains-symbol-properties-non-strict.js
     ! seal/symbol-object-contains-symbol-properties-strict.js
-    ! setPrototypeOf/bigint.js
     ! setPrototypeOf/set-error.js
     ! values/exception-during-enumeration.js
     ! values/function-length.js
@@ -1161,6 +1190,15 @@ built-ins/TypedArray
     ! of/length.js
     ! of/name.js
     ! of/prop-desc.js
+    ! prototype/Symbol.toStringTag/BigInt/detached-buffer.js
+    ! prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
+    ! prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
+    ! prototype/Symbol.toStringTag/BigInt/prop-desc.js
+    ! prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
+    ! prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
+    ! prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
+    ! prototype/buffer/BigInt/detached-buffer.js
+    ! prototype/buffer/BigInt/return-buffer.js
     ! prototype/buffer/detached-buffer.js
     ! prototype/buffer/invoked-as-func.js
     ! prototype/buffer/length.js
@@ -1168,6 +1206,8 @@ built-ins/TypedArray
     ! prototype/buffer/prop-desc.js
     ! prototype/buffer/this-has-no-typedarrayname-internal.js
     ! prototype/buffer/this-is-not-object.js
+    ! prototype/byteLength/BigInt/detached-buffer.js
+    ! prototype/byteLength/BigInt/return-bytelength.js
     ! prototype/byteLength/detached-buffer.js
     ! prototype/byteLength/invoked-as-func.js
     ! prototype/byteLength/length.js
@@ -1175,6 +1215,8 @@ built-ins/TypedArray
     ! prototype/byteLength/prop-desc.js
     ! prototype/byteLength/this-has-no-typedarrayname-internal.js
     ! prototype/byteLength/this-is-not-object.js
+    ! prototype/byteOffset/BigInt/detached-buffer.js
+    ! prototype/byteOffset/BigInt/return-byteoffset.js
     ! prototype/byteOffset/detached-buffer.js
     ! prototype/byteOffset/invoked-as-func.js
     ! prototype/byteOffset/length.js
@@ -1182,6 +1224,29 @@ built-ins/TypedArray
     ! prototype/byteOffset/prop-desc.js
     ! prototype/byteOffset/this-has-no-typedarrayname-internal.js
     ! prototype/byteOffset/this-is-not-object.js
+    ! prototype/copyWithin/BigInt/coerced-values-end.js
+    ! prototype/copyWithin/BigInt/coerced-values-start.js
+    ! prototype/copyWithin/BigInt/coerced-values-target.js
+    ! prototype/copyWithin/BigInt/detached-buffer.js
+    ! prototype/copyWithin/BigInt/get-length-ignores-length-prop.js
+    ! prototype/copyWithin/BigInt/negative-end.js
+    ! prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
+    ! prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
+    ! prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
+    ! prototype/copyWithin/BigInt/negative-start.js
+    ! prototype/copyWithin/BigInt/negative-target.js
+    ! prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
+    ! prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
+    ! prototype/copyWithin/BigInt/non-negative-target-and-start.js
+    ! prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
+    ! prototype/copyWithin/BigInt/return-abrupt-from-end-is-symbol.js
+    ! prototype/copyWithin/BigInt/return-abrupt-from-end.js
+    ! prototype/copyWithin/BigInt/return-abrupt-from-start-is-symbol.js
+    ! prototype/copyWithin/BigInt/return-abrupt-from-start.js
+    ! prototype/copyWithin/BigInt/return-abrupt-from-target-is-symbol.js
+    ! prototype/copyWithin/BigInt/return-abrupt-from-target.js
+    ! prototype/copyWithin/BigInt/return-this.js
+    ! prototype/copyWithin/BigInt/undefined-end.js
     ! prototype/copyWithin/bit-precision.js
     ! prototype/copyWithin/coerced-values-end.js
     ! prototype/copyWithin/coerced-values-start.js
@@ -1210,6 +1275,8 @@ built-ins/TypedArray
     ! prototype/copyWithin/this-is-not-object.js
     ! prototype/copyWithin/this-is-not-typedarray-instance.js
     ! prototype/copyWithin/undefined-end.js
+    ! prototype/entries/BigInt/detached-buffer.js
+    ! prototype/entries/BigInt/return-itor.js
     ! prototype/entries/detached-buffer.js
     ! prototype/entries/invoked-as-func.js
     ! prototype/entries/invoked-as-method.js
@@ -1220,6 +1287,20 @@ built-ins/TypedArray
     ! prototype/entries/return-itor.js
     ! prototype/entries/this-is-not-object.js
     ! prototype/entries/this-is-not-typedarray-instance.js
+    ! prototype/every/BigInt/callbackfn-arguments-with-thisarg.js
+    ! prototype/every/BigInt/callbackfn-arguments-without-thisarg.js
+    ! prototype/every/BigInt/callbackfn-detachbuffer.js
+    ! prototype/every/BigInt/callbackfn-no-interaction-over-non-integer.js
+    ! prototype/every/BigInt/callbackfn-not-callable-throws.js
+    ! prototype/every/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/every/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/every/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/every/BigInt/callbackfn-this.js
+    ! prototype/every/BigInt/detached-buffer.js
+    ! prototype/every/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/every/BigInt/returns-false-if-any-cb-returns-false.js
+    ! prototype/every/BigInt/returns-true-if-every-cb-returns-true.js
+    ! prototype/every/BigInt/values-are-not-cached.js
     ! prototype/every/callbackfn-arguments-with-thisarg.js
     ! prototype/every/callbackfn-arguments-without-thisarg.js
     ! prototype/every/callbackfn-detachbuffer.js
@@ -1241,6 +1322,23 @@ built-ins/TypedArray
     ! prototype/every/this-is-not-object.js
     ! prototype/every/this-is-not-typedarray-instance.js
     ! prototype/every/values-are-not-cached.js
+    ! prototype/fill/BigInt/coerced-indexes.js
+    ! prototype/fill/BigInt/detached-buffer.js
+    ! prototype/fill/BigInt/fill-values-conversion-once.js
+    ! prototype/fill/BigInt/fill-values-custom-start-and-end.js
+    ! prototype/fill/BigInt/fill-values-non-numeric-throw.js
+    ! prototype/fill/BigInt/fill-values-non-numeric.js
+    ! prototype/fill/BigInt/fill-values-relative-end.js
+    ! prototype/fill/BigInt/fill-values-relative-start.js
+    ! prototype/fill/BigInt/fill-values-symbol-throws.js
+    ! prototype/fill/BigInt/fill-values.js
+    ! prototype/fill/BigInt/get-length-ignores-length-prop.js
+    ! prototype/fill/BigInt/return-abrupt-from-end-as-symbol.js
+    ! prototype/fill/BigInt/return-abrupt-from-end.js
+    ! prototype/fill/BigInt/return-abrupt-from-set-value.js
+    ! prototype/fill/BigInt/return-abrupt-from-start-as-symbol.js
+    ! prototype/fill/BigInt/return-abrupt-from-start.js
+    ! prototype/fill/BigInt/return-this.js
     ! prototype/fill/coerced-indexes.js
     ! prototype/fill/detached-buffer.js
     ! prototype/fill/fill-values-conversion-once.js
@@ -1263,6 +1361,38 @@ built-ins/TypedArray
     ! prototype/fill/return-this.js
     ! prototype/fill/this-is-not-object.js
     ! prototype/fill/this-is-not-typedarray-instance.js
+    ! prototype/filter/BigInt/arraylength-internal.js
+    ! prototype/filter/BigInt/callbackfn-arguments-with-thisarg.js
+    ! prototype/filter/BigInt/callbackfn-arguments-without-thisarg.js
+    ! prototype/filter/BigInt/callbackfn-called-before-ctor.js
+    ! prototype/filter/BigInt/callbackfn-called-before-species.js
+    ! prototype/filter/BigInt/callbackfn-detachbuffer.js
+    ! prototype/filter/BigInt/callbackfn-no-iteration-over-non-integer.js
+    ! prototype/filter/BigInt/callbackfn-not-callable-throws.js
+    ! prototype/filter/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/filter/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/filter/BigInt/callbackfn-this.js
+    ! prototype/filter/BigInt/detached-buffer.js
+    ! prototype/filter/BigInt/result-does-not-share-buffer.js
+    ! prototype/filter/BigInt/result-empty-callbackfn-returns-false.js
+    ! prototype/filter/BigInt/result-full-callbackfn-returns-true.js
+    ! prototype/filter/BigInt/speciesctor-get-ctor-abrupt.js
+    ! prototype/filter/BigInt/speciesctor-get-ctor-inherited.js
+    ! prototype/filter/BigInt/speciesctor-get-ctor-returns-throws.js
+    ! prototype/filter/BigInt/speciesctor-get-ctor.js
+    ! prototype/filter/BigInt/speciesctor-get-species-abrupt.js
+    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length.js
+    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor.js
+    ! prototype/filter/BigInt/speciesctor-get-species-returns-throws.js
+    ! prototype/filter/BigInt/speciesctor-get-species-use-default-ctor.js
+    ! prototype/filter/BigInt/speciesctor-get-species.js
+    ! prototype/filter/BigInt/values-are-not-cached.js
+    ! prototype/filter/BigInt/values-are-set.js
     ! prototype/filter/arraylength-internal.js
     ! prototype/filter/callbackfn-arguments-with-thisarg.js
     ! prototype/filter/callbackfn-arguments-without-thisarg.js
@@ -1298,6 +1428,18 @@ built-ins/TypedArray
     ! prototype/filter/this-is-not-typedarray-instance.js
     ! prototype/filter/values-are-not-cached.js
     ! prototype/filter/values-are-set.js
+    ! prototype/find/BigInt/detached-buffer.js
+    ! prototype/find/BigInt/get-length-ignores-length-prop.js
+    ! prototype/find/BigInt/predicate-call-changes-value.js
+    ! prototype/find/BigInt/predicate-call-parameters.js
+    ! prototype/find/BigInt/predicate-call-this-non-strict.js
+    ! prototype/find/BigInt/predicate-call-this-strict.js
+    ! prototype/find/BigInt/predicate-is-not-callable-throws.js
+    ! prototype/find/BigInt/predicate-may-detach-buffer.js
+    ! prototype/find/BigInt/predicate-not-called-on-empty-array.js
+    ! prototype/find/BigInt/return-abrupt-from-predicate-call.js
+    ! prototype/find/BigInt/return-found-value-predicate-result-is-true.js
+    ! prototype/find/BigInt/return-undefined-if-predicate-returns-false-value.js
     ! prototype/find/detached-buffer.js
     ! prototype/find/get-length-ignores-length-prop.js
     ! prototype/find/invoked-as-func.js
@@ -1316,6 +1458,18 @@ built-ins/TypedArray
     ! prototype/find/return-undefined-if-predicate-returns-false-value.js
     ! prototype/find/this-is-not-object.js
     ! prototype/find/this-is-not-typedarray-instance.js
+    ! prototype/findIndex/BigInt/detached-buffer.js
+    ! prototype/findIndex/BigInt/get-length-ignores-length-prop.js
+    ! prototype/findIndex/BigInt/predicate-call-changes-value.js
+    ! prototype/findIndex/BigInt/predicate-call-parameters.js
+    ! prototype/findIndex/BigInt/predicate-call-this-non-strict.js
+    ! prototype/findIndex/BigInt/predicate-call-this-strict.js
+    ! prototype/findIndex/BigInt/predicate-is-not-callable-throws.js
+    ! prototype/findIndex/BigInt/predicate-may-detach-buffer.js
+    ! prototype/findIndex/BigInt/predicate-not-called-on-empty-array.js
+    ! prototype/findIndex/BigInt/return-abrupt-from-predicate-call.js
+    ! prototype/findIndex/BigInt/return-index-predicate-result-is-true.js
+    ! prototype/findIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
     ! prototype/findIndex/detached-buffer.js
     ! prototype/findIndex/get-length-ignores-length-prop.js
     ! prototype/findIndex/invoked-as-func.js
@@ -1334,6 +1488,19 @@ built-ins/TypedArray
     ! prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
     ! prototype/findIndex/this-is-not-object.js
     ! prototype/findIndex/this-is-not-typedarray-instance.js
+    ! prototype/forEach/BigInt/arraylength-internal.js
+    ! prototype/forEach/BigInt/callbackfn-arguments-with-thisarg.js
+    ! prototype/forEach/BigInt/callbackfn-arguments-without-thisarg.js
+    ! prototype/forEach/BigInt/callbackfn-detachbuffer.js
+    ! prototype/forEach/BigInt/callbackfn-is-not-callable.js
+    ! prototype/forEach/BigInt/callbackfn-no-interaction-over-non-integer.js
+    ! prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/forEach/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/forEach/BigInt/callbackfn-this.js
+    ! prototype/forEach/BigInt/detached-buffer.js
+    ! prototype/forEach/BigInt/returns-undefined.js
+    ! prototype/forEach/BigInt/values-are-not-cached.js
     ! prototype/forEach/arraylength-internal.js
     ! prototype/forEach/callbackfn-arguments-with-thisarg.js
     ! prototype/forEach/callbackfn-arguments-without-thisarg.js
@@ -1354,6 +1521,17 @@ built-ins/TypedArray
     ! prototype/forEach/this-is-not-object.js
     ! prototype/forEach/this-is-not-typedarray-instance.js
     ! prototype/forEach/values-are-not-cached.js
+    ! prototype/includes/BigInt/detached-buffer.js
+    ! prototype/includes/BigInt/fromIndex-equal-or-greater-length-returns-false.js
+    ! prototype/includes/BigInt/fromIndex-infinity.js
+    ! prototype/includes/BigInt/fromIndex-minus-zero.js
+    ! prototype/includes/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/includes/BigInt/length-zero-returns-false.js
+    ! prototype/includes/BigInt/return-abrupt-tointeger-fromindex-symbol.js
+    ! prototype/includes/BigInt/return-abrupt-tointeger-fromindex.js
+    ! prototype/includes/BigInt/search-found-returns-true.js
+    ! prototype/includes/BigInt/search-not-found-returns-false.js
+    ! prototype/includes/BigInt/tointeger-fromindex.js
     ! prototype/includes/detached-buffer.js
     ! prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
     ! prototype/includes/fromIndex-infinity.js
@@ -1372,6 +1550,17 @@ built-ins/TypedArray
     ! prototype/includes/this-is-not-object.js
     ! prototype/includes/this-is-not-typedarray-instance.js
     ! prototype/includes/tointeger-fromindex.js
+    ! prototype/indexOf/BigInt/detached-buffer.js
+    ! prototype/indexOf/BigInt/fromIndex-equal-or-greater-length-returns-minus-one.js
+    ! prototype/indexOf/BigInt/fromIndex-infinity.js
+    ! prototype/indexOf/BigInt/fromIndex-minus-zero.js
+    ! prototype/indexOf/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/indexOf/BigInt/length-zero-returns-minus-one.js
+    ! prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
+    ! prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex.js
+    ! prototype/indexOf/BigInt/search-found-returns-index.js
+    ! prototype/indexOf/BigInt/search-not-found-returns-minus-one.js
+    ! prototype/indexOf/BigInt/tointeger-fromindex.js
     ! prototype/indexOf/detached-buffer.js
     ! prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
     ! prototype/indexOf/fromIndex-infinity.js
@@ -1390,6 +1579,13 @@ built-ins/TypedArray
     ! prototype/indexOf/this-is-not-object.js
     ! prototype/indexOf/this-is-not-typedarray-instance.js
     ! prototype/indexOf/tointeger-fromindex.js
+    ! prototype/join/BigInt/custom-separator-result-from-tostring-on-each-simple-value.js
+    ! prototype/join/BigInt/detached-buffer.js
+    ! prototype/join/BigInt/empty-instance-empty-string.js
+    ! prototype/join/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/join/BigInt/result-from-tostring-on-each-simple-value.js
+    ! prototype/join/BigInt/return-abrupt-from-separator-symbol.js
+    ! prototype/join/BigInt/return-abrupt-from-separator.js
     ! prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
     ! prototype/join/custom-separator-result-from-tostring-on-each-value.js
     ! prototype/join/detached-buffer.js
@@ -1405,6 +1601,8 @@ built-ins/TypedArray
     ! prototype/join/return-abrupt-from-separator.js
     ! prototype/join/this-is-not-object.js
     ! prototype/join/this-is-not-typedarray-instance.js
+    ! prototype/keys/BigInt/detached-buffer.js
+    ! prototype/keys/BigInt/return-itor.js
     ! prototype/keys/detached-buffer.js
     ! prototype/keys/invoked-as-func.js
     ! prototype/keys/invoked-as-method.js
@@ -1415,6 +1613,16 @@ built-ins/TypedArray
     ! prototype/keys/return-itor.js
     ! prototype/keys/this-is-not-object.js
     ! prototype/keys/this-is-not-typedarray-instance.js
+    ! prototype/lastIndexOf/BigInt/detached-buffer.js
+    ! prototype/lastIndexOf/BigInt/fromIndex-infinity.js
+    ! prototype/lastIndexOf/BigInt/fromIndex-minus-zero.js
+    ! prototype/lastIndexOf/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/lastIndexOf/BigInt/length-zero-returns-minus-one.js
+    ! prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
+    ! prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex.js
+    ! prototype/lastIndexOf/BigInt/search-found-returns-index.js
+    ! prototype/lastIndexOf/BigInt/search-not-found-returns-minus-one.js
+    ! prototype/lastIndexOf/BigInt/tointeger-fromindex.js
     ! prototype/lastIndexOf/detached-buffer.js
     ! prototype/lastIndexOf/fromIndex-infinity.js
     ! prototype/lastIndexOf/fromIndex-minus-zero.js
@@ -1432,6 +1640,12 @@ built-ins/TypedArray
     ! prototype/lastIndexOf/this-is-not-object.js
     ! prototype/lastIndexOf/this-is-not-typedarray-instance.js
     ! prototype/lastIndexOf/tointeger-fromindex.js
+    ! prototype/length/BigInt/detached-buffer.js
+    ! prototype/length/BigInt/invoked-as-func.js
+    ! prototype/length/BigInt/prop-desc.js
+    ! prototype/length/BigInt/return-length.js
+    ! prototype/length/BigInt/this-has-no-typedarrayname-internal.js
+    ! prototype/length/BigInt/this-is-not-object.js
     ! prototype/length/detached-buffer.js
     ! prototype/length/invoked-as-func.js
     ! prototype/length/length.js
@@ -1439,6 +1653,22 @@ built-ins/TypedArray
     ! prototype/length/prop-desc.js
     ! prototype/length/this-has-no-typedarrayname-internal.js
     ! prototype/length/this-is-not-object.js
+    ! prototype/map/BigInt/arraylength-internal.js
+    ! prototype/map/BigInt/callbackfn-arguments-with-thisarg.js
+    ! prototype/map/BigInt/callbackfn-arguments-without-thisarg.js
+    ! prototype/map/BigInt/callbackfn-detachbuffer.js
+    ! prototype/map/BigInt/callbackfn-is-not-callable.js
+    ! prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
+    ! prototype/map/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/map/BigInt/callbackfn-return-affects-returned-object.js
+    ! prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/map/BigInt/callbackfn-return-does-not-copy-non-integer-properties.js
+    ! prototype/map/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/map/BigInt/callbackfn-this.js
+    ! prototype/map/BigInt/detached-buffer.js
+    ! prototype/map/BigInt/return-new-typedarray-from-empty-length.js
+    ! prototype/map/BigInt/return-new-typedarray-from-positive-length.js
+    ! prototype/map/BigInt/values-are-not-cached.js
     ! prototype/map/arraylength-internal.js
     ! prototype/map/callbackfn-arguments-with-thisarg.js
     ! prototype/map/callbackfn-arguments-without-thisarg.js
@@ -1464,6 +1694,23 @@ built-ins/TypedArray
     ! prototype/map/this-is-not-object.js
     ! prototype/map/this-is-not-typedarray-instance.js
     ! prototype/map/values-are-not-cached.js
+    ! prototype/reduce/BigInt/callbackfn-arguments-custom-accumulator.js
+    ! prototype/reduce/BigInt/callbackfn-arguments-default-accumulator.js
+    ! prototype/reduce/BigInt/callbackfn-detachbuffer.js
+    ! prototype/reduce/BigInt/callbackfn-is-not-callable-throws.js
+    ! prototype/reduce/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
+    ! prototype/reduce/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/reduce/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/reduce/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/reduce/BigInt/callbackfn-this.js
+    ! prototype/reduce/BigInt/detached-buffer.js
+    ! prototype/reduce/BigInt/empty-instance-return-initialvalue.js
+    ! prototype/reduce/BigInt/empty-instance-with-no-initialvalue-throws.js
+    ! prototype/reduce/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/reduce/BigInt/result-is-last-callbackfn-return.js
+    ! prototype/reduce/BigInt/result-of-any-type.js
+    ! prototype/reduce/BigInt/return-first-value-without-callbackfn.js
+    ! prototype/reduce/BigInt/values-are-not-cached.js
     ! prototype/reduce/callbackfn-arguments-custom-accumulator.js
     ! prototype/reduce/callbackfn-arguments-default-accumulator.js
     ! prototype/reduce/callbackfn-detachbuffer.js
@@ -1487,6 +1734,23 @@ built-ins/TypedArray
     ! prototype/reduce/this-is-not-object.js
     ! prototype/reduce/this-is-not-typedarray-instance.js
     ! prototype/reduce/values-are-not-cached.js
+    ! prototype/reduceRight/BigInt/callbackfn-arguments-custom-accumulator.js
+    ! prototype/reduceRight/BigInt/callbackfn-arguments-default-accumulator.js
+    ! prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
+    ! prototype/reduceRight/BigInt/callbackfn-is-not-callable-throws.js
+    ! prototype/reduceRight/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
+    ! prototype/reduceRight/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/reduceRight/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/reduceRight/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/reduceRight/BigInt/callbackfn-this.js
+    ! prototype/reduceRight/BigInt/detached-buffer.js
+    ! prototype/reduceRight/BigInt/empty-instance-return-initialvalue.js
+    ! prototype/reduceRight/BigInt/empty-instance-with-no-initialvalue-throws.js
+    ! prototype/reduceRight/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/reduceRight/BigInt/result-is-last-callbackfn-return.js
+    ! prototype/reduceRight/BigInt/result-of-any-type.js
+    ! prototype/reduceRight/BigInt/return-first-value-without-callbackfn.js
+    ! prototype/reduceRight/BigInt/values-are-not-cached.js
     ! prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
     ! prototype/reduceRight/callbackfn-arguments-default-accumulator.js
     ! prototype/reduceRight/callbackfn-detachbuffer.js
@@ -1510,6 +1774,11 @@ built-ins/TypedArray
     ! prototype/reduceRight/this-is-not-object.js
     ! prototype/reduceRight/this-is-not-typedarray-instance.js
     ! prototype/reduceRight/values-are-not-cached.js
+    ! prototype/reverse/BigInt/detached-buffer.js
+    ! prototype/reverse/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/reverse/BigInt/preserves-non-numeric-properties.js
+    ! prototype/reverse/BigInt/returns-original-object.js
+    ! prototype/reverse/BigInt/reverts.js
     ! prototype/reverse/detached-buffer.js
     ! prototype/reverse/get-length-uses-internal-arraylength.js
     ! prototype/reverse/invoked-as-func.js
@@ -1522,6 +1791,50 @@ built-ins/TypedArray
     ! prototype/reverse/reverts.js
     ! prototype/reverse/this-is-not-object.js
     ! prototype/reverse/this-is-not-typedarray-instance.js
+    ! prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
+    ! prototype/set/BigInt/array-arg-offset-tointeger.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset.js
+    ! prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
+    ! prototype/set/BigInt/array-arg-set-values-in-order.js
+    ! prototype/set/BigInt/array-arg-set-values.js
+    ! prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
+    ! prototype/set/BigInt/array-arg-src-values-are-not-cached.js
+    ! prototype/set/BigInt/array-arg-target-arraylength-internal.js
+    ! prototype/set/BigInt/array-arg-targetbuffer-detached-on-get-src-value-throws.js
+    ! prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
+    ! prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
+    ! prototype/set/BigInt/bigint-tobigint64.js
+    ! prototype/set/BigInt/bigint-tobiguint64.js
+    ! prototype/set/BigInt/boolean-tobigint.js
+    ! prototype/set/BigInt/null-tobigint.js
+    ! prototype/set/BigInt/number-tobigint.js
+    ! prototype/set/BigInt/src-typedarray-big.js
+    ! prototype/set/BigInt/src-typedarray-not-big-throws.js
+    ! prototype/set/BigInt/string-nan-tobigint.js
+    ! prototype/set/BigInt/string-tobigint.js
+    ! prototype/set/BigInt/symbol-tobigint.js
+    ! prototype/set/BigInt/typedarray-arg-negative-integer-offset-throws.js
+    ! prototype/set/BigInt/typedarray-arg-offset-tointeger.js
+    ! prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
+    ! prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset.js
+    ! prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
+    ! prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
+    ! prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
+    ! prototype/set/BigInt/typedarray-arg-src-arraylength-internal.js
+    ! prototype/set/BigInt/typedarray-arg-src-byteoffset-internal.js
+    ! prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
+    ! prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
+    ! prototype/set/BigInt/typedarray-arg-target-arraylength-internal.js
+    ! prototype/set/BigInt/typedarray-arg-target-byteoffset-internal.js
+    ! prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
+    ! prototype/set/BigInt/undefined-tobigint.js
     ! prototype/set/array-arg-negative-integer-offset-throws.js
     ! prototype/set/array-arg-return-abrupt-from-src-get-length.js
     ! prototype/set/array-arg-return-abrupt-from-src-get-value.js
@@ -1543,6 +1856,7 @@ built-ins/TypedArray
     ! prototype/set/length.js
     ! prototype/set/name.js
     ! prototype/set/prop-desc.js
+    ! prototype/set/src-typedarray-big-throws.js
     ! prototype/set/this-is-not-object.js
     ! prototype/set/this-is-not-typedarray-instance.js
     ! prototype/set/typedarray-arg-negative-integer-offset-throws.js
@@ -1558,6 +1872,60 @@ built-ins/TypedArray
     ! prototype/set/typedarray-arg-target-arraylength-internal.js
     ! prototype/set/typedarray-arg-target-byteoffset-internal.js
     ! prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
+    ! /length.js
+    ! /name.js
+    ! Symbol.species/length.js
+    ! Symbol.species/name.js
+    ! Symbol.species/prop-desc.js
+    ! Symbol.species/result.js
+    ! invoked.js
+    ! prototype.js
+    ! prototype/Symbol.iterator.js
+    ! prototype/Symbol.toStringTag/detached-buffer.js
+    ! prototype/Symbol.toStringTag/invoked-as-accessor.js
+    ! prototype/Symbol.toStringTag/invoked-as-func.js
+    ! prototype/Symbol.toStringTag/length.js
+    ! prototype/Symbol.toStringTag/name.js
+    ! prototype/Symbol.toStringTag/prop-desc.js
+    ! prototype/Symbol.toStringTag/return-typedarrayname.js
+    ! prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
+    ! prototype/Symbol.toStringTag/this-is-not-object.js
+    ! prototype/constructor.js
+    ! prototype/slice/BigInt/arraylength-internal.js
+    ! prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
+    ! prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
+    ! prototype/slice/BigInt/detached-buffer-get-ctor.js
+    ! prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
+    ! prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
+    ! prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
+    ! prototype/slice/BigInt/detached-buffer.js
+    ! prototype/slice/BigInt/infinity.js
+    ! prototype/slice/BigInt/minus-zero.js
+    ! prototype/slice/BigInt/result-does-not-copy-ordinary-properties.js
+    ! prototype/slice/BigInt/results-with-different-length.js
+    ! prototype/slice/BigInt/results-with-empty-length.js
+    ! prototype/slice/BigInt/results-with-same-length.js
+    ! prototype/slice/BigInt/return-abrupt-from-end-symbol.js
+    ! prototype/slice/BigInt/return-abrupt-from-end.js
+    ! prototype/slice/BigInt/return-abrupt-from-start-symbol.js
+    ! prototype/slice/BigInt/return-abrupt-from-start.js
+    ! prototype/slice/BigInt/set-values-from-different-ctor-type.js
+    ! prototype/slice/BigInt/speciesctor-get-ctor-abrupt.js
+    ! prototype/slice/BigInt/speciesctor-get-ctor-inherited.js
+    ! prototype/slice/BigInt/speciesctor-get-ctor-returns-throws.js
+    ! prototype/slice/BigInt/speciesctor-get-ctor.js
+    ! prototype/slice/BigInt/speciesctor-get-species-abrupt.js
+    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length.js
+    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor.js
+    ! prototype/slice/BigInt/speciesctor-get-species-returns-throws.js
+    ! prototype/slice/BigInt/speciesctor-get-species-use-default-ctor.js
+    ! prototype/slice/BigInt/speciesctor-get-species.js
+    ! prototype/slice/BigInt/tointeger-end.js
+    ! prototype/slice/BigInt/tointeger-start.js
     ! prototype/slice/arraylength-internal.js
     ! prototype/slice/bit-precision.js
     ! prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
@@ -1591,6 +1959,20 @@ built-ins/TypedArray
     ! prototype/slice/this-is-not-typedarray-instance.js
     ! prototype/slice/tointeger-end.js
     ! prototype/slice/tointeger-start.js
+    ! prototype/some/BigInt/callbackfn-arguments-with-thisarg.js
+    ! prototype/some/BigInt/callbackfn-arguments-without-thisarg.js
+    ! prototype/some/BigInt/callbackfn-detachbuffer.js
+    ! prototype/some/BigInt/callbackfn-no-interaction-over-non-integer.js
+    ! prototype/some/BigInt/callbackfn-not-callable-throws.js
+    ! prototype/some/BigInt/callbackfn-not-called-on-empty.js
+    ! prototype/some/BigInt/callbackfn-return-does-not-change-instance.js
+    ! prototype/some/BigInt/callbackfn-returns-abrupt.js
+    ! prototype/some/BigInt/callbackfn-this.js
+    ! prototype/some/BigInt/detached-buffer.js
+    ! prototype/some/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/some/BigInt/returns-false-if-every-cb-returns-false.js
+    ! prototype/some/BigInt/returns-true-if-any-cb-returns-true.js
+    ! prototype/some/BigInt/values-are-not-cached.js
     ! prototype/some/callbackfn-arguments-with-thisarg.js
     ! prototype/some/callbackfn-arguments-without-thisarg.js
     ! prototype/some/callbackfn-detachbuffer.js
@@ -1612,6 +1994,15 @@ built-ins/TypedArray
     ! prototype/some/this-is-not-object.js
     ! prototype/some/this-is-not-typedarray-instance.js
     ! prototype/some/values-are-not-cached.js
+    ! prototype/sort/BigInt/arraylength-internal.js
+    ! prototype/sort/BigInt/comparefn-call-throws.js
+    ! prototype/sort/BigInt/comparefn-calls.js
+    ! prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
+    ! prototype/sort/BigInt/detached-buffer-comparefn.js
+    ! prototype/sort/BigInt/detached-buffer.js
+    ! prototype/sort/BigInt/return-same-instance.js
+    ! prototype/sort/BigInt/sortcompare-with-no-tostring.js
+    ! prototype/sort/BigInt/sorted-values.js
     ! prototype/sort/arraylength-internal.js
     ! prototype/sort/comparefn-call-throws.js
     ! prototype/sort/comparefn-calls.js
@@ -1628,6 +2019,33 @@ built-ins/TypedArray
     ! prototype/sort/sorted-values.js
     ! prototype/sort/this-is-not-object.js
     ! prototype/sort/this-is-not-typedarray-instance.js
+    ! prototype/subarray/BigInt/detached-buffer.js
+    ! prototype/subarray/BigInt/infinity.js
+    ! prototype/subarray/BigInt/minus-zero.js
+    ! prototype/subarray/BigInt/result-does-not-copy-ordinary-properties.js
+    ! prototype/subarray/BigInt/result-is-new-instance-from-same-ctor.js
+    ! prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
+    ! prototype/subarray/BigInt/results-with-different-length.js
+    ! prototype/subarray/BigInt/results-with-empty-length.js
+    ! prototype/subarray/BigInt/results-with-same-length.js
+    ! prototype/subarray/BigInt/return-abrupt-from-begin-symbol.js
+    ! prototype/subarray/BigInt/return-abrupt-from-begin.js
+    ! prototype/subarray/BigInt/return-abrupt-from-end-symbol.js
+    ! prototype/subarray/BigInt/return-abrupt-from-end.js
+    ! prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
+    ! prototype/subarray/BigInt/speciesctor-get-ctor-inherited.js
+    ! prototype/subarray/BigInt/speciesctor-get-ctor-returns-throws.js
+    ! prototype/subarray/BigInt/speciesctor-get-ctor.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-returns-throws.js
+    ! prototype/subarray/BigInt/speciesctor-get-species-use-default-ctor.js
+    ! prototype/subarray/BigInt/speciesctor-get-species.js
+    ! prototype/subarray/BigInt/tointeger-begin.js
+    ! prototype/subarray/BigInt/tointeger-end.js
     ! prototype/subarray/detached-buffer.js
     ! prototype/subarray/infinity.js
     ! prototype/subarray/invoked-as-func.js
@@ -1648,15 +2066,19 @@ built-ins/TypedArray
     ! prototype/subarray/speciesctor-get-species.js
     ! prototype/subarray/this-is-not-object.js
     ! prototype/subarray/this-is-not-typedarray-instance.js
-    ! prototype/Symbol.toStringTag/detached-buffer.js
-    ! prototype/Symbol.toStringTag/invoked-as-accessor.js
-    ! prototype/Symbol.toStringTag/invoked-as-func.js
-    ! prototype/Symbol.toStringTag/length.js
-    ! prototype/Symbol.toStringTag/name.js
-    ! prototype/Symbol.toStringTag/prop-desc.js
-    ! prototype/Symbol.toStringTag/return-typedarrayname.js
-    ! prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
-    ! prototype/Symbol.toStringTag/this-is-not-object.js
+    ! prototype/toLocaleString/BigInt/calls-tolocalestring-from-each-value.js
+    ! prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
+    ! prototype/toLocaleString/BigInt/calls-valueof-from-each-value.js
+    ! prototype/toLocaleString/BigInt/detached-buffer.js
+    ! prototype/toLocaleString/BigInt/empty-instance-returns-empty-string.js
+    ! prototype/toLocaleString/BigInt/get-length-uses-internal-arraylength.js
+    ! prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tolocalestring.js
+    ! prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tostring.js
+    ! prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-valueof.js
+    ! prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tolocalestring.js
+    ! prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring.js
+    ! prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof.js
+    ! prototype/toLocaleString/BigInt/return-result.js
     ! prototype/toLocaleString/calls-tolocalestring-from-each-value.js
     ! prototype/toLocaleString/calls-tostring-from-each-value.js
     ! prototype/toLocaleString/calls-valueof-from-each-value.js
@@ -1675,7 +2097,11 @@ built-ins/TypedArray
     ! prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
     ! prototype/toLocaleString/this-is-not-object.js
     ! prototype/toLocaleString/this-is-not-typedarray-instance.js
+    ! prototype/toString.js
+    ! prototype/toString/BigInt/detached-buffer.js
     ! prototype/toString/detached-buffer.js
+    ! prototype/values/BigInt/detached-buffer.js
+    ! prototype/values/BigInt/return-itor.js
     ! prototype/values/detached-buffer.js
     ! prototype/values/invoked-as-func.js
     ! prototype/values/invoked-as-method.js
@@ -1686,54 +2112,150 @@ built-ins/TypedArray
     ! prototype/values/return-itor.js
     ! prototype/values/this-is-not-object.js
     ! prototype/values/this-is-not-typedarray-instance.js
-    ! prototype/constructor.js
-    ! prototype/Symbol.iterator.js
-    ! prototype/toString.js
-    ! Symbol.species/length.js
-    ! Symbol.species/name.js
-    ! Symbol.species/prop-desc.js
-    ! Symbol.species/result.js
-    ! invoked.js
-    ! /length.js
-    ! /name.js
-    ! prototype.js
 
 built-ins/TypedArrayConstructors
-    ! BigInt64Array/prototype.js
-    ! BigInt64Array/prototype/BYTES_PER_ELEMENT.js
-    ! BigInt64Array/prototype/constructor.js
-    ! BigInt64Array/prototype/not-typedarray-object.js
-    ! BigInt64Array/prototype/proto.js
     ! BigInt64Array/BYTES_PER_ELEMENT.js
     ! BigInt64Array/constructor.js
     ! BigInt64Array/length.js
     ! BigInt64Array/name.js
     ! BigInt64Array/prop-desc.js
     ! BigInt64Array/proto.js
-    ! BigUint64Array/prototype/BYTES_PER_ELEMENT.js
-    ! BigUint64Array/prototype/constructor.js
-    ! BigUint64Array/prototype/not-typedarray-object.js
-    ! BigUint64Array/prototype/proto.js
+    ! BigInt64Array/prototype.js
+    ! BigInt64Array/prototype/BYTES_PER_ELEMENT.js
+    ! BigInt64Array/prototype/constructor.js
+    ! BigInt64Array/prototype/not-typedarray-object.js
+    ! BigInt64Array/prototype/proto.js
+    ! BigUint64Array/BYTES_PER_ELEMENT.js
     ! BigUint64Array/constructor.js
     ! BigUint64Array/length.js
     ! BigUint64Array/name.js
     ! BigUint64Array/prop-desc.js
     ! BigUint64Array/proto.js
     ! BigUint64Array/prototype.js
+    ! BigUint64Array/prototype/BYTES_PER_ELEMENT.js
+    ! BigUint64Array/prototype/constructor.js
+    ! BigUint64Array/prototype/not-typedarray-object.js
+    ! BigUint64Array/prototype/proto.js
+    ! Float32Array/prototype/not-typedarray-object.js
+    ! Float32Array/prototype/proto.js
+    ! Float64Array/prototype/not-typedarray-object.js
+    ! Float64Array/prototype/proto.js
+    ! Int16Array/prototype/not-typedarray-object.js
+    ! Int16Array/prototype/proto.js
+    ! Int32Array/prototype/not-typedarray-object.js
+    ! Int32Array/prototype/proto.js
+    ! Int8Array/prototype/not-typedarray-object.js
+    ! Int8Array/prototype/proto.js
+    ! Uint16Array/prototype/not-typedarray-object.js
+    ! Uint16Array/prototype/proto.js
+    ! Uint32Array/prototype/not-typedarray-object.js
+    ! Uint32Array/prototype/proto.js
+    ! Uint8Array/prototype/not-typedarray-object.js
+    ! Uint8Array/prototype/proto.js
+    ! Uint8ClampedArray/prototype/not-typedarray-object.js
+    ! Uint8ClampedArray/prototype/proto.js
+    ! ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
+    ! ctors-bigint/buffer-arg/byteoffset-is-negative-throws.js
+    ! ctors-bigint/buffer-arg/byteoffset-is-negative-zero.js
+    ! ctors-bigint/buffer-arg/byteoffset-is-symbol-throws.js
+    ! ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size.js
+    ! ctors-bigint/buffer-arg/byteoffset-to-number-detachbuffer.js
+    ! ctors-bigint/buffer-arg/byteoffset-to-number-throws.js
+    ! ctors-bigint/buffer-arg/defined-length-and-offset.js
+    ! ctors-bigint/buffer-arg/defined-length.js
+    ! ctors-bigint/buffer-arg/defined-negative-length.js
+    ! ctors-bigint/buffer-arg/defined-offset.js
+    ! ctors-bigint/buffer-arg/detachedbuffer.js
+    ! ctors-bigint/buffer-arg/excessive-length-throws.js
+    ! ctors-bigint/buffer-arg/excessive-offset-throws.js
+    ! ctors-bigint/buffer-arg/invoked-with-undefined-newtarget.js
+    ! ctors-bigint/buffer-arg/is-referenced.js
+    ! ctors-bigint/buffer-arg/length-access-throws.js
+    ! ctors-bigint/buffer-arg/length-is-symbol-throws.js
+    ! ctors-bigint/buffer-arg/length-to-number-detachbuffer.js
+    ! ctors-bigint/buffer-arg/new-instance-extensibility.js
+    ! ctors-bigint/buffer-arg/returns-new-instance.js
+    ! ctors-bigint/buffer-arg/toindex-bytelength.js
+    ! ctors-bigint/buffer-arg/toindex-byteoffset.js
+    ! ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ! ctors-bigint/length-arg/init-zeros.js
+    ! ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
+    ! ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
+    ! ctors-bigint/length-arg/is-symbol-throws.js
+    ! ctors-bigint/length-arg/new-instance-extensibility.js
+    ! ctors-bigint/length-arg/returns-object.js
+    ! ctors-bigint/length-arg/toindex-length.js
+    ! ctors-bigint/length-arg/undefined-newtarget-throws.js
+    ! ctors-bigint/length-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ! ctors-bigint/no-args/new-instance-extensibility.js
+    ! ctors-bigint/no-args/returns-object.js
+    ! ctors-bigint/no-args/undefined-newtarget-throws.js
+    ! ctors-bigint/no-args/use-default-proto-if-custom-proto-is-not-object.js
+    ! ctors-bigint/object-arg/as-array-returns.js
+    ! ctors-bigint/object-arg/as-generator-iterable-returns.js
+    ! ctors-bigint/object-arg/bigint-tobigint64.js
+    ! ctors-bigint/object-arg/bigint-tobiguint64.js
+    ! ctors-bigint/object-arg/boolean-tobigint.js
+    ! ctors-bigint/object-arg/iterating-throws.js
+    ! ctors-bigint/object-arg/iterator-not-callable-throws.js
+    ! ctors-bigint/object-arg/iterator-throws.js
+    ! ctors-bigint/object-arg/length-excessive-throws.js
+    ! ctors-bigint/object-arg/length-is-symbol-throws.js
+    ! ctors-bigint/object-arg/length-throws.js
+    ! ctors-bigint/object-arg/new-instance-extensibility.js
+    ! ctors-bigint/object-arg/null-tobigint.js
+    ! ctors-bigint/object-arg/number-tobigint.js
+    ! ctors-bigint/object-arg/string-nan-tobigint.js
+    ! ctors-bigint/object-arg/string-tobigint.js
+    ! ctors-bigint/object-arg/symbol-tobigint.js
+    ! ctors-bigint/object-arg/throws-from-property.js
+    ! ctors-bigint/object-arg/throws-setting-obj-to-primitive-typeerror.js
+    ! ctors-bigint/object-arg/throws-setting-obj-to-primitive.js
+    ! ctors-bigint/object-arg/throws-setting-obj-tostring.js
+    ! ctors-bigint/object-arg/throws-setting-obj-valueof-typeerror.js
+    ! ctors-bigint/object-arg/throws-setting-obj-valueof.js
+    ! ctors-bigint/object-arg/throws-setting-property.js
+    ! ctors-bigint/object-arg/throws-setting-symbol-property.js
+    ! ctors-bigint/object-arg/undefined-newtarget-throws.js
+    ! ctors-bigint/object-arg/undefined-tobigint.js
+    ! ctors-bigint/object-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ! ctors-bigint/typedarray-arg/detached-when-species-retrieved-different-type.js
+    ! ctors-bigint/typedarray-arg/detached-when-species-retrieved-same-type.js
+    ! ctors-bigint/typedarray-arg/new-instance-extensibility.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-null.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
+    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js
+    ! ctors-bigint/typedarray-arg/other-ctor-returns-new-typedarray.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-null.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js
+    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
+    ! ctors-bigint/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
+    ! ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
+    ! ctors-bigint/typedarray-arg/undefined-newtarget-throws.js
     ! ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js
-    ! ctors/buffer-arg/byteoffset-is-negative-throws.js
     ! ctors/buffer-arg/byteoffset-is-negative-throws-sab.js
+    ! ctors/buffer-arg/byteoffset-is-negative-throws.js
     ! ctors/buffer-arg/byteoffset-is-negative-zero-sab.js
     ! ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js
     ! ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js
     ! ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
     ! ctors/buffer-arg/byteoffset-to-number-throws-sab.js
-    ! ctors/buffer-arg/custom-proto-access-throws.js
     ! ctors/buffer-arg/custom-proto-access-throws-sab.js
+    ! ctors/buffer-arg/custom-proto-access-throws.js
     ! ctors/buffer-arg/defined-length-and-offset-sab.js
     ! ctors/buffer-arg/defined-length-sab.js
-    ! ctors/buffer-arg/defined-negative-length.js
     ! ctors/buffer-arg/defined-negative-length-sab.js
+    ! ctors/buffer-arg/defined-negative-length.js
     ! ctors/buffer-arg/defined-offset-sab.js
     ! ctors/buffer-arg/detachedbuffer.js
     ! ctors/buffer-arg/excessive-length-throws-sab.js
@@ -1744,16 +2266,16 @@ built-ins/TypedArrayConstructors
     ! ctors/buffer-arg/length-is-symbol-throws-sab.js
     ! ctors/buffer-arg/length-to-number-detachbuffer.js
     ! ctors/buffer-arg/new-instance-extensibility-sab.js
-    ! ctors/buffer-arg/proto-from-ctor-realm.js
     ! ctors/buffer-arg/proto-from-ctor-realm-sab.js
+    ! ctors/buffer-arg/proto-from-ctor-realm.js
     ! ctors/buffer-arg/returns-new-instance-sab.js
     ! ctors/buffer-arg/toindex-bytelength-sab.js
     ! ctors/buffer-arg/toindex-byteoffset-sab.js
     ! ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js
-    ! ctors/buffer-arg/use-custom-proto-if-object.js
     ! ctors/buffer-arg/use-custom-proto-if-object-sab.js
-    ! ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ! ctors/buffer-arg/use-custom-proto-if-object.js
     ! ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js
+    ! ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
     ! ctors/length-arg/custom-proto-access-throws.js
     ! ctors/length-arg/is-infinity-throws-rangeerror.js
     ! ctors/length-arg/is-negative-integer-throws-rangeerror.js
@@ -1778,8 +2300,8 @@ built-ins/TypedArrayConstructors
     ! ctors/object-arg/proto-from-ctor-realm.js
     ! ctors/object-arg/returns.js
     ! ctors/object-arg/throws-from-property.js
-    ! ctors/object-arg/throws-setting-obj-to-primitive.js
     ! ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
+    ! ctors/object-arg/throws-setting-obj-to-primitive.js
     ! ctors/object-arg/throws-setting-property.js
     ! ctors/object-arg/throws-setting-symbol-property.js
     ! ctors/object-arg/use-custom-proto-if-object.js
@@ -1788,26 +2310,51 @@ built-ins/TypedArrayConstructors
     ! ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
     ! ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
+    ! ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
     ! ctors/typedarray-arg/proto-from-ctor-realm.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
+    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
+    ! ctors/typedarray-arg/src-typedarray-big-throws.js
     ! ctors/typedarray-arg/use-custom-proto-if-object.js
     ! ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! Float32Array/prototype/not-typedarray-object.js
-    ! Float32Array/prototype/proto.js
-    ! Float64Array/prototype/not-typedarray-object.js
-    ! Float64Array/prototype/proto.js
+    ! from/BigInt/arylk-get-length-error.js
+    ! from/BigInt/arylk-to-length-error.js
+    ! from/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
+    ! from/BigInt/custom-ctor-returns-other-instance.js
+    ! from/BigInt/custom-ctor-returns-smaller-instance-throws.js
+    ! from/BigInt/custom-ctor.js
+    ! from/BigInt/inherited.js
+    ! from/BigInt/invoked-as-func.js
+    ! from/BigInt/iter-access-error.js
+    ! from/BigInt/iter-invoke-error.js
+    ! from/BigInt/iter-next-error.js
+    ! from/BigInt/iter-next-value-error.js
+    ! from/BigInt/mapfn-abrupt-completion.js
+    ! from/BigInt/mapfn-arguments.js
+    ! from/BigInt/mapfn-is-not-callable.js
+    ! from/BigInt/mapfn-this-with-thisarg.js
+    ! from/BigInt/mapfn-this-without-thisarg-non-strict.js
+    ! from/BigInt/mapfn-this-without-thisarg-strict.js
+    ! from/BigInt/new-instance-empty.js
+    ! from/BigInt/new-instance-from-ordinary-object.js
+    ! from/BigInt/new-instance-from-sparse-array.js
+    ! from/BigInt/new-instance-using-custom-ctor.js
+    ! from/BigInt/new-instance-with-mapfn.js
+    ! from/BigInt/new-instance-without-mapfn.js
+    ! from/BigInt/property-abrupt-completion.js
+    ! from/BigInt/set-value-abrupt-completion.js
+    ! from/BigInt/source-value-is-symbol-throws.js
+    ! from/BigInt/this-is-not-constructor.js
     ! from/arylk-get-length-error.js
     ! from/arylk-to-length-error.js
     ! from/custom-ctor-returns-other-instance.js
@@ -1831,12 +2378,7 @@ built-ins/TypedArrayConstructors
     ! from/new-instance-without-mapfn.js
     ! from/property-abrupt-completion.js
     ! from/set-value-abrupt-completion.js
-    ! Int16Array/prototype/not-typedarray-object.js
-    ! Int16Array/prototype/proto.js
-    ! Int32Array/prototype/not-typedarray-object.js
-    ! Int32Array/prototype/proto.js
-    ! Int8Array/prototype/not-typedarray-object.js
-    ! Int8Array/prototype/proto.js
+    ! internals/DefineOwnProperty/BigInt/desc-value-throws.js
     ! internals/DefineOwnProperty/conversion-operation-consistent-nan.js
     ! internals/DefineOwnProperty/conversion-operation.js
     ! internals/DefineOwnProperty/desc-value-throws.js
@@ -1859,6 +2401,18 @@ built-ins/TypedArrayConstructors
     ! internals/DefineOwnProperty/set-value.js
     ! internals/DefineOwnProperty/this-is-not-extensible.js
     ! internals/DefineOwnProperty/tonumber-value-detached-buffer.js
+    ! internals/Get/BigInt/detached-buffer-key-is-not-numeric-index.js
+    ! internals/Get/BigInt/detached-buffer-key-is-symbol.js
+    ! internals/Get/BigInt/detached-buffer.js
+    ! internals/Get/BigInt/indexed-value.js
+    ! internals/Get/BigInt/infinity-detached-buffer.js
+    ! internals/Get/BigInt/key-is-not-canonical-index.js
+    ! internals/Get/BigInt/key-is-not-integer.js
+    ! internals/Get/BigInt/key-is-not-minus-zero.js
+    ! internals/Get/BigInt/key-is-not-numeric-index-get-throws.js
+    ! internals/Get/BigInt/key-is-not-numeric-index.js
+    ! internals/Get/BigInt/key-is-out-of-bounds.js
+    ! internals/Get/BigInt/key-is-symbol.js
     ! internals/Get/detached-buffer-key-is-not-numeric-index.js
     ! internals/Get/detached-buffer-key-is-symbol.js
     ! internals/Get/detached-buffer-realm.js
@@ -1872,12 +2426,24 @@ built-ins/TypedArrayConstructors
     ! internals/Get/key-is-not-numeric-index.js
     ! internals/Get/key-is-out-of-bounds.js
     ! internals/Get/key-is-symbol.js
+    ! internals/GetOwnProperty/BigInt/detached-buffer-key-is-not-number.js
+    ! internals/GetOwnProperty/BigInt/detached-buffer-key-is-symbol.js
+    ! internals/GetOwnProperty/BigInt/detached-buffer.js
+    ! internals/GetOwnProperty/BigInt/enumerate-detached-buffer.js
+    ! internals/GetOwnProperty/BigInt/index-prop-desc.js
+    ! internals/GetOwnProperty/BigInt/key-is-minus-zero.js
+    ! internals/GetOwnProperty/BigInt/key-is-not-canonical-index.js
+    ! internals/GetOwnProperty/BigInt/key-is-not-integer.js
+    ! internals/GetOwnProperty/BigInt/key-is-not-numeric-index.js
+    ! internals/GetOwnProperty/BigInt/key-is-out-of-bounds.js
+    ! internals/GetOwnProperty/BigInt/key-is-symbol.js
     ! internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     ! internals/GetOwnProperty/detached-buffer-key-is-symbol.js
     ! internals/GetOwnProperty/detached-buffer-realm.js
     ! internals/GetOwnProperty/detached-buffer.js
     ! internals/GetOwnProperty/enumerate-detached-buffer.js
     ! internals/GetOwnProperty/index-prop-desc.js
+    ! internals/HasProperty/BigInt/infinity-with-detached-buffer.js
     ! internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
     ! internals/HasProperty/detached-buffer-key-is-not-number.js
     ! internals/HasProperty/detached-buffer-key-is-symbol.js
@@ -1897,6 +2463,19 @@ built-ins/TypedArrayConstructors
     ! internals/OwnPropertyKeys/integer-indexes-and-string-keys.js
     ! internals/OwnPropertyKeys/integer-indexes.js
     ! internals/OwnPropertyKeys/not-enumerable-keys.js
+    ! internals/Set/BigInt/bigint-tobigint64.js
+    ! internals/Set/BigInt/bigint-tobiguint64.js
+    ! internals/Set/BigInt/boolean-tobigint.js
+    ! internals/Set/BigInt/detached-buffer.js
+    ! internals/Set/BigInt/key-is-not-numeric-index-set-throws.js
+    ! internals/Set/BigInt/null-tobigint.js
+    ! internals/Set/BigInt/number-tobigint.js
+    ! internals/Set/BigInt/string-nan-tobigint.js
+    ! internals/Set/BigInt/string-tobigint.js
+    ! internals/Set/BigInt/symbol-tobigint.js
+    ! internals/Set/BigInt/tonumber-value-throws.js
+    ! internals/Set/BigInt/undefined-tobigint.js
+    ! internals/Set/bigint-tonumber.js
     ! internals/Set/detached-buffer-key-is-not-numeric-index.js
     ! internals/Set/detached-buffer-key-is-symbol.js
     ! internals/Set/detached-buffer-realm.js
@@ -1910,6 +2489,18 @@ built-ins/TypedArrayConstructors
     ! internals/Set/key-is-symbol.js
     ! internals/Set/tonumber-value-detached-buffer.js
     ! internals/Set/tonumber-value-throws.js
+    ! of/BigInt/argument-is-symbol-throws.js
+    ! of/BigInt/argument-number-value-throws.js
+    ! of/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
+    ! of/BigInt/custom-ctor-returns-other-instance.js
+    ! of/BigInt/custom-ctor-returns-smaller-instance-throws.js
+    ! of/BigInt/custom-ctor.js
+    ! of/BigInt/inherited.js
+    ! of/BigInt/invoked-as-func.js
+    ! of/BigInt/new-instance-empty.js
+    ! of/BigInt/new-instance-using-custom-ctor.js
+    ! of/BigInt/new-instance.js
+    ! of/BigInt/this-is-not-constructor.js
     ! of/argument-number-value-throws.js
     ! of/custom-ctor-returns-other-instance.js
     ! of/custom-ctor.js
@@ -1918,22 +2509,44 @@ built-ins/TypedArrayConstructors
     ! of/new-instance-from-zero.js
     ! of/new-instance-using-custom-ctor.js
     ! of/new-instance.js
-    ! prototype/buffer/inherited.js
-    ! prototype/byteLength/inherited.js
-    ! prototype/byteOffset/inherited.js
-    ! prototype/length/inherited.js
-    ! prototype/set/inherited.js
-    ! prototype/subarray/inherited.js
-    ! prototype/toString/inherited.js
     ! prototype/Symbol.iterator.js
-    ! Uint16Array/prototype/not-typedarray-object.js
-    ! Uint16Array/prototype/proto.js
-    ! Uint32Array/prototype/not-typedarray-object.js
-    ! Uint32Array/prototype/proto.js
-    ! Uint8Array/prototype/not-typedarray-object.js
-    ! Uint8Array/prototype/proto.js
-    ! Uint8ClampedArray/prototype/not-typedarray-object.js
-    ! Uint8ClampedArray/prototype/proto.js
+    ! prototype/Symbol.toStringTag/bigint-inherited.js
+    ! prototype/bigint-Symbol.iterator.js
+    ! prototype/buffer/bigint-inherited.js
+    ! prototype/buffer/inherited.js
+    ! prototype/byteLength/bigint-inherited.js
+    ! prototype/byteLength/inherited.js
+    ! prototype/byteOffset/bigint-inherited.js
+    ! prototype/byteOffset/inherited.js
+    ! prototype/copyWithin/bigint-inherited.js
+    ! prototype/entries/bigint-inherited.js
+    ! prototype/every/bigint-inherited.js
+    ! prototype/fill/bigint-inherited.js
+    ! prototype/filter/bigint-inherited.js
+    ! prototype/find/bigint-inherited.js
+    ! prototype/findIndex/bigint-inherited.js
+    ! prototype/forEach/bigint-inherited.js
+    ! prototype/indexOf/bigint-inherited.js
+    ! prototype/join/bigint-inherited.js
+    ! prototype/keys/bigint-inherited.js
+    ! prototype/lastIndexOf/bigint-inherited.js
+    ! prototype/length/bigint-inherited.js
+    ! prototype/length/inherited.js
+    ! prototype/map/bigint-inherited.js
+    ! prototype/reduce/bigint-inherited.js
+    ! prototype/reduceRight/bigint-inherited.js
+    ! prototype/reverse/bigint-inherited.js
+    ! prototype/set/bigint-inherited.js
+    ! prototype/set/inherited.js
+    ! prototype/slice/bigint-inherited.js
+    ! prototype/some/bigint-inherited.js
+    ! prototype/sort/bigint-inherited.js
+    ! prototype/subarray/bigint-inherited.js
+    ! prototype/subarray/inherited.js
+    ! prototype/toLocaleString/bigint-inherited.js
+    ! prototype/toString/bigint-inherited.js
+    ! prototype/toString/inherited.js
+    ! prototype/values/bigint-inherited.js
 
 built-ins/undefined
 
@@ -2170,6 +2783,9 @@ language/eval-code
 language/export
 
 language/expressions/addition
+    ! bigint-and-number.js
+    ! bigint-arithmetic.js
+    ! coerce-bigint-to-string.js
     ! coerce-symbol-to-prim-err.js
     ! coerce-symbol-to-prim-invocation.js
     ! coerce-symbol-to-prim-return-obj.js
@@ -2406,14 +3022,25 @@ language/expressions/arrow-function
     ! syntax/early-errors/use-strict-with-non-simple-param.js
 
 language/expressions/bitwise-and
+    ! bigint-and-number.js
+    ! bigint-non-primitive.js
+    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/bitwise-not
+    ! bigint.js
+    ! bigint-non-primitive.js
 
 language/expressions/bitwise-or
+    ! bigint-and-number.js
+    ! bigint-non-primitive.js
+    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/bitwise-xor
+    ! bigint-and-number.js
+    ! bigint-non-primitive.js
+    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/call
@@ -2575,11 +3202,16 @@ language/expressions/delete
     ! identifier-strict.js
 
 language/expressions/division
+    ! bigint-and-number.js
+    ! bigint-arithmetic.js
+    ! bigint-complex-infinity.js
     ! order-of-evaluation.js
 
 language/expressions/does-not-equals
+    ! bigint-and-bigint.js
 
 language/expressions/equals
+    ! bigint-and-bigint.js
     ! coerce-symbol-to-prim-err.js
     ! coerce-symbol-to-prim-invocation.js
     ! coerce-symbol-to-prim-return-obj.js
@@ -2588,6 +3220,10 @@ language/expressions/equals
     ! to-prim-hint.js
 
 language/expressions/exponentiation
+    ! bigint-and-number.js
+    ! bigint-arithmetic.js
+    ! bigint-exp-operator-negative-throws.js
+    ! bigint-zero-base-zero-exponent.js
     ! order-of-evaluation.js
 
 language/expressions/function
@@ -2810,6 +3446,12 @@ language/expressions/generators
 language/expressions/greater-than
 
 language/expressions/greater-than-or-equal
+    ! bigint-and-bigint.js
+    ! bigint-and-number-extremes.js
+
+language/expressions/greater-than-or-equal
+    ! bigint-and-bigint.js
+    ! bigint-and-number-extremes.js
 
 language/expressions/grouping
 
@@ -2825,11 +3467,18 @@ language/expressions/instanceof
     ! symbol-hasinstance-to-boolean.js
 
 language/expressions/left-shift
+    ! bigint-and-number.js
+    ! bigint-non-primitive.js
+    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/less-than
+    ! bigint-and-bigint.js
+    ! bigint-and-number-extremes.js
 
 language/expressions/less-than-or-equal
+    ! bigint-and-bigint.js
+    ! bigint-and-number-extremes.js
 
 language/expressions/logical-and
 
@@ -2838,9 +3487,14 @@ language/expressions/logical-not
 language/expressions/logical-or
 
 language/expressions/modulus
+    ! bigint-and-number.js
+    ! bigint-arithmetic.js
+    ! bigint-modulo-zero.js
     ! order-of-evaluation.js
 
 language/expressions/multiplication
+    ! bigint-and-number.js
+    ! bigint-arithmetic.js
     ! order-of-evaluation.js
 
 language/expressions/object
@@ -3128,6 +3782,7 @@ language/expressions/postfix-decrement
     ! S11.3.2_A6_T1.js
     ! S11.3.2_A6_T2.js
     ! S11.3.2_A6_T3.js
+    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3135,11 +3790,12 @@ language/expressions/postfix-decrement
 
 language/expressions/postfix-increment
     ! 11.3.1-2-1-s.js
-    ! 11.3.1-2-2-s.js
     ! 11.3.1-2-1gs.js
+    ! 11.3.1-2-2-s.js
     ! S11.3.1_A6_T1.js
     ! S11.3.1_A6_T2.js
     ! S11.3.1_A6_T3.js
+    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3152,6 +3808,7 @@ language/expressions/prefix-decrement
     ! S11.4.5_A6_T1.js
     ! S11.4.5_A6_T2.js
     ! S11.4.5_A6_T3.js
+    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3163,6 +3820,7 @@ language/expressions/prefix-increment
     ! S11.4.4_A6_T1.js
     ! S11.4.4_A6_T2.js
     ! S11.4.4_A6_T3.js
+    ! bigint.js
     ! non-simple.js
     ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
@@ -3173,13 +3831,20 @@ language/expressions/property-accessors
 language/expressions/relational
 
 language/expressions/right-shift
+    ! bigint-and-number.js
+    ! bigint-non-primitive.js
+    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/strict-does-not-equals
+    ! bigint-and-bigint.js
 
 language/expressions/strict-equals
+    ! bigint-and-bigint.js
 
 language/expressions/subtraction
+    ! bigint-and-number.js
+    ! bigint-arithmetic.js
     ! order-of-evaluation.js
 
 language/expressions/super
@@ -3274,13 +3939,21 @@ language/expressions/this
     ! S11.1.1_A1.js
 
 language/expressions/typeof
+    ! bigint.js
     ! built-in-ordinary-objects-no-call.js
 
 language/expressions/unary-minus
+    ! bigint.js
+    ! bigint-non-primitive.js
 
 language/expressions/unary-plus
+    ! bigint-throws.js
 
 language/expressions/unsigned-right-shift
+    ! bigint-and-number.js
+    ! bigint-non-primitive.js
+    ! bigint-toprimitive.js
+    ! bigint.js
     ! order-of-evaluation.js
 
 language/expressions/void

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -151,8 +151,6 @@ built-ins/BigInt
     # Check IsInteger in ES2020, not IsSafeInteger
     # https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     ! out-of-bounds-integer-rangeerror.js
-    # Can not rewrite BigInt.prototype[Symbol.toStringTag]
-    ! prototype/Symbol.toStringTag.js
     ! prototype/toString/prototype-call.js
     ! prototype/toString/radix-err.js
     # Computed property is not support

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -618,9 +618,6 @@ built-ins/IteratorPrototype
 built-ins/JSON
     ! Symbol.toStringTag.js
     ! parse/S15.12.2_A1.js
-    ! stringify/bigint-order.js
-    ! stringify/bigint-tojson.js
-    ! stringify/bigint.js
 
 built-ins/Map
     ! iterator-is-undefined-throws.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -145,14 +145,10 @@ built-ins/BigInt
     ! asUintN/length.js
     ! asUintN/name.js
     ! asUintN/order-of-steps.js
-    ! constructor-from-decimal-string.js
-    ! constructor-trailing-leading-spaces.js
-    ! issafeinteger-true.js
     # Check IsInteger in ES2020, not IsSafeInteger
     # https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     ! out-of-bounds-integer-rangeerror.js
     ! prototype/toString/prototype-call.js
-    ! prototype/toString/radix-err.js
     # Computed property is not support
     ! prototype/toString/thisbigintvalue-not-valid-throws.js
 
@@ -3205,10 +3201,8 @@ language/expressions/division
     ! order-of-evaluation.js
 
 language/expressions/does-not-equals
-    ! bigint-and-bigint.js
 
 language/expressions/equals
-    ! bigint-and-bigint.js
     ! coerce-symbol-to-prim-err.js
     ! coerce-symbol-to-prim-invocation.js
     ! coerce-symbol-to-prim-return-obj.js
@@ -3834,10 +3828,8 @@ language/expressions/right-shift
     ! order-of-evaluation.js
 
 language/expressions/strict-does-not-equals
-    ! bigint-and-bigint.js
 
 language/expressions/strict-equals
-    ! bigint-and-bigint.js
 
 language/expressions/subtraction
     ! bigint-and-number.js
@@ -3939,7 +3931,6 @@ language/expressions/typeof
     ! built-in-ordinary-objects-no-call.js
 
 language/expressions/unary-minus
-    ! bigint.js
     ! bigint-non-primitive.js
 
 language/expressions/unary-plus

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3014,7 +3014,6 @@ language/expressions/bitwise-and
 
 language/expressions/bitwise-not
     ! bigint-non-primitive.js
-    ! bigint.js
 
 language/expressions/bitwise-or
     ! bigint-non-primitive.js


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt

# Compatibility
Raw `java.math.BigInteger` is now handled as JavaScript `BigInt`.
This leads to the following problems.
```java
final String script = "d + bi";
Utils.runWithAllOptimizationLevels(cx -> {
        cx.setLanguageVersion(Context.VERSION_ES6);

        Scriptable scope = cx.initStandardObjects();
        scope.put("d", scope, Double.valueOf(123));
        scope.put("bi", scope, new BigInteger("234"));

        Object result =  cx.evaluateString(scope, script, "", 1, null);
        Assert.assertEquals(Double.valueOf(357), result);
        return null;
});
```
It used to be interpreted as `123 + 234`, but now it is interpreted as `123 + 234n`, which results in an error. This will happen regardless of the `LanguageVersion`. It may be able to work around this by version checking if always pass the `Context` to `ScriptRuntime`.

# Benchmark
## master
```
SunSpiderBenchmark.accessBinaryTrees     avgt    5    7339.020 ±  163.986  us/op
SunSpiderBenchmark.accessFannkuch        avgt    5   24465.875 ±  486.237  us/op
SunSpiderBenchmark.accessNBody           avgt    5   18369.340 ±  834.781  us/op
SunSpiderBenchmark.accessNsieve          avgt    5    3967.743 ±   83.396  us/op
SunSpiderBenchmark.bitops3BitBitsInByte  avgt    5    2434.747 ±   69.952  us/op
SunSpiderBenchmark.bitopsBitsInByte      avgt    5   11837.858 ± 1274.065  us/op
SunSpiderBenchmark.bitopsBitwiseAnd      avgt    5   24415.034 ±  450.579  us/op
SunSpiderBenchmark.bitopsNsieveBits      avgt    5   19733.613 ±  825.524  us/op
SunSpiderBenchmark.controlflowRecursive  avgt    5    2924.783 ±   62.720  us/op
SunSpiderBenchmark.cryptoAes             avgt    5   10444.501 ±  305.440  us/op
SunSpiderBenchmark.cryptoMd5             avgt    5    7597.363 ±  538.611  us/op
SunSpiderBenchmark.cryptoSha1            avgt    5    5274.564 ±  555.156  us/op
SunSpiderBenchmark.dateFormatToFte       avgt    5   17574.064 ±  786.713  us/op
SunSpiderBenchmark.dateFormatXparb       avgt    5   24559.370 ± 2241.143  us/op
SunSpiderBenchmark.mathCordic            avgt    5    9568.241 ±  756.833  us/op
SunSpiderBenchmark.mathPartialSums       avgt    5   21454.715 ± 2229.847  us/op
SunSpiderBenchmark.mathSpectralNorm      avgt    5   10544.219 ±   77.957  us/op
SunSpiderBenchmark.regexpDna             avgt    5  110944.817 ± 1671.568  us/op
SunSpiderBenchmark.stringBase64          avgt    5   24295.712 ± 1267.732  us/op
SunSpiderBenchmark.stringFasta           avgt    5   29006.286 ±  533.307  us/op
SunSpiderBenchmark.stringTagcloud        avgt    5   37410.147 ±  825.179  us/op
SunSpiderBenchmark.stringUnpackCode      avgt    5   27798.423 ± 2576.532  us/op
SunSpiderBenchmark.stringValidateInput   avgt    5   16280.353 ± 1294.283  us/op
SunSpiderBenchmark.threeDCube            avgt    5   21931.051 ±  290.129  us/op
SunSpiderBenchmark.threeDMorph           avgt    5   14004.732 ±  513.980  us/op
SunSpiderBenchmark.threeDRayTrace        avgt    5   15150.070 ±  209.269  us/op

V8Benchmark.boyer          avgt    5  70481.542 ±  262.282  us/op
V8Benchmark.cryptoDecrypt  avgt    5  87530.566 ± 1282.020  us/op
V8Benchmark.cryptoEncrpyt  avgt    5   4824.302 ±   99.392  us/op
V8Benchmark.deltaBlue      avgt    5   6164.140 ±   54.848  us/op
V8Benchmark.earley         avgt    5  20443.091 ±  462.214  us/op
V8Benchmark.rayTrace       avgt    5  40234.364 ± 2703.675  us/op
V8Benchmark.richards       avgt    5   2912.571 ±   10.596  us/op
V8Benchmark.splay          avgt    5   2007.140 ±  383.734  us/op
```
## bigint
```
SunSpiderBenchmark.accessBinaryTrees     avgt    5    6857.694 ±  115.087  us/op
SunSpiderBenchmark.accessFannkuch        avgt    5   25297.146 ±  358.333  us/op
SunSpiderBenchmark.accessNBody           avgt    5   17830.198 ± 1607.994  us/op
SunSpiderBenchmark.accessNsieve          avgt    5    3661.630 ±  410.265  us/op
SunSpiderBenchmark.bitops3BitBitsInByte  avgt    5    1970.694 ±   57.911  us/op
SunSpiderBenchmark.bitopsBitsInByte      avgt    5   12308.511 ±  132.202  us/op
SunSpiderBenchmark.bitopsBitwiseAnd      avgt    5   22380.243 ±  531.675  us/op
SunSpiderBenchmark.bitopsNsieveBits      avgt    5   15186.223 ±  685.243  us/op
SunSpiderBenchmark.controlflowRecursive  avgt    5    2983.580 ±   30.732  us/op
SunSpiderBenchmark.cryptoAes             avgt    5   10921.327 ±  123.993  us/op
SunSpiderBenchmark.cryptoMd5             avgt    5    8026.452 ±  691.531  us/op
SunSpiderBenchmark.cryptoSha1            avgt    5    5661.606 ±  427.463  us/op
SunSpiderBenchmark.dateFormatToFte       avgt    5   17969.765 ±  314.480  us/op
SunSpiderBenchmark.dateFormatXparb       avgt    5   25856.467 ± 2411.417  us/op
SunSpiderBenchmark.mathCordic            avgt    5   10083.659 ±  980.310  us/op
SunSpiderBenchmark.mathPartialSums       avgt    5   22052.303 ±  724.467  us/op
SunSpiderBenchmark.mathSpectralNorm      avgt    5   12104.923 ±  434.196  us/op
SunSpiderBenchmark.regexpDna             avgt    5  107707.159 ± 7605.636  us/op
SunSpiderBenchmark.stringBase64          avgt    5   23835.379 ±  535.228  us/op
SunSpiderBenchmark.stringFasta           avgt    5   29075.257 ±  546.614  us/op
SunSpiderBenchmark.stringTagcloud        avgt    5   37760.985 ±  789.787  us/op
SunSpiderBenchmark.stringUnpackCode      avgt    5   29698.743 ±  717.608  us/op
SunSpiderBenchmark.stringValidateInput   avgt    5   16533.185 ±  278.765  us/op
SunSpiderBenchmark.threeDCube            avgt    5   22863.344 ±  459.779  us/op
SunSpiderBenchmark.threeDMorph           avgt    5   13546.212 ±  167.729  us/op
SunSpiderBenchmark.threeDRayTrace        avgt    5   15353.174 ±  224.194  us/op

V8Benchmark.boyer          avgt    5   68474.731 ± 3457.683  us/op
V8Benchmark.cryptoDecrypt  avgt    5  117865.924 ± 2687.926  us/op
V8Benchmark.cryptoEncrpyt  avgt    5    4895.171 ±  371.395  us/op
V8Benchmark.deltaBlue      avgt    5    6215.524 ±  255.234  us/op
V8Benchmark.earley         avgt    5   21386.777 ±  584.409  us/op
V8Benchmark.rayTrace       avgt    5   43347.104 ±  777.577  us/op
V8Benchmark.richards       avgt    5    2849.553 ±  141.519  us/op
V8Benchmark.splay          avgt    5    2041.655 ±  248.059  us/op
```
These two things seem to have changed a lot.
```
SunSpiderBenchmark.bitopsNsieveBits: 19733.613 => 15186.223
V8Benchmark.cryptoDecrypt: 87530.566 => 117865.924
```