### PR TITLE
Optimize two specific addition cases

### DIFF
--- a/benchmarks/org/mozilla/javascript/benchmarks/MathBenchmark.java
+++ b/benchmarks/org/mozilla/javascript/benchmarks/MathBenchmark.java
@@ -1,0 +1,141 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.io.FileReader;
+import java.io.IOException;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.openjdk.jmh.annotations.*;
+
+public class MathBenchmark {
+    @State(Scope.Thread)
+    public static class MathState {
+        Context cx;
+        Scriptable scope;
+
+        Function addConstantInts;
+        Function addIntAndConstant;
+        Function addTwoInts;
+        Function addConstantFloats;
+        Function addTwoFloats;
+        Function addStringsInLoop;
+        Function addMixedStrings;
+        Function subtractInts;
+        Function subtractFloats;
+        Function subtractTwoFloats;
+        Function bitwiseAnd;
+        Function bitwiseOr;
+        Function bitwiseLsh;
+        Function bitwiseRsh;
+        Function bitwiseSignedRsh;
+
+        @Setup(Level.Trial)
+        public void setup() throws IOException {
+            cx = Context.enter();
+            cx.setOptimizationLevel(9);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            scope = cx.initStandardObjects();
+
+            try (FileReader rdr = new FileReader("testsrc/benchmarks/micro/math-benchmarks.js")) {
+                cx.evaluateReader(scope, rdr, "math-benchmarks.js", 1, null);
+            }
+            addConstantInts = (Function) ScriptableObject.getProperty(scope, "addConstantInts");
+            addIntAndConstant = (Function) ScriptableObject.getProperty(scope, "addIntAndConstant");
+            addTwoInts = (Function) ScriptableObject.getProperty(scope, "addTwoInts");
+            addConstantFloats = (Function) ScriptableObject.getProperty(scope, "addConstantFloats");
+            addTwoFloats = (Function) ScriptableObject.getProperty(scope, "addTwoFloats");
+            addStringsInLoop = (Function) ScriptableObject.getProperty(scope, "addStringsInLoop");
+            addMixedStrings = (Function) ScriptableObject.getProperty(scope, "addMixedStrings");
+            subtractInts = (Function) ScriptableObject.getProperty(scope, "subtractInts");
+            subtractFloats = (Function) ScriptableObject.getProperty(scope, "subtractFloats");
+            subtractTwoFloats = (Function) ScriptableObject.getProperty(scope, "subtractTwoFloats");
+            bitwiseAnd = (Function) ScriptableObject.getProperty(scope, "bitwiseAnd");
+            bitwiseOr = (Function) ScriptableObject.getProperty(scope, "bitwiseOr");
+            bitwiseLsh = (Function) ScriptableObject.getProperty(scope, "bitwiseLsh");
+            bitwiseRsh = (Function) ScriptableObject.getProperty(scope, "bitwiseRsh");
+            bitwiseSignedRsh = (Function) ScriptableObject.getProperty(scope, "bitwiseSignedRsh");
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            cx.close();
+        }
+    }
+
+    @Benchmark
+    public Object addConstantInts(MathState state) {
+        return state.addConstantInts.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object addIntAndConstant(MathState state) {
+        return state.addIntAndConstant.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object addTwoInts(MathState state) {
+        return state.addTwoInts.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object addConstantFloats(MathState state) {
+        return state.addConstantFloats.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object addTwoFloats(MathState state) {
+        return state.addTwoFloats.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object addStringsInLoop(MathState state) {
+        return state.addStringsInLoop.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object addMixedStrings(MathState state) {
+        return state.addMixedStrings.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object subtractInts(MathState state) {
+        return state.subtractInts.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object subtractFloats(MathState state) {
+        return state.subtractFloats.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object subtractTwoFloats(MathState state) {
+        return state.subtractTwoFloats.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object bitwiseAnd(MathState state) {
+        return state.bitwiseAnd.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object bitwiseOr(MathState state) {
+        return state.bitwiseOr.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object bitwiseLsh(MathState state) {
+        return state.bitwiseLsh.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object bitwiseRsh(MathState state) {
+        return state.bitwiseRsh.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object bitwiseSignedRsh(MathState state) {
+        return state.bitwiseSignedRsh.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -108,10 +108,20 @@ task testBenchmark() {}
 testBenchmark.dependsOn sunSpiderBenchmark
 testBenchmark.dependsOn v8Benchmark
 
-task builtinBenchmarks(type: JavaExec, description: 'JMH benchmarks') {
+task microBenchmark(type: JavaExec, description: 'JMH micro benchmark') {
+    def benchmark = System.getProperty('benchmark')
+    if (benchmark == null) {
+        benchmark = "MathBenchmark"
+    }
     classpath = sourceSets.jmh.runtimeClasspath
     main = 'org.openjdk.jmh.Main'
-    args '-f', '1', '-bm', 'avgt', '-tu', 'ns', 'Builtin'
+    args '-f', '1', '-bm', 'avgt', '-tu', 'ns', '-r', '5', benchmark
+}
+
+task listBenchmarks(type: JavaExec, description: 'JMH benchmarks') {
+    classpath = sourceSets.jmh.runtimeClasspath
+    main = 'org.openjdk.jmh.Main'
+    args '-lp'
 }
 
 task jmhHelp(type: JavaExec, description: 'JMH benchmarks') {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2864,6 +2864,11 @@ public class ScriptRuntime {
         if (val1 instanceof Number && val2 instanceof Number) {
             return wrapNumber(((Number) val1).doubleValue() + ((Number) val2).doubleValue());
         }
+        if (val1 instanceof CharSequence && val2 instanceof CharSequence) {
+            // If we let this happen later, then the "getDefaultValue" logic
+            // undoes many optimizations
+            return new ConsString(toCharSequence(val1), toCharSequence(val2));
+        }
         if (val1 instanceof XMLObject) {
             Object test = ((XMLObject) val1).addValues(cx, true, val2);
             if (test != Scriptable.NOT_FOUND) {

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1195,10 +1195,16 @@ class BodyCodegen {
                             cfw.add(ByteCode.DADD);
                             break;
                         case Node.LEFT:
-                            addOptRuntimeInvoke("add", "(DLjava/lang/Object;)Ljava/lang/Object;");
+                            cfw.addALoad(contextLocal);
+                            addOptRuntimeInvoke(
+                                    "add",
+                                    "(DLjava/lang/Object;Lorg/mozilla/javascript/Context;)Ljava/lang/Object;");
                             break;
                         case Node.RIGHT:
-                            addOptRuntimeInvoke("add", "(Ljava/lang/Object;D)Ljava/lang/Object;");
+                            cfw.addALoad(contextLocal);
+                            addOptRuntimeInvoke(
+                                    "add",
+                                    "(Ljava/lang/Object;DLorg/mozilla/javascript/Context;)Ljava/lang/Object;");
                             break;
                         default:
                             cfw.addALoad(contextLocal);

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 package org.mozilla.javascript.optimizer;
 
 import org.mozilla.javascript.ArrowFunction;
 import org.mozilla.javascript.Callable;
-import org.mozilla.javascript.ConsString;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ES6Generator;
@@ -22,77 +20,54 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
-public final class OptRuntime extends ScriptRuntime
-{
+public final class OptRuntime extends ScriptRuntime {
     public static final Double oneObj = Double.valueOf(1.0);
     public static final Double minusOneObj = Double.valueOf(-1.0);
 
-    /**
-     * Implement ....() call shrinking optimizer code.
-     */
-    public static Object call0(Callable fun, Scriptable thisObj,
-                               Context cx, Scriptable scope)
-    {
+    /** Implement ....() call shrinking optimizer code. */
+    public static Object call0(Callable fun, Scriptable thisObj, Context cx, Scriptable scope) {
         return fun.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
-    /**
-     * Implement ....(arg) call shrinking optimizer code.
-     */
-    public static Object call1(Callable fun, Scriptable thisObj, Object arg0,
-                               Context cx, Scriptable scope)
-    {
-        return fun.call(cx, scope, thisObj, new Object[] { arg0 } );
+    /** Implement ....(arg) call shrinking optimizer code. */
+    public static Object call1(
+            Callable fun, Scriptable thisObj, Object arg0, Context cx, Scriptable scope) {
+        return fun.call(cx, scope, thisObj, new Object[] {arg0});
     }
 
-    /**
-     * Implement ....(arg0, arg1) call shrinking optimizer code.
-     */
-    public static Object call2(Callable fun, Scriptable thisObj,
-                               Object arg0, Object arg1,
-                               Context cx, Scriptable scope)
-    {
-        return fun.call(cx, scope, thisObj, new Object[] { arg0, arg1 });
+    /** Implement ....(arg0, arg1) call shrinking optimizer code. */
+    public static Object call2(
+            Callable fun,
+            Scriptable thisObj,
+            Object arg0,
+            Object arg1,
+            Context cx,
+            Scriptable scope) {
+        return fun.call(cx, scope, thisObj, new Object[] {arg0, arg1});
     }
 
-    /**
-     * Implement ....(arg0, arg1, ...) call shrinking optimizer code.
-     */
-    public static Object callN(Callable fun, Scriptable thisObj,
-                               Object[] args,
-                               Context cx, Scriptable scope)
-    {
+    /** Implement ....(arg0, arg1, ...) call shrinking optimizer code. */
+    public static Object callN(
+            Callable fun, Scriptable thisObj, Object[] args, Context cx, Scriptable scope) {
         return fun.call(cx, scope, thisObj, args);
     }
 
-    /**
-     * Implement name(args) call shrinking optimizer code.
-     */
-    public static Object callName(Object[] args, String name,
-                                  Context cx, Scriptable scope)
-    {
+    /** Implement name(args) call shrinking optimizer code. */
+    public static Object callName(Object[] args, String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, args);
     }
 
-    /**
-     * Implement name() call shrinking optimizer code.
-     */
-    public static Object callName0(String name,
-                                   Context cx, Scriptable scope)
-    {
+    /** Implement name() call shrinking optimizer code. */
+    public static Object callName0(String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
-    /**
-     * Implement x.property() call shrinking optimizer code.
-     */
-    public static Object callProp0(Object value, String property,
-                                   Context cx, Scriptable scope)
-    {
+    /** Implement x.property() call shrinking optimizer code. */
+    public static Object callProp0(Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
@@ -116,22 +91,15 @@ public final class OptRuntime extends ScriptRuntime
         return new ConsString(toString(val1), (CharSequence)val2);
     }
 
-    /**
-     * @deprecated Use {@link #elemIncrDecr(Object, double, Context, Scriptable, int)} instead
-     */
+    /** @deprecated Use {@link #elemIncrDecr(Object, double, Context, Scriptable, int)} instead */
     @Deprecated
-    public static Object elemIncrDecr(Object obj, double index,
-                                      Context cx, int incrDecrMask)
-    {
+    public static Object elemIncrDecr(Object obj, double index, Context cx, int incrDecrMask) {
         return elemIncrDecr(obj, index, cx, getTopCallScope(cx), incrDecrMask);
     }
 
-    public static Object elemIncrDecr(Object obj, double index,
-                                      Context cx, Scriptable scope,
-                                      int incrDecrMask)
-    {
-        return ScriptRuntime.elemIncrDecr(obj, Double.valueOf(index), cx, scope,
-                                          incrDecrMask);
+    public static Object elemIncrDecr(
+            Object obj, double index, Context cx, Scriptable scope, int incrDecrMask) {
+        return ScriptRuntime.elemIncrDecr(obj, Double.valueOf(index), cx, scope, incrDecrMask);
     }
 
     public static Object[] padStart(Object[] currentArgs, int count) {
@@ -140,37 +108,41 @@ public final class OptRuntime extends ScriptRuntime
         return result;
     }
 
-    public static void initFunction(NativeFunction fn, int functionType,
-                                    Scriptable scope, Context cx)
-    {
+    public static void initFunction(
+            NativeFunction fn, int functionType, Scriptable scope, Context cx) {
         ScriptRuntime.initFunction(cx, scope, fn, functionType, false);
     }
 
-    public static Function bindThis(NativeFunction fn, Context cx, Scriptable scope, Scriptable thisObj)
-    {
+    public static Function bindThis(
+            NativeFunction fn, Context cx, Scriptable scope, Scriptable thisObj) {
         return new ArrowFunction(cx, scope, fn, thisObj);
     }
 
-    public static Object callSpecial(Context cx, Callable fun,
-                                     Scriptable thisObj, Object[] args,
-                                     Scriptable scope,
-                                     Scriptable callerThis, int callType,
-                                     String fileName, int lineNumber)
-    {
-        return ScriptRuntime.callSpecial(cx, fun, thisObj, args, scope,
-                                         callerThis, callType,
-                                         fileName, lineNumber);
+    public static Object callSpecial(
+            Context cx,
+            Callable fun,
+            Scriptable thisObj,
+            Object[] args,
+            Scriptable scope,
+            Scriptable callerThis,
+            int callType,
+            String fileName,
+            int lineNumber) {
+        return ScriptRuntime.callSpecial(
+                cx, fun, thisObj, args, scope, callerThis, callType, fileName, lineNumber);
     }
 
-    public static Object newObjectSpecial(Context cx, Object fun,
-                                          Object[] args, Scriptable scope,
-                                          Scriptable callerThis, int callType)
-    {
+    public static Object newObjectSpecial(
+            Context cx,
+            Object fun,
+            Object[] args,
+            Scriptable scope,
+            Scriptable callerThis,
+            int callType) {
         return ScriptRuntime.newSpecial(cx, fun, args, scope, callType);
     }
 
-    public static Double wrapDouble(double num)
-    {
+    public static Double wrapDouble(double num) {
         if (num == 0.0) {
             if (1 / num > 0) {
                 // +0.0
@@ -186,24 +158,24 @@ public final class OptRuntime extends ScriptRuntime
         return Double.valueOf(num);
     }
 
-    static String encodeIntArray(int[] array)
-    {
+    static String encodeIntArray(int[] array) {
         // XXX: this extremely inefficient for small integers
-        if (array == null) { return null; }
+        if (array == null) {
+            return null;
+        }
         int n = array.length;
         char[] buffer = new char[1 + n * 2];
         buffer[0] = 1;
         for (int i = 0; i != n; ++i) {
             int value = array[i];
             int shift = 1 + i * 2;
-            buffer[shift] = (char)(value >>> 16);
-            buffer[shift + 1] = (char)value;
+            buffer[shift] = (char) (value >>> 16);
+            buffer[shift + 1] = (char) value;
         }
         return new String(buffer);
     }
 
-    private static int[] decodeIntArray(String str, int arraySize)
-    {
+    private static int[] decodeIntArray(String str, int arraySize) {
         // XXX: this extremely inefficient for small integers
         if (arraySize == 0) {
             if (str != null) throw new IllegalArgumentException();
@@ -220,48 +192,44 @@ public final class OptRuntime extends ScriptRuntime
         return array;
     }
 
-    public static Scriptable newArrayLiteral(Object[] objects,
-                                             String encodedInts,
-                                             int skipCount,
-                                             Context cx,
-                                             Scriptable scope)
-    {
+    public static Scriptable newArrayLiteral(
+            Object[] objects, String encodedInts, int skipCount, Context cx, Scriptable scope) {
         int[] skipIndexces = decodeIntArray(encodedInts, skipCount);
         return newArrayLiteral(objects, skipIndexces, cx, scope);
     }
 
-    public static void main(final Script script, final String[] args)
-    {
-        ContextFactory.getGlobal().call(cx -> {
-            ScriptableObject global = getGlobal(cx);
+    public static void main(final Script script, final String[] args) {
+        ContextFactory.getGlobal()
+                .call(
+                        cx -> {
+                            ScriptableObject global = getGlobal(cx);
 
-            // get the command line arguments and define "arguments"
-            // array in the top-level object
-            Object[] argsCopy = new Object[args.length];
-            System.arraycopy(args, 0, argsCopy, 0, args.length);
-            Scriptable argsObj = cx.newArray(global, argsCopy);
-            global.defineProperty("arguments", argsObj,
-                                  ScriptableObject.DONTENUM);
-            script.exec(cx, global);
-            return null;
-        });
+                            // get the command line arguments and define "arguments"
+                            // array in the top-level object
+                            Object[] argsCopy = new Object[args.length];
+                            System.arraycopy(args, 0, argsCopy, 0, args.length);
+                            Scriptable argsObj = cx.newArray(global, argsCopy);
+                            global.defineProperty("arguments", argsObj, ScriptableObject.DONTENUM);
+                            script.exec(cx, global);
+                            return null;
+                        });
     }
 
     public static void throwStopIteration(Object scope, Object genState) {
         Object value = getGeneratorReturnValue(genState);
         Object si =
-            (value == Undefined.instance) ?
-              NativeIterator.getStopIterationObject((Scriptable)scope) :
-              new NativeIterator.StopIteration(value);
+                (value == Undefined.instance)
+                        ? NativeIterator.getStopIterationObject((Scriptable) scope)
+                        : new NativeIterator.StopIteration(value);
         throw new JavaScriptException(si, "", 0);
     }
 
-    public static Scriptable createNativeGenerator(NativeFunction funObj,
-                                                   Scriptable scope,
-                                                   Scriptable thisObj,
-                                                   int maxLocals,
-                                                   int maxStack)
-    {
+    public static Scriptable createNativeGenerator(
+            NativeFunction funObj,
+            Scriptable scope,
+            Scriptable thisObj,
+            int maxLocals,
+            int maxStack) {
         GeneratorState gs = new GeneratorState(thisObj, maxLocals, maxStack);
         if (Context.getCurrentContext().getLanguageVersion() >= Context.VERSION_ES6) {
             return new ES6Generator(scope, funObj, gs);
@@ -272,15 +240,13 @@ public final class OptRuntime extends ScriptRuntime
 
     public static Object[] getGeneratorStackState(Object obj) {
         GeneratorState rgs = (GeneratorState) obj;
-        if (rgs.stackState == null)
-            rgs.stackState = new Object[rgs.maxStack];
+        if (rgs.stackState == null) rgs.stackState = new Object[rgs.maxStack];
         return rgs.stackState;
     }
 
     public static Object[] getGeneratorLocalsState(Object obj) {
         GeneratorState rgs = (GeneratorState) obj;
-        if (rgs.localsState == null)
-            rgs.localsState = new Object[rgs.maxLocals];
+        if (rgs.localsState == null) rgs.localsState = new Object[rgs.maxLocals];
         return rgs.localsState;
     }
 
@@ -296,18 +262,19 @@ public final class OptRuntime extends ScriptRuntime
 
     public static class GeneratorState {
         static final String CLASS_NAME =
-            "org/mozilla/javascript/optimizer/OptRuntime$GeneratorState";
+                "org/mozilla/javascript/optimizer/OptRuntime$GeneratorState";
 
         @SuppressWarnings("unused")
         public int resumptionPoint;
+
         static final String resumptionPoint_NAME = "resumptionPoint";
         static final String resumptionPoint_TYPE = "I";
 
         @SuppressWarnings("unused")
         public Scriptable thisObj;
+
         static final String thisObj_NAME = "thisObj";
-        static final String thisObj_TYPE =
-            "Lorg/mozilla/javascript/Scriptable;";
+        static final String thisObj_TYPE = "Lorg/mozilla/javascript/Scriptable;";
 
         Object[] stackState;
         Object[] localsState;

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -74,21 +74,21 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     public static Object add(Object val1, double val2, Context cx) {
-        if (val1 instanceof Integer) {
-            return ((Integer) val1) + val2;
-        }
         if (val1 instanceof Double) {
             return ((Double) val1) + val2;
+        }
+        if (val1 instanceof Integer) {
+            return ((Integer) val1) + val2;
         }
         return ScriptRuntime.add(val1, val2, cx);
     }
 
     public static Object add(double val1, Object val2, Context cx) {
-        if (val2 instanceof Integer) {
-            return val1 + ((Integer) val2);
-        }
         if (val2 instanceof Double) {
             return val1 + ((Double) val2);
+        }
+        if (val2 instanceof Integer) {
+            return val1 + ((Integer) val2);
         }
         return ScriptRuntime.add(val1, val2, cx);
     }

--- a/src/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/src/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -73,22 +73,24 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
-    public static Object add(Object val1, double val2)
-    {
-        if (val1 instanceof Scriptable)
-            val1 = ((Scriptable) val1).getDefaultValue(null);
-        if (!(val1 instanceof CharSequence))
-            return wrapDouble(toNumber(val1) + val2);
-        return new ConsString((CharSequence)val1, toString(val2));
+    public static Object add(Object val1, double val2, Context cx) {
+        if (val1 instanceof Integer) {
+            return ((Integer) val1) + val2;
+        }
+        if (val1 instanceof Double) {
+            return ((Double) val1) + val2;
+        }
+        return ScriptRuntime.add(val1, val2, cx);
     }
 
-    public static Object add(double val1, Object val2)
-    {
-        if (val2 instanceof Scriptable)
-            val2 = ((Scriptable) val2).getDefaultValue(null);
-        if (!(val2 instanceof CharSequence))
-            return wrapDouble(toNumber(val2) + val1);
-        return new ConsString(toString(val1), (CharSequence)val2);
+    public static Object add(double val1, Object val2, Context cx) {
+        if (val2 instanceof Integer) {
+            return val1 + ((Integer) val2);
+        }
+        if (val2 instanceof Double) {
+            return val1 + ((Double) val2);
+        }
+        return ScriptRuntime.add(val1, val2, cx);
     }
 
     /** @deprecated Use {@link #elemIncrDecr(Object, double, Context, Scriptable, int)} instead */

--- a/testsrc/benchmarks/micro/math-benchmarks.js
+++ b/testsrc/benchmarks/micro/math-benchmarks.js
@@ -1,0 +1,133 @@
+'use strict';
+
+function assertEquals(x, y) {
+  if (x !== y) {
+    throw 'Expected ' + x + ' to equal ' + y;
+  }
+}
+
+function makeOne() {
+  return 1;
+}
+
+function makeFour() {
+  return 2 + 2;
+}
+
+function makeTwo() {
+  return 1 + 1;
+}
+
+function makePi() {
+  return 3.14;
+}
+
+function addConstantInts() {
+  let result = 2 + 2;
+  assertEquals(result, 4);
+  return result;
+}
+
+function addIntAndConstant() {
+  let result = makeTwo() + 2;
+  assertEquals(result, 4);
+  return result;
+}
+
+function addTwoInts() {
+  let result = makeTwo() + makeTwo();
+  assertEquals(result,  4);
+  return result;
+}
+
+function addConstantFloats() {
+  let result = 3.14 + 1.1;
+  assertEquals(result,  4.24);
+  return result;
+}
+
+function addTwoFloats() {
+  let result = makePi() + makePi();
+  assertEquals(result,  6.28);
+  return result;
+}
+
+function subtractInts() {
+  let result = 4 - makeTwo();
+  assertEquals(result, 2);
+  return result;
+}
+
+function subtractFloats() {
+  let result = makePi() - 0.4;
+  assertEquals(result, 2.74);
+  return result;
+}
+
+function subtractTwoFloats() {
+  let result = makePi() - makePi();
+  assertEquals(result, 0);
+  return result;
+}
+
+function bitwiseAnd() {
+  let result = makeFour() & makeTwo();
+  assertEquals(result, 0);
+  return result;
+}
+
+function bitwiseOr() {
+  let result = makeFour() | makeTwo();
+  assertEquals(result, 6);
+  return result;
+}
+
+function bitwiseLsh() {
+  let result = makeTwo() << makeOne();
+  assertEquals(result, 4);
+  return result;
+}
+
+function bitwiseRsh() {
+  let result = makeFour() >> makeOne();
+  assertEquals(result, 2);
+  return result;
+}
+
+function bitwiseSignedRsh() {
+  let result = makeFour() >>> makeOne();
+  assertEquals(result, 2);
+  return result;
+}
+
+function addStringsInLoop() {
+  let s = "";
+  for (var i = 0; i < 10; i++) {
+    s += "aa";
+  }
+  assertEquals(s, "aaaaaaaaaaaaaaaaaaaa");
+  return s;
+}
+
+function addMixedStrings() {
+  let s = "Foo " + 100 + " bars, " + true + "!";
+  assertEquals(s, "Foo 100 bars, true!");
+  return s;
+}
+
+// Call everything once here so that tests fail fast
+addConstantInts();
+addIntAndConstant()
+addTwoInts();
+addConstantFloats();
+addTwoFloats();
+subtractInts();
+subtractFloats();
+subtractTwoFloats();
+addStringsInLoop();
+addMixedStrings();
+bitwiseAnd();
+bitwiseOr();
+bitwiseLsh();
+bitwiseRsh();
+bitwiseSignedRsh();


### PR DESCRIPTION
This adds a microbenchmark for math operations and two specific optimizations to the "add" optimization.

The first fixes some cases in which optimized math opeations would take a slower path before a faster one (and also would not fall back properly to BigInteger operations).

The second fixes string concatenation cases, especially when strings are concatenated in a loop.