### PR TITLE
A few small changes to NativeNumber

### DIFF
--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -23,6 +23,7 @@ final class NativeNumber extends IdScriptableObject {
 
     private static final int MAX_PRECISION = 100;
     private static final double MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
+    private static final double EPSILON = 2.220446049250313e-16; // Math.pow(2, -52)
 
     static void init(Scriptable scope, boolean sealed) {
         NativeNumber obj = new NativeNumber(0.0);
@@ -52,6 +53,7 @@ final class NativeNumber extends IdScriptableObject {
         ctor.defineProperty("MIN_VALUE", ScriptRuntime.wrapNumber(Double.MIN_VALUE), attr);
         ctor.defineProperty("MAX_SAFE_INTEGER", ScriptRuntime.wrapNumber(MAX_SAFE_INTEGER), attr);
         ctor.defineProperty("MIN_SAFE_INTEGER", ScriptRuntime.wrapNumber(MIN_SAFE_INTEGER), attr);
+        ctor.defineProperty("EPSILON", ScriptRuntime.wrapNumber(EPSILON), attr);
 
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isFinite, "isFinite", 1);
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isNaN, "isNaN", 1);

--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -59,8 +59,14 @@ final class NativeNumber extends IdScriptableObject {
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isNaN, "isNaN", 1);
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isInteger, "isInteger", 1);
         addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_isSafeInteger, "isSafeInteger", 1);
-        addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_parseFloat, "parseFloat", 1);
-        addIdFunctionProperty(ctor, NUMBER_TAG, ConstructorId_parseInt, "parseInt", 1);
+        Object parseFloat = ScriptRuntime.getTopLevelProp(ctor, "parseFloat");
+        if (parseFloat instanceof IdFunctionObject) {
+            ((IdFunctionObject) parseFloat).addAsProperty(ctor);
+        }
+        Object parseInt = ScriptRuntime.getTopLevelProp(ctor, "parseInt");
+        if (parseInt instanceof IdFunctionObject) {
+            ((IdFunctionObject) parseInt).addAsProperty(ctor);
+        }
 
         super.fillConstructorProperties(ctor);
     }
@@ -238,12 +244,6 @@ final class NativeNumber extends IdScriptableObject {
                 }
                 return Boolean.FALSE;
 
-            case ConstructorId_parseFloat:
-                return NativeGlobal.js_parseFloat(args);
-
-            case ConstructorId_parseInt:
-                return NativeGlobal.js_parseInt(args);
-
             default:
                 throw new IllegalArgumentException(String.valueOf(id));
         }
@@ -371,8 +371,6 @@ final class NativeNumber extends IdScriptableObject {
             ConstructorId_isNaN = -2,
             ConstructorId_isInteger = -3,
             ConstructorId_isSafeInteger = -4,
-            ConstructorId_parseFloat = -5,
-            ConstructorId_parseInt = -6,
             Id_constructor = 1,
             Id_toString = 2,
             Id_toLocaleString = 3,

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -651,7 +651,6 @@ built-ins/NativeErrors
     ! message_property_native_error.js
 
 built-ins/Number
-    ! EPSILON.js
     ! prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     ! prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     ! prototype/toExponential/undefined-fractiondigits.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -656,10 +656,6 @@ built-ins/Number
     ! prototype/toExponential/undefined-fractiondigits.js
     ! prototype/toLocaleString/length.js
     ! prototype/toPrecision/nan.js
-# Number.parseInt === parseInt and Number.parseFloat === parseFloat
-# but they aren't in Rhino
-    ! parseFloat.js
-    ! parseInt.js
 
 built-ins/Object
     ! assign/strings-and-symbol-order.js


### PR DESCRIPTION
- Implement `Number.EPSILON`
- `Number.parseFloat` and `Number.parseInt` use the same built-in function objects that are the initial value of the "parseFloat" and "parseInt" properties of the global object.

