### PR TITLE
fix support indexed accessor properties in Object Literals

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4289,25 +4289,27 @@ public class ScriptRuntime {
         Scriptable object = cx.newObject(scope);
         for (int i = 0, end = propertyIds.length; i != end; ++i) {
             Object id = propertyIds[i];
-            int getterSetter = getterSetters == null ? 0 : getterSetters[i];
+            int getterSetter = getterSetters == null ? 0 : getterSetters[i]; // -1 for GET, 1 for SET, 0 for a regular property
             Object value = propertyValues[i];
-            if (id instanceof String) {
-                if (getterSetter == 0) {
+            if (getterSetter == 0) {
+                if (id instanceof String) {
                     if (isSpecialProperty((String) id)) {
-                        Ref ref = specialRef(object, (String) id, cx, scope);
-                        ref.set(cx, scope, value);
-                    } else {
-                        object.put((String) id, object, value);
-                    }
+	                    Ref ref = specialRef(object, (String) id, cx, scope);
+	                    ref.set(cx, scope, value);
+	                } else {
+	                    object.put((String) id, object, value);
+	                }
                 } else {
-                    ScriptableObject so = (ScriptableObject) object;
-                    Callable getterOrSetter = (Callable) value;
-                    boolean isSetter = getterSetter == 1;
-                    so.setGetterOrSetter((String) id, 0, getterOrSetter, isSetter);
+                    int index = ((Integer) id).intValue();
+                    object.put(index, object, value);
                 }
             } else {
-                int index = ((Integer) id).intValue();
-                object.put(index, object, value);
+                ScriptableObject so = (ScriptableObject) object;
+                Callable getterOrSetter = (Callable) value;
+                boolean isSetter = getterSetter == 1;
+                String key = id instanceof String ? (String) id : null;
+                int index = key == null ? ((Integer) id).intValue() : 0;
+                so.setGetterOrSetter(key, index, getterOrSetter, isSetter);
             }
         }
         return object;

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4294,11 +4294,11 @@ public class ScriptRuntime {
             if (getterSetter == 0) {
                 if (id instanceof String) {
                     if (isSpecialProperty((String) id)) {
-	                    Ref ref = specialRef(object, (String) id, cx, scope);
-	                    ref.set(cx, scope, value);
-	                } else {
-	                    object.put((String) id, object, value);
-	                }
+                        Ref ref = specialRef(object, (String) id, cx, scope);
+                        ref.set(cx, scope, value);
+                    } else {
+                        object.put((String) id, object, value);
+                    }
                 } else {
                     int index = ((Integer) id).intValue();
                     object.put(index, object, value);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4289,7 +4289,9 @@ public class ScriptRuntime {
         Scriptable object = cx.newObject(scope);
         for (int i = 0, end = propertyIds.length; i != end; ++i) {
             Object id = propertyIds[i];
-            int getterSetter = getterSetters == null ? 0 : getterSetters[i]; // -1 for GET, 1 for SET, 0 for a regular property
+
+            // -1 for property getter, 1 for property setter, 0 for a regular value property
+            int getterSetter = getterSetters == null ? 0 : getterSetters[i];
             Object value = propertyValues[i];
             if (getterSetter == 0) {
                 if (id instanceof String) {

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -359,7 +359,6 @@ built-ins/Function
     ! prototype/apply/15.3.4.3-2-s.js
     ! prototype/apply/15.3.4.3-3-s.js
     ! prototype/apply/argarray-not-object.js
-    ! prototype/apply/get-index-abrupt.js
     ! prototype/apply/S15.3.4.3_A3_T1.js
     ! prototype/apply/S15.3.4.3_A3_T2.js
     ! prototype/apply/S15.3.4.3_A3_T3.js


### PR DESCRIPTION
Adds support for indexed accessor properties.

Without this, running the the current master of Test262 hangs on https://github.com/tc39/test262/blob/main/test/built-ins/Array/prototype/concat/arg-length-near-integer-limit.js, as the getter for index 0 is never called

Closes https://github.com/mozilla/rhino/issues/906
Closes https://github.com/mozilla/rhino/issues/775