### PR TITLE
Try optional catch binding

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -473,7 +473,7 @@ class CodeGenerator extends Icode {
                 {
                     int localIndex = getLocalBlockRef(node);
                     int scopeIndex = node.getExistingIntProp(Node.CATCH_SCOPE_PROP);
-                    String name = child.getString();
+                    String name = child.getType() == Token.NAME ? child.getString() : "";
                     child = child.getNext();
                     visitExpression(child, 0); // load expression object
                     addStringPrefix(name);

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -1685,12 +1685,20 @@ public class Parser {
                         break;
                 }
 
-                Block catchBlock = (Block) statements();
-                tryEnd = getNodeEnd(catchBlock);
+                Scope catchScope = new Scope(catchPos);
                 CatchClause catchNode = new CatchClause(catchPos);
+                catchNode.setLineno(ts.lineno);
+                pushScope(catchScope);
+                try {
+                    statements(catchScope);
+                } finally {
+                    popScope();
+                }
+
+                tryEnd = getNodeEnd(catchScope);
                 catchNode.setVarName(varName);
                 catchNode.setCatchCondition(catchCond);
-                catchNode.setBody(catchBlock);
+                catchNode.setBody(catchScope);
                 if (guardPos != -1) {
                     catchNode.setIfPosition(guardPos - catchPos);
                 }

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -1637,32 +1637,53 @@ public class Parser {
                     reportError("msg.catch.unreachable");
                 }
                 int catchPos = ts.tokenBeg, lp = -1, rp = -1, guardPos = -1;
-                if (mustMatchToken(Token.LP, "msg.no.paren.catch", true)) lp = ts.tokenBeg;
-
-                mustMatchToken(Token.NAME, "msg.bad.catchcond", true);
-
-                Name varName = createNameNode();
-                Comment jsdocNodeForName = getAndResetJsDoc();
-                if (jsdocNodeForName != null) {
-                    varName.setJsDocNode(jsdocNodeForName);
-                }
-                String varNameString = varName.getIdentifier();
-                if (inUseStrictDirective) {
-                    if ("eval".equals(varNameString) || "arguments".equals(varNameString)) {
-                        reportError("msg.bad.id.strict", varNameString);
-                    }
-                }
-
+                Name varName = null;
                 AstNode catchCond = null;
-                if (matchToken(Token.IF, true)) {
-                    guardPos = ts.tokenBeg;
-                    catchCond = expr();
-                } else {
-                    sawDefaultCatch = true;
-                }
 
-                if (mustMatchToken(Token.RP, "msg.bad.catchcond", true)) rp = ts.tokenBeg;
-                mustMatchToken(Token.LC, "msg.no.brace.catchblock", true);
+                switch (peekToken()) {
+                    case Token.LP:
+                        {
+                            matchToken(Token.LP, true);
+                            lp = ts.tokenBeg;
+                            mustMatchToken(Token.NAME, "msg.bad.catchcond", true);
+
+                            varName = createNameNode();
+                            Comment jsdocNodeForName = getAndResetJsDoc();
+                            if (jsdocNodeForName != null) {
+                                varName.setJsDocNode(jsdocNodeForName);
+                            }
+                            String varNameString = varName.getIdentifier();
+                            if (inUseStrictDirective) {
+                                if ("eval".equals(varNameString)
+                                        || "arguments".equals(varNameString)) {
+                                    reportError("msg.bad.id.strict", varNameString);
+                                }
+                            }
+
+                            if (matchToken(Token.IF, true)) {
+                                guardPos = ts.tokenBeg;
+                                catchCond = expr();
+                            } else {
+                                sawDefaultCatch = true;
+                            }
+
+                            if (mustMatchToken(Token.RP, "msg.bad.catchcond", true)) {
+                                rp = ts.tokenBeg;
+                            }
+                            mustMatchToken(Token.LC, "msg.no.brace.catchblock", true);
+                        }
+                        break;
+                    case Token.LC:
+                        if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
+                            matchToken(Token.LC, true);
+                        } else {
+                            reportError("msg.no.paren.catch");
+                        }
+                        break;
+                    default:
+                        reportError("msg.no.paren.catch");
+                        break;
+                }
 
                 Block catchBlock = (Block) statements();
                 tryEnd = getNodeEnd(catchBlock);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4108,7 +4108,9 @@ public class ScriptRuntime {
 
         NativeObject catchScopeObject = new NativeObject();
         // See ECMA 12.4
-        catchScopeObject.defineProperty(exceptionName, obj, ScriptableObject.PERMANENT);
+        if (exceptionName != null) {
+            catchScopeObject.defineProperty(exceptionName, obj, ScriptableObject.PERMANENT);
+        }
 
         if (isVisible(cx, t)) {
             // Add special Rhino object __exception__ defined in the catch

--- a/src/org/mozilla/javascript/ast/CatchClause.java
+++ b/src/org/mozilla/javascript/ast/CatchClause.java
@@ -50,7 +50,6 @@ public class CatchClause extends AstNode {
      * Sets catch variable node, and sets its parent to this node.
      *
      * @param varName catch variable
-     * @throws IllegalArgumentException if varName is {@code null}
      */
     public void setVarName(Name varName) {
         this.varName = varName;

--- a/src/org/mozilla/javascript/ast/CatchClause.java
+++ b/src/org/mozilla/javascript/ast/CatchClause.java
@@ -9,8 +9,7 @@ package org.mozilla.javascript.ast;
 import org.mozilla.javascript.Token;
 
 /**
- * Node representing a catch-clause of a try-statement.
- * Node type is {@link Token#CATCH}.
+ * Node representing a catch-clause of a try-statement. Node type is {@link Token#CATCH}.
  *
  * <pre><i>CatchClause</i> :
  *        <b>catch</b> ( <i><b>Identifier</b></i> [<b>if</b> Expression] ) Block</pre>
@@ -28,8 +27,7 @@ public class CatchClause extends AstNode {
         type = Token.CATCH;
     }
 
-    public CatchClause() {
-    }
+    public CatchClause() {}
 
     public CatchClause(int pos) {
         super(pos);
@@ -41,6 +39,7 @@ public class CatchClause extends AstNode {
 
     /**
      * Returns catch variable node
+     *
      * @return catch variable
      */
     public Name getVarName() {
@@ -49,17 +48,20 @@ public class CatchClause extends AstNode {
 
     /**
      * Sets catch variable node, and sets its parent to this node.
+     *
      * @param varName catch variable
      * @throws IllegalArgumentException if varName is {@code null}
      */
     public void setVarName(Name varName) {
-        assertNotNull(varName);
         this.varName = varName;
-        varName.setParent(this);
+        if (varName != null) {
+            varName.setParent(this);
+        }
     }
 
     /**
      * Returns catch condition node, if present
+     *
      * @return catch condition node, {@code null} if not present
      */
     public AstNode getCatchCondition() {
@@ -68,23 +70,24 @@ public class CatchClause extends AstNode {
 
     /**
      * Sets catch condition node, and sets its parent to this node.
-     * @param catchCondition catch condition node.  Can be {@code null}.
+     *
+     * @param catchCondition catch condition node. Can be {@code null}.
      */
     public void setCatchCondition(AstNode catchCondition) {
         this.catchCondition = catchCondition;
-        if (catchCondition != null)
+        if (catchCondition != null) {
             catchCondition.setParent(this);
+        }
     }
 
-    /**
-     * Returns catch body
-     */
+    /** Returns catch body */
     public Block getBody() {
         return body;
     }
 
     /**
      * Sets catch body, and sets its parent to this node.
+     *
      * @throws IllegalArgumentException if body is {@code null}
      */
     public void setBody(Block body) {
@@ -93,37 +96,27 @@ public class CatchClause extends AstNode {
         body.setParent(this);
     }
 
-    /**
-     * Returns left paren position
-     */
+    /** Returns left paren position */
     public int getLp() {
         return lp;
     }
 
-    /**
-     * Sets left paren position
-     */
+    /** Sets left paren position */
     public void setLp(int lp) {
         this.lp = lp;
     }
 
-    /**
-     * Returns right paren position
-     */
+    /** Returns right paren position */
     public int getRp() {
         return rp;
     }
 
-    /**
-     * Sets right paren position
-     */
+    /** Sets right paren position */
     public void setRp(int rp) {
         this.rp = rp;
     }
 
-    /**
-     * Sets both paren positions
-     */
+    /** Sets both paren positions */
     public void setParens(int lp, int rp) {
         this.lp = lp;
         this.rp = rp;
@@ -131,6 +124,7 @@ public class CatchClause extends AstNode {
 
     /**
      * Returns position of "if" keyword
+     *
      * @return position of "if" keyword, if present, or -1
      */
     public int getIfPosition() {
@@ -139,6 +133,7 @@ public class CatchClause extends AstNode {
 
     /**
      * Sets position of "if" keyword
+     *
      * @param ifPosition position of "if" keyword, if present, or -1
      */
     public void setIfPosition(int ifPosition) {
@@ -161,8 +156,8 @@ public class CatchClause extends AstNode {
     }
 
     /**
-     * Visits this node, the catch var name node, the condition if
-     * non-{@code null}, and the catch body.
+     * Visits this node, the catch var name node, the condition if non-{@code null}, and the catch
+     * body.
      */
     @Override
     public void visit(NodeVisitor v) {

--- a/src/org/mozilla/javascript/ast/CatchClause.java
+++ b/src/org/mozilla/javascript/ast/CatchClause.java
@@ -18,7 +18,7 @@ public class CatchClause extends AstNode {
 
     private Name varName;
     private AstNode catchCondition;
-    private Block body;
+    private Scope body;
     private int ifPosition = -1;
     private int lp = -1;
     private int rp = -1;
@@ -81,7 +81,7 @@ public class CatchClause extends AstNode {
     }
 
     /** Returns catch body */
-    public Block getBody() {
+    public Scope getBody() {
         return body;
     }
 
@@ -90,7 +90,7 @@ public class CatchClause extends AstNode {
      *
      * @throws IllegalArgumentException if body is {@code null}
      */
-    public void setBody(Block body) {
+    public void setBody(Scope body) {
         assertNotNull(body);
         this.body = body;
         body.setParent(this);

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -692,7 +692,10 @@ class BodyCodegen {
                     int local = getLocalBlockRegister(node);
                     int scopeIndex = node.getExistingIntProp(Node.CATCH_SCOPE_PROP);
 
-                    String name = child.getString(); // name of exception
+                    String name = null;
+                    if (child.getType() == Token.NAME) {
+                        name = child.getString(); // name of exception
+                    }
                     child = child.getNext();
                     generateExpression(child, node); // load expression object
                     if (scopeIndex == 0) {
@@ -701,7 +704,11 @@ class BodyCodegen {
                         // Load previous catch scope object
                         cfw.addALoad(local);
                     }
-                    cfw.addPush(name);
+                    if (name != null) {
+                        cfw.addPush(name);
+                    } else {
+                        cfw.add(ByteCode.ACONST_NULL);
+                    }
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
 

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -6,7 +6,7 @@ package org.mozilla.javascript.tests;
 
 import java.io.IOException;
 import java.util.List;
-
+import junit.framework.TestCase;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ErrorReporter;
@@ -47,70 +47,58 @@ import org.mozilla.javascript.ast.VariableInitializer;
 import org.mozilla.javascript.ast.WithStatement;
 import org.mozilla.javascript.testing.TestErrorReporter;
 
-import junit.framework.TestCase;
-
 public class ParserTest extends TestCase {
     CompilerEnvirons environment;
 
     @Override
     protected void setUp() throws Exception {
-      super.setUp();
-      environment = new CompilerEnvirons();
+        super.setUp();
+        environment = new CompilerEnvirons();
     }
 
     public void testAutoSemiColonBetweenNames() {
         AstRoot root = parse("\nx\ny\nz\n");
-        AstNode first = ((ExpressionStatement)
-            root.getFirstChild()).getExpression();
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("x", first.getString());
-        AstNode second = ((ExpressionStatement)
-            root.getFirstChild().getNext()).getExpression();
+        AstNode second = ((ExpressionStatement) root.getFirstChild().getNext()).getExpression();
         assertEquals("y", second.getString());
-        AstNode third = ((ExpressionStatement)
-            root.getFirstChild().getNext().getNext()).getExpression();
+        AstNode third =
+                ((ExpressionStatement) root.getFirstChild().getNext().getNext()).getExpression();
         assertEquals("z", third.getString());
     }
 
     public void testParseAutoSemiColonBeforeNewlineAndComments() throws IOException {
-        AstRoot root = parseAsReader(
-                "var s = 3\n"
-                + "/* */ /*  test comment */ var t = 1;");
+        AstRoot root = parseAsReader("var s = 3\n" + "/* */ /*  test comment */ var t = 1;");
         assertNotNull(root.getComments());
         assertEquals(2, root.getComments().size());
 
         assertEquals("var s = 3;\nvar t = 1;\n", root.toSource());
     }
-    
-    public void testCommentInArray() throws IOException{
-        //Test a single comment
-        AstRoot root = parseAsReader(
-                "var array = [/**/];");
+
+    public void testCommentInArray() throws IOException {
+        // Test a single comment
+        AstRoot root = parseAsReader("var array = [/**/];");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
-        assertEquals(root.toSource(),"var array = [];\n");
-        //Test multiple comments
-        root = parseAsReader(
-                "var array = [/*Hello*/ /*World*/ 1,2];");
+        assertEquals(root.toSource(), "var array = [];\n");
+        // Test multiple comments
+        root = parseAsReader("var array = [/*Hello*/ /*World*/ 1,2];");
         assertNotNull(root.getComments());
         assertEquals(2, root.getComments().size());
-        assertEquals(root.toSource(),"var array = [1, 2];\n");
-        //Test no comments
-        root = parseAsReader(
-                "var array = [1,2];");
+        assertEquals(root.toSource(), "var array = [1, 2];\n");
+        // Test no comments
+        root = parseAsReader("var array = [1,2];");
         assertNull(root.getComments());
-        assertEquals(root.toSource(),"var array = [1, 2];\n");
-        root = parseAsReader(
-                "var array = [1,/*hello*/2,/*World*/3];");
-        //Test comments in middle
+        assertEquals(root.toSource(), "var array = [1, 2];\n");
+        root = parseAsReader("var array = [1,/*hello*/2,/*World*/3];");
+        // Test comments in middle
         assertNotNull(root.getComments());
         assertEquals(2, root.getComments().size());
-        assertEquals(root.toSource(),"var array = [1, 2, 3];\n");
+        assertEquals(root.toSource(), "var array = [1, 2, 3];\n");
     }
 
     public void testNewlineAndComments() throws IOException {
-        AstRoot root = parseAsReader(
-                "var s = 3;\n"
-                + "/* */ /* txt */var t = 1");
+        AstRoot root = parseAsReader("var s = 3;\n" + "/* */ /* txt */var t = 1");
         assertNotNull(root.getComments());
         assertEquals(2, root.getComments().size());
 
@@ -118,15 +106,13 @@ public class ParserTest extends TestCase {
     }
 
     public void testNewlineAndCommentsFunction() {
-        AstRoot root = parse(
-            "f('2345' // Second arg\n);");
+        AstRoot root = parse("f('2345' // Second arg\n);");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
     }
 
     public void testNewlineAndCommentsFunction2() {
-        AstRoot root = parse(
-            "f('1234',\n// Before\n'2345' // Second arg\n);");
+        AstRoot root = parse("f('1234',\n// Before\n'2345' // Second arg\n);");
         assertNotNull(root.getComments());
         assertEquals(2, root.getComments().size());
     }
@@ -247,17 +233,18 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoLiteral() {
-        AstRoot root = parse(
-            "\nvar d =\n" +
-            "    \"foo\";\n" +
-            "var e =\n" +
-            "    1;\n" +
-            "var f = \n" +
-            "    1.2;\n" +
-            "var g = \n" +
-            "    2e5;\n" +
-            "var h = \n" +
-            "    'bar';\n");
+        AstRoot root =
+                parse(
+                        "\nvar d =\n"
+                                + "    \"foo\";\n"
+                                + "var e =\n"
+                                + "    1;\n"
+                                + "var f = \n"
+                                + "    1.2;\n"
+                                + "var g = \n"
+                                + "    2e5;\n"
+                                + "var h = \n"
+                                + "    'bar';\n");
 
         VariableDeclaration stmt1 = (VariableDeclaration) root.getFirstChild();
         List<VariableInitializer> vars1 = stmt1.getVariables();
@@ -272,7 +259,7 @@ public class ParserTest extends TestCase {
         AstNode secondVarLiteral = secondVar.getInitializer();
 
         VariableDeclaration stmt3 = (VariableDeclaration) stmt2.getNext();
-       List<VariableInitializer> vars3 = stmt3.getVariables();
+        List<VariableInitializer> vars3 = stmt3.getVariables();
         VariableInitializer thirdVar = vars3.get(0);
         Name thirdVarName = (Name) thirdVar.getTarget();
         AstNode thirdVarLiteral = thirdVar.getInitializer();
@@ -297,15 +284,16 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoSwitch() {
-        AstRoot root = parse(
-            "\nswitch (a) {\n" +
-            "   case\n" +
-            "     1:\n" +
-            "     b++;\n" +
-            "   case 2:\n" +
-            "   default:\n" +
-            "     b--;\n" +
-            "  }\n");
+        AstRoot root =
+                parse(
+                        "\nswitch (a) {\n"
+                                + "   case\n"
+                                + "     1:\n"
+                                + "     b++;\n"
+                                + "   case 2:\n"
+                                + "   default:\n"
+                                + "     b--;\n"
+                                + "  }\n");
 
         SwitchStatement switchStmt = (SwitchStatement) root.getFirstChild();
         AstNode switchVar = switchStmt.getExpression();
@@ -332,15 +320,15 @@ public class ParserTest extends TestCase {
         assertEquals(6, defaultCase.getLineno());
     }
 
-
     public void testLinenoFunctionParams() {
-        AstRoot root = parse(
-            "\nfunction\n" +
-            "    foo(\n" +
-            "    a,\n" +
-            "    b,\n" +
-            "    c) {\n" +
-            "}\n");
+        AstRoot root =
+                parse(
+                        "\nfunction\n"
+                                + "    foo(\n"
+                                + "    a,\n"
+                                + "    b,\n"
+                                + "    c) {\n"
+                                + "}\n");
         FunctionNode function = (FunctionNode) root.getFirstChild();
         Name functionName = function.getFunctionName();
 
@@ -359,76 +347,70 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoVarDecl() {
-      AstRoot root = parse(
-          "\nvar\n" +
-          "    a =\n" +
-          "    3\n");
+        AstRoot root = parse("\nvar\n" + "    a =\n" + "    3\n");
 
-      VariableDeclaration decl = (VariableDeclaration) root.getFirstChild();
-      List<VariableInitializer> vars = decl.getVariables();
-      VariableInitializer init = vars.get(0);
-      AstNode declName = init.getTarget();
-      AstNode expr = init.getInitializer();
+        VariableDeclaration decl = (VariableDeclaration) root.getFirstChild();
+        List<VariableInitializer> vars = decl.getVariables();
+        VariableInitializer init = vars.get(0);
+        AstNode declName = init.getTarget();
+        AstNode expr = init.getInitializer();
 
-      assertEquals(1, decl.getLineno());
-      assertEquals(2, init.getLineno());
-      assertEquals(2, declName.getLineno());
-      assertEquals(3, expr.getLineno());
+        assertEquals(1, decl.getLineno());
+        assertEquals(2, init.getLineno());
+        assertEquals(2, declName.getLineno());
+        assertEquals(3, expr.getLineno());
     }
 
     public void testLinenoReturn() {
-      AstRoot root = parse(
-          "\nfunction\n" +
-          "    foo(\n" +
-          "    a,\n" +
-          "    b,\n" +
-          "    c) {\n" +
-          "    return\n" +
-          "    4;\n" +
-          "}\n");
-      FunctionNode function = (FunctionNode) root.getFirstChild();
-      Name functionName = function.getFunctionName();
+        AstRoot root =
+                parse(
+                        "\nfunction\n"
+                                + "    foo(\n"
+                                + "    a,\n"
+                                + "    b,\n"
+                                + "    c) {\n"
+                                + "    return\n"
+                                + "    4;\n"
+                                + "}\n");
+        FunctionNode function = (FunctionNode) root.getFirstChild();
+        Name functionName = function.getFunctionName();
 
-      AstNode body = function.getBody();
-      ReturnStatement returnStmt = (ReturnStatement) body.getFirstChild();
-      ExpressionStatement exprStmt = (ExpressionStatement) returnStmt.getNext();
-      AstNode returnVal = exprStmt.getExpression();
+        AstNode body = function.getBody();
+        ReturnStatement returnStmt = (ReturnStatement) body.getFirstChild();
+        ExpressionStatement exprStmt = (ExpressionStatement) returnStmt.getNext();
+        AstNode returnVal = exprStmt.getExpression();
 
-      assertEquals(6, returnStmt.getLineno());
-      assertEquals(7, exprStmt.getLineno());
-      assertEquals(7, returnVal.getLineno());
+        assertEquals(6, returnStmt.getLineno());
+        assertEquals(7, exprStmt.getLineno());
+        assertEquals(7, returnVal.getLineno());
     }
 
     public void testLinenoFor() {
-        AstRoot root = parse(
-            "\nfor(\n" +
-            ";\n" +
-            ";\n" +
-            ") {\n" +
-            "}\n");
+        AstRoot root = parse("\nfor(\n" + ";\n" + ";\n" + ") {\n" + "}\n");
 
         ForLoop forLoop = (ForLoop) root.getFirstChild();
         AstNode initClause = forLoop.getInitializer();
         AstNode condClause = forLoop.getCondition();
         AstNode incrClause = forLoop.getIncrement();
 
-      assertEquals(1, forLoop.getLineno());
-      assertEquals(2, initClause.getLineno());
-      assertEquals(3, condClause.getLineno());
-      assertEquals(4, incrClause.getLineno());
+        assertEquals(1, forLoop.getLineno());
+        assertEquals(2, initClause.getLineno());
+        assertEquals(3, condClause.getLineno());
+        assertEquals(4, incrClause.getLineno());
     }
 
     public void testLinenoInfix() {
-        AstRoot root = parse(
-            "\nvar d = a\n" +
-            "    + \n" +
-            "    b;\n" +
-            "var\n" +
-            "    e =\n" +
-            "    a +\n" +
-            "    c;\n" +
-            "var f = b\n" +
-            "    / c;\n");
+        AstRoot root =
+                parse(
+                        "\nvar d = a\n"
+                                + "    + \n"
+                                + "    b;\n"
+                                + "var\n"
+                                + "    e =\n"
+                                + "    a +\n"
+                                + "    c;\n"
+                                + "var f = b\n"
+                                + "    / c;\n");
 
         VariableDeclaration stmt1 = (VariableDeclaration) root.getFirstChild();
         List<VariableInitializer> vars1 = stmt1.getVariables();
@@ -472,10 +454,7 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoPrefix() {
-        AstRoot root = parse(
-            "\na++;\n" +
-            "   --\n" +
-            "   b;\n");
+        AstRoot root = parse("\na++;\n" + "   --\n" + "   b;\n");
 
         ExpressionStatement first = (ExpressionStatement) root.getFirstChild();
         ExpressionStatement secondStmt = (ExpressionStatement) first.getNext();
@@ -488,19 +467,20 @@ public class ParserTest extends TestCase {
         assertEquals(2, secondOp.getLineno());
         assertEquals(1, firstVarRef.getLineno());
         assertEquals(3, secondVarRef.getLineno());
-      }
+    }
 
     public void testLinenoIf() {
-        AstRoot root = parse(
-            "\nif\n" +
-            "   (a == 3)\n" +
-            "   {\n" +
-            "     b = 0;\n" +
-            "   }\n" +
-            "     else\n" +
-            "   {\n" +
-            "     c = 1;\n" +
-            "   }\n");
+        AstRoot root =
+                parse(
+                        "\nif\n"
+                                + "   (a == 3)\n"
+                                + "   {\n"
+                                + "     b = 0;\n"
+                                + "   }\n"
+                                + "     else\n"
+                                + "   {\n"
+                                + "     c = 1;\n"
+                                + "   }\n");
 
         IfStatement ifStmt = (IfStatement) root.getFirstChild();
         AstNode condClause = ifStmt.getCondition();
@@ -514,20 +494,21 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoTry() {
-        AstRoot root = parse(
-            "\ntry {\n" +
-            "    var x = 1;\n" +
-            "} catch\n" +
-            "    (err)\n" +
-            "{\n" +
-            "} finally {\n" +
-            "    var y = 2;\n" +
-            "}\n");
+        AstRoot root =
+                parse(
+                        "\ntry {\n"
+                                + "    var x = 1;\n"
+                                + "} catch\n"
+                                + "    (err)\n"
+                                + "{\n"
+                                + "} finally {\n"
+                                + "    var y = 2;\n"
+                                + "}\n");
 
         TryStatement tryStmt = (TryStatement) root.getFirstChild();
         AstNode tryBlock = tryStmt.getTryBlock();
         List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
-        CatchClause catchClause= catchBlocks.get(0);
+        CatchClause catchClause = catchBlocks.get(0);
         Block catchVarBlock = catchClause.getBody();
         Name catchVar = catchClause.getVarName();
         AstNode finallyBlock = tryStmt.getFinallyBlock();
@@ -540,16 +521,10 @@ public class ParserTest extends TestCase {
         assertEquals(3, catchClause.getLineno());
         assertEquals(6, finallyBlock.getLineno());
         assertEquals(7, finallyStmt.getLineno());
-      }
+    }
 
     public void testLinenoConditional() {
-         AstRoot root = parse(
-            "\na\n" +
-            "    ?\n" +
-            "    b\n" +
-            "    :\n" +
-            "    c\n" +
-            "    ;\n");
+        AstRoot root = parse("\na\n" + "    ?\n" + "    b\n" + "    :\n" + "    c\n" + "    ;\n");
 
         ExpressionStatement ex = (ExpressionStatement) root.getFirstChild();
         ConditionalExpression hook = (ConditionalExpression) ex.getExpression();
@@ -564,11 +539,7 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoLabel() {
-        AstRoot root = parse(
-            "\nfoo:\n" +
-            "a = 1;\n" +
-            "bar:\n" +
-            "b = 2;\n");
+        AstRoot root = parse("\nfoo:\n" + "a = 1;\n" + "bar:\n" + "b = 2;\n");
 
         LabeledStatement firstStmt = (LabeledStatement) root.getFirstChild();
         LabeledStatement secondStmt = (LabeledStatement) firstStmt.getNext();
@@ -578,10 +549,7 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoCompare() {
-        AstRoot root = parse(
-            "\na\n" +
-            "<\n" +
-            "b\n");
+        AstRoot root = parse("\na\n" + "<\n" + "b\n");
 
         ExpressionStatement expr = (ExpressionStatement) root.getFirstChild();
         InfixExpression compare = (InfixExpression) expr.getExpression();
@@ -594,10 +562,7 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoEq() {
-        AstRoot root = parse(
-            "\na\n" +
-            "==\n" +
-            "b\n");
+        AstRoot root = parse("\na\n" + "==\n" + "b\n");
         ExpressionStatement expr = (ExpressionStatement) root.getFirstChild();
         InfixExpression compare = (InfixExpression) expr.getExpression();
         AstNode lhs = compare.getLeft();
@@ -609,10 +574,7 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoPlusEq() {
-        AstRoot root = parse(
-            "\na\n" +
-            "+=\n" +
-            "b\n");
+        AstRoot root = parse("\na\n" + "+=\n" + "b\n");
         ExpressionStatement expr = (ExpressionStatement) root.getFirstChild();
         Assignment assign = (Assignment) expr.getExpression();
         AstNode lhs = assign.getLeft();
@@ -624,10 +586,7 @@ public class ParserTest extends TestCase {
     }
 
     public void testLinenoComma() {
-        AstRoot root = parse(
-            "\na,\n" +
-            "    b,\n" +
-            "    c;\n");
+        AstRoot root = parse("\na,\n" + "    b,\n" + "    c;\n");
 
         ExpressionStatement stmt = (ExpressionStatement) root.getFirstChild();
         InfixExpression comma1 = (InfixExpression) stmt.getExpression();
@@ -644,287 +603,262 @@ public class ParserTest extends TestCase {
     }
 
     public void testRegexpLocation() {
-      AstNode root = parse(
-          "\nvar path =\n" +
-          "      replace(\n" +
-          "/a/g," +
-          "'/');\n");
+        AstNode root = parse("\nvar path =\n" + "      replace(\n" + "/a/g," + "'/');\n");
 
-      VariableDeclaration firstVarDecl =
-          (VariableDeclaration) root.getFirstChild();
-      List<VariableInitializer> vars1 = firstVarDecl.getVariables();
-      VariableInitializer firstInitializer = vars1.get(0);
-      Name firstVarName = (Name) firstInitializer.getTarget();
-      FunctionCall callNode =(FunctionCall) firstInitializer.getInitializer();
-      AstNode fnName = callNode.getTarget();
-      List<AstNode> args = callNode.getArguments();
-      RegExpLiteral regexObject = (RegExpLiteral) args.get(0);
-      AstNode aString = args.get(1);
+        VariableDeclaration firstVarDecl = (VariableDeclaration) root.getFirstChild();
+        List<VariableInitializer> vars1 = firstVarDecl.getVariables();
+        VariableInitializer firstInitializer = vars1.get(0);
+        Name firstVarName = (Name) firstInitializer.getTarget();
+        FunctionCall callNode = (FunctionCall) firstInitializer.getInitializer();
+        AstNode fnName = callNode.getTarget();
+        List<AstNode> args = callNode.getArguments();
+        RegExpLiteral regexObject = (RegExpLiteral) args.get(0);
+        AstNode aString = args.get(1);
 
-      assertEquals(1, firstVarDecl.getLineno());
-      assertEquals(1, firstVarName.getLineno());
-      assertEquals(2, callNode.getLineno());
-      assertEquals(2, fnName.getLineno());
-      assertEquals(3, regexObject.getLineno());
-      assertEquals(3, aString.getLineno());
+        assertEquals(1, firstVarDecl.getLineno());
+        assertEquals(1, firstVarName.getLineno());
+        assertEquals(2, callNode.getLineno());
+        assertEquals(2, fnName.getLineno());
+        assertEquals(3, regexObject.getLineno());
+        assertEquals(3, aString.getLineno());
     }
 
     public void testNestedOr() {
-      AstNode root = parse(
-          "\nif (a && \n" +
-          "    b() || \n" +
-          "    /* comment */\n" +
-          "    c) {\n" +
-          "}\n"
-                           );
+        AstNode root =
+                parse(
+                        "\nif (a && \n"
+                                + "    b() || \n"
+                                + "    /* comment */\n"
+                                + "    c) {\n"
+                                + "}\n");
 
-      IfStatement ifStmt = (IfStatement) root.getFirstChild();
-      InfixExpression orClause = (InfixExpression) ifStmt.getCondition();
-      InfixExpression andClause = (InfixExpression) orClause.getLeft();
-      AstNode cName = orClause.getRight();
+        IfStatement ifStmt = (IfStatement) root.getFirstChild();
+        InfixExpression orClause = (InfixExpression) ifStmt.getCondition();
+        InfixExpression andClause = (InfixExpression) orClause.getLeft();
+        AstNode cName = orClause.getRight();
 
-      assertEquals(1, ifStmt.getLineno());
-      assertEquals(1, orClause.getLineno());
-      assertEquals(1, andClause.getLineno());
-      assertEquals(4, cName.getLineno());
-
+        assertEquals(1, ifStmt.getLineno());
+        assertEquals(1, orClause.getLineno());
+        assertEquals(1, andClause.getLineno());
+        assertEquals(4, cName.getLineno());
     }
 
     public void testObjectLitGetterAndSetter() {
-        AstNode root = parse(
-            "'use strict';\n" +
-            "function App() {}\n" +
-            "App.prototype = {\n" +
-            "  get appData() { return this.appData_; },\n" +
-            "  set appData(data) { this.appData_ = data; }\n" +
-            "};");
+        AstNode root =
+                parse(
+                        "'use strict';\n"
+                                + "function App() {}\n"
+                                + "App.prototype = {\n"
+                                + "  get appData() { return this.appData_; },\n"
+                                + "  set appData(data) { this.appData_ = data; }\n"
+                                + "};");
         assertNotNull(root);
     }
 
     public void testObjectLitLocation() {
-      AstNode root = parse(
-          "\nvar foo =\n" +
-          "{ \n" +
-          "'A' : 'A', \n" +
-          "'B' : 'B', \n" +
-          "'C' : \n" +
-          "      'C' \n" +
-          "};\n");
+        AstNode root =
+                parse(
+                        "\nvar foo =\n"
+                                + "{ \n"
+                                + "'A' : 'A', \n"
+                                + "'B' : 'B', \n"
+                                + "'C' : \n"
+                                + "      'C' \n"
+                                + "};\n");
 
-      VariableDeclaration firstVarDecl =
-          (VariableDeclaration) root.getFirstChild();
-      List<VariableInitializer> vars1 = firstVarDecl.getVariables();
-      VariableInitializer firstInitializer = vars1.get(0);
-      Name firstVarName = (Name) firstInitializer.getTarget();
+        VariableDeclaration firstVarDecl = (VariableDeclaration) root.getFirstChild();
+        List<VariableInitializer> vars1 = firstVarDecl.getVariables();
+        VariableInitializer firstInitializer = vars1.get(0);
+        Name firstVarName = (Name) firstInitializer.getTarget();
 
-      ObjectLiteral objectLiteral =
-          (ObjectLiteral) firstInitializer.getInitializer();
-      List<ObjectProperty> props = objectLiteral.getElements();
-      ObjectProperty firstObjectLit = props.get(0);
-      ObjectProperty secondObjectLit = props.get(1);
-      ObjectProperty thirdObjectLit = props.get(2);
+        ObjectLiteral objectLiteral = (ObjectLiteral) firstInitializer.getInitializer();
+        List<ObjectProperty> props = objectLiteral.getElements();
+        ObjectProperty firstObjectLit = props.get(0);
+        ObjectProperty secondObjectLit = props.get(1);
+        ObjectProperty thirdObjectLit = props.get(2);
 
-      AstNode firstKey = firstObjectLit.getLeft();
-      AstNode firstValue = firstObjectLit.getRight();
-      AstNode secondKey = secondObjectLit.getLeft();
-      AstNode secondValue = secondObjectLit.getRight();
-      AstNode thirdKey = thirdObjectLit.getLeft();
-      AstNode thirdValue = thirdObjectLit.getRight();
+        AstNode firstKey = firstObjectLit.getLeft();
+        AstNode firstValue = firstObjectLit.getRight();
+        AstNode secondKey = secondObjectLit.getLeft();
+        AstNode secondValue = secondObjectLit.getRight();
+        AstNode thirdKey = thirdObjectLit.getLeft();
+        AstNode thirdValue = thirdObjectLit.getRight();
 
-      assertEquals(1, firstVarName.getLineno());
-      assertEquals(2, objectLiteral.getLineno());
-      assertEquals(3, firstObjectLit.getLineno());
-      assertEquals(3, firstKey.getLineno());
-      assertEquals(3, firstValue.getLineno());
+        assertEquals(1, firstVarName.getLineno());
+        assertEquals(2, objectLiteral.getLineno());
+        assertEquals(3, firstObjectLit.getLineno());
+        assertEquals(3, firstKey.getLineno());
+        assertEquals(3, firstValue.getLineno());
 
-      assertEquals(4, secondKey.getLineno());
-      assertEquals(4, secondValue.getLineno());
+        assertEquals(4, secondKey.getLineno());
+        assertEquals(4, secondValue.getLineno());
 
-      assertEquals(5, thirdKey.getLineno());
-      assertEquals(6, thirdValue.getLineno());
+        assertEquals(5, thirdKey.getLineno());
+        assertEquals(6, thirdValue.getLineno());
     }
 
     public void testTryWithoutCatchLocation() {
-      AstNode root = parse(
-          "\ntry {\n" +
-          "  var x = 1;\n" +
-          "} finally {\n" +
-          "  var y = 2;\n" +
-          "}\n");
+        AstNode root =
+                parse("\ntry {\n" + "  var x = 1;\n" + "} finally {\n" + "  var y = 2;\n" + "}\n");
 
-      TryStatement tryStmt = (TryStatement) root.getFirstChild();
-      AstNode tryBlock = tryStmt.getTryBlock();
-      List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
-      Scope finallyBlock = (Scope) tryStmt.getFinallyBlock();
-      AstNode finallyStmt = (AstNode) finallyBlock.getFirstChild();
+        TryStatement tryStmt = (TryStatement) root.getFirstChild();
+        AstNode tryBlock = tryStmt.getTryBlock();
+        List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
+        Scope finallyBlock = (Scope) tryStmt.getFinallyBlock();
+        AstNode finallyStmt = (AstNode) finallyBlock.getFirstChild();
 
-      assertEquals(1, tryStmt.getLineno());
-      assertEquals(1, tryBlock.getLineno());
-      assertEquals(3, finallyBlock.getLineno());
-      assertEquals(4, finallyStmt.getLineno());
+        assertEquals(1, tryStmt.getLineno());
+        assertEquals(1, tryBlock.getLineno());
+        assertEquals(3, finallyBlock.getLineno());
+        assertEquals(4, finallyStmt.getLineno());
     }
 
     public void testTryWithoutFinallyLocation() {
-      AstNode root = parse(
-          "\ntry {\n" +
-          "  var x = 1;\n" +
-          "} catch (ex) {\n" +
-          "  var y = 2;\n" +
-          "}\n");
+        AstNode root =
+                parse(
+                        "\ntry {\n"
+                                + "  var x = 1;\n"
+                                + "} catch (ex) {\n"
+                                + "  var y = 2;\n"
+                                + "}\n");
 
-      TryStatement tryStmt = (TryStatement) root.getFirstChild();
-      Scope tryBlock = (Scope) tryStmt.getTryBlock();
-      List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
-      CatchClause catchClause = catchBlocks.get(0);
-      AstNode catchStmt = catchClause.getBody();
-      AstNode exceptionVar = catchClause.getVarName();
-      AstNode varDecl = (AstNode) catchStmt.getFirstChild();
+        TryStatement tryStmt = (TryStatement) root.getFirstChild();
+        Scope tryBlock = (Scope) tryStmt.getTryBlock();
+        List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
+        CatchClause catchClause = catchBlocks.get(0);
+        AstNode catchStmt = catchClause.getBody();
+        AstNode exceptionVar = catchClause.getVarName();
+        AstNode varDecl = (AstNode) catchStmt.getFirstChild();
 
-      assertEquals(1, tryStmt.getLineno());
-      assertEquals(1, tryBlock.getLineno());
-      assertEquals(3, catchClause.getLineno());
-      assertEquals(3, catchStmt.getLineno());
-      assertEquals(3, exceptionVar.getLineno());
-      assertEquals(4, varDecl.getLineno());
+        assertEquals(1, tryStmt.getLineno());
+        assertEquals(1, tryBlock.getLineno());
+        assertEquals(3, catchClause.getLineno());
+        assertEquals(3, catchStmt.getLineno());
+        assertEquals(3, exceptionVar.getLineno());
+        assertEquals(4, varDecl.getLineno());
     }
 
     public void testLinenoMultilineEq() {
-      AstRoot root = parse(
-          "\nif\n" +
-          "    (((a == \n" +
-          "  3) && \n" +
-          "  (b == 2)) || \n" +
-          " (c == 1)) {\n" +
-          "}\n");
-      IfStatement ifStmt = (IfStatement) root.getFirstChild();
-      InfixExpression orTest = (InfixExpression) ifStmt.getCondition();
-      ParenthesizedExpression cTestParen =
-          (ParenthesizedExpression) orTest.getRight();
-      InfixExpression cTest = (InfixExpression) cTestParen.getExpression();
-      ParenthesizedExpression andTestParen =
-          (ParenthesizedExpression) orTest.getLeft();
-      InfixExpression andTest = (InfixExpression) andTestParen.getExpression();
-      AstNode aTest = andTest.getLeft();
-      AstNode bTest = andTest.getRight();
+        AstRoot root =
+                parse(
+                        "\nif\n"
+                                + "    (((a == \n"
+                                + "  3) && \n"
+                                + "  (b == 2)) || \n"
+                                + " (c == 1)) {\n"
+                                + "}\n");
+        IfStatement ifStmt = (IfStatement) root.getFirstChild();
+        InfixExpression orTest = (InfixExpression) ifStmt.getCondition();
+        ParenthesizedExpression cTestParen = (ParenthesizedExpression) orTest.getRight();
+        InfixExpression cTest = (InfixExpression) cTestParen.getExpression();
+        ParenthesizedExpression andTestParen = (ParenthesizedExpression) orTest.getLeft();
+        InfixExpression andTest = (InfixExpression) andTestParen.getExpression();
+        AstNode aTest = andTest.getLeft();
+        AstNode bTest = andTest.getRight();
 
-      assertEquals(1, ifStmt.getLineno());
-      assertEquals(2, orTest.getLineno());
-      assertEquals(2, andTest.getLineno());
-      assertEquals(2, aTest.getLineno());
-      assertEquals(4, bTest.getLineno());
-      assertEquals(5, cTest.getLineno());
-      assertEquals(5, cTestParen.getLineno());
-      assertEquals(2, andTestParen.getLineno());
+        assertEquals(1, ifStmt.getLineno());
+        assertEquals(2, orTest.getLineno());
+        assertEquals(2, andTest.getLineno());
+        assertEquals(2, aTest.getLineno());
+        assertEquals(4, bTest.getLineno());
+        assertEquals(5, cTest.getLineno());
+        assertEquals(5, cTestParen.getLineno());
+        assertEquals(2, andTestParen.getLineno());
     }
 
     public void testLinenoMultilineBitTest() {
-      AstRoot root = parse(
-          "\nif (\n" +
-          "      ((a \n" +
-          "        | 3 \n" +
-          "       ) == \n" +
-          "       (b \n" +
-          "        & 2)) && \n" +
-          "      ((a \n" +
-          "         ^ 0xffff) \n" +
-          "       != \n" +
-          "       (c \n" +
-          "        << 1))) {\n" +
-          "}\n");
+        AstRoot root =
+                parse(
+                        "\nif (\n"
+                                + "      ((a \n"
+                                + "        | 3 \n"
+                                + "       ) == \n"
+                                + "       (b \n"
+                                + "        & 2)) && \n"
+                                + "      ((a \n"
+                                + "         ^ 0xffff) \n"
+                                + "       != \n"
+                                + "       (c \n"
+                                + "        << 1))) {\n"
+                                + "}\n");
 
-      IfStatement ifStmt = (IfStatement) root.getFirstChild();
-      InfixExpression andTest = (InfixExpression) ifStmt.getCondition();
-      ParenthesizedExpression bigLHSExpr =
-          (ParenthesizedExpression) andTest.getLeft();
-      ParenthesizedExpression bigRHSExpr =
-          (ParenthesizedExpression) andTest.getRight();
+        IfStatement ifStmt = (IfStatement) root.getFirstChild();
+        InfixExpression andTest = (InfixExpression) ifStmt.getCondition();
+        ParenthesizedExpression bigLHSExpr = (ParenthesizedExpression) andTest.getLeft();
+        ParenthesizedExpression bigRHSExpr = (ParenthesizedExpression) andTest.getRight();
 
-      InfixExpression eqTest = (InfixExpression) bigLHSExpr.getExpression();
-      InfixExpression notEqTest = (InfixExpression) bigRHSExpr.getExpression();
+        InfixExpression eqTest = (InfixExpression) bigLHSExpr.getExpression();
+        InfixExpression notEqTest = (InfixExpression) bigRHSExpr.getExpression();
 
-      ParenthesizedExpression test1Expr =
-          (ParenthesizedExpression) eqTest.getLeft();
-      ParenthesizedExpression test2Expr =
-          (ParenthesizedExpression) eqTest.getRight();
+        ParenthesizedExpression test1Expr = (ParenthesizedExpression) eqTest.getLeft();
+        ParenthesizedExpression test2Expr = (ParenthesizedExpression) eqTest.getRight();
 
-      ParenthesizedExpression test3Expr =
-          (ParenthesizedExpression) notEqTest.getLeft();
-      ParenthesizedExpression test4Expr =
-          (ParenthesizedExpression) notEqTest.getRight();
+        ParenthesizedExpression test3Expr = (ParenthesizedExpression) notEqTest.getLeft();
+        ParenthesizedExpression test4Expr = (ParenthesizedExpression) notEqTest.getRight();
 
-      InfixExpression bitOrTest = (InfixExpression) test1Expr.getExpression();
-      InfixExpression bitAndTest = (InfixExpression) test2Expr.getExpression();
-      InfixExpression bitXorTest = (InfixExpression) test3Expr.getExpression();
-      InfixExpression bitShiftTest = (InfixExpression) test4Expr.getExpression();
+        InfixExpression bitOrTest = (InfixExpression) test1Expr.getExpression();
+        InfixExpression bitAndTest = (InfixExpression) test2Expr.getExpression();
+        InfixExpression bitXorTest = (InfixExpression) test3Expr.getExpression();
+        InfixExpression bitShiftTest = (InfixExpression) test4Expr.getExpression();
 
-      assertEquals(1, ifStmt.getLineno());
+        assertEquals(1, ifStmt.getLineno());
 
-      assertEquals(2, bigLHSExpr.getLineno());
-      assertEquals(7, bigRHSExpr.getLineno());
-      assertEquals(2, eqTest.getLineno());
-      assertEquals(7, notEqTest.getLineno());
+        assertEquals(2, bigLHSExpr.getLineno());
+        assertEquals(7, bigRHSExpr.getLineno());
+        assertEquals(2, eqTest.getLineno());
+        assertEquals(7, notEqTest.getLineno());
 
-      assertEquals(2, test1Expr.getLineno());
-      assertEquals(5, test2Expr.getLineno());
-      assertEquals(7, test3Expr.getLineno());
-      assertEquals(10, test4Expr.getLineno());
+        assertEquals(2, test1Expr.getLineno());
+        assertEquals(5, test2Expr.getLineno());
+        assertEquals(7, test3Expr.getLineno());
+        assertEquals(10, test4Expr.getLineno());
 
-      assertEquals(2, bitOrTest.getLineno());
-      assertEquals(5, bitAndTest.getLineno());
-      assertEquals(7, bitXorTest.getLineno());
-      assertEquals(10, bitShiftTest.getLineno());
+        assertEquals(2, bitOrTest.getLineno());
+        assertEquals(5, bitAndTest.getLineno());
+        assertEquals(7, bitXorTest.getLineno());
+        assertEquals(10, bitShiftTest.getLineno());
     }
 
     public void testLinenoFunctionCall() {
-      AstNode root = parse(
-          "\nfoo.\n" +
-          "bar.\n" +
-          "baz(1);");
+        AstNode root = parse("\nfoo.\n" + "bar.\n" + "baz(1);");
 
-      ExpressionStatement stmt = (ExpressionStatement) root.getFirstChild();
-      FunctionCall fc = (FunctionCall) stmt.getExpression();
-      // Line number should get closest to the actual paren.
-      assertEquals(3, fc.getLineno());
+        ExpressionStatement stmt = (ExpressionStatement) root.getFirstChild();
+        FunctionCall fc = (FunctionCall) stmt.getExpression();
+        // Line number should get closest to the actual paren.
+        assertEquals(3, fc.getLineno());
     }
 
     public void testLinenoName() {
-      AstNode root = parse(
-          "\na;\n" +
-          "b.\n" +
-          "c;\n");
+        AstNode root = parse("\na;\n" + "b.\n" + "c;\n");
 
-      ExpressionStatement exprStmt = (ExpressionStatement) root.getFirstChild();
-      AstNode aRef = exprStmt.getExpression();
-      ExpressionStatement bExprStmt = (ExpressionStatement) exprStmt.getNext();
-      AstNode bRef = bExprStmt.getExpression();
+        ExpressionStatement exprStmt = (ExpressionStatement) root.getFirstChild();
+        AstNode aRef = exprStmt.getExpression();
+        ExpressionStatement bExprStmt = (ExpressionStatement) exprStmt.getNext();
+        AstNode bRef = bExprStmt.getExpression();
 
-      assertEquals(1, aRef.getLineno());
-      assertEquals(2, bRef.getLineno());
+        assertEquals(1, aRef.getLineno());
+        assertEquals(2, bRef.getLineno());
     }
 
     public void testLinenoDeclaration() {
-      AstNode root = parse(
-          "\na.\n" +
-          "b=\n" +
-          "function() {};\n");
+        AstNode root = parse("\na.\n" + "b=\n" + "function() {};\n");
 
-      ExpressionStatement exprStmt = (ExpressionStatement) root.getFirstChild();
-      Assignment fnAssignment = (Assignment) exprStmt.getExpression();
-      PropertyGet aDotbName = (PropertyGet) fnAssignment.getLeft();
-      AstNode aName = aDotbName.getLeft();
-      AstNode bName = aDotbName.getRight();
-      FunctionNode fnNode = (FunctionNode) fnAssignment.getRight();
+        ExpressionStatement exprStmt = (ExpressionStatement) root.getFirstChild();
+        Assignment fnAssignment = (Assignment) exprStmt.getExpression();
+        PropertyGet aDotbName = (PropertyGet) fnAssignment.getLeft();
+        AstNode aName = aDotbName.getLeft();
+        AstNode bName = aDotbName.getRight();
+        FunctionNode fnNode = (FunctionNode) fnAssignment.getRight();
 
-      assertEquals(1, fnAssignment.getLineno());
-      assertEquals(1, aDotbName.getLineno());
-      assertEquals(1, aName.getLineno());
-      assertEquals(2, bName.getLineno());
-      assertEquals(3, fnNode.getLineno());
+        assertEquals(1, fnAssignment.getLineno());
+        assertEquals(1, aDotbName.getLineno());
+        assertEquals(1, aName.getLineno());
+        assertEquals(2, bName.getLineno());
+        assertEquals(3, fnNode.getLineno());
     }
 
     public void testInOperatorInForLoop1() {
-        parse("var a={};function b_(p){ return p;};" +
-              "for(var i=b_(\"length\" in a);i<0;) {}");
+        parse("var a={};function b_(p){ return p;};" + "for(var i=b_(\"length\" in a);i<0;) {}");
     }
 
     public void testInOperatorInForLoop2() {
@@ -939,8 +873,7 @@ public class ParserTest extends TestCase {
         AstRoot root = parse("/** @type number */var a;");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
-        assertEquals("/** @type number */",
-                     root.getComments().first().getValue());
+        assertEquals("/** @type number */", root.getComments().first().getValue());
         assertNotNull(root.getFirstChild().getNext().getJsDoc());
     }
 
@@ -948,8 +881,7 @@ public class ParserTest extends TestCase {
         AstRoot root = parse("/** @type number */a.b;");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
-        assertEquals("/** @type number */",
-                     root.getComments().first().getValue());
+        assertEquals("/** @type number */", root.getComments().first().getValue());
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild().getNext();
         assertNotNull(st.getExpression().getJsDoc());
     }
@@ -958,8 +890,7 @@ public class ParserTest extends TestCase {
         AstRoot root = parse("var a = /** @type number */(x);");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
-        assertEquals("/** @type number */",
-                     root.getComments().first().getValue());
+        assertEquals("/** @type number */", root.getComments().first().getValue());
         VariableDeclaration vd = (VariableDeclaration) root.getFirstChild();
         VariableInitializer vi = vd.getVariables().get(0);
         assertNotNull(vi.getInitializer().getJsDoc());
@@ -982,8 +913,7 @@ public class ParserTest extends TestCase {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        NumberLiteral number =
-            (NumberLiteral) lit.getElements().get(0).getLeft();
+        NumberLiteral number = (NumberLiteral) lit.getElements().get(0).getLeft();
         assertNotNull(number.getJsDoc());
     }
 
@@ -995,8 +925,8 @@ public class ParserTest extends TestCase {
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
         for (ObjectProperty el : lit.getElements()) {
-          assertNull(el.getLeft().getJsDoc());
-          assertNull(el.getRight().getJsDoc());
+            assertNull(el.getLeft().getJsDoc());
+            assertNull(el.getRight().getJsDoc());
         }
     }
 
@@ -1007,8 +937,7 @@ public class ParserTest extends TestCase {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        StringLiteral stringLit =
-            (StringLiteral) lit.getElements().get(0).getLeft();
+        StringLiteral stringLit = (StringLiteral) lit.getElements().get(0).getLeft();
         assertNotNull(stringLit.getJsDoc());
     }
 
@@ -1020,7 +949,7 @@ public class ParserTest extends TestCase {
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
         ParenthesizedExpression parens =
-            (ParenthesizedExpression) lit.getElements().get(0).getRight();
+                (ParenthesizedExpression) lit.getElements().get(0).getRight();
         assertNotNull(parens.getJsDoc());
     }
 
@@ -1031,8 +960,7 @@ public class ParserTest extends TestCase {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        Name objLitKey =
-            (Name) lit.getElements().get(0).getLeft();
+        Name objLitKey = (Name) lit.getElements().get(0).getLeft();
         assertNotNull(objLitKey.getJsDoc());
     }
 
@@ -1044,56 +972,51 @@ public class ParserTest extends TestCase {
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
         ParenthesizedExpression parens =
-            (ParenthesizedExpression) lit.getElements().get(0).getRight();
+                (ParenthesizedExpression) lit.getElements().get(0).getRight();
         assertNotNull(parens.getJsDoc());
     }
 
     public void testJSDocAttachment11() {
-      AstRoot root = parse("({/** attach me */ get foo() {}});");
-      assertNotNull(root.getComments());
-      assertEquals(1, root.getComments().size());
-      ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
-      ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
-      ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-      Name objLitKey =
-          (Name) lit.getElements().get(0).getLeft();
-      assertNotNull(objLitKey.getJsDoc());
-  }
+        AstRoot root = parse("({/** attach me */ get foo() {}});");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+        ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
+        ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
+        ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
+        Name objLitKey = (Name) lit.getElements().get(0).getLeft();
+        assertNotNull(objLitKey.getJsDoc());
+    }
 
     public void testJSDocAttachment12() {
-      AstRoot root = parse("({/** attach me */ get 1() {}});");
-      assertNotNull(root.getComments());
-      assertEquals(1, root.getComments().size());
-      ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
-      ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
-      ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-      NumberLiteral number =
-          (NumberLiteral) lit.getElements().get(0).getLeft();
-      assertNotNull(number.getJsDoc());
-  }
+        AstRoot root = parse("({/** attach me */ get 1() {}});");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+        ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
+        ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
+        ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
+        NumberLiteral number = (NumberLiteral) lit.getElements().get(0).getLeft();
+        assertNotNull(number.getJsDoc());
+    }
 
-  public void testJSDocAttachment13() {
-      AstRoot root = parse("({/** attach me */ get 'foo'() {}});");
-      assertNotNull(root.getComments());
-      assertEquals(1, root.getComments().size());
-      ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
-      ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
-      ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-      StringLiteral stringLit =
-          (StringLiteral) lit.getElements().get(0).getLeft();
-      assertNotNull(stringLit.getJsDoc());
-  }
+    public void testJSDocAttachment13() {
+        AstRoot root = parse("({/** attach me */ get 'foo'() {}});");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+        ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
+        ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
+        ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
+        StringLiteral stringLit = (StringLiteral) lit.getElements().get(0).getLeft();
+        assertNotNull(stringLit.getJsDoc());
+    }
 
     public void testJSDocAttachment14() {
         AstRoot root = parse("var a = (/** @type {!Foo} */ {});");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
-        assertEquals("/** @type {!Foo} */",
-                     root.getComments().first().getValue());
+        assertEquals("/** @type {!Foo} */", root.getComments().first().getValue());
         VariableDeclaration vd = (VariableDeclaration) root.getFirstChild();
         VariableInitializer vi = vd.getVariables().get(0);
-        assertNotNull(((ParenthesizedExpression)vi.getInitializer())
-                       .getExpression().getJsDoc());
+        assertNotNull(((ParenthesizedExpression) vi.getInitializer()).getExpression().getJsDoc());
     }
 
     public void testJSDocAttachment15() {
@@ -1106,10 +1029,11 @@ public class ParserTest extends TestCase {
     }
 
     public void testJSDocAttachment16() {
-        AstRoot root = parse(
-        "/** @suppress {with} */ with (context) {\n" +
-        "  eval('[' + expr + ']');\n" +
-        "}\n");
+        AstRoot root =
+                parse(
+                        "/** @suppress {with} */ with (context) {\n"
+                                + "  eval('[' + expr + ']');\n"
+                                + "}\n");
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
 
@@ -1118,42 +1042,37 @@ public class ParserTest extends TestCase {
     }
 
     public void testJSDocAttachment17() {
-      AstRoot root = parse(
-      "try { throw 'a'; } catch (/** @type {string} */ e) {\n" +
-      "}\n");
-      assertNotNull(root.getComments());
-      assertEquals(1, root.getComments().size());
+        AstRoot root = parse("try { throw 'a'; } catch (/** @type {string} */ e) {\n" + "}\n");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
 
-      TryStatement tryNode = (TryStatement) root.getFirstChild();
-      CatchClause catchNode = tryNode.getCatchClauses().get(0);
-      assertNotNull(catchNode.getVarName().getJsDoc());
+        TryStatement tryNode = (TryStatement) root.getFirstChild();
+        CatchClause catchNode = tryNode.getCatchClauses().get(0);
+        assertNotNull(catchNode.getVarName().getJsDoc());
     }
 
     public void testJSDocAttachment18() {
-      AstRoot root = parse(
-      "function f(/** @type {string} */ e) {}\n");
-      assertNotNull(root.getComments());
-      assertEquals(1, root.getComments().size());
+        AstRoot root = parse("function f(/** @type {string} */ e) {}\n");
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
 
-      FunctionNode function = (FunctionNode) root.getFirstChild();
-      AstNode param = function.getParams().get(0);
-      assertNotNull(param.getJsDoc());
+        FunctionNode function = (FunctionNode) root.getFirstChild();
+        AstNode param = function.getParams().get(0);
+        assertNotNull(param.getJsDoc());
     }
 
     public void testParsingWithoutJSDoc() {
         AstRoot root = parse("var a = /** @type number */(x);", false);
         assertNotNull(root.getComments());
         assertEquals(1, root.getComments().size());
-        assertEquals("/** @type number */",
-                     root.getComments().first().getValue());
+        assertEquals("/** @type number */", root.getComments().first().getValue());
         VariableDeclaration vd = (VariableDeclaration) root.getFirstChild();
         VariableInitializer vi = vd.getVariables().get(0);
         assertTrue(vi.getInitializer() instanceof ParenthesizedExpression);
     }
 
     public void testParseCommentsAsReader() throws IOException {
-        AstRoot root = parseAsReader(
-            "/** a */var a;\n /** b */var b; /** c */var c;");
+        AstRoot root = parseAsReader("/** a */var a;\n /** b */var b; /** c */var c;");
         assertNotNull(root.getComments());
         assertEquals(3, root.getComments().size());
         Comment[] comments = new Comment[3];
@@ -1167,19 +1086,19 @@ public class ParserTest extends TestCase {
         String js = "";
         for (int i = 0; i < 100; i++) {
             String stri = Integer.toString(i);
-            js += "/** Some comment for a" + stri + " */" +
-                  "var a" + stri + " = " + stri + ";\n";
+            js += "/** Some comment for a" + stri + " */" + "var a" + stri + " = " + stri + ";\n";
         }
         AstRoot root = parseAsReader(js);
     }
 
     public void testLinenoCommentsWithJSDoc() throws IOException {
-        AstRoot root = parseAsReader(
-            "/* foo \n" +
-            " bar \n" +
-            "*/\n" +
-            "/** @param {string} x */\n" +
-            "function a(x) {};\n");
+        AstRoot root =
+                parseAsReader(
+                        "/* foo \n"
+                                + " bar \n"
+                                + "*/\n"
+                                + "/** @param {string} x */\n"
+                                + "function a(x) {};\n");
         assertNotNull(root.getComments());
         assertEquals(2, root.getComments().size());
         Comment[] comments = new Comment[2];
@@ -1197,98 +1116,97 @@ public class ParserTest extends TestCase {
 
     public void testParseUnicodeFormatName() {
         AstRoot root = parse("A\u200DB");
-        AstNode first = ((ExpressionStatement)
-            root.getFirstChild()).getExpression();
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("AB", first.getString());
     }
 
     public void testParseUnicodeReservedKeywords1() {
         AstRoot root = parse("\\u0069\\u0066");
-        AstNode first = ((ExpressionStatement)
-            root.getFirstChild()).getExpression();
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("i\\u0066", first.getString());
     }
 
     public void testParseUnicodeReservedKeywords2() {
         AstRoot root = parse("v\\u0061\\u0072");
-        AstNode first = ((ExpressionStatement)
-            root.getFirstChild()).getExpression();
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("va\\u0072", first.getString());
     }
 
     public void testParseUnicodeReservedKeywords3() {
         // All are keyword "while"
-        AstRoot root = parse("w\\u0068\\u0069\\u006C\\u0065;" +
-            "\\u0077\\u0068il\\u0065; \\u0077h\\u0069le;");
-        AstNode first = ((ExpressionStatement)
-            root.getFirstChild()).getExpression();
-        AstNode second = ((ExpressionStatement)
-            root.getFirstChild().getNext()).getExpression();
-        AstNode third = ((ExpressionStatement)
-            root.getFirstChild().getNext().getNext()).getExpression();
+        AstRoot root =
+                parse(
+                        "w\\u0068\\u0069\\u006C\\u0065;"
+                                + "\\u0077\\u0068il\\u0065; \\u0077h\\u0069le;");
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
+        AstNode second = ((ExpressionStatement) root.getFirstChild().getNext()).getExpression();
+        AstNode third =
+                ((ExpressionStatement) root.getFirstChild().getNext().getNext()).getExpression();
         assertEquals("whil\\u0065", first.getString());
         assertEquals("whil\\u0065", second.getString());
         assertEquals("whil\\u0065", third.getString());
     }
 
     public void testParseObjectLiteral1() {
-      environment.setReservedKeywordAsIdentifier(true);
+        environment.setReservedKeywordAsIdentifier(true);
 
-      parse("({a:1});");
-      parse("({'a':1});");
-      parse("({0:1});");
+        parse("({a:1});");
+        parse("({'a':1});");
+        parse("({0:1});");
 
-      // property getter and setter definitions accept string and number
-      parse("({get a() {return 1}});");
-      parse("({get 'a'() {return 1}});");
-      parse("({get 0() {return 1}});");
+        // property getter and setter definitions accept string and number
+        parse("({get a() {return 1}});");
+        parse("({get 'a'() {return 1}});");
+        parse("({get 0() {return 1}});");
 
-      parse("({set a(a) {return 1}});");
-      parse("({set 'a'(a) {return 1}});");
-      parse("({set 0(a) {return 1}});");
+        parse("({set a(a) {return 1}});");
+        parse("({set 'a'(a) {return 1}});");
+        parse("({set 0(a) {return 1}});");
 
-      // keywords ok
-      parse("({function:1});");
-      // reserved words ok
-      parse("({float:1});");
+        // keywords ok
+        parse("({function:1});");
+        // reserved words ok
+        parse("({float:1});");
     }
 
     public void testParseObjectLiteral2() {
-      // keywords, fail
-      environment.setReservedKeywordAsIdentifier(false);
-      expectParseErrors("({function:1});",
-          new String[] { "invalid property id" });
+        // keywords, fail
+        environment.setReservedKeywordAsIdentifier(false);
+        expectParseErrors("({function:1});", new String[] {"invalid property id"});
 
-      environment.setReservedKeywordAsIdentifier(true);
+        environment.setReservedKeywordAsIdentifier(true);
 
-      // keywords ok
-      parse("({function:1});");
+        // keywords ok
+        parse("({function:1});");
     }
 
     public void testParseObjectLiteral3() {
-      environment.setLanguageVersion(Context.VERSION_1_8);
-      environment.setReservedKeywordAsIdentifier(true);
-      parse("var {get} = {get:1};");
+        environment.setLanguageVersion(Context.VERSION_1_8);
+        environment.setReservedKeywordAsIdentifier(true);
+        parse("var {get} = {get:1};");
 
-      environment.setReservedKeywordAsIdentifier(false);
-      parse("var {get} = {get:1};");
-      expectParseErrors("var {get} = {if:1};",
-          new String[] { "invalid property id" });
+        environment.setReservedKeywordAsIdentifier(false);
+        parse("var {get} = {get:1};");
+        expectParseErrors("var {get} = {if:1};", new String[] {"invalid property id"});
     }
 
     public void testParseKeywordPropertyAccess() {
-      environment.setReservedKeywordAsIdentifier(true);
+        environment.setReservedKeywordAsIdentifier(true);
 
-      // keywords ok
-      parse("({function:1}).function;");
+        // keywords ok
+        parse("({function:1}).function;");
 
-      // reserved words ok.
-      parse("({import:1}).import;");
+        // reserved words ok.
+        parse("({import:1}).import;");
     }
 
     public void testThrowStatement() {
         environment.setStrictMode(true);
-        parse("function A(a) { switch (a) { default: throw \"some error\" } }", null, new String[]{"missing ; after statement"}, true);
+        parse(
+                "function A(a) { switch (a) { default: throw \"some error\" } }",
+                null,
+                new String[] {"missing ; after statement"},
+                true);
     }
 
     public void testParseErrorRecovery() {
@@ -1305,8 +1223,9 @@ public class ParserTest extends TestCase {
 
     public void testIdentifierIsReservedWordMessage() {
         environment.setReservedKeywordAsIdentifier(false);
-        expectParseErrors("interface: while (true){ }",
-                new String[] { "identifier is a reserved word: interface" });
+        expectParseErrors(
+                "interface: while (true){ }",
+                new String[] {"identifier is a reserved word: interface"});
     }
 
     // Check that error recovery is working by returning a parsing exception, but only
@@ -1315,28 +1234,26 @@ public class ParserTest extends TestCase {
     // of parsing errors that are expected.
     private void expectErrorWithRecovery(String code, int maxErrors) {
         environment.setRecoverFromErrors(true);
-        environment.setErrorReporter(new ErrorReporter()
-        {
-            private int errorCount = 0;
+        environment.setErrorReporter(
+                new ErrorReporter() {
+                    private int errorCount = 0;
 
-            @Override
-            public void warning(String msg, String name, int line, String str, int col)
-            {
-                throw new AssertionError("Not expecting a warning");
-            }
+                    @Override
+                    public void warning(String msg, String name, int line, String str, int col) {
+                        throw new AssertionError("Not expecting a warning");
+                    }
 
-            @Override
-            public EvaluatorException runtimeError(String msg, String name, int line, String str, int col)
-            {
-                return new EvaluatorException(msg, name, line, str, col);
-            }
+                    @Override
+                    public EvaluatorException runtimeError(
+                            String msg, String name, int line, String str, int col) {
+                        return new EvaluatorException(msg, name, line, str, col);
+                    }
 
-            @Override
-            public void error(String msg, String name, int line, String str, int col)
-            {
-                assertTrue(++errorCount <= maxErrors);
-            }
-        });
+                    @Override
+                    public void error(String msg, String name, int line, String str, int col) {
+                        assertTrue(++errorCount <= maxErrors);
+                    }
+                });
 
         Parser p = new Parser(environment);
         try {
@@ -1348,34 +1265,36 @@ public class ParserTest extends TestCase {
     }
 
     public void testReportError() {
-      expectParseErrors("'use strict';(function(eval) {})();",
-                        new String[] { "\"eval\" is not a valid identifier for this use in strict mode." });
+        expectParseErrors(
+                "'use strict';(function(eval) {})();",
+                new String[] {"\"eval\" is not a valid identifier for this use in strict mode."});
     }
 
     public void testBasicFunction() {
-      AstNode root = parse("function f() { return 1; }");
-      FunctionNode f = (FunctionNode)root.getFirstChild();
-      assertEquals("f", f.getName());
-      assertFalse(f.isGenerator());
-      assertFalse(f.isES6Generator());
+        AstNode root = parse("function f() { return 1; }");
+        FunctionNode f = (FunctionNode) root.getFirstChild();
+        assertEquals("f", f.getName());
+        assertFalse(f.isGenerator());
+        assertFalse(f.isES6Generator());
     }
 
     public void testES6Generator() {
-      environment.setLanguageVersion(Context.VERSION_ES6);
-      AstNode root = parse("function * g() { return true; }");
-      FunctionNode f = (FunctionNode)root.getFirstChild();
-      assertEquals("g", f.getName());
-      assertTrue(f.isGenerator());
-      assertTrue(f.isES6Generator());
+        environment.setLanguageVersion(Context.VERSION_ES6);
+        AstNode root = parse("function * g() { return true; }");
+        FunctionNode f = (FunctionNode) root.getFirstChild();
+        assertEquals("g", f.getName());
+        assertTrue(f.isGenerator());
+        assertTrue(f.isES6Generator());
     }
 
     public void testES6GeneratorNot() {
-      expectParseErrors("function * notES6() { return true; }",
-        new String[] { "missing ( before function parameters." });
+        expectParseErrors(
+                "function * notES6() { return true; }",
+                new String[] {"missing ( before function parameters."});
     }
 
-    private void expectParseErrors(String string, String [] errors) {
-      parse(string, errors, null, false);
+    private void expectParseErrors(String string, String[] errors) {
+        parse(string, errors, null, false);
     }
 
     private AstRoot parse(String string) {
@@ -1383,30 +1302,36 @@ public class ParserTest extends TestCase {
     }
 
     private AstRoot parse(String string, boolean jsdoc) {
-       return parse(string, null, null, jsdoc);
+        return parse(string, null, null, jsdoc);
     }
 
     private AstRoot parse(
-        String string, final String [] errors, final String [] warnings,
-        boolean jsdoc) {
+            String string, final String[] errors, final String[] warnings, boolean jsdoc) {
         return parse(string, errors, warnings, jsdoc, environment);
     }
 
-    static AstRoot parse(String string, final String [] errors, final String [] warnings,
-        boolean jsdoc, CompilerEnvirons env) {
+    static AstRoot parse(
+            String string,
+            final String[] errors,
+            final String[] warnings,
+            boolean jsdoc,
+            CompilerEnvirons env) {
         TestErrorReporter testErrorReporter =
-            new TestErrorReporter(errors, warnings) {
-                @Override
-                public EvaluatorException runtimeError(
-                    String message, String sourceName, int line, String lineSource,
-                    int lineOffset) {
-                    if (errors == null) {
-                        throw new UnsupportedOperationException();
+                new TestErrorReporter(errors, warnings) {
+                    @Override
+                    public EvaluatorException runtimeError(
+                            String message,
+                            String sourceName,
+                            int line,
+                            String lineSource,
+                            int lineOffset) {
+                        if (errors == null) {
+                            throw new UnsupportedOperationException();
+                        }
+                        return new EvaluatorException(
+                                message, sourceName, line, lineSource, lineOffset);
                     }
-                    return new EvaluatorException(
-                        message, sourceName, line, lineSource, lineOffset);
-                }
-            };
+                };
         env.setErrorReporter(testErrorReporter);
 
         env.setRecordingComments(true);

--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -16,7 +16,6 @@ import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.Assignment;
 import org.mozilla.javascript.ast.AstNode;
 import org.mozilla.javascript.ast.AstRoot;
-import org.mozilla.javascript.ast.Block;
 import org.mozilla.javascript.ast.CatchClause;
 import org.mozilla.javascript.ast.Comment;
 import org.mozilla.javascript.ast.ConditionalExpression;
@@ -509,7 +508,7 @@ public class ParserTest extends TestCase {
         AstNode tryBlock = tryStmt.getTryBlock();
         List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
         CatchClause catchClause = catchBlocks.get(0);
-        Block catchVarBlock = catchClause.getBody();
+        Scope catchVarBlock = catchClause.getBody();
         Name catchVar = catchClause.getVarName();
         AstNode finallyBlock = tryStmt.getFinallyBlock();
         AstNode finallyStmt = (AstNode) finallyBlock.getFirstChild();

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -6580,7 +6580,7 @@ language/statements/generators 225/259 (86.87%)
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/statements/try 112/195 (57.44%)
+language/statements/try 110/195 (56.41%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6685,8 +6685,6 @@ language/statements/try 112/195 (57.44%)
     cptn-try.js
     early-catch-function.js
     early-catch-lex.js
-    optional-catch-binding-lexical.js
-    scope-catch-block-lex-close.js
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js
     scope-catch-param-var-none.js non-strict

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -6580,7 +6580,7 @@ language/statements/generators 225/259 (86.87%)
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/statements/try 115/195 (58.97%)
+language/statements/try 112/195 (57.44%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6685,10 +6685,7 @@ language/statements/try 115/195 (58.97%)
     cptn-try.js
     early-catch-function.js
     early-catch-lex.js
-    optional-catch-binding.js
-    optional-catch-binding-finally.js
     optional-catch-binding-lexical.js
-    optional-catch-binding-throws.js
     scope-catch-block-lex-close.js
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#the_exception_identifier
```js
  try {
    JSON.parse(text);
    return true;
  } catch {
    return false;
  }
```

The omission of the exception value is implemented, but there are another error. ref. #915
We need to either fix #915 or ignore `VerifyError`.

Closes #965 