### PR TITLE
Fix bug with calling function on custom global object from function defined within a function within a module

### DIFF
--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import org.mozilla.javascript.commonjs.module.ModuleScope;
 
 public class FunctionObject extends BaseFunction {
     private static final long serialVersionUID = -5332312783643935019L;
@@ -353,13 +354,15 @@ public class FunctionObject extends BaseFunction {
                 Class<?> clazz = member.getDeclaringClass();
                 if (!clazz.isInstance(thisObj)) {
                     boolean compatible = false;
-                    Scriptable parentScope = getParentScope();
-                    if (scope != parentScope) {
-                        // Call with dynamic scope for standalone function,
-                        // use parentScope as thisObj
-                        compatible = clazz.isInstance(parentScope);
-                        if (compatible) {
-                            thisObj = parentScope;
+                    if (thisObj == scope || thisObj instanceof ModuleScope) {
+                        Scriptable parentScope = getParentScope();
+                        if (scope != parentScope) {
+                            // Call with dynamic scope for standalone function,
+                            // use parentScope as thisObj
+                            compatible = clazz.isInstance(parentScope);
+                            if (compatible) {
+                                thisObj = parentScope;
+                            }
                         }
                     }
                     if (!compatible) {

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -353,15 +353,13 @@ public class FunctionObject extends BaseFunction {
                 Class<?> clazz = member.getDeclaringClass();
                 if (!clazz.isInstance(thisObj)) {
                     boolean compatible = false;
-                    if (thisObj == scope) {
-                        Scriptable parentScope = getParentScope();
-                        if (scope != parentScope) {
-                            // Call with dynamic scope for standalone function,
-                            // use parentScope as thisObj
-                            compatible = clazz.isInstance(parentScope);
-                            if (compatible) {
-                                thisObj = parentScope;
-                            }
+                    Scriptable parentScope = getParentScope();
+                    if (scope != parentScope) {
+                        // Call with dynamic scope for standalone function,
+                        // use parentScope as thisObj
+                        compatible = clazz.isInstance(parentScope);
+                        if (compatible) {
+                            thisObj = parentScope;
                         }
                     }
                     if (!compatible) {

--- a/src/org/mozilla/javascript/JavaScriptException.java
+++ b/src/org/mozilla/javascript/JavaScriptException.java
@@ -9,23 +9,20 @@
 package org.mozilla.javascript;
 
 /**
- * Java reflection of JavaScript exceptions.
- * Instances of this class are thrown by the JavaScript 'throw' keyword.
+ * Java reflection of JavaScript exceptions. Instances of this class are thrown by the JavaScript
+ * 'throw' keyword.
  *
  * @author Mike McCabe
  */
-public class JavaScriptException extends RhinoException
-{
+public class JavaScriptException extends RhinoException {
     private static final long serialVersionUID = -7666130513694669293L;
 
     /**
-     * @deprecated
-     * Use {@link WrappedException#WrappedException(Throwable)} to report
-     * exceptions in Java code.
+     * @deprecated Use {@link WrappedException#WrappedException(Throwable)} to report exceptions in
+     *     Java code.
      */
     @Deprecated
-    public JavaScriptException(Object value)
-    {
+    public JavaScriptException(Object value) {
         this(value, "", 0);
     }
 
@@ -34,14 +31,13 @@ public class JavaScriptException extends RhinoException
      *
      * @param value the JavaScript value thrown.
      */
-    public JavaScriptException(Object value, String sourceName, int lineNumber)
-    {
+    public JavaScriptException(Object value, String sourceName, int lineNumber) {
         recordErrorOrigin(sourceName, lineNumber, null, 0);
         this.value = value;
         // Fill in fileName and lineNumber automatically when not specified
         // explicitly, see Bugzilla issue #342807
-        if (value instanceof NativeError && Context.getContext()
-                .hasFeature(Context.FEATURE_LOCATION_INFORMATION_IN_ERROR)) {
+        if (value instanceof NativeError
+                && Context.getContext().hasFeature(Context.FEATURE_LOCATION_INFORMATION_IN_ERROR)) {
             NativeError error = (NativeError) value;
             if (!error.has("fileName", error)) {
                 error.put("fileName", error, sourceName);
@@ -52,52 +48,54 @@ public class JavaScriptException extends RhinoException
             // set stack property, see bug #549604
             error.setStackProvider(this);
         }
+
+        // generate details string when exception is first created,
+        // since details() may be called later from a different thread
+        // (e.g. when printing failed test results), which
+        // would cause ScriptRuntime.toString to fail.
+        this.details = getDetails();
     }
 
     @Override
-    public String details()
-    {
+    public String details() {
+        return this.details;
+    }
+
+    public String getDetails() {
         if (value == null) {
             return "null";
         } else if (value instanceof NativeError) {
             return value.toString();
         }
+
         try {
             return ScriptRuntime.toString(value);
         } catch (RuntimeException rte) {
             // ScriptRuntime.toString may throw a RuntimeException
             if (value instanceof Scriptable) {
-                return ScriptRuntime.defaultObjectToString((Scriptable)value);
+                return ScriptRuntime.defaultObjectToString((Scriptable) value);
             }
             return value.toString();
         }
     }
 
-    /**
-     * @return the value wrapped by this exception
-     */
-    public Object getValue()
-    {
+    /** @return the value wrapped by this exception */
+    public Object getValue() {
         return value;
     }
 
-    /**
-     * @deprecated Use {@link RhinoException#sourceName()} from the super class.
-     */
+    /** @deprecated Use {@link RhinoException#sourceName()} from the super class. */
     @Deprecated
-    public String getSourceName()
-    {
+    public String getSourceName() {
         return sourceName();
     }
 
-    /**
-     * @deprecated Use {@link RhinoException#lineNumber()} from the super class.
-     */
+    /** @deprecated Use {@link RhinoException#lineNumber()} from the super class. */
     @Deprecated
-    public int getLineNumber()
-    {
+    public int getLineNumber() {
         return lineNumber();
     }
 
     private Object value;
+    private String details;
 }

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -48,6 +48,40 @@ public class RequireTest extends TestCase {
         require.requireMain(cx, "testNonSandboxed");
     }
 
+    public static class CustomGlobal extends ScriptableObject {
+
+        private String x = "";
+
+        public int jsFunction_test(int x) {
+            return x + 1;
+        }
+
+        @Override
+        public String getClassName() {
+            return "CustomGlobal";
+        }
+    }
+
+    public void testCustomGlobal() throws Exception {
+        final Context cx = createContext();
+        final Scriptable scope = cx.initSafeStandardObjects();
+        ScriptableObject.defineClass(scope, CustomGlobal.class);
+
+        final Scriptable global = cx.newObject(scope, "CustomGlobal", null);
+
+        global.getPrototype().setPrototype(scope);
+        global.setParentScope(null);
+
+        final Require require = new Require(cx, global,
+                new StrongCachingModuleScriptProvider(
+                        new UrlModuleSourceProvider(Collections.singleton(
+                                getDirectory()), null)), null, null, true);
+
+        require.install(global);
+        cx.evaluateReader(global, getReader("testCustomGlobal.js"),
+                "testCustomGlobal.js", 1, null);
+    }
+
     public void testVariousUsageErrors() throws Exception {
         testWithSandboxedRequire("testNoArgsRequire");
     }

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -61,7 +61,7 @@ public class RequireTest extends TestCase {
 
     public void testCustomGlobal() throws Exception {
         final Context cx = createContext();
-        final Scriptable scope = cx.initSafeStandardObjects();
+        final Scriptable scope = cx.initStandardObjects();
         ScriptableObject.defineClass(scope, CustomGlobal.class);
 
         final Scriptable global = cx.newObject(scope, "CustomGlobal", null);
@@ -69,14 +69,26 @@ public class RequireTest extends TestCase {
         global.getPrototype().setPrototype(scope);
         global.setParentScope(null);
 
-        final Require require = new Require(cx, global,
-                new StrongCachingModuleScriptProvider(
-                        new UrlModuleSourceProvider(Collections.singleton(
-                                getDirectory()), null)), null, null, true);
+        final Require require =
+                new Require(
+                        cx,
+                        global,
+                        new StrongCachingModuleScriptProvider(
+                                new UrlModuleSourceProvider(
+                                        Collections.singleton(getDirectory()), null)),
+                        null,
+                        null,
+                        true);
 
         require.install(global);
-        cx.evaluateReader(global, getReader("testCustomGlobal.js"),
-                "testCustomGlobal.js", 1, null);
+
+        try {
+            cx.evaluateReader(
+                    global, getReader("testCustomGlobal.js"), "testCustomGlobal.js", 1, null);
+        } catch (Exception ex) {
+            System.err.println(ex.getMessage());
+            throw ex;
+        }
     }
 
     public void testVariousUsageErrors() throws Exception {

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -49,9 +49,6 @@ public class RequireTest extends TestCase {
     }
 
     public static class CustomGlobal extends ScriptableObject {
-
-        private String x = "";
-
         public int jsFunction_test(int x) {
             return x + 1;
         }

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/assert.js
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/assert.js
@@ -33,20 +33,12 @@ assert.AssertionError = function (options) {
     // V8 specific
     if (Error.captureStackTrace) {
         Error.captureStackTrace(this, (this.fail || assert.fail));
-        // Node specific, removes the node machinery stack frames
-        // XXX __filename will probably not always be the best way to detect Node
-        if (typeof __filename !== undefined) {
-            var stack = this.stack.split("\n");
-            for (var i = stack.length - 1; i >= 0; i--) {
-                if (stack[i].indexOf(__filename) != -1) {
-                    this.stack = stack.slice(0, i + 2).join("\n");
-                    break;
-                }
-            }
-        }
     }
 
 };
+
+// assert.AssertionError instanceof Error
+assert.AssertionError.prototype = Object.create(Error.prototype);
 
 // XXX extension
 // Ash Berlin
@@ -71,10 +63,6 @@ assert.AssertionError.prototype.toString = function (){
 assert.AssertionError.prototype.toSource = function () {
     return "new (require('assert').AssertionError)(" + Object.prototype.toSource.call(this) + ")";
 };
-
-// assert.AssertionError instanceof Error
-
-assert.AssertionError.prototype = Object.create(Error.prototype);
 
 // At present only the three keys mentioned above are used and
 // understood by the spec. Implementations or sub modules can pass
@@ -166,7 +154,7 @@ assert.deepEqual = function (actual, expected, message) {
         (this.fail || assert.fail)({
             "actual": actual,
             "expected": expected,
-            "message": message, 
+            "message": message,
             "operator": "deepEqual"
         });
     else
@@ -174,7 +162,7 @@ assert.deepEqual = function (actual, expected, message) {
 };
 
 function deepEqual(actual, expected) {
-    
+
     // 7.1. All identical values are equivalent, as determined by ===.
     if (actual === expected) {
         return true;
@@ -293,7 +281,7 @@ assert["throws"] = function (block, Error, message) {
         threw = true;
         exception = e;
     }
-    
+
     if (!threw) {
         (this.fail || assert.fail)({
             "message": message,

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal.js
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal.js
@@ -1,0 +1,13 @@
+var assert = require("assert");
+
+assert.strictEqual(test(1), 2);
+
+var testWrap = function(arg) { return test(arg); };
+
+assert.strictEqual(testWrap(2), 3);
+
+var testWrap2 = function() { return function(arg) { return test(arg); }; };
+
+assert.strictEqual(testWrap2()(3), 4);
+
+require('testCustomGlobal2');

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal.js
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal.js
@@ -11,3 +11,14 @@ var testWrap2 = function() { return function(arg) { return test(arg); }; };
 assert.strictEqual(testWrap2()(3), 4);
 
 require('testCustomGlobal2');
+
+var throws = false;
+try {
+    test.call({}, "oops");
+} catch (e) {
+    throws = true;
+    assert.strictEqual("Method \"test\" called on incompatible object.", e.message);
+}
+if (!throws) {
+    assert.fail("test() did not throw error when called on invalid object");
+}

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal2.js
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal2.js
@@ -9,3 +9,14 @@ assert.strictEqual(testWrap(5), 6);
 var testWrap2 = function() { return function(arg) { return test(arg); }; };
 
 assert.strictEqual(testWrap2()(6), 7);
+
+var throws = false;
+try {
+    test.call("hmm", "oops");
+} catch (e) {
+    throws = true;
+    assert.strictEqual("Method \"test\" called on incompatible object.", e.message);
+}
+if (!throws) {
+    assert.fail("test() did not throw error when called on string");
+}

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal2.js
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/testCustomGlobal2.js
@@ -1,0 +1,11 @@
+var assert = require("assert");
+
+assert.strictEqual(test(4), 5);
+
+var testWrap = function(arg) { return test(arg); };
+
+assert.strictEqual(testWrap(5), 6);
+
+var testWrap2 = function() { return function(arg) { return test(arg); }; };
+
+assert.strictEqual(testWrap2()(6), 7);


### PR DESCRIPTION
Rhino makes it possible to execute a script with a custom object as the root scope, which makes it easy to add custom functions at the top level. Inside a CommonJS module, these custom functions are also available at the root scope. However, when inside a CommonJS module, if the custom global function is called from a function defined within another function, Rhino unexpectedly throws the error:

```
org.mozilla.javascript.EcmaError: TypeError: Method "test" called on incompatible object.
```

In the test code below, the function `test(x)` is added at the root scope by defining the method `CustomGlobal.jsFunction_test` and setting a CustomGlobal instance as the root scope. In the current version of Rhino, it works everywhere, except when called within a module from a function defined within another function, like this:

```js
var testWrap2 = function() { return function(arg) { return test(arg); }; }
testWrap2()(6);
```

Removing the condition `if (thisObj == scope)` from FunctionObject.call fixes the bug.

When calling `testWrap2()(6);` within a module, the variables in FunctionObject.call have the following types:

* thisObj: org.mozilla.javascript.commonjs.module.ModuleScope
* scope: org.mozilla.javascript.NativeCall
* parentScope: CustomGlobal

Because `thisObj != scope` within a function defined inside another function, the previous code in FunctionObject.call did not try to invoke "test" on the CustomGlobal object returned by `getParentScope()`.

I'm not sure if there is a reason for the `thisObj != scope` condition, but removing the check for `thisObj != scope` doesn't cause any tests to fail.

Spotless wants to make a lot of changes to both of these Java files, but I didn't include these changes in this PR to improve readability.