### PR TITLE
fix #850 XMLList assignment by index of another node from the same XMLList

### DIFF
--- a/testsrc/jstests/gh-850-XMLList-assign-from-same-list.jstest
+++ b/testsrc/jstests/gh-850-XMLList-assign-from-same-list.jstest
@@ -1,0 +1,22 @@
+function assertEquals(expected, actual) {
+   if (expected != actual) {
+     throw "Expected '" + expected + "' but was '" + actual + "'";
+   }
+ }
+ var xml =<xml>
+   <group>Group One</group>
+   <group>Group Two</group>
+   <group>Group Three</group>
+</xml>;
+
+var expected = <xml>
+   <group>Group Three</group>
+   <group>Group Two</group>
+   <group>Group Three</group>
+</xml>
+
+xml.group[0]=xml.group[2];
+
+assertEquals(xml, expected)
+
+"success";

--- a/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlNode.java
+++ b/xmlimplsrc/org/mozilla/javascript/xmlimpl/XmlNode.java
@@ -539,10 +539,7 @@ class XmlNode implements Serializable {
     }
 
     void replaceWith(XmlNode other) {
-        Node replacement = other.dom;
-        if (replacement.getOwnerDocument() != this.dom.getOwnerDocument()) {
-            replacement = this.dom.getOwnerDocument().importNode(replacement, true);
-        }
+        Node replacement = this.dom.getOwnerDocument().importNode(other.dom, true);
         this.dom.getParentNode().replaceChild(replacement, this.dom);
     }
 


### PR DESCRIPTION
fixes #850

Patch originally proposed by Alberto Saez Torres. This fix has been in production for ~11 years in the Nextgen (formerly mirth) Connect integration engine. User written code relies heavily on e4x.

https://github.com/nextgenhealthcare/connect/blob/a8e3768f63660c7a3e4301236e43dadb635ab006/server/src/org/mozilla/javascript/xmlimpl/XmlNode.java#L541..L557
