### PR TITLE
Introduce automated code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,33 @@ Most issues are managed on GitHub:
 
 [https://github.com/mozilla/rhino/issues](https://github.com/mozilla/rhino/issues)
 
+## Contributing PRs
+
+To submit a new PR, please use the following process:
+
+* Ensure that your entire build passes "./gradlew check". This will include
+code formatting and style checks and runs the tests.
+* Please write tests for what you fixed, unless you can show us that existing
+tests cover the changes. Use existing tests, such as those in 
+"testsrc/org/mozilla/javascript/tests", as a guide.
+* If you fixed ECMAScript spec compatibility, take a look at test262.properties and see
+if you can un-disable some tests.
+* Push your change to GitHub and open a pull request.
+* Please be patient as Rhino is only maintained by volunteers and we may need
+some time to get back to you.
+* Thank you for contributing!
+
+### Code Formatting
+
+Code formatting was introduced in 2021. The "spotless" plugin will fail your
+build if you have changed any files that have not yet been reformatted. 
+Please use "spotlessApply" to reformat the necessary files.
+
+If you are the first person to touch a big file that spotless wants to make
+hundreds of lines of changes to, please try to put the reformatting changes
+alone into a single Git commit so that we can separate reformatting changes
+from more substantive changes.
+
 ## More Help
 
 The Google group is the best place to go with questions:

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'jacoco'
     id 'distribution'
     id 'checkstyle'
+    id 'com.diffplug.spotless' version "5.12.1"
     id 'com.github.spotbugs' version "4.6.2"
 }
 
@@ -379,6 +380,13 @@ spotbugs {
     effort = "less"
     reportLevel = "medium"
     excludeFilter = file("./spotbugs-exclude.xml")
+}
+
+spotless {
+    ratchetFrom 'code-formatting-required'
+    java {
+        googleJavaFormat().aosp()
+    }
 }
 
 jacocoTestReport.dependsOn test


### PR DESCRIPTION
This PR uses google-java-format, via the "spotless" plugin, to format
the Java code.

It uses the "ratchet" mode of Spotless. That means that all Java
code committed AFTER this commit will be required to be formatted
using google-java-format. This will let us reformat the codebase
gradually rather than in one huge chunk.

We are keeping "checkstyle" as it checks for a few other things like
"star imports" that we'd still like to avoid.