### PR TITLE
fix #839 Iterable Java Object

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -6,12 +6,17 @@
 package org.mozilla.javascript;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 public class NativeJavaMap extends NativeJavaObject {
 
     private Map<Object, Object> map;
+
+    static void init(ScriptableObject scope, boolean sealed) {
+        NativeJavaMapIterator.init(scope, sealed);
+    }
 
     @SuppressWarnings("unchecked")
     public NativeJavaMap(Scriptable scope, Object map) {
@@ -48,6 +53,14 @@ public class NativeJavaMap extends NativeJavaObject {
     }
 
     @Override
+    public boolean has(Symbol key, Scriptable start) {
+        if (SymbolKey.ITERATOR.equals(key)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public Object get(String name, Scriptable start) {
         Context cx = Context.getCurrentContext();
         if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
@@ -69,6 +82,14 @@ public class NativeJavaMap extends NativeJavaObject {
             }
         }
         return super.get(index, start);
+    }
+
+    @Override
+    public Object get(Symbol key, Scriptable start) {
+        if (SymbolKey.ITERATOR.equals(key)) {
+            return symbol_iterator;
+        }
+        return super.get(key, start);
     }
 
     @Override
@@ -106,5 +127,59 @@ public class NativeJavaMap extends NativeJavaObject {
             return ids.toArray();
         }
         return super.getIds();
+    }
+
+    private static Callable symbol_iterator = (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) -> {
+        if (!(thisObj instanceof NativeJavaMap)) {
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", SymbolKey.ITERATOR);
+        }
+        return new NativeJavaMapIterator(scope, ((NativeJavaMap)thisObj).map);
+    };
+
+    private static final class NativeJavaMapIterator extends ES6Iterator {
+        private static final long serialVersionUID = 1L;
+        private static final String ITERATOR_TAG = "JavaMapIterator";
+
+        static void init(ScriptableObject scope, boolean sealed) {
+            ES6Iterator.init(scope, sealed, new NativeJavaMapIterator(), ITERATOR_TAG);
+        }
+
+        /**
+         * Only for constructing the prototype object.
+         */
+        private NativeJavaMapIterator() {
+            super();
+        }
+
+        NativeJavaMapIterator(Scriptable scope, Map<Object, Object> map) {
+            super(scope, ITERATOR_TAG);
+            this.iterator = map.entrySet().iterator();
+        }
+
+        @Override
+        public String getClassName() {
+            return "Java Map Iterator";
+        }
+
+        @Override
+        protected boolean isDone(Context cx, Scriptable scope) {
+            return !iterator.hasNext();
+        }
+
+        @Override
+        protected Object nextValue(Context cx, Scriptable scope) {
+            if (!iterator.hasNext()) {
+                return cx.newArray(scope, new Object[] {Undefined.instance, Undefined.instance});
+            }
+            Map.Entry e = iterator.next();
+            return cx.newArray(scope, new Object[] {e.getKey(), e.getValue()});
+        }
+
+        @Override
+        protected String getTag() {
+            return ITERATOR_TAG;
+        }
+
+        private Iterator<Map.Entry<Object, Object>> iterator;
     }
 }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -200,6 +200,7 @@ public class ScriptRuntime {
         NativeStringIterator.init(scope, sealed);
 
         NativeJavaObject.init(scope, sealed);
+        NativeJavaMap.init(scope, sealed);
 
         boolean withXml = cx.hasFeature(Context.FEATURE_E4X) &&
                           cx.getE4xImplementationFactory() != null;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -199,6 +199,8 @@ public class ScriptRuntime {
         NativeArrayIterator.init(scope, sealed);
         NativeStringIterator.init(scope, sealed);
 
+        NativeJavaObject.init(scope, sealed);
+
         boolean withXml = cx.hasFeature(Context.FEATURE_E4X) &&
                           cx.getE4xImplementationFactory() != null;
 

--- a/testsrc/org/mozilla/javascript/tests/JavaIterableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/JavaIterableTest.java
@@ -1,0 +1,164 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mozilla.javascript.tests;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.EcmaError;
+import org.mozilla.javascript.NativeArray;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.tools.shell.Global;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class JavaIterableTest extends TestCase {
+    protected final Global global = new Global();
+
+    public JavaIterableTest() {
+        global.init(ContextFactory.getGlobal());
+    }
+
+    @Test
+    public void testMap() {
+        Map map = new LinkedHashMap();
+        String script =
+            "var a = [];\n" +
+            "for (var { key, value } of value.entrySet()) a.push(key, value);\n" +
+            "a";
+
+        NativeArray resEmpty = (NativeArray) runScript(script, map);
+        assertEquals(0, resEmpty.size());
+
+        Object o = new Object();
+        map.put("a", "b");
+        map.put(123, 234);
+        map.put(o, o);
+
+        {
+            NativeArray res = (NativeArray) runScript(script, map);
+            assertEquals(6, res.size());
+            assertEquals("a", res.get(0));
+            assertEquals("b", res.get(1));
+            assertEquals(123.0, Context.toNumber(res.get(2)));
+            assertEquals(234.0, Context.toNumber(res.get(3)));
+            assertEquals(o, res.get(4));
+            assertEquals(o, res.get(5));
+        }
+
+        {
+            NativeArray res = (NativeArray) runScript("Array.from(value.entrySet())", map);
+            assertEquals(3, res.size());
+
+            Map.Entry e0 = (Map.Entry)res.get(0);
+            assertEquals("a", e0.getKey());
+            assertEquals("b", e0.getValue());
+
+            Map.Entry e1 = (Map.Entry)res.get(1);
+            assertEquals(123.0, Context.toNumber(e1.getKey()));
+            assertEquals(234.0, Context.toNumber(e1.getValue()));
+
+            Map.Entry e2 = (Map.Entry)res.get(2);
+            assertEquals(o, e2.getKey());
+            assertEquals(o, e2.getValue());
+        }
+    }
+
+    @Test
+    public void testList() {
+        List list = new ArrayList();
+        String script =
+            "var a = [];\n" +
+            "for (var e of value) a.push(e);\n" +
+            "a";
+
+        NativeArray resEmpty = (NativeArray) runScript(script, list);
+        assertEquals(0, resEmpty.size());
+
+        Object o = new Object();
+        list.add("a");
+        list.add(123);
+        list.add(o);
+
+        {
+            NativeArray res = (NativeArray) runScript(script, list);
+            assertEquals(3, res.size());
+            assertEquals("a", res.get(0));
+            assertEquals(123.0, Context.toNumber(res.get(1)));
+            assertEquals(o, res.get(2));
+        }
+
+        {
+            NativeArray res = (NativeArray) runScript("Array.from(value)", list);
+            assertEquals(3, res.size());
+            assertEquals("a", res.get(0));
+            assertEquals(123.0, Context.toNumber(res.get(1)));
+            assertEquals(o, res.get(2));
+        }
+    }
+
+    @Test
+    public void testSet() {
+        Set set = new LinkedHashSet();
+        String script =
+            "var a = [];\n" +
+            "for (var e of value) a.push(e);\n" +
+            "a";
+
+        NativeArray resEmpty = (NativeArray) runScript(script, set);
+        assertEquals(0, resEmpty.size());
+
+        Object o = new Object();
+        set.add("a");
+        set.add("a");
+        set.add(123);
+        set.add(o);
+
+        {
+            NativeArray res = (NativeArray) runScript(script, set);
+            assertEquals(3, res.size());
+            assertEquals("a", res.get(0));
+            assertEquals(123.0, Context.toNumber(res.get(1)));
+            assertEquals(o, res.get(2));
+        }
+
+        {
+            NativeArray res = (NativeArray) runScript("Array.from(value)", set);
+            assertEquals(3, res.size());
+            assertEquals("a", res.get(0));
+            assertEquals(123.0, Context.toNumber(res.get(1)));
+            assertEquals(o, res.get(2));
+        }
+    }
+
+    @Test
+    public void testNoIterable() {
+        Object o = new Object();
+        String script ="for (var e of value) ;";
+
+        assertThrows(EcmaError.class, () -> {
+                runScript(script, o);
+            });
+    }
+
+    private Object runScript(String scriptSourceText, Object value) {
+        return ContextFactory.getGlobal().call(context -> {
+            context.setLanguageVersion(Context.VERSION_ES6);
+            Scriptable scope = context.initStandardObjects(global);
+            scope.put("value", scope, Context.javaToJS(value, scope));
+            return context.evaluateString(scope, scriptSourceText, "", 1, null);
+        });
+    }
+}


### PR DESCRIPTION
ref. #839
Implemented `Symbol.iterator` in `java.lang.Iterable` and `java.util.Map`.
`java.util.Iterator` is equivalent to the Iterator object in ECMAScript because it has state, so we did not implement `Symbol.iterator`.
`java.util.Map` can iterate over keys and values just like ECMAScript's `Map`. Nashorn works the same way.