### PR TITLE
Add AutoGrow for NativeJavaList / fix NPE in NativeJavaList/Map

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaList.java
+++ b/src/org/mozilla/javascript/NativeJavaList.java
@@ -24,7 +24,6 @@ public class NativeJavaList extends NativeJavaObject {
         return "JavaList";
     }
 
-
     @Override
     public boolean has(String name, Scriptable start) {
         if (name.equals("length")) {
@@ -94,7 +93,7 @@ public class NativeJavaList extends NativeJavaObject {
                 ((ArrayList<?>) list).ensureCapacity(minCapacity);
             }
             while (minCapacity > list.size()) {
-              list.add(null);
+                list.add(null);
             }
         }
     }
@@ -111,6 +110,6 @@ public class NativeJavaList extends NativeJavaObject {
     }
 
     private boolean isWithValidIndex(int index) {
-        return index >= 0  && index < list.size();
+        return index >= 0 && index < list.size();
     }
 }

--- a/src/org/mozilla/javascript/NativeJavaList.java
+++ b/src/org/mozilla/javascript/NativeJavaList.java
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.javascript;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class NativeJavaList extends NativeJavaObject {
@@ -62,7 +63,7 @@ public class NativeJavaList extends NativeJavaObject {
             Context cx = Context.getCurrentContext();
             Object obj = list.get(index);
             if (cx != null) {
-                return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+                return cx.getWrapFactory().wrap(cx, this, obj, obj == null ? null : obj.getClass());
             }
             return obj;
         }
@@ -79,11 +80,23 @@ public class NativeJavaList extends NativeJavaObject {
 
     @Override
     public void put(int index, Scriptable start, Object value) {
-        if (isWithValidIndex(index)) {
+        if (index >= 0) {
+            ensureCapacity(index + 1);
             list.set(index, Context.jsToJava(value, Object.class));
             return;
         }
         super.put(index, start, value);
+    }
+
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity > list.size()) {
+            if (list instanceof ArrayList) {
+                ((ArrayList<?>) list).ensureCapacity(minCapacity);
+            }
+            while (minCapacity > list.size()) {
+              list.add(null);
+            }
+        }
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -66,7 +66,7 @@ public class NativeJavaMap extends NativeJavaObject {
         if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(name)) {
                 Object obj = map.get(name);
-                return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+                return cx.getWrapFactory().wrap(cx, this, obj, obj == null ? null : obj.getClass());
             }
         }
         return super.get(name, start);
@@ -78,7 +78,7 @@ public class NativeJavaMap extends NativeJavaObject {
         if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(Integer.valueOf(index))) {
                 Object obj = map.get(Integer.valueOf(index));
-                return cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());
+                return cx.getWrapFactory().wrap(cx, this, obj, obj == null ? null : obj.getClass());
             }
         }
         return super.get(index, start);

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -119,7 +119,7 @@ public class NativeJavaMap extends NativeJavaObject {
             List<Object> ids = new ArrayList<>(map.size());
             for (Object key : map.keySet()) {
                 if (key instanceof Integer) {
-                    ids.add((Integer)key);
+                    ids.add((Integer) key);
                 } else {
                     ids.add(ScriptRuntime.toString(key));
                 }
@@ -129,12 +129,13 @@ public class NativeJavaMap extends NativeJavaObject {
         return super.getIds();
     }
 
-    private static Callable symbol_iterator = (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) -> {
-        if (!(thisObj instanceof NativeJavaMap)) {
-            throw ScriptRuntime.typeErrorById("msg.incompat.call", SymbolKey.ITERATOR);
-        }
-        return new NativeJavaMapIterator(scope, ((NativeJavaMap)thisObj).map);
-    };
+    private static Callable symbol_iterator =
+            (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) -> {
+                if (!(thisObj instanceof NativeJavaMap)) {
+                    throw ScriptRuntime.typeErrorById("msg.incompat.call", SymbolKey.ITERATOR);
+                }
+                return new NativeJavaMapIterator(scope, ((NativeJavaMap) thisObj).map);
+            };
 
     private static final class NativeJavaMapIterator extends ES6Iterator {
         private static final long serialVersionUID = 1L;
@@ -144,9 +145,7 @@ public class NativeJavaMap extends NativeJavaObject {
             ES6Iterator.init(scope, sealed, new NativeJavaMapIterator(), ITERATOR_TAG);
         }
 
-        /**
-         * Only for constructing the prototype object.
-         */
+        /** Only for constructing the prototype object. */
         private NativeJavaMapIterator() {
             super();
         }

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaListTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaListTest.java
@@ -6,6 +6,10 @@
  */
 package org.mozilla.javascript.tests;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
 import junit.framework.TestCase;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
@@ -13,21 +17,13 @@ import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.Function;
-
-/**
- * From @makusuko (Markus Sunela), imported from PR https://github.com/mozilla/rhino/pull/561
- */
+/** From @makusuko (Markus Sunela), imported from PR https://github.com/mozilla/rhino/pull/561 */
 public class NativeJavaListTest extends TestCase {
     protected final Global global = new Global();
 
     public NativeJavaListTest() {
         global.init(ContextFactory.getGlobal());
     }
-
 
     public void testAccessingNullValues() {
         List<Integer> list = new ArrayList<>();
@@ -43,14 +39,14 @@ public class NativeJavaListTest extends TestCase {
         assertEquals(11, list.size());
         assertEquals(null, list.get(9));
         assertEquals("Foo", list.get(10));
-        
+
         list = new LinkedList<>();
         runScriptAsInt("value[10] = 'Foo'", list);
         assertEquals(11, list.size());
         assertEquals(null, list.get(9));
         assertEquals("Foo", list.get(10));
     }
-    
+
     public void testAccessingJavaListIntegerValues() {
         List<Integer> list = new ArrayList<>();
         list.add(1);
@@ -114,7 +110,8 @@ public class NativeJavaListTest extends TestCase {
 
     public void testKeys() {
         List<String> list = new ArrayList<>();
-        NativeArray resEmpty = (NativeArray) runScript("Object.keys(value)", list, Function.identity());
+        NativeArray resEmpty =
+                (NativeArray) runScript("Object.keys(value)", list, Function.identity());
         assertEquals(0, resEmpty.size());
 
         list.add("a");
@@ -137,10 +134,13 @@ public class NativeJavaListTest extends TestCase {
     }
 
     private <T> T runScript(String scriptSourceText, Object value, Function<Object, T> convert) {
-        return ContextFactory.getGlobal().call(context -> {
-            Scriptable scope = context.initStandardObjects(global);
-            scope.put("value", scope, Context.javaToJS(value, scope));
-            return convert.apply(context.evaluateString(scope, scriptSourceText, "", 1, null));
-        });
+        return ContextFactory.getGlobal()
+                .call(
+                        context -> {
+                            Scriptable scope = context.initStandardObjects(global);
+                            scope.put("value", scope, Context.javaToJS(value, scope));
+                            return convert.apply(
+                                    context.evaluateString(scope, scriptSourceText, "", 1, null));
+                        });
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaListTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaListTest.java
@@ -14,6 +14,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -28,6 +29,28 @@ public class NativeJavaListTest extends TestCase {
     }
 
 
+    public void testAccessingNullValues() {
+        List<Integer> list = new ArrayList<>();
+        list.add(null);
+
+        assertEquals(null, runScript("value[0]", list, Function.identity()));
+        assertEquals(1, runScriptAsInt("value.length", list));
+    }
+
+    public void testAutoGrowList() {
+        List<String> list = new ArrayList<>();
+        runScriptAsInt("value[10] = 'Foo'", list);
+        assertEquals(11, list.size());
+        assertEquals(null, list.get(9));
+        assertEquals("Foo", list.get(10));
+        
+        list = new LinkedList<>();
+        runScriptAsInt("value[10] = 'Foo'", list);
+        assertEquals(11, list.size());
+        assertEquals(null, list.get(9));
+        assertEquals("Foo", list.get(10));
+    }
+    
     public void testAccessingJavaListIntegerValues() {
         List<Integer> list = new ArrayList<>();
         list.add(1);

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -6,6 +6,12 @@
  */
 package org.mozilla.javascript.tests;
 
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
 import junit.framework.TestCase;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
@@ -15,27 +21,19 @@ import org.mozilla.javascript.NativeJavaMethod;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Function;
-
-import static org.junit.Assert.*;
-
-/**
- * From @makusuko (Markus Sunela), imported from PR https://github.com/mozilla/rhino/pull/561
- */
+/** From @makusuko (Markus Sunela), imported from PR https://github.com/mozilla/rhino/pull/561 */
 public class NativeJavaMapTest extends TestCase {
     protected final Global global = new Global();
-    private final ContextFactory contextFactoryWithMapAccess = new ContextFactory() {
-        @Override
-        protected boolean hasFeature(Context cx, int featureIndex) {
-            if (featureIndex == Context.FEATURE_ENABLE_JAVA_MAP_ACCESS) {
-                return true;
-            }
-            return super.hasFeature(cx, featureIndex);
-        }
-    };
+    private final ContextFactory contextFactoryWithMapAccess =
+            new ContextFactory() {
+                @Override
+                protected boolean hasFeature(Context cx, int featureIndex) {
+                    if (featureIndex == Context.FEATURE_ENABLE_JAVA_MAP_ACCESS) {
+                        return true;
+                    }
+                    return super.hasFeature(cx, featureIndex);
+                }
+            };
 
     public NativeJavaMapTest() {
         global.init(ContextFactory.getGlobal());
@@ -49,7 +47,7 @@ public class NativeJavaMapTest extends TestCase {
         assertEquals(null, runScript("value.a", map, true));
         assertEquals(null, runScript("value[1]", map, true));
     }
-    
+
     public void testAccessingJavaMapIntegerValues() {
         Map<Number, Number> map = new HashMap<>();
         map.put(0, 1);
@@ -72,9 +70,9 @@ public class NativeJavaMapTest extends TestCase {
 
     public void testUpdatingJavaMapIntegerValues() {
         Map<Number, Number> map = new HashMap<>();
-        map.put(0,1);
-        map.put(1,2);
-        map.put(2,3);
+        map.put(0, 1);
+        map.put(1, 2);
+        map.put(2, 3);
 
         assertEquals(2, runScriptAsInt("value[1]", map, true));
         assertEquals(5, runScriptAsInt("value[1]=5;value[1]", map, true));
@@ -162,9 +160,7 @@ public class NativeJavaMapTest extends TestCase {
     public void testSymbolIterator() {
         Map map = new LinkedHashMap();
         String script =
-            "var a = [];\n" +
-            "for (var [key, value] of value) a.push(key, value);\n" +
-            "a";
+                "var a = [];\n" + "for (var [key, value] of value) a.push(key, value);\n" + "a";
 
         NativeArray resEmpty = (NativeArray) runScriptES6(script, map);
         assertEquals(0, resEmpty.size());
@@ -189,25 +185,27 @@ public class NativeJavaMapTest extends TestCase {
             NativeArray res = (NativeArray) runScriptES6("Array.from(value)", map);
             assertEquals(3, res.size());
 
-            NativeArray e0 = (NativeArray)res.get(0);
+            NativeArray e0 = (NativeArray) res.get(0);
             assertEquals("a", e0.get(0));
             assertEquals("b", e0.get(1));
 
-            NativeArray e1 = (NativeArray)res.get(1);
+            NativeArray e1 = (NativeArray) res.get(1);
             assertEquals(123.0, Context.toNumber(e1.get(0)));
             assertEquals(234.0, Context.toNumber(e1.get(1)));
 
-            NativeArray e2 = (NativeArray)res.get(2);
+            NativeArray e2 = (NativeArray) res.get(2);
             assertEquals(o, e2.get(0));
             assertEquals(o, e2.get(1));
         }
     }
 
     private int runScriptAsInt(String scriptSourceText, Object value, boolean enableJavaMapAccess) {
-        return runScript(scriptSourceText, value, Context::toNumber, enableJavaMapAccess).intValue();
+        return runScript(scriptSourceText, value, Context::toNumber, enableJavaMapAccess)
+                .intValue();
     }
 
-    private String runScriptAsString(String scriptSourceText, Object value, boolean enableJavaMapAccess) {
+    private String runScriptAsString(
+            String scriptSourceText, Object value, boolean enableJavaMapAccess) {
         return runScript(scriptSourceText, value, Context::toString, enableJavaMapAccess);
     }
 
@@ -215,24 +213,33 @@ public class NativeJavaMapTest extends TestCase {
         return runScript(scriptSourceText, value, Function.identity(), enableJavaMapAccess);
     }
 
-    private <T> T runScript(String scriptSourceText, Object value, Function<Object, T> convert, boolean enableJavaMapAccess) {
-        return getContextFactory(enableJavaMapAccess).call(context -> {
-            Scriptable scope = context.initStandardObjects(global);
-            scope.put("value", scope, Context.javaToJS(value, scope));
-            return convert.apply(context.evaluateString(scope, scriptSourceText, "", 1, null));
-        });
+    private <T> T runScript(
+            String scriptSourceText,
+            Object value,
+            Function<Object, T> convert,
+            boolean enableJavaMapAccess) {
+        return getContextFactory(enableJavaMapAccess)
+                .call(
+                        context -> {
+                            Scriptable scope = context.initStandardObjects(global);
+                            scope.put("value", scope, Context.javaToJS(value, scope));
+                            return convert.apply(
+                                    context.evaluateString(scope, scriptSourceText, "", 1, null));
+                        });
     }
 
     private Object runScriptES6(String scriptSourceText, Object value) {
-        return getContextFactory(false).call(context -> {
-            Scriptable scope = context.initStandardObjects(global);
-            context.setLanguageVersion(Context.VERSION_ES6);
-            scope.put("value", scope, Context.javaToJS(value, scope));
-            return context.evaluateString(scope, scriptSourceText, "", 1, null);
-        });
+        return getContextFactory(false)
+                .call(
+                        context -> {
+                            Scriptable scope = context.initStandardObjects(global);
+                            context.setLanguageVersion(Context.VERSION_ES6);
+                            scope.put("value", scope, Context.javaToJS(value, scope));
+                            return context.evaluateString(scope, scriptSourceText, "", 1, null);
+                        });
     }
 
     private ContextFactory getContextFactory(boolean enableJavaMapAccess) {
-         return enableJavaMapAccess ? contextFactoryWithMapAccess : ContextFactory.getGlobal();
+        return enableJavaMapAccess ? contextFactoryWithMapAccess : ContextFactory.getGlobal();
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -41,6 +41,15 @@ public class NativeJavaMapTest extends TestCase {
         global.init(ContextFactory.getGlobal());
     }
 
+    public void testAccessingNullValues() {
+        Map<Object, Number> map = new HashMap<>();
+        map.put("a", null);
+        map.put(1, null);
+        assertEquals(2, runScriptAsInt("value.size()", map, true));
+        assertEquals(null, runScript("value.a", map, true));
+        assertEquals(null, runScript("value[1]", map, true));
+    }
+    
     public void testAccessingJavaMapIntegerValues() {
         Map<Number, Number> map = new HashMap<>();
         map.put(0, 1);


### PR DESCRIPTION
This PR contains 2 code changes which should be unproblematic

1. When a List/Map contains null values there was an NPE on `cx.getWrapFactory().wrap(cx, this, obj, obj.getClass());` See: https://github.com/mozilla/rhino/commit/084908502006e3039c867dcf950c7c9548e8c34e
2. Support for auto grow, so that you can set values in a java.util.List. See https://github.com/mozilla/rhino/commit/cf84dbf60e417378eb171e20769ee92407cac808

The rest are spotless fixes

