### PR TITLE
Fix for pr 897

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,10 @@ test {
     systemProperty 'file.encoding', 'UTF-8'
     if (System.getProperty('quick') != null) {
         systemProperty 'TEST_OPTLEVEL', -1
+    } else {
+    	systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
     }
+    systemProperty 'test262properties', System.getProperty('test262properties')
     maxHeapSize = "1g"
     testLogging.showStandardStreams = true
     // Many tests do not clean up contexts properly. This makes the tests much

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,10 @@ test {
     systemProperty 'file.encoding', 'UTF-8'
     if (System.getProperty('quick') != null) {
         systemProperty 'TEST_OPTLEVEL', -1
-    } else if (System.getProperty('optLevel') {
-    	systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
+    } else {
+        if (System.getProperty('optLevel') {
+    	    systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
+        }
     }
     systemProperty 'test262properties', System.getProperty('test262properties')
     maxHeapSize = "1g"

--- a/build.gradle
+++ b/build.gradle
@@ -83,10 +83,8 @@ test {
     systemProperty 'file.encoding', 'UTF-8'
     if (System.getProperty('quick') != null) {
         systemProperty 'TEST_OPTLEVEL', -1
-    } else {
-        if (System.getProperty('optLevel') {
-    	    systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
-        }
+    } else if (System.getProperty('optLevel')) {
+        systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
     }
     systemProperty 'test262properties', System.getProperty('test262properties')
     maxHeapSize = "1g"

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ test {
     systemProperty 'file.encoding', 'UTF-8'
     if (System.getProperty('quick') != null) {
         systemProperty 'TEST_OPTLEVEL', -1
-    } else {
+    } else if (System.getProperty('optLevel') {
     	systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
     }
     systemProperty 'test262properties', System.getProperty('test262properties')

--- a/testsrc/README.md
+++ b/testsrc/README.md
@@ -20,13 +20,13 @@ After doing so, the `./gradlew test` command will also execute all tests that ar
 By default all tests are run 3 times, at optimization levels -1, 0 and 9.
 
 This behavior can be changed through different means:
-1. Quick disable
+1. Quick disable (will run tests with optimization level -1)
 ```
 ./gradlew test -Dquick
 ```
 2. Setting an explicit optimization level through the command line:
 ```
-./gradlew test -DTEST_OPTLEVEL=-1
+./gradlew test -DoptLevel=9
 ```
 3. Setting an explicit optimization level through the `TEST_262_OPTLEVEL` environment variable
 

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -108,9 +108,10 @@ public class Test262SuiteTest {
     }
 
     private static String getOverriddenLevel() {
-        String optLevel = System.getenv("TEST_262_OPTLEVEL");
-        if (optLevel == null) {
-            optLevel = System.getProperty("TEST_OPTLEVEL");
+        String optLevel = System.getProperty("TEST_OPTLEVEL");
+
+        if (optLevel == null || optLevel.equals("")) {
+            optLevel = System.getenv("TEST_262_OPTLEVEL");
         }
         return optLevel;
     }


### PR DESCRIPTION
1. -Dtest262properties option wasn't working
2. added -DoptLevel commandline option (and made it take prio over the TEST_262_OPTLEVEL env. var)