### PR TITLE
Number separator support

### DIFF
--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -1211,10 +1211,7 @@ class TokenStream
      * and ignore the number separator if there is one.
      */
     private int readDigits(int base, int c) throws IOException {
-        if ((base == 10 && isDigit(c))
-                || (base == 16 && isHexDigit(c))
-                || (base == 8 && isOctalDigit(c))
-                || (base == 2 && isDualDigit(c))) {
+        if (isValidDigit(base, c)) {
             addToString(c);
 
             c = getChar();
@@ -1236,19 +1233,13 @@ class TokenStream
                         return REPORT_NUMBER_FORMAT_ERROR;
                     }
 
-                    if (!((base == 10 && isDigit(c))
-                            || (base == 16 && isHexDigit(c))
-                            || (base == 8 && isOctalDigit(c))
-                            || (base == 2 && isDualDigit(c)))) {
+                    if (!isValidDigit(base, c)) {
                         // bad luck we have to roll back
                         ungetChar(c);
                         return NUMERIC_SEPARATOR;
                     }
                     addToString(NUMERIC_SEPARATOR);
-                } else if ((base == 10 && isDigit(c))
-                                || (base == 16 && isHexDigit(c))
-                                || (base == 8 && isOctalDigit(c))
-                                || (base == 2 && isDualDigit(c))) {
+                } else if (isValidDigit(base, c)) {
                     addToString(c);
                     c = getChar();
                     if (c == EOF_CHAR) {
@@ -1260,6 +1251,13 @@ class TokenStream
             }
         }
         return c;
+    }
+
+    private boolean isValidDigit(int base, int c) throws IOException {
+        return (base == 10 && isDigit(c))
+                || (base == 16 && isHexDigit(c))
+                || (base == 8 && isOctalDigit(c))
+                || (base == 2 && isDualDigit(c));
     }
 
     private static boolean isAlpha(int c)

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -28,8 +28,13 @@ class TokenStream
      * to check.  (And checking EOF by exception is annoying.)
      * Note distinction from EOF token type!
      */
-    private final static int
-        EOF_CHAR = -1;
+    private final static int EOF_CHAR = -1;
+
+    /*
+     * Return value for readDigits() to signal the caller has
+     * to return an number format problem.
+     */
+    private final static int REPORT_NUMBER_FORMAT_ERROR = -2;
 
     private final static char BYTE_ORDER_MARK = '\uFEFF';
 
@@ -771,40 +776,39 @@ class TokenStream
                     }
                 }
 
