### PR TITLE
Update JavaAdapter.java

### DIFF
--- a/src/org/mozilla/javascript/JavaAdapter.java
+++ b/src/org/mozilla/javascript/JavaAdapter.java
@@ -501,6 +501,7 @@ public final class JavaAdapter implements IdFunctionCall
             ArrayList<Method> list, HashSet<String> skip)
     {
         Method[] methods = c.getDeclaredMethods();
+        if(c.isInterface())methods=c.getMethods();
         for (int i = 0; i < methods.length; i++) {
             String methodKey = methods[i].getName() +
                 getMethodSignature(methods[i],


### PR DESCRIPTION
java interfaces may extend other interfaces.Therefore, you cannot obtain the methods of upper-layer interfaces through getDeclaredmethods.