### PR TITLE
Improve speed of bitwiseNOT.

### DIFF
--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1140,12 +1140,7 @@ class BodyCodegen
             }
 
             case Token.BITNOT:
-                generateExpression(child, node);
-                addScriptRuntimeInvoke("toInt32", "(Ljava/lang/Object;)I");
-                cfw.addPush(-1);         // implement ~a as (a ^ -1)
-                cfw.add(ByteCode.IXOR);
-                cfw.add(ByteCode.I2D);
-                addDoubleWrap();
+                visitBitNot(node, child);
                 break;
 
             case Token.VOID:
@@ -3455,6 +3450,23 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
             addObjectToDouble();
 
             cfw.addInvoke(ByteCode.INVOKESTATIC, "java/lang/Math", "pow", "(DD)D");
+            addDoubleWrap();
+        }
+    }
+
+    private void visitBitNot(Node node, Node child)
+    {
+        int childNumberFlag = node.getIntProp(Node.ISNUMBER_PROP, -1);
+        generateExpression(child, node);
+        if (childNumberFlag == -1) {
+            addScriptRuntimeInvoke("toInt32", "(Ljava/lang/Object;)I");
+        } else {
+            addScriptRuntimeInvoke("toInt32", "(D)I");
+        }
+        cfw.addPush(-1);         // implement ~a as (a ^ -1)
+        cfw.add(ByteCode.IXOR);
+        cfw.add(ByteCode.I2D);
+        if (childNumberFlag == -1) {
             addDoubleWrap();
         }
     }

--- a/src/org/mozilla/javascript/optimizer/Optimizer.java
+++ b/src/org/mozilla/javascript/optimizer/Optimizer.java
@@ -338,6 +338,18 @@ class Optimizer
                     n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
                     return NumberType;
                 }
+
+            case Token.BITNOT : {
+                    Node child = n.getFirstChild();
+                    int type = rewriteForNumberVariables(child, NumberType);
+                    if (type == NumberType && !convertParameter(child)) {
+                        n.putIntProp(Node.ISNUMBER_PROP, Node.BOTH);
+                        markDCPNumberContext(child);
+                        return NumberType;
+                    }
+                    return NoType;
+                }
+
             case Token.SETELEM :
             case Token.SETELEM_OP : {
                     Node arrayBase = n.getFirstChild();

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -2376,6 +2376,8 @@ language/expressions/arrow-function
     ! syntax/early-errors/asi-restriction-invalid.js
     ! syntax/early-errors/use-strict-with-non-simple-param.js
 
+language/expressions/bitwise-not
+
 language/expressions/delete
     ! 11.4.1-3-a-1-s.js
     ! 11.4.1-5-a-1-s.js


### PR DESCRIPTION
https://github.com/mozilla/rhino/pull/837#issuecomment-798295199
When it don't need to convert to Object, it don't.

before
```
# JMH version: 1.27
# VM version: JDK 1.8.0_282, OpenJDK 64-Bit Server VM, 25.282-b08
# VM invoker: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=JP -Duser.language=ja -Duser.variant
# JMH blackhole mode: full blackhole + dont-inline hint
# Warmup: 5 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.mozilla.javascript.benchmarks.SunSpiderBenchmark.bitopsNsieveBits

# Run progress: 26.92% complete, ETA 00:31:47
# Fork: 1 of 1
# Warmup Iteration   1: 19254.470 us/op
# Warmup Iteration   2: 18990.886 us/op
# Warmup Iteration   3: 19167.778 us/op
# Warmup Iteration   4: 19168.355 us/op
# Warmup Iteration   5: 19200.321 us/op
Iteration   1: 19247.105 us/op
Iteration   2: 19062.072 us/op
Iteration   3: 19205.020 us/op
Iteration   4: 19181.690 us/op
Iteration   5: 19168.668 us/op


Result "org.mozilla.javascript.benchmarks.SunSpiderBenchmark.bitopsNsieveBits":
  19172.911 ±(99.9%) 264.802 us/op [Average]
  (min, avg, max) = (19062.072, 19172.911, 19247.105), stdev = 68.768
  CI (99.9%): [18908.110, 19437.713] (assumes normal distribution)
```

after
```
# JMH version: 1.27
# VM version: JDK 1.8.0_282, OpenJDK 64-Bit Server VM, 25.282-b08
# VM invoker: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=JP -Duser.language=ja -Duser.variant
# JMH blackhole mode: full blackhole + dont-inline hint
# Warmup: 5 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.mozilla.javascript.benchmarks.SunSpiderBenchmark.bitopsNsieveBits

# Run progress: 26.92% complete, ETA 00:31:47
# Fork: 1 of 1
# Warmup Iteration   1: 10719.027 us/op
# Warmup Iteration   2: 10509.302 us/op
# Warmup Iteration   3: 10269.435 us/op
# Warmup Iteration   4: 10455.276 us/op
# Warmup Iteration   5: 10424.450 us/op
Iteration   1: 10484.017 us/op
Iteration   2: 10447.017 us/op
Iteration   3: 10589.642 us/op
Iteration   4: 10463.092 us/op
Iteration   5: 10521.481 us/op


Result "org.mozilla.javascript.benchmarks.SunSpiderBenchmark.bitopsNsieveBits":
  10501.050 ±(99.9%) 218.814 us/op [Average]
  (min, avg, max) = (10447.017, 10501.050, 10589.642), stdev = 56.825
  CI (99.9%): [10282.236, 10719.864] (assumes normal distribution)
```