### PR TITLE
Allow abstract LengthOfArrayLike to operate on XMLObject

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -19,6 +19,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.mozilla.javascript.regexp.NativeRegExp;
+import org.mozilla.javascript.xml.XMLObject;
 
 /**
  * This class implements the Array native object.
@@ -847,12 +848,16 @@ public class NativeArray extends IdScriptableObject implements List
      * or its value is not convertible to a number.
      */
     static long getLengthProperty(Context cx, Scriptable obj) {
-        // These will both give numeric lengths within Uint32 range.
+        // These will give numeric lengths within Uint32 range.
         if (obj instanceof NativeString) {
             return ((NativeString)obj).getLength();
         }
         if (obj instanceof NativeArray) {
             return ((NativeArray)obj).getLength();
+        }
+        if (obj instanceof XMLObject) {
+            Callable lengthFunc = (Callable) ((XMLObject) obj).get("length", obj);
+            return ((Number) lengthFunc.call(cx, obj, obj, ScriptRuntime.emptyArgs)).longValue();
         }
 
         Object len = ScriptableObject.getProperty(obj, "length");

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -17,17 +17,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
-
 import org.mozilla.javascript.regexp.NativeRegExp;
 import org.mozilla.javascript.xml.XMLObject;
 
 /**
  * This class implements the Array native object.
+ *
  * @author Norris Boyd
  * @author Mike McCabe
  */
-public class NativeArray extends IdScriptableObject implements List
-{
+public class NativeArray extends IdScriptableObject implements List {
     private static final long serialVersionUID = 7331366857676127338L;
 
     /*
@@ -45,8 +44,7 @@ public class NativeArray extends IdScriptableObject implements List
     private static final Object ARRAY_TAG = "Array";
     private static final Long NEGATIVE_ONE = Long.valueOf(-1);
 
-    static void init(Scriptable scope, boolean sealed)
-    {
+    static void init(Scriptable scope, boolean sealed) {
         NativeArray obj = new NativeArray(0);
         obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
     }
@@ -59,39 +57,32 @@ public class NativeArray extends IdScriptableObject implements List
         NativeArray.maximumInitialCapacity = maximumInitialCapacity;
     }
 
-    public NativeArray(long lengthArg)
-    {
+    public NativeArray(long lengthArg) {
         denseOnly = lengthArg <= maximumInitialCapacity;
         if (denseOnly) {
             int intLength = (int) lengthArg;
-            if (intLength < DEFAULT_INITIAL_CAPACITY)
-                intLength = DEFAULT_INITIAL_CAPACITY;
+            if (intLength < DEFAULT_INITIAL_CAPACITY) intLength = DEFAULT_INITIAL_CAPACITY;
             dense = new Object[intLength];
             Arrays.fill(dense, Scriptable.NOT_FOUND);
         }
         length = lengthArg;
     }
 
-    public NativeArray(Object[] array)
-    {
+    public NativeArray(Object[] array) {
         denseOnly = true;
         dense = array;
         length = array.length;
     }
 
     @Override
-    public String getClassName()
-    {
+    public String getClassName() {
         return "Array";
     }
 
-    private static final int
-        Id_length        =  1,
-        MAX_INSTANCE_ID  =  1;
+    private static final int Id_length = 1, MAX_INSTANCE_ID = 1;
 
     @Override
-    protected int getMaxInstanceId()
-    {
+    protected int getMaxInstanceId() {
         return MAX_INSTANCE_ID;
     }
 
@@ -103,8 +94,7 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     @Override
-    protected int findInstanceIdInfo(String s)
-    {
+    protected int findInstanceIdInfo(String s) {
         if (s.equals("length")) {
             return instanceIdInfo(lengthAttr, Id_length);
         }
@@ -112,15 +102,15 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     @Override
-    protected String getInstanceIdName(int id)
-    {
-        if (id == Id_length) { return "length"; }
+    protected String getInstanceIdName(int id) {
+        if (id == Id_length) {
+            return "length";
+        }
         return super.getInstanceIdName(id);
     }
 
     @Override
-    protected Object getInstanceIdValue(int id)
-    {
+    protected Object getInstanceIdValue(int id) {
         if (id == Id_length) {
             return ScriptRuntime.wrapNumber(length);
         }
@@ -128,71 +118,45 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     @Override
-    protected void setInstanceIdValue(int id, Object value)
-    {
+    protected void setInstanceIdValue(int id, Object value) {
         if (id == Id_length) {
-            setLength(value); return;
+            setLength(value);
+            return;
         }
         super.setInstanceIdValue(id, value);
     }
 
     @Override
-    protected void fillConstructorProperties(IdFunctionObject ctor)
-    {
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_join,
-                "join", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reverse,
-                "reverse", 0);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_sort,
-                "sort", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_push,
-                "push", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_pop,
-                "pop", 0);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_shift,
-                "shift", 0);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_unshift,
-                "unshift", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_splice,
-                "splice", 2);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_concat,
-                "concat", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_slice,
-                "slice", 2);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_indexOf,
-                "indexOf", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_lastIndexOf,
-                "lastIndexOf", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_every,
-                "every", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_filter,
-                "filter", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_forEach,
-                "forEach", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_map,
-                "map", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_some,
-                "some", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_find,
-                "find", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findIndex,
-                "findIndex", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduce,
-                "reduce", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduceRight,
-                "reduceRight", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_isArray,
-                "isArray", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_of,
-                "of", 0);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_from,
-                "from", 1);
+    protected void fillConstructorProperties(IdFunctionObject ctor) {
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_join, "join", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reverse, "reverse", 0);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_sort, "sort", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_push, "push", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_pop, "pop", 0);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_shift, "shift", 0);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_unshift, "unshift", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_splice, "splice", 2);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_concat, "concat", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_slice, "slice", 2);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_indexOf, "indexOf", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_lastIndexOf, "lastIndexOf", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_every, "every", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_filter, "filter", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_forEach, "forEach", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_map, "map", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_some, "some", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_find, "find", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findIndex, "findIndex", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduce, "reduce", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduceRight, "reduceRight", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_isArray, "isArray", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_of, "of", 0);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_from, "from", 1);
         super.fillConstructorProperties(ctor);
     }
 
     @Override
-    protected void initPrototypeId(int id)
-    {
+    protected void initPrototypeId(int id) {
         if (id == SymbolId_iterator) {
             initPrototypeMethod(ARRAY_TAG, id, SymbolKey.ITERATOR, "[Symbol.iterator]", 0);
             return;
@@ -201,228 +165,325 @@ public class NativeArray extends IdScriptableObject implements List
         String s, fnName = null;
         int arity;
         switch (id) {
-          case Id_constructor:    arity=1; s="constructor";    break;
-          case Id_toString:       arity=0; s="toString";       break;
-          case Id_toLocaleString: arity=0; s="toLocaleString"; break;
-          case Id_toSource:       arity=0; s="toSource";       break;
-          case Id_join:           arity=1; s="join";           break;
-          case Id_reverse:        arity=0; s="reverse";        break;
-          case Id_sort:           arity=1; s="sort";           break;
-          case Id_push:           arity=1; s="push";           break;
-          case Id_pop:            arity=0; s="pop";            break;
-          case Id_shift:          arity=0; s="shift";          break;
-          case Id_unshift:        arity=1; s="unshift";        break;
-          case Id_splice:         arity=2; s="splice";         break;
-          case Id_concat:         arity=1; s="concat";         break;
-          case Id_slice:          arity=2; s="slice";          break;
-          case Id_indexOf:        arity=1; s="indexOf";        break;
-          case Id_lastIndexOf:    arity=1; s="lastIndexOf";    break;
-          case Id_every:          arity=1; s="every";          break;
-          case Id_filter:         arity=1; s="filter";         break;
-          case Id_forEach:        arity=1; s="forEach";        break;
-          case Id_map:            arity=1; s="map";            break;
-          case Id_some:           arity=1; s="some";           break;
-          case Id_find:           arity=1; s="find";           break;
-          case Id_findIndex:      arity=1; s="findIndex";      break;
-          case Id_reduce:         arity=1; s="reduce";         break;
-          case Id_reduceRight:    arity=1; s="reduceRight";    break;
-          case Id_fill:           arity=1; s="fill";           break;
-          case Id_keys:           arity=0; s="keys";           break;
-          case Id_values:         arity=0; s="values";         break;
-          case Id_entries:        arity=0; s="entries";        break;
-          case Id_includes:       arity=1; s="includes";       break;
-          case Id_copyWithin:     arity=2; s="copyWithin";     break;
-          default: throw new IllegalArgumentException(String.valueOf(id));
+            case Id_constructor:
+                arity = 1;
+                s = "constructor";
+                break;
+            case Id_toString:
+                arity = 0;
+                s = "toString";
+                break;
+            case Id_toLocaleString:
+                arity = 0;
+                s = "toLocaleString";
+                break;
+            case Id_toSource:
+                arity = 0;
+                s = "toSource";
+                break;
+            case Id_join:
+                arity = 1;
+                s = "join";
+                break;
+            case Id_reverse:
+                arity = 0;
+                s = "reverse";
+                break;
+            case Id_sort:
+                arity = 1;
+                s = "sort";
+                break;
+            case Id_push:
+                arity = 1;
+                s = "push";
+                break;
+            case Id_pop:
+                arity = 0;
+                s = "pop";
+                break;
+            case Id_shift:
+                arity = 0;
+                s = "shift";
+                break;
+            case Id_unshift:
+                arity = 1;
+                s = "unshift";
+                break;
+            case Id_splice:
+                arity = 2;
+                s = "splice";
+                break;
+            case Id_concat:
+                arity = 1;
+                s = "concat";
+                break;
+            case Id_slice:
+                arity = 2;
+                s = "slice";
+                break;
+            case Id_indexOf:
+                arity = 1;
+                s = "indexOf";
+                break;
+            case Id_lastIndexOf:
+                arity = 1;
+                s = "lastIndexOf";
+                break;
+            case Id_every:
+                arity = 1;
+                s = "every";
+                break;
+            case Id_filter:
+                arity = 1;
+                s = "filter";
+                break;
+            case Id_forEach:
+                arity = 1;
+                s = "forEach";
+                break;
+            case Id_map:
+                arity = 1;
+                s = "map";
+                break;
+            case Id_some:
+                arity = 1;
+                s = "some";
+                break;
+            case Id_find:
+                arity = 1;
+                s = "find";
+                break;
+            case Id_findIndex:
+                arity = 1;
+                s = "findIndex";
+                break;
+            case Id_reduce:
+                arity = 1;
+                s = "reduce";
+                break;
+            case Id_reduceRight:
+                arity = 1;
+                s = "reduceRight";
+                break;
+            case Id_fill:
+                arity = 1;
+                s = "fill";
+                break;
+            case Id_keys:
+                arity = 0;
+                s = "keys";
+                break;
+            case Id_values:
+                arity = 0;
+                s = "values";
+                break;
+            case Id_entries:
+                arity = 0;
+                s = "entries";
+                break;
+            case Id_includes:
+                arity = 1;
+                s = "includes";
+                break;
+            case Id_copyWithin:
+                arity = 2;
+                s = "copyWithin";
+                break;
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
         }
 
         initPrototypeMethod(ARRAY_TAG, id, s, fnName, arity);
     }
 
     @Override
-    public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
-    {
+    public Object execIdCall(
+            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         if (!f.hasTag(ARRAY_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
         }
         int id = f.methodId();
-      again:
-        for (;;) {
+        again:
+        for (; ; ) {
             switch (id) {
-              case ConstructorId_join:
-              case ConstructorId_reverse:
-              case ConstructorId_sort:
-              case ConstructorId_push:
-              case ConstructorId_pop:
-              case ConstructorId_shift:
-              case ConstructorId_unshift:
-              case ConstructorId_splice:
-              case ConstructorId_concat:
-              case ConstructorId_slice:
-              case ConstructorId_indexOf:
-              case ConstructorId_lastIndexOf:
-              case ConstructorId_every:
-              case ConstructorId_filter:
-              case ConstructorId_forEach:
-              case ConstructorId_map:
-              case ConstructorId_some:
-              case ConstructorId_find:
-              case ConstructorId_findIndex:
-              case ConstructorId_reduce:
-              case ConstructorId_reduceRight: {
-                // this is a small trick; we will handle all the ConstructorId_xxx calls
-                // the same way the object calls are processed
-                // so we adjust the args, inverting the id and
-                // restarting the method selection
-                // Attention: the implementations have to be aware of this
-                if (args.length > 0) {
-                    thisObj = ScriptRuntime.toObject(cx, scope, args[0]);
-                    Object[] newArgs = new Object[args.length-1];
-                    for (int i=0; i < newArgs.length; i++)
-                        newArgs[i] = args[i+1];
-                    args = newArgs;
-                }
-                id = -id;
-                continue again;
-              }
+                case ConstructorId_join:
+                case ConstructorId_reverse:
+                case ConstructorId_sort:
+                case ConstructorId_push:
+                case ConstructorId_pop:
+                case ConstructorId_shift:
+                case ConstructorId_unshift:
+                case ConstructorId_splice:
+                case ConstructorId_concat:
+                case ConstructorId_slice:
+                case ConstructorId_indexOf:
+                case ConstructorId_lastIndexOf:
+                case ConstructorId_every:
+                case ConstructorId_filter:
+                case ConstructorId_forEach:
+                case ConstructorId_map:
+                case ConstructorId_some:
+                case ConstructorId_find:
+                case ConstructorId_findIndex:
+                case ConstructorId_reduce:
+                case ConstructorId_reduceRight:
+                    {
+                        // this is a small trick; we will handle all the ConstructorId_xxx calls
+                        // the same way the object calls are processed
+                        // so we adjust the args, inverting the id and
+                        // restarting the method selection
+                        // Attention: the implementations have to be aware of this
+                        if (args.length > 0) {
+                            thisObj = ScriptRuntime.toObject(cx, scope, args[0]);
+                            Object[] newArgs = new Object[args.length - 1];
+                            for (int i = 0; i < newArgs.length; i++) newArgs[i] = args[i + 1];
+                            args = newArgs;
+                        }
+                        id = -id;
+                        continue again;
+                    }
 
-              case ConstructorId_isArray:
-                return Boolean.valueOf(args.length > 0 && js_isArray(args[0]));
+                case ConstructorId_isArray:
+                    return Boolean.valueOf(args.length > 0 && js_isArray(args[0]));
 
-              case ConstructorId_of: {
-                  return js_of(cx, scope, thisObj, args);
-                }
+                case ConstructorId_of:
+                    {
+                        return js_of(cx, scope, thisObj, args);
+                    }
 
-              case ConstructorId_from: {
-                  return js_from(cx, scope, thisObj, args);
-                }
+                case ConstructorId_from:
+                    {
+                        return js_from(cx, scope, thisObj, args);
+                    }
 
-              case Id_constructor: {
-                boolean inNewExpr = (thisObj == null);
-                if (!inNewExpr) {
-                    // IdFunctionObject.construct will set up parent, proto
-                    return f.construct(cx, scope, args);
-                }
-                return jsConstructor(cx, scope, args);
-              }
+                case Id_constructor:
+                    {
+                        boolean inNewExpr = (thisObj == null);
+                        if (!inNewExpr) {
+                            // IdFunctionObject.construct will set up parent, proto
+                            return f.construct(cx, scope, args);
+                        }
+                        return jsConstructor(cx, scope, args);
+                    }
 
-              case Id_toString:
-                return toStringHelper(cx, scope, thisObj,
-                    cx.hasFeature(Context.FEATURE_TO_STRING_AS_SOURCE), false);
+                case Id_toString:
+                    return toStringHelper(
+                            cx,
+                            scope,
+                            thisObj,
+                            cx.hasFeature(Context.FEATURE_TO_STRING_AS_SOURCE),
+                            false);
 
-              case Id_toLocaleString:
-                return toStringHelper(cx, scope, thisObj, false, true);
+                case Id_toLocaleString:
+                    return toStringHelper(cx, scope, thisObj, false, true);
 
-              case Id_toSource:
-                return toStringHelper(cx, scope, thisObj, true, false);
+                case Id_toSource:
+                    return toStringHelper(cx, scope, thisObj, true, false);
 
-              case Id_join:
-                return js_join(cx, scope, thisObj, args);
+                case Id_join:
+                    return js_join(cx, scope, thisObj, args);
 
-              case Id_reverse:
-                return js_reverse(cx, scope, thisObj, args);
+                case Id_reverse:
+                    return js_reverse(cx, scope, thisObj, args);
 
-              case Id_sort:
-                return js_sort(cx, scope, thisObj, args);
+                case Id_sort:
+                    return js_sort(cx, scope, thisObj, args);
 
-              case Id_push:
-                return js_push(cx, scope, thisObj, args);
+                case Id_push:
+                    return js_push(cx, scope, thisObj, args);
 
-              case Id_pop:
-                return js_pop(cx, scope, thisObj, args);
+                case Id_pop:
+                    return js_pop(cx, scope, thisObj, args);
 
-              case Id_shift:
-                return js_shift(cx, scope, thisObj, args);
+                case Id_shift:
+                    return js_shift(cx, scope, thisObj, args);
 
-              case Id_unshift:
-                return js_unshift(cx, scope, thisObj, args);
+                case Id_unshift:
+                    return js_unshift(cx, scope, thisObj, args);
 
-              case Id_splice:
-                return js_splice(cx, scope, thisObj, args);
+                case Id_splice:
+                    return js_splice(cx, scope, thisObj, args);
 
-              case Id_concat:
-                return js_concat(cx, scope, thisObj, args);
+                case Id_concat:
+                    return js_concat(cx, scope, thisObj, args);
 
-              case Id_slice:
-                return js_slice(cx, scope, thisObj, args);
+                case Id_slice:
+                    return js_slice(cx, scope, thisObj, args);
 
-              case Id_indexOf:
-                return js_indexOf(cx, scope, thisObj, args);
+                case Id_indexOf:
+                    return js_indexOf(cx, scope, thisObj, args);
 
-              case Id_lastIndexOf:
-                return js_lastIndexOf(cx, scope, thisObj, args);
+                case Id_lastIndexOf:
+                    return js_lastIndexOf(cx, scope, thisObj, args);
 
-              case Id_includes:
-                return js_includes(cx, scope, thisObj, args);
+                case Id_includes:
+                    return js_includes(cx, scope, thisObj, args);
 
-              case Id_fill:
-                return js_fill(cx, scope, thisObj, args);
+                case Id_fill:
+                    return js_fill(cx, scope, thisObj, args);
 
-              case Id_copyWithin:
-                  return js_copyWithin(cx, scope, thisObj, args);
+                case Id_copyWithin:
+                    return js_copyWithin(cx, scope, thisObj, args);
 
-              case Id_every:
-              case Id_filter:
-              case Id_forEach:
-              case Id_map:
-              case Id_some:
-              case Id_find:
-              case Id_findIndex:
-                return iterativeMethod(cx, f, scope, thisObj, args);
-              case Id_reduce:
-              case Id_reduceRight:
-                return reduceMethod(cx, id, scope, thisObj, args);
+                case Id_every:
+                case Id_filter:
+                case Id_forEach:
+                case Id_map:
+                case Id_some:
+                case Id_find:
+                case Id_findIndex:
+                    return iterativeMethod(cx, f, scope, thisObj, args);
+                case Id_reduce:
+                case Id_reduceRight:
+                    return reduceMethod(cx, id, scope, thisObj, args);
 
-              case Id_keys:
-                thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
-                return new NativeArrayIterator(scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.KEYS);
+                case Id_keys:
+                    thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
+                    return new NativeArrayIterator(
+                            scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.KEYS);
 
-              case Id_entries:
-                thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
-                return new NativeArrayIterator(scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.ENTRIES);
+                case Id_entries:
+                    thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
+                    return new NativeArrayIterator(
+                            scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.ENTRIES);
 
-              case Id_values:
-              case SymbolId_iterator:
-                thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
-                return new NativeArrayIterator(scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.VALUES);
+                case Id_values:
+                case SymbolId_iterator:
+                    thisObj = ScriptRuntime.toObject(cx, scope, thisObj);
+                    return new NativeArrayIterator(
+                            scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.VALUES);
             }
-            throw new IllegalArgumentException("Array.prototype has no method: " + f.getFunctionName());
+            throw new IllegalArgumentException(
+                    "Array.prototype has no method: " + f.getFunctionName());
         }
     }
 
     @Override
-    public Object get(int index, Scriptable start)
-    {
-        if (!denseOnly && isGetterOrSetter(null, index, false))
-            return super.get(index, start);
-        if (dense != null && 0 <= index && index < dense.length)
-            return dense[index];
+    public Object get(int index, Scriptable start) {
+        if (!denseOnly && isGetterOrSetter(null, index, false)) return super.get(index, start);
+        if (dense != null && 0 <= index && index < dense.length) return dense[index];
         return super.get(index, start);
     }
 
     @Override
-    public boolean has(int index, Scriptable start)
-    {
-        if (!denseOnly && isGetterOrSetter(null, index, false))
-            return super.has(index, start);
-        if (dense != null && 0 <= index && index < dense.length)
-            return dense[index] != NOT_FOUND;
+    public boolean has(int index, Scriptable start) {
+        if (!denseOnly && isGetterOrSetter(null, index, false)) return super.has(index, start);
+        if (dense != null && 0 <= index && index < dense.length) return dense[index] != NOT_FOUND;
         return super.has(index, start);
     }
 
     private static long toArrayIndex(Object id) {
         if (id instanceof String) {
-            return toArrayIndex((String)id);
+            return toArrayIndex((String) id);
         } else if (id instanceof Number) {
-            return toArrayIndex(((Number)id).doubleValue());
+            return toArrayIndex(((Number) id).doubleValue());
         }
         return -1;
     }
 
     // if id is an array index (ECMA 15.4.0), return the number,
     // otherwise return -1L
-    private static long toArrayIndex(String id)
-    {
+    private static long toArrayIndex(String id) {
         long index = toArrayIndex(ScriptRuntime.toNumber(id));
         // Assume that ScriptRuntime.toString(index) is the same
         // as java.lang.Long.toString(index) for long
@@ -443,13 +504,12 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     private static int toDenseIndex(Object id) {
-      long index = toArrayIndex(id);
-      return 0 <= index && index < Integer.MAX_VALUE ? (int) index : -1;
+        long index = toArrayIndex(id);
+        return 0 <= index && index < Integer.MAX_VALUE ? (int) index : -1;
     }
 
     @Override
-    public void put(String id, Scriptable start, Object value)
-    {
+    public void put(String id, Scriptable start, Object value) {
         super.put(id, start, value);
         if (start == this) {
             // If the object is sealed, super will throw exception
@@ -461,41 +521,39 @@ public class NativeArray extends IdScriptableObject implements List
         }
     }
 
-    private boolean ensureCapacity(int capacity)
-    {
+    private boolean ensureCapacity(int capacity) {
         if (capacity > dense.length) {
             if (capacity > MAX_PRE_GROW_SIZE) {
                 denseOnly = false;
                 return false;
             }
-            capacity = Math.max(capacity, (int)(dense.length * GROW_FACTOR));
+            capacity = Math.max(capacity, (int) (dense.length * GROW_FACTOR));
             Object[] newDense = new Object[capacity];
             System.arraycopy(dense, 0, newDense, 0, dense.length);
-            Arrays.fill(newDense, dense.length, newDense.length,
-                        Scriptable.NOT_FOUND);
+            Arrays.fill(newDense, dense.length, newDense.length, Scriptable.NOT_FOUND);
             dense = newDense;
         }
         return true;
     }
 
     @Override
-    public void put(int index, Scriptable start, Object value)
-    {
-        if (start == this && !isSealed() && dense != null && 0 <= index &&
-            (denseOnly || !isGetterOrSetter(null, index, true)))
-        {
+    public void put(int index, Scriptable start, Object value) {
+        if (start == this
+                && !isSealed()
+                && dense != null
+                && 0 <= index
+                && (denseOnly || !isGetterOrSetter(null, index, true))) {
             if (!isExtensible() && this.length <= index) {
                 return;
             } else if (index < dense.length) {
                 dense[index] = value;
-                if (this.length <= index)
-                    this.length = (long)index + 1;
+                if (this.length <= index) this.length = (long) index + 1;
                 return;
-            } else if (denseOnly && index < dense.length * GROW_FACTOR &&
-                       ensureCapacity(index+1))
-            {
+            } else if (denseOnly
+                    && index < dense.length * GROW_FACTOR
+                    && ensureCapacity(index + 1)) {
                 dense[index] = value;
-                this.length = (long)index + 1;
+                this.length = (long) index + 1;
                 return;
             } else {
                 denseOnly = false;
@@ -506,17 +564,18 @@ public class NativeArray extends IdScriptableObject implements List
             // only set the array length if given an array index (ECMA 15.4.0)
             if (this.length <= index) {
                 // avoid overflowing index!
-                this.length = (long)index + 1;
+                this.length = (long) index + 1;
             }
         }
     }
 
     @Override
-    public void delete(int index)
-    {
-        if (dense != null && 0 <= index && index < dense.length &&
-            !isSealed() && (denseOnly || !isGetterOrSetter(null, index, true)))
-        {
+    public void delete(int index) {
+        if (dense != null
+                && 0 <= index
+                && index < dense.length
+                && !isSealed()
+                && (denseOnly || !isGetterOrSetter(null, index, true))) {
             dense[index] = NOT_FOUND;
         } else {
             super.delete(index);
@@ -524,16 +583,19 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     @Override
-    public Object[] getIds(boolean nonEnumerable, boolean getSymbols)
-    {
+    public Object[] getIds(boolean nonEnumerable, boolean getSymbols) {
         Object[] superIds = super.getIds(nonEnumerable, getSymbols);
-        if (dense == null) { return superIds; }
+        if (dense == null) {
+            return superIds;
+        }
         int N = dense.length;
         long currentLength = length;
         if (N > currentLength) {
-            N = (int)currentLength;
+            N = (int) currentLength;
         }
-        if (N == 0) { return superIds; }
+        if (N == 0) {
+            return superIds;
+        }
         int superLength = superIds.length;
         Object[] ids = new Object[N + superLength];
 
@@ -556,44 +618,42 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     public List<Integer> getIndexIds() {
-      Object[] ids = getIds();
-      List<Integer> indices = new ArrayList<Integer>(ids.length);
-      for (Object id : ids) {
-        int int32Id = ScriptRuntime.toInt32(id);
-        if (int32Id >= 0 && ScriptRuntime.toString(int32Id).equals(ScriptRuntime.toString(id))) {
-          indices.add(Integer.valueOf(int32Id));
+        Object[] ids = getIds();
+        List<Integer> indices = new ArrayList<Integer>(ids.length);
+        for (Object id : ids) {
+            int int32Id = ScriptRuntime.toInt32(id);
+            if (int32Id >= 0
+                    && ScriptRuntime.toString(int32Id).equals(ScriptRuntime.toString(id))) {
+                indices.add(Integer.valueOf(int32Id));
+            }
         }
-      }
-      return indices;
+        return indices;
     }
 
     @Override
-    public Object getDefaultValue(Class<?> hint)
-    {
+    public Object getDefaultValue(Class<?> hint) {
         if (hint == ScriptRuntime.NumberClass) {
             Context cx = Context.getContext();
-            if (cx.getLanguageVersion() == Context.VERSION_1_2)
-                return Long.valueOf(length);
+            if (cx.getLanguageVersion() == Context.VERSION_1_2) return Long.valueOf(length);
         }
         return super.getDefaultValue(hint);
     }
 
     private ScriptableObject defaultIndexPropertyDescriptor(Object value) {
-      Scriptable scope = getParentScope();
-      if (scope == null) scope = this;
-      ScriptableObject desc = new NativeObject();
-      ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
-      desc.defineProperty("value", value, EMPTY);
-      desc.defineProperty("writable", Boolean.TRUE, EMPTY);
-      desc.defineProperty("enumerable", Boolean.TRUE, EMPTY);
-      desc.defineProperty("configurable", Boolean.TRUE, EMPTY);
-      return desc;
+        Scriptable scope = getParentScope();
+        if (scope == null) scope = this;
+        ScriptableObject desc = new NativeObject();
+        ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
+        desc.defineProperty("value", value, EMPTY);
+        desc.defineProperty("writable", Boolean.TRUE, EMPTY);
+        desc.defineProperty("enumerable", Boolean.TRUE, EMPTY);
+        desc.defineProperty("configurable", Boolean.TRUE, EMPTY);
+        return desc;
     }
 
     @Override
     public int getAttributes(int index) {
-        if (dense != null && index >= 0 && index < dense.length
-                && dense[index] != NOT_FOUND) {
+        if (dense != null && index >= 0 && index < dense.length && dense[index] != NOT_FOUND) {
             return EMPTY;
         }
         return super.getAttributes(index);
@@ -601,45 +661,39 @@ public class NativeArray extends IdScriptableObject implements List
 
     @Override
     protected ScriptableObject getOwnPropertyDescriptor(Context cx, Object id) {
-      if (dense != null) {
-        int index = toDenseIndex(id);
-        if (0 <= index && index < dense.length && dense[index] != NOT_FOUND) {
-          Object value = dense[index];
-          return defaultIndexPropertyDescriptor(value);
+        if (dense != null) {
+            int index = toDenseIndex(id);
+            if (0 <= index && index < dense.length && dense[index] != NOT_FOUND) {
+                Object value = dense[index];
+                return defaultIndexPropertyDescriptor(value);
+            }
         }
-      }
-      return super.getOwnPropertyDescriptor(cx, id);
+        return super.getOwnPropertyDescriptor(cx, id);
     }
 
     @Override
-    protected void defineOwnProperty(Context cx, Object id,
-                                     ScriptableObject desc,
-                                     boolean checkValid) {
-      if (dense != null) {
-        Object[] values = dense;
-        dense = null;
-        denseOnly = false;
-        for (int i = 0; i < values.length; i++) {
-          if (values[i] != NOT_FOUND) {
-            put(i, this, values[i]);
-          }
+    protected void defineOwnProperty(
+            Context cx, Object id, ScriptableObject desc, boolean checkValid) {
+        if (dense != null) {
+            Object[] values = dense;
+            dense = null;
+            denseOnly = false;
+            for (int i = 0; i < values.length; i++) {
+                if (values[i] != NOT_FOUND) {
+                    put(i, this, values[i]);
+                }
+            }
         }
-      }
-      long index = toArrayIndex(id);
-      if (index >= length) {
-        length = index + 1;
-      }
-      super.defineOwnProperty(cx, id, desc, checkValid);
+        long index = toArrayIndex(id);
+        if (index >= length) {
+            length = index + 1;
+        }
+        super.defineOwnProperty(cx, id, desc, checkValid);
     }
 
-    /**
-     * See ECMA 15.4.1,2
-     */
-    private static Object jsConstructor(Context cx, Scriptable scope,
-                                        Object[] args)
-    {
-        if (args.length == 0)
-            return new NativeArray(0);
+    /** See ECMA 15.4.1,2 */
+    private static Object jsConstructor(Context cx, Scriptable scope, Object[] args) {
+        if (args.length == 0) return new NativeArray(0);
 
         // Only use 1 arg as first element for version 1.2; for
         // any other version (including 1.3) follow ECMA and use it as
@@ -652,21 +706,23 @@ public class NativeArray extends IdScriptableObject implements List
             return new NativeArray(args);
         }
         long len = ScriptRuntime.toUint32(arg0);
-        if (len != ((Number)arg0).doubleValue()) {
+        if (len != ((Number) arg0).doubleValue()) {
             String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
         return new NativeArray(len);
     }
 
-    private static Scriptable callConstructorOrCreateArray(Context cx, Scriptable scope,
-        Scriptable arg, long length, boolean lengthAlways) {
+    private static Scriptable callConstructorOrCreateArray(
+            Context cx, Scriptable scope, Scriptable arg, long length, boolean lengthAlways) {
         Scriptable result = null;
 
         if (arg instanceof Function) {
             try {
-                final Object[] args = (lengthAlways || (length > 0)) ?
-                    new Object[] { Long.valueOf(length) } : ScriptRuntime.emptyArgs;
+                final Object[] args =
+                        (lengthAlways || (length > 0))
+                                ? new Object[] {Long.valueOf(length)}
+                                : ScriptRuntime.emptyArgs;
                 result = ((Function) arg).construct(cx, scope, args);
             } catch (EcmaError ee) {
                 if (!"TypeError".equals(ee.getName())) {
@@ -679,7 +735,7 @@ public class NativeArray extends IdScriptableObject implements List
 
         if (result == null) {
             // "length" below is really a hint so don't worry if it's really large
-            result = cx.newArray(scope, (length > Integer.MAX_VALUE) ? 0 : (int)length);
+            result = cx.newArray(scope, (length > Integer.MAX_VALUE) ? 0 : (int) length);
         }
 
         return result;
@@ -687,7 +743,7 @@ public class NativeArray extends IdScriptableObject implements List
 
     private static Object js_from(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         final Scriptable items =
-            ScriptRuntime.toObject(scope, (args.length >= 1) ? args[0] : Undefined.instance);
+                ScriptRuntime.toObject(scope, (args.length >= 1) ? args[0] : Undefined.instance);
         Object mapArg = (args.length >= 2) ? args[1] : Undefined.instance;
         Scriptable thisArg = Undefined.SCRIPTABLE_UNDEFINED;
         final boolean mapping = !Undefined.isUndefined(mapArg);
@@ -697,31 +753,38 @@ public class NativeArray extends IdScriptableObject implements List
             if (!(mapArg instanceof Function)) {
                 throw ScriptRuntime.typeErrorById("msg.map.function.not");
             }
-            mapFn = (Function)mapArg;
+            mapFn = (Function) mapArg;
             if (args.length >= 3) {
                 thisArg = ensureScriptable(args[2]);
             }
         }
 
         Object iteratorProp = ScriptableObject.getProperty(items, SymbolKey.ITERATOR);
-        if (!(items instanceof NativeArray) && (iteratorProp != Scriptable.NOT_FOUND) &&
-            !Undefined.isUndefined(iteratorProp)) {
-          final Object iterator = ScriptRuntime.callIterator(items, cx, scope);
-          if (!Undefined.isUndefined(iterator)) {
-            final Scriptable result = callConstructorOrCreateArray(cx, scope, thisObj, 0, false);
-            long k = 0;
-            try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
-              for (Object temp : it) {
-                if (mapping) {
-                  temp = mapFn.call(cx, scope, thisArg, new Object[] { temp, Long.valueOf(k) });
+        if (!(items instanceof NativeArray)
+                && (iteratorProp != Scriptable.NOT_FOUND)
+                && !Undefined.isUndefined(iteratorProp)) {
+            final Object iterator = ScriptRuntime.callIterator(items, cx, scope);
+            if (!Undefined.isUndefined(iterator)) {
+                final Scriptable result =
+                        callConstructorOrCreateArray(cx, scope, thisObj, 0, false);
+                long k = 0;
+                try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
+                    for (Object temp : it) {
+                        if (mapping) {
+                            temp =
+                                    mapFn.call(
+                                            cx,
+                                            scope,
+                                            thisArg,
+                                            new Object[] {temp, Long.valueOf(k)});
+                        }
+                        defineElem(cx, result, k, temp);
+                        k++;
+                    }
                 }
-                defineElem(cx, result, k, temp);
-                k++;
-              }
+                setLengthProperty(cx, result, k);
+                return result;
             }
-            setLengthProperty(cx, result, k);
-            return result;
-          }
         }
 
         final long length = getLengthProperty(cx, items);
@@ -730,7 +793,7 @@ public class NativeArray extends IdScriptableObject implements List
             Object temp = getRawElem(items, k);
             if (temp != Scriptable.NOT_FOUND) {
                 if (mapping) {
-                    temp = mapFn.call(cx, scope, thisArg, new Object[] { temp, Long.valueOf(k) });
+                    temp = mapFn.call(cx, scope, thisArg, new Object[] {temp, Long.valueOf(k)});
                 }
                 defineElem(cx, result, k, temp);
             }
@@ -740,10 +803,9 @@ public class NativeArray extends IdScriptableObject implements List
         return result;
     }
 
-    private static Object js_of(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_of(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         final Scriptable result =
-            callConstructorOrCreateArray(cx, scope, thisObj, args.length, true);
+                callConstructorOrCreateArray(cx, scope, thisObj, args.length, true);
 
         for (int i = 0; i < args.length; i++) {
             defineElem(cx, result, i, args[i]);
@@ -764,17 +826,16 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     /**
-     * Change the value of the internal flag that determines whether all
-     * storage is handed by a dense backing array rather than an associative
-     * store.
+     * Change the value of the internal flag that determines whether all storage is handed by a
+     * dense backing array rather than an associative store.
+     *
      * @param denseOnly new value for denseOnly flag
-     * @throws IllegalArgumentException if an attempt is made to enable
-     *   denseOnly after it was disabled; NativeArray code is not written
-     *   to handle switching back to a dense representation
+     * @throws IllegalArgumentException if an attempt is made to enable denseOnly after it was
+     *     disabled; NativeArray code is not written to handle switching back to a dense
+     *     representation
      */
     void setDenseOnly(boolean denseOnly) {
-        if (denseOnly && !this.denseOnly)
-            throw new IllegalArgumentException();
+        if (denseOnly && !this.denseOnly) throw new IllegalArgumentException();
         this.denseOnly = denseOnly;
     }
 
@@ -802,10 +863,9 @@ public class NativeArray extends IdScriptableObject implements List
                 Arrays.fill(dense, (int) longVal, dense.length, NOT_FOUND);
                 length = longVal;
                 return;
-            } else if (longVal < MAX_PRE_GROW_SIZE &&
-                       longVal < (length * GROW_FACTOR) &&
-                       ensureCapacity((int)longVal))
-            {
+            } else if (longVal < MAX_PRE_GROW_SIZE
+                    && longVal < (length * GROW_FACTOR)
+                    && ensureCapacity((int) longVal)) {
                 length = longVal;
                 return;
             } else {
@@ -817,18 +877,16 @@ public class NativeArray extends IdScriptableObject implements List
             if (length - longVal > 0x1000) {
                 // assume that the representation is sparse
                 Object[] e = getIds(); // will only find in object itself
-                for (int i=0; i < e.length; i++) {
+                for (int i = 0; i < e.length; i++) {
                     Object id = e[i];
                     if (id instanceof String) {
                         // > MAXINT will appear as string
-                        String strId = (String)id;
+                        String strId = (String) id;
                         long index = toArrayIndex(strId);
-                        if (index >= longVal)
-                            delete(strId);
+                        if (index >= longVal) delete(strId);
                     } else {
-                        int index = ((Integer)id).intValue();
-                        if (index >= longVal)
-                            delete(index);
+                        int index = ((Integer) id).intValue();
+                        if (index >= longVal) delete(index);
                     }
                 }
             } else {
@@ -850,10 +908,10 @@ public class NativeArray extends IdScriptableObject implements List
     static long getLengthProperty(Context cx, Scriptable obj) {
         // These will give numeric lengths within Uint32 range.
         if (obj instanceof NativeString) {
-            return ((NativeString)obj).getLength();
+            return ((NativeString) obj).getLength();
         }
         if (obj instanceof NativeArray) {
-            return ((NativeArray)obj).getLength();
+            return ((NativeArray) obj).getLength();
         }
         if (obj instanceof XMLObject) {
             Callable lengthFunc = (Callable) ((XMLObject) obj).get("length", obj);
@@ -875,12 +933,10 @@ public class NativeArray extends IdScriptableObject implements List
         if (doubleLen < 0) {
             return 0;
         }
-        return (long)doubleLen;
+        return (long) doubleLen;
     }
 
-    private static Object setLengthProperty(Context cx, Scriptable target,
-                                            long length)
-    {
+    private static Object setLengthProperty(Context cx, Scriptable target, long length) {
         Object len = ScriptRuntime.wrapNumber(length);
         ScriptableObject.putProperty(target, "length", len);
         return len;
@@ -892,13 +948,15 @@ public class NativeArray extends IdScriptableObject implements List
      * functions... though this is probably premature optimization.
      */
     private static void deleteElem(Scriptable target, long index) {
-        int i = (int)index;
-        if (i == index) { target.delete(i); }
-        else { target.delete(Long.toString(index)); }
+        int i = (int) index;
+        if (i == index) {
+            target.delete(i);
+        } else {
+            target.delete(Long.toString(index));
+        }
     }
 
-    private static Object getElem(Context cx, Scriptable target, long index)
-    {
+    private static Object getElem(Context cx, Scriptable target, long index) {
         Object elem = getRawElem(target, index);
         return (elem != Scriptable.NOT_FOUND ? elem : Undefined.instance);
     }
@@ -908,34 +966,29 @@ public class NativeArray extends IdScriptableObject implements List
         if (index > Integer.MAX_VALUE) {
             return ScriptableObject.getProperty(target, Long.toString(index));
         }
-        return ScriptableObject.getProperty(target, (int)index);
+        return ScriptableObject.getProperty(target, (int) index);
     }
 
-    private static void defineElem(Context cx, Scriptable target, long index,
-                                   Object value)
-    {
+    private static void defineElem(Context cx, Scriptable target, long index, Object value) {
         if (index > Integer.MAX_VALUE) {
             String id = Long.toString(index);
             target.put(id, target, value);
         } else {
-            target.put((int)index, target, value);
+            target.put((int) index, target, value);
         }
     }
 
-    private static void setElem(Context cx, Scriptable target, long index,
-                                Object value)
-    {
+    private static void setElem(Context cx, Scriptable target, long index, Object value) {
         if (index > Integer.MAX_VALUE) {
             String id = Long.toString(index);
             ScriptableObject.putProperty(target, id, value);
         } else {
-            ScriptableObject.putProperty(target, (int)index, value);
+            ScriptableObject.putProperty(target, (int) index, value);
         }
     }
 
     // Similar as setElem(), but triggers deleteElem() if value is NOT_FOUND
-    private static void setRawElem(Context cx, Scriptable target, long index,
-                                   Object value) {
+    private static void setRawElem(Context cx, Scriptable target, long index, Object value) {
         if (value == NOT_FOUND) {
             deleteElem(target, index);
         } else {
@@ -943,10 +996,8 @@ public class NativeArray extends IdScriptableObject implements List
         }
     }
 
-    private static String toStringHelper(Context cx, Scriptable scope,
-                                         Scriptable thisObj,
-                                         boolean toSource, boolean toLocale)
-    {
+    private static String toStringHelper(
+            Context cx, Scriptable scope, Scriptable thisObj, boolean toSource, boolean toLocale) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         /* It's probably redundant to handle long lengths in this
@@ -987,13 +1038,14 @@ public class NativeArray extends IdScriptableObject implements List
                 cx.iterating.put(o, 0);
 
                 // make toSource print null and undefined values in recent versions
-                boolean skipUndefinedAndNull = !toSource
-                        || cx.getLanguageVersion() < Context.VERSION_1_5;
+                boolean skipUndefinedAndNull =
+                        !toSource || cx.getLanguageVersion() < Context.VERSION_1_5;
                 for (i = 0; i < length; i++) {
                     if (i > 0) result.append(separator);
                     Object elem = getRawElem(o, i);
-                    if (elem == NOT_FOUND || (skipUndefinedAndNull &&
-                            (elem == null || elem == Undefined.instance))) {
+                    if (elem == NOT_FOUND
+                            || (skipUndefinedAndNull
+                                    && (elem == null || elem == Undefined.instance))) {
                         haslast = false;
                         continue;
                     }
@@ -1003,17 +1055,17 @@ public class NativeArray extends IdScriptableObject implements List
                         result.append(ScriptRuntime.uneval(cx, scope, elem));
 
                     } else if (elem instanceof String) {
-                        result.append((String)elem);
+                        result.append((String) elem);
 
                     } else {
                         if (toLocale) {
                             Callable fun;
                             Scriptable funThis;
-                            fun = ScriptRuntime.getPropFunctionAndThis(
-                                      elem, "toLocaleString", cx, scope);
+                            fun =
+                                    ScriptRuntime.getPropFunctionAndThis(
+                                            elem, "toLocaleString", cx, scope);
                             funThis = ScriptRuntime.lastStoredScriptable(cx);
-                            elem = fun.call(cx, scope, funThis,
-                                            ScriptRuntime.emptyArgs);
+                            elem = fun.call(cx, scope, funThis, ScriptRuntime.emptyArgs);
                         }
                         result.append(ScriptRuntime.toString(elem));
                     }
@@ -1030,33 +1082,28 @@ public class NativeArray extends IdScriptableObject implements List
         }
 
         if (toSource) {
-            //for [,,].length behavior; we want toString to be symmetric.
-            if (!haslast && i > 0)
-                result.append(", ]");
-            else
-                result.append(']');
+            // for [,,].length behavior; we want toString to be symmetric.
+            if (!haslast && i > 0) result.append(", ]");
+            else result.append(']');
         }
         return result.toString();
     }
 
-    /**
-     * See ECMA 15.4.4.3
-     */
-    private static String js_join(Context cx, Scriptable scope, Scriptable thisObj,
-                                  Object[] args)
-    {
+    /** See ECMA 15.4.4.3 */
+    private static String js_join(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         long llength = getLengthProperty(cx, o);
-        int length = (int)llength;
+        int length = (int) llength;
         if (llength != length) {
             throw Context.reportRuntimeErrorById(
-                "msg.arraylength.too.big", String.valueOf(llength));
+                    "msg.arraylength.too.big", String.valueOf(llength));
         }
         // if no args, use "," as separator
-        String separator = (args.length < 1 || args[0] == Undefined.instance)
-                           ? ","
-                           : ScriptRuntime.toString(args[0]);
+        String separator =
+                (args.length < 1 || args[0] == Undefined.instance)
+                        ? ","
+                        : ScriptRuntime.toString(args[0]);
         if (o instanceof NativeArray) {
             NativeArray na = (NativeArray) o;
             if (na.denseOnly) {
@@ -1067,9 +1114,9 @@ public class NativeArray extends IdScriptableObject implements List
                     }
                     if (i < na.dense.length) {
                         Object temp = na.dense[i];
-                        if (temp != null && temp != Undefined.instance &&
-                            temp != Scriptable.NOT_FOUND)
-                        {
+                        if (temp != null
+                                && temp != Undefined.instance
+                                && temp != Scriptable.NOT_FOUND) {
                             sb.append(ScriptRuntime.toString(temp));
                         }
                     }
@@ -1105,17 +1152,15 @@ public class NativeArray extends IdScriptableObject implements List
         return sb.toString();
     }
 
-    /**
-     * See ECMA 15.4.4.4
-     */
-    private static Scriptable js_reverse(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    /** See ECMA 15.4.4.4 */
+    private static Scriptable js_reverse(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         if (o instanceof NativeArray) {
             NativeArray na = (NativeArray) o;
             if (na.denseOnly) {
-                for (int i=0, j=((int)na.length)-1; i < j; i++,j--) {
+                for (int i = 0, j = ((int) na.length) - 1; i < j; i++, j--) {
                     Object temp = na.dense[i];
                     na.dense[i] = na.dense[j];
                     na.dense[j] = temp;
@@ -1126,7 +1171,7 @@ public class NativeArray extends IdScriptableObject implements List
         long len = getLengthProperty(cx, o);
 
         long half = len / 2;
-        for(long i=0; i < half; i++) {
+        for (long i = 0; i < half; i++) {
             long j = len - i - 1;
             Object temp1 = getRawElem(o, i);
             Object temp2 = getRawElem(o, j);
@@ -1136,39 +1181,38 @@ public class NativeArray extends IdScriptableObject implements List
         return o;
     }
 
-    /**
-     * See ECMA 15.4.4.5
-     */
-    private static Scriptable js_sort(final Context cx, final Scriptable scope,
-            final Scriptable thisObj, final Object[] args)
-    {
+    /** See ECMA 15.4.4.5 */
+    private static Scriptable js_sort(
+            final Context cx,
+            final Scriptable scope,
+            final Scriptable thisObj,
+            final Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         final Comparator<Object> comparator;
         if (args.length > 0 && Undefined.instance != args[0]) {
-            final Callable jsCompareFunction = ScriptRuntime
-                    .getValueFunctionAndThis(args[0], cx);
+            final Callable jsCompareFunction = ScriptRuntime.getValueFunctionAndThis(args[0], cx);
             final Scriptable funThis = ScriptRuntime.lastStoredScriptable(cx);
             final Object[] cmpBuf = new Object[2]; // Buffer for cmp arguments
-            comparator = new ElementComparator(
-                new Comparator<Object>() {
-                  @Override
-                  public int compare(final Object x, final Object y) {
-                    // This comparator is invoked only for non-undefined objects
-                    cmpBuf[0] = x;
-                    cmpBuf[1] = y;
-                    Object ret = jsCompareFunction.call(cx, scope, funThis,
-                        cmpBuf);
-                    double d = ScriptRuntime.toNumber(ret);
-                    int cmp = Double.compare(d, 0);
-                    if (cmp < 0) {
-                      return -1;
-                    } else if (cmp > 0) {
-                      return +1;
-                    }
-                    return 0;
-                  }
-                });
+            comparator =
+                    new ElementComparator(
+                            new Comparator<Object>() {
+                                @Override
+                                public int compare(final Object x, final Object y) {
+                                    // This comparator is invoked only for non-undefined objects
+                                    cmpBuf[0] = x;
+                                    cmpBuf[1] = y;
+                                    Object ret = jsCompareFunction.call(cx, scope, funThis, cmpBuf);
+                                    double d = ScriptRuntime.toNumber(ret);
+                                    int cmp = Double.compare(d, 0);
+                                    if (cmp < 0) {
+                                        return -1;
+                                    } else if (cmp > 0) {
+                                        return +1;
+                                    }
+                                    return 0;
+                                }
+                            });
         } else {
             comparator = DEFAULT_COMPARATOR;
         }
@@ -1177,7 +1221,7 @@ public class NativeArray extends IdScriptableObject implements List
         final int length = (int) llength;
         if (llength != length) {
             throw Context.reportRuntimeErrorById(
-                "msg.arraylength.too.big", String.valueOf(llength));
+                    "msg.arraylength.too.big", String.valueOf(llength));
         }
         // copy the JS array into a working array, so it can be
         // sorted cheaply.
@@ -1196,18 +1240,14 @@ public class NativeArray extends IdScriptableObject implements List
         return o;
     }
 
-    private static Object js_push(Context cx, Scriptable scope, Scriptable thisObj,
-                                  Object[] args)
-    {
+    private static Object js_push(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         if (o instanceof NativeArray) {
             NativeArray na = (NativeArray) o;
-            if (na.denseOnly &&
-                na.ensureCapacity((int) na.length + args.length))
-            {
+            if (na.denseOnly && na.ensureCapacity((int) na.length + args.length)) {
                 for (int i = 0; i < args.length; i++) {
-                    na.dense[(int)na.length++] = args[i];
+                    na.dense[(int) na.length++] = args[i];
                 }
                 return ScriptRuntime.wrapNumber(na.length);
             }
@@ -1226,16 +1266,12 @@ public class NativeArray extends IdScriptableObject implements List
          */
         if (cx.getLanguageVersion() == Context.VERSION_1_2)
             // if JS1.2 && no arguments, return undefined.
-            return args.length == 0
-                ? Undefined.instance
-                : args[args.length - 1];
+            return args.length == 0 ? Undefined.instance : args[args.length - 1];
 
         return lengthObj;
     }
 
-    private static Object js_pop(Context cx, Scriptable scope, Scriptable thisObj,
-                                 Object[] args)
-    {
+    private static Object js_pop(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         Object result;
@@ -1243,8 +1279,8 @@ public class NativeArray extends IdScriptableObject implements List
             NativeArray na = (NativeArray) o;
             if (na.denseOnly && na.length > 0) {
                 na.length--;
-                result = na.dense[(int)na.length];
-                na.dense[(int)na.length] = NOT_FOUND;
+                result = na.dense[(int) na.length];
+                na.dense[(int) na.length] = NOT_FOUND;
                 return result;
             }
         }
@@ -1268,8 +1304,8 @@ public class NativeArray extends IdScriptableObject implements List
         return result;
     }
 
-    private static Object js_shift(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_shift(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         if (o instanceof NativeArray) {
@@ -1277,8 +1313,8 @@ public class NativeArray extends IdScriptableObject implements List
             if (na.denseOnly && na.length > 0) {
                 na.length--;
                 Object result = na.dense[0];
-                System.arraycopy(na.dense, 1, na.dense, 0, (int)na.length);
-                na.dense[(int)na.length] = NOT_FOUND;
+                System.arraycopy(na.dense, 1, na.dense, 0, (int) na.length);
+                na.dense[(int) na.length] = NOT_FOUND;
                 return result == NOT_FOUND ? Undefined.instance : result;
             }
         }
@@ -1311,17 +1347,14 @@ public class NativeArray extends IdScriptableObject implements List
         return result;
     }
 
-    private static Object js_unshift(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_unshift(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         if (o instanceof NativeArray) {
             NativeArray na = (NativeArray) o;
-            if (na.denseOnly &&
-                na.ensureCapacity((int)na.length + args.length))
-            {
-                System.arraycopy(na.dense, 0, na.dense, args.length,
-                                 (int) na.length);
+            if (na.denseOnly && na.ensureCapacity((int) na.length + args.length)) {
+                System.arraycopy(na.dense, 0, na.dense, args.length, (int) na.length);
                 for (int i = 0; i < args.length; i++) {
                     na.dense[i] = args[i];
                 }
@@ -1355,9 +1388,8 @@ public class NativeArray extends IdScriptableObject implements List
         return setLengthProperty(cx, o, length);
     }
 
-    private static Object js_splice(Context cx, Scriptable scope,
-                                    Scriptable thisObj, Object[] args)
-    {
+    private static Object js_splice(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         NativeArray na = null;
@@ -1370,8 +1402,7 @@ public class NativeArray extends IdScriptableObject implements List
         /* create an empty Array to return. */
         scope = getTopLevelScope(scope);
         int argc = args.length;
-        if (argc == 0)
-            return cx.newArray(scope, 0);
+        if (argc == 0) return cx.newArray(scope, 0);
         long length = getLengthProperty(cx, o);
 
         /* Convert the first argument into a starting index. */
@@ -1389,7 +1420,7 @@ public class NativeArray extends IdScriptableObject implements List
             } else if (dcount > (length - begin)) {
                 actualDeleteCount = length - begin;
             } else {
-                actualDeleteCount = (long)dcount;
+                actualDeleteCount = (long) dcount;
             }
             argc--;
         }
@@ -1408,9 +1439,7 @@ public class NativeArray extends IdScriptableObject implements List
         /* If there are elements to remove, put them into the return value. */
         Object result;
         if (actualDeleteCount != 0) {
-            if (actualDeleteCount == 1
-                && (cx.getLanguageVersion() == Context.VERSION_1_2))
-            {
+            if (actualDeleteCount == 1 && (cx.getLanguageVersion() == Context.VERSION_1_2)) {
                 /*
                  * JS lacks "list context", whereby in Perl one turns the
                  * single scalar that's spliced out into an array just by
@@ -1452,17 +1481,16 @@ public class NativeArray extends IdScriptableObject implements List
         }
 
         /* Find the direction (up or down) to copy and make way for argv. */
-        if (denseMode && length + delta < Integer.MAX_VALUE &&
-            na.ensureCapacity((int) (length + delta)))
-        {
-            System.arraycopy(na.dense, (int) end, na.dense,
-                             (int) (begin + argc), (int) (length - end));
+        if (denseMode
+                && length + delta < Integer.MAX_VALUE
+                && na.ensureCapacity((int) (length + delta))) {
+            System.arraycopy(
+                    na.dense, (int) end, na.dense, (int) (begin + argc), (int) (length - end));
             if (argc > 0) {
                 System.arraycopy(args, 2, na.dense, (int) begin, argc);
             }
             if (delta < 0) {
-                Arrays.fill(na.dense, (int) (length + delta), (int) length,
-                            NOT_FOUND);
+                Arrays.fill(na.dense, (int) (length + delta), (int) length, NOT_FOUND);
             }
             na.length = length + delta;
             return result;
@@ -1499,80 +1527,82 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     private static boolean isConcatSpreadable(Context cx, Scriptable scope, Object val) {
-      // First, look for the new @@isConcatSpreadable test as per ECMAScript 6 and up
-      if (val instanceof Scriptable) {
-        final Object spreadable =
-            ScriptableObject.getProperty((Scriptable)val, SymbolKey.IS_CONCAT_SPREADABLE);
-         if ((spreadable != Scriptable.NOT_FOUND) && !Undefined.isUndefined(spreadable)) {
-          // If @@isConcatSpreadable was undefined, we have to fall back to testing for an array.
-          // Otherwise, we found some value
-          return ScriptRuntime.toBoolean(spreadable);
+        // First, look for the new @@isConcatSpreadable test as per ECMAScript 6 and up
+        if (val instanceof Scriptable) {
+            final Object spreadable =
+                    ScriptableObject.getProperty((Scriptable) val, SymbolKey.IS_CONCAT_SPREADABLE);
+            if ((spreadable != Scriptable.NOT_FOUND) && !Undefined.isUndefined(spreadable)) {
+                // If @@isConcatSpreadable was undefined, we have to fall back to testing for an
+                // array.
+                // Otherwise, we found some value
+                return ScriptRuntime.toBoolean(spreadable);
+            }
         }
-      }
 
-      if (cx.getLanguageVersion() < Context.VERSION_ES6) {
-        // Otherwise, for older Rhino versions, fall back to the old algorithm, which treats things with
-        // the Array constructor as arrays. However, this is contrary to ES6!
-        final Function ctor = ScriptRuntime.getExistingCtor(cx, scope, "Array");
-        if (ScriptRuntime.instanceOf(val, ctor, cx)) {
-          return true;
+        if (cx.getLanguageVersion() < Context.VERSION_ES6) {
+            // Otherwise, for older Rhino versions, fall back to the old algorithm, which treats
+            // things with
+            // the Array constructor as arrays. However, this is contrary to ES6!
+            final Function ctor = ScriptRuntime.getExistingCtor(cx, scope, "Array");
+            if (ScriptRuntime.instanceOf(val, ctor, cx)) {
+                return true;
+            }
         }
-      }
 
-      // Otherwise, it's only spreadable if it's a native array
-      return js_isArray(val);
+        // Otherwise, it's only spreadable if it's a native array
+        return js_isArray(val);
     }
 
     // Concat elements of "arg" into the destination, with optimizations for native,
     // dense arrays.
-    private static long concatSpreadArg(Context cx,
-        Scriptable result, Scriptable arg, long offset) {
-      long srclen = getLengthProperty(cx, arg);
-      long newlen = srclen + offset;
+    private static long concatSpreadArg(
+            Context cx, Scriptable result, Scriptable arg, long offset) {
+        long srclen = getLengthProperty(cx, arg);
+        long newlen = srclen + offset;
 
-      // First, optimize for a pair of native, dense arrays
-      if ((newlen <= Integer.MAX_VALUE) && (result instanceof NativeArray)) {
-        final NativeArray denseResult = (NativeArray) result;
-        if (denseResult.denseOnly && (arg instanceof NativeArray)) {
-          final NativeArray denseArg = (NativeArray) arg;
-          if (denseArg.denseOnly) {
-            // Now we can optimize
-            denseResult.ensureCapacity((int) newlen);
-            System.arraycopy(denseArg.dense, 0, denseResult.dense, (int) offset, (int) srclen);
-            return newlen;
-          }
-          // We could also optimize here if we are copying to a dense target from a non-dense
-          // native array. However, if the source array is very sparse then the result will be
-          // very bad -- so don't.
+        // First, optimize for a pair of native, dense arrays
+        if ((newlen <= Integer.MAX_VALUE) && (result instanceof NativeArray)) {
+            final NativeArray denseResult = (NativeArray) result;
+            if (denseResult.denseOnly && (arg instanceof NativeArray)) {
+                final NativeArray denseArg = (NativeArray) arg;
+                if (denseArg.denseOnly) {
+                    // Now we can optimize
+                    denseResult.ensureCapacity((int) newlen);
+                    System.arraycopy(
+                            denseArg.dense, 0, denseResult.dense, (int) offset, (int) srclen);
+                    return newlen;
+                }
+                // We could also optimize here if we are copying to a dense target from a non-dense
+                // native array. However, if the source array is very sparse then the result will be
+                // very bad -- so don't.
+            }
         }
-      }
 
-      // If we get here then we have to do things the generic way
-      long dstpos = offset;
-      for (long srcpos = 0; srcpos < srclen; srcpos++, dstpos++) {
-        final Object temp = getRawElem(arg, srcpos);
-        if (temp != Scriptable.NOT_FOUND) {
-          defineElem(cx, result, dstpos, temp);
+        // If we get here then we have to do things the generic way
+        long dstpos = offset;
+        for (long srcpos = 0; srcpos < srclen; srcpos++, dstpos++) {
+            final Object temp = getRawElem(arg, srcpos);
+            if (temp != Scriptable.NOT_FOUND) {
+                defineElem(cx, result, dstpos, temp);
+            }
         }
-      }
-      return newlen;
+        return newlen;
     }
 
-    private static long doConcat(Context cx, Scriptable scope,
-      Scriptable result, Object arg, long offset) {
-      if (isConcatSpreadable(cx, scope, arg)) {
-        return concatSpreadArg(cx, result, (Scriptable) arg, offset);
-      }
-      defineElem(cx, result, offset, arg);
-      return offset + 1;
+    private static long doConcat(
+            Context cx, Scriptable scope, Scriptable result, Object arg, long offset) {
+        if (isConcatSpreadable(cx, scope, arg)) {
+            return concatSpreadArg(cx, result, (Scriptable) arg, offset);
+        }
+        defineElem(cx, result, offset, arg);
+        return offset + 1;
     }
 
     /*
      * See Ecma 262v3 15.4.4.4
      */
-    private static Scriptable js_concat(Context cx, Scriptable scope,
-                                        Scriptable thisObj, Object[] args)
-    {
+    private static Scriptable js_concat(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         // create an empty Array to return.
@@ -1581,15 +1611,15 @@ public class NativeArray extends IdScriptableObject implements List
 
         long length = doConcat(cx, scope, result, o, 0);
         for (Object arg : args) {
-          length = doConcat(cx, scope, result, arg, length);
+            length = doConcat(cx, scope, result, arg, length);
         }
 
         setLengthProperty(cx, result, length);
         return result;
     }
 
-    private static Scriptable js_slice(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Scriptable js_slice(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         long len = getLengthProperty(cx, o);
@@ -1630,18 +1660,18 @@ public class NativeArray extends IdScriptableObject implements List
             if (value + length < 0.0) {
                 result = 0;
             } else {
-                result = (long)(value + length);
+                result = (long) (value + length);
             }
         } else if (value > length) {
             result = length;
         } else {
-            result = (long)value;
+            result = (long) value;
         }
         return result;
     }
 
-    private static Object js_indexOf(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_indexOf(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
@@ -1661,11 +1691,10 @@ public class NativeArray extends IdScriptableObject implements List
             // default
             start = 0;
         } else {
-            start = (long)ScriptRuntime.toInteger(args[1]);
+            start = (long) ScriptRuntime.toInteger(args[1]);
             if (start < 0) {
                 start += length;
-                if (start < 0)
-                    start = 0;
+                if (start < 0) start = 0;
             }
             if (start > length - 1) return NEGATIVE_ONE;
         }
@@ -1673,21 +1702,19 @@ public class NativeArray extends IdScriptableObject implements List
             NativeArray na = (NativeArray) o;
             if (na.denseOnly) {
                 Scriptable proto = na.getPrototype();
-                for (int i=(int)start; i < length; i++) {
+                for (int i = (int) start; i < length; i++) {
                     Object val = na.dense[i];
                     if (val == NOT_FOUND && proto != null) {
                         val = ScriptableObject.getProperty(proto, i);
                     }
-                    if (val != NOT_FOUND &&
-                        ScriptRuntime.shallowEq(val, compareTo))
-                    {
+                    if (val != NOT_FOUND && ScriptRuntime.shallowEq(val, compareTo)) {
                         return Long.valueOf(i);
                     }
                 }
                 return NEGATIVE_ONE;
             }
         }
-        for (long i=start; i < length; i++) {
+        for (long i = start; i < length; i++) {
             Object val = getRawElem(o, i);
             if (val != NOT_FOUND && ScriptRuntime.shallowEq(val, compareTo)) {
                 return Long.valueOf(i);
@@ -1696,8 +1723,8 @@ public class NativeArray extends IdScriptableObject implements List
         return NEGATIVE_ONE;
     }
 
-    private static Object js_lastIndexOf(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_lastIndexOf(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
@@ -1716,34 +1743,30 @@ public class NativeArray extends IdScriptableObject implements List
         long start;
         if (args.length < 2) {
             // default
-            start = length-1;
+            start = length - 1;
         } else {
-            start = (long)ScriptRuntime.toInteger(args[1]);
-            if (start >= length)
-                start = length-1;
-            else if (start < 0)
-                start += length;
+            start = (long) ScriptRuntime.toInteger(args[1]);
+            if (start >= length) start = length - 1;
+            else if (start < 0) start += length;
             if (start < 0) return NEGATIVE_ONE;
         }
         if (o instanceof NativeArray) {
             NativeArray na = (NativeArray) o;
             if (na.denseOnly) {
                 Scriptable proto = na.getPrototype();
-                for (int i=(int)start; i >= 0; i--) {
+                for (int i = (int) start; i >= 0; i--) {
                     Object val = na.dense[i];
                     if (val == NOT_FOUND && proto != null) {
                         val = ScriptableObject.getProperty(proto, i);
                     }
-                    if (val != NOT_FOUND &&
-                        ScriptRuntime.shallowEq(val, compareTo))
-                    {
+                    if (val != NOT_FOUND && ScriptRuntime.shallowEq(val, compareTo)) {
                         return Long.valueOf(i);
                     }
                 }
                 return NEGATIVE_ONE;
             }
         }
-        for (long i=start; i >= 0; i--) {
+        for (long i = start; i >= 0; i--) {
             Object val = getRawElem(o, i);
             if (val != NOT_FOUND && ScriptRuntime.shallowEq(val, compareTo)) {
                 return Long.valueOf(i);
@@ -1755,11 +1778,12 @@ public class NativeArray extends IdScriptableObject implements List
     /*
        See ECMA-262 22.1.3.13
     */
-    private static Boolean js_includes(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Boolean js_includes(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-        long len = ScriptRuntime.toLength(new Object[]{getProperty(thisObj, "length")}, 0);
+        long len = ScriptRuntime.toLength(new Object[] {getProperty(thisObj, "length")}, 0);
         if (len == 0) return Boolean.FALSE;
 
         long k;
@@ -1769,8 +1793,7 @@ public class NativeArray extends IdScriptableObject implements List
             k = (long) ScriptRuntime.toInteger(args[1]);
             if (k < 0) {
                 k += len;
-                if (k < 0)
-                    k = 0;
+                if (k < 0) k = 0;
             }
             if (k > len - 1) return Boolean.FALSE;
         }
@@ -1805,8 +1828,7 @@ public class NativeArray extends IdScriptableObject implements List
         return Boolean.FALSE;
     }
 
-    private static Object js_fill(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_fill(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
         long len = getLengthProperty(cx, o);
 
@@ -1817,8 +1839,7 @@ public class NativeArray extends IdScriptableObject implements List
         final long k;
         if (relativeStart < 0) {
             k = Math.max((len + relativeStart), 0);
-        }
-        else {
+        } else {
             k = Math.min(relativeStart, len);
         }
 
@@ -1829,8 +1850,7 @@ public class NativeArray extends IdScriptableObject implements List
         final long fin;
         if (relativeEnd < 0) {
             fin = Math.max((len + relativeEnd), 0);
-        }
-        else {
+        } else {
             fin = Math.min(relativeEnd, len);
         }
 
@@ -1842,8 +1862,8 @@ public class NativeArray extends IdScriptableObject implements List
         return thisObj;
     }
 
-    private static Object js_copyWithin(Context cx, Scriptable scope, Scriptable thisObj, Object[] args)
-    {
+    private static Object js_copyWithin(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
         long len = getLengthProperty(cx, o);
 
@@ -1852,8 +1872,7 @@ public class NativeArray extends IdScriptableObject implements List
         long to;
         if (relativeTarget < 0) {
             to = Math.max((len + relativeTarget), 0);
-        }
-        else {
+        } else {
             to = Math.min(relativeTarget, len);
         }
 
@@ -1862,8 +1881,7 @@ public class NativeArray extends IdScriptableObject implements List
         long from;
         if (relativeStart < 0) {
             from = Math.max((len + relativeStart), 0);
-        }
-        else {
+        } else {
             from = Math.min(relativeStart, len);
         }
 
@@ -1874,8 +1892,7 @@ public class NativeArray extends IdScriptableObject implements List
         final long fin;
         if (relativeEnd < 0) {
             fin = Math.max((len + relativeEnd), 0);
-        }
-        else {
+        } else {
             fin = Math.min(relativeEnd, len);
         }
 
@@ -1893,7 +1910,7 @@ public class NativeArray extends IdScriptableObject implements List
             NativeArray na = (NativeArray) o;
             if (na.denseOnly) {
                 for (; count > 0; count--) {
-                    na.dense[(int)to] = na.dense[(int)from];
+                    na.dense[(int) to] = na.dense[(int) from];
                     from += direction;
                     to += direction;
                 }
@@ -1917,12 +1934,13 @@ public class NativeArray extends IdScriptableObject implements List
         return thisObj;
     }
 
-    /**
-     * Implements the methods "every", "filter", "forEach", "map", and "some".
-     */
-    private static Object iterativeMethod(Context cx, IdFunctionObject idFunctionObject, Scriptable scope,
-                                          Scriptable thisObj, Object[] args)
-    {
+    /** Implements the methods "every", "filter", "forEach", "map", and "some". */
+    private static Object iterativeMethod(
+            Context cx,
+            IdFunctionObject idFunctionObject,
+            Scriptable scope,
+            Scriptable thisObj,
+            Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         // execIdCall(..) uses a trick for all the ConstructorId_xxx calls
@@ -1944,11 +1962,15 @@ public class NativeArray extends IdScriptableObject implements List
         if (callbackArg == null || !(callbackArg instanceof Function)) {
             throw ScriptRuntime.notFunctionError(callbackArg);
         }
-        if (cx.getLanguageVersion() >= Context.VERSION_ES6 && (callbackArg instanceof NativeRegExp)) {
-            // Previously, it was allowed to pass RegExp instance as a callback (it implements Function)
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                && (callbackArg instanceof NativeRegExp)) {
+            // Previously, it was allowed to pass RegExp instance as a callback (it implements
+            // Function)
             // But according to ES2015 21.2.6 Properties of RegExp Instances:
-            // > RegExp instances are ordinary objects that inherit properties from the RegExp prototype object.
-            // > RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and [[OriginalFlags]].
+            // > RegExp instances are ordinary objects that inherit properties from the RegExp
+            // prototype object.
+            // > RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and
+            // [[OriginalFlags]].
             // so, no [[Call]] for RegExp-s
             throw ScriptRuntime.notFunctionError(callbackArg);
         }
@@ -1967,8 +1989,8 @@ public class NativeArray extends IdScriptableObject implements List
             int resultLength = id == Id_map ? (int) length : 0;
             array = cx.newArray(scope, resultLength);
         }
-        long j=0;
-        for (long i=0; i < length; i++) {
+        long j = 0;
+        for (long i = 0; i < length; i++) {
             Object[] innerArgs = new Object[3];
             Object elem = getRawElem(o, i);
             if (elem == Scriptable.NOT_FOUND) {
@@ -1983,55 +2005,47 @@ public class NativeArray extends IdScriptableObject implements List
             innerArgs[2] = o;
             Object result = f.call(cx, parent, thisArg, innerArgs);
             switch (id) {
-              case Id_every:
-                if (!ScriptRuntime.toBoolean(result))
-                    return Boolean.FALSE;
-                break;
-              case Id_filter:
-                if (ScriptRuntime.toBoolean(result))
-                    defineElem(cx, array, j++, innerArgs[0]);
-                break;
-              case Id_forEach:
-                break;
-              case Id_map:
-                defineElem(cx, array, i, result);
-                break;
-              case Id_some:
-                if (ScriptRuntime.toBoolean(result))
-                    return Boolean.TRUE;
-                break;
-              case Id_find:
-                if (ScriptRuntime.toBoolean(result))
-                    return elem;
-                break;
-              case Id_findIndex:
-                if (ScriptRuntime.toBoolean(result))
-                    return ScriptRuntime.wrapNumber(i);
-                break;
+                case Id_every:
+                    if (!ScriptRuntime.toBoolean(result)) return Boolean.FALSE;
+                    break;
+                case Id_filter:
+                    if (ScriptRuntime.toBoolean(result)) defineElem(cx, array, j++, innerArgs[0]);
+                    break;
+                case Id_forEach:
+                    break;
+                case Id_map:
+                    defineElem(cx, array, i, result);
+                    break;
+                case Id_some:
+                    if (ScriptRuntime.toBoolean(result)) return Boolean.TRUE;
+                    break;
+                case Id_find:
+                    if (ScriptRuntime.toBoolean(result)) return elem;
+                    break;
+                case Id_findIndex:
+                    if (ScriptRuntime.toBoolean(result)) return ScriptRuntime.wrapNumber(i);
+                    break;
             }
         }
         switch (id) {
-          case Id_every:
-            return Boolean.TRUE;
-          case Id_filter:
-          case Id_map:
-            return array;
-          case Id_some:
-            return Boolean.FALSE;
-          case Id_findIndex:
-            return ScriptRuntime.wrapNumber(-1);
-          case Id_forEach:
-          default:
-            return Undefined.instance;
+            case Id_every:
+                return Boolean.TRUE;
+            case Id_filter:
+            case Id_map:
+                return array;
+            case Id_some:
+                return Boolean.FALSE;
+            case Id_findIndex:
+                return ScriptRuntime.wrapNumber(-1);
+            case Id_forEach:
+            default:
+                return Undefined.instance;
         }
     }
 
-    /**
-     * Implements the methods "reduce" and "reduceRight".
-     */
-    private static Object reduceMethod(Context cx, int id, Scriptable scope,
-                                       Scriptable thisObj, Object[] args)
-    {
+    /** Implements the methods "reduce" and "reduceRight". */
+    private static Object reduceMethod(
+            Context cx, int id, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         long length = getLengthProperty(cx, o);
@@ -2054,7 +2068,7 @@ public class NativeArray extends IdScriptableObject implements List
                 // no initial value passed, use first element found as inital value
                 value = elem;
             } else {
-                Object[] innerArgs = { value, elem, Long.valueOf(index), o };
+                Object[] innerArgs = {value, elem, Long.valueOf(index), o};
                 value = f.call(cx, parent, parent, innerArgs);
             }
         }
@@ -2069,7 +2083,7 @@ public class NativeArray extends IdScriptableObject implements List
         if (!(o instanceof Scriptable)) {
             return false;
         }
-        return "Array".equals(((Scriptable)o).getClassName());
+        return "Array".equals(((Scriptable) o).getClassName());
     }
 
     // methods to implement java.util.List
@@ -2091,9 +2105,12 @@ public class NativeArray extends IdScriptableObject implements List
             throw new IllegalStateException();
         }
         int len = (int) longLen;
-        Object[] array = a.length >= len ?
-                a : (Object[]) java.lang.reflect.Array
-                .newInstance(a.getClass().getComponentType(), len);
+        Object[] array =
+                a.length >= len
+                        ? a
+                        : (Object[])
+                                java.lang.reflect.Array.newInstance(
+                                        a.getClass().getComponentType(), len);
         for (int i = 0; i < len; i++) {
             array[i] = get(i);
         }
@@ -2102,9 +2119,7 @@ public class NativeArray extends IdScriptableObject implements List
 
     @Override
     public boolean containsAll(Collection c) {
-        for (Object aC : c)
-            if (!contains(aC))
-                return false;
+        for (Object aC : c) if (!contains(aC)) return false;
         return true;
     }
 
@@ -2322,8 +2337,7 @@ public class NativeArray extends IdScriptableObject implements List
     }
 
     @Override
-    protected int findPrototypeId(Symbol k)
-    {
+    protected int findPrototypeId(Symbol k) {
         if (SymbolKey.ITERATOR.equals(k)) {
             return SymbolId_iterator;
         }
@@ -2335,268 +2349,251 @@ public class NativeArray extends IdScriptableObject implements List
     private static final Comparator<Object> STRING_COMPARATOR = new StringLikeComparator();
     private static final Comparator<Object> DEFAULT_COMPARATOR = new ElementComparator();
 
-    public static final class StringLikeComparator
-      implements Comparator<Object>, Serializable {
+    public static final class StringLikeComparator implements Comparator<Object>, Serializable {
 
-      private static final long serialVersionUID = 5299017659728190979L;
+        private static final long serialVersionUID = 5299017659728190979L;
 
-      @Override
-      public int compare(final Object x, final Object y) {
-        final String a = ScriptRuntime.toString(x);
-        final String b = ScriptRuntime.toString(y);
-        return a.compareTo(b);
-      }
+        @Override
+        public int compare(final Object x, final Object y) {
+            final String a = ScriptRuntime.toString(x);
+            final String b = ScriptRuntime.toString(y);
+            return a.compareTo(b);
+        }
     }
 
-    public static final class ElementComparator
-      implements Comparator<Object>, Serializable {
+    public static final class ElementComparator implements Comparator<Object>, Serializable {
 
-      private static final long serialVersionUID = -1189948017688708858L;
+        private static final long serialVersionUID = -1189948017688708858L;
 
-      private final Comparator<Object> child;
+        private final Comparator<Object> child;
 
-      public ElementComparator() {
-        child = STRING_COMPARATOR;
-      }
-
-      public ElementComparator(Comparator<Object> c) {
-        child = c;
-      }
-
-      @Override
-      public int compare(final Object x, final Object y) {
-        // Sort NOT_FOUND to very end, Undefined before that, exclusively, as per
-        // ECMA 22.1.3.25.1.
-        if (x == Undefined.instance) {
-          if (y == Undefined.instance) {
-            return 0;
-          }
-          if (y == NOT_FOUND) {
-            return -1;
-          }
-          return 1;
-        } else if (x == NOT_FOUND) {
-          return y == NOT_FOUND ? 0 : 1;
+        public ElementComparator() {
+            child = STRING_COMPARATOR;
         }
 
-        if (y == NOT_FOUND) {
-          return -1;
-        }
-        if (y == Undefined.instance) {
-          return -1;
+        public ElementComparator(Comparator<Object> c) {
+            child = c;
         }
 
-        return child.compare(x, y);
-      }
+        @Override
+        public int compare(final Object x, final Object y) {
+            // Sort NOT_FOUND to very end, Undefined before that, exclusively, as per
+            // ECMA 22.1.3.25.1.
+            if (x == Undefined.instance) {
+                if (y == Undefined.instance) {
+                    return 0;
+                }
+                if (y == NOT_FOUND) {
+                    return -1;
+                }
+                return 1;
+            } else if (x == NOT_FOUND) {
+                return y == NOT_FOUND ? 0 : 1;
+            }
+
+            if (y == NOT_FOUND) {
+                return -1;
+            }
+            if (y == Undefined.instance) {
+                return -1;
+            }
+
+            return child.compare(x, y);
+        }
     }
 
-// #string_id_map#
+    // #string_id_map#
 
     @Override
-    protected int findPrototypeId(String s)
-    {
+    protected int findPrototypeId(String s) {
         int id;
-// #generated# Last update: 2021-03-21 09:43:46 MEZ
+        // #generated# Last update: 2021-03-21 09:43:46 MEZ
         switch (s) {
-        case "constructor":
-            id = Id_constructor;
-            break;
-        case "toString":
-            id = Id_toString;
-            break;
-        case "toLocaleString":
-            id = Id_toLocaleString;
-            break;
-        case "toSource":
-            id = Id_toSource;
-            break;
-        case "join":
-            id = Id_join;
-            break;
-        case "reverse":
-            id = Id_reverse;
-            break;
-        case "sort":
-            id = Id_sort;
-            break;
-        case "push":
-            id = Id_push;
-            break;
-        case "pop":
-            id = Id_pop;
-            break;
-        case "shift":
-            id = Id_shift;
-            break;
-        case "unshift":
-            id = Id_unshift;
-            break;
-        case "splice":
-            id = Id_splice;
-            break;
-        case "concat":
-            id = Id_concat;
-            break;
-        case "slice":
-            id = Id_slice;
-            break;
-        case "indexOf":
-            id = Id_indexOf;
-            break;
-        case "lastIndexOf":
-            id = Id_lastIndexOf;
-            break;
-        case "every":
-            id = Id_every;
-            break;
-        case "filter":
-            id = Id_filter;
-            break;
-        case "forEach":
-            id = Id_forEach;
-            break;
-        case "map":
-            id = Id_map;
-            break;
-        case "some":
-            id = Id_some;
-            break;
-        case "find":
-            id = Id_find;
-            break;
-        case "findIndex":
-            id = Id_findIndex;
-            break;
-        case "reduce":
-            id = Id_reduce;
-            break;
-        case "reduceRight":
-            id = Id_reduceRight;
-            break;
-        case "fill":
-            id = Id_fill;
-            break;
-        case "keys":
-            id = Id_keys;
-            break;
-        case "values":
-            id = Id_values;
-            break;
-        case "entries":
-            id = Id_entries;
-            break;
-        case "includes":
-            id = Id_includes;
-            break;
-        case "copyWithin":
-            id = Id_copyWithin;
-            break;
-        default:
-            id = 0;
-            break;
+            case "constructor":
+                id = Id_constructor;
+                break;
+            case "toString":
+                id = Id_toString;
+                break;
+            case "toLocaleString":
+                id = Id_toLocaleString;
+                break;
+            case "toSource":
+                id = Id_toSource;
+                break;
+            case "join":
+                id = Id_join;
+                break;
+            case "reverse":
+                id = Id_reverse;
+                break;
+            case "sort":
+                id = Id_sort;
+                break;
+            case "push":
+                id = Id_push;
+                break;
+            case "pop":
+                id = Id_pop;
+                break;
+            case "shift":
+                id = Id_shift;
+                break;
+            case "unshift":
+                id = Id_unshift;
+                break;
+            case "splice":
+                id = Id_splice;
+                break;
+            case "concat":
+                id = Id_concat;
+                break;
+            case "slice":
+                id = Id_slice;
+                break;
+            case "indexOf":
+                id = Id_indexOf;
+                break;
+            case "lastIndexOf":
+                id = Id_lastIndexOf;
+                break;
+            case "every":
+                id = Id_every;
+                break;
+            case "filter":
+                id = Id_filter;
+                break;
+            case "forEach":
+                id = Id_forEach;
+                break;
+            case "map":
+                id = Id_map;
+                break;
+            case "some":
+                id = Id_some;
+                break;
+            case "find":
+                id = Id_find;
+                break;
+            case "findIndex":
+                id = Id_findIndex;
+                break;
+            case "reduce":
+                id = Id_reduce;
+                break;
+            case "reduceRight":
+                id = Id_reduceRight;
+                break;
+            case "fill":
+                id = Id_fill;
+                break;
+            case "keys":
+                id = Id_keys;
+                break;
+            case "values":
+                id = Id_values;
+                break;
+            case "entries":
+                id = Id_entries;
+                break;
+            case "includes":
+                id = Id_includes;
+                break;
+            case "copyWithin":
+                id = Id_copyWithin;
+                break;
+            default:
+                id = 0;
+                break;
         }
-// #/generated#
+        // #/generated#
         return id;
     }
 
-    private static final int
-        Id_constructor          = 1,
-        Id_toString             = 2,
-        Id_toLocaleString       = 3,
-        Id_toSource             = 4,
-        Id_join                 = 5,
-        Id_reverse              = 6,
-        Id_sort                 = 7,
-        Id_push                 = 8,
-        Id_pop                  = 9,
-        Id_shift                = 10,
-        Id_unshift              = 11,
-        Id_splice               = 12,
-        Id_concat               = 13,
-        Id_slice                = 14,
-        Id_indexOf              = 15,
-        Id_lastIndexOf          = 16,
-        Id_every                = 17,
-        Id_filter               = 18,
-        Id_forEach              = 19,
-        Id_map                  = 20,
-        Id_some                 = 21,
-        Id_find                 = 22,
-        Id_findIndex            = 23,
-        Id_reduce               = 24,
-        Id_reduceRight          = 25,
-        Id_fill                 = 26,
-        Id_keys                 = 27,
-        Id_values               = 28,
-        Id_entries              = 29,
-        Id_includes             = 30,
-        Id_copyWithin           = 31,
-        SymbolId_iterator       = 32,
+    private static final int Id_constructor = 1,
+            Id_toString = 2,
+            Id_toLocaleString = 3,
+            Id_toSource = 4,
+            Id_join = 5,
+            Id_reverse = 6,
+            Id_sort = 7,
+            Id_push = 8,
+            Id_pop = 9,
+            Id_shift = 10,
+            Id_unshift = 11,
+            Id_splice = 12,
+            Id_concat = 13,
+            Id_slice = 14,
+            Id_indexOf = 15,
+            Id_lastIndexOf = 16,
+            Id_every = 17,
+            Id_filter = 18,
+            Id_forEach = 19,
+            Id_map = 20,
+            Id_some = 21,
+            Id_find = 22,
+            Id_findIndex = 23,
+            Id_reduce = 24,
+            Id_reduceRight = 25,
+            Id_fill = 26,
+            Id_keys = 27,
+            Id_values = 28,
+            Id_entries = 29,
+            Id_includes = 30,
+            Id_copyWithin = 31,
+            SymbolId_iterator = 32,
+            MAX_PROTOTYPE_ID = SymbolId_iterator;
 
-        MAX_PROTOTYPE_ID        = SymbolId_iterator;
+    // #/string_id_map#
 
-// #/string_id_map#
+    private static final int ConstructorId_join = -Id_join,
+            ConstructorId_reverse = -Id_reverse,
+            ConstructorId_sort = -Id_sort,
+            ConstructorId_push = -Id_push,
+            ConstructorId_pop = -Id_pop,
+            ConstructorId_shift = -Id_shift,
+            ConstructorId_unshift = -Id_unshift,
+            ConstructorId_splice = -Id_splice,
+            ConstructorId_concat = -Id_concat,
+            ConstructorId_slice = -Id_slice,
+            ConstructorId_indexOf = -Id_indexOf,
+            ConstructorId_lastIndexOf = -Id_lastIndexOf,
+            ConstructorId_every = -Id_every,
+            ConstructorId_filter = -Id_filter,
+            ConstructorId_forEach = -Id_forEach,
+            ConstructorId_map = -Id_map,
+            ConstructorId_some = -Id_some,
+            ConstructorId_find = -Id_find,
+            ConstructorId_findIndex = -Id_findIndex,
+            ConstructorId_reduce = -Id_reduce,
+            ConstructorId_reduceRight = -Id_reduceRight,
+            ConstructorId_isArray = -26,
+            ConstructorId_of = -27,
+            ConstructorId_from = -28;
 
-    private static final int
-        ConstructorId_join                 = -Id_join,
-        ConstructorId_reverse              = -Id_reverse,
-        ConstructorId_sort                 = -Id_sort,
-        ConstructorId_push                 = -Id_push,
-        ConstructorId_pop                  = -Id_pop,
-        ConstructorId_shift                = -Id_shift,
-        ConstructorId_unshift              = -Id_unshift,
-        ConstructorId_splice               = -Id_splice,
-        ConstructorId_concat               = -Id_concat,
-        ConstructorId_slice                = -Id_slice,
-        ConstructorId_indexOf              = -Id_indexOf,
-        ConstructorId_lastIndexOf          = -Id_lastIndexOf,
-        ConstructorId_every                = -Id_every,
-        ConstructorId_filter               = -Id_filter,
-        ConstructorId_forEach              = -Id_forEach,
-        ConstructorId_map                  = -Id_map,
-        ConstructorId_some                 = -Id_some,
-        ConstructorId_find                 = -Id_find,
-        ConstructorId_findIndex            = -Id_findIndex,
-        ConstructorId_reduce               = -Id_reduce,
-        ConstructorId_reduceRight          = -Id_reduceRight,
-        ConstructorId_isArray              = -26,
-        ConstructorId_of                   = -27,
-        ConstructorId_from                 = -28;
-
-    /**
-     * Internal representation of the JavaScript array's length property.
-     */
+    /** Internal representation of the JavaScript array's length property. */
     private long length;
 
-    /**
-     * Attributes of the array's length property
-     */
+    /** Attributes of the array's length property */
     private int lengthAttr = DONTENUM | PERMANENT;
 
     /**
-     * Fast storage for dense arrays. Sparse arrays will use the superclass's
-     * hashtable storage scheme.
+     * Fast storage for dense arrays. Sparse arrays will use the superclass's hashtable storage
+     * scheme.
      */
     private Object[] dense;
 
-    /**
-     * True if all numeric properties are stored in <code>dense</code>.
-     */
+    /** True if all numeric properties are stored in <code>dense</code>. */
     private boolean denseOnly;
 
-    /**
-     * The maximum size of <code>dense</code> that will be allocated initially.
-     */
+    /** The maximum size of <code>dense</code> that will be allocated initially. */
     private static int maximumInitialCapacity = 10000;
 
-    /**
-     * The default capacity for <code>dense</code>.
-     */
+    /** The default capacity for <code>dense</code>. */
     private static final int DEFAULT_INITIAL_CAPACITY = 10;
 
-    /**
-     * The factor to grow <code>dense</code> by.
-     */
+    /** The factor to grow <code>dense</code> by. */
     private static final double GROW_FACTOR = 1.5;
-    private static final int MAX_PRE_GROW_SIZE = (int)(Integer.MAX_VALUE / GROW_FACTOR);
+
+    private static final int MAX_PRE_GROW_SIZE = (int) (Integer.MAX_VALUE / GROW_FACTOR);
 }

--- a/testsrc/jstests/xml-length-of-array-like.js
+++ b/testsrc/jstests/xml-length-of-array-like.js
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Test that ECMA-262 abstract method "LengthOfArrayLike" works on
+// XMLObject, which has a length method instead of length property.
+// The method is declared package-private, so we'll call it
+// indirectly instead.
+
+load('testsrc/assert.js');
+
+var xml = <xml><a>1</a><b>2</b><a>3</a><c>4</c></xml>;
+var {find, map, slice} = Array.prototype;
+
+var expected = 4;
+var actual = slice.call(xml.children(), 0).length;
+assertEquals(expected, actual);
+
+var expected = [<b>2</b>, <a>3</a>];
+var actual = slice.call(xml.children(), 1, 3);
+assertEquals(expected, actual);
+
+var expected = xml.a[1];
+var actual = find.call(xml.children(), x => x.toString() === "3");
+assertEquals(expected, actual);
+
+var expected = ["<a>1</a>", "<b>2</b>", "<a>3</a>", "<c>4</c>"];
+var actual = map.call(xml.children(), x => x.toXMLString());
+assertEquals(expected, actual);
+
+"success"

--- a/testsrc/org/mozilla/javascript/tests/XMLLengthOfArrayLikeTest.java
+++ b/testsrc/org/mozilla/javascript/tests/XMLLengthOfArrayLikeTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/xml-length-of-array-like.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class XMLLengthOfArrayLikeTest extends ScriptTestsBase {}


### PR DESCRIPTION
`XMLObject` is indexed like an array, but it has a `length()` method instead of a `length` property. This allows `XML` and `XMLList` objects to be used as arrays in several places, including many `Array.prototype` methods (see tests.)

This abstract method is implemented as `static long NativeArray.getLengthProperty(Context, Scriptable)`.
