### PR TITLE
Improve toNumeric speed

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -825,8 +825,10 @@ public class ScriptRuntime {
     }
 
     public static Number toNumeric(Object val) {
-        if (val instanceof BigInteger) {
-            return (BigInteger) val;
+        // toNumber does not allow java.math.BigInteger.
+        // toNumeric allows java.math.BigInteger.
+        if (val instanceof Number) {
+            return (Number) val;
         }
         return toNumber(val);
     }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -824,9 +824,14 @@ public class ScriptRuntime {
         }
     }
 
+    /**
+     * Convert the value to a Numeric (Number or BigInt).
+     *
+     * <p>toNumber does not allow java.math.BigInteger. toNumeric allows java.math.BigInteger.
+     *
+     * <p>See ECMA 7.1.3 (v11.0).
+     */
     public static Number toNumeric(Object val) {
-        // toNumber does not allow java.math.BigInteger.
-        // toNumeric allows java.math.BigInteger.
         if (val instanceof Number) {
             return (Number) val;
         }


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1kVJf1UTVSk_SZ4PqVtVMxnD_DMQ6zWxE4ijmsAFCa-o/edit?usp=sharing

This change did not change the `./gradlew testBenchmark` results much.
However, when I changed the measurements here, some of them improved greatly.
https://github.com/mozilla/rhino/blob/189b1096fced52490ddc96ea854210e7a3d7497e/benchmarks/org/mozilla/javascript/benchmarks/SunSpiderBenchmark.java#L28
https://github.com/mozilla/rhino/blob/189b1096fced52490ddc96ea854210e7a3d7497e/benchmarks/org/mozilla/javascript/benchmarks/V8Benchmark.java#L42
```diff
-      cx.setOptimizationLevel(9);
+      cx.setOptimizationLevel(0);
```
When OptimizationLevel is set to 9, optimization is performed by `childNumberFlag`, so it seems difficult to measure the speed decrease caused by BigInt.
https://github.com/mozilla/rhino/blob/189b1096fced52490ddc96ea854210e7a3d7497e/src/org/mozilla/javascript/optimizer/BodyCodegen.java#L3366

With this PR, when OptimizationLevel is 9, the SunSpiderBenchmark.accessFannkuch is slowed down when OptimizationLevel is 9. (Please see the `chart` sheet)
However, when OptimizationLevel is 0, there is a big improvement in SunSpiderBenchmark.accessNBody, SunSpiderBenchmark.accessNsieve, and V8Benchmark.cryptoDecrypt. (Please see the `chart.opt0` sheet)

Even when OptimizationLevel is set to 9, depending on how the code is written, the optimization by `childNumberFlag` may or may not be performed.