### PR TITLE
Allow JSON.stringify to operate on e4x XML values.

### DIFF
--- a/src/org/mozilla/javascript/NativeJSON.java
+++ b/src/org/mozilla/javascript/NativeJSON.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Stack;
 
 import org.mozilla.javascript.json.JsonParser;
+import org.mozilla.javascript.xml.XMLObject;
 
 /**
  * This class implements the JSON native object.
@@ -315,6 +316,8 @@ public final class NativeJSON extends IdScriptableObject
                     value = new NativeArray((Object[]) value);
                 }
             }
+        } else if (value instanceof XMLObject) {
+            value = ((XMLObject) value).toString();
         }
 
         if (value == null) return "null";

--- a/testsrc/jstests/stringify-xml.js
+++ b/testsrc/jstests/stringify-xml.js
@@ -1,0 +1,93 @@
+load('testsrc/assert.js');
+
+function replacer(key, value) {
+    var isXMLList = value instanceof XMLList;
+    var isXML = value instanceof XML;
+    return isXMLList ? 'XMLList with ' + value.length() + ' nodes' :
+        isXML ? 'XML with ' + value.children().length() + ' children' :
+        value;
+}
+
+XML.prettyPrinting = false;
+
+// empty object
+var xml = new XML();
+var obj = {test: xml};
+
+var expected = JSON.stringify({test: 'XML with 0 children'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var expected = JSON.stringify({test: ''});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+
+// empty list
+var xml = new XMLList();
+var obj = {test: xml};
+
+var expected = JSON.stringify({test: 'XMLList with 0 nodes'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var expected = JSON.stringify({test: ''});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+
+// no children
+var xml = <xml value="1"/>;
+var obj = {test: xml};
+
+var expected = JSON.stringify({test: 'XML with 0 children'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var expected = JSON.stringify({test: ''});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+
+// simple content
+var xml = <xml>simple</xml>;
+var obj = {test: xml};
+
+var expected = JSON.stringify({test: 'XML with 1 children'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var expected = JSON.stringify({test: 'simple'});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+
+// with children
+var xml = <xml>
+    <a>1</a>
+    <a>2</a>
+</xml>;
+var obj = {test: xml};
+
+var expected = JSON.stringify({test: 'XML with 2 children'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var expected = JSON.stringify({test: '<xml><a>1</a><a>2</a></xml>'});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+// list
+var xml = xml.a;
+var obj = {test: xml};
+
+var expected = JSON.stringify({test: 'XMLList with 2 nodes'});
+var actual = JSON.stringify(obj, replacer);
+assertEquals(expected, actual);
+
+var expected = JSON.stringify({test: '<a>1</a><a>2</a>'});
+var actual = JSON.stringify(obj);
+assertEquals(expected, actual);
+
+
+"success"

--- a/testsrc/org/mozilla/javascript/tests/StringifyXmlTest.java
+++ b/testsrc/org/mozilla/javascript/tests/StringifyXmlTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/stringify-xml.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class StringifyXmlTest extends ScriptTestsBase {}


### PR DESCRIPTION
Will simply return the toString() value of the XML object. User still has the ability to handle the object in the replacer function prior to converting to a string.

This has historically thrown various TypeErrors.