### PR TITLE
Allow JSON.stringify to operate on Java objects

### DIFF
--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -254,6 +254,10 @@ msg.invalid.date =\
 msg.toisostring.must.return.primitive =\
     toISOString must return a primitive value, but instead returned "{0}"
 
+# NativeJSON
+msg.json.cant.serialize =\
+    Do not know how to serialize a {0}
+
 # Parser
 msg.got.syntax.errors = \
     Compilation produced {0} syntax errors.

--- a/testsrc/jstests/stringify-java-objects.js
+++ b/testsrc/jstests/stringify-java-objects.js
@@ -1,0 +1,147 @@
+load('testsrc/assert.js');
+
+function replacer(key, value) {
+    var javatype = value instanceof java.lang.Object ? value.getClass().name : null;
+    return javatype ? 'replaced: ' + javatype : value;
+}
+
+// java.lang.String
+var javaString = new java.lang.String('test');
+
+var obj = {test: javaString};
+var expected = JSON.stringify({test: 'replaced: java.lang.String'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = {test: javaString};
+var expected = JSON.stringify({test: 'test'});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// java.lang.Double
+var javaDouble = java.lang.Double.valueOf(12.34);
+
+var obj = {test: javaDouble};
+var expected = JSON.stringify({test: 'replaced: java.lang.Double'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = {test: javaDouble};
+var expected = JSON.stringify({test: 12.34});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// java.lang.Boolean
+var javaBoolean = java.lang.Boolean.valueOf(false);
+
+var obj = {test: javaBoolean};
+var expected = JSON.stringify({test: 'replaced: java.lang.Boolean'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = {test: javaBoolean};
+var expected = JSON.stringify({test: false});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// java.util.Collection
+var javaCollection = new java.util.LinkedHashSet();
+    javaCollection.add('test');
+    javaCollection.add({nested: 'jsObj'});
+
+var obj = {test: javaCollection};
+var expected = JSON.stringify({test: 'replaced: java.util.LinkedHashSet'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = {test: javaCollection};
+var expected = JSON.stringify({test: ['test', {nested: 'jsObj'}]});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// java Array
+var javaArray = new java.lang.String('a,b,c').split(',');
+
+var obj = {test: javaArray};
+var expected = JSON.stringify({test: 'replaced: [Ljava.lang.String;'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = {test: javaArray};
+var expected = JSON.stringify({test: ['a','b','c']});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// java Map
+var javaMap = new java.util.HashMap();
+    javaMap.put(new java.lang.Object(), 'property skipped if key is not string-like');
+    javaMap.put('te' + 'st', 55);
+
+var obj = {test: javaMap};
+var expected = JSON.stringify({test: 'replaced: java.util.HashMap'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = javaMap;
+var expected = JSON.stringify({test: 55});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// complex object
+var obj = {
+    array: javaArray,
+    boxed: [javaDouble, javaBoolean],
+    objects: {
+        plainJS: {test: 1},
+        emptyMap: java.util.Collections.EMPTY_MAP,
+        otherMap: javaMap
+    }
+};
+var expected = JSON.stringify({
+    array: ['a','b','c'],
+    boxed: [12.34, false],
+    objects: {
+        plainJS: {test: 1},
+        emptyMap: {},
+        otherMap: {test: 55}
+    }
+});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// other Java object
+var javaObject = new java.net.URI('test://other/java/object');
+
+var obj = {test: javaObject};
+var expected = JSON.stringify({test: 'replaced: java.net.URI'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var obj = {test: javaObject};
+assertThrows(()=>JSON.stringify(obj), TypeError);
+
+// JavaAdapter with toJSON
+var javaObject = new JavaAdapter(java.lang.Object, {
+    toJSON: _ => ({javaAdapter: true})
+});
+
+var obj = javaObject;
+var expected = JSON.stringify({javaAdapter: true});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+// JavaAdapter without toJSON
+var javaObject = new JavaAdapter(java.lang.Object, {
+    toString: () => 'just an object'
+});
+
+var obj = {test: javaObject};
+var expected = /^replaced: adapter\d+$/;
+var actual = JSON.parse(JSON.stringify(obj, replacer)).test;
+assertEquals("string", typeof actual);
+assertTrue(expected.test(actual));
+
+var obj = {test: javaObject};
+assertThrows(()=>JSON.stringify(obj), TypeError);
+
+"success"

--- a/testsrc/org/mozilla/javascript/tests/StringifyJavaObjectsTest.java
+++ b/testsrc/org/mozilla/javascript/tests/StringifyJavaObjectsTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/stringify-java-objects.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class StringifyJavaObjectsTest extends ScriptTestsBase {}


### PR DESCRIPTION
- Boxed Primitives and Strings are unwrapped and converted to
  javascript primitives.
- Collections and Arrays will be converted to javascript arrays.
- Maps will be converted to javascript objects, but any non-string-
  like keys will be ignored.
- Other java classes will throw a TypeError.

Conversions occur after the replacer function is called if one is
provided, so custom handling is still possible.

Currently a StackOverflowError occurs when JSON.stringify encounters
a java object without a toJSON method.

fixes #578 