### PR TITLE
Refactor SlotMap and Slot classes

### DIFF
--- a/benchmarks/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
+++ b/benchmarks/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
@@ -3,26 +3,22 @@ package org.mozilla.javascript.benchmarks;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Random;
-
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.tools.shell.Global;
-
 import org.openjdk.jmh.annotations.*;
 
-public class ObjectBenchmark
-{
+public class ObjectBenchmark {
     static final Random rand = new Random();
 
     static final int intKeys = 1000;
     static final int stringKeys = 1000;
+    // "count" should match "@OperationsPerInvocation" annotations
     static final int count = 1000;
 
-    static void runCode(Context cx, Scriptable scope, String fileName)
-        throws IOException
-    {
+    static void runCode(Context cx, Scriptable scope, String fileName) throws IOException {
         try (FileReader rdr = new FileReader(fileName)) {
             cx.evaluateReader(scope, rdr, "test.js", 1, null);
         }
@@ -37,8 +33,7 @@ public class ObjectBenchmark
 
         @Setup(Level.Trial)
         @SuppressWarnings("unused")
-        public void create()
-            throws IOException {
+        public void create() throws IOException {
             cx = Context.enter();
             cx.setOptimizationLevel(9);
             cx.setLanguageVersion(Context.VERSION_ES6);
@@ -72,45 +67,61 @@ public class ObjectBenchmark
     }
 
     @Benchmark
+    @OperationsPerInvocation(1000)
     @SuppressWarnings("unused")
     public void createFields(FieldTestState state) {
         Function create = (Function) ScriptableObject.getProperty(state.scope, "createObject");
-        create.call(state.cx, state.scope, null, new Object[]{count, state.strings, state.ints});
+        create.call(state.cx, state.scope, null, new Object[] {count, state.strings, state.ints});
     }
 
     @Benchmark
+    @OperationsPerInvocation(1000)
     @SuppressWarnings("unused")
     public void accessFields(FieldTestState state) {
         Function create = (Function) ScriptableObject.getProperty(state.scope, "createObject");
-        Object o = create.call(state.cx, state.scope, null, new Object[]{1, state.strings, state.ints});
+        Object o =
+                create.call(
+                        state.cx, state.scope, null, new Object[] {1, state.strings, state.ints});
         Function access = (Function) ScriptableObject.getProperty(state.scope, "accessObject");
-        access.call(state.cx, state.scope, null, new Object[]{count, o, state.strings, state.ints});
+        access.call(
+                state.cx, state.scope, null, new Object[] {count, o, state.strings, state.ints});
     }
 
     @Benchmark
+    @OperationsPerInvocation(1000)
     @SuppressWarnings("unused")
     public void iterateFields(FieldTestState state) {
         Function create = (Function) ScriptableObject.getProperty(state.scope, "createObject");
-        Object o = create.call(state.cx, state.scope, null, new Object[]{1, state.strings, state.ints});
+        Object o =
+                create.call(
+                        state.cx, state.scope, null, new Object[] {1, state.strings, state.ints});
         Function iterate = (Function) ScriptableObject.getProperty(state.scope, "iterateObject");
-        iterate.call(state.cx, state.scope, null, new Object[]{count, o});
+        iterate.call(state.cx, state.scope, null, new Object[] {count, o});
     }
 
     @Benchmark
+    @OperationsPerInvocation(1000)
     @SuppressWarnings("unused")
     public void ownKeysFields(FieldTestState state) {
         Function create = (Function) ScriptableObject.getProperty(state.scope, "createObject");
-        Object o = create.call(state.cx, state.scope, null, new Object[]{1, state.strings, state.ints});
-        Function iterate = (Function) ScriptableObject.getProperty(state.scope, "iterateOwnKeysObject");
-        iterate.call(state.cx, state.scope, null, new Object[]{count, o});
+        Object o =
+                create.call(
+                        state.cx, state.scope, null, new Object[] {1, state.strings, state.ints});
+        Function iterate =
+                (Function) ScriptableObject.getProperty(state.scope, "iterateOwnKeysObject");
+        iterate.call(state.cx, state.scope, null, new Object[] {count, o});
     }
 
     @Benchmark
+    @OperationsPerInvocation(1000)
     @SuppressWarnings("unused")
     public void deleteFields(FieldTestState state) {
         Function create = (Function) ScriptableObject.getProperty(state.scope, "createObject");
-        Object o = create.call(state.cx, state.scope, null, new Object[]{1, state.strings, state.ints});
+        Object o =
+                create.call(
+                        state.cx, state.scope, null, new Object[] {1, state.strings, state.ints});
         Function delete = (Function) ScriptableObject.getProperty(state.scope, "deleteObject");
-        delete.call(state.cx, state.scope, null, new Object[]{count, o, state.strings, state.ints});
+        delete.call(
+                state.cx, state.scope, null, new Object[] {count, o, state.strings, state.ints});
     }
 }

--- a/benchmarks/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
+++ b/benchmarks/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
@@ -1,0 +1,161 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.util.Random;
+import org.mozilla.javascript.EmbeddedSlotMap;
+import org.mozilla.javascript.HashSlotMap;
+import org.mozilla.javascript.Slot;
+import org.mozilla.javascript.SlotMap;
+import org.openjdk.jmh.annotations.*;
+
+public class SlotMapBenchmark {
+    // Fixed seed for repeatability
+    private static final Random rand = new Random(0);
+
+    @State(Scope.Thread)
+    public static class EmbeddedState {
+        final EmbeddedSlotMap emptyMap = new EmbeddedSlotMap();
+        final EmbeddedSlotMap size10Map = new EmbeddedSlotMap();
+        final EmbeddedSlotMap size100Map = new EmbeddedSlotMap();
+        final String[] randomKeys = new String[100];
+        String size100LastKey;
+        String size10LastKey;
+
+        @Setup(Level.Trial)
+        public void create() {
+            String lastKey = null;
+            for (int i = 0; i < 10; i++) {
+                lastKey = insertRandomEntry(size10Map);
+            }
+            size10LastKey = lastKey;
+            for (int i = 0; i < 100; i++) {
+                lastKey = insertRandomEntry(size100Map);
+            }
+            size100LastKey = lastKey;
+            for (int i = 0; i < 100; i++) {
+                randomKeys[i] = makeRandomString();
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object embeddedInsert1Key(EmbeddedState state) {
+        Slot newSlot = null;
+        for (int i = 0; i < 100; i++) {
+            newSlot = state.emptyMap.modify(state.randomKeys[i], 0, 0);
+        }
+        if (newSlot == null) {
+            throw new AssertionError();
+        }
+        return newSlot;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object embeddedQueryKey10Entries(EmbeddedState state) {
+        Slot slot = null;
+        for (int i = 0; i < 100; i++) {
+            slot = state.size10Map.query(state.size10LastKey, 0);
+        }
+        if (slot == null) {
+            throw new AssertionError();
+        }
+        return slot;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object embeddedQueryKey100Entries(EmbeddedState state) {
+        Slot slot = null;
+        for (int i = 0; i < 100; i++) {
+            slot = state.size100Map.query(state.size100LastKey, 0);
+        }
+        if (slot == null) {
+            throw new AssertionError();
+        }
+        return slot;
+    }
+
+    @State(Scope.Thread)
+    public static class HashState {
+        final HashSlotMap emptyMap = new HashSlotMap();
+        final HashSlotMap size10Map = new HashSlotMap();
+        final HashSlotMap size100Map = new HashSlotMap();
+        final String[] randomKeys = new String[100];
+        String size100LastKey;
+        String size10LastKey;
+
+        @Setup(Level.Trial)
+        public void create() {
+            String lastKey = null;
+            for (int i = 0; i < 10; i++) {
+                lastKey = insertRandomEntry(size10Map);
+            }
+            size10LastKey = lastKey;
+            for (int i = 0; i < 100; i++) {
+                lastKey = insertRandomEntry(size100Map);
+            }
+            size100LastKey = lastKey;
+            for (int i = 0; i < 100; i++) {
+                randomKeys[i] = makeRandomString();
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object hashInsert1Key(HashState state) {
+        Slot newSlot = null;
+        for (int i = 0; i < 100; i++) {
+            newSlot = state.emptyMap.modify(state.randomKeys[i], 0, 0);
+        }
+        if (newSlot == null) {
+            throw new AssertionError();
+        }
+        return newSlot;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object hashQueryKey10Entries(HashState state) {
+        Slot slot = null;
+        for (int i = 0; i < 100; i++) {
+            slot = state.size10Map.query(state.size10LastKey, 0);
+        }
+        if (slot == null) {
+            throw new AssertionError();
+        }
+        return slot;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object hashQueryKey100Entries(HashState state) {
+        Slot slot = null;
+        for (int i = 0; i < 100; i++) {
+            slot = state.size100Map.query(state.size100LastKey, 0);
+        }
+        if (slot == null) {
+            throw new AssertionError();
+        }
+        return slot;
+    }
+
+    /** Make a new string between 1 and 50 characters out of random lower-case letters. */
+    private static String makeRandomString() {
+        int len = rand.nextInt(49) + 1;
+        char[] c = new char[len];
+        for (int cc = 0; cc < len; cc++) {
+            c[cc] = (char) ('a' + rand.nextInt(25));
+        }
+        return new String(c);
+    }
+
+    /** Insert a random key and value into the map */
+    private static String insertRandomEntry(SlotMap map) {
+        String key = makeRandomString();
+        Slot slot = map.modify(key, 0, 0);
+        slot.setValue(key, null, null);
+        return key;
+    }
+}

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -2557,6 +2557,14 @@ public class Context implements Closeable {
                 || (currentActivationCall != null && currentActivationCall.isStrict);
     }
 
+    public static boolean isCurrentContextStrict() {
+        Context cx = getCurrentContext();
+        if (cx == null) {
+            return false;
+        }
+        return cx.isStrictMode();
+    }
+
     private final ContextFactory factory;
     private boolean sealed;
     private Object sealKey;

--- a/src/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/src/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -15,11 +15,9 @@ package org.mozilla.javascript;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
 import org.mozilla.javascript.ScriptableObject.SlotAccess;
 
-public class EmbeddedSlotMap
-    implements SlotMap {
+public class EmbeddedSlotMap implements SlotMap {
 
     private ScriptableObject.Slot[] slots;
 
@@ -32,9 +30,7 @@ public class EmbeddedSlotMap
     // initial slot array size, must be a power of 2
     private static final int INITIAL_SLOT_SIZE = 4;
 
-    private static final class Iter
-        implements Iterator<ScriptableObject.Slot>
-    {
+    private static final class Iter implements Iterator<ScriptableObject.Slot> {
         private ScriptableObject.Slot next;
 
         Iter(ScriptableObject.Slot slot) {
@@ -57,9 +53,7 @@ public class EmbeddedSlotMap
         }
     }
 
-    public EmbeddedSlotMap()
-    {
-    }
+    public EmbeddedSlotMap() {}
 
     @Override
     public int size() {
@@ -76,25 +70,19 @@ public class EmbeddedSlotMap
         return new Iter(firstAdded);
     }
 
-    /**
-     * Locate the slot with the given name or index.
-     */
+    /** Locate the slot with the given name or index. */
     @Override
-    public ScriptableObject.Slot query(Object key, int index)
-    {
+    public ScriptableObject.Slot query(Object key, int index) {
         if (slots == null) {
             return null;
         }
 
         final int indexOrHash = (key != null ? key.hashCode() : index);
         final int slotIndex = getSlotIndex(slots.length, indexOrHash);
-        for (ScriptableObject.Slot slot = slots[slotIndex];
-            slot != null;
-            slot = slot.next) {
+        for (ScriptableObject.Slot slot = slots[slotIndex]; slot != null; slot = slot.next) {
             Object skey = slot.name;
-            if (indexOrHash == slot.indexOrHash &&
-                (skey == key ||
-                    (key != null && key.equals(skey)))) {
+            if (indexOrHash == slot.indexOrHash
+                    && (skey == key || (key != null && key.equals(skey)))) {
                 return slot;
             }
         }
@@ -102,15 +90,15 @@ public class EmbeddedSlotMap
     }
 
     /**
-     * Locate the slot with given name or index. Depending on the accessType
-     * parameter and the current slot status, a new slot may be allocated.
+     * Locate the slot with given name or index. Depending on the accessType parameter and the
+     * current slot status, a new slot may be allocated.
      *
      * @param key either a String or a Symbol object that identifies the property
      * @param index index or 0 if slot holds property name.
      */
     @Override
-    public ScriptableObject.Slot get(Object key, int index, ScriptableObject.SlotAccess accessType)
-    {
+    public ScriptableObject.Slot get(
+            Object key, int index, ScriptableObject.SlotAccess accessType) {
         if (slots == null && accessType == SlotAccess.QUERY) {
             return null;
         }
@@ -120,13 +108,10 @@ public class EmbeddedSlotMap
 
         if (slots != null) {
             final int slotIndex = getSlotIndex(slots.length, indexOrHash);
-            for (slot = slots[slotIndex];
-                 slot != null;
-                 slot = slot.next) {
+            for (slot = slots[slotIndex]; slot != null; slot = slot.next) {
                 Object skey = slot.name;
-                if (indexOrHash == slot.indexOrHash &&
-                        (skey == key ||
-                                (key != null && key.equals(skey)))) {
+                if (indexOrHash == slot.indexOrHash
+                        && (skey == key || (key != null && key.equals(skey)))) {
                     break;
                 }
             }
@@ -145,7 +130,7 @@ public class EmbeddedSlotMap
                     }
                     break;
                 case CONVERT_ACCESSOR_TO_DATA:
-                    if ( !(slot instanceof ScriptableObject.GetterSlot) ) {
+                    if (!(slot instanceof ScriptableObject.GetterSlot)) {
                         return slot;
                     }
                     break;
@@ -157,8 +142,11 @@ public class EmbeddedSlotMap
         return createSlot(key, indexOrHash, accessType, slot);
     }
 
-    private ScriptableObject.Slot createSlot(Object key, int indexOrHash,
-        ScriptableObject.SlotAccess accessType, ScriptableObject.Slot existingSlot) {
+    private ScriptableObject.Slot createSlot(
+            Object key,
+            int indexOrHash,
+            ScriptableObject.SlotAccess accessType,
+            ScriptableObject.Slot existingSlot) {
         if (count == 0) {
             // Always throw away old slots if any on empty insert.
             slots = new ScriptableObject.Slot[INITIAL_SLOT_SIZE];
@@ -169,9 +157,8 @@ public class EmbeddedSlotMap
             ScriptableObject.Slot prev = slots[insertPos];
             ScriptableObject.Slot slot = prev;
             while (slot != null) {
-                if (slot.indexOrHash == indexOrHash &&
-                    (slot.name == key ||
-                        (key != null && key.equals(slot.name)))) {
+                if (slot.indexOrHash == indexOrHash
+                        && (slot.name == key || (key != null && key.equals(slot.name)))) {
                     break;
                 }
                 prev = slot;
@@ -187,11 +174,11 @@ public class EmbeddedSlotMap
                 ScriptableObject.Slot newSlot;
 
                 if (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                    && !(slot instanceof ScriptableObject.GetterSlot)) {
-                    newSlot = new ScriptableObject.GetterSlot(key, indexOrHash,
-                        slot.getAttributes());
+                        && !(slot instanceof ScriptableObject.GetterSlot)) {
+                    newSlot =
+                            new ScriptableObject.GetterSlot(key, indexOrHash, slot.getAttributes());
                 } else if (accessType == SlotAccess.CONVERT_ACCESSOR_TO_DATA
-                    && (slot instanceof ScriptableObject.GetterSlot)) {
+                        && (slot instanceof ScriptableObject.GetterSlot)) {
                     newSlot = new ScriptableObject.Slot(key, indexOrHash, slot.getAttributes());
                 } else if (accessType == SlotAccess.MODIFY_CONST) {
                     return null;
@@ -238,9 +225,10 @@ public class EmbeddedSlotMap
             slots = newSlots;
         }
 
-        ScriptableObject.Slot newSlot = (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                ? new ScriptableObject.GetterSlot(key, indexOrHash, 0)
-                : new ScriptableObject.Slot(key, indexOrHash, 0));
+        ScriptableObject.Slot newSlot =
+                (accessType == SlotAccess.MODIFY_GETTER_SETTER
+                        ? new ScriptableObject.GetterSlot(key, indexOrHash, 0)
+                        : new ScriptableObject.Slot(key, indexOrHash, 0));
         if (accessType == SlotAccess.MODIFY_CONST) {
             newSlot.setAttributes(ScriptableObject.CONST);
         }
@@ -279,10 +267,8 @@ public class EmbeddedSlotMap
             ScriptableObject.Slot prev = slots[slotIndex];
             ScriptableObject.Slot slot = prev;
             while (slot != null) {
-                if (slot.indexOrHash == indexOrHash &&
-                        (slot.name == key ||
-                                (key != null && key.equals(slot.name))))
-                {
+                if (slot.indexOrHash == indexOrHash
+                        && (slot.name == key || (key != null && key.equals(slot.name)))) {
                     break;
                 }
                 prev = slot;
@@ -293,7 +279,8 @@ public class EmbeddedSlotMap
                 if ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0) {
                     Context cx = Context.getContext();
                     if (cx.isStrictMode()) {
-                        throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false", key);
+                        throw ScriptRuntime.typeErrorById(
+                                "msg.delete.property.with.configurable.false", key);
                     }
                     return;
                 }
@@ -327,8 +314,8 @@ public class EmbeddedSlotMap
         }
     }
 
-    private static void copyTable(ScriptableObject.Slot[] oldSlots, ScriptableObject.Slot[] newSlots)
-    {
+    private static void copyTable(
+            ScriptableObject.Slot[] oldSlots, ScriptableObject.Slot[] newSlots) {
         for (ScriptableObject.Slot slot : oldSlots) {
             while (slot != null) {
                 ScriptableObject.Slot nextSlot = slot.next;
@@ -340,20 +327,18 @@ public class EmbeddedSlotMap
     }
 
     /**
-     * Add slot with keys that are known to absent from the table.
-     * This is an optimization to use when inserting into empty table,
-     * after table growth or during deserialization.
+     * Add slot with keys that are known to absent from the table. This is an optimization to use
+     * when inserting into empty table, after table growth or during deserialization.
      */
-    private static void addKnownAbsentSlot(ScriptableObject.Slot[] addSlots, ScriptableObject.Slot slot)
-    {
+    private static void addKnownAbsentSlot(
+            ScriptableObject.Slot[] addSlots, ScriptableObject.Slot slot) {
         final int insertPos = getSlotIndex(addSlots.length, slot.indexOrHash);
         ScriptableObject.Slot old = addSlots[insertPos];
         addSlots[insertPos] = slot;
         slot.next = old;
     }
 
-    private static int getSlotIndex(int tableSize, int indexOrHash)
-    {
+    private static int getSlotIndex(int tableSize, int indexOrHash) {
         // This is a Java trick to efficiently "mod" the hash code by the table size.
         // It only works if the table size is a power of 2.
         // The performance improvement is measurable.

--- a/src/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/src/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -15,25 +15,25 @@ package org.mozilla.javascript;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import org.mozilla.javascript.ScriptableObject.SlotAccess;
+import java.util.Objects;
 
 public class EmbeddedSlotMap implements SlotMap {
 
-    private ScriptableObject.Slot[] slots;
+    private Slot[] slots;
 
     // gateways into the definition-order linked list of slots
-    private ScriptableObject.Slot firstAdded;
-    private ScriptableObject.Slot lastAdded;
+    private Slot firstAdded;
+    private Slot lastAdded;
 
     private int count;
 
     // initial slot array size, must be a power of 2
     private static final int INITIAL_SLOT_SIZE = 4;
 
-    private static final class Iter implements Iterator<ScriptableObject.Slot> {
-        private ScriptableObject.Slot next;
+    private static final class Iter implements Iterator<Slot> {
+        private Slot next;
 
-        Iter(ScriptableObject.Slot slot) {
+        Iter(Slot slot) {
             next = slot;
         }
 
@@ -43,8 +43,8 @@ public class EmbeddedSlotMap implements SlotMap {
         }
 
         @Override
-        public ScriptableObject.Slot next() {
-            ScriptableObject.Slot ret = next;
+        public Slot next() {
+            Slot ret = next;
             if (ret == null) {
                 throw new NoSuchElementException();
             }
@@ -66,23 +66,21 @@ public class EmbeddedSlotMap implements SlotMap {
     }
 
     @Override
-    public Iterator<ScriptableObject.Slot> iterator() {
+    public Iterator<Slot> iterator() {
         return new Iter(firstAdded);
     }
 
     /** Locate the slot with the given name or index. */
     @Override
-    public ScriptableObject.Slot query(Object key, int index) {
+    public Slot query(Object key, int index) {
         if (slots == null) {
             return null;
         }
 
-        final int indexOrHash = (key != null ? key.hashCode() : index);
-        final int slotIndex = getSlotIndex(slots.length, indexOrHash);
-        for (ScriptableObject.Slot slot = slots[slotIndex]; slot != null; slot = slot.next) {
-            Object skey = slot.name;
-            if (indexOrHash == slot.indexOrHash
-                    && (skey == key || (key != null && key.equals(skey)))) {
+        int indexOrHash = (key != null ? key.hashCode() : index);
+        int slotIndex = getSlotIndex(slots.length, indexOrHash);
+        for (Slot slot = slots[slotIndex]; slot != null; slot = slot.next) {
+            if (indexOrHash == slot.indexOrHash && Objects.equals(slot.name, key)) {
                 return slot;
             }
         }
@@ -90,161 +88,103 @@ public class EmbeddedSlotMap implements SlotMap {
     }
 
     /**
-     * Locate the slot with given name or index. Depending on the accessType parameter and the
-     * current slot status, a new slot may be allocated.
+     * Locate the slot with given name or index, and create a new one if necessary.
      *
      * @param key either a String or a Symbol object that identifies the property
      * @param index index or 0 if slot holds property name.
      */
     @Override
-    public ScriptableObject.Slot get(
-            Object key, int index, ScriptableObject.SlotAccess accessType) {
-        if (slots == null && accessType == SlotAccess.QUERY) {
-            return null;
-        }
-
+    public Slot modify(Object key, int index, int attributes) {
         final int indexOrHash = (key != null ? key.hashCode() : index);
-        ScriptableObject.Slot slot = null;
+        Slot slot;
 
         if (slots != null) {
             final int slotIndex = getSlotIndex(slots.length, indexOrHash);
             for (slot = slots[slotIndex]; slot != null; slot = slot.next) {
-                Object skey = slot.name;
-                if (indexOrHash == slot.indexOrHash
-                        && (skey == key || (key != null && key.equals(skey)))) {
+                if (indexOrHash == slot.indexOrHash && Objects.equals(slot.name, key)) {
                     break;
                 }
             }
-            switch (accessType) {
-                case QUERY:
-                    return slot;
-                case MODIFY:
-                case MODIFY_CONST:
-                    if (slot != null) {
-                        return slot;
-                    }
-                    break;
-                case MODIFY_GETTER_SETTER:
-                    if (slot instanceof ScriptableObject.GetterSlot) {
-                        return slot;
-                    }
-                    break;
-                case CONVERT_ACCESSOR_TO_DATA:
-                    if (!(slot instanceof ScriptableObject.GetterSlot)) {
-                        return slot;
-                    }
-                    break;
+            if (slot != null) {
+                return slot;
             }
         }
 
-        // A new slot has to be inserted or the old has to be replaced
-        // by GetterSlot. Time to synchronize.
-        return createSlot(key, indexOrHash, accessType, slot);
+        // A new slot has to be inserted.
+        return createSlot(key, indexOrHash, attributes);
     }
 
-    private ScriptableObject.Slot createSlot(
-            Object key,
-            int indexOrHash,
-            ScriptableObject.SlotAccess accessType,
-            ScriptableObject.Slot existingSlot) {
+    private Slot createSlot(Object key, int indexOrHash, int attributes) {
         if (count == 0) {
             // Always throw away old slots if any on empty insert.
-            slots = new ScriptableObject.Slot[INITIAL_SLOT_SIZE];
-        } else if (existingSlot != null) {
-            // Re-search the slot list because it is a singly-linked list to find
-            // where to replace it with a new object if necessary
-            final int insertPos = getSlotIndex(slots.length, indexOrHash);
-            ScriptableObject.Slot prev = slots[insertPos];
-            ScriptableObject.Slot slot = prev;
-            while (slot != null) {
-                if (slot.indexOrHash == indexOrHash
-                        && (slot.name == key || (key != null && key.equals(slot.name)))) {
-                    break;
-                }
-                prev = slot;
-                slot = slot.next;
-            }
-
-            if (slot != null) {
-                // A slot with same name/index already exists. This means that
-                // a slot is being redefined from a value to a getter slot or
-                // vice versa, or it could be a race in application code.
-                // Check if we need to replace the slot depending on the
-                // accessType flag and return the appropriate slot instance.
-                ScriptableObject.Slot newSlot;
-
-                if (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                        && !(slot instanceof ScriptableObject.GetterSlot)) {
-                    newSlot =
-                            new ScriptableObject.GetterSlot(key, indexOrHash, slot.getAttributes());
-                } else if (accessType == SlotAccess.CONVERT_ACCESSOR_TO_DATA
-                        && (slot instanceof ScriptableObject.GetterSlot)) {
-                    newSlot = new ScriptableObject.Slot(key, indexOrHash, slot.getAttributes());
-                } else if (accessType == SlotAccess.MODIFY_CONST) {
-                    return null;
-                } else {
-                    return slot;
-                }
-
-                newSlot.value = slot.value;
-                newSlot.next = slot.next;
-
-                // Replace new slot in linked list, keeping same order
-                if (slot == firstAdded) {
-                    firstAdded = newSlot;
-                } else {
-                    ScriptableObject.Slot ps = firstAdded;
-                    while ((ps != null) && (ps.orderedNext != slot)) {
-                        ps = ps.orderedNext;
-                    }
-                    if (ps != null) {
-                        ps.orderedNext = newSlot;
-                    }
-                }
-                newSlot.orderedNext = slot.orderedNext;
-                if (slot == lastAdded) {
-                    lastAdded = newSlot;
-                }
-
-                // add new slot to hash table
-                if (prev == slot) {
-                    slots[insertPos] = newSlot;
-                } else {
-                    prev.next = newSlot;
-                }
-                return newSlot;
-            }
+            slots = new Slot[INITIAL_SLOT_SIZE];
         }
 
-        // If we get here, then we are going to insert a new slot
         // Check if the table is not too full before inserting.
         if (4 * (count + 1) > 3 * slots.length) {
             // table size must be a power of 2 -- always grow by x2!
-            ScriptableObject.Slot[] newSlots = new ScriptableObject.Slot[slots.length * 2];
+            Slot[] newSlots = new Slot[slots.length * 2];
             copyTable(slots, newSlots);
             slots = newSlots;
         }
 
-        ScriptableObject.Slot newSlot =
-                (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                        ? new ScriptableObject.GetterSlot(key, indexOrHash, 0)
-                        : new ScriptableObject.Slot(key, indexOrHash, 0));
-        if (accessType == SlotAccess.MODIFY_CONST) {
-            newSlot.setAttributes(ScriptableObject.CONST);
-        }
+        Slot newSlot = new Slot(key, indexOrHash, attributes);
         insertNewSlot(newSlot);
         return newSlot;
     }
 
     @Override
-    public void addSlot(ScriptableObject.Slot newSlot) {
+    public void replace(Slot oldSlot, Slot newSlot) {
+        final int insertPos = getSlotIndex(slots.length, oldSlot.indexOrHash);
+        Slot prev = slots[insertPos];
+        Slot tmpSlot = prev;
+        // Find original slot and previous one in hash table
+        while (tmpSlot != null) {
+            if (tmpSlot == oldSlot) {
+                break;
+            }
+            prev = tmpSlot;
+            tmpSlot = tmpSlot.next;
+        }
+
+        // It's an error to call this when the slot isn't already there
+        assert (tmpSlot == oldSlot);
+
+        // add new slot to hash table
+        if (prev == oldSlot) {
+            slots[insertPos] = newSlot;
+        } else {
+            prev.next = newSlot;
+        }
+        newSlot.next = oldSlot.next;
+
+        // Replace new slot in linked list, keeping same order
+        if (oldSlot == firstAdded) {
+            firstAdded = newSlot;
+        } else {
+            Slot ps = firstAdded;
+            while ((ps != null) && (ps.orderedNext != oldSlot)) {
+                ps = ps.orderedNext;
+            }
+            if (ps != null) {
+                ps.orderedNext = newSlot;
+            }
+        }
+        newSlot.orderedNext = oldSlot.orderedNext;
+        if (oldSlot == lastAdded) {
+            lastAdded = newSlot;
+        }
+    }
+
+    @Override
+    public void add(Slot newSlot) {
         if (slots == null) {
-            slots = new ScriptableObject.Slot[INITIAL_SLOT_SIZE];
+            slots = new Slot[INITIAL_SLOT_SIZE];
         }
         insertNewSlot(newSlot);
     }
 
-    private void insertNewSlot(ScriptableObject.Slot newSlot) {
+    private void insertNewSlot(Slot newSlot) {
         ++count;
         // add new slot to linked list
         if (lastAdded != null) {
@@ -264,11 +204,10 @@ public class EmbeddedSlotMap implements SlotMap {
 
         if (count != 0) {
             final int slotIndex = getSlotIndex(slots.length, indexOrHash);
-            ScriptableObject.Slot prev = slots[slotIndex];
-            ScriptableObject.Slot slot = prev;
+            Slot prev = slots[slotIndex];
+            Slot slot = prev;
             while (slot != null) {
-                if (slot.indexOrHash == indexOrHash
-                        && (slot.name == key || (key != null && key.equals(slot.name)))) {
+                if (slot.indexOrHash == indexOrHash && Objects.equals(slot.name, key)) {
                     break;
                 }
                 prev = slot;
@@ -314,11 +253,10 @@ public class EmbeddedSlotMap implements SlotMap {
         }
     }
 
-    private static void copyTable(
-            ScriptableObject.Slot[] oldSlots, ScriptableObject.Slot[] newSlots) {
-        for (ScriptableObject.Slot slot : oldSlots) {
+    private static void copyTable(Slot[] oldSlots, Slot[] newSlots) {
+        for (Slot slot : oldSlots) {
             while (slot != null) {
-                ScriptableObject.Slot nextSlot = slot.next;
+                Slot nextSlot = slot.next;
                 slot.next = null;
                 addKnownAbsentSlot(newSlots, slot);
                 slot = nextSlot;
@@ -330,10 +268,9 @@ public class EmbeddedSlotMap implements SlotMap {
      * Add slot with keys that are known to absent from the table. This is an optimization to use
      * when inserting into empty table, after table growth or during deserialization.
      */
-    private static void addKnownAbsentSlot(
-            ScriptableObject.Slot[] addSlots, ScriptableObject.Slot slot) {
+    private static void addKnownAbsentSlot(Slot[] addSlots, Slot slot) {
         final int insertPos = getSlotIndex(addSlots.length, slot.indexOrHash);
-        ScriptableObject.Slot old = addSlots[insertPos];
+        Slot old = addSlots[insertPos];
         addSlots[insertPos] = slot;
         slot.next = old;
     }

--- a/src/org/mozilla/javascript/FunctionSlot.java
+++ b/src/org/mozilla/javascript/FunctionSlot.java
@@ -29,20 +29,7 @@ public class FunctionSlot extends Slot {
         // but the spec is super pedantic about things like the order of properties here,
         // so we need special support here.
         ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
-        desc.defineProperty(
-                "enumerable",
-                (getAttributes() & ScriptableObject.DONTENUM) == 0,
-                ScriptableObject.EMPTY);
-        desc.defineProperty(
-                "configurable",
-                (getAttributes() & ScriptableObject.PERMANENT) == 0,
-                ScriptableObject.EMPTY);
-        if (getter == null && setter == null) {
-            desc.defineProperty(
-                    "writable",
-                    (getAttributes() & ScriptableObject.READONLY) == 0,
-                    ScriptableObject.EMPTY);
-        }
+        desc.setCommonDescriptorProperties(getAttributes(), getter == null && setter == null);
 
         if (getter != null) {
             desc.defineProperty("get", getter, ScriptableObject.EMPTY);

--- a/src/org/mozilla/javascript/FunctionSlot.java
+++ b/src/org/mozilla/javascript/FunctionSlot.java
@@ -1,0 +1,102 @@
+package org.mozilla.javascript;
+
+/**
+ * This is a specialization of Slot to store values that are retrieved via calls to script
+ * functions.
+ */
+public class FunctionSlot extends Slot {
+    FunctionSlot(Slot oldSlot) {
+        super(oldSlot);
+    }
+
+    // These must be Object because they could be Undefined
+    Object getter;
+    Object setter;
+
+    @Override
+    boolean isValueSlot() {
+        return false;
+    }
+
+    @Override
+    boolean isSetterSlot() {
+        return true;
+    }
+
+    @Override
+    ScriptableObject getPropertyDescriptor(Context cx, Scriptable scope) {
+        // It sounds logical that this would be the same as the logic for a normal Slot,
+        // but the spec is super pedantic about things like the order of properties here,
+        // so we need special support here.
+        ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
+        desc.defineProperty(
+                "enumerable",
+                (getAttributes() & ScriptableObject.DONTENUM) == 0,
+                ScriptableObject.EMPTY);
+        desc.defineProperty(
+                "configurable",
+                (getAttributes() & ScriptableObject.PERMANENT) == 0,
+                ScriptableObject.EMPTY);
+        if (getter == null && setter == null) {
+            desc.defineProperty(
+                    "writable",
+                    (getAttributes() & ScriptableObject.READONLY) == 0,
+                    ScriptableObject.EMPTY);
+        }
+
+        if (getter != null) {
+            desc.defineProperty("get", getter, ScriptableObject.EMPTY);
+        }
+        if (setter != null) {
+            desc.defineProperty("set", setter, ScriptableObject.EMPTY);
+        }
+        return desc;
+    }
+
+    @Override
+    public boolean setValue(Object value, Scriptable owner, Scriptable start) {
+        if (setter == null) {
+            if (getter != null) {
+                throwNoSetterException(start, value);
+                return true;
+            }
+        } else {
+            if (setter instanceof Function) {
+                Function setterFunc = (Function) setter;
+                Context cx = Context.getContext();
+                setterFunc.call(cx, setterFunc.getParentScope(), start, new Object[] {value});
+            }
+            return true;
+        }
+        return super.setValue(value, owner, start);
+    }
+
+    @Override
+    public Object getValue(Scriptable start) {
+        if (getter != null) {
+            if (getter instanceof Function) {
+                Function getterFunc = (Function) getter;
+                Context cx = Context.getContext();
+                return getterFunc.call(
+                        cx, getterFunc.getParentScope(), start, ScriptRuntime.emptyArgs);
+            }
+        }
+        return this.value;
+    }
+
+    @Override
+    Function getSetterFunction(String name, Scriptable scope) {
+        if (setter instanceof Function) {
+            return (Function) setter;
+        }
+        return null;
+    }
+
+    @Override
+    Function getGetterFunction(String name, Scriptable scope) {
+        if (getter instanceof Function) {
+            return (Function) getter;
+        }
+        return null;
+    }
+}

--- a/src/org/mozilla/javascript/HashSlotMap.java
+++ b/src/org/mozilla/javascript/HashSlotMap.java
@@ -8,7 +8,6 @@ package org.mozilla.javascript;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import org.mozilla.javascript.ScriptableObject.SlotAccess;
 
 /**
  * This class implements the SlotMap interface using a java.util.HashMap. This class has more
@@ -18,8 +17,7 @@ import org.mozilla.javascript.ScriptableObject.SlotAccess;
  */
 public class HashSlotMap implements SlotMap {
 
-    private final LinkedHashMap<Object, ScriptableObject.Slot> map =
-            new LinkedHashMap<Object, ScriptableObject.Slot>();
+    private final LinkedHashMap<Object, Slot> map = new LinkedHashMap<>();
 
     @Override
     public int size() {
@@ -32,79 +30,44 @@ public class HashSlotMap implements SlotMap {
     }
 
     @Override
-    public ScriptableObject.Slot query(Object key, int index) {
-        Object name = key == null ? String.valueOf(index) : key;
+    public Slot query(Object key, int index) {
+        Object name = makeKey(key, index);
         return map.get(name);
     }
 
     @Override
-    public ScriptableObject.Slot get(
-            Object key, int index, ScriptableObject.SlotAccess accessType) {
-        Object name = key == null ? String.valueOf(index) : key;
-        ScriptableObject.Slot slot = map.get(name);
-        switch (accessType) {
-            case QUERY:
-                return slot;
-            case MODIFY:
-            case MODIFY_CONST:
-                if (slot != null) return slot;
-                break;
-            case MODIFY_GETTER_SETTER:
-                if (slot instanceof ScriptableObject.GetterSlot) return slot;
-                break;
-            case CONVERT_ACCESSOR_TO_DATA:
-                if (!(slot instanceof ScriptableObject.GetterSlot)) return slot;
-                break;
+    public Slot modify(Object key, int index, int attributes) {
+        Object name = makeKey(key, index);
+        Slot slot = map.get(name);
+        if (slot != null) {
+            return slot;
         }
 
-        return createSlot(key, index, name, accessType);
+        return createSlot(key, index, attributes);
     }
 
-    private ScriptableObject.Slot createSlot(
-            Object key, int index, Object name, ScriptableObject.SlotAccess accessType) {
-        ScriptableObject.Slot slot = map.get(name);
-        if (slot != null) {
-            ScriptableObject.Slot newSlot;
+    @Override
+    public void replace(Slot oldSlot, Slot newSlot) {
+        Object name = makeKey(oldSlot);
+        map.put(name, newSlot);
+    }
 
-            if (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                    && !(slot instanceof ScriptableObject.GetterSlot)) {
-                newSlot =
-                        new ScriptableObject.GetterSlot(
-                                name, slot.indexOrHash, slot.getAttributes());
-            } else if (accessType == SlotAccess.CONVERT_ACCESSOR_TO_DATA
-                    && (slot instanceof ScriptableObject.GetterSlot)) {
-                newSlot = new ScriptableObject.Slot(name, slot.indexOrHash, slot.getAttributes());
-            } else if (accessType == SlotAccess.MODIFY_CONST) {
-                return null;
-            } else {
-                return slot;
-            }
-            newSlot.value = slot.value;
-            map.put(name, newSlot);
-            return newSlot;
-        }
-
-        ScriptableObject.Slot newSlot =
-                (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                        ? new ScriptableObject.GetterSlot(key, index, 0)
-                        : new ScriptableObject.Slot(key, index, 0));
-        if (accessType == SlotAccess.MODIFY_CONST) {
-            newSlot.setAttributes(ScriptableObject.CONST);
-        }
-        addSlot(newSlot);
+    private Slot createSlot(Object key, int index, int attributes) {
+        Slot newSlot = new Slot(key, index, attributes);
+        add(newSlot);
         return newSlot;
     }
 
     @Override
-    public void addSlot(ScriptableObject.Slot newSlot) {
-        Object name = newSlot.name == null ? String.valueOf(newSlot.indexOrHash) : newSlot.name;
+    public void add(Slot newSlot) {
+        Object name = makeKey(newSlot);
         map.put(name, newSlot);
     }
 
     @Override
     public void remove(Object key, int index) {
-        Object name = key == null ? String.valueOf(index) : key;
-        ScriptableObject.Slot slot = map.get(name);
+        Object name = makeKey(key, index);
+        Slot slot = map.get(name);
         if (slot != null) {
             // non-configurable
             if ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0) {
@@ -120,7 +83,15 @@ public class HashSlotMap implements SlotMap {
     }
 
     @Override
-    public Iterator<ScriptableObject.Slot> iterator() {
+    public Iterator<Slot> iterator() {
         return map.values().iterator();
+    }
+
+    private Object makeKey(Object name, int index) {
+        return name == null ? String.valueOf(index) : name;
+    }
+
+    private Object makeKey(Slot slot) {
+        return slot.name == null ? String.valueOf(slot.indexOrHash) : slot.name;
     }
 }

--- a/src/org/mozilla/javascript/HashSlotMap.java
+++ b/src/org/mozilla/javascript/HashSlotMap.java
@@ -8,22 +8,18 @@ package org.mozilla.javascript;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-
 import org.mozilla.javascript.ScriptableObject.SlotAccess;
 
 /**
  * This class implements the SlotMap interface using a java.util.HashMap. This class has more
  * overhead than EmbeddedSlotMap, especially because it puts each "Slot" inside an intermediate
- * object. However it is much more resistant to large number of hash collisions than
- * EmbeddedSlotMap and therefore we use this implementation when an object gains a large
- * number of properties.
+ * object. However it is much more resistant to large number of hash collisions than EmbeddedSlotMap
+ * and therefore we use this implementation when an object gains a large number of properties.
  */
-
-public class HashSlotMap
-    implements SlotMap {
+public class HashSlotMap implements SlotMap {
 
     private final LinkedHashMap<Object, ScriptableObject.Slot> map =
-        new LinkedHashMap<Object, ScriptableObject.Slot>();
+            new LinkedHashMap<Object, ScriptableObject.Slot>();
 
     @Override
     public int size() {
@@ -36,14 +32,14 @@ public class HashSlotMap
     }
 
     @Override
-    public ScriptableObject.Slot query(Object key, int index)
-    {
+    public ScriptableObject.Slot query(Object key, int index) {
         Object name = key == null ? String.valueOf(index) : key;
         return map.get(name);
     }
 
     @Override
-    public ScriptableObject.Slot get(Object key, int index, ScriptableObject.SlotAccess accessType) {
+    public ScriptableObject.Slot get(
+            Object key, int index, ScriptableObject.SlotAccess accessType) {
         Object name = key == null ? String.valueOf(index) : key;
         ScriptableObject.Slot slot = map.get(name);
         switch (accessType) {
@@ -51,31 +47,30 @@ public class HashSlotMap
                 return slot;
             case MODIFY:
             case MODIFY_CONST:
-                if (slot != null)
-                    return slot;
+                if (slot != null) return slot;
                 break;
             case MODIFY_GETTER_SETTER:
-                if (slot instanceof ScriptableObject.GetterSlot)
-                    return slot;
+                if (slot instanceof ScriptableObject.GetterSlot) return slot;
                 break;
             case CONVERT_ACCESSOR_TO_DATA:
-                if ( !(slot instanceof ScriptableObject.GetterSlot) )
-                    return slot;
+                if (!(slot instanceof ScriptableObject.GetterSlot)) return slot;
                 break;
         }
 
         return createSlot(key, index, name, accessType);
     }
 
-    private ScriptableObject.Slot createSlot(Object key, int index,
-        Object name, ScriptableObject.SlotAccess accessType) {
+    private ScriptableObject.Slot createSlot(
+            Object key, int index, Object name, ScriptableObject.SlotAccess accessType) {
         ScriptableObject.Slot slot = map.get(name);
         if (slot != null) {
             ScriptableObject.Slot newSlot;
 
             if (accessType == SlotAccess.MODIFY_GETTER_SETTER
                     && !(slot instanceof ScriptableObject.GetterSlot)) {
-                newSlot = new ScriptableObject.GetterSlot(name, slot.indexOrHash, slot.getAttributes());
+                newSlot =
+                        new ScriptableObject.GetterSlot(
+                                name, slot.indexOrHash, slot.getAttributes());
             } else if (accessType == SlotAccess.CONVERT_ACCESSOR_TO_DATA
                     && (slot instanceof ScriptableObject.GetterSlot)) {
                 newSlot = new ScriptableObject.Slot(name, slot.indexOrHash, slot.getAttributes());
@@ -89,9 +84,10 @@ public class HashSlotMap
             return newSlot;
         }
 
-        ScriptableObject.Slot newSlot = (accessType == SlotAccess.MODIFY_GETTER_SETTER
-                ? new ScriptableObject.GetterSlot(key, index, 0)
-                : new ScriptableObject.Slot(key, index, 0));
+        ScriptableObject.Slot newSlot =
+                (accessType == SlotAccess.MODIFY_GETTER_SETTER
+                        ? new ScriptableObject.GetterSlot(key, index, 0)
+                        : new ScriptableObject.Slot(key, index, 0));
         if (accessType == SlotAccess.MODIFY_CONST) {
             newSlot.setAttributes(ScriptableObject.CONST);
         }
@@ -114,7 +110,8 @@ public class HashSlotMap
             if ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0) {
                 Context cx = Context.getContext();
                 if (cx.isStrictMode()) {
-                    throw ScriptRuntime.typeErrorById("msg.delete.property.with.configurable.false", key);
+                    throw ScriptRuntime.typeErrorById(
+                            "msg.delete.property.with.configurable.false", key);
                 }
                 return;
             }

--- a/src/org/mozilla/javascript/LazyLoadSlot.java
+++ b/src/org/mozilla/javascript/LazyLoadSlot.java
@@ -1,0 +1,25 @@
+package org.mozilla.javascript;
+
+/**
+ * This is a specialization of Slot to store values that are retrieved via calls to script
+ * functions. It's used to load built-in objects more efficiently.
+ */
+public class LazyLoadSlot extends Slot {
+    LazyLoadSlot(Slot oldSlot) {
+        super(oldSlot);
+    }
+
+    @Override
+    public Object getValue(Scriptable start) {
+        Object val = this.value;
+        if (val instanceof LazilyLoadedCtor) {
+            LazilyLoadedCtor initializer = (LazilyLoadedCtor) val;
+            try {
+                initializer.init();
+            } finally {
+                this.value = val = initializer.getValue();
+            }
+        }
+        return val;
+    }
+}

--- a/src/org/mozilla/javascript/MemberBoxSlot.java
+++ b/src/org/mozilla/javascript/MemberBoxSlot.java
@@ -28,22 +28,8 @@ public class MemberBoxSlot extends Slot {
         // but the spec is super pedantic about things like the order of properties here,
         // so we need special support here.
         ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
+        desc.setCommonDescriptorProperties(getAttributes(), getter == null && setter == null);
         String fName = name == null ? "f" : name.toString();
-        desc.defineProperty(
-                "enumerable",
-                (getAttributes() & ScriptableObject.DONTENUM) == 0,
-                ScriptableObject.EMPTY);
-        desc.defineProperty(
-                "configurable",
-                (getAttributes() & ScriptableObject.PERMANENT) == 0,
-                ScriptableObject.EMPTY);
-        if (getter == null && setter == null) {
-            desc.defineProperty(
-                    "writable",
-                    (getAttributes() & ScriptableObject.READONLY) == 0,
-                    ScriptableObject.EMPTY);
-        }
-
         if (getter != null) {
             desc.defineProperty(
                     "get", getter.asGetterFunction(fName, scope), ScriptableObject.EMPTY);

--- a/src/org/mozilla/javascript/MemberBoxSlot.java
+++ b/src/org/mozilla/javascript/MemberBoxSlot.java
@@ -56,16 +56,12 @@ public class MemberBoxSlot extends Slot {
             Class<?> valueType = pTypes[pTypes.length - 1];
             int tag = FunctionObject.getTypeTag(valueType);
             Object actualArg = FunctionObject.convertArg(cx, start, value, tag);
-            Object setterThis;
-            Object[] args;
+
             if (setter.delegateTo == null) {
-                setterThis = start;
-                args = new Object[] {actualArg};
+                setter.invoke(start, new Object[] {actualArg});
             } else {
-                setterThis = setter.delegateTo;
-                args = new Object[] {start, actualArg};
+                setter.invoke(setter.delegateTo, new Object[] {start, actualArg});
             }
-            setter.invoke(setterThis, args);
             return true;
         }
         return super.setValue(value, owner, start);
@@ -74,16 +70,10 @@ public class MemberBoxSlot extends Slot {
     @Override
     public Object getValue(Scriptable start) {
         if (getter != null) {
-            Object getterThis;
-            Object[] args;
             if (getter.delegateTo == null) {
-                getterThis = start;
-                args = ScriptRuntime.emptyArgs;
-            } else {
-                getterThis = getter.delegateTo;
-                args = new Object[] {start};
+                return getter.invoke(start, ScriptRuntime.emptyArgs);
             }
-            return getter.invoke(getterThis, args);
+            return getter.invoke(getter.delegateTo, new Object[] {start});
         }
         return super.getValue(start);
     }

--- a/src/org/mozilla/javascript/MemberBoxSlot.java
+++ b/src/org/mozilla/javascript/MemberBoxSlot.java
@@ -1,0 +1,120 @@
+package org.mozilla.javascript;
+
+/**
+ * This is a specialization of Slot to store values that are retrieved via reflection using the
+ * MemberBox class.
+ */
+public class MemberBoxSlot extends Slot {
+    MemberBoxSlot(Slot oldSlot) {
+        super(oldSlot);
+    }
+
+    MemberBox getter;
+    MemberBox setter;
+
+    @Override
+    boolean isValueSlot() {
+        return false;
+    }
+
+    @Override
+    boolean isSetterSlot() {
+        return true;
+    }
+
+    @Override
+    ScriptableObject getPropertyDescriptor(Context cx, Scriptable scope) {
+        // It sounds logical that this would be the same as the logic for a normal Slot,
+        // but the spec is super pedantic about things like the order of properties here,
+        // so we need special support here.
+        ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
+        String fName = name == null ? "f" : name.toString();
+        desc.defineProperty(
+                "enumerable",
+                (getAttributes() & ScriptableObject.DONTENUM) == 0,
+                ScriptableObject.EMPTY);
+        desc.defineProperty(
+                "configurable",
+                (getAttributes() & ScriptableObject.PERMANENT) == 0,
+                ScriptableObject.EMPTY);
+        if (getter == null && setter == null) {
+            desc.defineProperty(
+                    "writable",
+                    (getAttributes() & ScriptableObject.READONLY) == 0,
+                    ScriptableObject.EMPTY);
+        }
+
+        if (getter != null) {
+            desc.defineProperty(
+                    "get", getter.asGetterFunction(fName, scope), ScriptableObject.EMPTY);
+        }
+        if (setter != null) {
+            desc.defineProperty(
+                    "set", setter.asSetterFunction(fName, scope), ScriptableObject.EMPTY);
+        }
+        return desc;
+    }
+
+    @Override
+    public boolean setValue(Object value, Scriptable owner, Scriptable start) {
+        if (setter == null) {
+            if (getter != null) {
+                throwNoSetterException(start, value);
+                return true;
+            }
+        } else {
+            Context cx = Context.getContext();
+            Class<?>[] pTypes = setter.argTypes;
+            // XXX: cache tag since it is already calculated in
+            // defineProperty ?
+            Class<?> valueType = pTypes[pTypes.length - 1];
+            int tag = FunctionObject.getTypeTag(valueType);
+            Object actualArg = FunctionObject.convertArg(cx, start, value, tag);
+            Object setterThis;
+            Object[] args;
+            if (setter.delegateTo == null) {
+                setterThis = start;
+                args = new Object[] {actualArg};
+            } else {
+                setterThis = setter.delegateTo;
+                args = new Object[] {start, actualArg};
+            }
+            setter.invoke(setterThis, args);
+            return true;
+        }
+        return super.setValue(value, owner, start);
+    }
+
+    @Override
+    public Object getValue(Scriptable start) {
+        if (getter != null) {
+            Object getterThis;
+            Object[] args;
+            if (getter.delegateTo == null) {
+                getterThis = start;
+                args = ScriptRuntime.emptyArgs;
+            } else {
+                getterThis = getter.delegateTo;
+                args = new Object[] {start};
+            }
+            return getter.invoke(getterThis, args);
+        }
+        return super.getValue(start);
+    }
+
+    @Override
+    Function getSetterFunction(String name, Scriptable scope) {
+        if (setter == null) {
+            return null;
+        }
+        return setter.asSetterFunction(name, scope);
+    }
+
+    @Override
+    Function getGetterFunction(String name, Scriptable scope) {
+        if (getter == null) {
+            return null;
+        }
+        return getter.asGetterFunction(name, scope);
+    }
+}

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -324,25 +324,25 @@ public class NativeObject extends IdScriptableObject implements Map {
                     StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
                     int index = s.stringId != null ? 0 : s.index;
                     boolean isSetter = (id == Id___lookupSetter__);
-                    Object gs;
+                    Function gs;
                     for (; ; ) {
-                        gs = so.getGetterOrSetter(s.stringId, index, isSetter);
-                        if (gs != null) break;
+                        gs = so.getGetterOrSetter(s.stringId, index, this, isSetter);
+                        if (gs != null) {
+                            break;
+                        }
                         // If there is no getter or setter for the object itself,
                         // how about the prototype?
                         Scriptable v = so.getPrototype();
-                        if (v == null) break;
-                        if (v instanceof ScriptableObject) so = (ScriptableObject) v;
-                        else break;
+                        if (v == null) {
+                            break;
+                        }
+                        if (v instanceof ScriptableObject) {
+                            so = (ScriptableObject) v;
+                        } else {
+                            break;
+                        }
                     }
                     if (gs != null) {
-                        if (gs instanceof MemberBox) {
-                            if (isSetter) {
-                                gs = ((MemberBox) gs).asSetterFunction(s.stringId, this);
-                            } else {
-                                gs = ((MemberBox) gs).asGetterFunction(s.stringId, this);
-                            }
-                        }
                         return gs;
                     }
                 }

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -14,597 +14,633 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
 
 /**
- * This class implements the Object native object.
- * See ECMA 15.2.
+ * This class implements the Object native object. See ECMA 15.2.
+ *
  * @author Norris Boyd
  */
-public class NativeObject extends IdScriptableObject implements Map
-{
+public class NativeObject extends IdScriptableObject implements Map {
     private static final long serialVersionUID = -6345305608474346996L;
 
     private static final Object OBJECT_TAG = "Object";
 
-    static void init(Scriptable scope, boolean sealed)
-    {
+    static void init(Scriptable scope, boolean sealed) {
         NativeObject obj = new NativeObject();
         obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
     }
 
     @Override
-    public String getClassName()
-    {
+    public String getClassName() {
         return "Object";
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return ScriptRuntime.defaultObjectToString(this);
     }
 
     @Override
-    protected void fillConstructorProperties(IdFunctionObject ctor)
-    {
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getPrototypeOf,
-                "getPrototypeOf", 1);
+    protected void fillConstructorProperties(IdFunctionObject ctor) {
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getPrototypeOf, "getPrototypeOf", 1);
         if (Context.getCurrentContext().version >= Context.VERSION_ES6) {
-            addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_setPrototypeOf,
-                    "setPrototypeOf", 2);
+            addIdFunctionProperty(
+                    ctor, OBJECT_TAG, ConstructorId_setPrototypeOf, "setPrototypeOf", 2);
         }
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_keys,
-                "keys", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyNames,
-                "getOwnPropertyNames", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertySymbols,
-                "getOwnPropertySymbols", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getOwnPropertyDescriptor,
-                "getOwnPropertyDescriptor", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_defineProperty,
-                "defineProperty", 3);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isExtensible,
-                "isExtensible", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_preventExtensions,
-                "preventExtensions", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_defineProperties,
-                "defineProperties", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_create,
-                "create", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isSealed,
-                "isSealed", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isFrozen,
-                "isFrozen", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_seal,
-                "seal", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_freeze,
-                "freeze", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_assign,
-                "assign", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_is,
-                "is", 2);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_keys, "keys", 1);
+        addIdFunctionProperty(
+                ctor, OBJECT_TAG, ConstructorId_getOwnPropertyNames, "getOwnPropertyNames", 1);
+        addIdFunctionProperty(
+                ctor, OBJECT_TAG, ConstructorId_getOwnPropertySymbols, "getOwnPropertySymbols", 1);
+        addIdFunctionProperty(
+                ctor,
+                OBJECT_TAG,
+                ConstructorId_getOwnPropertyDescriptor,
+                "getOwnPropertyDescriptor",
+                2);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_defineProperty, "defineProperty", 3);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isExtensible, "isExtensible", 1);
+        addIdFunctionProperty(
+                ctor, OBJECT_TAG, ConstructorId_preventExtensions, "preventExtensions", 1);
+        addIdFunctionProperty(
+                ctor, OBJECT_TAG, ConstructorId_defineProperties, "defineProperties", 2);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_create, "create", 2);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isSealed, "isSealed", 1);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isFrozen, "isFrozen", 1);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_seal, "seal", 1);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_freeze, "freeze", 1);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_assign, "assign", 2);
+        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_is, "is", 2);
         super.fillConstructorProperties(ctor);
     }
 
     @Override
-    protected void initPrototypeId(int id)
-    {
+    protected void initPrototypeId(int id) {
         String s;
         int arity;
         switch (id) {
-          case Id_constructor:    arity=1; s="constructor";    break;
-          case Id_toString:       arity=0; s="toString";       break;
-          case Id_toLocaleString: arity=0; s="toLocaleString"; break;
-          case Id_valueOf:        arity=0; s="valueOf";        break;
-          case Id_hasOwnProperty: arity=1; s="hasOwnProperty"; break;
-          case Id_propertyIsEnumerable:
-            arity=1; s="propertyIsEnumerable"; break;
-          case Id_isPrototypeOf:  arity=1; s="isPrototypeOf";  break;
-          case Id_toSource:       arity=0; s="toSource";       break;
-          case Id___defineGetter__:
-            arity=2; s="__defineGetter__";     break;
-          case Id___defineSetter__:
-            arity=2; s="__defineSetter__";     break;
-          case Id___lookupGetter__:
-            arity=1; s="__lookupGetter__";     break;
-          case Id___lookupSetter__:
-            arity=1; s="__lookupSetter__";     break;
-          default: throw new IllegalArgumentException(String.valueOf(id));
+            case Id_constructor:
+                arity = 1;
+                s = "constructor";
+                break;
+            case Id_toString:
+                arity = 0;
+                s = "toString";
+                break;
+            case Id_toLocaleString:
+                arity = 0;
+                s = "toLocaleString";
+                break;
+            case Id_valueOf:
+                arity = 0;
+                s = "valueOf";
+                break;
+            case Id_hasOwnProperty:
+                arity = 1;
+                s = "hasOwnProperty";
+                break;
+            case Id_propertyIsEnumerable:
+                arity = 1;
+                s = "propertyIsEnumerable";
+                break;
+            case Id_isPrototypeOf:
+                arity = 1;
+                s = "isPrototypeOf";
+                break;
+            case Id_toSource:
+                arity = 0;
+                s = "toSource";
+                break;
+            case Id___defineGetter__:
+                arity = 2;
+                s = "__defineGetter__";
+                break;
+            case Id___defineSetter__:
+                arity = 2;
+                s = "__defineSetter__";
+                break;
+            case Id___lookupGetter__:
+                arity = 1;
+                s = "__lookupGetter__";
+                break;
+            case Id___lookupSetter__:
+                arity = 1;
+                s = "__lookupSetter__";
+                break;
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
         }
         initPrototypeMethod(OBJECT_TAG, id, s, arity);
     }
 
     @Override
-    public Object execIdCall(IdFunctionObject f, Context cx, Scriptable scope,
-                             Scriptable thisObj, Object[] args)
-    {
+    public Object execIdCall(
+            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         if (!f.hasTag(OBJECT_TAG)) {
             return super.execIdCall(f, cx, scope, thisObj, args);
         }
         int id = f.methodId();
         switch (id) {
-          case Id_constructor: {
-            if (thisObj != null) {
-                // BaseFunction.construct will set up parent, proto
-                return f.construct(cx, scope, args);
-            }
-            if (args.length == 0
-                    || args[0] == null
-                    || Undefined.isUndefined(args[0]))
-            {
-                return new NativeObject();
-            }
-            return ScriptRuntime.toObject(cx, scope, args[0]);
-          }
-
-          case Id_toLocaleString: {
-            Object toString = ScriptableObject.getProperty(thisObj, "toString");
-            if(!(toString instanceof Callable)) {
-                throw ScriptRuntime.notFunctionError(toString);
-            }
-            Callable fun = (Callable)toString;
-            return fun.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
-          }
-
-          case Id_toString: {
-            if (cx.hasFeature(Context.FEATURE_TO_STRING_AS_SOURCE)) {
-                String s = ScriptRuntime.defaultObjectToSource(cx, scope,
-                                                               thisObj, args);
-                int L = s.length();
-                if (L != 0 && s.charAt(0) == '(' && s.charAt(L - 1) == ')') {
-                    // Strip () that surrounds toSource
-                    s = s.substring(1, L - 1);
+            case Id_constructor:
+                {
+                    if (thisObj != null) {
+                        // BaseFunction.construct will set up parent, proto
+                        return f.construct(cx, scope, args);
+                    }
+                    if (args.length == 0 || args[0] == null || Undefined.isUndefined(args[0])) {
+                        return new NativeObject();
+                    }
+                    return ScriptRuntime.toObject(cx, scope, args[0]);
                 }
-                return s;
-            }
-            return ScriptRuntime.defaultObjectToString(thisObj);
-          }
 
-          case Id_valueOf:
-              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                  throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
-              }
-            return thisObj;
-
-          case Id_hasOwnProperty: {
-              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                  throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
-              }
-              boolean result;
-              Object arg = args.length < 1 ? Undefined.instance : args[0];
-              if (arg instanceof Symbol) {
-                  result = ensureSymbolScriptable(thisObj).has((Symbol) arg, thisObj);
-              } else {
-                  StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, arg);
-                  if (s.stringId == null) {
-                      result = thisObj.has(s.index, thisObj);
-                  } else {
-                      result = thisObj.has(s.stringId, thisObj);
-                  }
-              }
-              return ScriptRuntime.wrapBoolean(result);
-          }
-
-          case Id_propertyIsEnumerable: {
-              if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                  throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
-              }
-
-            boolean result;
-            Object arg = args.length < 1 ? Undefined.instance : args[0];
-
-            if (arg instanceof Symbol) {
-                result = ((SymbolScriptable)thisObj).has((Symbol)arg, thisObj);
-                if (result && thisObj instanceof ScriptableObject) {
-                    ScriptableObject so = (ScriptableObject)thisObj;
-                    int attrs = so.getAttributes((Symbol)arg);
-                    result = ((attrs & ScriptableObject.DONTENUM) == 0);
+            case Id_toLocaleString:
+                {
+                    Object toString = ScriptableObject.getProperty(thisObj, "toString");
+                    if (!(toString instanceof Callable)) {
+                        throw ScriptRuntime.notFunctionError(toString);
+                    }
+                    Callable fun = (Callable) toString;
+                    return fun.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
                 }
-            } else {
-                StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, arg);
-                // When checking if a property is enumerable, a missing property should return "false" instead of
-                // throwing an exception.  See: https://github.com/mozilla/rhino/issues/415
-                try {
-                    if (s.stringId == null) {
-                        result = thisObj.has(s.index, thisObj);
+
+            case Id_toString:
+                {
+                    if (cx.hasFeature(Context.FEATURE_TO_STRING_AS_SOURCE)) {
+                        String s =
+                                ScriptRuntime.defaultObjectToSource(
+                                        cx, scope,
+                                        thisObj, args);
+                        int L = s.length();
+                        if (L != 0 && s.charAt(0) == '(' && s.charAt(L - 1) == ')') {
+                            // Strip () that surrounds toSource
+                            s = s.substring(1, L - 1);
+                        }
+                        return s;
+                    }
+                    return ScriptRuntime.defaultObjectToString(thisObj);
+                }
+
+            case Id_valueOf:
+                if (cx.getLanguageVersion() >= Context.VERSION_1_8
+                        && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                    throw ScriptRuntime.typeErrorById(
+                            "msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                }
+                return thisObj;
+
+            case Id_hasOwnProperty:
+                {
+                    if (cx.getLanguageVersion() >= Context.VERSION_1_8
+                            && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                    }
+                    boolean result;
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (arg instanceof Symbol) {
+                        result = ensureSymbolScriptable(thisObj).has((Symbol) arg, thisObj);
+                    } else {
+                        StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, arg);
+                        if (s.stringId == null) {
+                            result = thisObj.has(s.index, thisObj);
+                        } else {
+                            result = thisObj.has(s.stringId, thisObj);
+                        }
+                    }
+                    return ScriptRuntime.wrapBoolean(result);
+                }
+
+            case Id_propertyIsEnumerable:
+                {
+                    if (cx.getLanguageVersion() >= Context.VERSION_1_8
+                            && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg." + (thisObj == null ? "null" : "undef") + ".to.object");
+                    }
+
+                    boolean result;
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+
+                    if (arg instanceof Symbol) {
+                        result = ((SymbolScriptable) thisObj).has((Symbol) arg, thisObj);
                         if (result && thisObj instanceof ScriptableObject) {
                             ScriptableObject so = (ScriptableObject) thisObj;
-                            int attrs = so.getAttributes(s.index);
+                            int attrs = so.getAttributes((Symbol) arg);
                             result = ((attrs & ScriptableObject.DONTENUM) == 0);
                         }
                     } else {
-                        result = thisObj.has(s.stringId, thisObj);
-                        if (result && thisObj instanceof ScriptableObject) {
-                            ScriptableObject so = (ScriptableObject) thisObj;
-                            int attrs = so.getAttributes(s.stringId);
-                            result = ((attrs & ScriptableObject.DONTENUM) == 0);
+                        StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, arg);
+                        // When checking if a property is enumerable, a missing property should
+                        // return "false" instead of
+                        // throwing an exception.  See: https://github.com/mozilla/rhino/issues/415
+                        try {
+                            if (s.stringId == null) {
+                                result = thisObj.has(s.index, thisObj);
+                                if (result && thisObj instanceof ScriptableObject) {
+                                    ScriptableObject so = (ScriptableObject) thisObj;
+                                    int attrs = so.getAttributes(s.index);
+                                    result = ((attrs & ScriptableObject.DONTENUM) == 0);
+                                }
+                            } else {
+                                result = thisObj.has(s.stringId, thisObj);
+                                if (result && thisObj instanceof ScriptableObject) {
+                                    ScriptableObject so = (ScriptableObject) thisObj;
+                                    int attrs = so.getAttributes(s.stringId);
+                                    result = ((attrs & ScriptableObject.DONTENUM) == 0);
+                                }
+                            }
+                        } catch (EvaluatorException ee) {
+                            if (ee.getMessage()
+                                    .startsWith(
+                                            ScriptRuntime.getMessageById(
+                                                    "msg.prop.not.found",
+                                                    s.stringId == null
+                                                            ? Integer.toString(s.index)
+                                                            : s.stringId))) {
+                                result = false;
+                            } else {
+                                throw ee;
+                            }
                         }
                     }
-                } catch (EvaluatorException ee) {
-                    if (ee.getMessage().startsWith(ScriptRuntime.getMessageById("msg.prop.not.found",
-                                                        s.stringId == null ? Integer.toString(s.index) : s.stringId))) {
-                        result = false;
-                    } else {
-                        throw ee;
+                    return ScriptRuntime.wrapBoolean(result);
+                }
+
+            case Id_isPrototypeOf:
+                {
+                    if (cx.getLanguageVersion() >= Context.VERSION_1_8
+                            && (thisObj == null || Undefined.isUndefined(thisObj))) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg." + (thisObj == null ? "null" : "undef") + ".to.object");
                     }
-                }
-            }
-            return ScriptRuntime.wrapBoolean(result);
-          }
 
-          case Id_isPrototypeOf: {
-            if (cx.getLanguageVersion() >= Context.VERSION_1_8 && (thisObj == null || Undefined.isUndefined(thisObj))) {
-                throw ScriptRuntime.typeErrorById("msg." + (thisObj == null ? "null" : "undef") + ".to.object");
-            }
-
-            boolean result = false;
-            if (args.length != 0 && args[0] instanceof Scriptable) {
-                Scriptable v = (Scriptable) args[0];
-                do {
-                    v = v.getPrototype();
-                    if (v == thisObj) {
-                        result = true;
-                        break;
+                    boolean result = false;
+                    if (args.length != 0 && args[0] instanceof Scriptable) {
+                        Scriptable v = (Scriptable) args[0];
+                        do {
+                            v = v.getPrototype();
+                            if (v == thisObj) {
+                                result = true;
+                                break;
+                            }
+                        } while (v != null);
                     }
-                } while (v != null);
-            }
-            return ScriptRuntime.wrapBoolean(result);
-          }
+                    return ScriptRuntime.wrapBoolean(result);
+                }
 
-          case Id_toSource:
-            return ScriptRuntime.defaultObjectToSource(cx, scope, thisObj,
-                                                       args);
-          case Id___defineGetter__:
-          case Id___defineSetter__:
-            {
-                if (args.length < 2 || !(args[1] instanceof Callable)) {
-                    Object badArg = (args.length >= 2 ? args[1] : Undefined.instance);
-                    throw ScriptRuntime.notFunctionError(badArg);
+            case Id_toSource:
+                return ScriptRuntime.defaultObjectToSource(cx, scope, thisObj, args);
+            case Id___defineGetter__:
+            case Id___defineSetter__:
+                {
+                    if (args.length < 2 || !(args[1] instanceof Callable)) {
+                        Object badArg = (args.length >= 2 ? args[1] : Undefined.instance);
+                        throw ScriptRuntime.notFunctionError(badArg);
+                    }
+                    if (!(thisObj instanceof ScriptableObject)) {
+                        throw Context.reportRuntimeErrorById(
+                                "msg.extend.scriptable",
+                                thisObj == null ? "null" : thisObj.getClass().getName(),
+                                String.valueOf(args[0]));
+                    }
+                    ScriptableObject so = (ScriptableObject) thisObj;
+                    StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
+                    int index = s.stringId != null ? 0 : s.index;
+                    Callable getterOrSetter = (Callable) args[1];
+                    boolean isSetter = (id == Id___defineSetter__);
+                    so.setGetterOrSetter(s.stringId, index, getterOrSetter, isSetter);
+                    if (so instanceof NativeArray) ((NativeArray) so).setDenseOnly(false);
                 }
-                if (!(thisObj instanceof ScriptableObject)) {
-                    throw Context.reportRuntimeErrorById(
-                        "msg.extend.scriptable",
-                        thisObj == null ? "null" : thisObj.getClass().getName(),
-                        String.valueOf(args[0]));
-                }
-                ScriptableObject so = (ScriptableObject)thisObj;
-                StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
-                int index = s.stringId != null ? 0 : s.index;
-                Callable getterOrSetter = (Callable)args[1];
-                boolean isSetter = (id == Id___defineSetter__);
-                so.setGetterOrSetter(s.stringId, index, getterOrSetter, isSetter);
-                if (so instanceof NativeArray)
-                    ((NativeArray)so).setDenseOnly(false);
-            }
-            return Undefined.instance;
+                return Undefined.instance;
 
             case Id___lookupGetter__:
             case Id___lookupSetter__:
-              {
-                  if (args.length < 1 ||
-                      !(thisObj instanceof ScriptableObject))
-                      return Undefined.instance;
+                {
+                    if (args.length < 1 || !(thisObj instanceof ScriptableObject))
+                        return Undefined.instance;
 
-                  ScriptableObject so = (ScriptableObject)thisObj;
-                  StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
-                  int index = s.stringId != null ? 0 : s.index;
-                  boolean isSetter = (id == Id___lookupSetter__);
-                  Object gs;
-                  for (;;) {
-                      gs = so.getGetterOrSetter(s.stringId, index, isSetter);
-                      if (gs != null)
-                          break;
-                      // If there is no getter or setter for the object itself,
-                      // how about the prototype?
-                      Scriptable v = so.getPrototype();
-                      if (v == null)
-                          break;
-                      if (v instanceof ScriptableObject)
-                          so = (ScriptableObject)v;
-                      else
-                          break;
-                  }
-                  if (gs != null) {
-                      if (gs instanceof MemberBox) {
-                          if (isSetter) {
-                              gs = ((MemberBox) gs).asSetterFunction(s.stringId, this);
-                          } else {
-                              gs = ((MemberBox) gs).asGetterFunction(s.stringId, this);
-                          }
-                      }
-                      return gs;
-                  }
-              }
-              return Undefined.instance;
-
-          case ConstructorId_getPrototypeOf:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                Scriptable obj = getCompatibleObject(cx, scope, arg);
-                return obj.getPrototype();
-              }
-          case ConstructorId_setPrototypeOf:
-              {
-                if (args.length < 2) {
-                    throw ScriptRuntime.typeErrorById("msg.method.missing.parameter", "Object.setPrototypeOf", "2", Integer.toString(args.length));
-                }
-                Scriptable proto = (args[1] == null) ? null : ensureScriptable(args[1]);
-                if (proto instanceof Symbol) {
-                    throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(proto));
-                }
-
-                final Object arg0 = args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
-                    ScriptRuntimeES6.requireObjectCoercible(cx, arg0, f);
-                }
-                if ( !(arg0 instanceof ScriptableObject) ) {
-                    return arg0;
-                }
-                ScriptableObject obj = (ScriptableObject) arg0;
-                if (!obj.isExtensible()) {
-                    throw ScriptRuntime.typeErrorById("msg.not.extensible");
-                }
-
-                // cycle detection
-                Scriptable prototypeProto = proto;
-                while (prototypeProto != null) {
-                    if (prototypeProto == obj) {
-                        throw ScriptRuntime.typeErrorById("msg.object.cyclic.prototype", obj.getClass().getSimpleName());
+                    ScriptableObject so = (ScriptableObject) thisObj;
+                    StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(cx, args[0]);
+                    int index = s.stringId != null ? 0 : s.index;
+                    boolean isSetter = (id == Id___lookupSetter__);
+                    Object gs;
+                    for (; ; ) {
+                        gs = so.getGetterOrSetter(s.stringId, index, isSetter);
+                        if (gs != null) break;
+                        // If there is no getter or setter for the object itself,
+                        // how about the prototype?
+                        Scriptable v = so.getPrototype();
+                        if (v == null) break;
+                        if (v instanceof ScriptableObject) so = (ScriptableObject) v;
+                        else break;
                     }
-                    prototypeProto = prototypeProto.getPrototype();
+                    if (gs != null) {
+                        if (gs instanceof MemberBox) {
+                            if (isSetter) {
+                                gs = ((MemberBox) gs).asSetterFunction(s.stringId, this);
+                            } else {
+                                gs = ((MemberBox) gs).asGetterFunction(s.stringId, this);
+                            }
+                        }
+                        return gs;
+                    }
                 }
-                obj.setPrototype(proto);
-                return obj;
-              }
-          case ConstructorId_keys:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                Scriptable obj = getCompatibleObject(cx, scope, arg);
-                Object[] ids = obj.getIds();
-                for (int i = 0; i < ids.length; i++) {
-                  ids[i] = ScriptRuntime.toString(ids[i]);
+                return Undefined.instance;
+
+            case ConstructorId_getPrototypeOf:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    Scriptable obj = getCompatibleObject(cx, scope, arg);
+                    return obj.getPrototype();
                 }
-                return cx.newArray(scope, ids);
-              }
-          case ConstructorId_getOwnPropertyNames:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                Scriptable s = getCompatibleObject(cx, scope, arg);
-                ScriptableObject obj = ensureScriptableObject(s);
-                Object[] ids = obj.getIds(true, false);
-                for (int i = 0; i < ids.length; i++) {
-                  ids[i] = ScriptRuntime.toString(ids[i]);
+            case ConstructorId_setPrototypeOf:
+                {
+                    if (args.length < 2) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg.method.missing.parameter",
+                                "Object.setPrototypeOf",
+                                "2",
+                                Integer.toString(args.length));
+                    }
+                    Scriptable proto = (args[1] == null) ? null : ensureScriptable(args[1]);
+                    if (proto instanceof Symbol) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg.arg.not.object", ScriptRuntime.typeof(proto));
+                    }
+
+                    final Object arg0 = args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
+                        ScriptRuntimeES6.requireObjectCoercible(cx, arg0, f);
+                    }
+                    if (!(arg0 instanceof ScriptableObject)) {
+                        return arg0;
+                    }
+                    ScriptableObject obj = (ScriptableObject) arg0;
+                    if (!obj.isExtensible()) {
+                        throw ScriptRuntime.typeErrorById("msg.not.extensible");
+                    }
+
+                    // cycle detection
+                    Scriptable prototypeProto = proto;
+                    while (prototypeProto != null) {
+                        if (prototypeProto == obj) {
+                            throw ScriptRuntime.typeErrorById(
+                                    "msg.object.cyclic.prototype", obj.getClass().getSimpleName());
+                        }
+                        prototypeProto = prototypeProto.getPrototype();
+                    }
+                    obj.setPrototype(proto);
+                    return obj;
                 }
-                return cx.newArray(scope, ids);
-              }
+            case ConstructorId_keys:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    Scriptable obj = getCompatibleObject(cx, scope, arg);
+                    Object[] ids = obj.getIds();
+                    for (int i = 0; i < ids.length; i++) {
+                        ids[i] = ScriptRuntime.toString(ids[i]);
+                    }
+                    return cx.newArray(scope, ids);
+                }
+            case ConstructorId_getOwnPropertyNames:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    Scriptable s = getCompatibleObject(cx, scope, arg);
+                    ScriptableObject obj = ensureScriptableObject(s);
+                    Object[] ids = obj.getIds(true, false);
+                    for (int i = 0; i < ids.length; i++) {
+                        ids[i] = ScriptRuntime.toString(ids[i]);
+                    }
+                    return cx.newArray(scope, ids);
+                }
             case ConstructorId_getOwnPropertySymbols:
-            {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                Scriptable s = getCompatibleObject(cx, scope, arg);
-                ScriptableObject obj = ensureScriptableObject(s);
-                Object[] ids = obj.getIds(true, true);
-                ArrayList<Object> syms = new ArrayList<Object>();
-                for (int i = 0; i < ids.length; i++) {
-                    if (ids[i] instanceof Symbol) {
-                        syms.add(ids[i]);
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    Scriptable s = getCompatibleObject(cx, scope, arg);
+                    ScriptableObject obj = ensureScriptableObject(s);
+                    Object[] ids = obj.getIds(true, true);
+                    ArrayList<Object> syms = new ArrayList<Object>();
+                    for (int i = 0; i < ids.length; i++) {
+                        if (ids[i] instanceof Symbol) {
+                            syms.add(ids[i]);
+                        }
                     }
+                    return cx.newArray(scope, syms.toArray());
                 }
-                return cx.newArray(scope, syms.toArray());
-            }
-          case ConstructorId_getOwnPropertyDescriptor:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                // TODO(norris): There's a deeper issue here if
-                // arg instanceof Scriptable. Should we create a new
-                // interface to admit the new ECMAScript 5 operations?
-                Scriptable s = getCompatibleObject(cx, scope, arg);
-                ScriptableObject obj = ensureScriptableObject(s);
-                Object nameArg = args.length < 2 ? Undefined.instance : args[1];
-                Scriptable desc = obj.getOwnPropertyDescriptor(cx, nameArg);
-                return desc == null ? Undefined.instance : desc;
-              }
-          case ConstructorId_defineProperty:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                ScriptableObject obj = ensureScriptableObject(arg);
-                Object name = args.length < 2 ? Undefined.instance : args[1];
-                Object descArg = args.length < 3 ? Undefined.instance : args[2];
-                ScriptableObject desc = ensureScriptableObject(descArg);
-                obj.defineOwnProperty(cx, name, desc);
-                return obj;
-              }
-          case ConstructorId_isExtensible:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6
-                        && !(arg instanceof ScriptableObject)) {
-                  return Boolean.FALSE;
+            case ConstructorId_getOwnPropertyDescriptor:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    // TODO(norris): There's a deeper issue here if
+                    // arg instanceof Scriptable. Should we create a new
+                    // interface to admit the new ECMAScript 5 operations?
+                    Scriptable s = getCompatibleObject(cx, scope, arg);
+                    ScriptableObject obj = ensureScriptableObject(s);
+                    Object nameArg = args.length < 2 ? Undefined.instance : args[1];
+                    Scriptable desc = obj.getOwnPropertyDescriptor(cx, nameArg);
+                    return desc == null ? Undefined.instance : desc;
+                }
+            case ConstructorId_defineProperty:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    ScriptableObject obj = ensureScriptableObject(arg);
+                    Object name = args.length < 2 ? Undefined.instance : args[1];
+                    Object descArg = args.length < 3 ? Undefined.instance : args[2];
+                    ScriptableObject desc = ensureScriptableObject(descArg);
+                    obj.defineOwnProperty(cx, name, desc);
+                    return obj;
+                }
+            case ConstructorId_isExtensible:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                            && !(arg instanceof ScriptableObject)) {
+                        return Boolean.FALSE;
+                    }
+
+                    ScriptableObject obj = ensureScriptableObject(arg);
+                    return Boolean.valueOf(obj.isExtensible());
+                }
+            case ConstructorId_preventExtensions:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                            && !(arg instanceof ScriptableObject)) {
+                        return arg;
+                    }
+
+                    ScriptableObject obj = ensureScriptableObject(arg);
+                    obj.preventExtensions();
+                    return obj;
+                }
+            case ConstructorId_defineProperties:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    ScriptableObject obj = ensureScriptableObject(arg);
+                    Object propsObj = args.length < 2 ? Undefined.instance : args[1];
+                    Scriptable props = Context.toObject(propsObj, scope);
+                    obj.defineOwnProperties(cx, ensureScriptableObject(props));
+                    return obj;
+                }
+            case ConstructorId_create:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    Scriptable obj = (arg == null) ? null : ensureScriptable(arg);
+
+                    ScriptableObject newObject = new NativeObject();
+                    newObject.setParentScope(scope);
+                    newObject.setPrototype(obj);
+
+                    if (args.length > 1 && !Undefined.isUndefined(args[1])) {
+                        Scriptable props = Context.toObject(args[1], scope);
+                        newObject.defineOwnProperties(cx, ensureScriptableObject(props));
+                    }
+
+                    return newObject;
+                }
+            case ConstructorId_isSealed:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                            && !(arg instanceof ScriptableObject)) {
+                        return Boolean.TRUE;
+                    }
+
+                    ScriptableObject obj = ensureScriptableObject(arg);
+
+                    if (obj.isExtensible()) return Boolean.FALSE;
+
+                    for (Object name : obj.getAllIds()) {
+                        Object configurable =
+                                obj.getOwnPropertyDescriptor(cx, name).get("configurable");
+                        if (Boolean.TRUE.equals(configurable)) return Boolean.FALSE;
+                    }
+
+                    return Boolean.TRUE;
+                }
+            case ConstructorId_isFrozen:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                            && !(arg instanceof ScriptableObject)) {
+                        return Boolean.TRUE;
+                    }
+
+                    ScriptableObject obj = ensureScriptableObject(arg);
+
+                    if (obj.isExtensible()) return Boolean.FALSE;
+
+                    for (Object name : obj.getAllIds()) {
+                        ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
+                        if (Boolean.TRUE.equals(desc.get("configurable"))) return Boolean.FALSE;
+                        if (isDataDescriptor(desc) && Boolean.TRUE.equals(desc.get("writable")))
+                            return Boolean.FALSE;
+                    }
+
+                    return Boolean.TRUE;
+                }
+            case ConstructorId_seal:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                            && !(arg instanceof ScriptableObject)) {
+                        return arg;
+                    }
+
+                    ScriptableObject obj = ensureScriptableObject(arg);
+
+                    for (Object name : obj.getAllIds()) {
+                        ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
+                        if (Boolean.TRUE.equals(desc.get("configurable"))) {
+                            desc.put("configurable", desc, Boolean.FALSE);
+                            obj.defineOwnProperty(cx, name, desc, false);
+                        }
+                    }
+                    obj.preventExtensions();
+
+                    return obj;
+                }
+            case ConstructorId_freeze:
+                {
+                    Object arg = args.length < 1 ? Undefined.instance : args[0];
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                            && !(arg instanceof ScriptableObject)) {
+                        return arg;
+                    }
+
+                    ScriptableObject obj = ensureScriptableObject(arg);
+
+                    for (Object name : obj.getIds(true, true)) {
+                        ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
+                        if (isDataDescriptor(desc) && Boolean.TRUE.equals(desc.get("writable"))) {
+                            desc.put("writable", desc, Boolean.FALSE);
+                        }
+                        if (Boolean.TRUE.equals(desc.get("configurable"))) {
+                            desc.put("configurable", desc, Boolean.FALSE);
+                        }
+                        obj.defineOwnProperty(cx, name, desc, false);
+                    }
+                    obj.preventExtensions();
+
+                    return obj;
                 }
 
-                ScriptableObject obj = ensureScriptableObject(arg);
-                return Boolean.valueOf(obj.isExtensible());
-              }
-          case ConstructorId_preventExtensions:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6
-                        && !(arg instanceof ScriptableObject)) {
-                  return arg;
+            case ConstructorId_assign:
+                {
+                    Scriptable targetObj;
+                    if (args.length > 0) {
+                        targetObj = ScriptRuntime.toObject(cx, scope, args[0]);
+                    } else {
+                        targetObj = ScriptRuntime.toObject(cx, scope, Undefined.instance);
+                    }
+                    for (int i = 1; i < args.length; i++) {
+                        if ((args[i] == null) || Undefined.isUndefined(args[i])) {
+                            continue;
+                        }
+                        Scriptable sourceObj = ScriptRuntime.toObject(cx, scope, args[i]);
+                        Object[] ids = sourceObj.getIds();
+                        for (Object key : ids) {
+                            if (targetObj instanceof ScriptableObject) {
+                                ScriptableObject desc =
+                                        ((ScriptableObject) targetObj)
+                                                .getOwnPropertyDescriptor(cx, key);
+                                if (desc != null
+                                        && isDataDescriptor(desc)
+                                        && isFalse(desc.get("writable"))) {
+                                    throw ScriptRuntime.typeErrorById(
+                                            "msg.change.value.with.writable.false", key);
+                                }
+                            }
+                            if (key instanceof String) {
+                                Object val = sourceObj.get((String) key, sourceObj);
+                                if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {
+                                    targetObj.put((String) key, targetObj, val);
+                                }
+                            } else if (key instanceof Number) {
+                                int ii = ScriptRuntime.toInt32(key);
+                                Object val = sourceObj.get(ii, sourceObj);
+                                if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {
+                                    targetObj.put(ii, targetObj, val);
+                                }
+                            }
+                        }
+                    }
+                    return targetObj;
                 }
 
-                ScriptableObject obj = ensureScriptableObject(arg);
-                obj.preventExtensions();
-                return obj;
-              }
-          case ConstructorId_defineProperties:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                ScriptableObject obj = ensureScriptableObject(arg);
-                Object propsObj = args.length < 2 ? Undefined.instance : args[1];
-                Scriptable props = Context.toObject(propsObj, scope);
-                obj.defineOwnProperties(cx, ensureScriptableObject(props));
-                return obj;
-              }
-          case ConstructorId_create:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                Scriptable obj = (arg == null) ? null : ensureScriptable(arg);
-
-                ScriptableObject newObject = new NativeObject();
-                newObject.setParentScope(scope);
-                newObject.setPrototype(obj);
-
-                if (args.length > 1 && !Undefined.isUndefined(args[1])) {
-                  Scriptable props = Context.toObject(args[1], scope);
-                  newObject.defineOwnProperties(cx, ensureScriptableObject(props));
+            case ConstructorId_is:
+                {
+                    Object a1 = args.length < 1 ? Undefined.instance : args[0];
+                    Object a2 = args.length < 2 ? Undefined.instance : args[1];
+                    return ScriptRuntime.wrapBoolean(ScriptRuntime.same(a1, a2));
                 }
 
-                return newObject;
-              }
-          case ConstructorId_isSealed:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6
-                        && !(arg instanceof ScriptableObject)) {
-                  return Boolean.TRUE;
-                }
-
-                ScriptableObject obj = ensureScriptableObject(arg);
-
-                if (obj.isExtensible()) return Boolean.FALSE;
-
-                for (Object name: obj.getAllIds()) {
-                  Object configurable = obj.getOwnPropertyDescriptor(cx, name).get("configurable");
-                  if (Boolean.TRUE.equals(configurable))
-                    return Boolean.FALSE;
-                }
-
-                return Boolean.TRUE;
-              }
-          case ConstructorId_isFrozen:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6
-                        && !(arg instanceof ScriptableObject)) {
-                  return Boolean.TRUE;
-                }
-
-                ScriptableObject obj = ensureScriptableObject(arg);
-
-                if (obj.isExtensible()) return Boolean.FALSE;
-
-                for (Object name: obj.getAllIds()) {
-                  ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
-                  if (Boolean.TRUE.equals(desc.get("configurable")))
-                    return Boolean.FALSE;
-                  if (isDataDescriptor(desc) && Boolean.TRUE.equals(desc.get("writable")))
-                    return Boolean.FALSE;
-                }
-
-                return Boolean.TRUE;
-              }
-          case ConstructorId_seal:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6
-                        && !(arg instanceof ScriptableObject)) {
-                  return arg;
-                }
-
-                ScriptableObject obj = ensureScriptableObject(arg);
-
-                for (Object name: obj.getAllIds()) {
-                  ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
-                  if (Boolean.TRUE.equals(desc.get("configurable"))) {
-                    desc.put("configurable", desc, Boolean.FALSE);
-                    obj.defineOwnProperty(cx, name, desc, false);
-                  }
-                }
-                obj.preventExtensions();
-
-                return obj;
-              }
-          case ConstructorId_freeze:
-              {
-                Object arg = args.length < 1 ? Undefined.instance : args[0];
-                if (cx.getLanguageVersion() >= Context.VERSION_ES6
-                      && !(arg instanceof ScriptableObject)) {
-                  return arg;
-                }
-
-                ScriptableObject obj = ensureScriptableObject(arg);
-
-                for (Object name: obj.getIds(true, true)) {
-                  ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
-                  if (isDataDescriptor(desc) && Boolean.TRUE.equals(desc.get("writable"))) {
-                    desc.put("writable", desc, Boolean.FALSE);
-                  }
-                  if (Boolean.TRUE.equals(desc.get("configurable"))) {
-                    desc.put("configurable", desc, Boolean.FALSE);
-                  }
-                  obj.defineOwnProperty(cx, name, desc, false);
-                }
-                obj.preventExtensions();
-
-                return obj;
-              }
-
-          case ConstructorId_assign:
-          {
-            Scriptable targetObj;
-            if (args.length > 0) {
-              targetObj = ScriptRuntime.toObject(cx, scope, args[0]);
-            }
-            else {
-              targetObj = ScriptRuntime.toObject(cx, scope, Undefined.instance);
-            }
-            for (int i = 1; i < args.length; i++) {
-              if ((args[i] == null) || Undefined.isUndefined(args[i])) {
-                continue;
-              }
-              Scriptable sourceObj = ScriptRuntime.toObject(cx, scope, args[i]);
-              Object[] ids = sourceObj.getIds();
-              for (Object key : ids) {
-                if (targetObj instanceof ScriptableObject) {
-                  ScriptableObject desc = ((ScriptableObject) targetObj).getOwnPropertyDescriptor(cx, key);
-                  if (desc != null && isDataDescriptor(desc) && isFalse(desc.get("writable"))) {
-                      throw ScriptRuntime.typeErrorById("msg.change.value.with.writable.false", key);
-                  }
-                }
-                if (key instanceof String) {
-                  Object val = sourceObj.get((String) key, sourceObj);
-                  if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {
-                    targetObj.put((String) key, targetObj, val);
-                  }
-                } else if (key instanceof Number) {
-                  int ii = ScriptRuntime.toInt32(key);
-                  Object val = sourceObj.get(ii, sourceObj);
-                  if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {
-                    targetObj.put(ii, targetObj, val);
-                  }
-                }
-              }
-            }
-            return targetObj;
-          }
-
-          case ConstructorId_is:
-          {
-            Object a1 = args.length < 1 ? Undefined.instance : args[0];
-            Object a2 = args.length < 2 ? Undefined.instance : args[1];
-            return ScriptRuntime.wrapBoolean(ScriptRuntime.same(a1, a2));
-          }
-
-
-          default:
-            throw new IllegalArgumentException(String.valueOf(id));
+            default:
+                throw new IllegalArgumentException(String.valueOf(id));
         }
     }
 
-    private static Scriptable getCompatibleObject(Context cx, Scriptable scope, Object arg)
-    {
+    private static Scriptable getCompatibleObject(Context cx, Scriptable scope, Object arg) {
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             Scriptable s = ScriptRuntime.toObject(cx, scope, arg);
             return ensureScriptable(s);
@@ -627,8 +663,7 @@ public class NativeObject extends IdScriptableObject implements Map
     @Override
     public boolean containsValue(Object value) {
         for (Object obj : values()) {
-            if (value == obj ||
-                    value != null && value.equals(obj)) {
+            if (value == obj || value != null && value.equals(obj)) {
                 return true;
             }
         }
@@ -676,7 +711,6 @@ public class NativeObject extends IdScriptableObject implements Map
         throw new UnsupportedOperationException();
     }
 
-
     class EntrySet extends AbstractSet<Entry<Object, Object>> {
         @Override
         public Iterator<Entry<Object, Object>> iterator() {
@@ -717,13 +751,15 @@ public class NativeObject extends IdScriptableObject implements Map
                             }
                             Map.Entry<?, ?> e = (Map.Entry<?, ?>) other;
                             return (ekey == null ? e.getKey() == null : ekey.equals(e.getKey()))
-                                && (value == null ? e.getValue() == null : value.equals(e.getValue()));
+                                    && (value == null
+                                            ? e.getValue() == null
+                                            : value.equals(e.getValue()));
                         }
 
                         @Override
                         public int hashCode() {
-                            return (ekey == null ? 0 : ekey.hashCode()) ^
-                                   (value == null ? 0 : value.hashCode());
+                            return (ekey == null ? 0 : ekey.hashCode())
+                                    ^ (value == null ? 0 : value.hashCode());
                         }
 
                         @Override
@@ -773,7 +809,7 @@ public class NativeObject extends IdScriptableObject implements Map
                 public Object next() {
                     try {
                         return (key = ids[index++]);
-                    } catch(ArrayIndexOutOfBoundsException e) {
+                    } catch (ArrayIndexOutOfBoundsException e) {
                         key = null;
                         throw new NoSuchElementException();
                     }
@@ -787,7 +823,7 @@ public class NativeObject extends IdScriptableObject implements Map
                     NativeObject.this.remove(key);
                     key = null;
                 }
-           };
+            };
         }
 
         @Override
@@ -832,91 +868,87 @@ public class NativeObject extends IdScriptableObject implements Map
         }
     }
 
-
-// #string_id_map#
+    // #string_id_map#
 
     @Override
-    protected int findPrototypeId(String s)
-    {
+    protected int findPrototypeId(String s) {
         int id;
-// #generated# Last update: 2021-03-21 09:51:05 MEZ
+        // #generated# Last update: 2021-03-21 09:51:05 MEZ
         switch (s) {
-        case "constructor":
-            id = Id_constructor;
-            break;
-        case "toString":
-            id = Id_toString;
-            break;
-        case "toLocaleString":
-            id = Id_toLocaleString;
-            break;
-        case "valueOf":
-            id = Id_valueOf;
-            break;
-        case "hasOwnProperty":
-            id = Id_hasOwnProperty;
-            break;
-        case "propertyIsEnumerable":
-            id = Id_propertyIsEnumerable;
-            break;
-        case "isPrototypeOf":
-            id = Id_isPrototypeOf;
-            break;
-        case "toSource":
-            id = Id_toSource;
-            break;
-        case "__defineGetter__":
-            id = Id___defineGetter__;
-            break;
-        case "__defineSetter__":
-            id = Id___defineSetter__;
-            break;
-        case "__lookupGetter__":
-            id = Id___lookupGetter__;
-            break;
-        case "__lookupSetter__":
-            id = Id___lookupSetter__;
-            break;
-        default:
-            id = 0;
-            break;
+            case "constructor":
+                id = Id_constructor;
+                break;
+            case "toString":
+                id = Id_toString;
+                break;
+            case "toLocaleString":
+                id = Id_toLocaleString;
+                break;
+            case "valueOf":
+                id = Id_valueOf;
+                break;
+            case "hasOwnProperty":
+                id = Id_hasOwnProperty;
+                break;
+            case "propertyIsEnumerable":
+                id = Id_propertyIsEnumerable;
+                break;
+            case "isPrototypeOf":
+                id = Id_isPrototypeOf;
+                break;
+            case "toSource":
+                id = Id_toSource;
+                break;
+            case "__defineGetter__":
+                id = Id___defineGetter__;
+                break;
+            case "__defineSetter__":
+                id = Id___defineSetter__;
+                break;
+            case "__lookupGetter__":
+                id = Id___lookupGetter__;
+                break;
+            case "__lookupSetter__":
+                id = Id___lookupSetter__;
+                break;
+            default:
+                id = 0;
+                break;
         }
-// #/generated#
+        // #/generated#
         return id;
     }
 
-    private static final int
-        ConstructorId_getPrototypeOf = -1,
-        ConstructorId_keys = -2,
-        ConstructorId_getOwnPropertyNames = -3,
-        ConstructorId_getOwnPropertyDescriptor = -4,
-        ConstructorId_defineProperty = -5,
-        ConstructorId_isExtensible = -6,
-        ConstructorId_preventExtensions = -7,
-        ConstructorId_defineProperties= -8,
-        ConstructorId_create = -9,
-        ConstructorId_isSealed = -10,
-        ConstructorId_isFrozen = -11,
-        ConstructorId_seal = -12,
-        ConstructorId_freeze = -13,
-        ConstructorId_getOwnPropertySymbols = -14,
-        ConstructorId_assign = -15,
-        ConstructorId_is = -16,
-        ConstructorId_setPrototypeOf = -17,
+    private static final int ConstructorId_getPrototypeOf = -1,
+            ConstructorId_keys = -2,
+            ConstructorId_getOwnPropertyNames = -3,
+            ConstructorId_getOwnPropertyDescriptor = -4,
+            ConstructorId_defineProperty = -5,
+            ConstructorId_isExtensible = -6,
+            ConstructorId_preventExtensions = -7,
+            ConstructorId_defineProperties = -8,
+            ConstructorId_create = -9,
+            ConstructorId_isSealed = -10,
+            ConstructorId_isFrozen = -11,
+            ConstructorId_seal = -12,
+            ConstructorId_freeze = -13,
+            ConstructorId_getOwnPropertySymbols = -14,
+            ConstructorId_assign = -15,
+            ConstructorId_is = -16,
+            ConstructorId_setPrototypeOf = -17,
+            Id_constructor = 1,
+            Id_toString = 2,
+            Id_toLocaleString = 3,
+            Id_valueOf = 4,
+            Id_hasOwnProperty = 5,
+            Id_propertyIsEnumerable = 6,
+            Id_isPrototypeOf = 7,
+            Id_toSource = 8,
+            Id___defineGetter__ = 9,
+            Id___defineSetter__ = 10,
+            Id___lookupGetter__ = 11,
+            Id___lookupSetter__ = 12,
+            MAX_PROTOTYPE_ID = 12;
 
-        Id_constructor           = 1,
-        Id_toString              = 2,
-        Id_toLocaleString        = 3,
-        Id_valueOf               = 4,
-        Id_hasOwnProperty        = 5,
-        Id_propertyIsEnumerable  = 6,
-        Id_isPrototypeOf         = 7,
-        Id_toSource              = 8,
-        Id___defineGetter__      = 9,
-        Id___defineSetter__      = 10,
-        Id___lookupGetter__      = 11,
-        Id___lookupSetter__      = 12,
-        MAX_PROTOTYPE_ID         = 12;
-
-// #/string_id_map#
+    // #/string_id_map#
 }

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
 import org.mozilla.javascript.annotations.JSConstructor;
 import org.mozilla.javascript.annotations.JSFunction;
@@ -34,58 +33,51 @@ import org.mozilla.javascript.annotations.JSStaticFunction;
 import org.mozilla.javascript.debug.DebuggableObject;
 
 /**
- * This is the default implementation of the Scriptable interface. This
- * class provides convenient default behavior that makes it easier to
- * define host objects.
- * <p>
- * Various properties and methods of JavaScript objects can be conveniently
- * defined using methods of ScriptableObject.
- * <p>
- * Classes extending ScriptableObject must define the getClassName method.
+ * This is the default implementation of the Scriptable interface. This class provides convenient
+ * default behavior that makes it easier to define host objects.
+ *
+ * <p>Various properties and methods of JavaScript objects can be conveniently defined using methods
+ * of ScriptableObject.
+ *
+ * <p>Classes extending ScriptableObject must define the getClassName method.
  *
  * @see org.mozilla.javascript.Scriptable
  * @author Norris Boyd
  */
-
-public abstract class ScriptableObject implements Scriptable,
-                                                  SymbolScriptable,
-                                                  Serializable,
-                                                  DebuggableObject,
-                                                  ConstProperties
-{
+public abstract class ScriptableObject
+        implements Scriptable, SymbolScriptable, Serializable, DebuggableObject, ConstProperties {
 
     private static final long serialVersionUID = 2829861078851942586L;
 
     /**
      * The empty property attribute.
      *
-     * Used by getAttributes() and setAttributes().
+     * <p>Used by getAttributes() and setAttributes().
      *
      * @see org.mozilla.javascript.ScriptableObject#getAttributes(String)
      * @see org.mozilla.javascript.ScriptableObject#setAttributes(String, int)
      */
-    public static final int EMPTY =     0x00;
+    public static final int EMPTY = 0x00;
 
     /**
      * Property attribute indicating assignment to this property is ignored.
      *
-     * @see org.mozilla.javascript.ScriptableObject
-     *      #put(String, Scriptable, Object)
+     * @see org.mozilla.javascript.ScriptableObject #put(String, Scriptable, Object)
      * @see org.mozilla.javascript.ScriptableObject#getAttributes(String)
      * @see org.mozilla.javascript.ScriptableObject#setAttributes(String, int)
      */
-    public static final int READONLY =  0x01;
+    public static final int READONLY = 0x01;
 
     /**
      * Property attribute indicating property is not enumerated.
      *
-     * Only enumerated properties will be returned by getIds().
+     * <p>Only enumerated properties will be returned by getIds().
      *
      * @see org.mozilla.javascript.ScriptableObject#getIds()
      * @see org.mozilla.javascript.ScriptableObject#getAttributes(String)
      * @see org.mozilla.javascript.ScriptableObject#setAttributes(String, int)
      */
-    public static final int DONTENUM =  0x02;
+    public static final int DONTENUM = 0x02;
 
     /**
      * Property attribute indicating property cannot be deleted.
@@ -97,36 +89,35 @@ public abstract class ScriptableObject implements Scriptable,
     public static final int PERMANENT = 0x04;
 
     /**
-     * Property attribute indicating that this is a const property that has not
-     * been assigned yet.  The first 'const' assignment to the property will
-     * clear this bit.
+     * Property attribute indicating that this is a const property that has not been assigned yet.
+     * The first 'const' assignment to the property will clear this bit.
      */
     public static final int UNINITIALIZED_CONST = 0x08;
 
-    public static final int CONST = PERMANENT|READONLY|UNINITIALIZED_CONST;
-    /**
-     * The prototype of this object.
-     */
+    public static final int CONST = PERMANENT | READONLY | UNINITIALIZED_CONST;
+    /** The prototype of this object. */
     private Scriptable prototypeObject;
 
-    /**
-     * The parent scope of this object.
-     */
+    /** The parent scope of this object. */
     private Scriptable parentScopeObject;
 
     /**
-     * This holds all the slots. It may or may not be thread-safe, and may expand itself to
-     * a different data structure depending on the size of the object.
+     * This holds all the slots. It may or may not be thread-safe, and may expand itself to a
+     * different data structure depending on the size of the object.
      */
     private transient SlotMapContainer slotMap;
 
     // Where external array data is stored.
     private transient ExternalArrayData externalData;
 
-    private volatile Map<Object,Object> associatedValues;
+    private volatile Map<Object, Object> associatedValues;
 
     enum SlotAccess {
-        QUERY, MODIFY, MODIFY_CONST, MODIFY_GETTER_SETTER, CONVERT_ACCESSOR_TO_DATA
+        QUERY,
+        MODIFY,
+        MODIFY_CONST,
+        MODIFY_GETTER_SETTER,
+        CONVERT_ACCESSOR_TO_DATA
     }
 
     private boolean isExtensible = true;
@@ -143,29 +134,25 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * This is the object that is stored in the SlotMap. For historical reasons it remains
-     * inside this class. SlotMap references a number of members of this class directly.
+     * This is the object that is stored in the SlotMap. For historical reasons it remains inside
+     * this class. SlotMap references a number of members of this class directly.
      */
-    static class Slot implements Serializable
-    {
+    static class Slot implements Serializable {
         private static final long serialVersionUID = -6090581677123995491L;
-        Object name; // This can change due to caching
+        Object name; // This can change due to cachings
         int indexOrHash;
         private short attributes;
         Object value;
         transient Slot next; // next in hash table bucket
         transient Slot orderedNext; // next in linked list
 
-        Slot(Object name, int indexOrHash, int attributes)
-        {
+        Slot(Object name, int indexOrHash, int attributes) {
             this.name = name;
             this.indexOrHash = indexOrHash;
-            this.attributes = (short)attributes;
+            this.attributes = (short) attributes;
         }
 
-        private void readObject(ObjectInputStream in)
-            throws IOException, ClassNotFoundException
-        {
+        private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             if (name != null) {
                 indexOrHash = name.hashCode();
@@ -190,26 +177,22 @@ public abstract class ScriptableObject implements Scriptable,
             return value;
         }
 
-        int getAttributes()
-        {
+        int getAttributes() {
             return attributes;
         }
 
-        synchronized void setAttributes(int value)
-        {
+        synchronized void setAttributes(int value) {
             checkValidAttributes(value);
-            attributes = (short)value;
+            attributes = (short) value;
         }
 
         ScriptableObject getPropertyDescriptor(Context cx, Scriptable scope) {
             return buildDataDescriptor(scope, value, attributes);
         }
-
     }
 
-    protected static ScriptableObject buildDataDescriptor(Scriptable scope,
-                                                          Object value,
-                                                          int attributes) {
+    protected static ScriptableObject buildDataDescriptor(
+            Scriptable scope, Object value, int attributes) {
         ScriptableObject desc = new NativeObject();
         ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
         desc.defineProperty("value", value, EMPTY);
@@ -220,18 +203,16 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * A GetterSlot is a specialication of a Slot for properties that are assigned functions
-     * via Object.defineProperty() and its friends instead of regular values.
+     * A GetterSlot is a specialication of a Slot for properties that are assigned functions via
+     * Object.defineProperty() and its friends instead of regular values.
      */
-    static final class GetterSlot extends Slot
-    {
+    static final class GetterSlot extends Slot {
         private static final long serialVersionUID = -4900574849788797588L;
 
         Object getter;
         Object setter;
 
-        GetterSlot(Object name, int indexOrHash, int attributes)
-        {
+        GetterSlot(Object name, int indexOrHash, int attributes) {
             super(name, indexOrHash, attributes);
         }
 
@@ -248,19 +229,23 @@ public abstract class ScriptableObject implements Scriptable,
 
             String fName = name == null ? "f" : name.toString();
             if (getter != null) {
-                if ( getter instanceof MemberBox ) {
-                    desc.defineProperty("get", ((MemberBox) getter).asGetterFunction(fName, scope), EMPTY);
-                } else if ( getter instanceof Member ) {
-                    desc.defineProperty("get", new FunctionObject(fName, (Member)getter, scope), EMPTY);
+                if (getter instanceof MemberBox) {
+                    desc.defineProperty(
+                            "get", ((MemberBox) getter).asGetterFunction(fName, scope), EMPTY);
+                } else if (getter instanceof Member) {
+                    desc.defineProperty(
+                            "get", new FunctionObject(fName, (Member) getter, scope), EMPTY);
                 } else {
                     desc.defineProperty("get", getter, EMPTY);
                 }
             }
             if (setter != null) {
-                if ( setter instanceof MemberBox ) {
-                    desc.defineProperty("set", ((MemberBox) setter).asSetterFunction(fName, scope), EMPTY);
-                } else if ( setter instanceof Member ) {
-                    desc.defineProperty("set", new FunctionObject(fName, (Member) setter, scope), EMPTY);
+                if (setter instanceof MemberBox) {
+                    desc.defineProperty(
+                            "set", ((MemberBox) setter).asSetterFunction(fName, scope), EMPTY);
+                } else if (setter instanceof Member) {
+                    desc.defineProperty(
+                            "set", new FunctionObject(fName, (Member) setter, scope), EMPTY);
                 } else {
                     desc.defineProperty("set", setter, EMPTY);
                 }
@@ -273,16 +258,18 @@ public abstract class ScriptableObject implements Scriptable,
             if (setter == null) {
                 if (getter != null) {
                     Context cx = Context.getContext();
-                    if (cx.isStrictMode() ||
-                        // Based on TC39 ES3.1 Draft of 9-Feb-2009, 8.12.4, step 2,
-                        // we should throw a TypeError in this case.
-                        cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
+                    if (cx.isStrictMode()
+                            ||
+                            // Based on TC39 ES3.1 Draft of 9-Feb-2009, 8.12.4, step 2,
+                            // we should throw a TypeError in this case.
+                            cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
 
                         String prop = "";
                         if (name != null) {
                             prop = "[" + start.getClassName() + "]." + name;
                         }
-                        throw ScriptRuntime.typeErrorById("msg.set.prop.no.setter", prop, Context.toString(value));
+                        throw ScriptRuntime.typeErrorById(
+                                "msg.set.prop.no.setter", prop, Context.toString(value));
                     }
                     // Assignment to a property with only a getter defined. The
                     // assignment is ignored. See bug 478047.
@@ -291,7 +278,7 @@ public abstract class ScriptableObject implements Scriptable,
             } else {
                 Context cx = Context.getContext();
                 if (setter instanceof MemberBox) {
-                    MemberBox nativeSetter = (MemberBox)setter;
+                    MemberBox nativeSetter = (MemberBox) setter;
                     Class<?> pTypes[] = nativeSetter.argTypes;
                     // XXX: cache tag since it is already calculated in
                     // defineProperty ?
@@ -302,15 +289,15 @@ public abstract class ScriptableObject implements Scriptable,
                     Object[] args;
                     if (nativeSetter.delegateTo == null) {
                         setterThis = start;
-                        args = new Object[] { actualArg };
+                        args = new Object[] {actualArg};
                     } else {
                         setterThis = nativeSetter.delegateTo;
-                        args = new Object[] { start, actualArg };
+                        args = new Object[] {start, actualArg};
                     }
                     nativeSetter.invoke(setterThis, args);
                 } else if (setter instanceof Function) {
-                    Function f = (Function)setter;
-                    f.call(cx, f.getParentScope(), start, new Object[] { value });
+                    Function f = (Function) setter;
+                    f.call(cx, f.getParentScope(), start, new Object[] {value});
                 }
                 return true;
             }
@@ -321,7 +308,7 @@ public abstract class ScriptableObject implements Scriptable,
         Object getValue(Scriptable start) {
             if (getter != null) {
                 if (getter instanceof MemberBox) {
-                    MemberBox nativeGetter = (MemberBox)getter;
+                    MemberBox nativeGetter = (MemberBox) getter;
                     Object getterThis;
                     Object[] args;
                     if (nativeGetter.delegateTo == null) {
@@ -329,19 +316,18 @@ public abstract class ScriptableObject implements Scriptable,
                         args = ScriptRuntime.emptyArgs;
                     } else {
                         getterThis = nativeGetter.delegateTo;
-                        args = new Object[] { start };
+                        args = new Object[] {start};
                     }
                     return nativeGetter.invoke(getterThis, args);
                 } else if (getter instanceof Function) {
-                    Function f = (Function)getter;
+                    Function f = (Function) getter;
                     Context cx = Context.getContext();
-                    return f.call(cx, f.getParentScope(), start,
-                                  ScriptRuntime.emptyArgs);
+                    return f.call(cx, f.getParentScope(), start, ScriptRuntime.emptyArgs);
                 }
             }
             Object val = this.value;
             if (val instanceof LazilyLoadedCtor) {
-                LazilyLoadedCtor initializer = (LazilyLoadedCtor)val;
+                LazilyLoadedCtor initializer = (LazilyLoadedCtor) val;
                 try {
                     initializer.init();
                 } finally {
@@ -352,16 +338,14 @@ public abstract class ScriptableObject implements Scriptable,
         }
     }
 
-    static void checkValidAttributes(int attributes)
-    {
+    static void checkValidAttributes(int attributes) {
         final int mask = READONLY | DONTENUM | PERMANENT | UNINITIALIZED_CONST;
         if ((attributes & ~mask) != 0) {
             throw new IllegalArgumentException(String.valueOf(attributes));
         }
     }
 
-    private static SlotMapContainer createSlotMap(int initialSize)
-    {
+    private static SlotMapContainer createSlotMap(int initialSize) {
         Context cx = Context.getCurrentContext();
         if ((cx != null) && cx.hasFeature(Context.FEATURE_THREAD_SAFE_OBJECTS)) {
             return new ThreadSafeSlotMapContainer(initialSize);
@@ -369,15 +353,12 @@ public abstract class ScriptableObject implements Scriptable,
         return new SlotMapContainer(initialSize);
     }
 
-    public ScriptableObject()
-    {
+    public ScriptableObject() {
         slotMap = createSlotMap(0);
     }
 
-    public ScriptableObject(Scriptable scope, Scriptable prototype)
-    {
-        if (scope == null)
-            throw new IllegalArgumentException();
+    public ScriptableObject(Scriptable scope, Scriptable prototype) {
+        if (scope == null) throw new IllegalArgumentException();
 
         parentScopeObject = scope;
         prototypeObject = prototype;
@@ -386,8 +367,9 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Gets the value that will be returned by calling the typeof operator on this object.
-     * @return default is "object" unless {@link #avoidObjectDetection()} is <code>true</code> in which
-     * case it returns "undefined"
+     *
+     * @return default is "object" unless {@link #avoidObjectDetection()} is <code>true</code> in
+     *     which case it returns "undefined"
      */
     public String getTypeOf() {
         return avoidObjectDetection() ? "undefined" : "object";
@@ -396,9 +378,8 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Return the name of the class.
      *
-     * This is typically the same name as the constructor.
-     * Classes extending ScriptableObject must implement this abstract
-     * method.
+     * <p>This is typically the same name as the constructor. Classes extending ScriptableObject
+     * must implement this abstract method.
      */
     @Override
     public abstract String getClassName();
@@ -411,8 +392,7 @@ public abstract class ScriptableObject implements Scriptable,
      * @return true if and only if the property was found in the object
      */
     @Override
-    public boolean has(String name, Scriptable start)
-    {
+    public boolean has(String name, Scriptable start) {
         return null != slotMap.query(name, 0);
     }
 
@@ -424,36 +404,30 @@ public abstract class ScriptableObject implements Scriptable,
      * @return true if and only if the property was found in the object
      */
     @Override
-    public boolean has(int index, Scriptable start)
-    {
+    public boolean has(int index, Scriptable start) {
         if (externalData != null) {
             return (index < externalData.getArrayLength());
         }
         return null != slotMap.query(null, index);
     }
 
-    /**
-     * A version of "has" that supports symbols.
-     */
+    /** A version of "has" that supports symbols. */
     @Override
-    public boolean has(Symbol key, Scriptable start)
-    {
+    public boolean has(Symbol key, Scriptable start) {
         return null != slotMap.query(key, 0);
     }
 
     /**
      * Returns the value of the named property or NOT_FOUND.
      *
-     * If the property was created using defineProperty, the
-     * appropriate getter method is called.
+     * <p>If the property was created using defineProperty, the appropriate getter method is called.
      *
      * @param name the name of the property
      * @param start the object in which the lookup began
      * @return the value of the property (may be null), or NOT_FOUND
      */
     @Override
-    public Object get(String name, Scriptable start)
-    {
+    public Object get(String name, Scriptable start) {
         Slot slot = slotMap.query(name, 0);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
@@ -469,8 +443,7 @@ public abstract class ScriptableObject implements Scriptable,
      * @return the value of the property (may be null), or NOT_FOUND
      */
     @Override
-    public Object get(int index, Scriptable start)
-    {
+    public Object get(int index, Scriptable start) {
         if (externalData != null) {
             if (index < externalData.getArrayLength()) {
                 return externalData.getArrayElement(index);
@@ -485,12 +458,9 @@ public abstract class ScriptableObject implements Scriptable,
         return slot.getValue(start);
     }
 
-    /**
-     * Another version of Get that supports Symbol keyed properties.
-     */
+    /** Another version of Get that supports Symbol keyed properties. */
     @Override
-    public Object get(Symbol key, Scriptable start)
-    {
+    public Object get(Symbol key, Scriptable start) {
         Slot slot = slotMap.query(key, 0);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
@@ -501,23 +471,18 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Sets the value of the named property, creating it if need be.
      *
-     * If the property was created using defineProperty, the
-     * appropriate setter method is called. <p>
+     * <p>If the property was created using defineProperty, the appropriate setter method is called.
      *
-     * If the property's attributes include READONLY, no action is
-     * taken.
-     * This method will actually set the property in the start
-     * object.
+     * <p>If the property's attributes include READONLY, no action is taken. This method will
+     * actually set the property in the start object.
      *
      * @param name the name of the property
      * @param start the object whose property is being set
      * @param value value to set the property to
      */
     @Override
-    public void put(String name, Scriptable start, Object value)
-    {
-        if (putImpl(name, 0, start, value))
-            return;
+    public void put(String name, Scriptable start, Object value) {
+        if (putImpl(name, 0, start, value)) return;
 
         if (start == this) throw Kit.codeBug();
         start.put(name, start, value);
@@ -531,36 +496,33 @@ public abstract class ScriptableObject implements Scriptable,
      * @param value value to set the property to
      */
     @Override
-    public void put(int index, Scriptable start, Object value)
-    {
+    public void put(int index, Scriptable start, Object value) {
         if (externalData != null) {
             if (index < externalData.getArrayLength()) {
                 externalData.setArrayElement(index, value);
             } else {
                 throw new JavaScriptException(
-                    ScriptRuntime.newNativeError(Context.getCurrentContext(), this,
-                                                 TopLevel.NativeErrors.RangeError,
-                                                 new Object[] { "External array index out of bounds " }),
-                    null, 0);
+                        ScriptRuntime.newNativeError(
+                                Context.getCurrentContext(),
+                                this,
+                                TopLevel.NativeErrors.RangeError,
+                                new Object[] {"External array index out of bounds "}),
+                        null,
+                        0);
             }
             return;
         }
 
-        if (putImpl(null, index, start, value))
-            return;
+        if (putImpl(null, index, start, value)) return;
 
         if (start == this) throw Kit.codeBug();
         start.put(index, start, value);
     }
 
-    /**
-     * Implementation of put required by SymbolScriptable objects.
-     */
+    /** Implementation of put required by SymbolScriptable objects. */
     @Override
-    public void put(Symbol key, Scriptable start, Object value)
-    {
-        if (putImpl(key, 0, start, value))
-            return;
+    public void put(Symbol key, Scriptable start, Object value) {
+        if (putImpl(key, 0, start, value)) return;
 
         if (start == this) throw Kit.codeBug();
         ensureSymbolScriptable(start).put(key, start, value);
@@ -569,14 +531,12 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Removes a named property from the object.
      *
-     * If the property is not found, or it has the PERMANENT attribute,
-     * no action is taken.
+     * <p>If the property is not found, or it has the PERMANENT attribute, no action is taken.
      *
      * @param name the name of the property
      */
     @Override
-    public void delete(String name)
-    {
+    public void delete(String name) {
         checkNotSealed(name, 0);
         slotMap.remove(name, 0);
     }
@@ -584,24 +544,19 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Removes the indexed property from the object.
      *
-     * If the property is not found, or it has the PERMANENT attribute,
-     * no action is taken.
+     * <p>If the property is not found, or it has the PERMANENT attribute, no action is taken.
      *
      * @param index the numeric index for the property
      */
     @Override
-    public void delete(int index)
-    {
+    public void delete(int index) {
         checkNotSealed(null, index);
         slotMap.remove(null, index);
     }
 
-    /**
-     * Removes an object like the others, but using a Symbol as the key.
-     */
+    /** Removes an object like the others, but using a Symbol as the key. */
     @Override
-    public void delete(Symbol key)
-    {
+    public void delete(Symbol key) {
         checkNotSealed(key, 0);
         slotMap.remove(key, 0);
     }
@@ -609,107 +564,90 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Sets the value of the named const property, creating it if need be.
      *
-     * If the property was created using defineProperty, the
-     * appropriate setter method is called. <p>
+     * <p>If the property was created using defineProperty, the appropriate setter method is called.
      *
-     * If the property's attributes include READONLY, no action is
-     * taken.
-     * This method will actually set the property in the start
-     * object.
+     * <p>If the property's attributes include READONLY, no action is taken. This method will
+     * actually set the property in the start object.
      *
      * @param name the name of the property
      * @param start the object whose property is being set
      * @param value value to set the property to
      */
     @Override
-    public void putConst(String name, Scriptable start, Object value)
-    {
-        if (putConstImpl(name, 0, start, value, READONLY))
-            return;
+    public void putConst(String name, Scriptable start, Object value) {
+        if (putConstImpl(name, 0, start, value, READONLY)) return;
 
         if (start == this) throw Kit.codeBug();
         if (start instanceof ConstProperties)
-            ((ConstProperties)start).putConst(name, start, value);
-        else
-            start.put(name, start, value);
+            ((ConstProperties) start).putConst(name, start, value);
+        else start.put(name, start, value);
     }
 
     @Override
-    public void defineConst(String name, Scriptable start)
-    {
-        if (putConstImpl(name, 0, start, Undefined.instance, UNINITIALIZED_CONST))
-            return;
+    public void defineConst(String name, Scriptable start) {
+        if (putConstImpl(name, 0, start, Undefined.instance, UNINITIALIZED_CONST)) return;
 
         if (start == this) throw Kit.codeBug();
-        if (start instanceof ConstProperties)
-            ((ConstProperties)start).defineConst(name, start);
+        if (start instanceof ConstProperties) ((ConstProperties) start).defineConst(name, start);
     }
 
     /**
      * Returns true if the named property is defined as a const on this object.
+     *
      * @param name
-     * @return true if the named property is defined as a const, false
-     * otherwise.
+     * @return true if the named property is defined as a const, false otherwise.
      */
     @Override
-    public boolean isConst(String name)
-    {
+    public boolean isConst(String name) {
         Slot slot = slotMap.query(name, 0);
         if (slot == null) {
             return false;
         }
-        return (slot.getAttributes() & (PERMANENT|READONLY)) ==
-                                       (PERMANENT|READONLY);
-
+        return (slot.getAttributes() & (PERMANENT | READONLY)) == (PERMANENT | READONLY);
     }
 
     /**
-     * @deprecated Use {@link #getAttributes(String name)}. The engine always
-     * ignored the start argument.
+     * @deprecated Use {@link #getAttributes(String name)}. The engine always ignored the start
+     *     argument.
      */
     @Deprecated
-    public final int getAttributes(String name, Scriptable start)
-    {
+    public final int getAttributes(String name, Scriptable start) {
         return getAttributes(name);
     }
 
     /**
-     * @deprecated Use {@link #getAttributes(int index)}. The engine always
-     * ignored the start argument.
+     * @deprecated Use {@link #getAttributes(int index)}. The engine always ignored the start
+     *     argument.
      */
     @Deprecated
-    public final int getAttributes(int index, Scriptable start)
-    {
+    public final int getAttributes(int index, Scriptable start) {
         return getAttributes(index);
     }
 
     /**
-     * @deprecated Use {@link #setAttributes(String name, int attributes)}.
-     * The engine always ignored the start argument.
+     * @deprecated Use {@link #setAttributes(String name, int attributes)}. The engine always
+     *     ignored the start argument.
      */
     @Deprecated
-    public final void setAttributes(String name, Scriptable start,
-                                    int attributes)
-    {
+    public final void setAttributes(String name, Scriptable start, int attributes) {
         setAttributes(name, attributes);
     }
 
     /**
-     * @deprecated Use {@link #setAttributes(int index, int attributes)}.
-     * The engine always ignored the start argument.
+     * @deprecated Use {@link #setAttributes(int index, int attributes)}. The engine always ignored
+     *     the start argument.
      */
     @Deprecated
-    public void setAttributes(int index, Scriptable start,
-                              int attributes)
-    {
+    public void setAttributes(int index, Scriptable start, int attributes) {
         setAttributes(index, attributes);
     }
 
     /**
      * Get the attributes of a named property.
      *
-     * The property is specified by <code>name</code>
-     * as defined for <code>has</code>.<p>
+     * <p>The property is specified by <code>name</code> as defined for <code>has</code>.
+     *
+     * <p>
      *
      * @param name the identifier for the property
      * @return the bitset of attributes
@@ -720,8 +658,7 @@ public abstract class ScriptableObject implements Scriptable,
      * @see org.mozilla.javascript.ScriptableObject#PERMANENT
      * @see org.mozilla.javascript.ScriptableObject#EMPTY
      */
-    public int getAttributes(String name)
-    {
+    public int getAttributes(String name) {
         return findAttributeSlot(name, 0, SlotAccess.QUERY).getAttributes();
     }
 
@@ -729,8 +666,7 @@ public abstract class ScriptableObject implements Scriptable,
      * Get the attributes of an indexed property.
      *
      * @param index the numeric index for the property
-     * @exception EvaluatorException if the named property is not found
-     *            is not found
+     * @exception EvaluatorException if the named property is not found is not found
      * @return the bitset of attributes
      * @see org.mozilla.javascript.ScriptableObject#has(String, Scriptable)
      * @see org.mozilla.javascript.ScriptableObject#READONLY
@@ -738,28 +674,22 @@ public abstract class ScriptableObject implements Scriptable,
      * @see org.mozilla.javascript.ScriptableObject#PERMANENT
      * @see org.mozilla.javascript.ScriptableObject#EMPTY
      */
-    public int getAttributes(int index)
-    {
+    public int getAttributes(int index) {
         return findAttributeSlot(null, index, SlotAccess.QUERY).getAttributes();
     }
 
-    public int getAttributes(Symbol sym)
-    {
+    public int getAttributes(Symbol sym) {
         return findAttributeSlot(sym, SlotAccess.QUERY).getAttributes();
     }
-
 
     /**
      * Set the attributes of a named property.
      *
-     * The property is specified by <code>name</code>
-     * as defined for <code>has</code>.<p>
+     * <p>The property is specified by <code>name</code> as defined for <code>has</code>.
      *
-     * The possible attributes are READONLY, DONTENUM,
-     * and PERMANENT. Combinations of attributes
-     * are expressed by the bitwise OR of attributes.
-     * EMPTY is the state of no attributes set. Any unused
-     * bits are reserved for future use.
+     * <p>The possible attributes are READONLY, DONTENUM, and PERMANENT. Combinations of attributes
+     * are expressed by the bitwise OR of attributes. EMPTY is the state of no attributes set. Any
+     * unused bits are reserved for future use.
      *
      * @param name the name of the property
      * @param attributes the bitset of attributes
@@ -770,8 +700,7 @@ public abstract class ScriptableObject implements Scriptable,
      * @see org.mozilla.javascript.ScriptableObject#PERMANENT
      * @see org.mozilla.javascript.ScriptableObject#EMPTY
      */
-    public void setAttributes(String name, int attributes)
-    {
+    public void setAttributes(String name, int attributes) {
         checkNotSealed(name, 0);
         findAttributeSlot(name, 0, SlotAccess.MODIFY).setAttributes(attributes);
     }
@@ -788,35 +717,26 @@ public abstract class ScriptableObject implements Scriptable,
      * @see org.mozilla.javascript.ScriptableObject#PERMANENT
      * @see org.mozilla.javascript.ScriptableObject#EMPTY
      */
-    public void setAttributes(int index, int attributes)
-    {
+    public void setAttributes(int index, int attributes) {
         checkNotSealed(null, index);
         findAttributeSlot(null, index, SlotAccess.MODIFY).setAttributes(attributes);
     }
 
-    /**
-     * Set attributes of a Symbol-keyed property.
-     */
-    public void setAttributes(Symbol key, int attributes)
-    {
+    /** Set attributes of a Symbol-keyed property. */
+    public void setAttributes(Symbol key, int attributes) {
         checkNotSealed(key, 0);
         findAttributeSlot(key, SlotAccess.MODIFY).setAttributes(attributes);
     }
 
-    /**
-     * XXX: write docs.
-     */
-    public void setGetterOrSetter(String name, int index,
-                                  Callable getterOrSetter, boolean isSetter)
-    {
+    /** XXX: write docs. */
+    public void setGetterOrSetter(
+            String name, int index, Callable getterOrSetter, boolean isSetter) {
         setGetterOrSetter(name, index, getterOrSetter, isSetter, false);
     }
 
-    private void setGetterOrSetter(String name, int index, Callable getterOrSetter,
-                                   boolean isSetter, boolean force)
-    {
-        if (name != null && index != 0)
-            throw new IllegalArgumentException(name);
+    private void setGetterOrSetter(
+            String name, int index, Callable getterOrSetter, boolean isSetter, boolean force) {
+        if (name != null && index != 0) throw new IllegalArgumentException(name);
 
         if (!force) {
             checkNotSealed(name, index);
@@ -824,11 +744,10 @@ public abstract class ScriptableObject implements Scriptable,
 
         final GetterSlot gslot;
         if (isExtensible()) {
-            gslot = (GetterSlot)slotMap.get(name, index, SlotAccess.MODIFY_GETTER_SETTER);
+            gslot = (GetterSlot) slotMap.get(name, index, SlotAccess.MODIFY_GETTER_SETTER);
         } else {
             Slot slot = slotMap.query(name, index);
-            if (!(slot instanceof GetterSlot))
-                return;
+            if (!(slot instanceof GetterSlot)) return;
             gslot = (GetterSlot) slot;
         }
 
@@ -847,27 +766,22 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Get the getter or setter for a given property. Used by __lookupGetter__
-     * and __lookupSetter__.
+     * Get the getter or setter for a given property. Used by __lookupGetter__ and __lookupSetter__.
      *
      * @param name Name of the object. If nonnull, index must be 0.
      * @param index Index of the object. If nonzero, name must be null.
      * @param isSetter If true, return the setter, otherwise return the getter.
-     * @exception IllegalArgumentException if both name and index are nonnull
-     *            and nonzero respectively.
-     * @return Null if the property does not exist. Otherwise returns either
-     *         the getter or the setter for the property, depending on
-     *         the value of isSetter (may be undefined if unset).
+     * @exception IllegalArgumentException if both name and index are nonnull and nonzero
+     *     respectively.
+     * @return Null if the property does not exist. Otherwise returns either the getter or the
+     *     setter for the property, depending on the value of isSetter (may be undefined if unset).
      */
-    public Object getGetterOrSetter(String name, int index, boolean isSetter)
-    {
-        if (name != null && index != 0)
-            throw new IllegalArgumentException(name);
+    public Object getGetterOrSetter(String name, int index, boolean isSetter) {
+        if (name != null && index != 0) throw new IllegalArgumentException(name);
         Slot slot = slotMap.query(name, index);
-        if (slot == null)
-            return null;
+        if (slot == null) return null;
         if (slot instanceof GetterSlot) {
-            GetterSlot gslot = (GetterSlot)slot;
+            GetterSlot gslot = (GetterSlot) slot;
             Object result = isSetter ? gslot.setter : gslot.getter;
             return result != null ? result : Undefined.instance;
         }
@@ -876,6 +790,7 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Returns whether a property is a getter or a setter
+     *
      * @param name property name
      * @param index property index
      * @param setter true to check for a setter, false for a getter
@@ -884,20 +799,16 @@ public abstract class ScriptableObject implements Scriptable,
     protected boolean isGetterOrSetter(String name, int index, boolean setter) {
         Slot slot = slotMap.query(name, index);
         if (slot instanceof GetterSlot) {
-            if (setter && ((GetterSlot)slot).setter != null) return true;
-            if (!setter && ((GetterSlot)slot).getter != null) return true;
+            if (setter && ((GetterSlot) slot).setter != null) return true;
+            if (!setter && ((GetterSlot) slot).getter != null) return true;
         }
         return false;
     }
 
-    void addLazilyInitializedValue(String name, int index,
-                                   LazilyLoadedCtor init, int attributes)
-    {
-        if (name != null && index != 0)
-            throw new IllegalArgumentException(name);
+    void addLazilyInitializedValue(String name, int index, LazilyLoadedCtor init, int attributes) {
+        if (name != null && index != 0) throw new IllegalArgumentException(name);
         checkNotSealed(name, index);
-        GetterSlot gslot = (GetterSlot)slotMap.get(name, index,
-            SlotAccess.MODIFY_GETTER_SETTER);
+        GetterSlot gslot = (GetterSlot) slotMap.get(name, index, SlotAccess.MODIFY_GETTER_SETTER);
         gslot.setAttributes(attributes);
         gslot.getter = null;
         gslot.setter = null;
@@ -905,25 +816,24 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Attach the specified object to this object, and delegate all indexed property lookups to it. In other words,
-     * if the object has 3 elements, then an attempt to look up or modify "[0]", "[1]", or "[2]" will be delegated
-     * to this object. Additional indexed properties outside the range specified, and additional non-indexed
-     * properties, may still be added. The object specified must implement the ExternalArrayData interface.
+     * Attach the specified object to this object, and delegate all indexed property lookups to it.
+     * In other words, if the object has 3 elements, then an attempt to look up or modify "[0]",
+     * "[1]", or "[2]" will be delegated to this object. Additional indexed properties outside the
+     * range specified, and additional non-indexed properties, may still be added. The object
+     * specified must implement the ExternalArrayData interface.
      *
-     * @param array the List to use for delegated property access. Set this to null to revert back to regular
-     *              property access.
+     * @param array the List to use for delegated property access. Set this to null to revert back
+     *     to regular property access.
      * @since 1.7.6
      */
-    public void setExternalArrayData(ExternalArrayData array)
-    {
+    public void setExternalArrayData(ExternalArrayData array) {
         externalData = array;
 
         if (array == null) {
             delete("length");
         } else {
             // Define "length" to return whatever length the List gives us.
-            defineProperty("length", null,
-                           GET_ARRAY_LENGTH, null, READONLY | DONTENUM);
+            defineProperty("length", null, GET_ARRAY_LENGTH, null, READONLY | DONTENUM);
         }
     }
 
@@ -933,65 +843,52 @@ public abstract class ScriptableObject implements Scriptable,
      * @return the array, or null if it was never set
      * @since 1.7.6
      */
-    public ExternalArrayData getExternalArrayData()
-    {
+    public ExternalArrayData getExternalArrayData() {
         return externalData;
     }
 
     /**
-     * This is a function used by setExternalArrayData to dynamically get the "length" property value.
+     * This is a function used by setExternalArrayData to dynamically get the "length" property
+     * value.
      */
-    public Object getExternalArrayLength()
-    {
+    public Object getExternalArrayLength() {
         return Integer.valueOf(externalData == null ? 0 : externalData.getArrayLength());
     }
 
-    /**
-     * Returns the prototype of the object.
-     */
+    /** Returns the prototype of the object. */
     @Override
-    public Scriptable getPrototype()
-    {
+    public Scriptable getPrototype() {
         return prototypeObject;
     }
 
-    /**
-     * Sets the prototype of the object.
-     */
+    /** Sets the prototype of the object. */
     @Override
-    public void setPrototype(Scriptable m)
-    {
+    public void setPrototype(Scriptable m) {
         prototypeObject = m;
     }
 
-    /**
-     * Returns the parent (enclosing) scope of the object.
-     */
+    /** Returns the parent (enclosing) scope of the object. */
     @Override
-    public Scriptable getParentScope()
-    {
+    public Scriptable getParentScope() {
         return parentScopeObject;
     }
 
-    /**
-     * Sets the parent (enclosing) scope of the object.
-     */
+    /** Sets the parent (enclosing) scope of the object. */
     @Override
-    public void setParentScope(Scriptable m)
-    {
+    public void setParentScope(Scriptable m) {
         parentScopeObject = m;
     }
 
     /**
      * Returns an array of ids for the properties of the object.
      *
-     * <p>Any properties with the attribute DONTENUM are not listed. <p>
+     * <p>Any properties with the attribute DONTENUM are not listed.
      *
-     * @return an array of java.lang.Objects with an entry for every
-     * listed property. Properties accessed via an integer index will
-     * have a corresponding
-     * Integer entry in the returned array. Properties accessed by
-     * a String will have a String entry in the returned array.
+     * <p>
+     *
+     * @return an array of java.lang.Objects with an entry for every listed property. Properties
+     *     accessed via an integer index will have a corresponding Integer entry in the returned
+     *     array. Properties accessed by a String will have a String entry in the returned array.
      */
     @Override
     public Object[] getIds() {
@@ -1001,13 +898,13 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Returns an array of ids for the properties of the object.
      *
-     * <p>All properties, even those with attribute DONTENUM, are listed. <p>
+     * <p>All properties, even those with attribute DONTENUM, are listed.
      *
-     * @return an array of java.lang.Objects with an entry for every
-     * listed property. Properties accessed via an integer index will
-     * have a corresponding
-     * Integer entry in the returned array. Properties accessed by
-     * a String will have a String entry in the returned array.
+     * <p>
+     *
+     * @return an array of java.lang.Objects with an entry for every listed property. Properties
+     *     accessed via an integer index will have a corresponding Integer entry in the returned
+     *     array. Properties accessed by a String will have a String entry in the returned array.
      */
     @Override
     public Object[] getAllIds() {
@@ -1017,27 +914,23 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Implements the [[DefaultValue]] internal method.
      *
-     * <p>Note that the toPrimitive conversion is a no-op for
-     * every type other than Object, for which [[DefaultValue]]
-     * is called. See ECMA 9.1.<p>
+     * <p>Note that the toPrimitive conversion is a no-op for every type other than Object, for
+     * which [[DefaultValue]] is called. See ECMA 9.1.
      *
-     * A <code>hint</code> of null means "no hint".
+     * <p>A <code>hint</code> of null means "no hint".
      *
      * @param typeHint the type hint
      * @return the default value for the object
-     *
-     * See ECMA 8.6.2.6.
+     *     <p>See ECMA 8.6.2.6.
      */
     @Override
-    public Object getDefaultValue(Class<?> typeHint)
-    {
+    public Object getDefaultValue(Class<?> typeHint) {
         return getDefaultValue(this, typeHint);
     }
 
-    public static Object getDefaultValue(Scriptable object, Class<?> typeHint)
-    {
+    public static Object getDefaultValue(Scriptable object, Class<?> typeHint) {
         Context cx = null;
-        for (int i=0; i < 2; i++) {
+        for (int i = 0; i < 2; i++) {
             boolean tryToString;
             if (typeHint == ScriptRuntime.StringClass) {
                 tryToString = (i == 0);
@@ -1052,8 +945,7 @@ public abstract class ScriptableObject implements Scriptable,
                 methodName = "valueOf";
             }
             Object v = getProperty(object, methodName);
-            if (!(v instanceof Function))
-                continue;
+            if (!(v instanceof Function)) continue;
             Function fun = (Function) v;
             if (cx == null) {
                 cx = Context.getContext();
@@ -1064,16 +956,14 @@ public abstract class ScriptableObject implements Scriptable,
                     return v;
                 }
                 if (typeHint == ScriptRuntime.ScriptableClass
-                    || typeHint == ScriptRuntime.FunctionClass)
-                {
+                        || typeHint == ScriptRuntime.FunctionClass) {
                     return v;
                 }
                 if (tryToString && v instanceof Wrapper) {
                     // Let a wrapped java.lang.String pass for a primitive
                     // string.
-                    Object u = ((Wrapper)v).unwrap();
-                    if (u instanceof String)
-                        return u;
+                    Object u = ((Wrapper) v).unwrap();
+                    if (u instanceof String) return u;
                 }
             }
         }
@@ -1087,10 +977,8 @@ public abstract class ScriptableObject implements Scriptable,
      *
      * <p>This operator has been proposed to ECMA.
      *
-     * @param instance The value that appeared on the LHS of the instanceof
-     *              operator
+     * @param instance The value that appeared on the LHS of the instanceof operator
      * @return true if "this" appears in value's prototype chain
-     *
      */
     @Override
     public boolean hasInstance(Scriptable instance) {
@@ -1102,13 +990,12 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Emulate the SpiderMonkey (and Firefox) feature of allowing
-     * custom objects to avoid detection by normal "object detection"
-     * code patterns. This is used to implement document.all.
-     * See https://bugzilla.mozilla.org/show_bug.cgi?id=412247.
-     * This is an analog to JOF_DETECTING from SpiderMonkey; see
-     * https://bugzilla.mozilla.org/show_bug.cgi?id=248549.
-     * Other than this special case, embeddings should return false.
+     * Emulate the SpiderMonkey (and Firefox) feature of allowing custom objects to avoid detection
+     * by normal "object detection" code patterns. This is used to implement document.all. See
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=412247. This is an analog to JOF_DETECTING from
+     * SpiderMonkey; see https://bugzilla.mozilla.org/show_bug.cgi?id=248549. Other than this
+     * special case, embeddings should return false.
+     *
      * @return true if this object should avoid object detection
      * @since 1.7R1
      */
@@ -1117,230 +1004,190 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Custom <code>==</code> operator.
-     * Must return {@link Scriptable#NOT_FOUND} if this object does not
-     * have custom equality operator for the given value,
-     * <code>Boolean.TRUE</code> if this object is equivalent to <code>value</code>,
-     * <code>Boolean.FALSE</code> if this object is not equivalent to
-     * <code>value</code>.
-     * <p>
-     * The default implementation returns Boolean.TRUE
-     * if <code>this == value</code> or {@link Scriptable#NOT_FOUND} otherwise.
-     * It indicates that by default custom equality is available only if
-     * <code>value</code> is <code>this</code> in which case true is returned.
+     * Custom <code>==</code> operator. Must return {@link Scriptable#NOT_FOUND} if this object does
+     * not have custom equality operator for the given value, <code>Boolean.TRUE</code> if this
+     * object is equivalent to <code>value</code>, <code>Boolean.FALSE</code> if this object is not
+     * equivalent to <code>value</code>.
+     *
+     * <p>The default implementation returns Boolean.TRUE if <code>this == value</code> or {@link
+     * Scriptable#NOT_FOUND} otherwise. It indicates that by default custom equality is available
+     * only if <code>value</code> is <code>this</code> in which case true is returned.
      */
-    protected Object equivalentValues(Object value)
-    {
+    protected Object equivalentValues(Object value) {
         return (this == value) ? Boolean.TRUE : Scriptable.NOT_FOUND;
     }
 
     /**
      * Defines JavaScript objects from a Java class that implements Scriptable.
      *
-     * If the given class has a method
+     * <p>If the given class has a method
+     *
      * <pre>
      * static void init(Context cx, Scriptable scope, boolean sealed);</pre>
      *
      * or its compatibility form
+     *
      * <pre>
      * static void init(Scriptable scope);</pre>
      *
-     * then it is invoked and no further initialization is done.<p>
+     * then it is invoked and no further initialization is done.
      *
-     * However, if no such a method is found, then the class's constructors and
-     * methods are used to initialize a class in the following manner.<p>
+     * <p>However, if no such a method is found, then the class's constructors and methods are used
+     * to initialize a class in the following manner.
      *
-     * First, the zero-parameter constructor of the class is called to
-     * create the prototype. If no such constructor exists,
-     * a {@link EvaluatorException} is thrown. <p>
+     * <p>First, the zero-parameter constructor of the class is called to create the prototype. If
+     * no such constructor exists, a {@link EvaluatorException} is thrown.
      *
-     * Next, all methods are scanned for special prefixes that indicate that they
-     * have special meaning for defining JavaScript objects.
-     * These special prefixes are
+     * <p>Next, all methods are scanned for special prefixes that indicate that they have special
+     * meaning for defining JavaScript objects. These special prefixes are
+     *
      * <ul>
-     * <li><code>jsFunction_</code> for a JavaScript function
-     * <li><code>jsStaticFunction_</code> for a JavaScript function that
-     *           is a property of the constructor
-     * <li><code>jsGet_</code> for a getter of a JavaScript property
-     * <li><code>jsSet_</code> for a setter of a JavaScript property
-     * <li><code>jsConstructor</code> for a JavaScript function that
-     *           is the constructor
-     * </ul><p>
+     *   <li><code>jsFunction_</code> for a JavaScript function
+     *   <li><code>jsStaticFunction_</code> for a JavaScript function that is a property of the
+     *       constructor
+     *   <li><code>jsGet_</code> for a getter of a JavaScript property
+     *   <li><code>jsSet_</code> for a setter of a JavaScript property
+     *   <li><code>jsConstructor</code> for a JavaScript function that is the constructor
+     * </ul>
      *
-     * If the method's name begins with "jsFunction_", a JavaScript function
-     * is created with a name formed from the rest of the Java method name
-     * following "jsFunction_". So a Java method named "jsFunction_foo" will
-     * define a JavaScript method "foo". Calling this JavaScript function
-     * will cause the Java method to be called. The parameters of the method
-     * must be of number and types as defined by the FunctionObject class.
-     * The JavaScript function is then added as a property
-     * of the prototype. <p>
+     * <p>If the method's name begins with "jsFunction_", a JavaScript function is created with a
+     * name formed from the rest of the Java method name following "jsFunction_". So a Java method
+     * named "jsFunction_foo" will define a JavaScript method "foo". Calling this JavaScript
+     * function will cause the Java method to be called. The parameters of the method must be of
+     * number and types as defined by the FunctionObject class. The JavaScript function is then
+     * added as a property of the prototype.
      *
-     * If the method's name begins with "jsStaticFunction_", it is handled
-     * similarly except that the resulting JavaScript function is added as a
-     * property of the constructor object. The Java method must be static.
+     * <p>If the method's name begins with "jsStaticFunction_", it is handled similarly except that
+     * the resulting JavaScript function is added as a property of the constructor object. The Java
+     * method must be static.
      *
-     * If the method's name begins with "jsGet_" or "jsSet_", the method is
-     * considered to define a property. Accesses to the defined property
-     * will result in calls to these getter and setter methods. If no
-     * setter is defined, the property is defined as READONLY.<p>
+     * <p>If the method's name begins with "jsGet_" or "jsSet_", the method is considered to define
+     * a property. Accesses to the defined property will result in calls to these getter and setter
+     * methods. If no setter is defined, the property is defined as READONLY.
      *
-     * If the method's name is "jsConstructor", the method is
-     * considered to define the body of the constructor. Only one
-     * method of this name may be defined. You may use the varargs forms
-     * for constructors documented in {@link FunctionObject#FunctionObject(String, Member, Scriptable)}
+     * <p>If the method's name is "jsConstructor", the method is considered to define the body of
+     * the constructor. Only one method of this name may be defined. You may use the varargs forms
+     * for constructors documented in {@link FunctionObject#FunctionObject(String, Member,
+     * Scriptable)}
      *
-     * If no method is found that can serve as constructor, a Java
-     * constructor will be selected to serve as the JavaScript
-     * constructor in the following manner. If the class has only one
-     * Java constructor, that constructor is used to define
-     * the JavaScript constructor. If the the class has two constructors,
-     * one must be the zero-argument constructor (otherwise an
-     * {@link EvaluatorException} would have already been thrown
-     * when the prototype was to be created). In this case
-     * the Java constructor with one or more parameters will be used
-     * to define the JavaScript constructor. If the class has three
-     * or more constructors, an {@link EvaluatorException}
-     * will be thrown.<p>
+     * <p>If no method is found that can serve as constructor, a Java constructor will be selected
+     * to serve as the JavaScript constructor in the following manner. If the class has only one
+     * Java constructor, that constructor is used to define the JavaScript constructor. If the the
+     * class has two constructors, one must be the zero-argument constructor (otherwise an {@link
+     * EvaluatorException} would have already been thrown when the prototype was to be created). In
+     * this case the Java constructor with one or more parameters will be used to define the
+     * JavaScript constructor. If the class has three or more constructors, an {@link
+     * EvaluatorException} will be thrown.
      *
-     * Finally, if there is a method
+     * <p>Finally, if there is a method
+     *
      * <pre>
      * static void finishInit(Scriptable scope, FunctionObject constructor,
      *                        Scriptable prototype)</pre>
      *
-     * it will be called to finish any initialization. The <code>scope</code>
-     * argument will be passed, along with the newly created constructor and
-     * the newly created prototype.<p>
+     * it will be called to finish any initialization. The <code>scope</code> argument will be
+     * passed, along with the newly created constructor and the newly created prototype.
+     *
+     * <p>
      *
      * @param scope The scope in which to define the constructor.
-     * @param clazz The Java class to use to define the JavaScript objects
-     *              and properties.
-     * @exception IllegalAccessException if access is not available
-     *            to a reflected class member
-     * @exception InstantiationException if unable to instantiate
-     *            the named class
-     * @exception InvocationTargetException if an exception is thrown
-     *            during execution of methods of the named class
+     * @param clazz The Java class to use to define the JavaScript objects and properties.
+     * @exception IllegalAccessException if access is not available to a reflected class member
+     * @exception InstantiationException if unable to instantiate the named class
+     * @exception InvocationTargetException if an exception is thrown during execution of methods of
+     *     the named class
      * @see org.mozilla.javascript.Function
      * @see org.mozilla.javascript.FunctionObject
      * @see org.mozilla.javascript.ScriptableObject#READONLY
-     * @see org.mozilla.javascript.ScriptableObject
-     *      #defineProperty(String, Class, int)
+     * @see org.mozilla.javascript.ScriptableObject #defineProperty(String, Class, int)
      */
-    public static <T extends Scriptable> void defineClass(
-            Scriptable scope, Class<T> clazz)
-        throws IllegalAccessException, InstantiationException,
-               InvocationTargetException
-    {
+    public static <T extends Scriptable> void defineClass(Scriptable scope, Class<T> clazz)
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
         defineClass(scope, clazz, false, false);
     }
 
     /**
-     * Defines JavaScript objects from a Java class, optionally
-     * allowing sealing.
+     * Defines JavaScript objects from a Java class, optionally allowing sealing.
      *
-     * Similar to <code>defineClass(Scriptable scope, Class clazz)</code>
-     * except that sealing is allowed. An object that is sealed cannot have
-     * properties added or removed. Note that sealing is not allowed in
-     * the current ECMA/ISO language specification, but is likely for
-     * the next version.
+     * <p>Similar to <code>defineClass(Scriptable scope, Class clazz)</code> except that sealing is
+     * allowed. An object that is sealed cannot have properties added or removed. Note that sealing
+     * is not allowed in the current ECMA/ISO language specification, but is likely for the next
+     * version.
      *
      * @param scope The scope in which to define the constructor.
-     * @param clazz The Java class to use to define the JavaScript objects
-     *              and properties. The class must implement Scriptable.
-     * @param sealed Whether or not to create sealed standard objects that
-     *               cannot be modified.
-     * @exception IllegalAccessException if access is not available
-     *            to a reflected class member
-     * @exception InstantiationException if unable to instantiate
-     *            the named class
-     * @exception InvocationTargetException if an exception is thrown
-     *            during execution of methods of the named class
+     * @param clazz The Java class to use to define the JavaScript objects and properties. The class
+     *     must implement Scriptable.
+     * @param sealed Whether or not to create sealed standard objects that cannot be modified.
+     * @exception IllegalAccessException if access is not available to a reflected class member
+     * @exception InstantiationException if unable to instantiate the named class
+     * @exception InvocationTargetException if an exception is thrown during execution of methods of
+     *     the named class
      * @since 1.4R3
      */
     public static <T extends Scriptable> void defineClass(
             Scriptable scope, Class<T> clazz, boolean sealed)
-        throws IllegalAccessException, InstantiationException,
-               InvocationTargetException
-    {
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
         defineClass(scope, clazz, sealed, false);
     }
 
     /**
-     * Defines JavaScript objects from a Java class, optionally
-     * allowing sealing and mapping of Java inheritance to JavaScript
-     * prototype-based inheritance.
+     * Defines JavaScript objects from a Java class, optionally allowing sealing and mapping of Java
+     * inheritance to JavaScript prototype-based inheritance.
      *
-     * Similar to <code>defineClass(Scriptable scope, Class clazz)</code>
-     * except that sealing and inheritance mapping are allowed. An object
-     * that is sealed cannot have properties added or removed. Note that
-     * sealing is not allowed in the current ECMA/ISO language specification,
-     * but is likely for the next version.
+     * <p>Similar to <code>defineClass(Scriptable scope, Class clazz)</code> except that sealing and
+     * inheritance mapping are allowed. An object that is sealed cannot have properties added or
+     * removed. Note that sealing is not allowed in the current ECMA/ISO language specification, but
+     * is likely for the next version.
      *
      * @param scope The scope in which to define the constructor.
-     * @param clazz The Java class to use to define the JavaScript objects
-     *              and properties. The class must implement Scriptable.
-     * @param sealed Whether or not to create sealed standard objects that
-     *               cannot be modified.
-     * @param mapInheritance Whether or not to map Java inheritance to
-     *                       JavaScript prototype-based inheritance.
+     * @param clazz The Java class to use to define the JavaScript objects and properties. The class
+     *     must implement Scriptable.
+     * @param sealed Whether or not to create sealed standard objects that cannot be modified.
+     * @param mapInheritance Whether or not to map Java inheritance to JavaScript prototype-based
+     *     inheritance.
      * @return the class name for the prototype of the specified class
-     * @exception IllegalAccessException if access is not available
-     *            to a reflected class member
-     * @exception InstantiationException if unable to instantiate
-     *            the named class
-     * @exception InvocationTargetException if an exception is thrown
-     *            during execution of methods of the named class
+     * @exception IllegalAccessException if access is not available to a reflected class member
+     * @exception InstantiationException if unable to instantiate the named class
+     * @exception InvocationTargetException if an exception is thrown during execution of methods of
+     *     the named class
      * @since 1.6R2
      */
     public static <T extends Scriptable> String defineClass(
-            Scriptable scope, Class<T> clazz, boolean sealed,
-            boolean mapInheritance)
-        throws IllegalAccessException, InstantiationException,
-               InvocationTargetException
-    {
-        BaseFunction ctor = buildClassCtor(scope, clazz, sealed,
-                                           mapInheritance);
-        if (ctor == null)
-            return null;
+            Scriptable scope, Class<T> clazz, boolean sealed, boolean mapInheritance)
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        BaseFunction ctor = buildClassCtor(scope, clazz, sealed, mapInheritance);
+        if (ctor == null) return null;
         String name = ctor.getClassPrototype().getClassName();
         defineProperty(scope, name, ctor, ScriptableObject.DONTENUM);
         return name;
     }
 
     static <T extends Scriptable> BaseFunction buildClassCtor(
-            Scriptable scope, Class<T> clazz,
-            boolean sealed,
-            boolean mapInheritance)
-        throws IllegalAccessException, InstantiationException,
-               InvocationTargetException
-    {
+            Scriptable scope, Class<T> clazz, boolean sealed, boolean mapInheritance)
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
         Method[] methods = FunctionObject.getMethodList(clazz);
-        for (int i=0; i < methods.length; i++) {
+        for (int i = 0; i < methods.length; i++) {
             Method method = methods[i];
-            if (!method.getName().equals("init"))
-                continue;
+            if (!method.getName().equals("init")) continue;
             Class<?>[] parmTypes = method.getParameterTypes();
-            if (parmTypes.length == 3 &&
-                parmTypes[0] == ScriptRuntime.ContextClass &&
-                parmTypes[1] == ScriptRuntime.ScriptableClass &&
-                parmTypes[2] == Boolean.TYPE &&
-                Modifier.isStatic(method.getModifiers()))
-            {
-                Object args[] = { Context.getContext(), scope,
-                                  sealed ? Boolean.TRUE : Boolean.FALSE };
+            if (parmTypes.length == 3
+                    && parmTypes[0] == ScriptRuntime.ContextClass
+                    && parmTypes[1] == ScriptRuntime.ScriptableClass
+                    && parmTypes[2] == Boolean.TYPE
+                    && Modifier.isStatic(method.getModifiers())) {
+                Object args[] = {
+                    Context.getContext(), scope, sealed ? Boolean.TRUE : Boolean.FALSE
+                };
                 method.invoke(null, args);
                 return null;
             }
-            if (parmTypes.length == 1 &&
-                parmTypes[0] == ScriptRuntime.ScriptableClass &&
-                Modifier.isStatic(method.getModifiers()))
-            {
-                Object args[] = { scope };
+            if (parmTypes.length == 1
+                    && parmTypes[0] == ScriptRuntime.ScriptableClass
+                    && Modifier.isStatic(method.getModifiers())) {
+                Object args[] = {scope};
                 method.invoke(null, args);
                 return null;
             }
-
         }
 
         // If we got here, there isn't an "init" method with the right
@@ -1348,15 +1195,14 @@ public abstract class ScriptableObject implements Scriptable,
 
         Constructor<?>[] ctors = clazz.getConstructors();
         Constructor<?> protoCtor = null;
-        for (int i=0; i < ctors.length; i++) {
+        for (int i = 0; i < ctors.length; i++) {
             if (ctors[i].getParameterTypes().length == 0) {
                 protoCtor = ctors[i];
                 break;
             }
         }
         if (protoCtor == null) {
-            throw Context.reportRuntimeErrorById(
-                      "msg.zero.arg.ctor", clazz.getName());
+            throw Context.reportRuntimeErrorById("msg.zero.arg.ctor", clazz.getName());
         }
 
         Scriptable proto = (Scriptable) protoCtor.newInstance(ScriptRuntime.emptyArgs);
@@ -1365,9 +1211,9 @@ public abstract class ScriptableObject implements Scriptable,
         // check for possible redefinition
         Object existing = getProperty(getTopLevelScope(scope), className);
         if (existing instanceof BaseFunction) {
-            Object existingProto = ((BaseFunction)existing).getPrototypeProperty();
+            Object existingProto = ((BaseFunction) existing).getPrototypeProperty();
             if (existingProto != null && clazz.equals(existingProto.getClass())) {
-                return (BaseFunction)existing;
+                return (BaseFunction) existing;
             }
         }
 
@@ -1376,13 +1222,12 @@ public abstract class ScriptableObject implements Scriptable,
         Scriptable superProto = null;
         if (mapInheritance) {
             Class<? super T> superClass = clazz.getSuperclass();
-            if (ScriptRuntime.ScriptableClass.isAssignableFrom(superClass) &&
-                !Modifier.isAbstract(superClass.getModifiers()))
-            {
-                Class<? extends Scriptable> superScriptable =
-                    extendsScriptable(superClass);
-                String name = ScriptableObject.defineClass(scope,
-                        superScriptable, sealed, mapInheritance);
+            if (ScriptRuntime.ScriptableClass.isAssignableFrom(superClass)
+                    && !Modifier.isAbstract(superClass.getModifiers())) {
+                Class<? extends Scriptable> superScriptable = extendsScriptable(superClass);
+                String name =
+                        ScriptableObject.defineClass(
+                                scope, superScriptable, sealed, mapInheritance);
                 if (name != null) {
                     superProto = ScriptableObject.getClassPrototype(scope, name);
                 }
@@ -1413,27 +1258,22 @@ public abstract class ScriptableObject implements Scriptable,
             if (ctors.length == 1) {
                 ctorMember = ctors[0];
             } else if (ctors.length == 2) {
-                if (ctors[0].getParameterTypes().length == 0)
-                    ctorMember = ctors[1];
-                else if (ctors[1].getParameterTypes().length == 0)
-                    ctorMember = ctors[0];
+                if (ctors[0].getParameterTypes().length == 0) ctorMember = ctors[1];
+                else if (ctors[1].getParameterTypes().length == 0) ctorMember = ctors[0];
             }
             if (ctorMember == null) {
-                throw Context.reportRuntimeErrorById(
-                          "msg.ctor.multiple.parms", clazz.getName());
+                throw Context.reportRuntimeErrorById("msg.ctor.multiple.parms", clazz.getName());
             }
         }
 
         FunctionObject ctor = new FunctionObject(className, ctorMember, scope);
         if (ctor.isVarArgsMethod()) {
-            throw Context.reportRuntimeErrorById
-                ("msg.varargs.ctor", ctorMember.getName());
+            throw Context.reportRuntimeErrorById("msg.varargs.ctor", ctorMember.getName());
         }
         ctor.initAsConstructor(scope, proto);
 
         Method finishInit = null;
-        HashSet<String> staticNames = new HashSet<String>(),
-                        instanceNames = new HashSet<String>();
+        HashSet<String> staticNames = new HashSet<String>(), instanceNames = new HashSet<String>();
         for (Method method : methods) {
             if (method == ctorMember) {
                 continue;
@@ -1441,21 +1281,18 @@ public abstract class ScriptableObject implements Scriptable,
             String name = method.getName();
             if (name.equals("finishInit")) {
                 Class<?>[] parmTypes = method.getParameterTypes();
-                if (parmTypes.length == 3 &&
-                    parmTypes[0] == ScriptRuntime.ScriptableClass &&
-                    parmTypes[1] == FunctionObject.class &&
-                    parmTypes[2] == ScriptRuntime.ScriptableClass &&
-                    Modifier.isStatic(method.getModifiers()))
-                {
+                if (parmTypes.length == 3
+                        && parmTypes[0] == ScriptRuntime.ScriptableClass
+                        && parmTypes[1] == FunctionObject.class
+                        && parmTypes[2] == ScriptRuntime.ScriptableClass
+                        && Modifier.isStatic(method.getModifiers())) {
                     finishInit = method;
                     continue;
                 }
             }
             // ignore any compiler generated methods.
-            if (name.indexOf('$') != -1)
-                continue;
-            if (name.equals(ctorName))
-                continue;
+            if (name.indexOf('$') != -1) continue;
+            if (name.equals(ctorName)) continue;
 
             Annotation annotation = null;
             String prefix = null;
@@ -1483,13 +1320,12 @@ public abstract class ScriptableObject implements Scriptable,
                 }
             }
 
-            boolean isStatic = annotation instanceof JSStaticFunction
-                    || prefix == staticFunctionPrefix;
+            boolean isStatic =
+                    annotation instanceof JSStaticFunction || prefix == staticFunctionPrefix;
             HashSet<String> names = isStatic ? staticNames : instanceNames;
             String propName = getPropertyName(name, prefix, annotation);
             if (names.contains(propName)) {
-                throw Context.reportRuntimeErrorById("duplicate.defineClass.name",
-                        name, propName);
+                throw Context.reportRuntimeErrorById("duplicate.defineClass.name", name, propName);
             }
             names.add(propName);
             name = propName;
@@ -1497,17 +1333,14 @@ public abstract class ScriptableObject implements Scriptable,
             if (annotation instanceof JSGetter || prefix == getterPrefix) {
                 if (!(proto instanceof ScriptableObject)) {
                     throw Context.reportRuntimeErrorById(
-                        "msg.extend.scriptable",
-                        proto.getClass().toString(), name);
+                            "msg.extend.scriptable", proto.getClass().toString(), name);
                 }
                 Method setter = findSetterMethod(methods, name, setterPrefix);
-                int attr = ScriptableObject.PERMANENT |
-                           ScriptableObject.DONTENUM  |
-                           (setter != null ? 0
-                                           : ScriptableObject.READONLY);
-                ((ScriptableObject) proto).defineProperty(name, null,
-                                                          method, setter,
-                                                          attr);
+                int attr =
+                        ScriptableObject.PERMANENT
+                                | ScriptableObject.DONTENUM
+                                | (setter != null ? 0 : ScriptableObject.READONLY);
+                ((ScriptableObject) proto).defineProperty(name, null, method, setter, attr);
                 continue;
             }
 
@@ -1518,8 +1351,7 @@ public abstract class ScriptableObject implements Scriptable,
 
             FunctionObject f = new FunctionObject(name, method, proto);
             if (f.isVarArgsConstructor()) {
-                throw Context.reportRuntimeErrorById
-                    ("msg.varargs.fun", ctorMember.getName());
+                throw Context.reportRuntimeErrorById("msg.varargs.fun", ctorMember.getName());
             }
             defineProperty(isStatic ? ctor : proto, name, f, DONTENUM);
             if (sealed) {
@@ -1529,7 +1361,7 @@ public abstract class ScriptableObject implements Scriptable,
 
         // Call user code to complete initialization if necessary.
         if (finishInit != null) {
-            Object[] finishArgs = { scope, ctor, proto };
+            Object[] finishArgs = {scope, ctor, proto};
             finishInit.invoke(null, finishArgs);
         }
 
@@ -1544,8 +1376,8 @@ public abstract class ScriptableObject implements Scriptable,
         return ctor;
     }
 
-    private static Member findAnnotatedMember(AccessibleObject[] members,
-                                              Class<? extends Annotation> annotation) {
+    private static Member findAnnotatedMember(
+            AccessibleObject[] members, Class<? extends Annotation> annotation) {
         for (AccessibleObject member : members) {
             if (member.isAnnotationPresent(annotation)) {
                 return (Member) member;
@@ -1554,17 +1386,14 @@ public abstract class ScriptableObject implements Scriptable,
         return null;
     }
 
-    private static Method findSetterMethod(Method[] methods,
-                                           String name,
-                                           String prefix) {
-        String newStyleName = "set"
-                + Character.toUpperCase(name.charAt(0))
-                + name.substring(1);
+    private static Method findSetterMethod(Method[] methods, String name, String prefix) {
+        String newStyleName = "set" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
         for (Method method : methods) {
             JSSetter annotation = method.getAnnotation(JSSetter.class);
             if (annotation != null) {
-                if (name.equals(annotation.value()) ||
-                        ("".equals(annotation.value()) && newStyleName.equals(method.getName()))) {
+                if (name.equals(annotation.value())
+                        || ("".equals(annotation.value())
+                                && newStyleName.equals(method.getName()))) {
                     return method;
                 }
             }
@@ -1578,9 +1407,7 @@ public abstract class ScriptableObject implements Scriptable,
         return null;
     }
 
-    private static String getPropertyName(String methodName,
-                                          String prefix,
-                                          Annotation annotation) {
+    private static String getPropertyName(String methodName, String prefix, Annotation annotation) {
         if (prefix != null) {
             return methodName.substring(prefix.length());
         }
@@ -1593,9 +1420,10 @@ public abstract class ScriptableObject implements Scriptable,
                     if (Character.isUpperCase(propName.charAt(0))) {
                         if (propName.length() == 1) {
                             propName = propName.toLowerCase();
-                        } else if (!Character.isUpperCase(propName.charAt(1))){
-                            propName = Character.toLowerCase(propName.charAt(0))
-                                    + propName.substring(1);
+                        } else if (!Character.isUpperCase(propName.charAt(1))) {
+                            propName =
+                                    Character.toLowerCase(propName.charAt(0))
+                                            + propName.substring(1);
                         }
                     }
                 }
@@ -1612,26 +1440,22 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     @SuppressWarnings({"unchecked"})
-    private static <T extends Scriptable> Class<T> extendsScriptable(Class<?> c)
-    {
-        if (ScriptRuntime.ScriptableClass.isAssignableFrom(c))
-            return (Class<T>) c;
+    private static <T extends Scriptable> Class<T> extendsScriptable(Class<?> c) {
+        if (ScriptRuntime.ScriptableClass.isAssignableFrom(c)) return (Class<T>) c;
         return null;
     }
 
     /**
      * Define a JavaScript property.
      *
-     * Creates the property with an initial value and sets its attributes.
+     * <p>Creates the property with an initial value and sets its attributes.
      *
      * @param propertyName the name of the property to define.
      * @param value the initial value of the property
      * @param attributes the attributes of the JavaScript property
      * @see org.mozilla.javascript.Scriptable#put(String, Scriptable, Object)
      */
-    public void defineProperty(String propertyName, Object value,
-                               int attributes)
-    {
+    public void defineProperty(String propertyName, Object value, int attributes) {
         checkNotSealed(propertyName, 0);
         put(propertyName, this, value);
         setAttributes(propertyName, attributes);
@@ -1639,79 +1463,70 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * A version of defineProperty that uses a Symbol key.
+     *
      * @param key symbol of the property to define.
      * @param value the initial value of the property
      * @param attributes the attributes of the JavaScript property
      */
-    public void defineProperty(Symbol key, Object value,
-                               int attributes)
-    {
+    public void defineProperty(Symbol key, Object value, int attributes) {
         checkNotSealed(key, 0);
         put(key, this, value);
         setAttributes(key, attributes);
     }
 
     /**
-     * Utility method to add properties to arbitrary Scriptable object.
-     * If destination is instance of ScriptableObject, calls
-     * defineProperty there, otherwise calls put in destination
-     * ignoring attributes
+     * Utility method to add properties to arbitrary Scriptable object. If destination is instance
+     * of ScriptableObject, calls defineProperty there, otherwise calls put in destination ignoring
+     * attributes
+     *
      * @param destination ScriptableObject to define the property on
      * @param propertyName the name of the property to define.
      * @param value the initial value of the property
      * @param attributes the attributes of the JavaScript property
      */
-    public static void defineProperty(Scriptable destination,
-                                      String propertyName, Object value,
-                                      int attributes)
-    {
+    public static void defineProperty(
+            Scriptable destination, String propertyName, Object value, int attributes) {
         if (!(destination instanceof ScriptableObject)) {
             destination.put(propertyName, destination, value);
             return;
         }
-        ScriptableObject so = (ScriptableObject)destination;
+        ScriptableObject so = (ScriptableObject) destination;
         so.defineProperty(propertyName, value, attributes);
     }
 
     /**
-     * Utility method to add properties to arbitrary Scriptable object.
-     * If destination is instance of ScriptableObject, calls
-     * defineProperty there, otherwise calls put in destination
-     * ignoring attributes
+     * Utility method to add properties to arbitrary Scriptable object. If destination is instance
+     * of ScriptableObject, calls defineProperty there, otherwise calls put in destination ignoring
+     * attributes
+     *
      * @param destination ScriptableObject to define the property on
      * @param propertyName the name of the property to define.
      */
-    public static void defineConstProperty(Scriptable destination,
-                                           String propertyName)
-    {
+    public static void defineConstProperty(Scriptable destination, String propertyName) {
         if (destination instanceof ConstProperties) {
-            ConstProperties cp = (ConstProperties)destination;
+            ConstProperties cp = (ConstProperties) destination;
             cp.defineConst(propertyName, destination);
-        } else
-            defineProperty(destination, propertyName, Undefined.instance, CONST);
+        } else defineProperty(destination, propertyName, Undefined.instance, CONST);
     }
 
     /**
      * Define a JavaScript property with getter and setter side effects.
      *
-     * If the setter is not found, the attribute READONLY is added to
-     * the given attributes. <p>
+     * <p>If the setter is not found, the attribute READONLY is added to the given attributes.
      *
-     * The getter must be a method with zero parameters, and the setter, if
-     * found, must be a method with one parameter.<p>
+     * <p>The getter must be a method with zero parameters, and the setter, if found, must be a
+     * method with one parameter.
      *
-     * @param propertyName the name of the property to define. This name
-     *                    also affects the name of the setter and getter
-     *                    to search for. If the propertyId is "foo", then
-     *                    <code>clazz</code> will be searched for "getFoo"
-     *                    and "setFoo" methods.
+     * <p>
+     *
+     * @param propertyName the name of the property to define. This name also affects the name of
+     *     the setter and getter to search for. If the propertyId is "foo", then <code>clazz</code>
+     *     will be searched for "getFoo" and "setFoo" methods.
      * @param clazz the Java class to search for the getter and setter
      * @param attributes the attributes of the JavaScript property
      * @see org.mozilla.javascript.Scriptable#put(String, Scriptable, Object)
      */
-    public void defineProperty(String propertyName, Class<?> clazz,
-                               int attributes)
-    {
+    public void defineProperty(String propertyName, Class<?> clazz, int attributes) {
         int length = propertyName.length();
         if (length == 0) throw new IllegalArgumentException();
         char[] buf = new char[3 + length];
@@ -1727,56 +1542,53 @@ public abstract class ScriptableObject implements Scriptable,
         Method[] methods = FunctionObject.getMethodList(clazz);
         Method getter = FunctionObject.findSingleMethod(methods, getterName);
         Method setter = FunctionObject.findSingleMethod(methods, setterName);
-        if (setter == null)
-            attributes |= ScriptableObject.READONLY;
-        defineProperty(propertyName, null, getter,
-                       setter == null ? null : setter, attributes);
+        if (setter == null) attributes |= ScriptableObject.READONLY;
+        defineProperty(propertyName, null, getter, setter == null ? null : setter, attributes);
     }
 
     /**
      * Define a JavaScript property.
      *
-     * Use this method only if you wish to define getters and setters for
-     * a given property in a ScriptableObject. To create a property without
-     * special getter or setter side effects, use
+     * <p>Use this method only if you wish to define getters and setters for a given property in a
+     * ScriptableObject. To create a property without special getter or setter side effects, use
      * <code>defineProperty(String,int)</code>.
      *
-     * If <code>setter</code> is null, the attribute READONLY is added to
-     * the given attributes.<p>
+     * <p>If <code>setter</code> is null, the attribute READONLY is added to the given attributes.
      *
-     * Several forms of getters or setters are allowed. In all cases the
-     * type of the value parameter can be any one of the following types:
-     * Object, String, boolean, Scriptable, byte, short, int, long, float,
-     * or double. The runtime will perform appropriate conversions based
-     * upon the type of the parameter (see description in FunctionObject).
-     * The first forms are nonstatic methods of the class referred to
-     * by 'this':
+     * <p>Several forms of getters or setters are allowed. In all cases the type of the value
+     * parameter can be any one of the following types: Object, String, boolean, Scriptable, byte,
+     * short, int, long, float, or double. The runtime will perform appropriate conversions based
+     * upon the type of the parameter (see description in FunctionObject). The first forms are
+     * nonstatic methods of the class referred to by 'this':
+     *
      * <pre>
      * Object getFoo();
      * void setFoo(SomeType value);</pre>
-     * Next are static methods that may be of any class; the object whose
-     * property is being accessed is passed in as an extra argument:
+     *
+     * Next are static methods that may be of any class; the object whose property is being accessed
+     * is passed in as an extra argument:
+     *
      * <pre>
      * static Object getFoo(Scriptable obj);
      * static void setFoo(Scriptable obj, SomeType value);</pre>
-     * Finally, it is possible to delegate to another object entirely using
-     * the <code>delegateTo</code> parameter. In this case the methods are
-     * nonstatic methods of the class delegated to, and the object whose
-     * property is being accessed is passed in as an extra argument:
+     *
+     * Finally, it is possible to delegate to another object entirely using the <code>delegateTo
+     * </code> parameter. In this case the methods are nonstatic methods of the class delegated to,
+     * and the object whose property is being accessed is passed in as an extra argument:
+     *
      * <pre>
      * Object getFoo(Scriptable obj);
      * void setFoo(Scriptable obj, SomeType value);</pre>
      *
      * @param propertyName the name of the property to define.
-     * @param delegateTo an object to call the getter and setter methods on,
-     *                   or null, depending on the form used above.
+     * @param delegateTo an object to call the getter and setter methods on, or null, depending on
+     *     the form used above.
      * @param getter the method to invoke to get the value of the property
      * @param setter the method to invoke to set the value of the property
      * @param attributes the attributes of the JavaScript property
      */
-    public void defineProperty(String propertyName, Object delegateTo,
-                               Method getter, Method setter, int attributes)
-    {
+    public void defineProperty(
+            String propertyName, Object delegateTo, Method getter, Method setter, int attributes) {
         MemberBox getterBox = null;
         if (getter != null) {
             getterBox = new MemberBox(getter);
@@ -1801,9 +1613,8 @@ public abstract class ScriptableObject implements Scriptable,
             } else if (parmTypes.length == 1) {
                 Object argType = parmTypes[0];
                 // Allow ScriptableObject for compatibility
-                if (!(argType == ScriptRuntime.ScriptableClass ||
-                      argType == ScriptRuntime.ScriptableObjectClass))
-                {
+                if (!(argType == ScriptRuntime.ScriptableClass
+                        || argType == ScriptRuntime.ScriptableObjectClass)) {
                     errorId = "msg.bad.getter.parms";
                 } else if (!delegatedForm) {
                     errorId = "msg.bad.getter.parms";
@@ -1819,8 +1630,7 @@ public abstract class ScriptableObject implements Scriptable,
         MemberBox setterBox = null;
         if (setter != null) {
             if (setter.getReturnType() != Void.TYPE)
-                throw Context.reportRuntimeErrorById("msg.setter.return",
-                                                  setter.toString());
+                throw Context.reportRuntimeErrorById("msg.setter.return", setter.toString());
 
             setterBox = new MemberBox(setter);
 
@@ -1844,9 +1654,8 @@ public abstract class ScriptableObject implements Scriptable,
             } else if (parmTypes.length == 2) {
                 Object argType = parmTypes[0];
                 // Allow ScriptableObject for compatibility
-                if (!(argType == ScriptRuntime.ScriptableClass ||
-                      argType == ScriptRuntime.ScriptableObjectClass))
-                {
+                if (!(argType == ScriptRuntime.ScriptableClass
+                        || argType == ScriptRuntime.ScriptableObjectClass)) {
                     errorId = "msg.setter2.parms";
                 } else if (!delegatedForm) {
                     errorId = "msg.setter1.parms";
@@ -1859,8 +1668,8 @@ public abstract class ScriptableObject implements Scriptable,
             }
         }
 
-        GetterSlot gslot = (GetterSlot)slotMap.get(propertyName, 0,
-            SlotAccess.MODIFY_GETTER_SETTER);
+        GetterSlot gslot =
+                (GetterSlot) slotMap.get(propertyName, 0, SlotAccess.MODIFY_GETTER_SETTER);
         gslot.setAttributes(attributes);
         gslot.getter = getterBox;
         gslot.setter = setterBox;
@@ -1901,22 +1710,21 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Defines a property on an object.
      *
-     * Based on [[DefineOwnProperty]] from 8.12.10 of the spec.
+     * <p>Based on [[DefineOwnProperty]] from 8.12.10 of the spec.
      *
      * @param cx the current Context
      * @param id the name/index of the property
      * @param desc the new property descriptor, as described in 8.6.1
      * @param checkValid whether to perform validity checks
      */
-    protected void defineOwnProperty(Context cx, Object id, ScriptableObject desc,
-                                     boolean checkValid) {
+    protected void defineOwnProperty(
+            Context cx, Object id, ScriptableObject desc, boolean checkValid) {
 
         Slot slot = getSlot(cx, id, SlotAccess.QUERY);
         boolean isNew = slot == null;
 
         if (checkValid) {
-            ScriptableObject current = slot == null ?
-                    null : slot.getPropertyDescriptor(cx, this);
+            ScriptableObject current = slot == null ? null : slot.getPropertyDescriptor(cx, this);
             checkPropertyChange(id, current, desc);
         }
 
@@ -1924,14 +1732,18 @@ public abstract class ScriptableObject implements Scriptable,
         final int attributes;
 
         if (slot == null) { // new slot
-            slot = getSlot(cx, id, isAccessor ? SlotAccess.MODIFY_GETTER_SETTER : SlotAccess.MODIFY);
-            attributes = applyDescriptorToAttributeBitset(DONTENUM|READONLY|PERMANENT, desc);
+            slot =
+                    getSlot(
+                            cx,
+                            id,
+                            isAccessor ? SlotAccess.MODIFY_GETTER_SETTER : SlotAccess.MODIFY);
+            attributes = applyDescriptorToAttributeBitset(DONTENUM | READONLY | PERMANENT, desc);
         } else {
             attributes = applyDescriptorToAttributeBitset(slot.getAttributes(), desc);
         }
 
         if (isAccessor) {
-            if ( !(slot instanceof GetterSlot) ) {
+            if (!(slot instanceof GetterSlot)) {
                 slot = getSlot(cx, id, SlotAccess.MODIFY_GETTER_SETTER);
             }
 
@@ -1965,13 +1777,11 @@ public abstract class ScriptableObject implements Scriptable,
 
     protected void checkPropertyDefinition(ScriptableObject desc) {
         Object getter = getProperty(desc, "get");
-        if (getter != NOT_FOUND && getter != Undefined.instance
-                && !(getter instanceof Callable)) {
+        if (getter != NOT_FOUND && getter != Undefined.instance && !(getter instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(getter);
         }
         Object setter = getProperty(desc, "set");
-        if (setter != NOT_FOUND && setter != Undefined.instance
-                && !(setter instanceof Callable)) {
+        if (setter != NOT_FOUND && setter != Undefined.instance && !(setter instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(setter);
         }
         if (isDataDescriptor(desc) && isAccessorDescriptor(desc)) {
@@ -1979,18 +1789,17 @@ public abstract class ScriptableObject implements Scriptable,
         }
     }
 
-    protected void checkPropertyChange(Object id, ScriptableObject current,
-                                       ScriptableObject desc) {
+    protected void checkPropertyChange(Object id, ScriptableObject current, ScriptableObject desc) {
         if (current == null) { // new property
             if (!isExtensible()) throw ScriptRuntime.typeErrorById("msg.not.extensible");
         } else {
             if (isFalse(current.get("configurable", current))) {
                 if (isTrue(getProperty(desc, "configurable")))
+                    throw ScriptRuntime.typeErrorById("msg.change.configurable.false.to.true", id);
+                if (isTrue(current.get("enumerable", current))
+                        != isTrue(getProperty(desc, "enumerable")))
                     throw ScriptRuntime.typeErrorById(
-                        "msg.change.configurable.false.to.true", id);
-                if (isTrue(current.get("enumerable", current)) != isTrue(getProperty(desc, "enumerable")))
-                    throw ScriptRuntime.typeErrorById(
-                        "msg.change.enumerable.with.configurable.false", id);
+                            "msg.change.enumerable.with.configurable.false", id);
                 boolean isData = isDataDescriptor(desc);
                 boolean isAccessor = isAccessorDescriptor(desc);
                 if (!isData && !isAccessor) {
@@ -1999,26 +1808,27 @@ public abstract class ScriptableObject implements Scriptable,
                     if (isFalse(current.get("writable", current))) {
                         if (isTrue(getProperty(desc, "writable")))
                             throw ScriptRuntime.typeErrorById(
-                                "msg.change.writable.false.to.true.with.configurable.false", id);
+                                    "msg.change.writable.false.to.true.with.configurable.false",
+                                    id);
 
                         if (!sameValue(getProperty(desc, "value"), current.get("value", current)))
                             throw ScriptRuntime.typeErrorById(
-                                "msg.change.value.with.writable.false", id);
+                                    "msg.change.value.with.writable.false", id);
                     }
                 } else if (isAccessor && isAccessorDescriptor(current)) {
                     if (!sameValue(getProperty(desc, "set"), current.get("set", current)))
                         throw ScriptRuntime.typeErrorById(
-                            "msg.change.setter.with.configurable.false", id);
+                                "msg.change.setter.with.configurable.false", id);
 
                     if (!sameValue(getProperty(desc, "get"), current.get("get", current)))
                         throw ScriptRuntime.typeErrorById(
-                            "msg.change.getter.with.configurable.false", id);
+                                "msg.change.getter.with.configurable.false", id);
                 } else {
                     if (isDataDescriptor(current))
                         throw ScriptRuntime.typeErrorById(
-                            "msg.change.property.data.to.accessor.with.configurable.false", id);
+                                "msg.change.property.data.to.accessor.with.configurable.false", id);
                     throw ScriptRuntime.typeErrorById(
-                        "msg.change.property.accessor.to.data.with.configurable.false", id);
+                            "msg.change.property.accessor.to.data.with.configurable.false", id);
                 }
             }
         }
@@ -2033,8 +1843,8 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Implements SameValue as described in ES5 9.12, additionally checking
-     * if new value is defined.
+     * Implements SameValue as described in ES5 9.12, additionally checking if new value is defined.
+     *
      * @param newValue the new value
      * @param currentValue the current value
      * @return true if values are the same as defined by ES5 9.12
@@ -2049,8 +1859,8 @@ public abstract class ScriptableObject implements Scriptable,
         // Special rules for numbers: NaN is considered the same value,
         // while zeroes with different signs are considered different.
         if (currentValue instanceof Number && newValue instanceof Number) {
-            double d1 = ((Number)currentValue).doubleValue();
-            double d2 = ((Number)newValue).doubleValue();
+            double d1 = ((Number) currentValue).doubleValue();
+            double d2 = ((Number) newValue).doubleValue();
             if (Double.isNaN(d1) && Double.isNaN(d2)) {
                 return true;
             }
@@ -2061,25 +1871,29 @@ public abstract class ScriptableObject implements Scriptable,
         return ScriptRuntime.shallowEq(currentValue, newValue);
     }
 
-    protected int applyDescriptorToAttributeBitset(int attributes,
-                                                   ScriptableObject desc)
-    {
+    protected int applyDescriptorToAttributeBitset(int attributes, ScriptableObject desc) {
         Object enumerable = getProperty(desc, "enumerable");
         if (enumerable != NOT_FOUND) {
-            attributes = ScriptRuntime.toBoolean(enumerable)
-                    ? attributes & ~DONTENUM : attributes | DONTENUM;
+            attributes =
+                    ScriptRuntime.toBoolean(enumerable)
+                            ? attributes & ~DONTENUM
+                            : attributes | DONTENUM;
         }
 
         Object writable = getProperty(desc, "writable");
         if (writable != NOT_FOUND) {
-            attributes = ScriptRuntime.toBoolean(writable)
-                    ? attributes & ~READONLY : attributes | READONLY;
+            attributes =
+                    ScriptRuntime.toBoolean(writable)
+                            ? attributes & ~READONLY
+                            : attributes | READONLY;
         }
 
         Object configurable = getProperty(desc, "configurable");
         if (configurable != NOT_FOUND) {
-            attributes = ScriptRuntime.toBoolean(configurable)
-                    ? attributes & ~PERMANENT : attributes | PERMANENT;
+            attributes =
+                    ScriptRuntime.toBoolean(configurable)
+                            ? attributes & ~PERMANENT
+                            : attributes | PERMANENT;
         }
 
         return attributes;
@@ -2087,6 +1901,7 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Implements IsDataDescriptor as described in ES5 8.10.2
+     *
      * @param desc a property descriptor
      * @return true if this is a data descriptor.
      */
@@ -2096,6 +1911,7 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Implements IsAccessorDescriptor as described in ES5 8.10.1
+     *
      * @param desc a property descriptor
      * @return true if this is an accessor descriptor.
      */
@@ -2105,6 +1921,7 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Implements IsGenericDescriptor as described in ES5 8.10.3
+     *
      * @param desc a property descriptor
      * @return true if this is a generic descriptor.
      */
@@ -2113,46 +1930,43 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     protected static Scriptable ensureScriptable(Object arg) {
-        if ( !(arg instanceof Scriptable) )
+        if (!(arg instanceof Scriptable))
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(arg));
         return (Scriptable) arg;
     }
 
     protected static SymbolScriptable ensureSymbolScriptable(Object arg) {
-        if ( !(arg instanceof SymbolScriptable) )
-            throw ScriptRuntime.typeErrorById("msg.object.not.symbolscriptable", ScriptRuntime.typeof(arg));
+        if (!(arg instanceof SymbolScriptable))
+            throw ScriptRuntime.typeErrorById(
+                    "msg.object.not.symbolscriptable", ScriptRuntime.typeof(arg));
         return (SymbolScriptable) arg;
     }
 
     protected static ScriptableObject ensureScriptableObject(Object arg) {
-        if ( !(arg instanceof ScriptableObject) )
+        if (!(arg instanceof ScriptableObject))
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(arg));
         return (ScriptableObject) arg;
     }
 
     /**
-     * Search for names in a class, adding the resulting methods
-     * as properties.
+     * Search for names in a class, adding the resulting methods as properties.
      *
-     * <p> Uses reflection to find the methods of the given names. Then
-     * FunctionObjects are constructed from the methods found, and
-     * are added to this object as properties with the given names.
+     * <p>Uses reflection to find the methods of the given names. Then FunctionObjects are
+     * constructed from the methods found, and are added to this object as properties with the given
+     * names.
      *
      * @param names the names of the Methods to add as function properties
      * @param clazz the class to search for the Methods
      * @param attributes the attributes of the new properties
      * @see org.mozilla.javascript.FunctionObject
      */
-    public void defineFunctionProperties(String[] names, Class<?> clazz,
-                                         int attributes)
-    {
+    public void defineFunctionProperties(String[] names, Class<?> clazz, int attributes) {
         Method[] methods = FunctionObject.getMethodList(clazz);
-        for (int i=0; i < names.length; i++) {
+        for (int i = 0; i < names.length; i++) {
             String name = names[i];
             Method m = FunctionObject.findSingleMethod(methods, name);
             if (m == null) {
-                throw Context.reportRuntimeErrorById(
-                    "msg.method.not.found", name, clazz.getName());
+                throw Context.reportRuntimeErrorById("msg.method.not.found", name, clazz.getName());
             }
             FunctionObject f = new FunctionObject(name, m, this);
             defineProperty(name, f, attributes);
@@ -2160,66 +1974,58 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Get the Object.prototype property.
-     * See ECMA 15.2.4.
+     * Get the Object.prototype property. See ECMA 15.2.4.
+     *
      * @param scope an object in the scope chain
      */
     public static Scriptable getObjectPrototype(Scriptable scope) {
-        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope),
-                TopLevel.Builtins.Object);
+        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope), TopLevel.Builtins.Object);
     }
 
     /**
-     * Get the Function.prototype property.
-     * See ECMA 15.3.4.
+     * Get the Function.prototype property. See ECMA 15.3.4.
+     *
      * @param scope an object in the scope chain
      */
     public static Scriptable getFunctionPrototype(Scriptable scope) {
-        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope),
-                TopLevel.Builtins.Function);
+        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope), TopLevel.Builtins.Function);
     }
 
     public static Scriptable getGeneratorFunctionPrototype(Scriptable scope) {
-        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope),
-                TopLevel.Builtins.GeneratorFunction);
+        return TopLevel.getBuiltinPrototype(
+                getTopLevelScope(scope), TopLevel.Builtins.GeneratorFunction);
     }
 
     public static Scriptable getArrayPrototype(Scriptable scope) {
-        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope),
-                TopLevel.Builtins.Array);
+        return TopLevel.getBuiltinPrototype(getTopLevelScope(scope), TopLevel.Builtins.Array);
     }
 
     /**
      * Get the prototype for the named class.
      *
-     * For example, <code>getClassPrototype(s, "Date")</code> will first
-     * walk up the parent chain to find the outermost scope, then will
-     * search that scope for the Date constructor, and then will
-     * return Date.prototype. If any of the lookups fail, or
-     * the prototype is not a JavaScript object, then null will
-     * be returned.
+     * <p>For example, <code>getClassPrototype(s, "Date")</code> will first walk up the parent chain
+     * to find the outermost scope, then will search that scope for the Date constructor, and then
+     * will return Date.prototype. If any of the lookups fail, or the prototype is not a JavaScript
+     * object, then null will be returned.
      *
      * @param scope an object in the scope chain
      * @param className the name of the constructor
-     * @return the prototype for the named class, or null if it
-     *         cannot be found.
+     * @return the prototype for the named class, or null if it cannot be found.
      */
-    public static Scriptable getClassPrototype(Scriptable scope,
-                                               String className)
-    {
+    public static Scriptable getClassPrototype(Scriptable scope, String className) {
         scope = getTopLevelScope(scope);
         Object ctor = getProperty(scope, className);
         Object proto;
         if (ctor instanceof BaseFunction) {
-            proto = ((BaseFunction)ctor).getPrototypeProperty();
+            proto = ((BaseFunction) ctor).getPrototypeProperty();
         } else if (ctor instanceof Scriptable) {
-            Scriptable ctorObj = (Scriptable)ctor;
+            Scriptable ctorObj = (Scriptable) ctor;
             proto = ctorObj.get("prototype", ctorObj);
         } else {
             return null;
         }
         if (proto instanceof Scriptable) {
-            return (Scriptable)proto;
+            return (Scriptable) proto;
         }
         return null;
     }
@@ -2227,15 +2033,14 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * Get the global scope.
      *
-     * <p>Walks the parent scope chain to find an object with a null
-     * parent scope (the global object).
+     * <p>Walks the parent scope chain to find an object with a null parent scope (the global
+     * object).
      *
      * @param obj a JavaScript object
      * @return the corresponding global scope
      */
-    public static Scriptable getTopLevelScope(Scriptable obj)
-    {
-        for (;;) {
+    public static Scriptable getTopLevelScope(Scriptable obj) {
+        for (; ; ) {
             Scriptable parent = obj.getParentScope();
             if (parent == null) {
                 return obj;
@@ -2245,19 +2050,19 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     public boolean isExtensible() {
-      return isExtensible;
+        return isExtensible;
     }
 
     public void preventExtensions() {
-      isExtensible = false;
+        isExtensible = false;
     }
 
     /**
      * Seal this object.
      *
-     * It is an error to add properties to or delete properties from
-     * a sealed object. It is possible to change the value of an
-     * existing property. Once an object is sealed it may not be unsealed.
+     * <p>It is an error to add properties to or delete properties from a sealed object. It is
+     * possible to change the value of an existing property. Once an object is sealed it may not be
+     * unsealed.
      *
      * @since 1.4R3
      */
@@ -2294,10 +2099,8 @@ public abstract class ScriptableObject implements Scriptable,
         return isSealed;
     }
 
-    private void checkNotSealed(Object key, int index)
-    {
-        if (!isSealed())
-            return;
+    private void checkNotSealed(Object key, int index) {
+        if (!isSealed()) return;
 
         String str = (key != null) ? key.toString() : Integer.toString(index);
         throw Context.reportRuntimeErrorById("msg.modify.sealed", str);
@@ -2305,67 +2108,61 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Gets a named property from an object or any object in its prototype chain.
+     *
+     * <p>Searches the prototype chain for a property named <code>name</code>.
+     *
      * <p>
-     * Searches the prototype chain for a property named <code>name</code>.
-     * <p>
+     *
      * @param obj a JavaScript object
      * @param name a property name
-     * @return the value of a property with name <code>name</code> found in
-     *         <code>obj</code> or any object in its prototype chain, or
-     *         <code>Scriptable.NOT_FOUND</code> if not found
+     * @return the value of a property with name <code>name</code> found in <code>obj</code> or any
+     *     object in its prototype chain, or <code>Scriptable.NOT_FOUND</code> if not found
      * @since 1.5R2
      */
-    public static Object getProperty(Scriptable obj, String name)
-    {
+    public static Object getProperty(Scriptable obj, String name) {
         Scriptable start = obj;
         Object result;
         do {
             result = obj.get(name, start);
-            if (result != Scriptable.NOT_FOUND)
-                break;
+            if (result != Scriptable.NOT_FOUND) break;
             obj = obj.getPrototype();
         } while (obj != null);
         return result;
     }
 
-    /**
-     * This is a version of getProperty that works with Symbols.
-     */
-    public static Object getProperty(Scriptable obj, Symbol key)
-    {
+    /** This is a version of getProperty that works with Symbols. */
+    public static Object getProperty(Scriptable obj, Symbol key) {
         Scriptable start = obj;
         Object result;
         do {
             result = ensureSymbolScriptable(obj).get(key, start);
-            if (result != Scriptable.NOT_FOUND)
-                break;
+            if (result != Scriptable.NOT_FOUND) break;
             obj = obj.getPrototype();
         } while (obj != null);
         return result;
     }
 
     /**
-     * Gets an indexed property from an object or any object in its prototype
-     * chain and coerces it to the requested Java type.
+     * Gets an indexed property from an object or any object in its prototype chain and coerces it
+     * to the requested Java type.
+     *
+     * <p>Searches the prototype chain for a property with integral index <code>index</code>. Note
+     * that if you wish to look for properties with numerical but non-integral indicies, you should
+     * use getProperty(Scriptable,String) with the string value of the index.
+     *
      * <p>
-     * Searches the prototype chain for a property with integral index
-     * <code>index</code>. Note that if you wish to look for properties with numerical
-     * but non-integral indicies, you should use getProperty(Scriptable,String) with
-     * the string value of the index.
-     * <p>
+     *
      * @param s a JavaScript object
      * @param index an integral index
      * @param type the required Java type of the result
-     * @return the value of a property with name <code>name</code> found in
-     *         <code>obj</code> or any object in its prototype chain, or
-     *         null if not found. Note that it does not return
-     *         {@link Scriptable#NOT_FOUND} as it can ordinarily not be
-     *         converted to most of the types.
+     * @return the value of a property with name <code>name</code> found in <code>obj</code> or any
+     *     object in its prototype chain, or null if not found. Note that it does not return {@link
+     *     Scriptable#NOT_FOUND} as it can ordinarily not be converted to most of the types.
      * @since 1.7R3
      */
     public static <T> T getTypedProperty(Scriptable s, int index, Class<T> type) {
         Object val = getProperty(s, index);
-        if(val == Scriptable.NOT_FOUND) {
+        if (val == Scriptable.NOT_FOUND) {
             val = null;
         }
         return type.cast(Context.jsToJava(val, type));
@@ -2373,258 +2170,234 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Gets an indexed property from an object or any object in its prototype chain.
+     *
+     * <p>Searches the prototype chain for a property with integral index <code>index</code>. Note
+     * that if you wish to look for properties with numerical but non-integral indicies, you should
+     * use getProperty(Scriptable,String) with the string value of the index.
+     *
      * <p>
-     * Searches the prototype chain for a property with integral index
-     * <code>index</code>. Note that if you wish to look for properties with numerical
-     * but non-integral indicies, you should use getProperty(Scriptable,String) with
-     * the string value of the index.
-     * <p>
+     *
      * @param obj a JavaScript object
      * @param index an integral index
-     * @return the value of a property with index <code>index</code> found in
-     *         <code>obj</code> or any object in its prototype chain, or
-     *         <code>Scriptable.NOT_FOUND</code> if not found
+     * @return the value of a property with index <code>index</code> found in <code>obj</code> or
+     *     any object in its prototype chain, or <code>Scriptable.NOT_FOUND</code> if not found
      * @since 1.5R2
      */
-    public static Object getProperty(Scriptable obj, int index)
-    {
+    public static Object getProperty(Scriptable obj, int index) {
         Scriptable start = obj;
         Object result;
         do {
             result = obj.get(index, start);
-            if (result != Scriptable.NOT_FOUND)
-                break;
+            if (result != Scriptable.NOT_FOUND) break;
             obj = obj.getPrototype();
         } while (obj != null);
         return result;
     }
 
     /**
-     * Gets a named property from an object or any object in its prototype chain
-     * and coerces it to the requested Java type.
+     * Gets a named property from an object or any object in its prototype chain and coerces it to
+     * the requested Java type.
+     *
+     * <p>Searches the prototype chain for a property named <code>name</code>.
+     *
      * <p>
-     * Searches the prototype chain for a property named <code>name</code>.
-     * <p>
+     *
      * @param s a JavaScript object
      * @param name a property name
      * @param type the required Java type of the result
-     * @return the value of a property with name <code>name</code> found in
-     *         <code>obj</code> or any object in its prototype chain, or
-     *         null if not found. Note that it does not return
-     *         {@link Scriptable#NOT_FOUND} as it can ordinarily not be
-     *         converted to most of the types.
+     * @return the value of a property with name <code>name</code> found in <code>obj</code> or any
+     *     object in its prototype chain, or null if not found. Note that it does not return {@link
+     *     Scriptable#NOT_FOUND} as it can ordinarily not be converted to most of the types.
      * @since 1.7R3
      */
     public static <T> T getTypedProperty(Scriptable s, String name, Class<T> type) {
         Object val = getProperty(s, name);
-        if(val == Scriptable.NOT_FOUND) {
+        if (val == Scriptable.NOT_FOUND) {
             val = null;
         }
         return type.cast(Context.jsToJava(val, type));
     }
 
     /**
-     * Returns whether a named property is defined in an object or any object
-     * in its prototype chain.
+     * Returns whether a named property is defined in an object or any object in its prototype
+     * chain.
+     *
+     * <p>Searches the prototype chain for a property named <code>name</code>.
+     *
      * <p>
-     * Searches the prototype chain for a property named <code>name</code>.
-     * <p>
+     *
      * @param obj a JavaScript object
      * @param name a property name
      * @return the true if property was found
      * @since 1.5R2
      */
-    public static boolean hasProperty(Scriptable obj, String name)
-    {
+    public static boolean hasProperty(Scriptable obj, String name) {
         return null != getBase(obj, name);
     }
 
     /**
-     * If hasProperty(obj, name) would return true, then if the property that
-     * was found is compatible with the new property, this method just returns.
-     * If the property is not compatible, then an exception is thrown.
+     * If hasProperty(obj, name) would return true, then if the property that was found is
+     * compatible with the new property, this method just returns. If the property is not
+     * compatible, then an exception is thrown.
      *
-     * A property redefinition is incompatible if the first definition was a
-     * const declaration or if this one is.  They are compatible only if neither
-     * was const.
+     * <p>A property redefinition is incompatible if the first definition was a const declaration or
+     * if this one is. They are compatible only if neither was const.
      */
-    public static void redefineProperty(Scriptable obj, String name,
-                                        boolean isConst)
-    {
+    public static void redefineProperty(Scriptable obj, String name, boolean isConst) {
         Scriptable base = getBase(obj, name);
-        if (base == null)
-            return;
+        if (base == null) return;
         if (base instanceof ConstProperties) {
-            ConstProperties cp = (ConstProperties)base;
+            ConstProperties cp = (ConstProperties) base;
 
-            if (cp.isConst(name))
-                throw ScriptRuntime.typeErrorById("msg.const.redecl", name);
+            if (cp.isConst(name)) throw ScriptRuntime.typeErrorById("msg.const.redecl", name);
         }
-        if (isConst)
-            throw ScriptRuntime.typeErrorById("msg.var.redecl", name);
+        if (isConst) throw ScriptRuntime.typeErrorById("msg.var.redecl", name);
     }
     /**
-     * Returns whether an indexed property is defined in an object or any object
-     * in its prototype chain.
+     * Returns whether an indexed property is defined in an object or any object in its prototype
+     * chain.
+     *
+     * <p>Searches the prototype chain for a property with index <code>index</code>.
+     *
      * <p>
-     * Searches the prototype chain for a property with index <code>index</code>.
-     * <p>
+     *
      * @param obj a JavaScript object
      * @param index a property index
      * @return the true if property was found
      * @since 1.5R2
      */
-    public static boolean hasProperty(Scriptable obj, int index)
-    {
+    public static boolean hasProperty(Scriptable obj, int index) {
         return null != getBase(obj, index);
     }
 
-    /**
-     * A version of hasProperty for properties with Symbol keys.
-     */
-    public static boolean hasProperty(Scriptable obj, Symbol key)
-    {
+    /** A version of hasProperty for properties with Symbol keys. */
+    public static boolean hasProperty(Scriptable obj, Symbol key) {
         return null != getBase(obj, key);
     }
 
     /**
      * Puts a named property in an object or in an object in its prototype chain.
-     * <p>
-     * Searches for the named property in the prototype chain. If it is found,
-     * the value of the property in <code>obj</code> is changed through a call
-     * to {@link Scriptable#put(String, Scriptable, Object)} on the
-     * prototype passing <code>obj</code> as the <code>start</code> argument.
-     * This allows the prototype to veto the property setting in case the
-     * prototype defines the property with [[ReadOnly]] attribute. If the
-     * property is not found, it is added in <code>obj</code>.
+     *
+     * <p>Searches for the named property in the prototype chain. If it is found, the value of the
+     * property in <code>obj</code> is changed through a call to {@link Scriptable#put(String,
+     * Scriptable, Object)} on the prototype passing <code>obj</code> as the <code>start</code>
+     * argument. This allows the prototype to veto the property setting in case the prototype
+     * defines the property with [[ReadOnly]] attribute. If the property is not found, it is added
+     * in <code>obj</code>.
+     *
      * @param obj a JavaScript object
      * @param name a property name
      * @param value any JavaScript value accepted by Scriptable.put
      * @since 1.5R2
      */
-    public static void putProperty(Scriptable obj, String name, Object value)
-    {
+    public static void putProperty(Scriptable obj, String name, Object value) {
         Scriptable base = getBase(obj, name);
-        if (base == null)
-            base = obj;
+        if (base == null) base = obj;
         base.put(name, obj, value);
     }
 
-    /**
-     * This is a version of putProperty for Symbol keys.
-     */
-    public static void putProperty(Scriptable obj, Symbol key, Object value)
-    {
+    /** This is a version of putProperty for Symbol keys. */
+    public static void putProperty(Scriptable obj, Symbol key, Object value) {
         Scriptable base = getBase(obj, key);
-        if (base == null)
-            base = obj;
+        if (base == null) base = obj;
         ensureSymbolScriptable(base).put(key, obj, value);
     }
 
     /**
      * Puts a named property in an object or in an object in its prototype chain.
-     * <p>
-     * Searches for the named property in the prototype chain. If it is found,
-     * the value of the property in <code>obj</code> is changed through a call
-     * to {@link Scriptable#put(String, Scriptable, Object)} on the
-     * prototype passing <code>obj</code> as the <code>start</code> argument.
-     * This allows the prototype to veto the property setting in case the
-     * prototype defines the property with [[ReadOnly]] attribute. If the
-     * property is not found, it is added in <code>obj</code>.
+     *
+     * <p>Searches for the named property in the prototype chain. If it is found, the value of the
+     * property in <code>obj</code> is changed through a call to {@link Scriptable#put(String,
+     * Scriptable, Object)} on the prototype passing <code>obj</code> as the <code>start</code>
+     * argument. This allows the prototype to veto the property setting in case the prototype
+     * defines the property with [[ReadOnly]] attribute. If the property is not found, it is added
+     * in <code>obj</code>.
+     *
      * @param obj a JavaScript object
      * @param name a property name
      * @param value any JavaScript value accepted by Scriptable.put
      * @since 1.5R2
      */
-    public static void putConstProperty(Scriptable obj, String name, Object value)
-    {
+    public static void putConstProperty(Scriptable obj, String name, Object value) {
         Scriptable base = getBase(obj, name);
-        if (base == null)
-            base = obj;
-        if (base instanceof ConstProperties)
-            ((ConstProperties)base).putConst(name, obj, value);
+        if (base == null) base = obj;
+        if (base instanceof ConstProperties) ((ConstProperties) base).putConst(name, obj, value);
     }
 
     /**
      * Puts an indexed property in an object or in an object in its prototype chain.
-     * <p>
-     * Searches for the indexed property in the prototype chain. If it is found,
-     * the value of the property in <code>obj</code> is changed through a call
-     * to {@link Scriptable#put(int, Scriptable, Object)} on the prototype
-     * passing <code>obj</code> as the <code>start</code> argument. This allows
-     * the prototype to veto the property setting in case the prototype defines
-     * the property with [[ReadOnly]] attribute. If the property is not found,
-     * it is added in <code>obj</code>.
+     *
+     * <p>Searches for the indexed property in the prototype chain. If it is found, the value of the
+     * property in <code>obj</code> is changed through a call to {@link Scriptable#put(int,
+     * Scriptable, Object)} on the prototype passing <code>obj</code> as the <code>start</code>
+     * argument. This allows the prototype to veto the property setting in case the prototype
+     * defines the property with [[ReadOnly]] attribute. If the property is not found, it is added
+     * in <code>obj</code>.
+     *
      * @param obj a JavaScript object
      * @param index a property index
      * @param value any JavaScript value accepted by Scriptable.put
      * @since 1.5R2
      */
-    public static void putProperty(Scriptable obj, int index, Object value)
-    {
+    public static void putProperty(Scriptable obj, int index, Object value) {
         Scriptable base = getBase(obj, index);
-        if (base == null)
-            base = obj;
+        if (base == null) base = obj;
         base.put(index, obj, value);
     }
 
     /**
      * Removes the property from an object or its prototype chain.
-     * <p>
-     * Searches for a property with <code>name</code> in obj or
-     * its prototype chain. If it is found, the object's delete
-     * method is called.
+     *
+     * <p>Searches for a property with <code>name</code> in obj or its prototype chain. If it is
+     * found, the object's delete method is called.
+     *
      * @param obj a JavaScript object
      * @param name a property name
      * @return true if the property doesn't exist or was successfully removed
      * @since 1.5R2
      */
-    public static boolean deleteProperty(Scriptable obj, String name)
-    {
+    public static boolean deleteProperty(Scriptable obj, String name) {
         Scriptable base = getBase(obj, name);
-        if (base == null)
-            return true;
+        if (base == null) return true;
         base.delete(name);
         return !base.has(name, obj);
     }
 
     /**
      * Removes the property from an object or its prototype chain.
-     * <p>
-     * Searches for a property with <code>index</code> in obj or
-     * its prototype chain. If it is found, the object's delete
-     * method is called.
+     *
+     * <p>Searches for a property with <code>index</code> in obj or its prototype chain. If it is
+     * found, the object's delete method is called.
+     *
      * @param obj a JavaScript object
      * @param index a property index
      * @return true if the property doesn't exist or was successfully removed
      * @since 1.5R2
      */
-    public static boolean deleteProperty(Scriptable obj, int index)
-    {
+    public static boolean deleteProperty(Scriptable obj, int index) {
         Scriptable base = getBase(obj, index);
-        if (base == null)
-            return true;
+        if (base == null) return true;
         base.delete(index);
         return !base.has(index, obj);
     }
 
     /**
      * Returns an array of all ids from an object and its prototypes.
+     *
      * <p>
+     *
      * @param obj a JavaScript object
-     * @return an array of all ids from all object in the prototype chain.
-     *         If a given id occurs multiple times in the prototype chain,
-     *         it will occur only once in this list.
+     * @return an array of all ids from all object in the prototype chain. If a given id occurs
+     *     multiple times in the prototype chain, it will occur only once in this list.
      * @since 1.5R2
      */
-    public static Object[] getPropertyIds(Scriptable obj)
-    {
+    public static Object[] getPropertyIds(Scriptable obj) {
         if (obj == null) {
             return ScriptRuntime.emptyArgs;
         }
         Object[] result = obj.getIds();
         ObjToIntMap map = null;
-        for (;;) {
+        for (; ; ) {
             obj = obj.getPrototype();
             if (obj == null) {
                 break;
@@ -2656,34 +2429,30 @@ public abstract class ScriptableObject implements Scriptable,
 
     /**
      * Call a method of an object.
+     *
      * @param obj the JavaScript object
      * @param methodName the name of the function property
      * @param args the arguments for the call
-     *
      * @see Context#getCurrentContext()
      */
-    public static Object callMethod(Scriptable obj, String methodName,
-                                    Object[] args)
-    {
+    public static Object callMethod(Scriptable obj, String methodName, Object[] args) {
         return callMethod(null, obj, methodName, args);
     }
 
     /**
      * Call a method of an object.
+     *
      * @param cx the Context object associated with the current thread.
      * @param obj the JavaScript object
      * @param methodName the name of the function property
      * @param args the arguments for the call
      */
-    public static Object callMethod(Context cx, Scriptable obj,
-                                    String methodName,
-                                    Object[] args)
-    {
+    public static Object callMethod(Context cx, Scriptable obj, String methodName, Object[] args) {
         Object funObj = getProperty(obj, methodName);
         if (!(funObj instanceof Function)) {
             throw ScriptRuntime.notFunctionError(obj, methodName);
         }
-        Function fun = (Function)funObj;
+        Function fun = (Function) funObj;
         // XXX: What should be the scope when calling funObj?
         // The following favor scope stored in the object on the assumption
         // that is more useful especially under dynamic scope setup.
@@ -2698,66 +2467,57 @@ public abstract class ScriptableObject implements Scriptable,
         return Context.call(null, fun, scope, obj, args);
     }
 
-    private static Scriptable getBase(Scriptable obj, String name)
-    {
+    private static Scriptable getBase(Scriptable obj, String name) {
         do {
-            if (obj.has(name, obj))
-                break;
+            if (obj.has(name, obj)) break;
             obj = obj.getPrototype();
-        } while(obj != null);
+        } while (obj != null);
         return obj;
     }
 
-    private static Scriptable getBase(Scriptable obj, int index)
-    {
+    private static Scriptable getBase(Scriptable obj, int index) {
         do {
-            if (obj.has(index, obj))
-                break;
+            if (obj.has(index, obj)) break;
             obj = obj.getPrototype();
-        } while(obj != null);
+        } while (obj != null);
         return obj;
     }
 
-    private static Scriptable getBase(Scriptable obj, Symbol key)
-    {
+    private static Scriptable getBase(Scriptable obj, Symbol key) {
         do {
-            if (ensureSymbolScriptable(obj).has(key, obj))
-                break;
+            if (ensureSymbolScriptable(obj).has(key, obj)) break;
             obj = obj.getPrototype();
-        } while(obj != null);
+        } while (obj != null);
         return obj;
     }
 
     /**
      * Get arbitrary application-specific value associated with this object.
+     *
      * @param key key object to select particular value.
      * @see #associateValue(Object key, Object value)
      */
-    public final Object getAssociatedValue(Object key)
-    {
-        Map<Object,Object> h = associatedValues;
-        if (h == null)
-            return null;
+    public final Object getAssociatedValue(Object key) {
+        Map<Object, Object> h = associatedValues;
+        if (h == null) return null;
         return h.get(key);
     }
 
     /**
-     * Get arbitrary application-specific value associated with the top scope
-     * of the given scope.
-     * The method first calls {@link #getTopLevelScope(Scriptable scope)}
-     * and then searches the prototype chain of the top scope for the first
-     * object containing the associated value with the given key.
+     * Get arbitrary application-specific value associated with the top scope of the given scope.
+     * The method first calls {@link #getTopLevelScope(Scriptable scope)} and then searches the
+     * prototype chain of the top scope for the first object containing the associated value with
+     * the given key.
      *
      * @param scope the starting scope.
      * @param key key object to select particular value.
      * @see #getAssociatedValue(Object key)
      */
-    public static Object getTopScopeValue(Scriptable scope, Object key)
-    {
+    public static Object getTopScopeValue(Scriptable scope, Object key) {
         scope = ScriptableObject.getTopLevelScope(scope);
-        for (;;) {
+        for (; ; ) {
             if (scope instanceof ScriptableObject) {
-                ScriptableObject so = (ScriptableObject)scope;
+                ScriptableObject so = (ScriptableObject) scope;
                 Object value = so.getAssociatedValue(key);
                 if (value != null) {
                     return value;
@@ -2771,49 +2531,46 @@ public abstract class ScriptableObject implements Scriptable,
     }
 
     /**
-     * Associate arbitrary application-specific value with this object.
-     * Value can only be associated with the given object and key only once.
-     * The method ignores any subsequent attempts to change the already
-     * associated value.
-     * <p> The associated values are not serialized.
+     * Associate arbitrary application-specific value with this object. Value can only be associated
+     * with the given object and key only once. The method ignores any subsequent attempts to change
+     * the already associated value.
+     *
+     * <p>The associated values are not serialized.
+     *
      * @param key key object to select particular value.
      * @param value the value to associate
-     * @return the passed value if the method is called first time for the
-     * given key or old value for any subsequent calls.
+     * @return the passed value if the method is called first time for the given key or old value
+     *     for any subsequent calls.
      * @see #getAssociatedValue(Object key)
      */
-    public synchronized final Object associateValue(Object key, Object value)
-    {
+    public final synchronized Object associateValue(Object key, Object value) {
         if (value == null) throw new IllegalArgumentException();
-        Map<Object,Object> h = associatedValues;
+        Map<Object, Object> h = associatedValues;
         if (h == null) {
-            h = new HashMap<Object,Object>();
+            h = new HashMap<Object, Object>();
             associatedValues = h;
         }
         return Kit.initHash(h, key, value);
     }
 
     /**
-     *
      * @param key
      * @param index
      * @param start
      * @param value
-     * @return false if this != start and no slot was found.  true if this == start
-     * or this != start and a READONLY slot was found.
+     * @return false if this != start and no slot was found. true if this == start or this != start
+     *     and a READONLY slot was found.
      */
-    private boolean putImpl(Object key, int index, Scriptable start,
-                            Object value)
-    {
+    private boolean putImpl(Object key, int index, Scriptable start, Object value) {
         // This method is very hot (basically called on each assignment)
         // so we inline the extensible/sealed checks below.
         Slot slot;
         if (this != start) {
             slot = slotMap.query(key, index);
-            if(!isExtensible
+            if (!isExtensible
                     && (slot == null
-                        || (!(slot instanceof GetterSlot)
-                                && (slot.getAttributes() & READONLY) != 0))
+                            || (!(slot instanceof GetterSlot)
+                                    && (slot.getAttributes() & READONLY) != 0))
                     && Context.getContext().isStrictMode()) {
                 throw ScriptRuntime.typeErrorById("msg.not.extensible");
             }
@@ -2822,8 +2579,9 @@ public abstract class ScriptableObject implements Scriptable,
             }
         } else if (!isExtensible) {
             slot = slotMap.query(key, index);
-            if((slot == null
-                        || (!(slot instanceof GetterSlot) && (slot.getAttributes() & READONLY) != 0))
+            if ((slot == null
+                            || (!(slot instanceof GetterSlot)
+                                    && (slot.getAttributes() & READONLY) != 0))
                     && Context.getContext().isStrictMode()) {
                 throw ScriptRuntime.typeErrorById("msg.not.extensible");
             }
@@ -2839,21 +2597,18 @@ public abstract class ScriptableObject implements Scriptable,
         return slot.setValue(value, this, start);
     }
 
-
     /**
-     *
      * @param name
      * @param index
      * @param start
      * @param value
-     * @param constFlag EMPTY means normal put.  UNINITIALIZED_CONST means
-     * defineConstProperty.  READONLY means const initialization expression.
-     * @return false if this != start and no slot was found.  true if this == start
-     * or this != start and a READONLY slot was found.
+     * @param constFlag EMPTY means normal put. UNINITIALIZED_CONST means defineConstProperty.
+     *     READONLY means const initialization expression.
+     * @return false if this != start and no slot was found. true if this == start or this != start
+     *     and a READONLY slot was found.
      */
-    private boolean putConstImpl(String name, int index, Scriptable start,
-                                 Object value, int constFlag)
-    {
+    private boolean putConstImpl(
+            String name, int index, Scriptable start, Object value, int constFlag) {
         assert (constFlag != EMPTY);
         if (!isExtensible) {
             Context cx = Context.getContext();
@@ -2890,8 +2645,7 @@ public abstract class ScriptableObject implements Scriptable,
         return slot.setValue(value, this, start);
     }
 
-    private Slot findAttributeSlot(String name, int index, SlotAccess accessType)
-    {
+    private Slot findAttributeSlot(String name, int index, SlotAccess accessType) {
         Slot slot = slotMap.get(name, index, accessType);
         if (slot == null) {
             String str = (name != null ? name : Integer.toString(index));
@@ -2900,8 +2654,7 @@ public abstract class ScriptableObject implements Scriptable,
         return slot;
     }
 
-    private Slot findAttributeSlot(Symbol key, SlotAccess accessType)
-    {
+    private Slot findAttributeSlot(Symbol key, SlotAccess accessType) {
         Slot slot = slotMap.get(key, 0, accessType);
         if (slot == null) {
             throw Context.reportRuntimeErrorById("msg.prop.not.found", key);
@@ -2929,8 +2682,8 @@ public abstract class ScriptableObject implements Scriptable,
         final long stamp = slotMap.readLock();
         try {
             for (Slot slot : slotMap) {
-                if ((getNonEnumerable || (slot.getAttributes() & DONTENUM) == 0) &&
-                    (getSymbols || !(slot.name instanceof Symbol))) {
+                if ((getNonEnumerable || (slot.getAttributes() & DONTENUM) == 0)
+                        && (getSymbols || !(slot.name instanceof Symbol))) {
                     if (c == externalLen) {
                         // Special handling to combine external array with additional properties
                         Object[] oldA = a;
@@ -2939,9 +2692,7 @@ public abstract class ScriptableObject implements Scriptable,
                             System.arraycopy(oldA, 0, a, 0, externalLen);
                         }
                     }
-                    a[c++] = slot.name != null
-                        ? slot.name
-                        : Integer.valueOf(slot.indexOrHash);
+                    a[c++] = slot.name != null ? slot.name : Integer.valueOf(slot.indexOrHash);
                 }
             }
         } finally {
@@ -2965,9 +2716,7 @@ public abstract class ScriptableObject implements Scriptable,
         return result;
     }
 
-    private void writeObject(ObjectOutputStream out)
-        throws IOException
-    {
+    private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         final long stamp = slotMap.readLock();
         try {
@@ -2985,15 +2734,13 @@ public abstract class ScriptableObject implements Scriptable,
         }
     }
 
-    private void readObject(ObjectInputStream in)
-        throws IOException, ClassNotFoundException
-    {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
         int tableSize = in.readInt();
         slotMap = createSlotMap(tableSize);
         for (int i = 0; i < tableSize; i++) {
-            Slot slot = (Slot)in.readObject();
+            Slot slot = (Slot) in.readObject();
             slotMap.addSlot(slot);
         }
     }
@@ -3027,7 +2774,6 @@ public abstract class ScriptableObject implements Scriptable,
         return slotMap.isEmpty();
     }
 
-
     public Object get(Object key) {
         Object value = null;
         if (key instanceof String) {
@@ -3051,18 +2797,15 @@ public abstract class ScriptableObject implements Scriptable,
     /**
      * This comparator sorts property fields in spec-compliant order. Numeric ids first, in numeric
      * order, followed by string ids, in insertion order. Since this class already keeps string keys
-     * in insertion-time order, we treat all as equal. The "Arrays.sort" method will then not
-     * change their order, but simply move all the numeric properties to the front, since this
-     * method is defined to be stable.
+     * in insertion-time order, we treat all as equal. The "Arrays.sort" method will then not change
+     * their order, but simply move all the numeric properties to the front, since this method is
+     * defined to be stable.
      */
-    public static final class KeyComparator
-        implements Comparator<Object>, Serializable
-    {
+    public static final class KeyComparator implements Comparator<Object>, Serializable {
         private static final long serialVersionUID = 6411335891523988149L;
 
         @Override
-        public int compare(Object o1, Object o2)
-        {
+        public int compare(Object o1, Object o2) {
             if (o1 instanceof Integer) {
                 if (o2 instanceof Integer) {
                     int i1 = ((Integer) o1).intValue();

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -130,10 +130,16 @@ public abstract class ScriptableObject
         ScriptableObject desc = new NativeObject();
         ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
         desc.defineProperty("value", value, EMPTY);
-        desc.defineProperty("writable", (attributes & READONLY) == 0, EMPTY);
-        desc.defineProperty("enumerable", (attributes & DONTENUM) == 0, EMPTY);
-        desc.defineProperty("configurable", (attributes & PERMANENT) == 0, EMPTY);
+        desc.setCommonDescriptorProperties(attributes, true);
         return desc;
+    }
+
+    protected void setCommonDescriptorProperties(int attributes, boolean defineWritable) {
+        if (defineWritable) {
+            defineProperty("writable", (attributes & READONLY) == 0, EMPTY);
+        }
+        defineProperty("enumerable", (attributes & DONTENUM) == 0, EMPTY);
+        defineProperty("configurable", (attributes & PERMANENT) == 0, EMPTY);
     }
 
     static void checkValidAttributes(int attributes) {

--- a/src/org/mozilla/javascript/Slot.java
+++ b/src/org/mozilla/javascript/Slot.java
@@ -6,7 +6,9 @@ import java.io.Serializable;
 
 /**
  * A Slot is the base class for all properties stored in the ScriptableObject class. There are a
- * number of different types of slots. This base class represents an "ordinary" property such a s
+ * number of different types of slots. This base class represents an "ordinary" property such as a
+ * primitive type or another object. Separate classes are used to represent properties that have
+ * various types of getter and setter methods.
  */
 public class Slot implements Serializable {
     private static final long serialVersionUID = -6090581677123995491L;

--- a/src/org/mozilla/javascript/Slot.java
+++ b/src/org/mozilla/javascript/Slot.java
@@ -1,0 +1,117 @@
+package org.mozilla.javascript;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+/**
+ * A Slot is the base class for all properties stored in the ScriptableObject class. There are a
+ * number of different types of slots. This base class represents an "ordinary" property such a s
+ */
+public class Slot implements Serializable {
+    private static final long serialVersionUID = -6090581677123995491L;
+    Object name; // This can change due to caching
+    int indexOrHash;
+    private short attributes;
+    Object value;
+    transient Slot next; // next in hash table bucket
+    transient Slot orderedNext; // next in linked list
+
+    Slot(Object name, int indexOrHash, int attributes) {
+        this.name = name;
+        this.indexOrHash = indexOrHash;
+        this.attributes = (short) attributes;
+    }
+
+    /**
+     * Return true if this is a base-class "Slot". Sadly too much code breaks if we try to do this
+     * any other way.
+     */
+    boolean isValueSlot() {
+        return true;
+    }
+
+    /**
+     * Return true if this is a "setter slot" which, which we need to know for some legacy support.
+     */
+    boolean isSetterSlot() {
+        return false;
+    }
+
+    protected Slot(Slot oldSlot) {
+        name = oldSlot.name;
+        indexOrHash = oldSlot.indexOrHash;
+        attributes = oldSlot.attributes;
+        value = oldSlot.value;
+        next = oldSlot.next;
+        orderedNext = oldSlot.orderedNext;
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (name != null) {
+            indexOrHash = name.hashCode();
+        }
+    }
+
+    public boolean setValue(Object value, Scriptable owner, Scriptable start) {
+        if ((attributes & ScriptableObject.READONLY) != 0) {
+            if (Context.isCurrentContextStrict()) {
+                throw ScriptRuntime.typeErrorById("msg.modify.readonly", name);
+            }
+            return true;
+        }
+        if (owner == start) {
+            this.value = value;
+            return true;
+        }
+        return false;
+    }
+
+    public Object getValue(Scriptable start) {
+        return value;
+    }
+
+    int getAttributes() {
+        return attributes;
+    }
+
+    synchronized void setAttributes(int value) {
+        ScriptableObject.checkValidAttributes(value);
+        attributes = (short) value;
+    }
+
+    ScriptableObject getPropertyDescriptor(Context cx, Scriptable scope) {
+        return ScriptableObject.buildDataDescriptor(scope, value, attributes);
+    }
+
+    protected void throwNoSetterException(Scriptable start, Object newValue) {
+        Context cx = Context.getContext();
+        if (cx.isStrictMode()
+                ||
+                // Based on TC39 ES3.1 Draft of 9-Feb-2009, 8.12.4, step 2,
+                // we should throw a TypeError in this case.
+                cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
+
+            String prop = "";
+            if (name != null) {
+                prop = "[" + start.getClassName() + "]." + name;
+            }
+            throw ScriptRuntime.typeErrorById(
+                    "msg.set.prop.no.setter", prop, Context.toString(newValue));
+        }
+    }
+
+    /**
+     * Return a JavaScript function that represents the "setter". This is used by some legacy
+     * functionality. Return null if there is no setter.
+     */
+    Function getSetterFunction(String name, Scriptable scope) {
+        return null;
+    }
+
+    /** Same for the "getter." */
+    Function getGetterFunction(String name, Scriptable scope) {
+        return null;
+    }
+}

--- a/src/org/mozilla/javascript/SlotMap.java
+++ b/src/org/mozilla/javascript/SlotMap.java
@@ -7,51 +7,40 @@
 package org.mozilla.javascript;
 
 /**
- * A SlotMap is an interface to the main data structure that contains all the "Slots"
- * that back a ScriptableObject. It is the primary property map in Rhino. It is
- * Iterable but does not implement java.util.Map because that comes with a bunch
- * of overhead that we do not need.
+ * A SlotMap is an interface to the main data structure that contains all the "Slots" that back a
+ * ScriptableObject. It is the primary property map in Rhino. It is Iterable but does not implement
+ * java.util.Map because that comes with a bunch of overhead that we do not need.
  *
- * This class generally has a bit of a strange interface, and its interactions with
- * ScriptableObject are complex. Many attempts to make this interface more elegant have
- * resulted in substantial performance regressions so we are doing the best that we can.
+ * <p>This class generally has a bit of a strange interface, and its interactions with
+ * ScriptableObject are complex. Many attempts to make this interface more elegant have resulted in
+ * substantial performance regressions so we are doing the best that we can.
  */
+public interface SlotMap extends Iterable<ScriptableObject.Slot> {
 
-public interface SlotMap
-    extends Iterable<ScriptableObject.Slot> {
-
-    /**
-     * Return the size of the map.
-     */
+    /** Return the size of the map. */
     int size();
 
-    /**
-     * Return whether the map is empty.
-     */
+    /** Return whether the map is empty. */
     boolean isEmpty();
 
     /**
-     * Return the Slot that matches EITHER "key" or "index". (It will use "key"
-     * if it is not null, and otherwise "index". "accessType" is one of the
-     * constants defined in ScriptableObject.
+     * Return the Slot that matches EITHER "key" or "index". (It will use "key" if it is not null,
+     * and otherwise "index". "accessType" is one of the constants defined in ScriptableObject.
      */
     ScriptableObject.Slot get(Object key, int index, ScriptableObject.SlotAccess accessType);
 
     /**
-     * This is an optimization that is the same as get with an accessType of SLOT_QUERY.
-     * It should be used instead of SLOT_QUERY because it is more efficient.
+     * This is an optimization that is the same as get with an accessType of SLOT_QUERY. It should
+     * be used instead of SLOT_QUERY because it is more efficient.
      */
     ScriptableObject.Slot query(Object key, int index);
 
     /**
-     * Insert a new slot to the map. Both "name" and "indexOrHash" must be populated.
-     * Note that ScriptableObject generally adds slots via the "get" method.
+     * Insert a new slot to the map. Both "name" and "indexOrHash" must be populated. Note that
+     * ScriptableObject generally adds slots via the "get" method.
      */
     void addSlot(ScriptableObject.Slot newSlot);
 
-    /**
-     * Remove the slot at either "key" or "index".
-     */
+    /** Remove the slot at either "key" or "index". */
     void remove(Object key, int index);
 }
-

--- a/src/org/mozilla/javascript/SlotMap.java
+++ b/src/org/mozilla/javascript/SlotMap.java
@@ -26,10 +26,22 @@ public interface SlotMap extends Iterable<Slot> {
     /**
      * Return the Slot that matches EITHER "key" or "index". (It will use "key" if it is not null,
      * and otherwise "index".) If no slot exists, then create a default slot class.
+     *
+     * @param key The key for the slot, which should be a String or a Symbol.
+     * @param index if key is zero, then this will be used as the key instead.
+     * @param attributes the attributes to be set on the slot if a new slot is created. Existing
+     *     slots will not be modified.
+     * @return a Slot, which will be created anew if no such slot exists.
      */
     Slot modify(Object key, int index, int attributes);
 
-    /** Retrieve the slot at EITHER key or index, or return null if the slot cannot be found. */
+    /**
+     * Retrieve the slot at EITHER key or index, or return null if the slot cannot be found.
+     *
+     * @param key The key for the slot, which should be a String or a Symbol.
+     * @param index if key is zero, then this will be used as the key instead.
+     * @return either the Slot that matched the key and index, or null
+     */
     Slot query(Object key, int index);
 
     /** Replace "slot" with a new slot. This is used to change slot types. */
@@ -41,6 +53,11 @@ public interface SlotMap extends Iterable<Slot> {
      */
     void add(Slot newSlot);
 
-    /** Remove the slot at either "key" or "index". */
+    /**
+     * Remove the slot at either "key" or "index".
+     *
+     * @param key The key for the slot, which should be a String or a Symbol.
+     * @param index if key is zero, then this will be used as the key instead.
+     */
     void remove(Object key, int index);
 }

--- a/src/org/mozilla/javascript/SlotMap.java
+++ b/src/org/mozilla/javascript/SlotMap.java
@@ -15,7 +15,7 @@ package org.mozilla.javascript;
  * ScriptableObject are complex. Many attempts to make this interface more elegant have resulted in
  * substantial performance regressions so we are doing the best that we can.
  */
-public interface SlotMap extends Iterable<ScriptableObject.Slot> {
+public interface SlotMap extends Iterable<Slot> {
 
     /** Return the size of the map. */
     int size();
@@ -25,21 +25,21 @@ public interface SlotMap extends Iterable<ScriptableObject.Slot> {
 
     /**
      * Return the Slot that matches EITHER "key" or "index". (It will use "key" if it is not null,
-     * and otherwise "index". "accessType" is one of the constants defined in ScriptableObject.
+     * and otherwise "index".) If no slot exists, then create a default slot class.
      */
-    ScriptableObject.Slot get(Object key, int index, ScriptableObject.SlotAccess accessType);
+    Slot modify(Object key, int index, int attributes);
 
-    /**
-     * This is an optimization that is the same as get with an accessType of SLOT_QUERY. It should
-     * be used instead of SLOT_QUERY because it is more efficient.
-     */
-    ScriptableObject.Slot query(Object key, int index);
+    /** Retrieve the slot at EITHER key or index, or return null if the slot cannot be found. */
+    Slot query(Object key, int index);
+
+    /** Replace "slot" with a new slot. This is used to change slot types. */
+    void replace(Slot oldSlot, Slot newSlot);
 
     /**
      * Insert a new slot to the map. Both "name" and "indexOrHash" must be populated. Note that
-     * ScriptableObject generally adds slots via the "get" method.
+     * ScriptableObject generally adds slots via the "modify" method.
      */
-    void addSlot(ScriptableObject.Slot newSlot);
+    void add(Slot newSlot);
 
     /** Remove the slot at either "key" or "index". */
     void remove(Object key, int index);

--- a/src/org/mozilla/javascript/SlotMapContainer.java
+++ b/src/org/mozilla/javascript/SlotMapContainer.java
@@ -89,7 +89,7 @@ class SlotMapContainer implements SlotMap {
     }
 
     public void unlockRead(long stamp) {
-        // No locking in the default implementationock.unlockRead(stamp);
+        // No locking in the default implementation
     }
 
     /**

--- a/src/org/mozilla/javascript/SlotMapContainer.java
+++ b/src/org/mozilla/javascript/SlotMapContainer.java
@@ -7,8 +7,6 @@
 package org.mozilla.javascript;
 
 import java.util.Iterator;
-import org.mozilla.javascript.ScriptableObject.Slot;
-import org.mozilla.javascript.ScriptableObject.SlotAccess;
 
 /**
  * This class holds the various SlotMaps of various types, and knows how to atomically switch
@@ -23,7 +21,13 @@ class SlotMapContainer implements SlotMap {
      */
     private static final int LARGE_HASH_SIZE = 2000;
 
+    private static final int DEFAULT_SIZE = 10;
+
     protected SlotMap map;
+
+    SlotMapContainer() {
+        this(DEFAULT_SIZE);
+    }
 
     SlotMapContainer(int initialSize) {
         if (initialSize > LARGE_HASH_SIZE) {
@@ -48,11 +52,14 @@ class SlotMapContainer implements SlotMap {
     }
 
     @Override
-    public Slot get(Object key, int index, SlotAccess accessType) {
-        if (accessType != SlotAccess.QUERY) {
-            checkMapSize();
-        }
-        return map.get(key, index, accessType);
+    public Slot modify(Object key, int index, int attributes) {
+        checkMapSize();
+        return map.modify(key, index, attributes);
+    }
+
+    @Override
+    public void replace(Slot oldSlot, Slot newSlot) {
+        map.replace(oldSlot, newSlot);
     }
 
     @Override
@@ -61,9 +68,9 @@ class SlotMapContainer implements SlotMap {
     }
 
     @Override
-    public void addSlot(Slot newSlot) {
+    public void add(Slot newSlot) {
         checkMapSize();
-        map.addSlot(newSlot);
+        map.add(newSlot);
     }
 
     @Override
@@ -93,7 +100,7 @@ class SlotMapContainer implements SlotMap {
         if ((map instanceof EmbeddedSlotMap) && map.size() >= LARGE_HASH_SIZE) {
             SlotMap newMap = new HashSlotMap();
             for (Slot s : map) {
-                newMap.addSlot(s);
+                newMap.add(s);
             }
             map = newMap;
         }

--- a/src/org/mozilla/javascript/SlotMapContainer.java
+++ b/src/org/mozilla/javascript/SlotMapContainer.java
@@ -7,104 +7,95 @@
 package org.mozilla.javascript;
 
 import java.util.Iterator;
-
 import org.mozilla.javascript.ScriptableObject.Slot;
 import org.mozilla.javascript.ScriptableObject.SlotAccess;
 
 /**
- * This class holds the various SlotMaps of various types, and knows how to atomically
- * switch between them when we need to so that we use the right data structure at the right time.
+ * This class holds the various SlotMaps of various types, and knows how to atomically switch
+ * between them when we need to so that we use the right data structure at the right time.
  */
-class SlotMapContainer
-  implements SlotMap {
+class SlotMapContainer implements SlotMap {
 
-  /**
-   * Once the object has this many properties in it, we will replace the EmbeddedSlotMap
-   * with HashSlotMap. We can adjust this parameter to balance
-   * performance for typical objects versus performance for huge objects with many collisions.
-   */
-  private static final int LARGE_HASH_SIZE = 2000;
+    /**
+     * Once the object has this many properties in it, we will replace the EmbeddedSlotMap with
+     * HashSlotMap. We can adjust this parameter to balance performance for typical objects versus
+     * performance for huge objects with many collisions.
+     */
+    private static final int LARGE_HASH_SIZE = 2000;
 
-  protected SlotMap map;
+    protected SlotMap map;
 
-  SlotMapContainer(int initialSize)
-  {
-    if (initialSize > LARGE_HASH_SIZE) {
-      map = new HashSlotMap();
-    } else {
-      map = new EmbeddedSlotMap();
+    SlotMapContainer(int initialSize) {
+        if (initialSize > LARGE_HASH_SIZE) {
+            map = new HashSlotMap();
+        } else {
+            map = new EmbeddedSlotMap();
+        }
     }
-  }
 
-  @Override
-  public int size() {
-    return map.size();
-  }
-
-  public int dirtySize()
-  {
-    return map.size();
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return map.isEmpty();
-  }
-
-  @Override
-  public Slot get(Object key, int index, SlotAccess accessType)
-  {
-    if (accessType != SlotAccess.QUERY) {
-      checkMapSize();
+    @Override
+    public int size() {
+        return map.size();
     }
-    return map.get(key, index, accessType);
-  }
 
-  @Override
-  public Slot query(Object key, int index) {
-    return map.query(key, index);
-  }
-
-  @Override
-  public void addSlot(Slot newSlot)
-  {
-    checkMapSize();
-    map.addSlot(newSlot);
-  }
-
-  @Override
-  public void remove(Object key, int index) {
-    map.remove(key, index);
-  }
-
-  @Override
-  public Iterator<Slot> iterator() {
-    return map.iterator();
-  }
-
-  public long readLock()
-  {
-    // No locking in the default implementation
-    return 0L;
-  }
-
-  public void unlockRead(long stamp)
-  {
-    // No locking in the default implementationock.unlockRead(stamp);
-  }
-
-  /**
-   * Before inserting a new item in the map, check and see if we need to expand from the embedded
-   * map to a HashMap that is more robust against large numbers of hash collisions.
-   */
-  protected void checkMapSize()
-  {
-    if ((map instanceof EmbeddedSlotMap) && map.size() >= LARGE_HASH_SIZE) {
-      SlotMap newMap = new HashSlotMap();
-      for (Slot s : map) {
-        newMap.addSlot(s);
-      }
-      map = newMap;
+    public int dirtySize() {
+        return map.size();
     }
-  }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public Slot get(Object key, int index, SlotAccess accessType) {
+        if (accessType != SlotAccess.QUERY) {
+            checkMapSize();
+        }
+        return map.get(key, index, accessType);
+    }
+
+    @Override
+    public Slot query(Object key, int index) {
+        return map.query(key, index);
+    }
+
+    @Override
+    public void addSlot(Slot newSlot) {
+        checkMapSize();
+        map.addSlot(newSlot);
+    }
+
+    @Override
+    public void remove(Object key, int index) {
+        map.remove(key, index);
+    }
+
+    @Override
+    public Iterator<Slot> iterator() {
+        return map.iterator();
+    }
+
+    public long readLock() {
+        // No locking in the default implementation
+        return 0L;
+    }
+
+    public void unlockRead(long stamp) {
+        // No locking in the default implementationock.unlockRead(stamp);
+    }
+
+    /**
+     * Before inserting a new item in the map, check and see if we need to expand from the embedded
+     * map to a HashMap that is more robust against large numbers of hash collisions.
+     */
+    protected void checkMapSize() {
+        if ((map instanceof EmbeddedSlotMap) && map.size() >= LARGE_HASH_SIZE) {
+            SlotMap newMap = new HashSlotMap();
+            for (Slot s : map) {
+                newMap.addSlot(s);
+            }
+            map = newMap;
+        }
+    }
 }

--- a/src/org/mozilla/javascript/ThreadSafeSlotMapContainer.java
+++ b/src/org/mozilla/javascript/ThreadSafeSlotMapContainer.java
@@ -8,156 +8,141 @@ package org.mozilla.javascript;
 
 import java.util.Iterator;
 import java.util.concurrent.locks.StampedLock;
-
 import org.mozilla.javascript.ScriptableObject.Slot;
 import org.mozilla.javascript.ScriptableObject.SlotAccess;
 
 /**
- * This class extends the SlotMapContainer so that we have thread-safe access to all
- * the properties of an object.
+ * This class extends the SlotMapContainer so that we have thread-safe access to all the properties
+ * of an object.
  */
-class ThreadSafeSlotMapContainer
-  extends SlotMapContainer {
+class ThreadSafeSlotMapContainer extends SlotMapContainer {
 
-  private final StampedLock lock = new StampedLock();
+    private final StampedLock lock = new StampedLock();
 
-
-  ThreadSafeSlotMapContainer(int initialSize)
-  {
-    super(initialSize);
-  }
-
-  @Override
-  public int size()
-  {
-    long stamp = lock.tryOptimisticRead();
-    int s = map.size();
-    if (lock.validate(stamp)) {
-      return s;
+    ThreadSafeSlotMapContainer(int initialSize) {
+        super(initialSize);
     }
 
-    stamp = lock.readLock();
-    try {
-      return map.size();
-    } finally {
-      lock.unlockRead(stamp);
-    }
-  }
+    @Override
+    public int size() {
+        long stamp = lock.tryOptimisticRead();
+        int s = map.size();
+        if (lock.validate(stamp)) {
+            return s;
+        }
 
-  @Override
-  public int dirtySize()
-  {
-    assert(lock.isReadLocked());
-    return map.size();
-  }
-
-  @Override
-  public boolean isEmpty()
-  {
-    long stamp = lock.tryOptimisticRead();
-    boolean e = map.isEmpty();
-    if (lock.validate(stamp)) {
-       return e;
+        stamp = lock.readLock();
+        try {
+            return map.size();
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
-    stamp = lock.readLock();
-    try {
-      return map.isEmpty();
-    } finally {
-      lock.unlockRead(stamp);
-    }
-  }
-
-  @Override
-  public Slot get(Object key, int index, SlotAccess accessType)
-  {
-    final long stamp = lock.writeLock();
-    try {
-      if (accessType != SlotAccess.QUERY) {
-        checkMapSize();
-      }
-      return map.get(key, index, accessType);
-    } finally {
-      lock.unlockWrite(stamp);
-    }
-  }
-
-  @Override
-  public Slot query(Object key, int index)
-  {
-    long stamp = lock.tryOptimisticRead();
-    Slot s = map.query(key, index);
-    if (lock.validate(stamp)) {
-      return s;
+    @Override
+    public int dirtySize() {
+        assert (lock.isReadLocked());
+        return map.size();
     }
 
-    stamp = lock.readLock();
-    try {
-      return map.query(key, index);
-    } finally {
-      lock.unlockRead(stamp);
+    @Override
+    public boolean isEmpty() {
+        long stamp = lock.tryOptimisticRead();
+        boolean e = map.isEmpty();
+        if (lock.validate(stamp)) {
+            return e;
+        }
+
+        stamp = lock.readLock();
+        try {
+            return map.isEmpty();
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
-  }
 
-  @Override
-  public void addSlot(Slot newSlot)
-  {
-    final long stamp = lock.writeLock();
-    try {
-      checkMapSize();
-      map.addSlot(newSlot);
-    } finally {
-      lock.unlockWrite(stamp);
+    @Override
+    public Slot get(Object key, int index, SlotAccess accessType) {
+        final long stamp = lock.writeLock();
+        try {
+            if (accessType != SlotAccess.QUERY) {
+                checkMapSize();
+            }
+            return map.get(key, index, accessType);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
     }
-  }
 
-  @Override
-  public void remove(Object key, int index)
-  {
-    final long stamp = lock.writeLock();
-    try {
-      map.remove(key, index);
-    } finally {
-      lock.unlockWrite(stamp);
+    @Override
+    public Slot query(Object key, int index) {
+        long stamp = lock.tryOptimisticRead();
+        Slot s = map.query(key, index);
+        if (lock.validate(stamp)) {
+            return s;
+        }
+
+        stamp = lock.readLock();
+        try {
+            return map.query(key, index);
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
-  }
 
-  /**
-   * Take out a read lock on the slot map, if locking is implemented. The caller MUST call
-   * this method before using the iterator, and MUST NOT call this method otherwise.
-   */
-  @Override
-  public long readLock()
-  {
-    return lock.readLock();
-  }
+    @Override
+    public void addSlot(Slot newSlot) {
+        final long stamp = lock.writeLock();
+        try {
+            checkMapSize();
+            map.addSlot(newSlot);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
 
-  /**
-   * Unlock the lock taken out by readLock.
-   *
-   * @param stamp the value returned by readLock.
-   */
-  @Override
-  public void unlockRead(long stamp)
-  {
-    lock.unlockRead(stamp);
-  }
+    @Override
+    public void remove(Object key, int index) {
+        final long stamp = lock.writeLock();
+        try {
+            map.remove(key, index);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
 
-  @Override
-  public Iterator<Slot> iterator()
-  {
-    assert(lock.isReadLocked());
-    return map.iterator();
-  }
+    /**
+     * Take out a read lock on the slot map, if locking is implemented. The caller MUST call this
+     * method before using the iterator, and MUST NOT call this method otherwise.
+     */
+    @Override
+    public long readLock() {
+        return lock.readLock();
+    }
 
-  /**
-   * Before inserting a new item in the map, check and see if we need to expand from the embedded
-   * map to a HashMap that is more robust against large numbers of hash collisions.
-   */
-  @Override
-  protected void checkMapSize()
-  {
-    assert(lock.isWriteLocked());
-    super.checkMapSize();
-  }
+    /**
+     * Unlock the lock taken out by readLock.
+     *
+     * @param stamp the value returned by readLock.
+     */
+    @Override
+    public void unlockRead(long stamp) {
+        lock.unlockRead(stamp);
+    }
+
+    @Override
+    public Iterator<Slot> iterator() {
+        assert (lock.isReadLocked());
+        return map.iterator();
+    }
+
+    /**
+     * Before inserting a new item in the map, check and see if we need to expand from the embedded
+     * map to a HashMap that is more robust against large numbers of hash collisions.
+     */
+    @Override
+    protected void checkMapSize() {
+        assert (lock.isWriteLocked());
+        super.checkMapSize();
+    }
 }

--- a/testsrc/org/mozilla/javascript/SlotMapTest.java
+++ b/testsrc/org/mozilla/javascript/SlotMapTest.java
@@ -1,0 +1,281 @@
+package org.mozilla.javascript;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Random;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class SlotMapTest {
+    // Random number generator with fixed seed to ensure repeatable tests
+    private static final Random rand = new Random(0);
+
+    private final SlotMap map;
+
+    public SlotMapTest(Class<SlotMap> mapClass)
+            throws IllegalAccessException, InstantiationException {
+        this.map = mapClass.newInstance();
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> mapTypes() {
+        return Arrays.asList(
+                new Object[][] {
+                    {EmbeddedSlotMap.class},
+                    {HashSlotMap.class},
+                    {SlotMapContainer.class},
+                    {ThreadSafeSlotMapContainer.class},
+                });
+    }
+
+    @Test
+    public void testEmpty() {
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+        assertNull(map.query("notfound", 0));
+        assertNull(map.query(null, 123));
+    }
+
+    @Test
+    public void testCrudOneString() {
+        assertNull(map.query("foo", 0));
+        Slot slot = map.modify("foo", 0, 0);
+        assertNotNull(slot);
+        slot.value = "Testing";
+        assertEquals(1, map.size());
+        assertFalse(map.isEmpty());
+        Slot newSlot = new Slot(slot);
+        map.replace(slot, newSlot);
+        Slot foundNewSlot = map.query("foo", 0);
+        assertEquals("Testing", foundNewSlot.value);
+        assertSame(foundNewSlot, newSlot);
+        map.remove("foo", 0);
+        assertNull(map.query("foo", 0));
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testCrudOneIndex() {
+        assertNull(map.query(null, 11));
+        Slot slot = map.modify(null, 11, 0);
+        assertNotNull(slot);
+        slot.value = "Testing";
+        assertEquals(1, map.size());
+        assertFalse(map.isEmpty());
+        Slot newSlot = new Slot(slot);
+        map.replace(slot, newSlot);
+        Slot foundNewSlot = map.query(null, 11);
+        assertEquals("Testing", foundNewSlot.value);
+        assertSame(foundNewSlot, newSlot);
+        map.remove(null, 11);
+        assertNull(map.query(null, 11));
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    private static final int NUM_INDICES = 67;
+
+    @Test
+    public void testManyKeysAndIndices() {
+        for (int i = 0; i < NUM_INDICES; i++) {
+            Slot newSlot = map.modify(null, i, 0);
+            newSlot.value = i;
+        }
+        for (String key : KEYS) {
+            Slot newSlot = map.modify(key, 0, 0);
+            newSlot.value = key;
+        }
+        assertEquals(KEYS.length + NUM_INDICES, map.size());
+        assertFalse(map.isEmpty());
+        verifyIndicesAndKeys();
+
+        // Randomly replace some stuff
+        for (int i = 0; i < 20; i++) {
+            int ix = rand.nextInt(NUM_INDICES);
+            Slot slot = map.query(null, ix);
+            assertNotNull(slot);
+            Slot newSlot = new Slot(slot);
+            map.replace(slot, newSlot);
+        }
+        for (int i = 0; i < 20; i++) {
+            int ix = rand.nextInt(KEYS.length);
+            Slot slot = map.query(KEYS[ix], 0);
+            assertNotNull(slot);
+            Slot newSlot = new Slot(slot);
+            map.replace(slot, newSlot);
+        }
+        verifyIndicesAndKeys();
+
+        HashSet<Integer> removedIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            int ix = rand.nextInt(NUM_INDICES);
+            map.remove(null, ix);
+            removedIds.add(ix);
+        }
+        HashSet<String> removedKeys = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            int ix = rand.nextInt(NUM_INDICES);
+            map.remove(KEYS[ix], ix);
+            removedKeys.add(KEYS[ix]);
+        }
+
+        for (int i = 0; i < NUM_INDICES; i++) {
+            Slot slot = map.query(null, i);
+            if (removedIds.contains(i)) {
+                assertNull(slot);
+            } else {
+                assertNotNull(slot);
+                assertEquals(i, slot.value);
+            }
+        }
+        for (String key : KEYS) {
+            Slot slot = map.query(key, 0);
+            if (removedKeys.contains(key)) {
+                assertNull(slot);
+            } else {
+                assertNotNull(slot);
+                assertEquals(key, slot.value);
+            }
+        }
+    }
+
+    private void verifyIndicesAndKeys() {
+        long lockStamp = 0;
+        if (map instanceof SlotMapContainer) {
+            lockStamp = ((SlotMapContainer) map).readLock();
+        }
+        try {
+            Iterator<Slot> it = map.iterator();
+            for (int i = 0; i < NUM_INDICES; i++) {
+                Slot slot = map.query(null, i);
+                assertNotNull(slot);
+                assertEquals(i, slot.value);
+                assertTrue(it.hasNext());
+                assertEquals(slot, it.next());
+            }
+            for (String key : KEYS) {
+                Slot slot = map.query(key, 0);
+                assertNotNull(slot);
+                assertEquals(key, slot.value);
+                assertTrue(it.hasNext());
+                assertEquals(slot, it.next());
+            }
+            assertFalse(it.hasNext());
+        } finally {
+            if (map instanceof SlotMapContainer) {
+                ((SlotMapContainer) map).unlockRead(lockStamp);
+            }
+        }
+    }
+
+    // These keys come from the hash collision test and may help ensure that we have a few
+    // collisions for proper testing of the embedded slot map.
+    private static final String[] KEYS = {
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBAaBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaAaBBBBBBBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaAaBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaAaBBBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBAaBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAaBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBAaBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBBAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBBAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBBBBAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBAaBBBBBBBBBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBBBAaAaAaAaAa",
+        "AaAaAaAaAaAaAaAaAaAaAaBBBBAaAaAaAaBB",
+        "AaAaAaAaAaAaAaAaAaAaAaBBBBAaAaAaBBAa",
+    };
+}


### PR DESCRIPTION
Ensure that Slot and all related classes are separate classes now and not just nested inside ScriptableObject.

Also, break the two Slot implementations (regular and "GetterSlot") into four so we can use inheritance rather than complex "instanceof" logic to implement the different types of slots.

This simplifies the structure and logic and will make it easier to extend stuff later.
