### PR TITLE
Optimize Token.POS and Token.NEG

### DIFF
--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1233,16 +1233,29 @@ class BodyCodegen {
                 break;
 
             case Token.POS:
-                generateExpression(child, node);
-                addObjectToDouble();
-                addDoubleWrap();
-                break;
+                {
+                    int childNumberFlag = node.getIntProp(Node.ISNUMBER_PROP, -1);
+                    generateExpression(child, node);
+                    if (childNumberFlag == -1) {
+                        addObjectToDouble();
+                        addDoubleWrap();
+                    }
+                    break;
+                }
 
             case Token.NEG:
-                generateExpression(child, node);
-                addObjectToNumeric();
-                addScriptRuntimeInvoke("negate", "(Ljava/lang/Number;" + ")Ljava/lang/Number;");
-                break;
+                {
+                    int childNumberFlag = node.getIntProp(Node.ISNUMBER_PROP, -1);
+                    generateExpression(child, node);
+                    if (childNumberFlag == -1) {
+                        addObjectToNumeric();
+                        addScriptRuntimeInvoke(
+                                "negate", "(Ljava/lang/Number;" + ")Ljava/lang/Number;");
+                    } else {
+                        cfw.add(ByteCode.DNEG);
+                    }
+                    break;
+                }
 
             case Token.TO_DOUBLE:
                 // cnvt to double (not Double)

--- a/src/org/mozilla/javascript/optimizer/Optimizer.java
+++ b/src/org/mozilla/javascript/optimizer/Optimizer.java
@@ -303,6 +303,8 @@ class Optimizer {
                 }
 
             case Token.BITNOT:
+            case Token.POS:
+            case Token.NEG:
                 {
                     Node child = n.getFirstChild();
                     int type = rewriteForNumberVariables(child, NumberType);

--- a/testsrc/jstests/es2020/bigint.js
+++ b/testsrc/jstests/es2020/bigint.js
@@ -7,16 +7,32 @@ load("testsrc/assert.js");
 // optimizer test
 const one = 1n;
 assertEquals(2n, (() => 1n + one)());
+assertEquals(2n, (() => one + 1n)());
 assertEquals(0n, (() => 1n - one)());
+assertEquals(0n, (() => one - 1n)());
 assertEquals(1n, (() => 1n * one)());
+assertEquals(1n, (() => one * 1n)());
 assertEquals(1n, (() => 1n / one)());
+assertEquals(1n, (() => one / 1n)());
 assertEquals(0n, (() => 1n % one)());
+assertEquals(0n, (() => one % 1n)());
 assertEquals(1n, (() => 1n ** one)());
+assertEquals(1n, (() => one ** 1n)());
+
 assertEquals(0n, (() => 1n ^ one)());
+assertEquals(0n, (() => one ^ 1n)());
 assertEquals(1n, (() => 1n | one)());
+assertEquals(1n, (() => one | 1n)());
 assertEquals(1n, (() => 1n & one)());
+assertEquals(1n, (() => one & 1n)());
 assertEquals(2n, (() => 1n << one)());
+assertEquals(2n, (() => one << 1n)());
 assertEquals(0n, (() => 1n >> one)());
+assertEquals(0n, (() => one >> 1n)());
+
+assertEquals(-2n, (() => { var n = 1n; return ~n; })());
+assertThrows(() => {var n = 1n; return +n; }, TypeError);
+assertEquals(-1n, (() => { var n = 1n; return -n; })());
 
 // Out of range check for BigInt
 const MAX_INT = 2n ** 31n - 1n;

--- a/testsrc/jstests/optimizer/isnumber-prop.js
+++ b/testsrc/jstests/optimizer/isnumber-prop.js
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+// Optimizer.rewriteForNumberVariables
+const one = 1;
+
+assertEquals(2, (() => 1 + one)());
+assertEquals(2, (() => one + 1)());
+assertEquals(0, (() => 1 - one)());
+assertEquals(0, (() => one - 1)());
+assertEquals(1, (() => 1 * one)());
+assertEquals(1, (() => one * 1)());
+assertEquals(1, (() => 1 / one)());
+assertEquals(1, (() => one / 1)());
+assertEquals(0, (() => 1 % one)());
+assertEquals(0, (() => one % 1)());
+assertEquals(1, (() => 1 ** one)());
+assertEquals(1, (() => one ** 1)());
+
+assertEquals(0, (() => 1 ^ one)());
+assertEquals(0, (() => one ^ 1)());
+assertEquals(1, (() => 1 | one)());
+assertEquals(1, (() => one | 1)());
+assertEquals(1, (() => 1 & one)());
+assertEquals(1, (() => one & 1)());
+assertEquals(2, (() => 1 << one)());
+assertEquals(2, (() => one << 1)());
+assertEquals(0, (() => 1 >> one)());
+assertEquals(0, (() => one >> 1)());
+
+assertEquals(-2, (() => { var n = 1; return ~n; })());
+assertEquals(1, (() => { var n = 1; return +n; })());
+assertEquals(-1, (() => { var n = 1; return -n; })());
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/Bug708801Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug708801Test.java
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/**
- * 
- */
+/** */
 package org.mozilla.javascript.tests;
 
 import static java.lang.String.format;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import org.junit.Test;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
@@ -33,24 +30,22 @@ import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.optimizer.Codegen;
 import org.mozilla.javascript.optimizer.OptFunctionNode;
 
-/**
- * @author André Bargull
- * 
- */
+/** @author André Bargull */
 public class Bug708801Test {
-    private static final ContextFactory factory = new ContextFactory() {
-        static final int COMPILER_MODE = 9;
+    private static final ContextFactory factory =
+            new ContextFactory() {
+                static final int COMPILER_MODE = 9;
 
-        @Override
-        protected Context makeContext() {
-            Context cx = super.makeContext();
-            cx.setLanguageVersion(Context.VERSION_1_8);
-            cx.setOptimizationLevel(COMPILER_MODE);
-            return cx;
-        }
-    };
+                @Override
+                protected Context makeContext() {
+                    Context cx = super.makeContext();
+                    cx.setLanguageVersion(Context.VERSION_1_8);
+                    cx.setOptimizationLevel(COMPILER_MODE);
+                    return cx;
+                }
+            };
 
-    private static abstract class Action implements ContextAction<Object> {
+    private abstract static class Action implements ContextAction<Object> {
         protected Context cx;
         protected ScriptableObject scope;
 
@@ -59,18 +54,14 @@ public class Bug708801Test {
             return cx.evaluateString(scope, s, "<eval>", 1, null);
         }
 
-        /**
-         * Compiles {@code source} and returns the transformed and optimized
-         * {@link ScriptNode}
-         */
+        /** Compiles {@code source} and returns the transformed and optimized {@link ScriptNode} */
         protected ScriptNode compile(CharSequence source) {
             final String mainMethodClassName = "Main";
             final String scriptClassName = "Main";
 
             CompilerEnvirons compilerEnv = new CompilerEnvirons();
             compilerEnv.initFromContext(cx);
-            ErrorReporter compilationErrorReporter = compilerEnv
-                    .getErrorReporter();
+            ErrorReporter compilationErrorReporter = compilerEnv.getErrorReporter();
             Parser p = new Parser(compilerEnv, compilationErrorReporter);
             AstRoot ast = p.parse(source.toString(), "<eval>", 1);
             IRFactory irf = new IRFactory(compilerEnv);
@@ -78,15 +69,15 @@ public class Bug708801Test {
 
             Codegen codegen = new Codegen();
             codegen.setMainMethodClass(mainMethodClassName);
-            codegen.compileToClassFile(compilerEnv, scriptClassName, tree,
-                    tree.getEncodedSource(), false);
+            codegen.compileToClassFile(
+                    compilerEnv, scriptClassName, tree, tree.getEncodedSource(), false);
 
             return tree;
         }
 
         /**
-         * Checks every variable {@code v} in {@code source} is marked as a
-         * number-variable iff {@code numbers} contains {@code v}
+         * Checks every variable {@code v} in {@code source} is marked as a number-variable iff
+         * {@code numbers} contains {@code v}
          */
         protected void assertNumberVars(CharSequence source, String... numbers) {
             // wrap source in function
@@ -123,194 +114,196 @@ public class Bug708801Test {
 
     @Test
     public void testIncDec() {
-        factory.call(new Action() {
-            @Override
-            protected Object run() {
-                // pre-inc
-                assertNumberVars("var b; ++b");
-                assertNumberVars("var b=0; ++b", "b");
-                assertNumberVars("var b; ++[1][++b]");
-                assertNumberVars("var b=0; ++[1][++b]", "b");
-                assertNumberVars("var b; ++[1][b=0,++b]", "b");
-                // pre-dec
-                assertNumberVars("var b; --b");
-                assertNumberVars("var b=0; --b", "b");
-                assertNumberVars("var b; --[1][--b]");
-                assertNumberVars("var b=0; --[1][--b]", "b");
-                assertNumberVars("var b; --[1][b=0,--b]", "b");
-                // post-inc
-                assertNumberVars("var b; b++");
-                assertNumberVars("var b=0; b++", "b");
-                assertNumberVars("var b; [1][b++]++");
-                assertNumberVars("var b=0; [1][b++]++", "b");
-                assertNumberVars("var b; [1][b=0,b++]++", "b");
-                // post-dec
-                assertNumberVars("var b; b--");
-                assertNumberVars("var b=0; b--", "b");
-                assertNumberVars("var b; [1][b--]--");
-                assertNumberVars("var b=0; [1][b--]--", "b");
-                assertNumberVars("var b; [1][b=0,b--]--", "b");
-                return null;
-            }
-        });
+        factory.call(
+                new Action() {
+                    @Override
+                    protected Object run() {
+                        // pre-inc
+                        assertNumberVars("var b; ++b");
+                        assertNumberVars("var b=0; ++b", "b");
+                        assertNumberVars("var b; ++[1][++b]");
+                        assertNumberVars("var b=0; ++[1][++b]", "b");
+                        assertNumberVars("var b; ++[1][b=0,++b]", "b");
+                        // pre-dec
+                        assertNumberVars("var b; --b");
+                        assertNumberVars("var b=0; --b", "b");
+                        assertNumberVars("var b; --[1][--b]");
+                        assertNumberVars("var b=0; --[1][--b]", "b");
+                        assertNumberVars("var b; --[1][b=0,--b]", "b");
+                        // post-inc
+                        assertNumberVars("var b; b++");
+                        assertNumberVars("var b=0; b++", "b");
+                        assertNumberVars("var b; [1][b++]++");
+                        assertNumberVars("var b=0; [1][b++]++", "b");
+                        assertNumberVars("var b; [1][b=0,b++]++", "b");
+                        // post-dec
+                        assertNumberVars("var b; b--");
+                        assertNumberVars("var b=0; b--", "b");
+                        assertNumberVars("var b; [1][b--]--");
+                        assertNumberVars("var b=0; [1][b--]--", "b");
+                        assertNumberVars("var b; [1][b=0,b--]--", "b");
+                        return null;
+                    }
+                });
     }
 
     @Test
     public void testTypeofName() {
-        factory.call(new Action() {
-            @Override
-            protected Object run() {
-                // Token.TYPEOFNAME
-                assertNumberVars("var b; typeof b");
-                assertNumberVars("var b=0; typeof b", "b");
-                assertNumberVars("var b; if(new Date()<0){b=0} typeof b");
-                // Token.TYPEOF
-                assertNumberVars("var b; typeof (b,b)");
-                assertNumberVars("var b=0; typeof (b,b)", "b");
-                assertNumberVars("var b; if(new Date()<0){b=0} typeof (b,b)");
+        factory.call(
+                new Action() {
+                    @Override
+                    protected Object run() {
+                        // Token.TYPEOFNAME
+                        assertNumberVars("var b; typeof b");
+                        assertNumberVars("var b=0; typeof b", "b");
+                        assertNumberVars("var b; if(new Date()<0){b=0} typeof b");
+                        // Token.TYPEOF
+                        assertNumberVars("var b; typeof (b,b)");
+                        assertNumberVars("var b=0; typeof (b,b)", "b");
+                        assertNumberVars("var b; if(new Date()<0){b=0} typeof (b,b)");
 
-                return null;
-            }
-        });
+                        return null;
+                    }
+                });
     }
 
     @Test
     public void testEval() {
-        factory.call(new Action() {
-            @Override
-            protected Object run() {
-                // direct eval => requires activation
-                assertNumberVars("var b; eval('typeof b')");
-                assertNumberVars("var b=0; eval('typeof b')");
-                assertNumberVars("var b; if(new Date()<0){b=0} eval('typeof b')");
+        factory.call(
+                new Action() {
+                    @Override
+                    protected Object run() {
+                        // direct eval => requires activation
+                        assertNumberVars("var b; eval('typeof b')");
+                        assertNumberVars("var b=0; eval('typeof b')");
+                        assertNumberVars("var b; if(new Date()<0){b=0} eval('typeof b')");
 
-                // indirect eval => requires no activation
-                assertNumberVars("var b; (1,eval)('typeof b');");
-                assertNumberVars("var b=0; (1,eval)('typeof b')", "b");
-                assertNumberVars(
-                        "var b; if(new Date()<0){b=0} (1,eval)('typeof b')",
-                        "b");
+                        // indirect eval => requires no activation
+                        assertNumberVars("var b; (1,eval)('typeof b');");
+                        assertNumberVars("var b=0; (1,eval)('typeof b')", "b");
+                        assertNumberVars("var b; if(new Date()<0){b=0} (1,eval)('typeof b')", "b");
 
-                return null;
-            }
-        });
+                        return null;
+                    }
+                });
     }
 
     @Test
     public void testRelOp() {
-        factory.call(new Action() {
-            @Override
-            protected Object run() {
-                // relational operators: <, <=, >, >=
-                assertNumberVars("var b = 1 < 1");
-                assertNumberVars("var b = 1 <= 1");
-                assertNumberVars("var b = 1 > 1");
-                assertNumberVars("var b = 1 >= 1");
-                // equality operators: ==, !=, ===, !==
-                assertNumberVars("var b = 1 == 1");
-                assertNumberVars("var b = 1 != 1");
-                assertNumberVars("var b = 1 === 1");
-                assertNumberVars("var b = 1 !== 1");
+        factory.call(
+                new Action() {
+                    @Override
+                    protected Object run() {
+                        // relational operators: <, <=, >, >=
+                        assertNumberVars("var b = 1 < 1");
+                        assertNumberVars("var b = 1 <= 1");
+                        assertNumberVars("var b = 1 > 1");
+                        assertNumberVars("var b = 1 >= 1");
+                        // equality operators: ==, !=, ===, !==
+                        assertNumberVars("var b = 1 == 1");
+                        assertNumberVars("var b = 1 != 1");
+                        assertNumberVars("var b = 1 === 1");
+                        assertNumberVars("var b = 1 !== 1");
 
-                return null;
-            }
-        });
+                        return null;
+                    }
+                });
     }
 
     @Test
     public void testMore() {
-        factory.call(new Action() {
-            @Override
-            protected Object run() {
-                // simple assignment:
-                assertNumberVars("var b");
-                assertNumberVars("var b = 1", "b");
-                assertNumberVars("var b = 'a'");
-                assertNumberVars("var b = true");
-                assertNumberVars("var b = /(?:)/");
-                assertNumberVars("var b = o");
-                assertNumberVars("var b = fn");
-                // use before assignment
-                assertNumberVars("b; var b = 1");
-                assertNumberVars("b || c; var b = 1, c = 2");
-                assertNumberVars("if(b) var b = 1");
-                assertNumberVars("typeof b; var b=1");
-                assertNumberVars("typeof (b,b); var b=1");
-                // relational operators: in, instanceof
-                assertNumberVars("var b = 1 instanceof 1");
-                assertNumberVars("var b = 1 in 1");
-                // other operators with nested comma expression:
-                assertNumberVars("var b = !(1,1)");
-                assertNumberVars("var b = typeof(1,1)");
-                assertNumberVars("var b = void(1,1)");
-                // nested assignment
-                assertNumberVars("var b = 1; var f = (b = 'a')");
-                // let expression:
-                assertNumberVars("var b = let(x=1) x", "b", "x");
-                assertNumberVars("var b = let(x=1,y=1) x,y", "b", "x", "y");
-                // conditional operator:
-                assertNumberVars("var b = 0 ? 1 : 2", "b");
-                assertNumberVars("var b = 'a' ? 1 : 2", "b");
-                // comma expression:
-                assertNumberVars("var b = (0,1)", "b");
-                assertNumberVars("var b = ('a',1)", "b");
-                // assignment operations:
-                assertNumberVars("var b; var c=0; b=c", "b", "c");
-                assertNumberVars("var b; var c=0; b=(c=1)", "b", "c");
-                assertNumberVars("var b; var c=0; b=(c='a')");
-                assertNumberVars("var b; var c=0; b=(c+=1)", "b", "c");
-                assertNumberVars("var b; var c=0; b=(c*=1)", "b", "c");
-                assertNumberVars("var b; var c=0; b=(c%=1)", "b", "c");
-                assertNumberVars("var b; var c=0; b=(c/=1)", "b", "c");
-                // property access:
-                assertNumberVars("var b; b=(o.p)");
-                assertNumberVars("var b; b=(o.p=1)", "b");
-                assertNumberVars("var b; b=(o.p+=1)");
-                assertNumberVars("var b; b=(o['p']=1)", "b");
-                assertNumberVars("var b; b=(o['p']+=1)");
-                assertNumberVars("var b; var o = {p:0}; b=(o.p=1)", "b");
-                assertNumberVars("var b; var o = {p:0}; b=(o.p+=1)");
-                assertNumberVars("var b; var o = {p:0}; b=(o['p']=1)", "b");
-                assertNumberVars("var b; var o = {p:0}; b=(o['p']+=1)");
-                assertNumberVars("var b = 1; b.p = true", "b");
-                assertNumberVars("var b = 1; b.p", "b");
-                assertNumberVars("var b = 1; b.p()", "b");
-                assertNumberVars("var b = 1; b[0] = true", "b");
-                assertNumberVars("var b = 1; b[0]", "b");
-                assertNumberVars("var b = 1; b[0]()", "b");
-                // assignment (global)
-                assertNumberVars("var b = foo");
-                assertNumberVars("var b = foo1=1", "b");
-                assertNumberVars("var b = foo2+=1");
-                // boolean operators:
-                assertNumberVars("var b = 1||2", "b");
-                assertNumberVars("var b; var c=1; b=c||2", "b", "c");
-                assertNumberVars("var b; var c=1; b=c||c||2", "b", "c");
-                assertNumberVars("var b = 1&&2", "b");
-                assertNumberVars("var b; var c=1; b=c&&2", "b", "c");
-                assertNumberVars("var b; var c=1; b=c&&c&&2", "b", "c");
-                // bit not:
-                assertNumberVars("var b = ~0", "b");
-                assertNumberVars("var b = ~o", "b");
-                assertNumberVars("var b; var c=1; b=~c", "b", "c");
-                // increment, function call:
-                assertNumberVars("var b; var g; b = (g=0,g++)", "b", "g");
-                assertNumberVars("var b; var x = fn(b=1)", "b");
-                assertNumberVars("var b; var x = fn(b=1).p++", "b", "x");
-                assertNumberVars("var b; ({1:{}})[b=1].p++", "b");
-                assertNumberVars("var b; o[b=1]++", "b");
-                // destructuring
-                assertNumberVars("var r,s; [r,s] = [1,1]");
-                assertNumberVars("var r=0, s=0; [r,s] = [1,1]");
-                assertNumberVars("var r,s; ({a: r, b: s}) = {a:1, b:1}");
-                assertNumberVars("var r=0, s=0; ({a: r, b: s}) = {a:1, b:1}");
-                // array comprehension
-                assertNumberVars("var b=[i*i for each (i in [1,2,3])]");
-                assertNumberVars("var b=[j*j for each (j in [1,2,3]) if (j>1)]");
+        factory.call(
+                new Action() {
+                    @Override
+                    protected Object run() {
+                        // simple assignment:
+                        assertNumberVars("var b");
+                        assertNumberVars("var b = 1", "b");
+                        assertNumberVars("var b = 'a'");
+                        assertNumberVars("var b = true");
+                        assertNumberVars("var b = /(?:)/");
+                        assertNumberVars("var b = o");
+                        assertNumberVars("var b = fn");
+                        // use before assignment
+                        assertNumberVars("b; var b = 1");
+                        assertNumberVars("b || c; var b = 1, c = 2");
+                        assertNumberVars("if(b) var b = 1");
+                        assertNumberVars("typeof b; var b=1");
+                        assertNumberVars("typeof (b,b); var b=1");
+                        // relational operators: in, instanceof
+                        assertNumberVars("var b = 1 instanceof 1");
+                        assertNumberVars("var b = 1 in 1");
+                        // other operators with nested comma expression:
+                        assertNumberVars("var b = !(1,1)");
+                        assertNumberVars("var b = typeof(1,1)");
+                        assertNumberVars("var b = void(1,1)");
+                        // nested assignment
+                        assertNumberVars("var b = 1; var f = (b = 'a')");
+                        // let expression:
+                        assertNumberVars("var b = let(x=1) x", "b", "x");
+                        assertNumberVars("var b = let(x=1,y=1) x,y", "b", "x", "y");
+                        // conditional operator:
+                        assertNumberVars("var b = 0 ? 1 : 2", "b");
+                        assertNumberVars("var b = 'a' ? 1 : 2", "b");
+                        // comma expression:
+                        assertNumberVars("var b = (0,1)", "b");
+                        assertNumberVars("var b = ('a',1)", "b");
+                        // assignment operations:
+                        assertNumberVars("var b; var c=0; b=c", "b", "c");
+                        assertNumberVars("var b; var c=0; b=(c=1)", "b", "c");
+                        assertNumberVars("var b; var c=0; b=(c='a')");
+                        assertNumberVars("var b; var c=0; b=(c+=1)", "b", "c");
+                        assertNumberVars("var b; var c=0; b=(c*=1)", "b", "c");
+                        assertNumberVars("var b; var c=0; b=(c%=1)", "b", "c");
+                        assertNumberVars("var b; var c=0; b=(c/=1)", "b", "c");
+                        // property access:
+                        assertNumberVars("var b; b=(o.p)");
+                        assertNumberVars("var b; b=(o.p=1)", "b");
+                        assertNumberVars("var b; b=(o.p+=1)");
+                        assertNumberVars("var b; b=(o['p']=1)", "b");
+                        assertNumberVars("var b; b=(o['p']+=1)");
+                        assertNumberVars("var b; var o = {p:0}; b=(o.p=1)", "b");
+                        assertNumberVars("var b; var o = {p:0}; b=(o.p+=1)");
+                        assertNumberVars("var b; var o = {p:0}; b=(o['p']=1)", "b");
+                        assertNumberVars("var b; var o = {p:0}; b=(o['p']+=1)");
+                        assertNumberVars("var b = 1; b.p = true", "b");
+                        assertNumberVars("var b = 1; b.p", "b");
+                        assertNumberVars("var b = 1; b.p()", "b");
+                        assertNumberVars("var b = 1; b[0] = true", "b");
+                        assertNumberVars("var b = 1; b[0]", "b");
+                        assertNumberVars("var b = 1; b[0]()", "b");
+                        // assignment (global)
+                        assertNumberVars("var b = foo");
+                        assertNumberVars("var b = foo1=1", "b");
+                        assertNumberVars("var b = foo2+=1");
+                        // boolean operators:
+                        assertNumberVars("var b = 1||2", "b");
+                        assertNumberVars("var b; var c=1; b=c||2", "b", "c");
+                        assertNumberVars("var b; var c=1; b=c||c||2", "b", "c");
+                        assertNumberVars("var b = 1&&2", "b");
+                        assertNumberVars("var b; var c=1; b=c&&2", "b", "c");
+                        assertNumberVars("var b; var c=1; b=c&&c&&2", "b", "c");
+                        // bit not:
+                        assertNumberVars("var b = ~0", "b");
+                        assertNumberVars("var b = ~o", "b");
+                        assertNumberVars("var b; var c=1; b=~c", "b", "c");
+                        // increment, function call:
+                        assertNumberVars("var b; var g; b = (g=0,g++)", "b", "g");
+                        assertNumberVars("var b; var x = fn(b=1)", "b");
+                        assertNumberVars("var b; var x = fn(b=1).p++", "b", "x");
+                        assertNumberVars("var b; ({1:{}})[b=1].p++", "b");
+                        assertNumberVars("var b; o[b=1]++", "b");
+                        // destructuring
+                        assertNumberVars("var r,s; [r,s] = [1,1]");
+                        assertNumberVars("var r=0, s=0; [r,s] = [1,1]");
+                        assertNumberVars("var r,s; ({a: r, b: s}) = {a:1, b:1}");
+                        assertNumberVars("var r=0, s=0; ({a: r, b: s}) = {a:1, b:1}");
+                        // array comprehension
+                        assertNumberVars("var b=[i*i for each (i in [1,2,3])]");
+                        assertNumberVars("var b=[j*j for each (j in [1,2,3]) if (j>1)]");
 
-                return null;
-            }
-        });
+                        return null;
+                    }
+                });
     }
-
 }

--- a/testsrc/org/mozilla/javascript/tests/Bug708801Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Bug708801Test.java
@@ -286,7 +286,21 @@ public class Bug708801Test {
                         // bit not:
                         assertNumberVars("var b = ~0", "b");
                         assertNumberVars("var b = ~o", "b");
+                        assertNumberVars("var b = ~o.a", "b");
+                        assertNumberVars("var b = ~o[0]", "b");
                         assertNumberVars("var b; var c=1; b=~c", "b", "c");
+                        // unary plus:
+                        assertNumberVars("var b = +0", "b");
+                        assertNumberVars("var b = +o", "b");
+                        assertNumberVars("var b = +o.a", "b");
+                        assertNumberVars("var b = +o[0]", "b");
+                        assertNumberVars("var b; var c=1; b=+c", "b", "c");
+                        // unary minus:
+                        assertNumberVars("var b = -0", "b");
+                        assertNumberVars("var b = -o", "b");
+                        assertNumberVars("var b = -o.a", "b");
+                        assertNumberVars("var b = -o[0]", "b");
+                        assertNumberVars("var b; var c=1; b=-c", "b", "c");
                         // increment, function call:
                         assertNumberVars("var b; var g; b = (g=0,g++)", "b", "g");
                         assertNumberVars("var b; var x = fn(b=1)", "b");

--- a/testsrc/org/mozilla/javascript/tests/optimizer/IsNumberPropTest.java
+++ b/testsrc/org/mozilla/javascript/tests/optimizer/IsNumberPropTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.optimizer;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/optimizer/isnumber-prop.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class IsNumberPropTest extends ScriptTestsBase {}


### PR DESCRIPTION
Optimized the unary operators plus and minus, just like #851.

SunSpiderBenchmark.accessFannkuch is now slower, but V8Benchmark.boyer is now faster.
https://docs.google.com/spreadsheets/d/1cjeRNOJWjxEroZmRmuP-42FGL9--fLQLyILLxPfAKAM/edit?usp=sharing

In particular, this kind of code is now faster.
```js
function f() {
  var a = 0;
  for (var i = 0; i < 10000000; i++) {
    a = +a;
    a = -a;
    a = +a;
    a = -a;
    a = +a;
    a = -a;
    a = +a;
    a = -a;
    a = +a;
    a = -a;
  }
}
f();
```
```sh
# master
$ time java -jar buildGradle/libs/rhino-1.7.14-SNAPSHOT.jar -opt 9 -version 200 test.js

real	0m0.634s
user	0m0.855s
sys	0m0.227s

# opt-posneg
$ time java -jar buildGradle/libs/rhino-1.7.14-SNAPSHOT.jar -opt 9 -version 200 test.js

real	0m0.213s
user	0m0.359s
sys	0m0.053s

```