### PR TITLE
fix for stringify array replacer mozilla/rhino#725

### DIFF
--- a/testsrc/jstests/json-stringify-array-replacer.jstest
+++ b/testsrc/jstests/json-stringify-array-replacer.jstest
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This test is a stand-in for the following until they are run by the Test262SuiteTest.
+// https://github.com/tc39/test262/blob/70bc32edab22b44db9d671ce505db8842ae200b6/test/built-ins/JSON/stringify/replacer-array-duplicates.js
+// https://github.com/tc39/test262/blob/70bc32edab22b44db9d671ce505db8842ae200b6/test/built-ins/JSON/stringify/replacer-array-number.js
+
+
+function assertEqual(actual, expected) {
+    if (actual !== expected) throw 'expected: <' + expected + '> but found <' + actual + '>';
+}
+
+var obj = {"0":1, "1":2, "2":3, "name":4};
+var actual = JSON.stringify(obj, ["0", "1", "name", "name"]);
+var expected = JSON.stringify({"0":1, "1":2, "name":4});
+assertEqual(expected, actual);
+
+var obj = {"2":"b","3":"c","1":"a"};
+var expected = JSON.stringify({"1":"a","2":"b","3":"c"});
+
+var actual = JSON.stringify(obj, ["1","2","3"]);
+assertEqual(expected, actual);
+
+var actual = JSON.stringify(obj, [1,2,3]);
+assertEqual(expected, actual);
+
+"success"


### PR DESCRIPTION
- Per spec, Numbers in an array replacer should be converted to strings
  prior to adding to the property list
- Duplicates should be removed during construction of the property list
- Changed some variables declared as List  to Collection instead because
  that is sufficient for how they are being used
- Moved LinkedList to array conversion from happening in every iteration of
  the jo method to happening once in the stringify method
- Convert strings items representing integers to their Integer value for
  correct property lookup

fixes #725 