-                boolean isEmpty = true;
-                if (base == 16) {
-                    while (isHexDigit(c)) {
-                        addToString(c);
-                        c = getChar();
-                        isEmpty = false;
+                int emptyDetector = stringBufferTop;
+                if (base == 10 || base == 16 || (base == 8 && !isOldOctal) || base == 2) {
+                    c = readDigits(base, c);
+                    if(c == REPORT_NUMBER_FORMAT_ERROR) {
+                        parser.addError("msg.caught.nfe");
+                        return Token.ERROR;
                     }
                 } else {
                     while (isDigit(c)) {
-                        if (base == 8 && c >= '8') {
-                            if (isOldOctal) {
-                                /*
-                                 * We permit 08 and 09 as decimal numbers, which
-                                 * makes our behavior a superset of the ECMA
-                                 * numeric grammar.  We might not always be so
-                                 * permissive, so we warn about it.
-                                 */
-                                parser.addWarning("msg.bad.octal.literal",
-                                                  c == '8' ? "8" : "9");
-                                base = 10;
-                            } else {
+                        // finally the oldOctal case
+                        if (c >= '8') {
+                            /*
+                             * We permit 08 and 09 as decimal numbers, which
+                             * makes our behavior a superset of the ECMA
+                             * numeric grammar.  We might not always be so
+                             * permissive, so we warn about it.
+                             */
+                            parser.addWarning("msg.bad.octal.literal",
+                                              c == '8' ? "8" : "9");
+                            base = 10;
+
+                            c = readDigits(base, c);
+                            if(c == REPORT_NUMBER_FORMAT_ERROR) {
                                 parser.addError("msg.caught.nfe");
                                 return Token.ERROR;
                             }
-                        } else if (base == 2 && c >= '2') {
-                            parser.addError("msg.caught.nfe");
-                            return Token.ERROR;
+                            break;
                         }
                         addToString(c);
                         c = getChar();
-                        isEmpty = false;
                     }
                 }
-                if (isEmpty && (isBinary || isOctal || isHex)) {
+                if (stringBufferTop == emptyDetector && (isBinary || isOctal || isHex)) {
                     parser.addError("msg.caught.nfe");
                     return Token.ERROR;
                 }
@@ -814,10 +818,13 @@ class TokenStream
                 if (base == 10) {
                     if (c == '.') {
                         isInteger = false;
-                        do {
-                            addToString(c);
-                            c = getChar();
-                        } while (isDigit(c));
+                        addToString(c);
+                        c = getChar();
+                        c = readDigits(base, c);
+                        if(c == REPORT_NUMBER_FORMAT_ERROR) {
+                            parser.addError("msg.caught.nfe");
+                            return Token.ERROR;
+                        }
                     }
                     if (c == 'e' || c == 'E') {
                         isInteger = false;
@@ -831,10 +838,11 @@ class TokenStream
                             parser.addError("msg.missing.exponent");
                             return Token.ERROR;
                         }
-                        do {
-                            addToString(c);
-                            c = getChar();
-                        } while (isDigit(c));
+                        c = readDigits(base, c);
+                        if(c == REPORT_NUMBER_FORMAT_ERROR) {
+                            parser.addError("msg.caught.nfe");
+                            return Token.ERROR;
+                        }
                     }
                 }
                 ungetChar(c);
@@ -1185,6 +1193,62 @@ class TokenStream
         }
     }
 
+    /*
+     * Helper to read the next digits according to the base
+     * and ignore the number separator if there is one.
+     */
+    private int readDigits(int base, int c) throws IOException {
+        if ((base == 10 && isDigit(c))
+                || (base == 16 && isHexDigit(c))
+                || (base == 8 && isOctalDigit(c))
+                || (base == 2 && isDualDigit(c))) {
+            addToString(c);
+
+            c = getChar();
+            if (c == EOF_CHAR) {
+                return EOF_CHAR;
+            }
+
+            while (true) {
+                if (c == '_') {
+                    // we do no peek here, we are optimistic for performance
+                    // reasons and because peekChar() only does an getChar/ungetChar.
+                    c = getChar();
+                    if (c == EOF_CHAR) {
+                        return EOF_CHAR;
+                    }
+                    // if the line ends after the separator we have
+                    // to report this as an error
+                    if (c == '\n') {
+                        return REPORT_NUMBER_FORMAT_ERROR;
+                    }
+
+                    if (!((base == 10 && isDigit(c))
+                            || (base == 16 && isHexDigit(c))
+                            || (base == 8 && isOctalDigit(c))
+                            || (base == 2 && isDualDigit(c)))) {
+                        // bad luck we have to roll back
+                        ungetChar(c);
+                        return '_';
+                    }
+                } else if ((base == 10 && isDigit(c))
+                                || (base == 16 && isHexDigit(c))
+                                || (base == 8 && isOctalDigit(c))
+                                || (base == 2 && isDualDigit(c))) {
+                    addToString(c);
+                    c = getChar();
+                    if (c == EOF_CHAR) {
+                        return EOF_CHAR;
+                    }
+
+                } else {
+                    return c;
+                }
+            }
+        }
+        return c;
+    }
+
     private static boolean isAlpha(int c)
     {
         // Use 'Z' < 'a'
@@ -1194,12 +1258,22 @@ class TokenStream
         return 'a' <= c && c <= 'z';
     }
 
-    static boolean isDigit(int c)
+    private static boolean isDualDigit(int c)
+    {
+        return '0' == c || c == '1';
+    }
+
+    private static boolean isOctalDigit(int c)
+    {
+        return '0' <= c && c <= '7';
+    }
+
+    private static boolean isDigit(int c)
     {
         return '0' <= c && c <= '9';
     }
 
-    static boolean isHexDigit(int c)
+    private static boolean isHexDigit(int c)
     {
         return ('0' <= c && c <= '9') ||  ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F');
     }

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -610,7 +610,6 @@ class TokenStream
     {
         int c;
 
-    retry:
         for (;;) {
             // Eat whitespace, possibly sensitive to newlines.
             for (;;) {
@@ -774,13 +773,13 @@ class TokenStream
 
                 boolean isEmpty = true;
                 if (base == 16) {
-                    while (0 <= Kit.xDigitToInt(c, 0)) {
+                    while (isHexDigit(c)) {
                         addToString(c);
                         c = getChar();
                         isEmpty = false;
                     }
                 } else {
-                    while ('0' <= c && c <= '9') {
+                    while (isDigit(c)) {
                         if (base == 8 && c >= '8') {
                             if (isOldOctal) {
                                 /*
@@ -812,15 +811,16 @@ class TokenStream
 
                 boolean isInteger = true;
 
-                if (base == 10 && (c == '.' || c == 'e' || c == 'E')) {
-                    isInteger = false;
+                if (base == 10) {
                     if (c == '.') {
+                        isInteger = false;
                         do {
                             addToString(c);
                             c = getChar();
                         } while (isDigit(c));
                     }
                     if (c == 'e' || c == 'E') {
+                        isInteger = false;
                         addToString(c);
                         c = getChar();
                         if (c == '+' || c == '-') {
@@ -1197,6 +1197,11 @@ class TokenStream
     static boolean isDigit(int c)
     {
         return '0' <= c && c <= '9';
+    }
+
+    static boolean isHexDigit(int c)
+    {
+        return ('0' <= c && c <= '9') ||  ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F');
     }
 
     /* As defined in ECMA.  jsscan.c uses C isspace() (which allows

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -1224,12 +1224,9 @@ class TokenStream
                     // we do no peek here, we are optimistic for performance
                     // reasons and because peekChar() only does an getChar/ungetChar.
                     c = getChar();
-                    if (c == EOF_CHAR) {
-                        return EOF_CHAR;
-                    }
                     // if the line ends after the separator we have
                     // to report this as an error
-                    if (c == '\n') {
+                    if (c == '\n' || c == EOF_CHAR) {
                         return REPORT_NUMBER_FORMAT_ERROR;
                     }
 

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -1211,7 +1211,7 @@ class TokenStream
      * and ignore the number separator if there is one.
      */
     private int readDigits(int base, int c) throws IOException {
-        if (isValidDigit(base, c)) {
+        if (isDigit(base, c)) {
             addToString(c);
 
             c = getChar();
@@ -1233,13 +1233,13 @@ class TokenStream
                         return REPORT_NUMBER_FORMAT_ERROR;
                     }
 
-                    if (!isValidDigit(base, c)) {
+                    if (!isDigit(base, c)) {
                         // bad luck we have to roll back
                         ungetChar(c);
                         return NUMERIC_SEPARATOR;
                     }
                     addToString(NUMERIC_SEPARATOR);
-                } else if (isValidDigit(base, c)) {
+                } else if (isDigit(base, c)) {
                     addToString(c);
                     c = getChar();
                     if (c == EOF_CHAR) {
@@ -1253,13 +1253,6 @@ class TokenStream
         return c;
     }
 
-    private boolean isValidDigit(int base, int c) throws IOException {
-        return (base == 10 && isDigit(c))
-                || (base == 16 && isHexDigit(c))
-                || (base == 8 && isOctalDigit(c))
-                || (base == 2 && isDualDigit(c));
-    }
-
     private static boolean isAlpha(int c)
     {
         // Use 'Z' < 'a'
@@ -1267,6 +1260,13 @@ class TokenStream
             return 'A' <= c;
         }
         return 'a' <= c && c <= 'z';
+    }
+
+    private boolean isDigit(int base, int c) throws IOException {
+        return (base == 10 && isDigit(c))
+                || (base == 16 && isHexDigit(c))
+                || (base == 8 && isOctalDigit(c))
+                || (base == 2 && isDualDigit(c));
     }
 
     private static boolean isDualDigit(int c)

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -87,8 +87,7 @@ public class Test262SuiteTest {
             "regexp-unicode-property-escapes",
             "super",
             "tail-call-optimization",
-            "u180e",
-            "numeric-separator-literal"
+            "u180e"
     ));
 
     static {

--- a/testsrc/org/mozilla/javascript/tests/es6/NumericSeparatorTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NumericSeparatorTest.java
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.ScriptableObject;
+
+public class NumericSeparatorTest {
+    private Context cx;
+    private ScriptableObject scope;
+
+    @Before
+    public void setUp() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        scope = cx.initStandardObjects();
+    }
+
+    @After
+    public void tearDown() {
+        Context.exit();
+    }
+
+    /**
+     * Special Tokenizer test for numeric constant at end.
+     */
+    @Test
+    public void numericAtEndOneDigit() {
+        Object result = cx.evaluateString(scope, "1","test", 1, null);
+        assertEquals(1.0, result);
+    }
+
+    /**
+     * Special Tokenizer test for numeric constant at end.
+     */
+    @Test
+    public void numericAtEndManyDigits() {
+        Object result = cx.evaluateString(scope, "1234","test", 1, null);
+        assertEquals(1234, result);
+    }
+
+    /**
+     * Special Tokenizer test for numeric separator constant at end.
+     */
+    @Test(expected = EvaluatorException.class)
+    public void numericSeparatorAtEnd() {
+        cx.evaluateString(scope, "1_","test", 1, null);
+    }
+}

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3666,6 +3666,8 @@ language/literals
     ! string/S7.8.4_A7.2_T6.js
     ! string/legacy-non-octal-escape-sequence-strict.js
     ! string/legacy-octal-escape-sequence-strict.js
+    ! string/unicode-escape-nls-err-double.js
+    ! string/unicode-escape-nls-err-single.js
 # Weird case of SyntaxError thrown at the script execution ('runtime')
 # not on compilation ('early'), but only for opt levels >= 0
     ! regexp/early-err-pattern.js


### PR DESCRIPTION
spend some time to bring the numeric separator support to rhino (https://github.com/tc39/proposal-numeric-separator)

* 600 more tests in the Test262 test suite (no notable runtime degradation at my local machine)
* i have not added an es6 switch because i think this will not break any old code
* the code is a bit strange and chatty but the idea was to do as less checks as possible

feedback welcome