### PR TITLE
update test262 +test262.properties file (re)generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ test {
         systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
     }
     systemProperty 'test262properties', System.getProperty('test262properties')
+    systemProperty 'updateTest262properties', System.getProperty('updateTest262properties')
     maxHeapSize = "1g"
     testLogging.showStandardStreams = true
     // Many tests do not clean up contexts properly. This makes the tests much

--- a/testsrc/README.md
+++ b/testsrc/README.md
@@ -84,22 +84,19 @@ While the test262.properties file does support this (because it is a Java Proper
 While the [test262.properties](test262.properties) file could be manually updated, the tooling also comes with a mechanism to (re)generate the file based on the current revision of the test262 submodule and the results of running Test262SuiteTest against this revision on all standard optLevels (-1, 0 & 9)
 
 ```
-./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest -DupdateTest262properties [-Dtest262properties=testsrc/myOwn.properties]
+./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest --rerun-tasks -DupdateTest262properties [-Dtest262properties=testsrc/myOwn.properties]
 ```
 The .properties file generation can be parameterized to affect the output:
-- rollup: include only a single line for a subfolder that contains only failing tests. Default: true
-- stats: include stats on the # of failed and total tests. Default: true
-- unsupported: include files containing tests for unsupported features: Default: false
+- rollup: include only a single line for a subfolder that contains only failing tests
+- stats: include stats on the # of failed and total tests
+- unsupported: include files containing tests for unsupported features
 
 These defaults can be overridden by specifying a value for the `generateTest262properties` parameter:
-- all: rollup, stats and unsupported all true
+- all: rollup, stats and unsupported all true (default)
 - none: rollup, stats and unsupported all false
 - [rollup][stats][unsupported]: the ones included will be true
 
-Note: the tests must actually run for the .properties file to be updated. If gradle determines that nothing has changed since the last time the `test` command was run, it won't run the tests. Gradle can be forced to ignore its cache by including the `--rerun-tasks` commandline argument:
-```
-./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest --rerun-tasks -DupdateTest262properties
-```
+Note: the tests must actually run for the .properties file to be updated. If gradle determines that nothing has changed since the last time the `test` command was run, it won't run the tests. The `--rerun-tasks` argument forces gradle to run all tests 
 
 ## Running specific tests from the official ECMAScript Test Suite (test262)
 The default setup for running the test262 test suite is defined in [test262.properties](test262.properties).

--- a/testsrc/README.md
+++ b/testsrc/README.md
@@ -16,6 +16,9 @@ git submodule update
 
 After doing so, the `./gradlew test` command will also execute all tests that are part of the official ECMAScript Test Suite
 
+As Rhino isn't 100% compliant with the latest ECMAScript standard, there is a mechanism to define which tests to run/skip,
+through the [test262.properties](test262.properties) file, the format of which is discussed in the [test262.properties format](#test262.properties-format) section
+
 ## Optimization levels
 By default all tests are run 3 times, at optimization levels -1, 0 and 9.
 
@@ -32,14 +35,72 @@ This behavior can be changed through different means:
 
 ## Running a specific TestSuite
 ```
-./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest 
+./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest
 ```
 
+## test262.properties format
+The [test262.properties](test262.properties) file is used to specify which tests from the official ECMAScript Test Suite to include/exclude,
+so that the test suite can pass even though Rhino is not yet 100% standards compliant
+
+The [test262.properties](test262.properties) file:
+- lists the subfolders of the [test262](../test262) folder to include or exclude when running tests
+- lists the .js test files that are expected to fail per (sub)folder
+
+**Basics**
+```
+built-ins/Array <- include all the tests in the test262/built-ins/Array folder
+    from/calling-from-valid-1-noStrict.js <- but expect that this tests fails
+```
+If `built-ins/Array/from/calling-from-valid-1-noStrict.js` indeed fails, it wont fail the test suite. If it passes, this will be logged while running the test suite
+
+**Skipping entire folders**
+```
+~built-ins/decodeURI
+    name.js
+    S15.1.3.1_A2.4_T1.js
+    S15.1.3.1_A5.2.js
+```
+Folders can be prefixed with a `~` to mark the folder to be skipped entirely, for example because it contains all tests for a feature not yet supported by Rhino or because running the tests take a long time.
+Any files listed for a skipped folder will be skipped as well.
+
+**Expecting all files in a (sub)folder to fail**
+```
+built-ins/Array
+    *prototype/flatMap
+```
+If all files in a (sub) folder are expected to fail, instead of listing all files explicitly, the folder can be marked as expected to contain only failing tests by prefixing the folder path with an `*`
+
+**Comments**
+The test262.properties file uses the Java Properties format, with the folder/.js file paths being the property key. The value of each 'property' can be used to store a comment
+```
+~built-ins/Array All tests on the built-in Array class
+    *prototype/flatMap haven't gotten around to implementing flatMap yet
+```
+
+A Java Properties file can also have entire lines as comments, by prefixing the line with either `!` or `#`.
+While the test262.properties file does support this (because it is a Java Properties file), such line comments will be lost when (re)generating the test262.properties file!
+
+## Updating the test262.properties file
+While the [test262.properties](test262.properties) file could be manually updated, the tooling also comes with a mechanism to (re)generate the file based on the current revision of the test262 submodule and the results of running Test262SuiteTest against this revision on all standard optLevels (-1, 0 & 9)
+
+```
+./gradlew --tests org.mozilla.javascript.tests.Test262SuiteTest -DupdateTest262properties [-Dtest262properties=testsrc/myOwn.properties]
+```
+The .properties file generation can be parameterized to affect the output:
+- rollup: include only a single line for a subfolder that contains only failing tests. Default: true
+- stats: include stats on the # of failed and total tests. Default: true
+- unsupported: include files containing tests for unsupported features: Default: false
+
+These defaults can be overridden by specifying a value for the `generateTest262properties` parameter:
+- all: rollup, stats and unsupported all true
+- none: rollup, stats and unsupported all false
+- [rollup][stats][unsupported]: the ones included will be true
+
 ## Running specific tests from the official ECMAScript Test Suite (test262)
-As Rhino isn't 100% compliant with the latest ECMAScript standard, there is a mechanism to define which tests to run/skip. 
-The default is [test262.properties](test262.properties).
+The default setup for running the test262 test suite is defined in [test262.properties](test262.properties).
 
 Another .properties file to use can be specified using the `test262properties` commandline property
 ```
 ./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest -Dtest262properties=testsrc/myOwn.properties
 ```
+This allows the creation of a custom .properties file containing for example just the tests for one specific feature being implemented, which allows for (quickly) running just the tests for that specific feature

--- a/testsrc/README.md
+++ b/testsrc/README.md
@@ -60,21 +60,21 @@ If `built-ins/Array/from/calling-from-valid-1-noStrict.js` indeed fails, it wont
     S15.1.3.1_A2.4_T1.js
     S15.1.3.1_A5.2.js
 ```
-Folders can be prefixed with a `~` to mark the folder to be skipped entirely, for example because it contains all tests for a feature not yet supported by Rhino or because running the tests take a long time.
+Toplevel folders can be prefixed with a `~` to mark the folder to be skipped entirely, for example because it contains all tests for a feature not yet supported by Rhino or because running the tests take a long time.
 Any files listed for a skipped folder will be skipped as well.
 
 **Expecting all files in a (sub)folder to fail**
 ```
-built-ins/Array
-    *prototype/flatMap
+built-ins/Array <-- topLevel folder
+    prototype/flatMap <-- subfolder under topLevel folder
 ```
-If all files in a (sub) folder are expected to fail, instead of listing all files explicitly, the folder can be marked as expected to contain only failing tests by prefixing the folder path with an `*`
+If all files in a subfolder below a topLevel folderare expected to fail, instead of listing all files explicitly, just the path of the folder needs to be included under the topLevel folder
 
 **Comments**
 The test262.properties file uses the Java Properties format, with the folder/.js file paths being the property key. The value of each 'property' can be used to store a comment
 ```
 ~built-ins/Array All tests on the built-in Array class
-    *prototype/flatMap haven't gotten around to implementing flatMap yet
+    prototype/flatMap haven't gotten around to implementing flatMap yet
 ```
 
 A Java Properties file can also have entire lines as comments, by prefixing the line with either `!` or `#`.

--- a/testsrc/README.md
+++ b/testsrc/README.md
@@ -84,7 +84,7 @@ While the test262.properties file does support this (because it is a Java Proper
 While the [test262.properties](test262.properties) file could be manually updated, the tooling also comes with a mechanism to (re)generate the file based on the current revision of the test262 submodule and the results of running Test262SuiteTest against this revision on all standard optLevels (-1, 0 & 9)
 
 ```
-./gradlew --tests org.mozilla.javascript.tests.Test262SuiteTest -DupdateTest262properties [-Dtest262properties=testsrc/myOwn.properties]
+./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest -DupdateTest262properties [-Dtest262properties=testsrc/myOwn.properties]
 ```
 The .properties file generation can be parameterized to affect the output:
 - rollup: include only a single line for a subfolder that contains only failing tests. Default: true
@@ -95,6 +95,11 @@ These defaults can be overridden by specifying a value for the `generateTest262p
 - all: rollup, stats and unsupported all true
 - none: rollup, stats and unsupported all false
 - [rollup][stats][unsupported]: the ones included will be true
+
+Note: the tests must actually run for the .properties file to be updated. If gradle determines that nothing has changed since the last time the `test` command was run, it won't run the tests. Gradle can be forced to ignore its cache by including the `--rerun-tasks` commandline argument:
+```
+./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest --rerun-tasks -DupdateTest262properties
+```
 
 ## Running specific tests from the official ECMAScript Test Suite (test262)
 The default setup for running the test262 test suite is defined in [test262.properties](test262.properties).

--- a/testsrc/org/mozilla/javascript/drivers/TestUtils.java
+++ b/testsrc/org/mozilla/javascript/drivers/TestUtils.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-
 import org.mozilla.javascript.ContextFactory;
 
 public class TestUtils {
@@ -31,53 +30,47 @@ public class TestUtils {
     }
 
     public static File[] recursiveListFiles(File dir, FileFilter filter) {
-        if (!dir.isDirectory())
-            throw new IllegalArgumentException(dir + " is not a directory");
+        if (!dir.isDirectory()) throw new IllegalArgumentException(dir + " is not a directory");
         List<File> fileList = new ArrayList<File>();
         recursiveListFilesHelper(dir, filter, fileList);
         return fileList.toArray(new File[fileList.size()]);
     }
 
-    public static void recursiveListFilesHelper(File dir, FileFilter filter,
-                                                List<File> fileList)
-    {
-        for (File f: dir.listFiles()) {
+    public static void recursiveListFilesHelper(File dir, FileFilter filter, List<File> fileList) {
+        for (File f : dir.listFiles()) {
             if (f.isDirectory()) {
                 recursiveListFilesHelper(f, filter, fileList);
             } else {
-                if (filter.accept(f))
-                    fileList.add(f);
+                if (filter.accept(f)) fileList.add(f);
             }
         }
     }
 
-    public static void addTestsFromFile(String filename, List<String> list)
-            throws IOException {
+    public static void addTestsFromFile(String filename, List<String> list) throws IOException {
         addTestsFromStream(new FileInputStream(new File(filename)), list);
     }
 
-    public static void addTestsFromStream(InputStream in, List<String> list)
-            throws IOException {
+    public static void addTestsFromStream(InputStream in, List<String> list) throws IOException {
         Properties props = new Properties();
         props.load(in);
-        for (Object obj: props.keySet()) {
+        for (Object obj : props.keySet()) {
             list.add(obj.toString());
         }
     }
 
     public static String[] loadTestsFromResource(String resource, String[] inherited)
             throws IOException {
-        List<String> list = inherited == null ?
-                new ArrayList<String>() :
-                new ArrayList<String>(Arrays.asList(inherited));
+        List<String> list =
+                inherited == null
+                        ? new ArrayList<String>()
+                        : new ArrayList<String>(Arrays.asList(inherited));
         InputStream in = JsTestsBase.class.getResourceAsStream(resource);
-        if (in != null)
-            addTestsFromStream(in, list);
+        if (in != null) addTestsFromStream(in, list);
         return list.toArray(new String[0]);
     }
 
     public static boolean matches(String[] patterns, String path) {
-        for (int i=0; i<patterns.length; i++) {
+        for (int i = 0; i < patterns.length; i++) {
             if (path.startsWith(patterns[i])) {
                 return true;
             }

--- a/testsrc/org/mozilla/javascript/drivers/TestUtils.java
+++ b/testsrc/org/mozilla/javascript/drivers/TestUtils.java
@@ -85,11 +85,12 @@ public class TestUtils {
         return false;
     }
 
-    public static final FileFilter JS_FILE_FILTER = new FileFilter() {
-        @Override
-        public boolean accept(File pathname) {
-            return pathname.getAbsolutePath().endsWith(".js");
-        }
-    };
-
+    public static final FileFilter JS_FILE_FILTER =
+            new FileFilter() {
+                @Override
+                public boolean accept(File pathname) {
+                    String path = pathname.getAbsolutePath();
+                    return path.endsWith(".js") && !path.endsWith("_FIXTURE.js");
+                }
+            };
 }

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -330,8 +330,13 @@ public class Test262SuiteTest {
                         String excludeSubstr = m.group(1);
                         int excludeCount = 0;
                         for (File file : dirFiles) {
-                            String path = file.getPath().replaceAll("\\\\", "/");
-                            if (path.endsWith(excludeSubstr)) {
+                            String path =
+                                    target.toPath()
+                                            .relativize(file.toPath())
+                                            .toString()
+                                            .replaceAll("\\\\", "/");
+
+                            if (path.equals(excludeSubstr)) {
                                 failingFiles.add(file);
                                 excludeCount++;
                             }

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -603,7 +603,7 @@ public class Test262SuiteTest {
 	                                return p1.startsWith(p2) ? -1 : 1;
 	                            }
 	
-	                            return f1.toString().compareToIgnoreCase(f2.toString());
+	                            return f1.toString().replaceFirst("\\.js$", "").compareToIgnoreCase(f2.toString().replaceFirst("\\.js$", ""));
 	                        });
                 }
 

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -65,7 +65,6 @@ public class Test262SuiteTest {
     private static final String FLAG_NO_STRICT = "noStrict";
 
     static final int[] DEFAULT_OPT_LEVELS = new int[] {-1, 0, 9};
-    ;
     static final int[] OPT_LEVELS;
 
     private static final File testDir = new File("test262/test");

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -556,7 +557,7 @@ public class Test262SuiteTest {
                 lineNo++;
 
                 if (!splitLine.matches()) {
-                    if (!line.isBlank()) {
+                    if (line.length() > 0) {
                         System.err.format(
                                 "WARN: Unexpected content '%s' at line #%d%n", line, lineNo);
                     }
@@ -623,7 +624,7 @@ public class Test262SuiteTest {
                     }
 
                     continue;
-                } else if (!splitLine.group(1).isBlank()) {
+                } else if (splitLine.group(1).trim().length() > 0) {
                     // comments
 
                     continue;

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -141,7 +141,8 @@ public class Test262SuiteTest {
                 default:
                     rollUpEnabled = updateProps.isEmpty() || updateProps.indexOf("rollup") != -1;
                     statsEnabled = updateProps.isEmpty() || updateProps.indexOf("stats") != -1;
-                    includeUnsupported = updateProps.isEmpty() || updateProps.indexOf("unsupported") != -1;
+                    includeUnsupported =
+                            updateProps.isEmpty() || updateProps.indexOf("unsupported") != -1;
             }
 
             if (getOverriddenLevel() != null) {
@@ -199,7 +200,8 @@ public class Test262SuiteTest {
             int rollUpCount = 0;
             int rolledUpFailureCount = 0;
 
-            // Converting to an array, so a regular loop over an array can be used, as there's the need to peek the next entry
+            // Converting to an array, so a regular loop over an array can be used,
+            // as there's the need to peek the next entry
             Test262Case[] testCases = new Test262Case[RESULT_TRACKERS.size()];
             RESULT_TRACKERS.keySet().toArray(testCases);
 
@@ -215,7 +217,8 @@ public class Test262SuiteTest {
                 String testResult = null;
 
                 Path testFilePath = testFile.toPath();
-                // hardcoded for just language/expression and language/statements to be split out on a deeper level
+                // hardcoded for just language/expression and language/statements
+                // to be split out on a deeper level
                 int reportDepth =
                         testFilePath.getNameCount() > 3
                                         && testFilePath.getName(2).toString().equals("language")
@@ -242,7 +245,8 @@ public class Test262SuiteTest {
                 if (rollUpEnabled
                         && (!testFilePath.startsWith(previousTestFileParentPath)
                                 || !testFilePath.getParent().equals(previousTestFileParentPath))) {
-                    if (!previousReportingDir.equals(previousTestFileParentPath) && rollUpCount > 1) {
+                    if (!previousReportingDir.equals(previousTestFileParentPath)
+                            && rollUpCount > 1) {
                         failures.add(
                                 "    *"
                                         + currentReportingDir
@@ -589,22 +593,25 @@ public class Test262SuiteTest {
                 recursiveListFilesHelper(target, JS_FILE_FILTER, dirFiles);
 
                 if (updateTest262Properties) {
-	                // Make sure files are always sorted the same way, alphabetically, with
-	                // subdirectories first
-	                // as to make sure that the output is stable when (re)generating the
-	                // test262.properties file
-	                dirFiles.sort(
-	                        (f1, f2) -> { // return -1: before, 0: equal, 1: after
-	                            String p1 = f1.getParent();
-	                            String p2 = f2.getParent();
-	
-	                            // making sure files come after subdirectories
-	                            if (!p1.equals(p2) && (p1.startsWith(p2) || p2.startsWith(p1))) {
-	                                return p1.startsWith(p2) ? -1 : 1;
-	                            }
-	
-	                            return f1.toString().replaceFirst("\\.js$", "").compareToIgnoreCase(f2.toString().replaceFirst("\\.js$", ""));
-	                        });
+                    // Make sure files are always sorted the same way, alphabetically, with
+                    // subdirectories first
+                    // as to make sure that the output is stable when (re)generating the
+                    // test262.properties file
+                    dirFiles.sort(
+                            (f1, f2) -> { // return -1: before, 0: equal, 1: after
+                                String p1 = f1.getParent();
+                                String p2 = f2.getParent();
+
+                                // making sure files come after subdirectories
+                                if (!p1.equals(p2) && (p1.startsWith(p2) || p2.startsWith(p1))) {
+                                    return p1.startsWith(p2) ? -1 : 1;
+                                }
+
+                                return f1.toString()
+                                        .replaceFirst("\\.js$", "")
+                                        .compareToIgnoreCase(
+                                                f2.toString().replaceFirst("\\.js$", ""));
+                            });
                 }
 
                 // if the directory is skipped, but has files below it, add those as to not loose
@@ -633,23 +640,29 @@ public class Test262SuiteTest {
                         comment = splitLine.group(4);
 
                         boolean hasFiles = false;
-                        
+
                         if (!line.endsWith(".js")) {
                             File potentialSubfolderTarget = new File(target, line);
-                            
+
                             if (allFailed && potentialSubfolderTarget.exists()) {
-                            	hasFiles = dirFiles
-                            			.stream()
-                            			.filter(file -> {
-                            				if (file.toPath().startsWith(potentialSubfolderTarget.toPath())) {
-                            					 filesExpectedToFail.put(file, null);
-                            					 return true;
-                            				}
-                            				return false;
-                            			})
-                            			.count() != 0;
+                                hasFiles =
+                                        dirFiles.stream()
+                                                        .filter(
+                                                                file -> {
+                                                                    if (file.toPath()
+                                                                            .startsWith(
+                                                                                    potentialSubfolderTarget
+                                                                                            .toPath())) {
+                                                                        filesExpectedToFail.put(
+                                                                                file, null);
+                                                                        return true;
+                                                                    }
+                                                                    return false;
+                                                                })
+                                                        .count()
+                                                != 0;
                             } else {
-                            	break;
+                                break;
                             }
                         }
 
@@ -658,8 +671,7 @@ public class Test262SuiteTest {
                             continue;
                         }
 
-                        for (File file :
-                                dirFiles) {
+                        for (File file : dirFiles) {
                             String path =
                                     target.toPath()
                                             .relativize(file.toPath())
@@ -784,9 +796,7 @@ public class Test262SuiteTest {
             }
 
             for (int optLevel : OPT_LEVELS) {
-                if (!testCase.hasFlag(FLAG_ONLY_STRICT)
-                        || testCase.hasFlag(
-                                FLAG_RAW)) {
+                if (!testCase.hasFlag(FLAG_ONLY_STRICT) || testCase.hasFlag(FLAG_RAW)) {
                     result.add(
                             new Object[] {
                                 caseShortPath, optLevel, false, testCase, markedAsFailing

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -85,6 +85,8 @@ public class Test262SuiteTest {
     static final Set<String> UNSUPPORTED_FEATURES =
             new HashSet<>(
                     Arrays.asList(
+                            "Array.prototype.flatMap",
+                            "Array.prototype.flat",
                             "Atomics",
                             "IsHTMLDDA",
                             "Promise.prototype.finally",
@@ -94,6 +96,7 @@ public class Test262SuiteTest {
                             "Reflect.set",
                             "Reflect.setPrototypeOf",
                             "SharedArrayBuffer",
+                            "Symbol.species",
                             "async-functions",
                             "async-iteration",
                             "class",
@@ -109,6 +112,7 @@ public class Test262SuiteTest {
                             "regexp-lookbehind",
                             "regexp-named-groups",
                             "regexp-unicode-property-escapes",
+                            "rest-parameters",
                             "super",
                             "String.prototype.matchAll",
                             "Symbol.matchAll",
@@ -137,10 +141,7 @@ public class Test262SuiteTest {
                 default:
                     rollUpEnabled = updateProps.isEmpty() || updateProps.indexOf("rollup") != -1;
                     statsEnabled = updateProps.isEmpty() || updateProps.indexOf("stats") != -1;
-                    includeUnsupported =
-                            updateProps.isEmpty()
-                                    ? false
-                                    : updateProps.indexOf("unsupported") != -1;
+                    includeUnsupported = updateProps.isEmpty() || updateProps.indexOf("unsupported") != -1;
             }
 
             if (getOverriddenLevel() != null) {

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -194,7 +194,7 @@ public class Test262SuiteTest {
             Path currentReportingDir;
             List<String> failures = new ArrayList<String>();
             int testCount = 0;
-            Path testFileParent =
+            Path previousTestFileParentPath =
                     testDir.toPath(); // tracks the current directory for which files are processed
             int rollUpCount = 0;
             int rolledUpFailureCount = 0;
@@ -240,13 +240,13 @@ public class Test262SuiteTest {
                 // If so, dont list all failing files, but list only the directory with the all
                 // failed marker (*)
                 if (rollUpEnabled
-                        && (!testFilePath.startsWith(testFileParent)
-                                || !testFilePath.getParent().equals(testFileParent))) {
-                    if (!previousReportingDir.equals(testFileParent) && rollUpCount > 1) {
+                        && (!testFilePath.startsWith(previousTestFileParentPath)
+                                || !testFilePath.getParent().equals(previousTestFileParentPath))) {
+                    if (!previousReportingDir.equals(previousTestFileParentPath) && rollUpCount > 1) {
                         failures.add(
                                 "    *"
                                         + currentReportingDir
-                                                .relativize(testFileParent)
+                                                .relativize(previousTestFileParentPath)
                                                 .toString()
                                                 .replace("\\", "/")
                                         + (statsEnabled
@@ -263,7 +263,7 @@ public class Test262SuiteTest {
                         }
                     }
 
-                    testFileParent = testFilePath.getParent();
+                    previousTestFileParentPath = testFilePath.getParent();
                     rollUpCount = 0;
                 }
 

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -115,8 +115,6 @@ public class Test262SuiteTest {
                             "super",
                             "String.prototype.matchAll",
                             "Symbol.matchAll",
-                            // "Symbol.unscopable",
-                            // "Symbol.species",
                             "tail-call-optimization",
                             "json-superset",
                             "hashbang",

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,10 +1,10 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array
-    from/calling-from-valid-1-noStrict.js Spec pretty clearly says this should be undefined
+built-ins/Array 106/2583 (4.1%)
+    from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
-    from/iter-map-fn-this-non-strict.js Error propagation needs work in general
-    from/iter-set-elem-prop-err.js Error propagation needs work in general
+    from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
+    from/iter-set-elem-prop-err.js non-strict Error propagation needs work in general
     from/source-object-constructor.js Error propagation needs work in general
     from/source-object-iterator-1.js Uses "get" syntax that's not implemented
     from/source-object-iterator-2.js Uses "get" syntax that's not implemented
@@ -18,51 +18,21 @@ built-ins/Array
     prototype/concat/create-species-non-ctor.js
     prototype/concat/create-species-poisoned.js
     prototype/concat/create-species.js
-    prototype/copyWithin/return-abrupt-from-delete-target.js Not throwing properly on unwritable
-    prototype/every/15.4.4.16-5-1-s.js
-    prototype/filter/15.4.4.20-5-1-s.js
+    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
+    prototype/every/15.4.4.16-5-1-s.js non-strict
+    prototype/filter/15.4.4.20-5-1-s.js non-strict
     prototype/filter/create-ctor-non-object.js
     prototype/filter/create-ctor-poisoned.js
     prototype/filter/create-species-abrupt.js
     prototype/filter/create-species-non-ctor.js
     prototype/filter/create-species-poisoned.js
     prototype/filter/create-species.js
-    prototype/findIndex/predicate-call-this-strict.js
-    prototype/find/predicate-call-this-strict.js
-    prototype/flatMap/array-like-objects-nested.js
-    prototype/flatMap/array-like-objects-poisoned-length.js
-    prototype/flatMap/array-like-objects-typedarrays.js
-    prototype/flatMap/array-like-objects.js
-    prototype/flatMap/bound-function-argument.js
-    prototype/flatMap/depth-always-one.js
-    prototype/flatMap/length.js
-    prototype/flatMap/name.js
-    prototype/flatMap/non-callable-argument-throws.js
-    prototype/flatMap/prop-desc.js
-    prototype/flatMap/proxy-access-count.js
-    prototype/flatMap/this-value-ctor-non-object.js
-    prototype/flatMap/this-value-ctor-object-species-bad-throws.js
-    prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
-    prototype/flatMap/this-value-ctor-object-species.js
-    prototype/flatMap/this-value-null-undefined-throws.js
-    prototype/flatMap/thisArg-argument.js
-    prototype/flat/array-like-objects.js
-    prototype/flat/bound-function-call.js
-    prototype/flat/empty-array-elements.js
-    prototype/flat/empty-object-elements.js
-    prototype/flat/length.js
-    prototype/flat/name.js
-    prototype/flat/non-numeric-depth-should-not-throw.js
-    prototype/flat/non-object-ctor-throws.js
-    prototype/flat/null-undefined-elements.js
-    prototype/flat/null-undefined-input-throws.js
-    prototype/flat/positive-infinity.js
-    prototype/flat/prop-desc.js
-    prototype/flat/proxy-access-count.js
-    prototype/flat/symbol-object-create-null-depth-throws.js
-    prototype/forEach/15.4.4.18-5-1-s.js
-    prototype/map/15.4.4.19-5-1-s.js
+    prototype/findIndex/predicate-call-this-strict.js strict
+    prototype/find/predicate-call-this-strict.js strict
+    *prototype/flatMap 18/18 (100.0%)
+    *prototype/flat 14/14 (100.0%)
+    prototype/forEach/15.4.4.18-5-1-s.js non-strict
+    prototype/map/15.4.4.19-5-1-s.js non-strict
     prototype/map/create-ctor-non-object.js
     prototype/map/create-ctor-poisoned.js
     prototype/map/create-species-abrupt.js
@@ -71,8 +41,8 @@ built-ins/Array
     prototype/map/create-species.js
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
-    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js
-    prototype/reduce/15.4.4.21-9-c-ii-4-s.js
+    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
+    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
     prototype/slice/create-ctor-non-object.js
     prototype/slice/create-ctor-poisoned.js
@@ -82,8 +52,8 @@ built-ins/Array
     prototype/slice/create-species-poisoned.js
     prototype/slice/create-species.js
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
-    prototype/some/15.4.4.17-5-1-s.js
-    prototype/sort/S15.4.4.11_A8.js
+    prototype/some/15.4.4.17-5-1-s.js non-strict
+    prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/sort/stability-2048-elements.js
     prototype/sort/stability-513-elements.js
     prototype/splice/clamps-length-to-integer-limit.js
@@ -96,19 +66,15 @@ built-ins/Array
     prototype/splice/create-species-poisoned.js
     prototype/splice/create-species.js
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
-    prototype/splice/S15.4.4.12_A6.1_T3.js
+    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
-    prototype/Symbol.unscopables/prop-desc.js Object.preventExtensions doesn't seem to throw
-    prototype/Symbol.unscopables/value.js Object.preventExtensions doesn't seem to throw
-    prototype/toLocaleString/primitive_this_value.js
-    prototype/toLocaleString/primitive_this_value_getter.js
+    *prototype/Symbol.unscopables 2/2 (100.0%)
+    prototype/toLocaleString/primitive_this_value.js strict
+    prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/Symbol.iterator.js Expects a particular string value
-    Symbol.species/length.js
-    Symbol.species/return-value.js
-    Symbol.species/symbol-species-name.js
-    Symbol.species/symbol-species.js
+    *Symbol.species 4/4 (100.0%)
 
-built-ins/ArrayBuffer
+built-ins/ArrayBuffer 22/72 (30.56%)
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-accessor.js
     prototype/byteLength/length.js
@@ -126,26 +92,23 @@ built-ins/ArrayBuffer
     prototype/slice/species-returns-smaller-arraybuffer.js
     prototype/slice/species.js
     prototype/Symbol.toStringTag.js
-    Symbol.species/length.js
-    Symbol.species/return-value.js
-    Symbol.species/symbol-species-name.js
-    Symbol.species/symbol-species.js
+    *Symbol.species 4/4 (100.0%)
     undefined-newtarget-throws.js
 
-built-ins/ArrayIteratorPrototype
+built-ins/ArrayIteratorPrototype 1/27 (3.7%)
     next/detach-typedarray-in-progress.js
 
 ~built-ins/AsyncFunction
 
 ~built-ins/Atomics
 
-built-ins/BigInt
+built-ins/BigInt 2/54 (3.7%)
     prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     prototype/toString/thisbigintvalue-not-valid-throws.js Computed property is not support
 
-built-ins/Boolean
+built-ins/Boolean 0/47 (0.0%)
 
-built-ins/DataView
+built-ins/DataView 116/405 (28.64%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-accessor.js
     prototype/buffer/length.js
@@ -263,7 +226,7 @@ built-ins/DataView
     detached-buffer.js
     newtarget-undefined-throws.js
 
-built-ins/Date
+built-ins/Date 32/697 (4.59%)
     prototype/setFullYear/15.9.5.40_1.js
     prototype/Symbol.toPrimitive/hint-default-first-invalid.js
     prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
@@ -307,45 +270,45 @@ built-ins/Date
     S15.1.3.2_A2.4_T1.js
     S15.1.3.2_A5.2.js
 
-built-ins/encodeURI
+built-ins/encodeURI 2/29 (6.9%)
     name.js
     S15.1.3.3_A5.2.js
 
-built-ins/encodeURIComponent
+built-ins/encodeURIComponent 2/29 (6.9%)
     name.js
     S15.1.3.4_A5.2.js
 
-built-ins/Error
+built-ins/Error 2/36 (5.56%)
     prototype/S15.11.4_A2.js
 
-built-ins/eval
+built-ins/eval 2/8 (25.0%)
     length-non-configurable.js
     name.js
 
-built-ins/Function
-    length/S15.3.5.1_A1_T3.js
+built-ins/Function 145/459 (31.59%)
+    length/S15.3.5.1_A1_T3.js strict
     length/S15.3.5.1_A2_T1.js
     length/S15.3.5.1_A2_T2.js
     length/S15.3.5.1_A2_T3.js
-    length/S15.3.5.1_A3_T3.js
-    length/S15.3.5.1_A4_T3.js
-    prototype/apply/15.3.4.3-1-s.js
-    prototype/apply/15.3.4.3-2-s.js
-    prototype/apply/15.3.4.3-3-s.js
+    length/S15.3.5.1_A3_T3.js strict
+    length/S15.3.5.1_A4_T3.js strict
+    prototype/apply/15.3.4.3-1-s.js strict
+    prototype/apply/15.3.4.3-2-s.js strict
+    prototype/apply/15.3.4.3-3-s.js strict
     prototype/apply/argarray-not-object.js
-    prototype/apply/S15.3.4.3_A3_T1.js
-    prototype/apply/S15.3.4.3_A3_T2.js
-    prototype/apply/S15.3.4.3_A3_T3.js
-    prototype/apply/S15.3.4.3_A3_T4.js
-    prototype/apply/S15.3.4.3_A3_T5.js
-    prototype/apply/S15.3.4.3_A3_T6.js
-    prototype/apply/S15.3.4.3_A3_T7.js
-    prototype/apply/S15.3.4.3_A3_T8.js
-    prototype/apply/S15.3.4.3_A5_T4.js
-    prototype/apply/S15.3.4.3_A7_T1.js
-    prototype/apply/S15.3.4.3_A7_T2.js
-    prototype/apply/S15.3.4.3_A7_T5.js
-    prototype/apply/S15.3.4.3_A7_T7.js
+    prototype/apply/S15.3.4.3_A3_T1.js non-interpreted
+    prototype/apply/S15.3.4.3_A3_T2.js non-interpreted
+    prototype/apply/S15.3.4.3_A3_T3.js non-interpreted
+    prototype/apply/S15.3.4.3_A3_T4.js non-interpreted
+    prototype/apply/S15.3.4.3_A3_T5.js non-interpreted
+    prototype/apply/S15.3.4.3_A3_T6.js {non-strict: [0, 9]}
+    prototype/apply/S15.3.4.3_A3_T7.js non-interpreted
+    prototype/apply/S15.3.4.3_A3_T8.js {non-strict: [0, 9]}
+    prototype/apply/S15.3.4.3_A5_T4.js {non-strict: [0, 9]}
+    prototype/apply/S15.3.4.3_A7_T1.js non-interpreted
+    prototype/apply/S15.3.4.3_A7_T2.js non-interpreted
+    prototype/apply/S15.3.4.3_A7_T5.js non-interpreted
+    prototype/apply/S15.3.4.3_A7_T7.js non-interpreted
     prototype/apply/this-not-callable.js
     prototype/bind/15.3.4.5-15-2.js
     prototype/bind/15.3.4.5-15-5.js
@@ -355,24 +318,24 @@ built-ins/Function
     prototype/bind/instance-name-non-string.js
     prototype/bind/instance-name.js
     prototype/bind/length-exceeds-int32.js
-    prototype/call/15.3.4.4-1-s.js
-    prototype/call/15.3.4.4-2-s.js
-    prototype/call/15.3.4.4-3-s.js
+    prototype/call/15.3.4.4-1-s.js strict
+    prototype/call/15.3.4.4-2-s.js strict
+    prototype/call/15.3.4.4-3-s.js strict
     prototype/call/S15.3.4.4_A13.js
     prototype/call/S15.3.4.4_A14.js
-    prototype/call/S15.3.4.4_A3_T1.js
-    prototype/call/S15.3.4.4_A3_T2.js
-    prototype/call/S15.3.4.4_A3_T3.js
-    prototype/call/S15.3.4.4_A3_T4.js
-    prototype/call/S15.3.4.4_A3_T5.js
-    prototype/call/S15.3.4.4_A3_T6.js
-    prototype/call/S15.3.4.4_A3_T7.js
-    prototype/call/S15.3.4.4_A3_T8.js
-    prototype/call/S15.3.4.4_A5_T4.js
-    prototype/call/S15.3.4.4_A6_T1.js
-    prototype/call/S15.3.4.4_A6_T2.js
-    prototype/call/S15.3.4.4_A6_T5.js
-    prototype/call/S15.3.4.4_A6_T7.js
+    prototype/call/S15.3.4.4_A3_T1.js non-interpreted
+    prototype/call/S15.3.4.4_A3_T2.js non-interpreted
+    prototype/call/S15.3.4.4_A3_T3.js non-interpreted
+    prototype/call/S15.3.4.4_A3_T4.js non-interpreted
+    prototype/call/S15.3.4.4_A3_T5.js non-interpreted
+    prototype/call/S15.3.4.4_A3_T6.js {non-strict: [0, 9]}
+    prototype/call/S15.3.4.4_A3_T7.js non-interpreted
+    prototype/call/S15.3.4.4_A3_T8.js {non-strict: [0, 9]}
+    prototype/call/S15.3.4.4_A5_T4.js {non-strict: [0, 9]}
+    prototype/call/S15.3.4.4_A6_T1.js non-interpreted
+    prototype/call/S15.3.4.4_A6_T2.js non-interpreted
+    prototype/call/S15.3.4.4_A6_T5.js non-interpreted
+    prototype/call/S15.3.4.4_A6_T7.js non-interpreted
     prototype/Symbol.hasInstance/length.js
     prototype/Symbol.hasInstance/name.js
     prototype/Symbol.hasInstance/prop-desc.js
@@ -428,78 +391,58 @@ built-ins/Function
     prototype/restricted-property-arguments.js
     prototype/restricted-property-caller.js
     prototype/S15.3.4_A5.js
-    15.3.2.1-10-6gs.js
-    15.3.2.1-11-1-s.js
-    15.3.2.1-11-1.js
-    15.3.2.1-11-2-s.js
-    15.3.2.1-11-3-s.js
-    15.3.2.1-11-3.js
-    15.3.2.1-11-4-s.js
-    15.3.2.1-11-5-s.js
-    15.3.2.1-11-5.js
-    15.3.2.1-11-6-s.js
-    15.3.2.1-11-7-s.js
-    15.3.2.1-11-8-s.js
-    15.3.2.1-11-9-s.js
-    15.3.5-1gs.js
-    15.3.5-2gs.js
-    15.3.5.4_2-11gs.js
-    15.3.5.4_2-13gs.js
-    15.3.5.4_2-15gs.js
-    15.3.5.4_2-17gs.js
-    15.3.5.4_2-19gs.js
-    15.3.5.4_2-1gs.js
-    15.3.5.4_2-21gs.js
-    15.3.5.4_2-22gs.js
-    15.3.5.4_2-23gs.js
-    15.3.5.4_2-24gs.js
-    15.3.5.4_2-25gs.js
-    15.3.5.4_2-26gs.js
-    15.3.5.4_2-27gs.js
-    15.3.5.4_2-28gs.js
-    15.3.5.4_2-29gs.js
-    15.3.5.4_2-3gs.js
-    15.3.5.4_2-48gs.js
-    15.3.5.4_2-50gs.js
-    15.3.5.4_2-52gs.js
-    15.3.5.4_2-54gs.js
-    15.3.5.4_2-5gs.js
-    15.3.5.4_2-7gs.js
-    15.3.5.4_2-9gs.js
+    15.3.2.1-10-6gs.js non-strict
+    15.3.2.1-11-1-s.js non-strict
+    15.3.2.1-11-1.js strict
+    15.3.2.1-11-2-s.js strict
+    15.3.2.1-11-3-s.js non-strict
+    15.3.2.1-11-3.js strict
+    15.3.2.1-11-4-s.js strict
+    15.3.2.1-11-5-s.js non-strict
+    15.3.2.1-11-5.js strict
+    15.3.2.1-11-6-s.js strict
+    15.3.2.1-11-7-s.js strict
+    15.3.2.1-11-8-s.js strict
+    15.3.2.1-11-9-s.js strict
+    15.3.5-1gs.js strict
+    15.3.5-2gs.js strict
+    15.3.5.4_2-11gs.js strict
+    15.3.5.4_2-13gs.js strict
+    15.3.5.4_2-15gs.js strict
+    15.3.5.4_2-17gs.js strict
+    15.3.5.4_2-19gs.js strict
+    15.3.5.4_2-1gs.js strict
+    15.3.5.4_2-21gs.js strict
+    15.3.5.4_2-22gs.js strict
+    15.3.5.4_2-23gs.js strict
+    15.3.5.4_2-24gs.js strict
+    15.3.5.4_2-25gs.js strict
+    15.3.5.4_2-26gs.js strict
+    15.3.5.4_2-27gs.js strict
+    15.3.5.4_2-28gs.js strict
+    15.3.5.4_2-29gs.js strict
+    15.3.5.4_2-3gs.js strict
+    15.3.5.4_2-48gs.js strict
+    15.3.5.4_2-50gs.js strict
+    15.3.5.4_2-52gs.js strict
+    15.3.5.4_2-54gs.js strict
+    15.3.5.4_2-5gs.js strict
+    15.3.5.4_2-7gs.js strict
+    15.3.5.4_2-9gs.js strict
     instance-name.js
-    StrictFunction_restricted-properties.js
+    StrictFunction_restricted-properties.js strict
 
 ~built-ins/GeneratorFunction
 
-built-ins/GeneratorPrototype
-    next/from-state-executing.js
+built-ins/GeneratorPrototype 35/57 (61.4%)
+    next/from-state-executing.js non-interpreted
     next/length.js
     next/name.js
     next/property-descriptor.js
     next/this-val-not-generator.js
     next/this-val-not-object.js
-    return/from-state-completed.js
-    return/from-state-executing.js
-    return/from-state-suspended-start.js
-    return/length.js
-    return/name.js
-    return/property-descriptor.js
-    return/this-val-not-generator.js
-    return/this-val-not-object.js
-    return/try-catch-before-try.js
-    return/try-catch-following-catch.js
-    return/try-catch-within-catch.js
-    return/try-catch-within-try.js
-    return/try-finally-before-try.js
-    return/try-finally-following-finally.js
-    return/try-finally-nested-try-catch-within-catch.js
-    return/try-finally-nested-try-catch-within-finally.js
-    return/try-finally-nested-try-catch-within-inner-try.js
-    return/try-finally-nested-try-catch-within-outer-try-after-nested.js
-    return/try-finally-nested-try-catch-within-outer-try-before-nested.js
-    return/try-finally-within-finally.js
-    return/try-finally-within-try.js
-    throw/from-state-executing.js
+    *return 21/21 (100.0%)
+    throw/from-state-executing.js non-interpreted
     throw/length.js
     throw/name.js
     throw/property-descriptor.js
@@ -508,13 +451,13 @@ built-ins/GeneratorPrototype
     constructor.js
     Symbol.toStringTag.js
 
-built-ins/global
+built-ins/global 2/33 (6.06%)
     global-object.js
     property-descriptor.js
 
-built-ins/Infinity
+built-ins/Infinity 0/7 (0.0%)
 
-built-ins/isFinite
+built-ins/isFinite 8/16 (50.0%)
     length.js
     name.js
     toprimitive-call-abrupt.js
@@ -524,7 +467,7 @@ built-ins/isFinite
     toprimitive-result-is-symbol-throws.js
     toprimitive-valid-result.js
 
-built-ins/isNaN
+built-ins/isNaN 8/16 (50.0%)
     length.js
     name.js
     toprimitive-call-abrupt.js
@@ -536,7 +479,7 @@ built-ins/isNaN
 
 ~built-ins/IteratorPrototype
 
-built-ins/JSON
+built-ins/JSON 11/109 (10.09%)
     parse/S15.12.2_A1.js
     parse/text-negative-zero.js
     stringify/replacer-array-number.js
@@ -549,22 +492,19 @@ built-ins/JSON
     stringify/value-tojson-arguments.js
     Symbol.toStringTag.js
 
-built-ins/Map
-    Symbol.species/length.js
-    Symbol.species/return-value.js
-    Symbol.species/symbol-species-name.js
-    Symbol.species/symbol-species.js
+built-ins/Map 5/143 (3.5%)
+    *Symbol.species 4/4 (100.0%)
     iterator-is-undefined-throws.js
 
-built-ins/MapIteratorPrototype
+built-ins/MapIteratorPrototype 0/11 (0.0%)
 
-built-ins/Math
+built-ins/Math 2/273 (0.73%)
     log2/log2-basicTests.js calculation is not exact
     Symbol.toStringTag.js
 
-built-ins/NaN
+built-ins/NaN 0/7 (0.0%)
 
-built-ins/NativeErrors
+built-ins/NativeErrors 37/73 (50.68%)
     EvalError/prototype/not-error-object.js
     RangeError/prototype/not-error-object.js
     ReferenceError/prototype/not-error-object.js
@@ -572,43 +512,43 @@ built-ins/NativeErrors
     TypeError/prototype/not-error-object.js
     URIError/prototype/not-error-object.js
 
-built-ins/Number
+built-ins/Number 5/277 (1.81%)
     prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     prototype/toExponential/undefined-fractiondigits.js
     prototype/toLocaleString/length.js
     prototype/toPrecision/nan.js
 
-built-ins/Object
+built-ins/Object 100/3097 (3.23%)
     assign/strings-and-symbol-order.js
     create/15.2.3.5-4-311.js
-    defineProperties/15.2.3.7-6-a-112.js
-    defineProperties/15.2.3.7-6-a-113.js
+    defineProperties/15.2.3.7-6-a-112.js non-strict
+    defineProperties/15.2.3.7-6-a-113.js non-strict
     defineProperties/15.2.3.7-6-a-118.js
     defineProperties/15.2.3.7-6-a-164.js
     defineProperties/15.2.3.7-6-a-165.js
-    defineProperties/15.2.3.7-6-a-166.js
-    defineProperties/15.2.3.7-6-a-168.js
-    defineProperties/15.2.3.7-6-a-169.js
-    defineProperties/15.2.3.7-6-a-170.js
-    defineProperties/15.2.3.7-6-a-172.js
-    defineProperties/15.2.3.7-6-a-173.js
+    defineProperties/15.2.3.7-6-a-166.js non-strict
+    defineProperties/15.2.3.7-6-a-168.js non-strict
+    defineProperties/15.2.3.7-6-a-169.js non-strict
+    defineProperties/15.2.3.7-6-a-170.js non-strict
+    defineProperties/15.2.3.7-6-a-172.js non-strict
+    defineProperties/15.2.3.7-6-a-173.js non-strict
     defineProperties/15.2.3.7-6-a-175.js
     defineProperties/15.2.3.7-6-a-176.js
     defineProperties/15.2.3.7-6-a-184.js
     defineProperties/15.2.3.7-6-a-185.js
     defineProperties/15.2.3.7-6-a-282.js
-    defineProperty/15.2.3.6-4-116.js
-    defineProperty/15.2.3.6-4-117.js
+    defineProperty/15.2.3.6-4-116.js non-strict
+    defineProperty/15.2.3.6-4-117.js non-strict
     defineProperty/15.2.3.6-4-122.js
     defineProperty/15.2.3.6-4-168.js
     defineProperty/15.2.3.6-4-169.js
-    defineProperty/15.2.3.6-4-170.js
-    defineProperty/15.2.3.6-4-172.js
-    defineProperty/15.2.3.6-4-173.js
-    defineProperty/15.2.3.6-4-174.js
-    defineProperty/15.2.3.6-4-176.js
-    defineProperty/15.2.3.6-4-177.js
+    defineProperty/15.2.3.6-4-170.js non-strict
+    defineProperty/15.2.3.6-4-172.js non-strict
+    defineProperty/15.2.3.6-4-173.js non-strict
+    defineProperty/15.2.3.6-4-174.js non-strict
+    defineProperty/15.2.3.6-4-176.js non-strict
+    defineProperty/15.2.3.6-4-177.js non-strict
     defineProperty/15.2.3.6-4-188.js
     defineProperty/15.2.3.6-4-189.js
     defineProperty/15.2.3.6-4-206.js
@@ -616,8 +556,8 @@ built-ins/Object
     defineProperty/15.2.3.6-4-255.js
     defineProperty/15.2.3.6-4-256.js
     defineProperty/15.2.3.6-4-293-1.js
-    defineProperty/15.2.3.6-4-293-3.js
-    defineProperty/15.2.3.6-4-293-4.js
+    defineProperty/15.2.3.6-4-293-3.js non-strict
+    defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
     fromEntries/evaluation-order.js
     fromEntries/iterator-closed-for-null-entry.js
@@ -667,8 +607,8 @@ built-ins/Object
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    prototype/toLocaleString/primitive_this_value.js
-    prototype/toLocaleString/primitive_this_value_getter.js
+    prototype/toLocaleString/primitive_this_value.js strict
+    prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/toLocaleString/S15.2.4.3_A12.js
     prototype/toLocaleString/S15.2.4.3_A13.js
     prototype/toString/get-symbol-tag-err.js
@@ -681,11 +621,11 @@ built-ins/Object
     prototype/valueOf/S15.2.4.4_A14.js
     prototype/valueOf/S15.2.4.4_A15.js
 
-built-ins/parseFloat
+built-ins/parseFloat 2/56 (3.57%)
     name.js
     S15.1.2.3_A7.2.js
 
-built-ins/parseInt
+built-ins/parseInt 2/58 (3.45%)
     name.js
     S15.1.2.2_A9.2.js
 
@@ -695,40 +635,9 @@ built-ins/parseInt
 
 ~built-ins/Reflect
 
-built-ins/RegExp
-    CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
-    CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
-    CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
-    CharacterClassEscapes/character-class-digit-class-escape.js
-    CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
-    CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
-    CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
-    CharacterClassEscapes/character-class-non-digit-class-escape.js
-    CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
-    CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
-    CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
-    CharacterClassEscapes/character-class-non-whitespace-class-escape.js
-    CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
-    CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
-    CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
-    CharacterClassEscapes/character-class-non-word-class-escape.js
-    CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
-    CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
-    CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
-    CharacterClassEscapes/character-class-whitespace-class-escape.js
-    CharacterClassEscapes/character-class-word-class-escape-flags-u.js
-    CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
-    CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
-    CharacterClassEscapes/character-class-word-class-escape.js
-    match-indices/indices-array-element.js
-    match-indices/indices-array-matched.js
-    match-indices/indices-array-non-unicode-match.js
-    match-indices/indices-array-properties.js
-    match-indices/indices-array-unicode-match.js
-    match-indices/indices-array-unicode-property-names.js
-    match-indices/indices-array-unmatched.js
-    match-indices/indices-array.js
-    match-indices/indices-property.js
+built-ins/RegExp 262/798 (32.83%)
+    *CharacterClassEscapes 24/24 (100.0%)
+    *match-indices 9/9 (100.0%)
     prototype/exec/failure-lastindex-access.js
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
@@ -740,16 +649,7 @@ built-ins/RegExp
     prototype/exec/y-fail-return.js
     prototype/exec/y-init-lastindex.js
     prototype/exec/y-set-lastindex.js
-    prototype/flags/coercion-global.js
-    prototype/flags/coercion-ignoreCase.js
-    prototype/flags/coercion-multiline.js
-    prototype/flags/coercion-sticky.js
-    prototype/flags/coercion-unicode.js
-    prototype/flags/length.js
-    prototype/flags/name.js
-    prototype/flags/prop-desc.js
-    prototype/flags/this-val-non-obj.js
-    prototype/flags/this-val-regexp-prototype.js
+    *prototype/flags 10/10 (100.0%)
     prototype/global/15.10.7.2-2.js
     prototype/global/length.js
     prototype/global/name.js
@@ -772,13 +672,7 @@ built-ins/RegExp
     prototype/source/value-empty.js
     prototype/source/value-line-terminator.js
     prototype/source/value-u.js
-    prototype/sticky/length.js
-    prototype/sticky/name.js
-    prototype/sticky/prop-desc.js
-    prototype/sticky/this-val-invalid-obj.js
-    prototype/sticky/this-val-non-obj.js
-    prototype/sticky/this-val-regexp-prototype.js
-    prototype/sticky/this-val-regexp.js
+    *prototype/sticky 7/7 (100.0%)
     prototype/Symbol.match/builtin-coerce-lastindex.js
     prototype/Symbol.match/builtin-failure-y-return-val.js
     prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
@@ -826,8 +720,8 @@ built-ins/RegExp
     prototype/Symbol.replace/fn-coerce-replacement.js
     prototype/Symbol.replace/fn-err.js
     prototype/Symbol.replace/fn-invoke-args.js
-    prototype/Symbol.replace/fn-invoke-this-no-strict.js
-    prototype/Symbol.replace/fn-invoke-this-strict.js
+    prototype/Symbol.replace/fn-invoke-this-no-strict.js non-strict
+    prototype/Symbol.replace/fn-invoke-this-strict.js strict
     prototype/Symbol.replace/g-init-lastindex-err.js
     prototype/Symbol.replace/g-init-lastindex.js
     prototype/Symbol.replace/g-pos-decrement.js
@@ -925,19 +819,10 @@ built-ins/RegExp
     prototype/test/y-fail-return.js
     prototype/test/y-init-lastindex.js
     prototype/test/y-set-lastindex.js
-    prototype/unicode/length.js
-    prototype/unicode/name.js
-    prototype/unicode/prop-desc.js
-    prototype/unicode/this-val-invalid-obj.js
-    prototype/unicode/this-val-non-obj.js
-    prototype/unicode/this-val-regexp-prototype.js
-    prototype/unicode/this-val-regexp.js
+    *prototype/unicode 7/7 (100.0%)
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
-    Symbol.species/length.js
-    Symbol.species/return-value.js
-    Symbol.species/symbol-species-name.js
-    Symbol.species/symbol-species.js
+    *Symbol.species 4/4 (100.0%)
     15.10.4.1-1.js
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
@@ -959,17 +844,14 @@ built-ins/RegExp
     unicode_identity_escape.js
     valid-flags-y.js
 
-built-ins/Set
-    Symbol.species/length.js
-    Symbol.species/return-value.js
-    Symbol.species/symbol-species-name.js
-    Symbol.species/symbol-species.js
+built-ins/Set 4/187 (2.14%)
+    *Symbol.species 4/4 (100.0%)
 
-built-ins/SetIteratorPrototype
+built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String
+built-ins/String 44/1033 (4.26%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/match/cstm-matcher-get-err.js
@@ -977,7 +859,7 @@ built-ins/String
     prototype/match/invoke-builtin-match.js
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
-    prototype/replace/S15.5.4.11_A12.js
+    prototype/replace/S15.5.4.11_A12.js non-strict
     prototype/search/cstm-search-get-err.js
     prototype/search/cstm-search-invocation.js
     prototype/search/invoke-builtin-search-searcher-undef.js
@@ -1015,9 +897,9 @@ built-ins/String
     prototype/trimStart/this-value-object-valueof-meth-priority.js
     prototype/trimStart/this-value-object-valueof-returns-object-err.js
 
-built-ins/StringIteratorPrototype
+built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol
+built-ins/Symbol 14/68 (20.59%)
     asyncIterator/prop-desc.js
     keyFor/arg-non-symbol.js
     prototype/description/description-symboldescriptivestring.js
@@ -1033,7 +915,7 @@ built-ins/Symbol
     species/builtin-getter-name.js
     species/subclassing.js
 
-built-ins/ThrowTypeError
+built-ins/ThrowTypeError 7/12 (58.33%)
     extensible.js
     forbidden-arguments.js
     frozen.js
@@ -1042,7 +924,7 @@ built-ins/ThrowTypeError
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray
+built-ins/TypedArray 950/1033 (91.97%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/iter-access-error.js
@@ -1055,8 +937,7 @@ built-ins/TypedArray
     of/length.js
     of/name.js
     of/prop-desc.js
-    prototype/buffer/BigInt/detached-buffer.js
-    prototype/buffer/BigInt/return-buffer.js
+    *prototype/buffer/BigInt 2/2 (100.0%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-func.js
     prototype/buffer/length.js
@@ -1064,8 +945,7 @@ built-ins/TypedArray
     prototype/buffer/prop-desc.js
     prototype/buffer/this-has-no-typedarrayname-internal.js
     prototype/buffer/this-is-not-object.js
-    prototype/byteLength/BigInt/detached-buffer.js
-    prototype/byteLength/BigInt/return-bytelength.js
+    *prototype/byteLength/BigInt 2/2 (100.0%)
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-func.js
     prototype/byteLength/length.js
@@ -1073,8 +953,7 @@ built-ins/TypedArray
     prototype/byteLength/prop-desc.js
     prototype/byteLength/this-has-no-typedarrayname-internal.js
     prototype/byteLength/this-is-not-object.js
-    prototype/byteOffset/BigInt/detached-buffer.js
-    prototype/byteOffset/BigInt/return-byteoffset.js
+    *prototype/byteOffset/BigInt 2/2 (100.0%)
     prototype/byteOffset/detached-buffer.js
     prototype/byteOffset/invoked-as-func.js
     prototype/byteOffset/length.js
@@ -1082,29 +961,7 @@ built-ins/TypedArray
     prototype/byteOffset/prop-desc.js
     prototype/byteOffset/this-has-no-typedarrayname-internal.js
     prototype/byteOffset/this-is-not-object.js
-    prototype/copyWithin/BigInt/coerced-values-end.js
-    prototype/copyWithin/BigInt/coerced-values-start.js
-    prototype/copyWithin/BigInt/coerced-values-target.js
-    prototype/copyWithin/BigInt/detached-buffer.js
-    prototype/copyWithin/BigInt/get-length-ignores-length-prop.js
-    prototype/copyWithin/BigInt/negative-end.js
-    prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
-    prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
-    prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
-    prototype/copyWithin/BigInt/negative-start.js
-    prototype/copyWithin/BigInt/negative-target.js
-    prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
-    prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
-    prototype/copyWithin/BigInt/non-negative-target-and-start.js
-    prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
-    prototype/copyWithin/BigInt/return-abrupt-from-end-is-symbol.js
-    prototype/copyWithin/BigInt/return-abrupt-from-end.js
-    prototype/copyWithin/BigInt/return-abrupt-from-start-is-symbol.js
-    prototype/copyWithin/BigInt/return-abrupt-from-start.js
-    prototype/copyWithin/BigInt/return-abrupt-from-target-is-symbol.js
-    prototype/copyWithin/BigInt/return-abrupt-from-target.js
-    prototype/copyWithin/BigInt/return-this.js
-    prototype/copyWithin/BigInt/undefined-end.js
+    *prototype/copyWithin/BigInt 23/23 (100.0%)
     prototype/copyWithin/bit-precision.js
     prototype/copyWithin/coerced-values-end.js
     prototype/copyWithin/coerced-values-start.js
@@ -1133,33 +990,9 @@ built-ins/TypedArray
     prototype/copyWithin/this-is-not-object.js
     prototype/copyWithin/this-is-not-typedarray-instance.js
     prototype/copyWithin/undefined-end.js
-    prototype/entries/BigInt/detached-buffer.js
-    prototype/entries/BigInt/iter-prototype.js
-    prototype/entries/BigInt/return-itor.js
-    prototype/entries/detached-buffer.js
-    prototype/entries/invoked-as-func.js
-    prototype/entries/invoked-as-method.js
-    prototype/entries/iter-prototype.js
-    prototype/entries/length.js
-    prototype/entries/name.js
-    prototype/entries/prop-desc.js
-    prototype/entries/return-itor.js
-    prototype/entries/this-is-not-object.js
-    prototype/entries/this-is-not-typedarray-instance.js
-    prototype/every/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/every/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/every/BigInt/callbackfn-detachbuffer.js
-    prototype/every/BigInt/callbackfn-no-interaction-over-non-integer.js
-    prototype/every/BigInt/callbackfn-not-callable-throws.js
-    prototype/every/BigInt/callbackfn-not-called-on-empty.js
-    prototype/every/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/every/BigInt/callbackfn-returns-abrupt.js
-    prototype/every/BigInt/callbackfn-this.js
-    prototype/every/BigInt/detached-buffer.js
-    prototype/every/BigInt/get-length-uses-internal-arraylength.js
-    prototype/every/BigInt/returns-false-if-any-cb-returns-false.js
-    prototype/every/BigInt/returns-true-if-every-cb-returns-true.js
-    prototype/every/BigInt/values-are-not-cached.js
+    *prototype/entries/BigInt 3/3 (100.0%)
+    *prototype/entries 10/10 (100.0%)
+    *prototype/every/BigInt 14/14 (100.0%)
     prototype/every/callbackfn-arguments-with-thisarg.js
     prototype/every/callbackfn-arguments-without-thisarg.js
     prototype/every/callbackfn-detachbuffer.js
@@ -1180,23 +1013,7 @@ built-ins/TypedArray
     prototype/every/this-is-not-object.js
     prototype/every/this-is-not-typedarray-instance.js
     prototype/every/values-are-not-cached.js
-    prototype/fill/BigInt/coerced-indexes.js
-    prototype/fill/BigInt/detached-buffer.js
-    prototype/fill/BigInt/fill-values-conversion-once.js
-    prototype/fill/BigInt/fill-values-custom-start-and-end.js
-    prototype/fill/BigInt/fill-values-non-numeric-throw.js
-    prototype/fill/BigInt/fill-values-non-numeric.js
-    prototype/fill/BigInt/fill-values-relative-end.js
-    prototype/fill/BigInt/fill-values-relative-start.js
-    prototype/fill/BigInt/fill-values-symbol-throws.js
-    prototype/fill/BigInt/fill-values.js
-    prototype/fill/BigInt/get-length-ignores-length-prop.js
-    prototype/fill/BigInt/return-abrupt-from-end-as-symbol.js
-    prototype/fill/BigInt/return-abrupt-from-end.js
-    prototype/fill/BigInt/return-abrupt-from-set-value.js
-    prototype/fill/BigInt/return-abrupt-from-start-as-symbol.js
-    prototype/fill/BigInt/return-abrupt-from-start.js
-    prototype/fill/BigInt/return-this.js
+    *prototype/fill/BigInt 17/17 (100.0%)
     prototype/fill/coerced-indexes.js
     prototype/fill/detached-buffer.js
     prototype/fill/fill-values-conversion-once.js
@@ -1219,38 +1036,7 @@ built-ins/TypedArray
     prototype/fill/return-this.js
     prototype/fill/this-is-not-object.js
     prototype/fill/this-is-not-typedarray-instance.js
-    prototype/filter/BigInt/arraylength-internal.js
-    prototype/filter/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/filter/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/filter/BigInt/callbackfn-called-before-ctor.js
-    prototype/filter/BigInt/callbackfn-called-before-species.js
-    prototype/filter/BigInt/callbackfn-detachbuffer.js
-    prototype/filter/BigInt/callbackfn-no-iteration-over-non-integer.js
-    prototype/filter/BigInt/callbackfn-not-callable-throws.js
-    prototype/filter/BigInt/callbackfn-not-called-on-empty.js
-    prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/filter/BigInt/callbackfn-returns-abrupt.js
-    prototype/filter/BigInt/callbackfn-this.js
-    prototype/filter/BigInt/detached-buffer.js
-    prototype/filter/BigInt/result-does-not-share-buffer.js
-    prototype/filter/BigInt/result-empty-callbackfn-returns-false.js
-    prototype/filter/BigInt/result-full-callbackfn-returns-true.js
-    prototype/filter/BigInt/speciesctor-get-ctor-abrupt.js
-    prototype/filter/BigInt/speciesctor-get-ctor-inherited.js
-    prototype/filter/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/filter/BigInt/speciesctor-get-ctor.js
-    prototype/filter/BigInt/speciesctor-get-species-abrupt.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/filter/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/filter/BigInt/speciesctor-get-species.js
-    prototype/filter/BigInt/values-are-not-cached.js
-    prototype/filter/BigInt/values-are-set.js
+    *prototype/filter/BigInt 32/32 (100.0%)
     prototype/filter/arraylength-internal.js
     prototype/filter/callbackfn-arguments-with-thisarg.js
     prototype/filter/callbackfn-arguments-without-thisarg.js
@@ -1285,30 +1071,8 @@ built-ins/TypedArray
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/filter/values-are-not-cached.js
     prototype/filter/values-are-set.js
-    prototype/find/BigInt/detached-buffer.js
-    prototype/find/BigInt/get-length-ignores-length-prop.js
-    prototype/find/BigInt/predicate-call-changes-value.js
-    prototype/find/BigInt/predicate-call-parameters.js
-    prototype/find/BigInt/predicate-call-this-non-strict.js
-    prototype/find/BigInt/predicate-call-this-strict.js
-    prototype/find/BigInt/predicate-is-not-callable-throws.js
-    prototype/find/BigInt/predicate-may-detach-buffer.js
-    prototype/find/BigInt/predicate-not-called-on-empty-array.js
-    prototype/find/BigInt/return-abrupt-from-predicate-call.js
-    prototype/find/BigInt/return-found-value-predicate-result-is-true.js
-    prototype/find/BigInt/return-undefined-if-predicate-returns-false-value.js
-    prototype/findIndex/BigInt/detached-buffer.js
-    prototype/findIndex/BigInt/get-length-ignores-length-prop.js
-    prototype/findIndex/BigInt/predicate-call-changes-value.js
-    prototype/findIndex/BigInt/predicate-call-parameters.js
-    prototype/findIndex/BigInt/predicate-call-this-non-strict.js
-    prototype/findIndex/BigInt/predicate-call-this-strict.js
-    prototype/findIndex/BigInt/predicate-is-not-callable-throws.js
-    prototype/findIndex/BigInt/predicate-may-detach-buffer.js
-    prototype/findIndex/BigInt/predicate-not-called-on-empty-array.js
-    prototype/findIndex/BigInt/return-abrupt-from-predicate-call.js
-    prototype/findIndex/BigInt/return-index-predicate-result-is-true.js
-    prototype/findIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
+    *prototype/find/BigInt 12/12 (100.0%)
+    *prototype/findIndex/BigInt 12/12 (100.0%)
     prototype/findIndex/detached-buffer.js
     prototype/findIndex/get-length-ignores-length-prop.js
     prototype/findIndex/invoked-as-func.js
@@ -1317,8 +1081,8 @@ built-ins/TypedArray
     prototype/findIndex/name.js
     prototype/findIndex/predicate-call-changes-value.js
     prototype/findIndex/predicate-call-parameters.js
-    prototype/findIndex/predicate-call-this-non-strict.js
-    prototype/findIndex/predicate-call-this-strict.js
+    prototype/findIndex/predicate-call-this-non-strict.js non-strict
+    prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/predicate-may-detach-buffer.js
     prototype/findIndex/predicate-not-called-on-empty-array.js
     prototype/findIndex/prop-desc.js
@@ -1335,8 +1099,8 @@ built-ins/TypedArray
     prototype/find/name.js
     prototype/find/predicate-call-changes-value.js
     prototype/find/predicate-call-parameters.js
-    prototype/find/predicate-call-this-non-strict.js
-    prototype/find/predicate-call-this-strict.js
+    prototype/find/predicate-call-this-non-strict.js non-strict
+    prototype/find/predicate-call-this-strict.js strict
     prototype/find/predicate-may-detach-buffer.js
     prototype/find/predicate-not-called-on-empty-array.js
     prototype/find/prop-desc.js
@@ -1345,19 +1109,7 @@ built-ins/TypedArray
     prototype/find/return-undefined-if-predicate-returns-false-value.js
     prototype/find/this-is-not-object.js
     prototype/find/this-is-not-typedarray-instance.js
-    prototype/forEach/BigInt/arraylength-internal.js
-    prototype/forEach/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/forEach/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/forEach/BigInt/callbackfn-detachbuffer.js
-    prototype/forEach/BigInt/callbackfn-is-not-callable.js
-    prototype/forEach/BigInt/callbackfn-no-interaction-over-non-integer.js
-    prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
-    prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/forEach/BigInt/callbackfn-returns-abrupt.js
-    prototype/forEach/BigInt/callbackfn-this.js
-    prototype/forEach/BigInt/detached-buffer.js
-    prototype/forEach/BigInt/returns-undefined.js
-    prototype/forEach/BigInt/values-are-not-cached.js
+    *prototype/forEach/BigInt 13/13 (100.0%)
     prototype/forEach/arraylength-internal.js
     prototype/forEach/callbackfn-arguments-with-thisarg.js
     prototype/forEach/callbackfn-arguments-without-thisarg.js
@@ -1377,17 +1129,7 @@ built-ins/TypedArray
     prototype/forEach/this-is-not-object.js
     prototype/forEach/this-is-not-typedarray-instance.js
     prototype/forEach/values-are-not-cached.js
-    prototype/includes/BigInt/detached-buffer.js
-    prototype/includes/BigInt/fromIndex-equal-or-greater-length-returns-false.js
-    prototype/includes/BigInt/fromIndex-infinity.js
-    prototype/includes/BigInt/fromIndex-minus-zero.js
-    prototype/includes/BigInt/get-length-uses-internal-arraylength.js
-    prototype/includes/BigInt/length-zero-returns-false.js
-    prototype/includes/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/includes/BigInt/return-abrupt-tointeger-fromindex.js
-    prototype/includes/BigInt/search-found-returns-true.js
-    prototype/includes/BigInt/search-not-found-returns-false.js
-    prototype/includes/BigInt/tointeger-fromindex.js
+    *prototype/includes/BigInt 11/11 (100.0%)
     prototype/includes/detached-buffer.js
     prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
     prototype/includes/fromIndex-infinity.js
@@ -1406,17 +1148,7 @@ built-ins/TypedArray
     prototype/includes/this-is-not-object.js
     prototype/includes/this-is-not-typedarray-instance.js
     prototype/includes/tointeger-fromindex.js
-    prototype/indexOf/BigInt/detached-buffer.js
-    prototype/indexOf/BigInt/fromIndex-equal-or-greater-length-returns-minus-one.js
-    prototype/indexOf/BigInt/fromIndex-infinity.js
-    prototype/indexOf/BigInt/fromIndex-minus-zero.js
-    prototype/indexOf/BigInt/get-length-uses-internal-arraylength.js
-    prototype/indexOf/BigInt/length-zero-returns-minus-one.js
-    prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex.js
-    prototype/indexOf/BigInt/search-found-returns-index.js
-    prototype/indexOf/BigInt/search-not-found-returns-minus-one.js
-    prototype/indexOf/BigInt/tointeger-fromindex.js
+    *prototype/indexOf/BigInt 11/11 (100.0%)
     prototype/indexOf/detached-buffer.js
     prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
     prototype/indexOf/fromIndex-infinity.js
@@ -1435,13 +1167,7 @@ built-ins/TypedArray
     prototype/indexOf/this-is-not-object.js
     prototype/indexOf/this-is-not-typedarray-instance.js
     prototype/indexOf/tointeger-fromindex.js
-    prototype/join/BigInt/custom-separator-result-from-tostring-on-each-simple-value.js
-    prototype/join/BigInt/detached-buffer.js
-    prototype/join/BigInt/empty-instance-empty-string.js
-    prototype/join/BigInt/get-length-uses-internal-arraylength.js
-    prototype/join/BigInt/result-from-tostring-on-each-simple-value.js
-    prototype/join/BigInt/return-abrupt-from-separator-symbol.js
-    prototype/join/BigInt/return-abrupt-from-separator.js
+    *prototype/join/BigInt 7/7 (100.0%)
     prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
     prototype/join/custom-separator-result-from-tostring-on-each-value.js
     prototype/join/detached-buffer.js
@@ -1457,29 +1183,9 @@ built-ins/TypedArray
     prototype/join/return-abrupt-from-separator.js
     prototype/join/this-is-not-object.js
     prototype/join/this-is-not-typedarray-instance.js
-    prototype/keys/BigInt/detached-buffer.js
-    prototype/keys/BigInt/iter-prototype.js
-    prototype/keys/BigInt/return-itor.js
-    prototype/keys/detached-buffer.js
-    prototype/keys/invoked-as-func.js
-    prototype/keys/invoked-as-method.js
-    prototype/keys/iter-prototype.js
-    prototype/keys/length.js
-    prototype/keys/name.js
-    prototype/keys/prop-desc.js
-    prototype/keys/return-itor.js
-    prototype/keys/this-is-not-object.js
-    prototype/keys/this-is-not-typedarray-instance.js
-    prototype/lastIndexOf/BigInt/detached-buffer.js
-    prototype/lastIndexOf/BigInt/fromIndex-infinity.js
-    prototype/lastIndexOf/BigInt/fromIndex-minus-zero.js
-    prototype/lastIndexOf/BigInt/get-length-uses-internal-arraylength.js
-    prototype/lastIndexOf/BigInt/length-zero-returns-minus-one.js
-    prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex.js
-    prototype/lastIndexOf/BigInt/search-found-returns-index.js
-    prototype/lastIndexOf/BigInt/search-not-found-returns-minus-one.js
-    prototype/lastIndexOf/BigInt/tointeger-fromindex.js
+    *prototype/keys/BigInt 3/3 (100.0%)
+    *prototype/keys 10/10 (100.0%)
+    *prototype/lastIndexOf/BigInt 10/10 (100.0%)
     prototype/lastIndexOf/detached-buffer.js
     prototype/lastIndexOf/fromIndex-infinity.js
     prototype/lastIndexOf/fromIndex-minus-zero.js
@@ -1497,8 +1203,7 @@ built-ins/TypedArray
     prototype/lastIndexOf/this-is-not-object.js
     prototype/lastIndexOf/this-is-not-typedarray-instance.js
     prototype/lastIndexOf/tointeger-fromindex.js
-    prototype/length/BigInt/detached-buffer.js
-    prototype/length/BigInt/return-length.js
+    *prototype/length/BigInt 2/2 (100.0%)
     prototype/length/detached-buffer.js
     prototype/length/invoked-as-func.js
     prototype/length/length.js
@@ -1506,36 +1211,7 @@ built-ins/TypedArray
     prototype/length/prop-desc.js
     prototype/length/this-has-no-typedarrayname-internal.js
     prototype/length/this-is-not-object.js
-    prototype/map/BigInt/arraylength-internal.js
-    prototype/map/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/map/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/map/BigInt/callbackfn-detachbuffer.js
-    prototype/map/BigInt/callbackfn-is-not-callable.js
-    prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
-    prototype/map/BigInt/callbackfn-not-called-on-empty.js
-    prototype/map/BigInt/callbackfn-return-affects-returned-object.js
-    prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/map/BigInt/callbackfn-return-does-not-copy-non-integer-properties.js
-    prototype/map/BigInt/callbackfn-returns-abrupt.js
-    prototype/map/BigInt/callbackfn-this.js
-    prototype/map/BigInt/detached-buffer.js
-    prototype/map/BigInt/return-new-typedarray-from-empty-length.js
-    prototype/map/BigInt/return-new-typedarray-from-positive-length.js
-    prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
-    prototype/map/BigInt/speciesctor-get-ctor-inherited.js
-    prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/map/BigInt/speciesctor-get-ctor.js
-    prototype/map/BigInt/speciesctor-get-species-abrupt.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/map/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/map/BigInt/speciesctor-get-species.js
-    prototype/map/BigInt/values-are-not-cached.js
+    *prototype/map/BigInt 30/30 (100.0%)
     prototype/map/arraylength-internal.js
     prototype/map/callbackfn-arguments-with-thisarg.js
     prototype/map/callbackfn-arguments-without-thisarg.js
@@ -1570,40 +1246,8 @@ built-ins/TypedArray
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/map/values-are-not-cached.js
-    prototype/reduce/BigInt/callbackfn-arguments-custom-accumulator.js
-    prototype/reduce/BigInt/callbackfn-arguments-default-accumulator.js
-    prototype/reduce/BigInt/callbackfn-detachbuffer.js
-    prototype/reduce/BigInt/callbackfn-is-not-callable-throws.js
-    prototype/reduce/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduce/BigInt/callbackfn-not-called-on-empty.js
-    prototype/reduce/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/reduce/BigInt/callbackfn-returns-abrupt.js
-    prototype/reduce/BigInt/callbackfn-this.js
-    prototype/reduce/BigInt/detached-buffer.js
-    prototype/reduce/BigInt/empty-instance-return-initialvalue.js
-    prototype/reduce/BigInt/empty-instance-with-no-initialvalue-throws.js
-    prototype/reduce/BigInt/get-length-uses-internal-arraylength.js
-    prototype/reduce/BigInt/result-is-last-callbackfn-return.js
-    prototype/reduce/BigInt/result-of-any-type.js
-    prototype/reduce/BigInt/return-first-value-without-callbackfn.js
-    prototype/reduce/BigInt/values-are-not-cached.js
-    prototype/reduceRight/BigInt/callbackfn-arguments-custom-accumulator.js
-    prototype/reduceRight/BigInt/callbackfn-arguments-default-accumulator.js
-    prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
-    prototype/reduceRight/BigInt/callbackfn-is-not-callable-throws.js
-    prototype/reduceRight/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduceRight/BigInt/callbackfn-not-called-on-empty.js
-    prototype/reduceRight/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/reduceRight/BigInt/callbackfn-returns-abrupt.js
-    prototype/reduceRight/BigInt/callbackfn-this.js
-    prototype/reduceRight/BigInt/detached-buffer.js
-    prototype/reduceRight/BigInt/empty-instance-return-initialvalue.js
-    prototype/reduceRight/BigInt/empty-instance-with-no-initialvalue-throws.js
-    prototype/reduceRight/BigInt/get-length-uses-internal-arraylength.js
-    prototype/reduceRight/BigInt/result-is-last-callbackfn-return.js
-    prototype/reduceRight/BigInt/result-of-any-type.js
-    prototype/reduceRight/BigInt/return-first-value-without-callbackfn.js
-    prototype/reduceRight/BigInt/values-are-not-cached.js
+    *prototype/reduce/BigInt 17/17 (100.0%)
+    *prototype/reduceRight/BigInt 17/17 (100.0%)
     prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
     prototype/reduceRight/callbackfn-arguments-default-accumulator.js
     prototype/reduceRight/callbackfn-detachbuffer.js
@@ -1648,67 +1292,9 @@ built-ins/TypedArray
     prototype/reduce/this-is-not-object.js
     prototype/reduce/this-is-not-typedarray-instance.js
     prototype/reduce/values-are-not-cached.js
-    prototype/reverse/BigInt/detached-buffer.js
-    prototype/reverse/BigInt/get-length-uses-internal-arraylength.js
-    prototype/reverse/BigInt/preserves-non-numeric-properties.js
-    prototype/reverse/BigInt/returns-original-object.js
-    prototype/reverse/BigInt/reverts.js
-    prototype/reverse/detached-buffer.js
-    prototype/reverse/get-length-uses-internal-arraylength.js
-    prototype/reverse/invoked-as-func.js
-    prototype/reverse/invoked-as-method.js
-    prototype/reverse/length.js
-    prototype/reverse/name.js
-    prototype/reverse/preserves-non-numeric-properties.js
-    prototype/reverse/prop-desc.js
-    prototype/reverse/returns-original-object.js
-    prototype/reverse/reverts.js
-    prototype/reverse/this-is-not-object.js
-    prototype/reverse/this-is-not-typedarray-instance.js
-    prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
-    prototype/set/BigInt/array-arg-offset-tointeger.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
-    prototype/set/BigInt/array-arg-set-values-in-order.js
-    prototype/set/BigInt/array-arg-set-values.js
-    prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
-    prototype/set/BigInt/array-arg-src-values-are-not-cached.js
-    prototype/set/BigInt/array-arg-target-arraylength-internal.js
-    prototype/set/BigInt/array-arg-targetbuffer-detached-on-get-src-value-throws.js
-    prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
-    prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
-    prototype/set/BigInt/bigint-tobigint64.js
-    prototype/set/BigInt/bigint-tobiguint64.js
-    prototype/set/BigInt/boolean-tobigint.js
-    prototype/set/BigInt/null-tobigint.js
-    prototype/set/BigInt/number-tobigint.js
-    prototype/set/BigInt/src-typedarray-big.js
-    prototype/set/BigInt/src-typedarray-not-big-throws.js
-    prototype/set/BigInt/string-nan-tobigint.js
-    prototype/set/BigInt/string-tobigint.js
-    prototype/set/BigInt/symbol-tobigint.js
-    prototype/set/BigInt/typedarray-arg-negative-integer-offset-throws.js
-    prototype/set/BigInt/typedarray-arg-offset-tointeger.js
-    prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
-    prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset.js
-    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
-    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
-    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
-    prototype/set/BigInt/typedarray-arg-src-arraylength-internal.js
-    prototype/set/BigInt/typedarray-arg-src-byteoffset-internal.js
-    prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
-    prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
-    prototype/set/BigInt/typedarray-arg-target-arraylength-internal.js
-    prototype/set/BigInt/typedarray-arg-target-byteoffset-internal.js
-    prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    prototype/set/BigInt/undefined-tobigint.js
+    *prototype/reverse/BigInt 5/5 (100.0%)
+    *prototype/reverse 12/12 (100.0%)
+    *prototype/set/BigInt 44/44 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-return-abrupt-from-src-get-length.js
     prototype/set/array-arg-return-abrupt-from-src-get-value.js
@@ -1742,41 +1328,7 @@ built-ins/TypedArray
     prototype/set/typedarray-arg-target-arraylength-internal.js
     prototype/set/typedarray-arg-target-byteoffset-internal.js
     prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    prototype/slice/BigInt/arraylength-internal.js
-    prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
-    prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
-    prototype/slice/BigInt/detached-buffer-get-ctor.js
-    prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
-    prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
-    prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
-    prototype/slice/BigInt/detached-buffer.js
-    prototype/slice/BigInt/infinity.js
-    prototype/slice/BigInt/minus-zero.js
-    prototype/slice/BigInt/result-does-not-copy-ordinary-properties.js
-    prototype/slice/BigInt/results-with-different-length.js
-    prototype/slice/BigInt/results-with-empty-length.js
-    prototype/slice/BigInt/results-with-same-length.js
-    prototype/slice/BigInt/return-abrupt-from-end-symbol.js
-    prototype/slice/BigInt/return-abrupt-from-end.js
-    prototype/slice/BigInt/return-abrupt-from-start-symbol.js
-    prototype/slice/BigInt/return-abrupt-from-start.js
-    prototype/slice/BigInt/set-values-from-different-ctor-type.js
-    prototype/slice/BigInt/speciesctor-get-ctor-abrupt.js
-    prototype/slice/BigInt/speciesctor-get-ctor-inherited.js
-    prototype/slice/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/slice/BigInt/speciesctor-get-ctor.js
-    prototype/slice/BigInt/speciesctor-get-species-abrupt.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/slice/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/slice/BigInt/speciesctor-get-species.js
-    prototype/slice/BigInt/tointeger-end.js
-    prototype/slice/BigInt/tointeger-start.js
+    *prototype/slice/BigInt 35/35 (100.0%)
     prototype/slice/arraylength-internal.js
     prototype/slice/bit-precision.js
     prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
@@ -1810,20 +1362,7 @@ built-ins/TypedArray
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/slice/tointeger-end.js
     prototype/slice/tointeger-start.js
-    prototype/some/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/some/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/some/BigInt/callbackfn-detachbuffer.js
-    prototype/some/BigInt/callbackfn-no-interaction-over-non-integer.js
-    prototype/some/BigInt/callbackfn-not-callable-throws.js
-    prototype/some/BigInt/callbackfn-not-called-on-empty.js
-    prototype/some/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/some/BigInt/callbackfn-returns-abrupt.js
-    prototype/some/BigInt/callbackfn-this.js
-    prototype/some/BigInt/detached-buffer.js
-    prototype/some/BigInt/get-length-uses-internal-arraylength.js
-    prototype/some/BigInt/returns-false-if-every-cb-returns-false.js
-    prototype/some/BigInt/returns-true-if-any-cb-returns-true.js
-    prototype/some/BigInt/values-are-not-cached.js
+    *prototype/some/BigInt 14/14 (100.0%)
     prototype/some/callbackfn-arguments-with-thisarg.js
     prototype/some/callbackfn-arguments-without-thisarg.js
     prototype/some/callbackfn-detachbuffer.js
@@ -1844,15 +1383,7 @@ built-ins/TypedArray
     prototype/some/this-is-not-object.js
     prototype/some/this-is-not-typedarray-instance.js
     prototype/some/values-are-not-cached.js
-    prototype/sort/BigInt/arraylength-internal.js
-    prototype/sort/BigInt/comparefn-call-throws.js
-    prototype/sort/BigInt/comparefn-calls.js
-    prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
-    prototype/sort/BigInt/detached-buffer-comparefn.js
-    prototype/sort/BigInt/detached-buffer.js
-    prototype/sort/BigInt/return-same-instance.js
-    prototype/sort/BigInt/sortcompare-with-no-tostring.js
-    prototype/sort/BigInt/sorted-values.js
+    *prototype/sort/BigInt 9/9 (100.0%)
     prototype/sort/arraylength-internal.js
     prototype/sort/comparefn-call-throws.js
     prototype/sort/comparefn-calls.js
@@ -1871,33 +1402,7 @@ built-ins/TypedArray
     prototype/sort/stability.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
-    prototype/subarray/BigInt/detached-buffer.js
-    prototype/subarray/BigInt/infinity.js
-    prototype/subarray/BigInt/minus-zero.js
-    prototype/subarray/BigInt/result-does-not-copy-ordinary-properties.js
-    prototype/subarray/BigInt/result-is-new-instance-from-same-ctor.js
-    prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
-    prototype/subarray/BigInt/results-with-different-length.js
-    prototype/subarray/BigInt/results-with-empty-length.js
-    prototype/subarray/BigInt/results-with-same-length.js
-    prototype/subarray/BigInt/return-abrupt-from-begin-symbol.js
-    prototype/subarray/BigInt/return-abrupt-from-begin.js
-    prototype/subarray/BigInt/return-abrupt-from-end-symbol.js
-    prototype/subarray/BigInt/return-abrupt-from-end.js
-    prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
-    prototype/subarray/BigInt/speciesctor-get-ctor-inherited.js
-    prototype/subarray/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/subarray/BigInt/speciesctor-get-ctor.js
-    prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/subarray/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/subarray/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/subarray/BigInt/speciesctor-get-species.js
-    prototype/subarray/BigInt/tointeger-begin.js
-    prototype/subarray/BigInt/tointeger-end.js
+    *prototype/subarray/BigInt 27/27 (100.0%)
     prototype/subarray/detached-buffer.js
     prototype/subarray/infinity.js
     prototype/subarray/invoked-as-func.js
@@ -1918,37 +1423,9 @@ built-ins/TypedArray
     prototype/subarray/speciesctor-get-species.js
     prototype/subarray/this-is-not-object.js
     prototype/subarray/this-is-not-typedarray-instance.js
-    prototype/Symbol.toStringTag/BigInt/detached-buffer.js
-    prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
-    prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
-    prototype/Symbol.toStringTag/BigInt/length.js
-    prototype/Symbol.toStringTag/BigInt/name.js
-    prototype/Symbol.toStringTag/BigInt/prop-desc.js
-    prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
-    prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
-    prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
-    prototype/Symbol.toStringTag/detached-buffer.js
-    prototype/Symbol.toStringTag/invoked-as-accessor.js
-    prototype/Symbol.toStringTag/invoked-as-func.js
-    prototype/Symbol.toStringTag/length.js
-    prototype/Symbol.toStringTag/name.js
-    prototype/Symbol.toStringTag/prop-desc.js
-    prototype/Symbol.toStringTag/return-typedarrayname.js
-    prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
-    prototype/Symbol.toStringTag/this-is-not-object.js
-    prototype/toLocaleString/BigInt/calls-tolocalestring-from-each-value.js
-    prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
-    prototype/toLocaleString/BigInt/calls-valueof-from-each-value.js
-    prototype/toLocaleString/BigInt/detached-buffer.js
-    prototype/toLocaleString/BigInt/empty-instance-returns-empty-string.js
-    prototype/toLocaleString/BigInt/get-length-uses-internal-arraylength.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tolocalestring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tostring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-valueof.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tolocalestring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof.js
-    prototype/toLocaleString/BigInt/return-result.js
+    *prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
+    *prototype/Symbol.toStringTag 9/9 (100.0%)
+    *prototype/toLocaleString/BigInt 13/13 (100.0%)
     prototype/toLocaleString/calls-tolocalestring-from-each-value.js
     prototype/toLocaleString/calls-tostring-from-each-value.js
     prototype/toLocaleString/calls-valueof-from-each-value.js
@@ -1969,142 +1446,25 @@ built-ins/TypedArray
     prototype/toLocaleString/this-is-not-typedarray-instance.js
     prototype/toString/BigInt/detached-buffer.js
     prototype/toString/detached-buffer.js
-    prototype/values/BigInt/detached-buffer.js
-    prototype/values/BigInt/iter-prototype.js
-    prototype/values/BigInt/return-itor.js
-    prototype/values/detached-buffer.js
-    prototype/values/invoked-as-func.js
-    prototype/values/invoked-as-method.js
-    prototype/values/iter-prototype.js
-    prototype/values/length.js
-    prototype/values/name.js
-    prototype/values/prop-desc.js
-    prototype/values/return-itor.js
-    prototype/values/this-is-not-object.js
-    prototype/values/this-is-not-typedarray-instance.js
-    prototype/constructor.js
-    prototype/Symbol.iterator.js
-    prototype/toString.js
-    Symbol.species/length.js
-    Symbol.species/name.js
-    Symbol.species/prop-desc.js
-    Symbol.species/result.js
+    *prototype/values/BigInt 3/3 (100.0%)
+    *prototype/values 10/10 (100.0%)
+    *prototype 3/3 (100.0%)
+    *Symbol.species 4/4 (100.0%)
     invoked.js
     length.js
     name.js
     prototype.js
 
-built-ins/TypedArrayConstructors
-    BigInt64Array/prototype/BYTES_PER_ELEMENT.js
-    BigInt64Array/prototype/constructor.js
-    BigInt64Array/prototype/not-typedarray-object.js
-    BigInt64Array/prototype/proto.js
-    BigInt64Array/BYTES_PER_ELEMENT.js
-    BigInt64Array/constructor.js
-    BigInt64Array/length.js
-    BigInt64Array/name.js
-    BigInt64Array/prop-desc.js
-    BigInt64Array/proto.js
-    BigInt64Array/prototype.js
-    BigUint64Array/prototype/BYTES_PER_ELEMENT.js
-    BigUint64Array/prototype/constructor.js
-    BigUint64Array/prototype/not-typedarray-object.js
-    BigUint64Array/prototype/proto.js
-    BigUint64Array/BYTES_PER_ELEMENT.js
-    BigUint64Array/constructor.js
-    BigUint64Array/length.js
-    BigUint64Array/name.js
-    BigUint64Array/prop-desc.js
-    BigUint64Array/proto.js
-    BigUint64Array/prototype.js
-    ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
-    ctors-bigint/buffer-arg/byteoffset-is-negative-throws.js
-    ctors-bigint/buffer-arg/byteoffset-is-negative-zero.js
-    ctors-bigint/buffer-arg/byteoffset-is-symbol-throws.js
-    ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size.js
-    ctors-bigint/buffer-arg/byteoffset-to-number-detachbuffer.js
-    ctors-bigint/buffer-arg/byteoffset-to-number-throws.js
-    ctors-bigint/buffer-arg/defined-length-and-offset.js
-    ctors-bigint/buffer-arg/defined-length.js
-    ctors-bigint/buffer-arg/defined-negative-length.js
-    ctors-bigint/buffer-arg/defined-offset.js
-    ctors-bigint/buffer-arg/detachedbuffer.js
-    ctors-bigint/buffer-arg/excessive-length-throws.js
-    ctors-bigint/buffer-arg/excessive-offset-throws.js
-    ctors-bigint/buffer-arg/invoked-with-undefined-newtarget.js
-    ctors-bigint/buffer-arg/is-referenced.js
-    ctors-bigint/buffer-arg/length-access-throws.js
-    ctors-bigint/buffer-arg/length-is-symbol-throws.js
-    ctors-bigint/buffer-arg/length-to-number-detachbuffer.js
-    ctors-bigint/buffer-arg/new-instance-extensibility.js
-    ctors-bigint/buffer-arg/returns-new-instance.js
-    ctors-bigint/buffer-arg/toindex-bytelength.js
-    ctors-bigint/buffer-arg/toindex-byteoffset.js
-    ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ctors-bigint/length-arg/init-zeros.js
-    ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
-    ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
-    ctors-bigint/length-arg/is-symbol-throws.js
-    ctors-bigint/length-arg/new-instance-extensibility.js
-    ctors-bigint/length-arg/returns-object.js
-    ctors-bigint/length-arg/toindex-length.js
-    ctors-bigint/length-arg/undefined-newtarget-throws.js
-    ctors-bigint/length-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ctors-bigint/no-args/new-instance-extensibility.js
-    ctors-bigint/no-args/returns-object.js
-    ctors-bigint/no-args/undefined-newtarget-throws.js
-    ctors-bigint/no-args/use-default-proto-if-custom-proto-is-not-object.js
-    ctors-bigint/object-arg/as-array-returns.js
-    ctors-bigint/object-arg/as-generator-iterable-returns.js
-    ctors-bigint/object-arg/bigint-tobigint64.js
-    ctors-bigint/object-arg/bigint-tobiguint64.js
-    ctors-bigint/object-arg/boolean-tobigint.js
-    ctors-bigint/object-arg/iterating-throws.js
-    ctors-bigint/object-arg/iterator-not-callable-throws.js
-    ctors-bigint/object-arg/iterator-throws.js
-    ctors-bigint/object-arg/length-excessive-throws.js
-    ctors-bigint/object-arg/length-is-symbol-throws.js
-    ctors-bigint/object-arg/length-throws.js
-    ctors-bigint/object-arg/new-instance-extensibility.js
-    ctors-bigint/object-arg/null-tobigint.js
-    ctors-bigint/object-arg/number-tobigint.js
-    ctors-bigint/object-arg/string-nan-tobigint.js
-    ctors-bigint/object-arg/string-tobigint.js
-    ctors-bigint/object-arg/symbol-tobigint.js
-    ctors-bigint/object-arg/throws-from-property.js
-    ctors-bigint/object-arg/throws-setting-obj-to-primitive-typeerror.js
-    ctors-bigint/object-arg/throws-setting-obj-to-primitive.js
-    ctors-bigint/object-arg/throws-setting-obj-tostring.js
-    ctors-bigint/object-arg/throws-setting-obj-valueof-typeerror.js
-    ctors-bigint/object-arg/throws-setting-obj-valueof.js
-    ctors-bigint/object-arg/throws-setting-property.js
-    ctors-bigint/object-arg/throws-setting-symbol-property.js
-    ctors-bigint/object-arg/undefined-newtarget-throws.js
-    ctors-bigint/object-arg/undefined-tobigint.js
-    ctors-bigint/object-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ctors-bigint/typedarray-arg/detached-when-species-retrieved-different-type.js
-    ctors-bigint/typedarray-arg/detached-when-species-retrieved-same-type.js
-    ctors-bigint/typedarray-arg/new-instance-extensibility.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-null.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
-    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js
-    ctors-bigint/typedarray-arg/other-ctor-returns-new-typedarray.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-null.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
-    ctors-bigint/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
-    ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
-    ctors-bigint/typedarray-arg/undefined-newtarget-throws.js
+built-ins/TypedArrayConstructors 339/498 (68.07%)
+    *BigInt64Array/prototype 4/4 (100.0%)
+    *BigInt64Array 7/7 (100.0%)
+    *BigUint64Array/prototype 4/4 (100.0%)
+    *BigUint64Array 7/7 (100.0%)
+    *ctors-bigint/buffer-arg 24/24 (100.0%)
+    *ctors-bigint/length-arg 9/9 (100.0%)
+    *ctors-bigint/no-args 4/4 (100.0%)
+    *ctors-bigint/object-arg 28/28 (100.0%)
+    *ctors-bigint/typedarray-arg 23/23 (100.0%)
     ctors/buffer-arg/byteoffset-is-negative-throws.js
     ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
     ctors/buffer-arg/defined-negative-length.js
@@ -2152,34 +1512,7 @@ built-ins/TypedArrayConstructors
     Float32Array/prototype/proto.js
     Float64Array/prototype/not-typedarray-object.js
     Float64Array/prototype/proto.js
-    from/BigInt/arylk-get-length-error.js
-    from/BigInt/arylk-to-length-error.js
-    from/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
-    from/BigInt/custom-ctor-returns-other-instance.js
-    from/BigInt/custom-ctor-returns-smaller-instance-throws.js
-    from/BigInt/custom-ctor.js
-    from/BigInt/inherited.js
-    from/BigInt/invoked-as-func.js
-    from/BigInt/iter-access-error.js
-    from/BigInt/iter-invoke-error.js
-    from/BigInt/iter-next-error.js
-    from/BigInt/iter-next-value-error.js
-    from/BigInt/mapfn-abrupt-completion.js
-    from/BigInt/mapfn-arguments.js
-    from/BigInt/mapfn-is-not-callable.js
-    from/BigInt/mapfn-this-with-thisarg.js
-    from/BigInt/mapfn-this-without-thisarg-non-strict.js
-    from/BigInt/mapfn-this-without-thisarg-strict.js
-    from/BigInt/new-instance-empty.js
-    from/BigInt/new-instance-from-ordinary-object.js
-    from/BigInt/new-instance-from-sparse-array.js
-    from/BigInt/new-instance-using-custom-ctor.js
-    from/BigInt/new-instance-with-mapfn.js
-    from/BigInt/new-instance-without-mapfn.js
-    from/BigInt/property-abrupt-completion.js
-    from/BigInt/set-value-abrupt-completion.js
-    from/BigInt/source-value-is-symbol-throws.js
-    from/BigInt/this-is-not-constructor.js
+    *from/BigInt 28/28 (100.0%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/custom-ctor-returns-other-instance.js
@@ -2191,8 +1524,8 @@ built-ins/TypedArrayConstructors
     from/mapfn-abrupt-completion.js
     from/mapfn-arguments.js
     from/mapfn-this-with-thisarg.js
-    from/mapfn-this-without-thisarg-non-strict.js
-    from/mapfn-this-without-thisarg-strict.js
+    from/mapfn-this-without-thisarg-non-strict.js non-strict
+    from/mapfn-this-without-thisarg-strict.js strict
     from/nan-conversion.js
     from/new-instance-empty.js
     from/new-instance-from-ordinary-object.js
@@ -2210,32 +1543,9 @@ built-ins/TypedArrayConstructors
     Int8Array/prototype/not-typedarray-object.js
     Int8Array/prototype/proto.js
     internals/DefineOwnProperty/BigInt/desc-value-throws.js
-    internals/DefineOwnProperty/conversion-operation-consistent-nan.js
-    internals/DefineOwnProperty/conversion-operation.js
-    internals/DefineOwnProperty/desc-value-throws.js
-    internals/Get/BigInt/detached-buffer-key-is-not-numeric-index.js
-    internals/Get/BigInt/detached-buffer-key-is-symbol.js
-    internals/Get/BigInt/detached-buffer.js
-    internals/Get/BigInt/indexed-value.js
-    internals/Get/BigInt/infinity-detached-buffer.js
-    internals/Get/BigInt/key-is-not-canonical-index.js
-    internals/Get/BigInt/key-is-not-integer.js
-    internals/Get/BigInt/key-is-not-minus-zero.js
-    internals/Get/BigInt/key-is-not-numeric-index-get-throws.js
-    internals/Get/BigInt/key-is-not-numeric-index.js
-    internals/Get/BigInt/key-is-out-of-bounds.js
-    internals/Get/BigInt/key-is-symbol.js
-    internals/GetOwnProperty/BigInt/detached-buffer-key-is-not-number.js
-    internals/GetOwnProperty/BigInt/detached-buffer-key-is-symbol.js
-    internals/GetOwnProperty/BigInt/detached-buffer.js
-    internals/GetOwnProperty/BigInt/enumerate-detached-buffer.js
-    internals/GetOwnProperty/BigInt/index-prop-desc.js
-    internals/GetOwnProperty/BigInt/key-is-minus-zero.js
-    internals/GetOwnProperty/BigInt/key-is-not-canonical-index.js
-    internals/GetOwnProperty/BigInt/key-is-not-integer.js
-    internals/GetOwnProperty/BigInt/key-is-not-numeric-index.js
-    internals/GetOwnProperty/BigInt/key-is-out-of-bounds.js
-    internals/GetOwnProperty/BigInt/key-is-symbol.js
+    *internals/DefineOwnProperty 3/3 (100.0%)
+    *internals/Get/BigInt 12/12 (100.0%)
+    *internals/GetOwnProperty/BigInt 11/11 (100.0%)
     internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     internals/GetOwnProperty/detached-buffer-key-is-symbol.js
     internals/GetOwnProperty/detached-buffer.js
@@ -2252,34 +1562,12 @@ built-ins/TypedArrayConstructors
     internals/Get/key-is-not-numeric-index.js
     internals/Get/key-is-out-of-bounds.js
     internals/Get/key-is-symbol.js
-    internals/HasProperty/BigInt/infinity-with-detached-buffer.js
-    internals/HasProperty/infinity-with-detached-buffer.js
-    internals/Set/BigInt/bigint-tobigint64.js
-    internals/Set/BigInt/bigint-tobiguint64.js
-    internals/Set/BigInt/boolean-tobigint.js
-    internals/Set/BigInt/detached-buffer.js
-    internals/Set/BigInt/key-is-not-numeric-index-set-throws.js
-    internals/Set/BigInt/null-tobigint.js
-    internals/Set/BigInt/number-tobigint.js
-    internals/Set/BigInt/string-nan-tobigint.js
-    internals/Set/BigInt/string-tobigint.js
-    internals/Set/BigInt/symbol-tobigint.js
-    internals/Set/BigInt/tonumber-value-throws.js
-    internals/Set/BigInt/undefined-tobigint.js
+    internals/HasProperty/BigInt/infinity-with-detached-buffer.js non-strict
+    internals/HasProperty/infinity-with-detached-buffer.js non-strict
+    *internals/Set/BigInt 12/12 (100.0%)
     internals/Set/detached-buffer.js
     internals/Set/tonumber-value-throws.js
-    of/BigInt/argument-is-symbol-throws.js
-    of/BigInt/argument-number-value-throws.js
-    of/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
-    of/BigInt/custom-ctor-returns-other-instance.js
-    of/BigInt/custom-ctor-returns-smaller-instance-throws.js
-    of/BigInt/custom-ctor.js
-    of/BigInt/inherited.js
-    of/BigInt/invoked-as-func.js
-    of/BigInt/new-instance-empty.js
-    of/BigInt/new-instance-using-custom-ctor.js
-    of/BigInt/new-instance.js
-    of/BigInt/this-is-not-constructor.js
+    *of/BigInt 12/12 (100.0%)
     of/argument-number-value-throws.js
     of/custom-ctor-returns-other-instance.js
     of/custom-ctor.js
@@ -2288,12 +1576,9 @@ built-ins/TypedArrayConstructors
     of/new-instance-from-zero.js
     of/new-instance-using-custom-ctor.js
     of/new-instance.js
-    prototype/buffer/bigint-inherited.js
-    prototype/buffer/inherited.js
-    prototype/byteLength/bigint-inherited.js
-    prototype/byteLength/inherited.js
-    prototype/byteOffset/bigint-inherited.js
-    prototype/byteOffset/inherited.js
+    *prototype/buffer 2/2 (100.0%)
+    *prototype/byteLength 2/2 (100.0%)
+    *prototype/byteOffset 2/2 (100.0%)
     prototype/copyWithin/bigint-inherited.js
     prototype/entries/bigint-inherited.js
     prototype/every/bigint-inherited.js
@@ -2306,26 +1591,21 @@ built-ins/TypedArrayConstructors
     prototype/join/bigint-inherited.js
     prototype/keys/bigint-inherited.js
     prototype/lastIndexOf/bigint-inherited.js
-    prototype/length/bigint-inherited.js
-    prototype/length/inherited.js
+    *prototype/length 2/2 (100.0%)
     prototype/map/bigint-inherited.js
     prototype/reduceRight/bigint-inherited.js
     prototype/reduce/bigint-inherited.js
     prototype/reverse/bigint-inherited.js
-    prototype/set/bigint-inherited.js
-    prototype/set/inherited.js
+    *prototype/set 2/2 (100.0%)
     prototype/slice/bigint-inherited.js
     prototype/some/bigint-inherited.js
     prototype/sort/bigint-inherited.js
-    prototype/subarray/bigint-inherited.js
-    prototype/subarray/inherited.js
+    *prototype/subarray 2/2 (100.0%)
     prototype/Symbol.toStringTag/bigint-inherited.js
     prototype/toLocaleString/bigint-inherited.js
-    prototype/toString/bigint-inherited.js
-    prototype/toString/inherited.js
+    *prototype/toString 2/2 (100.0%)
     prototype/values/bigint-inherited.js
-    prototype/bigint-Symbol.iterator.js
-    prototype/Symbol.iterator.js
+    *prototype 2/2 (100.0%)
     Uint16Array/prototype/not-typedarray-object.js
     Uint16Array/prototype/proto.js
     Uint32Array/prototype/not-typedarray-object.js
@@ -2335,52 +1615,52 @@ built-ins/TypedArrayConstructors
     Uint8ClampedArray/prototype/not-typedarray-object.js
     Uint8ClampedArray/prototype/proto.js
 
-built-ins/undefined
+built-ins/undefined 0/8 (0.0%)
 
-built-ins/WeakMap
+built-ins/WeakMap 0/87 (0.0%)
 
-built-ins/WeakSet
+built-ins/WeakSet 0/74 (0.0%)
 
-language/arguments-object
-    mapped/mapped-arguments-nonconfigurable-3.js
-    mapped/mapped-arguments-nonconfigurable-delete-1.js
-    mapped/mapped-arguments-nonconfigurable-delete-2.js
-    mapped/mapped-arguments-nonconfigurable-delete-3.js
-    mapped/mapped-arguments-nonconfigurable-delete-4.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js
-    mapped/nonconfigurable-descriptors-basic.js
-    mapped/nonconfigurable-descriptors-set-value-by-arguments.js
-    mapped/nonconfigurable-descriptors-set-value-with-define-property.js
-    mapped/nonconfigurable-descriptors-with-param-assign.js
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
-    mapped/nonconfigurable-nonwritable-descriptors-basic.js
-    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
-    mapped/nonwritable-nonconfigurable-descriptors-basic.js
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
-    mapped/Symbol.iterator.js
-    unmapped/Symbol.iterator.js
+language/arguments-object 91/162 (56.17%)
+    mapped/mapped-arguments-nonconfigurable-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict
+    mapped/nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict
+    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict
+    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
+    mapped/Symbol.iterator.js non-strict
+    unmapped/Symbol.iterator.js non-strict
     unmapped/via-params-dflt.js
-    unmapped/via-params-dstr.js
+    unmapped/via-params-dstr.js non-strict
     unmapped/via-params-rest.js
     arguments-caller.js
     cls-decl-gen-meth-args-trailing-comma-multiple.js
@@ -2434,20 +1714,20 @@ language/arguments-object
     gen-meth-args-trailing-comma-undefined.js
     meth-args-trailing-comma-spread-operator.js
 
-language/asi
+language/asi 1/101 (0.99%)
     S7.9_A5.7_T1.js
 
-language/block-scope
+language/block-scope 46/109 (42.2%)
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
     syntax/for-in/disallow-initialization-assignment.js
     syntax/for-in/mixed-values-in-iteration.js
-    syntax/function-declarations/in-statement-position-do-statement-while-expression.js
-    syntax/function-declarations/in-statement-position-for-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement.js
-    syntax/function-declarations/in-statement-position-while-expression-statement.js
+    syntax/function-declarations/in-statement-position-do-statement-while-expression.js strict
+    syntax/function-declarations/in-statement-position-for-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement.js strict
+    syntax/function-declarations/in-statement-position-while-expression-statement.js strict
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-class.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
@@ -2456,7 +1736,7 @@ language/block-scope
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-class.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
@@ -2485,7 +1765,7 @@ language/block-scope
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
-language/comments
+language/comments 5/20 (25.0%)
     multi-line-asi-carriage-return.js
     multi-line-asi-line-feed.js
     multi-line-asi-line-separator.js
@@ -2494,7 +1774,7 @@ language/comments
 
 ~language/computed-property-names
 
-language/destructuring
+language/destructuring 9/15 (60.0%)
     binding/syntax/array-elements-with-initializer.js
     binding/syntax/array-elements-with-object-patterns.js
     binding/syntax/array-rest-elements.js
@@ -2505,53 +1785,53 @@ language/destructuring
     binding/initialization-requires-object-coercible-null.js
     binding/initialization-requires-object-coercible-undefined.js
 
-language/directive-prologue
-    14.1-1-s.js
-    14.1-10-s.js
-    14.1-11-s.js
-    14.1-12-s.js
-    14.1-13-s.js
-    14.1-14-s.js
-    14.1-15-s.js
-    14.1-16-s.js
-    14.1-17-s.js
-    14.1-2-s.js
-    14.1-3-s.js
-    14.1-4-s.js
-    14.1-5-s.js
-    14.1-6-s.js
-    14.1-7-s.js
-    14.1-8-s.js
-    14.1-9-s.js
-    func-decl-inside-func-decl-parse.js
+language/directive-prologue 18/62 (29.03%)
+    14.1-1-s.js {non-strict: [-1]}
+    14.1-10-s.js {non-strict: [-1]}
+    14.1-11-s.js {non-strict: [-1]}
+    14.1-12-s.js {non-strict: [-1]}
+    14.1-13-s.js {non-strict: [-1]}
+    14.1-14-s.js {non-strict: [-1]}
+    14.1-15-s.js {non-strict: [-1]}
+    14.1-16-s.js {non-strict: [0, 9]}
+    14.1-17-s.js {non-strict: [0, 9]}
+    14.1-2-s.js {non-strict: [-1]}
+    14.1-3-s.js {non-strict: [0, 9]}
+    14.1-4-s.js {non-strict: [0, 9]}
+    14.1-5-s.js {non-strict: [0, 9]}
+    14.1-6-s.js {non-strict: [0, 9]}
+    14.1-7-s.js {non-strict: [0, 9]}
+    14.1-8-s.js {non-strict: [-1]}
+    14.1-9-s.js {non-strict: [-1]}
+    func-decl-inside-func-decl-parse.js non-strict
 
-language/eval-code
-    direct/block-decl-eval-source-is-strict-nostrict.js
-    direct/block-decl-eval-source-is-strict-onlystrict.js
-    direct/block-decl-onlystrict.js
+language/eval-code 40/126 (31.75%)
+    direct/block-decl-eval-source-is-strict-nostrict.js non-strict
+    direct/block-decl-eval-source-is-strict-onlystrict.js strict
+    direct/block-decl-onlystrict.js strict
     direct/lex-env-distinct-const.js
     direct/lex-env-distinct-let.js
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
-    direct/non-definable-global-var.js
-    direct/switch-case-decl-eval-source-is-strict-nostrict.js
-    direct/switch-case-decl-eval-source-is-strict-onlystrict.js
-    direct/switch-case-decl-onlystrict.js
-    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js
-    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js
-    direct/switch-dflt-decl-onlystrict.js
-    direct/this-value-func-strict-caller.js
-    direct/var-env-func-init-global-update-configurable.js
-    direct/var-env-func-strict-caller-2.js
-    direct/var-env-func-strict-caller.js
+    direct/non-definable-global-var.js non-strict
+    direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
+    direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
+    direct/switch-case-decl-onlystrict.js strict
+    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js non-strict
+    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js strict
+    direct/switch-dflt-decl-onlystrict.js strict
+    direct/this-value-func-strict-caller.js strict
+    direct/var-env-func-init-global-update-configurable.js non-strict
+    direct/var-env-func-strict-caller-2.js strict
+    direct/var-env-func-strict-caller.js strict
     direct/var-env-func-strict-source.js
-    direct/var-env-global-lex-non-strict.js
-    direct/var-env-lower-lex-non-strict.js
-    direct/var-env-var-strict-caller-2.js
-    direct/var-env-var-strict-caller-3.js
-    direct/var-env-var-strict-caller.js
+    direct/var-env-global-lex-non-strict.js non-strict
+    direct/var-env-lower-lex-non-strict.js non-strict
+    direct/var-env-var-strict-caller-2.js strict
+    direct/var-env-var-strict-caller-3.js strict
+    direct/var-env-var-strict-caller.js strict
     direct/var-env-var-strict-source.js
-    indirect/always-non-strict.js
+    indirect/always-non-strict.js strict
     indirect/block-decl-strict.js
     indirect/lex-env-distinct-const.js
     indirect/lex-env-distinct-let.js
@@ -2559,7 +1839,7 @@ language/eval-code
     indirect/lex-env-no-init-let.js
     indirect/non-definable-function-with-function.js
     indirect/non-definable-function-with-variable.js
-    indirect/non-definable-global-var.js
+    indirect/non-definable-global-var.js non-strict
     indirect/switch-case-decl-strict.js
     indirect/switch-dflt-decl-strict.js
     indirect/var-env-func-init-global-update-configurable.js
@@ -2569,7 +1849,7 @@ language/eval-code
 
 ~language/export
 
-language/expressions/addition
+language/expressions/addition 6/45 (13.33%)
     coerce-symbol-to-prim-err.js
     coerce-symbol-to-prim-invocation.js
     coerce-symbol-to-prim-return-obj.js
@@ -2577,7 +1857,7 @@ language/expressions/addition
     get-symbol-to-prim-err.js
     order-of-evaluation.js
 
-language/expressions/arrow-function
+language/expressions/arrow-function 168/219 (76.71%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-ptrn-elem-ary-elem-init.js
@@ -2671,19 +1951,19 @@ language/expressions/arrow-function
     dstr/syntax-error-ident-ref-for-escaped.js
     dstr/syntax-error-ident-ref-function-escaped.js
     dstr/syntax-error-ident-ref-if-escaped.js
-    dstr/syntax-error-ident-ref-implements-escaped.js
+    dstr/syntax-error-ident-ref-implements-escaped.js strict
     dstr/syntax-error-ident-ref-import-escaped.js
     dstr/syntax-error-ident-ref-in-escaped.js
     dstr/syntax-error-ident-ref-instanceof-escaped.js
-    dstr/syntax-error-ident-ref-interface-escaped.js
-    dstr/syntax-error-ident-ref-let-escaped.js
+    dstr/syntax-error-ident-ref-interface-escaped.js strict
+    dstr/syntax-error-ident-ref-let-escaped.js strict
     dstr/syntax-error-ident-ref-new-escaped.js
-    dstr/syntax-error-ident-ref-package-escaped.js
-    dstr/syntax-error-ident-ref-private-escaped.js
-    dstr/syntax-error-ident-ref-protected-escaped.js
-    dstr/syntax-error-ident-ref-public-escaped.js
+    dstr/syntax-error-ident-ref-package-escaped.js strict
+    dstr/syntax-error-ident-ref-private-escaped.js strict
+    dstr/syntax-error-ident-ref-protected-escaped.js strict
+    dstr/syntax-error-ident-ref-public-escaped.js strict
     dstr/syntax-error-ident-ref-return-escaped.js
-    dstr/syntax-error-ident-ref-static-escaped.js
+    dstr/syntax-error-ident-ref-static-escaped.js strict
     dstr/syntax-error-ident-ref-super-escaped.js
     dstr/syntax-error-ident-ref-switch-escaped.js
     dstr/syntax-error-ident-ref-this-escaped.js
@@ -2694,33 +1974,9 @@ language/expressions/arrow-function
     dstr/syntax-error-ident-ref-void-escaped.js
     dstr/syntax-error-ident-ref-while-escaped.js
     dstr/syntax-error-ident-ref-with-escaped.js
-    syntax/early-errors/arrowparameters-bindingidentifier-identifier-futurereservedword.js
-    syntax/early-errors/arrowparameters-bindingidentifier-identifier-strict-futurereservedword.js
-    syntax/early-errors/arrowparameters-bindingidentifier-identifier.js
-    syntax/early-errors/arrowparameters-bindingidentifier-no-arguments.js
-    syntax/early-errors/arrowparameters-bindingidentifier-no-eval.js
-    syntax/early-errors/arrowparameters-bindingidentifier-no-yield.js
-    syntax/early-errors/arrowparameters-bindingidentifier-rest.js
-    syntax/early-errors/arrowparameters-cover-no-arguments.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-3.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-4.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-5.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates-rest.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates.js
-    syntax/early-errors/arrowparameters-cover-no-eval.js
-    syntax/early-errors/arrowparameters-cover-no-yield.js
-    syntax/early-errors/asi-restriction-invalid-parenless-parameters-expression-body.js
-    syntax/early-errors/asi-restriction-invalid-parenless-parameters.js
-    syntax/early-errors/asi-restriction-invalid.js
-    syntax/early-errors/use-strict-with-non-simple-param.js
-    syntax/arrowparameters-bindingidentifier-yield.js
-    syntax/arrowparameters-cover-formalparameters-yield.js
+    *syntax/early-errors 25/25 (100.0%)
+    syntax/arrowparameters-bindingidentifier-yield.js non-strict
+    syntax/arrowparameters-cover-formalparameters-yield.js non-strict
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-initialize-1.js
     syntax/arrowparameters-cover-initialize-2.js
@@ -2739,37 +1995,37 @@ language/expressions/arrow-function
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
     rest-params-trailing-comma-early-error.js
-    scope-body-lex-distinct.js
-    scope-param-elem-var-close.js
-    scope-param-elem-var-open.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-param-elem-var-close.js non-strict
+    scope-param-elem-var-open.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/bitwise-and
+language/expressions/bitwise-and 2/27 (7.41%)
     bigint-non-primitive.js
     order-of-evaluation.js
 
-language/expressions/bitwise-not
+language/expressions/bitwise-not 1/16 (6.25%)
     bigint-non-primitive.js
 
-language/expressions/bitwise-or
-    bigint-non-primitive.js
-    order-of-evaluation.js
-
-language/expressions/bitwise-xor
+language/expressions/bitwise-or 2/27 (7.41%)
     bigint-non-primitive.js
     order-of-evaluation.js
 
-language/expressions/call
+language/expressions/bitwise-xor 2/27 (7.41%)
+    bigint-non-primitive.js
+    order-of-evaluation.js
+
+language/expressions/call 53/85 (62.35%)
     11.2.3-3_1.js
     11.2.3-3_2.js
     11.2.3-3_4.js
     11.2.3-3_5.js
     11.2.3-3_6.js
     11.2.3-3_7.js
-    11.2.3-3_8.js
+    11.2.3-3_8.js non-strict
     eval-spread-empty-leading.js
     eval-spread-empty-trailing.js
     eval-spread-empty.js
@@ -2819,43 +2075,43 @@ language/expressions/call
 
 ~language/expressions/class
 
-language/expressions/comma
+language/expressions/comma 0/5 (0.0%)
 
-language/expressions/compound-assignment
-    11.13.2-34-s.js
-    11.13.2-35-s.js
-    11.13.2-36-s.js
-    11.13.2-37-s.js
-    11.13.2-38-s.js
-    11.13.2-39-s.js
-    11.13.2-40-s.js
-    11.13.2-41-s.js
-    11.13.2-42-s.js
-    11.13.2-43-s.js
-    11.13.2-44-s.js
-    11.13.2-6-1gs.js
-    add-arguments-strict.js
-    add-eval-strict.js
+language/expressions/compound-assignment 77/408 (18.87%)
+    11.13.2-34-s.js strict
+    11.13.2-35-s.js strict
+    11.13.2-36-s.js strict
+    11.13.2-37-s.js strict
+    11.13.2-38-s.js strict
+    11.13.2-39-s.js strict
+    11.13.2-40-s.js strict
+    11.13.2-41-s.js strict
+    11.13.2-42-s.js strict
+    11.13.2-43-s.js strict
+    11.13.2-44-s.js strict
+    11.13.2-6-1gs.js strict
+    add-arguments-strict.js strict
+    add-eval-strict.js strict
     add-non-simple.js
-    and-arguments-strict.js
-    and-eval-strict.js
+    and-arguments-strict.js strict
+    and-eval-strict.js strict
     btws-and-non-simple.js
     btws-or-non-simple.js
     btws-xor-non-simple.js
-    div-arguments-strict.js
-    div-eval-strict.js
+    div-arguments-strict.js strict
+    div-eval-strict.js strict
     div-non-simple.js
     left-shift-non-simple.js
-    lshift-arguments-strict.js
-    lshift-eval-strict.js
-    mod-arguments-strict.js
+    lshift-arguments-strict.js strict
+    lshift-eval-strict.js strict
+    mod-arguments-strict.js strict
     mod-div-non-simple.js
-    mod-eval-strict.js
-    mult-arguments-strict.js
-    mult-eval-strict.js
+    mod-eval-strict.js strict
+    mult-arguments-strict.js strict
+    mult-eval-strict.js strict
     mult-non-simple.js
-    or-arguments-strict.js
-    or-eval-strict.js
+    or-arguments-strict.js strict
+    or-eval-strict.js strict
     right-shift-non-simple.js
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
@@ -2890,31 +2146,31 @@ language/expressions/compound-assignment
     S11.13.2_A7.9_T1.js
     S11.13.2_A7.9_T2.js
     S11.13.2_A7.9_T4.js
-    srshift-arguments-strict.js
-    srshift-eval-strict.js
-    sub-arguments-strict.js
-    sub-eval-strict.js
+    srshift-arguments-strict.js strict
+    srshift-eval-strict.js strict
+    sub-arguments-strict.js strict
+    sub-eval-strict.js strict
     subtract-non-simple.js
-    urshift-arguments-strict.js
-    urshift-eval-strict.js
-    xor-arguments-strict.js
-    xor-eval-strict.js
+    urshift-arguments-strict.js strict
+    urshift-eval-strict.js strict
+    xor-arguments-strict.js strict
+    xor-eval-strict.js strict
 
-language/expressions/concatenation
+language/expressions/concatenation 0/5 (0.0%)
 
-language/expressions/conditional
+language/expressions/conditional 0/19 (0.0%)
 
-language/expressions/delete
-    11.4.1-5-a-28-s.js
-    11.4.1-5-a-5gs.js
-    identifier-strict.js
+language/expressions/delete 3/59 (5.08%)
+    11.4.1-5-a-28-s.js strict
+    11.4.1-5-a-5gs.js strict
+    identifier-strict.js strict
 
-language/expressions/division
+language/expressions/division 1/42 (2.38%)
     order-of-evaluation.js
 
-language/expressions/does-not-equals
+language/expressions/does-not-equals 0/38 (0.0%)
 
-language/expressions/equals
+language/expressions/equals 6/47 (12.77%)
     coerce-symbol-to-prim-err.js
     coerce-symbol-to-prim-invocation.js
     coerce-symbol-to-prim-return-obj.js
@@ -2922,10 +2178,10 @@ language/expressions/equals
     get-symbol-to-prim-err.js
     to-prim-hint.js
 
-language/expressions/exponentiation
+language/expressions/exponentiation 1/41 (2.44%)
     order-of-evaluation.js
 
-language/expressions/function
+language/expressions/function 94/131 (71.76%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-ptrn-elem-ary-elem-init.js
@@ -2997,34 +2253,34 @@ language/expressions/function
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
-    arguments-with-arguments-fn.js
-    arguments-with-arguments-lex.js
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     dflt-params-trailing-comma.js
-    name-arguments-strict-body.js
-    name-eval-strict-body.js
+    name-arguments-strict-body.js non-strict
+    name-eval-strict-body.js non-strict
     name.js
     object-destructuring-param-strict-body.js
-    param-duplicated-strict-body-1.js
-    param-duplicated-strict-body-2.js
-    param-duplicated-strict-body-3.js
-    param-eval-strict-body.js
+    param-duplicated-strict-body-1.js non-strict
+    param-duplicated-strict-body-2.js non-strict
+    param-duplicated-strict-body-3.js non-strict
+    param-eval-strict-body.js non-strict
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
-    scope-body-lex-distinct.js
-    scope-name-var-open-non-strict.js
-    scope-name-var-open-strict.js
-    scope-param-elem-var-close.js
-    scope-param-elem-var-open.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-name-var-open-non-strict.js non-strict
+    scope-name-var-open-strict.js strict
+    scope-param-elem-var-close.js non-strict
+    scope-param-elem-var-open.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/generators
+language/expressions/generators 121/162 (74.69%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
-    dstr/ary-name-iter-val.js
+    dstr/ary-name-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
@@ -3045,10 +2301,10 @@ language/expressions/generators
     dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
-    dstr/ary-ptrn-elem-id-iter-done.js
+    dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
-    dstr/ary-ptrn-elem-id-iter-val.js
+    dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-prop-id-init.js
@@ -3080,10 +2336,10 @@ language/expressions/generators
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
-    dstr/obj-ptrn-id-trailing-comma.js
+    dstr/obj-ptrn-id-trailing-comma.js non-interpreted
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary-init.js
-    dstr/obj-ptrn-prop-ary-trailing-comma.js
+    dstr/obj-ptrn-prop-ary-trailing-comma.js non-interpreted
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-eval-err.js
@@ -3096,8 +2352,8 @@ language/expressions/generators
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
-    arguments-with-arguments-fn.js
-    arguments-with-arguments-lex.js
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     default-proto.js
     dflt-params-trailing-comma.js
@@ -3110,8 +2366,8 @@ language/expressions/generators
     named-yield-as-binding-identifier-escaped.js
     named-yield-as-identifier-reference-escaped.js
     named-yield-as-label-identifier-escaped.js
-    named-yield-identifier-non-strict.js
-    named-yield-identifier-spread-non-strict.js
+    named-yield-identifier-non-strict.js non-strict
+    named-yield-identifier-spread-non-strict.js non-strict
     named-yield-spread-arr-multiple.js
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
@@ -3121,41 +2377,41 @@ language/expressions/generators
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js
-    scope-body-lex-distinct.js
-    scope-name-var-close.js
-    scope-name-var-open-non-strict.js
-    scope-name-var-open-strict.js
-    scope-param-elem-var-close.js
-    scope-param-elem-var-open.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-name-var-close.js non-interpreted
+    scope-name-var-open-non-strict.js non-strict
+    scope-name-var-open-strict.js strict
+    scope-param-elem-var-close.js non-strict
+    scope-param-elem-var-open.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     yield-as-binding-identifier-escaped.js
-    yield-as-function-expression-binding-identifier.js
-    yield-as-identifier-in-nested-function.js
+    yield-as-function-expression-binding-identifier.js non-strict
+    yield-as-identifier-in-nested-function.js non-strict
     yield-as-identifier-reference-escaped.js
     yield-as-label-identifier-escaped.js
-    yield-identifier-non-strict.js
-    yield-identifier-spread-non-strict.js
+    yield-identifier-non-strict.js non-strict
+    yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/expressions/greater-than
+language/expressions/greater-than 2/49 (4.08%)
     bigint-and-incomparable-string.js
     bigint-and-string.js
 
-language/expressions/greater-than-or-equal
+language/expressions/greater-than-or-equal 1/43 (2.33%)
     bigint-and-incomparable-string.js
 
-language/expressions/grouping
+language/expressions/grouping 0/9 (0.0%)
 
-language/expressions/in
+language/expressions/in 0/14 (0.0%)
 
-language/expressions/instanceof
+language/expressions/instanceof 7/43 (16.28%)
     S11.8.6_A6_T1.js
     S11.8.6_A6_T2.js
     S11.8.6_A6_T4.js
@@ -3164,30 +2420,30 @@ language/expressions/instanceof
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift
+language/expressions/left-shift 2/42 (4.76%)
     bigint-non-primitive.js
     order-of-evaluation.js
 
-language/expressions/less-than
+language/expressions/less-than 1/45 (2.22%)
     bigint-and-incomparable-string.js
 
-language/expressions/less-than-or-equal
+language/expressions/less-than-or-equal 2/47 (4.26%)
     bigint-and-incomparable-string.js
     bigint-and-string.js
 
-language/expressions/logical-and
+language/expressions/logical-and 0/17 (0.0%)
 
-language/expressions/logical-not
+language/expressions/logical-not 0/19 (0.0%)
 
-language/expressions/logical-or
+language/expressions/logical-or 0/17 (0.0%)
 
-language/expressions/modulus
+language/expressions/modulus 1/37 (2.7%)
     order-of-evaluation.js
 
-language/expressions/multiplication
+language/expressions/multiplication 1/37 (2.7%)
     order-of-evaluation.js
 
-language/expressions/object
+language/expressions/object 411/525 (78.29%)
     dstr/gen-meth-ary-init-iter-close.js
     dstr/gen-meth-ary-init-iter-get-err.js
     dstr/gen-meth-ary-init-iter-no-close.js
@@ -3342,22 +2598,22 @@ language/expressions/object
     method-definition/gen-meth-dflt-params-trailing-comma.js
     method-definition/gen-meth-params-trailing-comma-multiple.js
     method-definition/gen-meth-params-trailing-comma-single.js
-    method-definition/gen-yield-identifier-non-strict.js
-    method-definition/gen-yield-identifier-spread-non-strict.js
+    method-definition/gen-yield-identifier-non-strict.js non-strict
+    method-definition/gen-yield-identifier-spread-non-strict.js non-strict
     method-definition/gen-yield-spread-arr-multiple.js
     method-definition/gen-yield-spread-arr-single.js
     method-definition/gen-yield-spread-obj.js
     method-definition/generator-invoke-ctor.js
-    method-definition/generator-invoke-fn-no-strict.js
-    method-definition/generator-invoke-fn-strict.js
+    method-definition/generator-invoke-fn-no-strict.js non-strict
+    method-definition/generator-invoke-fn-strict.js non-strict
     method-definition/generator-length.js
     method-definition/generator-name-prop-string.js
     method-definition/generator-name-prop-symbol.js
     method-definition/generator-no-yield.js
     method-definition/generator-params.js
     method-definition/generator-prop-name-eval-error.js
-    method-definition/generator-prop-name-yield-expr.js
-    method-definition/generator-prop-name-yield-id.js
+    method-definition/generator-prop-name-yield-expr.js non-strict
+    method-definition/generator-prop-name-yield-id.js non-strict
     method-definition/generator-property-desc.js
     method-definition/generator-prototype-prop.js
     method-definition/generator-prototype.js
@@ -3369,23 +2625,23 @@ language/expressions/object
     method-definition/meth-params-trailing-comma-multiple.js
     method-definition/meth-params-trailing-comma-single.js
     method-definition/name-invoke-ctor.js
-    method-definition/name-invoke-fn-strict.js
+    method-definition/name-invoke-fn-strict.js non-strict
     method-definition/name-length.js
     method-definition/name-name-prop-string.js
     method-definition/name-name-prop-symbol.js
-    method-definition/name-param-id-yield.js
-    method-definition/name-param-init-yield.js
+    method-definition/name-param-id-yield.js non-strict
+    method-definition/name-param-init-yield.js non-strict
     method-definition/name-param-redecl.js
     method-definition/name-prop-name-eval-error.js
-    method-definition/name-prop-name-yield-expr.js
-    method-definition/name-prop-name-yield-id.js
+    method-definition/name-prop-name-yield-expr.js non-strict
+    method-definition/name-prop-name-yield-id.js non-strict
     method-definition/name-prototype-prop.js
     method-definition/object-method-returns-promise.js
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
-    method-definition/yield-as-function-expression-binding-identifier.js
-    method-definition/yield-as-generator-method-binding-identifier.js
-    method-definition/yield-as-identifier-in-nested-function.js
+    method-definition/yield-as-function-expression-binding-identifier.js non-strict
+    method-definition/yield-as-generator-method-binding-identifier.js non-strict
+    method-definition/yield-as-identifier-in-nested-function.js non-strict
     method-definition/yield-as-literal-property-name.js
     method-definition/yield-as-property-name.js
     method-definition/yield-as-statement.js
@@ -3393,16 +2649,16 @@ language/expressions/object
     method-definition/yield-newline.js
     method-definition/yield-return.js
     method-definition/yield-star-before-newline.js
-    11.1.5-2gs.js
-    11.1.5_4-4-a-3.js
-    11.1.5_4-4-b-1.js
+    11.1.5-2gs.js strict
+    11.1.5_4-4-a-3.js strict
+    11.1.5_4-4-b-1.js strict
     __proto__-permitted-dup.js
     accessor-name-computed-err-evaluation.js
     accessor-name-computed-err-to-prop-key.js
     accessor-name-computed-err-unresolvable.js
     accessor-name-computed-in.js
     accessor-name-computed-yield-expr.js
-    accessor-name-computed-yield-id.js
+    accessor-name-computed-yield-id.js non-strict
     accessor-name-computed.js
     accessor-name-literal-numeric-binary.js
     accessor-name-literal-numeric-exponent.js
@@ -3444,19 +2700,19 @@ language/expressions/object
     covered-ident-name-prop-name-literal-for-escaped.js
     covered-ident-name-prop-name-literal-function-escaped.js
     covered-ident-name-prop-name-literal-if-escaped.js
-    covered-ident-name-prop-name-literal-implements-escaped.js
+    covered-ident-name-prop-name-literal-implements-escaped.js strict
     covered-ident-name-prop-name-literal-import-escaped.js
     covered-ident-name-prop-name-literal-in-escaped.js
     covered-ident-name-prop-name-literal-instanceof-escaped.js
-    covered-ident-name-prop-name-literal-interface-escaped.js
+    covered-ident-name-prop-name-literal-interface-escaped.js strict
     covered-ident-name-prop-name-literal-let-escaped.js
     covered-ident-name-prop-name-literal-new-escaped.js
-    covered-ident-name-prop-name-literal-package-escaped.js
-    covered-ident-name-prop-name-literal-private-escaped.js
-    covered-ident-name-prop-name-literal-protected-escaped.js
-    covered-ident-name-prop-name-literal-public-escaped.js
+    covered-ident-name-prop-name-literal-package-escaped.js strict
+    covered-ident-name-prop-name-literal-private-escaped.js strict
+    covered-ident-name-prop-name-literal-protected-escaped.js strict
+    covered-ident-name-prop-name-literal-public-escaped.js strict
     covered-ident-name-prop-name-literal-return-escaped.js
-    covered-ident-name-prop-name-literal-static-escaped.js
+    covered-ident-name-prop-name-literal-static-escaped.js strict
     covered-ident-name-prop-name-literal-super-escaped.js
     covered-ident-name-prop-name-literal-switch-escaped.js
     covered-ident-name-prop-name-literal-this-escaped.js
@@ -3473,8 +2729,8 @@ language/expressions/object
     fn-name-cover.js
     fn-name-fn.js
     fn-name-gen.js
-    getter-body-strict-inside.js
-    getter-body-strict-outside.js
+    getter-body-strict-inside.js non-strict
+    getter-body-strict-outside.js strict
     getter-super-prop.js
     ident-name-method-def-break-escaped.js
     ident-name-method-def-case-escaped.js
@@ -3496,19 +2752,19 @@ language/expressions/object
     ident-name-method-def-for-escaped.js
     ident-name-method-def-function-escaped.js
     ident-name-method-def-if-escaped.js
-    ident-name-method-def-implements-escaped.js
+    ident-name-method-def-implements-escaped.js strict
     ident-name-method-def-import-escaped.js
     ident-name-method-def-in-escaped.js
     ident-name-method-def-instanceof-escaped.js
-    ident-name-method-def-interface-escaped.js
+    ident-name-method-def-interface-escaped.js strict
     ident-name-method-def-let-escaped.js
     ident-name-method-def-new-escaped.js
-    ident-name-method-def-package-escaped.js
-    ident-name-method-def-private-escaped.js
-    ident-name-method-def-protected-escaped.js
-    ident-name-method-def-public-escaped.js
+    ident-name-method-def-package-escaped.js strict
+    ident-name-method-def-private-escaped.js strict
+    ident-name-method-def-protected-escaped.js strict
+    ident-name-method-def-public-escaped.js strict
     ident-name-method-def-return-escaped.js
-    ident-name-method-def-static-escaped.js
+    ident-name-method-def-static-escaped.js strict
     ident-name-method-def-super-escaped.js
     ident-name-method-def-switch-escaped.js
     ident-name-method-def-this-escaped.js
@@ -3539,19 +2795,19 @@ language/expressions/object
     ident-name-prop-name-literal-for-escaped.js
     ident-name-prop-name-literal-function-escaped.js
     ident-name-prop-name-literal-if-escaped.js
-    ident-name-prop-name-literal-implements-escaped.js
+    ident-name-prop-name-literal-implements-escaped.js strict
     ident-name-prop-name-literal-import-escaped.js
     ident-name-prop-name-literal-in-escaped.js
     ident-name-prop-name-literal-instanceof-escaped.js
-    ident-name-prop-name-literal-interface-escaped.js
+    ident-name-prop-name-literal-interface-escaped.js strict
     ident-name-prop-name-literal-let-escaped.js
     ident-name-prop-name-literal-new-escaped.js
-    ident-name-prop-name-literal-package-escaped.js
-    ident-name-prop-name-literal-private-escaped.js
-    ident-name-prop-name-literal-protected-escaped.js
-    ident-name-prop-name-literal-public-escaped.js
+    ident-name-prop-name-literal-package-escaped.js strict
+    ident-name-prop-name-literal-private-escaped.js strict
+    ident-name-prop-name-literal-protected-escaped.js strict
+    ident-name-prop-name-literal-public-escaped.js strict
     ident-name-prop-name-literal-return-escaped.js
-    ident-name-prop-name-literal-static-escaped.js
+    ident-name-prop-name-literal-static-escaped.js strict
     ident-name-prop-name-literal-super-escaped.js
     ident-name-prop-name-literal-switch-escaped.js
     ident-name-prop-name-literal-this-escaped.js
@@ -3562,198 +2818,198 @@ language/expressions/object
     ident-name-prop-name-literal-void-escaped.js
     ident-name-prop-name-literal-while-escaped.js
     ident-name-prop-name-literal-with-escaped.js
-    let-non-strict-access.js
-    let-non-strict-syntax.js
+    let-non-strict-access.js non-strict
+    let-non-strict-syntax.js non-strict
     method.js
-    prop-def-id-eval-error.js
-    prop-dup-data-data.js
-    prop-dup-data-set.js
-    prop-dup-get-data.js
-    prop-dup-get-get.js
-    prop-dup-get-set-get.js
-    prop-dup-set-data.js
-    prop-dup-set-get-set.js
-    prop-dup-set-set.js
-    scope-gen-meth-body-lex-distinct.js
-    scope-gen-meth-param-elem-var-close.js
-    scope-gen-meth-param-elem-var-open.js
-    scope-gen-meth-param-rest-elem-var-close.js
-    scope-gen-meth-param-rest-elem-var-open.js
+    prop-def-id-eval-error.js non-strict
+    prop-dup-data-data.js strict
+    prop-dup-data-set.js strict
+    prop-dup-get-data.js strict
+    prop-dup-get-get.js strict
+    prop-dup-get-set-get.js strict
+    prop-dup-set-data.js strict
+    prop-dup-set-get-set.js strict
+    prop-dup-set-set.js strict
+    scope-gen-meth-body-lex-distinct.js non-strict
+    scope-gen-meth-param-elem-var-close.js non-strict
+    scope-gen-meth-param-elem-var-open.js non-strict
+    scope-gen-meth-param-rest-elem-var-close.js non-strict
+    scope-gen-meth-param-rest-elem-var-open.js non-strict
     scope-gen-meth-paramsbody-var-close.js
     scope-gen-meth-paramsbody-var-open.js
-    scope-getter-body-lex-distinc.js
-    scope-meth-body-lex-distinct.js
-    scope-meth-param-elem-var-close.js
-    scope-meth-param-elem-var-open.js
-    scope-meth-param-rest-elem-var-close.js
-    scope-meth-param-rest-elem-var-open.js
+    scope-getter-body-lex-distinc.js non-strict
+    scope-meth-body-lex-distinct.js non-strict
+    scope-meth-param-elem-var-close.js non-strict
+    scope-meth-param-elem-var-open.js non-strict
+    scope-meth-param-rest-elem-var-close.js non-strict
+    scope-meth-param-rest-elem-var-open.js non-strict
     scope-meth-paramsbody-var-close.js
     scope-meth-paramsbody-var-open.js
-    scope-setter-body-lex-distinc.js
+    scope-setter-body-lex-distinc.js non-strict
     scope-setter-paramsbody-var-close.js
     scope-setter-paramsbody-var-open.js
-    setter-body-strict-inside.js
-    setter-body-strict-outside.js
-    setter-param-arguments-strict-inside.js
-    setter-param-eval-strict-inside.js
+    setter-body-strict-inside.js non-strict
+    setter-body-strict-outside.js strict
+    setter-param-arguments-strict-inside.js non-strict
+    setter-param-eval-strict-inside.js non-strict
     setter-super-prop.js
-    yield-non-strict-access.js
-    yield-non-strict-syntax.js
+    yield-non-strict-access.js non-strict
+    yield-non-strict-syntax.js non-strict
 
-language/expressions/postfix-decrement
-    arguments.js
-    eval.js
+language/expressions/postfix-decrement 6/34 (17.65%)
+    arguments.js strict
+    eval.js strict
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
     target-cover-yieldexpr.js
 
-language/expressions/postfix-increment
-    11.3.1-2-1gs.js
-    arguments.js
-    eval.js
+language/expressions/postfix-increment 7/35 (20.0%)
+    11.3.1-2-1gs.js strict
+    arguments.js strict
+    eval.js strict
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
     target-cover-yieldexpr.js
 
-language/expressions/prefix-decrement
-    11.4.5-2-2gs.js
-    arguments.js
-    eval.js
+language/expressions/prefix-decrement 7/31 (22.58%)
+    11.4.5-2-2gs.js strict
+    arguments.js strict
+    eval.js strict
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
     target-cover-yieldexpr.js
 
-language/expressions/prefix-increment
-    arguments.js
-    eval.js
+language/expressions/prefix-increment 6/30 (20.0%)
+    arguments.js strict
+    eval.js strict
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
     target-cover-yieldexpr.js
 
-language/expressions/property-accessors
+language/expressions/property-accessors 0/21 (0.0%)
 
-language/expressions/relational
+language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift
+language/expressions/right-shift 2/34 (5.88%)
     bigint-non-primitive.js
     order-of-evaluation.js
 
-language/expressions/strict-does-not-equals
+language/expressions/strict-does-not-equals 0/30 (0.0%)
 
-language/expressions/strict-equals
+language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction
+language/expressions/subtraction 1/35 (2.86%)
     order-of-evaluation.js
 
 ~language/expressions/super
 
-language/expressions/tagged-template
-    call-expression-context-strict.js
+language/expressions/tagged-template 1/24 (4.17%)
+    call-expression-context-strict.js strict
 
-language/expressions/template-literal
+language/expressions/template-literal 0/52 (0.0%)
 
-language/expressions/this
+language/expressions/this 1/6 (16.67%)
     S11.1.1_A1.js
 
-language/expressions/typeof
+language/expressions/typeof 1/15 (6.67%)
     built-in-ordinary-objects-no-call.js
 
-language/expressions/unary-minus
+language/expressions/unary-minus 1/14 (7.14%)
     bigint-non-primitive.js
 
-language/expressions/unary-plus
+language/expressions/unary-plus 0/17 (0.0%)
 
-language/expressions/unsigned-right-shift
+language/expressions/unsigned-right-shift 2/42 (4.76%)
     bigint-non-primitive.js
     order-of-evaluation.js
 
-language/expressions/void
+language/expressions/void 0/9 (0.0%)
 
-language/expressions/yield
+language/expressions/yield 3/61 (4.92%)
     rhs-omitted.js
     rhs-primitive.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code
-    10.4.3-1-1-s.js
-    10.4.3-1-10-s.js
+language/function-code 123/217 (56.68%)
+    10.4.3-1-1-s.js non-strict
+    10.4.3-1-10-s.js non-strict
     10.4.3-1-100-s.js
     10.4.3-1-100gs.js
     10.4.3-1-102-s.js
     10.4.3-1-102gs.js
-    10.4.3-1-104.js
-    10.4.3-1-106.js
-    10.4.3-1-10gs.js
-    10.4.3-1-11-s.js
-    10.4.3-1-11gs.js
-    10.4.3-1-12-s.js
-    10.4.3-1-12gs.js
-    10.4.3-1-14-s.js
-    10.4.3-1-14gs.js
-    10.4.3-1-16-s.js
-    10.4.3-1-16gs.js
-    10.4.3-1-17-s.js
-    10.4.3-1-2-s.js
-    10.4.3-1-27-s.js
-    10.4.3-1-27gs.js
-    10.4.3-1-28-s.js
-    10.4.3-1-28gs.js
-    10.4.3-1-29-s.js
-    10.4.3-1-29gs.js
-    10.4.3-1-3-s.js
-    10.4.3-1-30-s.js
-    10.4.3-1-30gs.js
-    10.4.3-1-31-s.js
-    10.4.3-1-31gs.js
-    10.4.3-1-32-s.js
-    10.4.3-1-32gs.js
-    10.4.3-1-33-s.js
-    10.4.3-1-33gs.js
-    10.4.3-1-34-s.js
-    10.4.3-1-34gs.js
-    10.4.3-1-35-s.js
-    10.4.3-1-35gs.js
-    10.4.3-1-36-s.js
-    10.4.3-1-36gs.js
-    10.4.3-1-37-s.js
-    10.4.3-1-37gs.js
-    10.4.3-1-38-s.js
-    10.4.3-1-38gs.js
-    10.4.3-1-39-s.js
-    10.4.3-1-39gs.js
-    10.4.3-1-4-s.js
-    10.4.3-1-40-s.js
-    10.4.3-1-40gs.js
-    10.4.3-1-41-s.js
-    10.4.3-1-41gs.js
-    10.4.3-1-42-s.js
-    10.4.3-1-42gs.js
-    10.4.3-1-43-s.js
-    10.4.3-1-43gs.js
-    10.4.3-1-44-s.js
-    10.4.3-1-44gs.js
-    10.4.3-1-45-s.js
-    10.4.3-1-45gs.js
-    10.4.3-1-46-s.js
-    10.4.3-1-46gs.js
-    10.4.3-1-47-s.js
-    10.4.3-1-47gs.js
-    10.4.3-1-48-s.js
-    10.4.3-1-48gs.js
-    10.4.3-1-49-s.js
-    10.4.3-1-49gs.js
-    10.4.3-1-50-s.js
-    10.4.3-1-50gs.js
-    10.4.3-1-51-s.js
-    10.4.3-1-51gs.js
-    10.4.3-1-52-s.js
-    10.4.3-1-52gs.js
-    10.4.3-1-53-s.js
-    10.4.3-1-53gs.js
+    10.4.3-1-104.js strict
+    10.4.3-1-106.js strict
+    10.4.3-1-10gs.js non-strict
+    10.4.3-1-11-s.js strict
+    10.4.3-1-11gs.js strict
+    10.4.3-1-12-s.js non-strict
+    10.4.3-1-12gs.js non-strict
+    10.4.3-1-14-s.js non-strict
+    10.4.3-1-14gs.js non-strict
+    10.4.3-1-16-s.js non-strict
+    10.4.3-1-16gs.js non-strict
+    10.4.3-1-17-s.js strict
+    10.4.3-1-2-s.js non-strict
+    10.4.3-1-27-s.js strict
+    10.4.3-1-27gs.js strict
+    10.4.3-1-28-s.js strict
+    10.4.3-1-28gs.js strict
+    10.4.3-1-29-s.js strict
+    10.4.3-1-29gs.js strict
+    10.4.3-1-3-s.js non-strict
+    10.4.3-1-30-s.js strict
+    10.4.3-1-30gs.js strict
+    10.4.3-1-31-s.js strict
+    10.4.3-1-31gs.js strict
+    10.4.3-1-32-s.js strict
+    10.4.3-1-32gs.js strict
+    10.4.3-1-33-s.js strict
+    10.4.3-1-33gs.js strict
+    10.4.3-1-34-s.js strict
+    10.4.3-1-34gs.js strict
+    10.4.3-1-35-s.js strict
+    10.4.3-1-35gs.js strict
+    10.4.3-1-36-s.js non-strict
+    10.4.3-1-36gs.js non-strict
+    10.4.3-1-37-s.js non-strict
+    10.4.3-1-37gs.js non-strict
+    10.4.3-1-38-s.js non-strict
+    10.4.3-1-38gs.js non-strict
+    10.4.3-1-39-s.js non-strict
+    10.4.3-1-39gs.js non-strict
+    10.4.3-1-4-s.js non-strict
+    10.4.3-1-40-s.js non-strict
+    10.4.3-1-40gs.js non-strict
+    10.4.3-1-41-s.js non-strict
+    10.4.3-1-41gs.js non-strict
+    10.4.3-1-42-s.js non-strict
+    10.4.3-1-42gs.js non-strict
+    10.4.3-1-43-s.js non-strict
+    10.4.3-1-43gs.js non-strict
+    10.4.3-1-44-s.js non-strict
+    10.4.3-1-44gs.js non-strict
+    10.4.3-1-45-s.js non-strict
+    10.4.3-1-45gs.js non-strict
+    10.4.3-1-46-s.js non-strict
+    10.4.3-1-46gs.js non-strict
+    10.4.3-1-47-s.js non-strict
+    10.4.3-1-47gs.js non-strict
+    10.4.3-1-48-s.js non-strict
+    10.4.3-1-48gs.js non-strict
+    10.4.3-1-49-s.js non-strict
+    10.4.3-1-49gs.js non-strict
+    10.4.3-1-50-s.js non-strict
+    10.4.3-1-50gs.js non-strict
+    10.4.3-1-51-s.js non-strict
+    10.4.3-1-51gs.js non-strict
+    10.4.3-1-52-s.js non-strict
+    10.4.3-1-52gs.js non-strict
+    10.4.3-1-53-s.js non-strict
+    10.4.3-1-53gs.js non-strict
     10.4.3-1-62-s.js
     10.4.3-1-62gs.js
     10.4.3-1-63-s.js
@@ -3764,51 +3020,51 @@ language/function-code
     10.4.3-1-65gs.js
     10.4.3-1-66-s.js
     10.4.3-1-66gs.js
-    10.4.3-1-67-s.js
-    10.4.3-1-67gs.js
-    10.4.3-1-68-s.js
-    10.4.3-1-68gs.js
-    10.4.3-1-7-s.js
+    10.4.3-1-67-s.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-67gs.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-68-s.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-68gs.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-7-s.js strict
     10.4.3-1-71-s.js
     10.4.3-1-71gs.js
-    10.4.3-1-72-s.js
-    10.4.3-1-72gs.js
-    10.4.3-1-73-s.js
-    10.4.3-1-73gs.js
+    10.4.3-1-72-s.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-72gs.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-73-s.js {strict: [-1], non-strict: [-1]}
+    10.4.3-1-73gs.js {strict: [-1], non-strict: [-1]}
     10.4.3-1-76-s.js
     10.4.3-1-76gs.js
     10.4.3-1-77-s.js
     10.4.3-1-77gs.js
     10.4.3-1-78-s.js
     10.4.3-1-78gs.js
-    10.4.3-1-7gs.js
-    10.4.3-1-8-s.js
-    10.4.3-1-86-s.js
-    10.4.3-1-86gs.js
-    10.4.3-1-87-s.js
-    10.4.3-1-87gs.js
-    10.4.3-1-8gs.js
-    10.4.3-1-9-s.js
-    10.4.3-1-90-s.js
-    10.4.3-1-90gs.js
-    10.4.3-1-91-s.js
-    10.4.3-1-91gs.js
-    10.4.3-1-92-s.js
-    10.4.3-1-92gs.js
-    10.4.3-1-9gs.js
-    block-decl-onlystrict.js
+    10.4.3-1-7gs.js strict
+    10.4.3-1-8-s.js non-strict
+    10.4.3-1-86-s.js {non-strict: [0, 9]}
+    10.4.3-1-86gs.js {non-strict: [0, 9]}
+    10.4.3-1-87-s.js {non-strict: [0, 9]}
+    10.4.3-1-87gs.js {non-strict: [0, 9]}
+    10.4.3-1-8gs.js non-strict
+    10.4.3-1-9-s.js strict
+    10.4.3-1-90-s.js {non-strict: [0, 9]}
+    10.4.3-1-90gs.js {non-strict: [0, 9]}
+    10.4.3-1-91-s.js {non-strict: [0, 9]}
+    10.4.3-1-91gs.js {non-strict: [0, 9]}
+    10.4.3-1-92-s.js {non-strict: [0, 9]}
+    10.4.3-1-92gs.js {non-strict: [0, 9]}
+    10.4.3-1-9gs.js strict
+    block-decl-onlystrict.js strict
     eval-param-env-with-computed-key.js
     eval-param-env-with-prop-initializer.js
-    S10.4.3_A1.js
-    switch-case-decl-onlystrict.js
-    switch-dflt-decl-onlystrict.js
+    S10.4.3_A1.js strict
+    switch-case-decl-onlystrict.js strict
+    switch-dflt-decl-onlystrict.js strict
 
 ~language/future-reserved-words
 
-language/global-code
-    block-decl-strict.js
+language/global-code 24/31 (77.42%)
+    block-decl-strict.js strict
     decl-lex-configurable-global.js
-    decl-lex-deletion.js
+    decl-lex-deletion.js non-strict
     decl-lex-restricted-global.js
     decl-lex.js
     export.js
@@ -3818,7 +3074,7 @@ language/global-code
     script-decl-func-err-non-configurable.js
     script-decl-func-err-non-extensible.js
     script-decl-func.js
-    script-decl-lex-deletion.js
+    script-decl-lex-deletion.js non-strict
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
@@ -3826,14 +3082,14 @@ language/global-code
     script-decl-var-collision.js
     script-decl-var-err.js
     script-decl-var.js
-    switch-case-decl-strict.js
-    switch-dflt-decl-strict.js
-    yield-non-strict.js
-    yield-strict.js
+    switch-case-decl-strict.js strict
+    switch-dflt-decl-strict.js strict
+    yield-non-strict.js non-strict
+    yield-strict.js strict
 
-language/identifier-resolution
+language/identifier-resolution 0/12 (0.0%)
 
-language/identifiers
+language/identifiers 122/145 (84.14%)
     other_id_continue.js
     other_id_start.js
     part-digits-via-escape-hex.js
@@ -3947,7 +3203,7 @@ language/identifiers
     val-with-via-escape-hex.js
     val-with-via-escape-hex4.js
     val-with.js
-    val-yield-strict.js
+    val-yield-strict.js strict
     vals-eng-alpha-lower-via-escape-hex.js
     vals-eng-alpha-upper-via-escape-hex.js
     vals-rus-alpha-lower-via-escape-hex.js
@@ -3959,15 +3215,15 @@ language/identifiers
 
 ~language/import
 
-language/keywords
+language/keywords 0/25 (0.0%)
 
-language/line-terminators
+language/line-terminators 4/41 (9.76%)
     S7.3_A6_T1.js
     S7.3_A6_T2.js
     S7.3_A6_T3.js
     S7.3_A6_T4.js
 
-language/literals
+language/literals 47/364 (12.91%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     bigint/legacy-octal-like-invalid-00n.js
@@ -4001,11 +3257,11 @@ language/literals
     regexp/u-surrogate-pairs.js
     regexp/u-unicode-esc.js
     regexp/y-assertion-start.js
-    string/legacy-non-octal-escape-sequence-strict.js
+    string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
-    string/legacy-octal-escape-sequence-strict.js
-    string/S7.8.4_A4.3_T1.js
-    string/S7.8.4_A4.3_T2.js
+    string/legacy-octal-escape-sequence-strict.js strict
+    string/S7.8.4_A4.3_T1.js strict
+    string/S7.8.4_A4.3_T2.js strict
     string/S7.8.4_A7.1_T4.js
     string/S7.8.4_A7.2_T1.js
     string/S7.8.4_A7.2_T2.js
@@ -4018,14 +3274,14 @@ language/literals
 
 ~language/module-code
 
-language/punctuators
+language/punctuators 5/11 (45.45%)
     S7.7_A2_T1.js
     S7.7_A2_T2.js
     S7.7_A2_T3.js
     S7.7_A2_T4.js
     S7.7_A2_T5.js
 
-language/reserved-words
+language/reserved-words 7/26 (26.92%)
     await-script.js
     ident-reference-false-escaped.js
     ident-reference-null-escaped.js
@@ -4034,7 +3290,7 @@ language/reserved-words
     label-ident-null-escaped.js
     label-ident-true-escaped.js
 
-language/rest-parameters
+language/rest-parameters 10/11 (90.91%)
     array-pattern.js
     arrow-function.js
     expected-argument-count.js
@@ -4046,9 +3302,9 @@ language/rest-parameters
     rest-parameters-produce-an-array.js
     with-new-target.js
 
-language/source-text
+language/source-text 0/1 (0.0%)
 
-language/statements/for
+language/statements/for 239/360 (66.39%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-no-close.js
@@ -4187,7 +3443,7 @@ language/statements/for
     dstr/let-obj-ptrn-id-init-unresolvable.js
     dstr/let-obj-ptrn-list-err.js
     dstr/let-obj-ptrn-prop-ary-init.js
-    dstr/let-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-eval-err.js
@@ -4278,18 +3534,18 @@ language/statements/for
     head-init-expr-check-empty-inc-empty-completion.js
     head-init-var-check-empty-inc-empty-completion.js
     head-let-bound-names-in-stmt.js
-    head-lhs-let.js
+    head-lhs-let.js non-strict
     labelled-fn-stmt-expr.js
     labelled-fn-stmt-let.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-open.js
 
-language/statements/for-in
+language/statements/for-in 36/110 (32.73%)
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
     cptn-decl-itr.js
@@ -4309,25 +3565,25 @@ language/statements/for-in
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
     head-let-fresh-binding-per-iteration.js
-    head-lhs-let.js
+    head-lhs-let.js non-strict
     head-var-bound-names-dup.js
-    head-var-bound-names-let.js
-    identifier-let-allowed-as-lefthandside-expression-not-strict.js
+    head-var-bound-names-let.js non-strict
+    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-close.js
     scope-body-lex-open.js
     scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js
+    scope-head-var-none.js non-strict
 
-language/statements/for-of
+language/statements/for-of 431/681 (63.29%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -4336,10 +3592,10 @@ language/statements/for-of
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
     dstr/array-elem-init-order.js
-    dstr/array-elem-init-simple-no-strict.js
+    dstr/array-elem-init-simple-no-strict.js non-strict
     dstr/array-elem-init-yield-expr.js
-    dstr/array-elem-init-yield-ident-invalid.js
-    dstr/array-elem-init-yield-ident-valid.js
+    dstr/array-elem-init-yield-ident-invalid.js strict
+    dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close-err.js
     dstr/array-elem-iter-nrml-close-null.js
@@ -4351,18 +3607,18 @@ language/statements/for-of
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
     dstr/array-elem-iter-thrw-close.js
-    dstr/array-elem-nested-array-yield-ident-valid.js
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
     dstr/array-elem-nested-obj-invalid.js
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-invalid.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js
-    dstr/array-elem-put-const.js
+    dstr/array-elem-nested-obj-yield-ident-invalid.js strict
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref.js
-    dstr/array-elem-target-simple-strict.js
-    dstr/array-elem-target-yield-valid.js
+    dstr/array-elem-target-simple-strict.js strict
+    dstr/array-elem-target-yield-valid.js non-strict
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-null.js
@@ -4428,14 +3684,14 @@ language/statements/for-of
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-undefined.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
     dstr/array-rest-nested-array.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
     dstr/array-rest-nested-obj.js
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
@@ -4443,10 +3699,10 @@ language/statements/for-of
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref.js
-    dstr/array-rest-put-unresolvable-no-strict.js
-    dstr/array-rest-put-unresolvable-strict.js
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict
+    dstr/array-rest-put-unresolvable-strict.js strict
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js
+    dstr/array-rest-yield-ident-valid.js non-strict
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-no-close.js
@@ -4599,7 +3855,7 @@ language/statements/for-of
     dstr/let-obj-ptrn-prop-obj.js
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict
     dstr/obj-id-init-assignment-missing.js
     dstr/obj-id-init-assignment-null.js
     dstr/obj-id-init-assignment-truthy.js
@@ -4612,12 +3868,12 @@ language/statements/for-of
     dstr/obj-id-init-in.js
     dstr/obj-id-init-let.js
     dstr/obj-id-init-order.js
-    dstr/obj-id-init-simple-no-strict.js
+    dstr/obj-id-init-simple-no-strict.js non-strict
     dstr/obj-id-init-yield-expr.js
-    dstr/obj-id-init-yield-ident-valid.js
-    dstr/obj-id-put-const.js
+    dstr/obj-id-init-yield-ident-valid.js non-strict
+    dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
-    dstr/obj-id-simple-strict.js
+    dstr/obj-id-simple-strict.js strict
     dstr/obj-prop-elem-init-assignment-missing.js
     dstr/obj-prop-elem-init-assignment-null.js
     dstr/obj-prop-elem-init-assignment-truthy.js
@@ -4630,18 +3886,18 @@ language/statements/for-of
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
     dstr/obj-prop-elem-init-yield-expr.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation-error.js
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-nested-array-yield-expr.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js
-    dstr/obj-prop-put-const.js
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
+    dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
@@ -4735,7 +3991,7 @@ language/statements/for-of
     head-let-bound-names-in-stmt.js
     head-let-fresh-binding-per-iteration.js
     head-let-init.js
-    head-var-bound-names-let.js
+    head-var-bound-names-let.js non-strict
     head-var-init.js
     head-var-no-expr.js
     iterator-close-get-method-error.js
@@ -4749,21 +4005,21 @@ language/statements/for-of
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-close.js
     scope-body-lex-open.js
     scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js
+    scope-head-var-none.js non-strict
 
-language/statements/generators
+language/statements/generators 112/147 (76.19%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
-    dstr/ary-name-iter-val.js
+    dstr/ary-name-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
@@ -4784,10 +4040,10 @@ language/statements/generators
     dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
-    dstr/ary-ptrn-elem-id-iter-done.js
+    dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
-    dstr/ary-ptrn-elem-id-iter-val.js
+    dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-prop-id-init.js
@@ -4819,10 +4075,10 @@ language/statements/generators
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
-    dstr/obj-ptrn-id-trailing-comma.js
+    dstr/obj-ptrn-id-trailing-comma.js non-interpreted
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary-init.js
-    dstr/obj-ptrn-prop-ary-trailing-comma.js
+    dstr/obj-ptrn-prop-ary-trailing-comma.js non-interpreted
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-eval-err.js
@@ -4835,8 +4091,8 @@ language/statements/generators
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
-    arguments-with-arguments-fn.js
-    arguments-with-arguments-lex.js
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
     default-proto.js
@@ -4853,40 +4109,40 @@ language/statements/generators
     prototype-relation-to-function.js
     prototype-value.js
     restricted-properties.js
-    scope-body-lex-distinct.js
-    scope-param-elem-var-close.js
-    scope-param-elem-var-open.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-param-elem-var-close.js non-strict
+    scope-param-elem-var-open.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     yield-as-binding-identifier-escaped.js
-    yield-as-function-expression-binding-identifier.js
-    yield-as-generator-declaration-binding-identifier.js
-    yield-as-identifier-in-nested-function.js
+    yield-as-function-expression-binding-identifier.js non-strict
+    yield-as-generator-declaration-binding-identifier.js non-strict
+    yield-as-identifier-in-nested-function.js non-strict
     yield-as-identifier-reference-escaped.js
     yield-as-label-identifier-escaped.js
-    yield-identifier-non-strict.js
-    yield-identifier-spread-non-strict.js
+    yield-identifier-non-strict.js non-strict
+    yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/types
+language/types 10/110 (9.09%)
     boolean/S8.3_A2.1.js
     boolean/S8.3_A2.2.js
     number/S8.5_A10_T1.js
-    number/S8.5_A10_T2.js
+    number/S8.5_A10_T2.js non-strict
     number/S8.5_A4_T1.js
-    number/S8.5_A4_T2.js
+    number/S8.5_A4_T2.js non-strict
     reference/S8.7.2_A1_T1.js
     reference/S8.7.2_A1_T2.js
     undefined/S8.1_A3_T1.js
-    undefined/S8.1_A3_T2.js
+    undefined/S8.1_A3_T2.js non-strict
 
-language/white-space
+language/white-space 5/40 (12.5%)
     S7.2_A5_T1.js
     S7.2_A5_T2.js
     S7.2_A5_T3.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -9,12 +9,12 @@ built-ins/Array 161/2624 (6.14%)
     from/source-object-constructor.js Error propagation needs work in general
     from/source-object-iterator-1.js Uses "get" syntax that's not implemented
     from/source-object-iterator-2.js Uses "get" syntax that's not implemented
-    isArray/proxy-revoked.js {unsupported: [Proxy]}
     isArray/proxy.js {unsupported: [Proxy]}
+    isArray/proxy-revoked.js {unsupported: [Proxy]}
     length/define-own-prop-length-overflow-realm.js {unsupported: [cross-realm]}
     of/proto-from-ctor-realm.js {unsupported: [cross-realm]}
-    of/return-abrupt-from-data-property-using-proxy.js {unsupported: [Proxy]}
     of/return-abrupt-from-data-property.js Object.preventExtensions doesn't seem to throw
+    of/return-abrupt-from-data-property-using-proxy.js {unsupported: [Proxy]}
     prototype/concat/Array.prototype.concat_large-typed-array.js new
     prototype/concat/Array.prototype.concat_non-array.js
     prototype/concat/Array.prototype.concat_small-typed-array.js
@@ -24,15 +24,15 @@ built-ins/Array 161/2624 (6.14%)
     prototype/concat/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
     prototype/concat/create-proxy.js {unsupported: [Proxy, Symbol.species]}
     prototype/concat/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/concat/create-species.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-abrupt.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-non-ctor.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-null.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species.js {unsupported: [Symbol.species]}
     prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js {unsupported: [Proxy]}
-    prototype/concat/is-concat-spreadable-proxy-revoked.js {unsupported: [Proxy]}
     prototype/concat/is-concat-spreadable-proxy.js {unsupported: [Proxy]}
+    prototype/concat/is-concat-spreadable-proxy-revoked.js {unsupported: [Proxy]}
     prototype/copyWithin/return-abrupt-from-delete-proxy-target.js {unsupported: [Proxy]}
     prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
     prototype/copyWithin/return-abrupt-from-has-start.js {unsupported: [Proxy]}
@@ -44,12 +44,12 @@ built-ins/Array 161/2624 (6.14%)
     prototype/filter/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
     prototype/filter/create-proxy.js {unsupported: [Proxy, Symbol.species]}
     prototype/filter/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/filter/create-species.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-abrupt.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-non-ctor.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-null.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/filter/create-species.js {unsupported: [Symbol.species]}
     prototype/filter/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
@@ -66,13 +66,13 @@ built-ins/Array 161/2624 (6.14%)
     prototype/map/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
     prototype/map/create-proxy.js {unsupported: [Proxy, Symbol.species]}
     prototype/map/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/map/create-species.js {unsupported: [Symbol.species]}
     prototype/map/create-species-abrupt.js {unsupported: [Symbol.species]}
     prototype/map/create-species-non-ctor.js {unsupported: [Symbol.species]}
     prototype/map/create-species-null.js {unsupported: [Symbol.species]}
     prototype/map/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
     prototype/map/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/map/create-species.js {unsupported: [Symbol.species]}
+    prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
     prototype/map/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
@@ -86,13 +86,13 @@ built-ins/Array 161/2624 (6.14%)
     prototype/slice/create-proxied-array-invalid-len.js {unsupported: [Proxy]}
     prototype/slice/create-proxy.js {unsupported: [Proxy, Symbol.species]}
     prototype/slice/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/slice/create-species.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-abrupt.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-neg-zero.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-non-ctor.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-null.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species.js {unsupported: [Symbol.species]}
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
     prototype/slice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/some/15.4.4.17-5-1-s.js non-strict
@@ -106,15 +106,15 @@ built-ins/Array 161/2624 (6.14%)
     prototype/splice/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
     prototype/splice/create-proxy.js {unsupported: [Proxy, Symbol.species]}
     prototype/splice/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/splice/create-species.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-abrupt.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-length-exceeding-integer-limit.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-neg-zero.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-non-ctor.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-null.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-undef-invalid-len.js {unsupported: [Proxy]}
     prototype/splice/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-undef-invalid-len.js {unsupported: [Proxy]}
     prototype/splice/property-traps-order-with-species.js {unsupported: [Proxy, Symbol.species]}
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
     prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
@@ -138,6 +138,7 @@ built-ins/ArrayBuffer 30/80 (37.5%)
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
     prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/slice/species.js {unsupported: [Symbol.species]}
     prototype/slice/species-constructor-is-not-object.js
     prototype/slice/species-constructor-is-undefined.js
     prototype/slice/species-is-not-constructor.js {unsupported: [Symbol.species]}
@@ -148,7 +149,6 @@ built-ins/ArrayBuffer 30/80 (37.5%)
     prototype/slice/species-returns-not-arraybuffer.js {unsupported: [Symbol.species]}
     prototype/slice/species-returns-same-arraybuffer.js {unsupported: [Symbol.species]}
     prototype/slice/species-returns-smaller-arraybuffer.js {unsupported: [Symbol.species]}
-    prototype/slice/species.js {unsupported: [Symbol.species]}
     prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/Symbol.toStringTag.js
     *Symbol.species 4/4 (100.0%)
@@ -207,50 +207,50 @@ built-ins/DataView 166/455 (36.48%)
     prototype/byteOffset/prop-desc.js
     prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getBigInt64/detached-buffer.js
     prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigInt64/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getBigInt64/detached-buffer.js
     prototype/getBigInt64/index-is-out-of-range.js
     prototype/getBigInt64/length.js
     prototype/getBigInt64/name.js
     prototype/getBigInt64/negative-byteoffset-throws.js
     prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigInt64/return-value-clean-arraybuffer.js
-    prototype/getBigInt64/return-values-custom-offset.js
     prototype/getBigInt64/return-values.js
+    prototype/getBigInt64/return-values-custom-offset.js
     prototype/getBigInt64/to-boolean-littleendian.js
+    prototype/getBigInt64/toindex-byteoffset.js
     prototype/getBigInt64/toindex-byteoffset-errors.js {unsupported: [computed-property-names]}
     prototype/getBigInt64/toindex-byteoffset-toprimitive.js {unsupported: [computed-property-names]}
     prototype/getBigInt64/toindex-byteoffset-wrapped-values.js {unsupported: [computed-property-names]}
-    prototype/getBigInt64/toindex-byteoffset.js
+    prototype/getBigUint64/detached-buffer.js
     prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getBigUint64/detached-buffer.js
     prototype/getBigUint64/index-is-out-of-range.js
     prototype/getBigUint64/length.js
     prototype/getBigUint64/name.js
     prototype/getBigUint64/negative-byteoffset-throws.js
     prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigUint64/return-value-clean-arraybuffer.js
-    prototype/getBigUint64/return-values-custom-offset.js
     prototype/getBigUint64/return-values.js
+    prototype/getBigUint64/return-values-custom-offset.js
     prototype/getBigUint64/to-boolean-littleendian.js
+    prototype/getBigUint64/toindex-byteoffset.js
     prototype/getBigUint64/toindex-byteoffset-errors.js {unsupported: [computed-property-names]}
     prototype/getBigUint64/toindex-byteoffset-toprimitive.js {unsupported: [computed-property-names]}
     prototype/getBigUint64/toindex-byteoffset-wrapped-values.js {unsupported: [computed-property-names]}
-    prototype/getBigUint64/toindex-byteoffset.js
+    prototype/getFloat32/detached-buffer.js
     prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getFloat32/detached-buffer.js
+    prototype/getFloat64/detached-buffer.js
     prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getFloat64/detached-buffer.js
+    prototype/getInt16/detached-buffer.js
     prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getInt16/detached-buffer.js
+    prototype/getInt32/detached-buffer.js
     prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getInt32/detached-buffer.js
     prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
@@ -261,22 +261,22 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getInt32/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/to-boolean-littleendian-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt8/detached-buffer.js
     prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getInt8/detached-buffer.js
+    prototype/getUint16/detached-buffer.js
     prototype/getUint16/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getUint16/detached-buffer.js
+    prototype/getUint32/detached-buffer.js
     prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getUint32/detached-buffer.js
+    prototype/getUint8/detached-buffer.js
     prototype/getUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js
-    prototype/getUint8/detached-buffer.js
+    prototype/setBigInt64/detached-buffer.js
     prototype/setBigInt64/detached-buffer-after-bigint-value.js
     prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/setBigInt64/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setBigInt64/detached-buffer.js
     prototype/setBigInt64/index-check-before-value-conversion.js
     prototype/setBigInt64/index-is-out-of-range.js
     prototype/setBigInt64/length.js
@@ -289,49 +289,49 @@ built-ins/DataView 166/455 (36.48%)
     prototype/setBigInt64/set-values-return-undefined.js
     prototype/setBigInt64/to-boolean-littleendian.js
     prototype/setBigInt64/toindex-byteoffset.js
+    prototype/setFloat32/detached-buffer.js
     prototype/setFloat32/detached-buffer-after-number-value.js
     prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setFloat32/detached-buffer.js
+    prototype/setFloat64/detached-buffer.js
     prototype/setFloat64/detached-buffer-after-number-value.js
     prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setFloat64/detached-buffer.js
+    prototype/setInt16/detached-buffer.js
     prototype/setInt16/detached-buffer-after-number-value.js
     prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setInt16/detached-buffer.js
+    prototype/setInt32/detached-buffer.js
     prototype/setInt32/detached-buffer-after-number-value.js
     prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setInt32/detached-buffer.js
+    prototype/setInt8/detached-buffer.js
     prototype/setInt8/detached-buffer-after-number-value.js
     prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setInt8/detached-buffer.js
+    prototype/setUint16/detached-buffer.js
     prototype/setUint16/detached-buffer-after-number-value.js
     prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setUint16/detached-buffer.js
+    prototype/setUint32/detached-buffer.js
     prototype/setUint32/detached-buffer-after-number-value.js
     prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setUint32/detached-buffer.js
+    prototype/setUint8/detached-buffer.js
     prototype/setUint8/detached-buffer-after-number-value.js
     prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
-    prototype/setUint8/detached-buffer.js
     prototype/Symbol.toStringTag.js
     buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
     buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
     byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     custom-proto-access-detaches-buffer.js {unsupported: [Reflect.construct]}
-    custom-proto-access-throws-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
     custom-proto-access-throws.js {unsupported: [Reflect.construct]}
-    custom-proto-if-not-object-fallbacks-to-default-prototype-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
+    custom-proto-access-throws-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
     custom-proto-if-not-object-fallbacks-to-default-prototype.js {unsupported: [Reflect.construct]}
-    custom-proto-if-object-is-used-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
+    custom-proto-if-not-object-fallbacks-to-default-prototype-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
     custom-proto-if-object-is-used.js {unsupported: [Reflect.construct]}
+    custom-proto-if-object-is-used-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
     defined-bytelength-and-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     defined-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     defined-byteoffset-undefined-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
@@ -341,10 +341,10 @@ built-ins/DataView 166/455 (36.48%)
     instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     negative-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
     negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    newtarget-undefined-throws-sab.js {unsupported: [SharedArrayBuffer]}
     newtarget-undefined-throws.js
-    proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect, cross-realm]}
+    newtarget-undefined-throws-sab.js {unsupported: [SharedArrayBuffer]}
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect, cross-realm]}
     return-abrupt-tonumber-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     return-abrupt-tonumber-bytelength-symbol-sab.js {unsupported: [SharedArrayBuffer]}
     return-abrupt-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
@@ -385,8 +385,8 @@ built-ins/Date 37/702 (5.27%)
     value-symbol-to-prim-invocation.js
     value-symbol-to-prim-return-obj.js
     value-symbol-to-prim-return-prim.js
-    value-to-primitive-call-err.js
     value-to-primitive-call.js
+    value-to-primitive-call-err.js
     value-to-primitive-get-meth-err.js
     value-to-primitive-result-faulty.js
     value-to-primitive-result-non-string-prim.js
@@ -431,8 +431,8 @@ built-ins/Function 195/509 (38.31%)
     prototype/apply/15.3.4.3-1-s.js strict
     prototype/apply/15.3.4.3-2-s.js strict
     prototype/apply/15.3.4.3-3-s.js strict
-    prototype/apply/argarray-not-object-realm.js {unsupported: [cross-realm]}
     prototype/apply/argarray-not-object.js
+    prototype/apply/argarray-not-object-realm.js {unsupported: [cross-realm]}
     prototype/apply/S15.3.4.3_A3_T1.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T2.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T3.js non-interpreted
@@ -446,21 +446,21 @@ built-ins/Function 195/509 (38.31%)
     prototype/apply/S15.3.4.3_A7_T2.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T5.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T7.js non-interpreted
-    prototype/apply/this-not-callable-realm.js {unsupported: [cross-realm]}
     prototype/apply/this-not-callable.js
+    prototype/apply/this-not-callable-realm.js {unsupported: [cross-realm]}
     prototype/bind/15.3.4.5-15-2.js
     prototype/bind/15.3.4.5-15-5.js
     prototype/bind/BoundFunction_restricted-properties.js
-    prototype/bind/get-fn-realm-recursive.js {unsupported: [cross-realm]}
     prototype/bind/get-fn-realm.js {unsupported: [cross-realm]}
-    prototype/bind/instance-construct-newtarget-boundtarget-bound.js {unsupported: [Reflect, new.target]}
+    prototype/bind/get-fn-realm-recursive.js {unsupported: [cross-realm]}
     prototype/bind/instance-construct-newtarget-boundtarget.js {unsupported: [Reflect, new.target]}
+    prototype/bind/instance-construct-newtarget-boundtarget-bound.js {unsupported: [Reflect, new.target]}
     prototype/bind/instance-construct-newtarget-self-new.js {unsupported: [new.target]}
     prototype/bind/instance-construct-newtarget-self-reflect.js {unsupported: [Reflect, new.target]}
+    prototype/bind/instance-name.js
     prototype/bind/instance-name-chained.js
     prototype/bind/instance-name-error.js
     prototype/bind/instance-name-non-string.js
-    prototype/bind/instance-name.js
     prototype/bind/length-exceeds-int32.js
     prototype/bind/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     prototype/call/15.3.4.4-1-s.js strict
@@ -497,15 +497,15 @@ built-ins/Function 195/509 (38.31%)
     prototype/toString/async-function-expression.js {unsupported: [async-functions]}
     prototype/toString/async-generator-declaration.js {unsupported: [async-iteration]}
     prototype/toString/async-generator-expression.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-class-expression-static.js {unsupported: [async-iteration]}
     prototype/toString/async-generator-method-class-expression.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-class-statement-static.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-expression-static.js {unsupported: [async-iteration]}
     prototype/toString/async-generator-method-class-statement.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-statement-static.js {unsupported: [async-iteration]}
     prototype/toString/async-generator-method-object.js {unsupported: [async-iteration]}
-    prototype/toString/async-method-class-expression-static.js {unsupported: [async-functions]}
     prototype/toString/async-method-class-expression.js {unsupported: [async-functions]}
-    prototype/toString/async-method-class-statement-static.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-expression-static.js {unsupported: [async-functions]}
     prototype/toString/async-method-class-statement.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-statement-static.js {unsupported: [async-functions]}
     prototype/toString/async-method-object.js {unsupported: [async-functions]}
     prototype/toString/AsyncFunction.js {unsupported: [async-functions]}
     prototype/toString/AsyncGenerator.js {unsupported: [async-iteration]}
@@ -514,26 +514,26 @@ built-ins/Function 195/509 (38.31%)
     prototype/toString/class-declaration-implicit-ctor.js
     prototype/toString/class-expression-explicit-ctor.js
     prototype/toString/class-expression-implicit-ctor.js
-    prototype/toString/function-declaration-non-simple-parameter-list.js
-    prototype/toString/function-declaration.js
-    prototype/toString/function-expression.js
     prototype/toString/Function.js
+    prototype/toString/function-declaration.js
+    prototype/toString/function-declaration-non-simple-parameter-list.js
+    prototype/toString/function-expression.js
     prototype/toString/generator-function-declaration.js
     prototype/toString/generator-function-expression.js
     prototype/toString/generator-method.js
     prototype/toString/GeneratorFunction.js
-    prototype/toString/getter-class-expression-static.js
     prototype/toString/getter-class-expression.js
-    prototype/toString/getter-class-statement-static.js
+    prototype/toString/getter-class-expression-static.js
     prototype/toString/getter-class-statement.js
+    prototype/toString/getter-class-statement-static.js
     prototype/toString/getter-object.js
-    prototype/toString/line-terminator-normalisation-CR-LF.js
     prototype/toString/line-terminator-normalisation-CR.js
+    prototype/toString/line-terminator-normalisation-CR-LF.js
     prototype/toString/line-terminator-normalisation-LF.js
-    prototype/toString/method-class-expression-static.js
     prototype/toString/method-class-expression.js
-    prototype/toString/method-class-statement-static.js
+    prototype/toString/method-class-expression-static.js
     prototype/toString/method-class-statement.js
+    prototype/toString/method-class-statement-static.js
     prototype/toString/method-computed-property-name.js
     prototype/toString/method-object.js
     prototype/toString/private-method-class-expression.js
@@ -553,10 +553,10 @@ built-ins/Function 195/509 (38.31%)
     prototype/toString/proxy-non-callable-throws.js {unsupported: [Proxy]}
     prototype/toString/S15.3.4.2_A12.js
     prototype/toString/S15.3.4.2_A13.js
-    prototype/toString/setter-class-expression-static.js
     prototype/toString/setter-class-expression.js
-    prototype/toString/setter-class-statement-static.js
+    prototype/toString/setter-class-expression-static.js
     prototype/toString/setter-class-statement.js
+    prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
     prototype/toString/unicode.js
@@ -566,14 +566,14 @@ built-ins/Function 195/509 (38.31%)
     prototype/restricted-property-caller.js
     prototype/S15.3.4_A5.js
     15.3.2.1-10-6gs.js non-strict
-    15.3.2.1-11-1-s.js non-strict
     15.3.2.1-11-1.js strict
+    15.3.2.1-11-1-s.js non-strict
     15.3.2.1-11-2-s.js strict
-    15.3.2.1-11-3-s.js non-strict
     15.3.2.1-11-3.js strict
+    15.3.2.1-11-3-s.js non-strict
     15.3.2.1-11-4-s.js strict
-    15.3.2.1-11-5-s.js non-strict
     15.3.2.1-11-5.js strict
+    15.3.2.1-11-5-s.js non-strict
     15.3.2.1-11-6-s.js strict
     15.3.2.1-11-7-s.js strict
     15.3.2.1-11-8-s.js strict
@@ -659,8 +659,8 @@ built-ins/isNaN 8/16 (50.0%)
 
 built-ins/JSON 33/131 (25.19%)
     parse/builtin.js {unsupported: [Reflect.construct]}
-    parse/revived-proxy-revoked.js {unsupported: [Proxy]}
     parse/revived-proxy.js {unsupported: [Proxy]}
+    parse/revived-proxy-revoked.js {unsupported: [Proxy]}
     parse/reviver-array-define-prop-err.js {unsupported: [Proxy]}
     parse/reviver-array-delete-err.js {unsupported: [Proxy]}
     parse/reviver-array-length-coerce-err.js {unsupported: [Proxy]}
@@ -673,19 +673,19 @@ built-ins/JSON 33/131 (25.19%)
     stringify/builtin.js {unsupported: [Reflect.construct]}
     stringify/replacer-array-abrupt.js {unsupported: [Proxy]}
     stringify/replacer-array-number.js
-    stringify/replacer-array-proxy-revoked-realm.js {unsupported: [Proxy, cross-realm]}
-    stringify/replacer-array-proxy-revoked.js {unsupported: [Proxy]}
     stringify/replacer-array-proxy.js {unsupported: [Proxy]}
+    stringify/replacer-array-proxy-revoked.js {unsupported: [Proxy]}
+    stringify/replacer-array-proxy-revoked-realm.js {unsupported: [Proxy, cross-realm]}
     stringify/replacer-array-wrong-type.js {unsupported: [Proxy]}
     stringify/replacer-function-arguments.js
     stringify/replacer-function-result.js
     stringify/value-array-abrupt.js {unsupported: [Proxy]}
-    stringify/value-array-proxy-revoked.js {unsupported: [Proxy]}
     stringify/value-array-proxy.js {unsupported: [Proxy]}
+    stringify/value-array-proxy-revoked.js {unsupported: [Proxy]}
     stringify/value-bigint-cross-realm.js {unsupported: [cross-realm]}
     stringify/value-bigint-tojson-receiver.js
-    stringify/value-object-proxy-revoked.js {unsupported: [Proxy]}
     stringify/value-object-proxy.js {unsupported: [Proxy]}
+    stringify/value-object-proxy-revoked.js {unsupported: [Proxy]}
     stringify/value-string-escape-ascii.js
     stringify/value-string-escape-unicode.js
     stringify/value-symbol.js
@@ -720,8 +720,8 @@ built-ins/NativeErrors 43/79 (54.43%)
     URIError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
 built-ins/Number 9/281 (3.2%)
-    prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
+    prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/undefined-fractiondigits.js
     prototype/toLocaleString/length.js
     prototype/toPrecision/nan.js
@@ -831,8 +831,8 @@ built-ins/Object 118/3115 (3.79%)
     prototype/toLocaleString/S15.2.4.3_A13.js
     prototype/toString/get-symbol-tag-err.js
     prototype/toString/proxy-array.js {unsupported: [Proxy]}
-    prototype/toString/proxy-function-async.js {unsupported: [Proxy, async-functions]}
     prototype/toString/proxy-function.js {unsupported: [Proxy, async-functions]}
+    prototype/toString/proxy-function-async.js {unsupported: [Proxy, async-functions]}
     prototype/toString/proxy-revoked.js {unsupported: [Proxy]}
     prototype/toString/symbol-tag-non-str-bigint.js
     prototype/toString/symbol-tag-non-str-builtin.js
@@ -881,8 +881,8 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/exec/u-captured-value.js
     prototype/exec/u-lastindex-adv.js
     prototype/exec/u-lastindex-value.js
-    prototype/exec/y-fail-lastindex-no-write.js
     prototype/exec/y-fail-lastindex.js
+    prototype/exec/y-fail-lastindex-no-write.js
     prototype/exec/y-fail-return.js
     prototype/exec/y-init-lastindex.js
     prototype/exec/y-set-lastindex.js
@@ -917,14 +917,14 @@ built-ins/RegExp 896/1432 (62.57%)
     *prototype/Symbol.matchAll 25/25 (100.0%)
     prototype/Symbol.match/builtin-coerce-lastindex.js
     prototype/Symbol.match/builtin-failure-y-return-val.js
-    prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
     prototype/Symbol.match/builtin-failure-y-set-lastindex.js
+    prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
     prototype/Symbol.match/builtin-infer-unicode.js
-    prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
     prototype/Symbol.match/builtin-success-g-set-lastindex.js
+    prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
     prototype/Symbol.match/builtin-success-u-return-val-groups.js
-    prototype/Symbol.match/builtin-success-y-set-lastindex-err.js
     prototype/Symbol.match/builtin-success-y-set-lastindex.js
+    prototype/Symbol.match/builtin-success-y-set-lastindex-err.js
     prototype/Symbol.match/builtin-y-coerce-lastindex-err.js
     prototype/Symbol.match/coerce-global.js
     prototype/Symbol.match/exec-err.js
@@ -945,27 +945,27 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.match/this-val-non-regexp.js
     prototype/Symbol.match/u-advance-after-empty.js
     prototype/Symbol.match/y-fail-global-return.js
-    prototype/Symbol.match/y-fail-lastindex-no-write.js
     prototype/Symbol.match/y-fail-lastindex.js
+    prototype/Symbol.match/y-fail-lastindex-no-write.js
     prototype/Symbol.match/y-fail-return.js
     prototype/Symbol.match/y-init-lastindex.js
     prototype/Symbol.match/y-set-lastindex.js
-    prototype/Symbol.replace/arg-1-coerce-err.js
     prototype/Symbol.replace/arg-1-coerce.js
-    prototype/Symbol.replace/arg-2-coerce-err.js
+    prototype/Symbol.replace/arg-1-coerce-err.js
     prototype/Symbol.replace/arg-2-coerce.js
+    prototype/Symbol.replace/arg-2-coerce-err.js
     prototype/Symbol.replace/coerce-global.js
     prototype/Symbol.replace/coerce-unicode.js
     prototype/Symbol.replace/exec-err.js
     prototype/Symbol.replace/exec-invocation.js
-    prototype/Symbol.replace/fn-coerce-replacement-err.js
     prototype/Symbol.replace/fn-coerce-replacement.js
+    prototype/Symbol.replace/fn-coerce-replacement-err.js
     prototype/Symbol.replace/fn-err.js
     prototype/Symbol.replace/fn-invoke-args.js
     prototype/Symbol.replace/fn-invoke-this-no-strict.js non-strict
     prototype/Symbol.replace/fn-invoke-this-strict.js strict
-    prototype/Symbol.replace/g-init-lastindex-err.js
     prototype/Symbol.replace/g-init-lastindex.js
+    prototype/Symbol.replace/g-init-lastindex-err.js
     prototype/Symbol.replace/g-pos-decrement.js
     prototype/Symbol.replace/g-pos-increment.js
     prototype/Symbol.replace/get-exec-err.js
@@ -977,14 +977,14 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.replace/prop-desc.js
     prototype/Symbol.replace/replace-with-trailing.js
     prototype/Symbol.replace/replace-without-trailing.js
-    prototype/Symbol.replace/result-coerce-capture-err.js
     prototype/Symbol.replace/result-coerce-capture.js
-    prototype/Symbol.replace/result-coerce-index-err.js
+    prototype/Symbol.replace/result-coerce-capture-err.js
     prototype/Symbol.replace/result-coerce-index.js
-    prototype/Symbol.replace/result-coerce-length-err.js
+    prototype/Symbol.replace/result-coerce-index-err.js
     prototype/Symbol.replace/result-coerce-length.js
-    prototype/Symbol.replace/result-coerce-matched-err.js
+    prototype/Symbol.replace/result-coerce-length-err.js
     prototype/Symbol.replace/result-coerce-matched.js
+    prototype/Symbol.replace/result-coerce-matched-err.js
     prototype/Symbol.replace/result-get-capture-err.js
     prototype/Symbol.replace/result-get-index-err.js
     prototype/Symbol.replace/result-get-length-err.js
@@ -997,8 +997,8 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.replace/subst-matched.js
     prototype/Symbol.replace/u-advance-after-empty.js
     prototype/Symbol.replace/y-fail-global-return.js
-    prototype/Symbol.replace/y-fail-lastindex-no-write.js
     prototype/Symbol.replace/y-fail-lastindex.js
+    prototype/Symbol.replace/y-fail-lastindex-no-write.js
     prototype/Symbol.replace/y-fail-return.js
     prototype/Symbol.replace/y-init-lastindex.js
     prototype/Symbol.replace/y-set-lastindex.js
@@ -1007,25 +1007,26 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.search/get-lastindex-err.js
     prototype/Symbol.search/lastindex-no-restore.js
     prototype/Symbol.search/match-err.js
-    prototype/Symbol.search/set-lastindex-init-err.js
     prototype/Symbol.search/set-lastindex-init.js
-    prototype/Symbol.search/set-lastindex-restore-err.js
+    prototype/Symbol.search/set-lastindex-init-err.js
     prototype/Symbol.search/set-lastindex-restore.js
+    prototype/Symbol.search/set-lastindex-restore-err.js
     prototype/Symbol.search/success-get-index-err.js
     prototype/Symbol.search/u-lastindex-advance.js
     prototype/Symbol.search/y-fail-return.js
-    prototype/Symbol.split/coerce-flags-err.js
     prototype/Symbol.split/coerce-flags.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/coerce-limit-err.js
+    prototype/Symbol.split/coerce-flags-err.js
     prototype/Symbol.split/coerce-limit.js
-    prototype/Symbol.split/coerce-string-err.js
+    prototype/Symbol.split/coerce-limit-err.js
     prototype/Symbol.split/coerce-string.js
+    prototype/Symbol.split/coerce-string-err.js
     prototype/Symbol.split/get-flags-err.js
     prototype/Symbol.split/last-index-exceeds-str-size.js
     prototype/Symbol.split/length.js
     prototype/Symbol.split/limit-0-bail.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/name.js
     prototype/Symbol.split/prop-desc.js
+    prototype/Symbol.split/species-ctor.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/species-ctor-ctor-get-err.js
     prototype/Symbol.split/species-ctor-ctor-non-obj.js
     prototype/Symbol.split/species-ctor-ctor-undef.js
@@ -1034,20 +1035,19 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.split/species-ctor-species-non-ctor.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/species-ctor-species-undef.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/species-ctor-y.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/species-ctor.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/splitter-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
     prototype/Symbol.split/str-adv-thru-empty-match.js
-    prototype/Symbol.split/str-coerce-lastindex-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-coerce-lastindex.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-empty-match-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-coerce-lastindex-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-empty-match.js
+    prototype/Symbol.split/str-empty-match-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-empty-no-match.js
     prototype/Symbol.split/str-get-lastindex-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-limit-capturing.js
     prototype/Symbol.split/str-limit.js
+    prototype/Symbol.split/str-limit-capturing.js
     prototype/Symbol.split/str-match-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-result-coerce-length-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-result-coerce-length.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-result-coerce-length-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-result-get-capture-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-result-get-length-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-set-lastindex-err.js {unsupported: [Symbol.species]}
@@ -1057,8 +1057,8 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.split/u-lastindex-adv-thru-failure.js
     prototype/Symbol.split/u-lastindex-adv-thru-match.js
     prototype/test/S15.10.6.3_A1_T22.js
-    prototype/test/y-fail-lastindex-no-write.js
     prototype/test/y-fail-lastindex.js
+    prototype/test/y-fail-lastindex-no-write.js
     prototype/test/y-fail-return.js
     prototype/test/y-init-lastindex.js
     prototype/test/y-set-lastindex.js
@@ -1072,12 +1072,12 @@ built-ins/RegExp 896/1432 (62.57%)
     call_with_regexp_not_same_constructor.js
     character-class-escape-non-whitespace-u180e.js {unsupported: [u180e]}
     duplicate-flags.js {unsupported: [regexp-dotall]}
+    from-regexp-like.js
     from-regexp-like-flag-override.js
     from-regexp-like-get-ctor-err.js
     from-regexp-like-get-flags-err.js
     from-regexp-like-get-source-err.js
     from-regexp-like-short-circuit.js
-    from-regexp-like.js
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     S15.10.1_A1_T13.js
     S15.10.1_A1_T14.js
@@ -1119,8 +1119,8 @@ built-ins/String 75/1064 (7.05%)
     prototype/replace/S15.5.4.11_A12.js non-strict
     prototype/search/cstm-search-get-err.js
     prototype/search/cstm-search-invocation.js
-    prototype/search/invoke-builtin-search-searcher-undef.js
     prototype/search/invoke-builtin-search.js
+    prototype/search/invoke-builtin-search-searcher-undef.js
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
@@ -1293,14 +1293,14 @@ built-ins/TypedArray 984/1054 (93.36%)
     *prototype/fill/BigInt 17/17 (100.0%)
     prototype/fill/coerced-indexes.js
     prototype/fill/detached-buffer.js
+    prototype/fill/fill-values.js
     prototype/fill/fill-values-conversion-once.js
-    prototype/fill/fill-values-conversion-operations-consistent-nan.js
     prototype/fill/fill-values-conversion-operations.js
+    prototype/fill/fill-values-conversion-operations-consistent-nan.js
     prototype/fill/fill-values-custom-start-and-end.js
     prototype/fill/fill-values-non-numeric.js
     prototype/fill/fill-values-relative-end.js
     prototype/fill/fill-values-relative-start.js
-    prototype/fill/fill-values.js
     prototype/fill/get-length-ignores-length-prop.js
     prototype/fill/invoked-as-func.js
     prototype/fill/invoked-as-method.js
@@ -1335,19 +1335,19 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/filter/result-does-not-share-buffer.js
     prototype/filter/result-empty-callbackfn-returns-false.js
     prototype/filter/result-full-callbackfn-returns-true.js
+    prototype/filter/speciesctor-get-ctor.js
     prototype/filter/speciesctor-get-ctor-abrupt.js
     prototype/filter/speciesctor-get-ctor-inherited.js
-    prototype/filter/speciesctor-get-ctor.js
+    prototype/filter/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
     prototype/filter/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/filter/values-are-not-cached.js
@@ -1419,8 +1419,8 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/includes/get-length-uses-internal-arraylength.js
     prototype/includes/invoked-as-func.js
     prototype/includes/invoked-as-method.js
-    prototype/includes/length-zero-returns-false.js
     prototype/includes/length.js
+    prototype/includes/length-zero-returns-false.js
     prototype/includes/name.js
     prototype/includes/prop-desc.js
     prototype/includes/return-abrupt-tointeger-fromindex.js
@@ -1438,8 +1438,8 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/indexOf/get-length-uses-internal-arraylength.js
     prototype/indexOf/invoked-as-func.js
     prototype/indexOf/invoked-as-method.js
-    prototype/indexOf/length-zero-returns-minus-one.js
     prototype/indexOf/length.js
+    prototype/indexOf/length-zero-returns-minus-one.js
     prototype/indexOf/name.js
     prototype/indexOf/prop-desc.js
     prototype/indexOf/return-abrupt-tointeger-fromindex.js
@@ -1474,8 +1474,8 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/lastIndexOf/get-length-uses-internal-arraylength.js
     prototype/lastIndexOf/invoked-as-func.js
     prototype/lastIndexOf/invoked-as-method.js
-    prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/length.js
+    prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/name.js
     prototype/lastIndexOf/prop-desc.js
     prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
@@ -1512,23 +1512,23 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/map/length.js
     prototype/map/name.js
     prototype/map/prop-desc.js
-    prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
     prototype/map/return-new-typedarray-conversion-operation.js
+    prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
     prototype/map/return-new-typedarray-from-empty-length.js
     prototype/map/return-new-typedarray-from-positive-length.js
+    prototype/map/speciesctor-get-ctor.js
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-ctor-inherited.js
-    prototype/map/speciesctor-get-ctor.js
+    prototype/map/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
     prototype/map/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/map/values-are-not-cached.js
@@ -1586,13 +1586,13 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-return-abrupt-from-src-get-length.js
     prototype/set/array-arg-return-abrupt-from-src-get-value.js
-    prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
     prototype/set/array-arg-return-abrupt-from-src-length.js
-    prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+    prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
     prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
+    prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
     prototype/set/array-arg-return-abrupt-from-toobject-offset.js
-    prototype/set/array-arg-set-values-in-order.js
     prototype/set/array-arg-set-values.js
+    prototype/set/array-arg-set-values-in-order.js
     prototype/set/array-arg-src-tonumber-value-conversions.js
     prototype/set/array-arg-src-values-are-not-cached.js
     prototype/set/array-arg-target-arraylength-internal.js
@@ -1623,12 +1623,12 @@ built-ins/TypedArray 984/1054 (93.36%)
     *prototype/slice/BigInt 35/35 (100.0%)
     prototype/slice/arraylength-internal.js
     prototype/slice/bit-precision.js
+    prototype/slice/detached-buffer.js
     prototype/slice/detached-buffer-custom-ctor-other-targettype.js {unsupported: [Symbol.species]}
     prototype/slice/detached-buffer-custom-ctor-same-targettype.js {unsupported: [Symbol.species]}
     prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
     prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js {unsupported: [Symbol.species]}
     prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js {unsupported: [Symbol.species]}
-    prototype/slice/detached-buffer.js
     prototype/slice/infinity.js
     prototype/slice/invoked-as-func.js
     prototype/slice/invoked-as-method.js
@@ -1643,19 +1643,19 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/slice/return-abrupt-from-end.js
     prototype/slice/return-abrupt-from-start.js
     prototype/slice/set-values-from-different-ctor-type.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-ctor.js
     prototype/slice/speciesctor-get-ctor-abrupt.js
     prototype/slice/speciesctor-get-ctor-inherited.js
-    prototype/slice/speciesctor-get-ctor.js
+    prototype/slice/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/slice/tointeger-end.js
@@ -1686,8 +1686,8 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/sort/arraylength-internal.js
     prototype/sort/comparefn-call-throws.js
     prototype/sort/comparefn-calls.js
-    prototype/sort/detached-buffer-comparefn.js
     prototype/sort/detached-buffer.js
+    prototype/sort/detached-buffer-comparefn.js
     prototype/sort/invoked-as-func.js
     prototype/sort/invoked-as-method.js
     prototype/sort/length.js
@@ -1696,8 +1696,8 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/sort/return-same-instance.js
     prototype/sort/sort-tonumber.js
     prototype/sort/sortcompare-with-no-tostring.js
-    prototype/sort/sorted-values-nan.js
     prototype/sort/sorted-values.js
+    prototype/sort/sorted-values-nan.js
     prototype/sort/stability.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
@@ -1709,18 +1709,18 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/subarray/length.js
     prototype/subarray/name.js
     prototype/subarray/prop-desc.js
+    prototype/subarray/speciesctor-get-ctor.js
     prototype/subarray/speciesctor-get-ctor-abrupt.js
     prototype/subarray/speciesctor-get-ctor-inherited.js
     prototype/subarray/speciesctor-get-ctor-returns-throws.js
-    prototype/subarray/speciesctor-get-ctor.js
+    prototype/subarray/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/subarray/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
     prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
     prototype/subarray/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
     prototype/subarray/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
     prototype/subarray/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/subarray/this-is-not-object.js
     prototype/subarray/this-is-not-typedarray-instance.js
     *prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
@@ -1766,19 +1766,19 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     *ctors-bigint/object-arg 31/31 (100.0%)
     *ctors-bigint/typedarray-arg 27/27 (100.0%)
     ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-throws.js
+    ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
     ctors/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
     ctors/buffer-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
+    ctors/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
     ctors/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-negative-length.js
+    ctors/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/detachedbuffer.js
     ctors/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -1789,16 +1789,16 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     ctors/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/length-to-number-detachbuffer.js
     ctors/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect, cross-realm]}
     ctors/buffer-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect, cross-realm]}
     ctors/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
     ctors/buffer-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
-    ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
     ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/length-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
     ctors/length-arg/is-infinity-throws-rangeerror.js
     ctors/length-arg/is-negative-integer-throws-rangeerror.js
@@ -1823,8 +1823,8 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     ctors/object-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     ctors/object-arg/returns.js
     ctors/object-arg/throws-from-property.js
-    ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
     ctors/object-arg/throws-setting-obj-to-primitive.js
+    ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
     ctors/object-arg/throws-setting-property.js
     ctors/object-arg/throws-setting-symbol-property.js
     ctors/object-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
@@ -1833,8 +1833,8 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     ctors/typedarray-arg/detached-when-species-retrieved-different-type.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/detached-when-species-retrieved-same-type.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
     ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
     ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
     ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js {unsupported: [Symbol.species]}
@@ -1843,8 +1843,8 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     ctors/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-species-null.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js {unsupported: [Symbol.species]}
@@ -1861,8 +1861,8 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     *from/BigInt 28/28 (100.0%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
-    from/custom-ctor-returns-other-instance.js
     from/custom-ctor.js
+    from/custom-ctor-returns-other-instance.js
     from/iter-access-error.js
     from/iter-invoke-error.js
     from/iter-next-error.js
@@ -1892,18 +1892,18 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     *internals/DefineOwnProperty 22/22 (100.0%)
     *internals/Get/BigInt 14/14 (100.0%)
     *internals/GetOwnProperty/BigInt 12/12 (100.0%)
+    internals/GetOwnProperty/detached-buffer.js
     internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     internals/GetOwnProperty/detached-buffer-key-is-symbol.js
     internals/GetOwnProperty/detached-buffer-realm.js {unsupported: [cross-realm]}
-    internals/GetOwnProperty/detached-buffer.js
     internals/GetOwnProperty/enumerate-detached-buffer.js
     internals/GetOwnProperty/index-prop-desc.js
+    internals/Get/detached-buffer.js
     internals/Get/detached-buffer-key-is-not-numeric-index.js
     internals/Get/detached-buffer-key-is-symbol.js
     internals/Get/detached-buffer-realm.js {unsupported: [cross-realm]}
-    internals/Get/detached-buffer.js
-    internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/indexed-value.js
+    internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/infinity-detached-buffer.js
     internals/Get/key-is-not-canonical-index.js
     internals/Get/key-is-not-integer.js
@@ -1916,10 +1916,10 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     *internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
     *internals/OwnPropertyKeys 4/4 (100.0%)
     *internals/Set/BigInt 23/23 (100.0%)
+    internals/Set/detached-buffer.js
     internals/Set/detached-buffer-key-is-not-numeric-index.js {unsupported: [Reflect]}
     internals/Set/detached-buffer-key-is-symbol.js {unsupported: [Reflect]}
     internals/Set/detached-buffer-realm.js {unsupported: [cross-realm]}
-    internals/Set/detached-buffer.js
     internals/Set/indexed-value.js {unsupported: [Reflect]}
     internals/Set/key-is-minus-zero.js {unsupported: [Reflect]}
     internals/Set/key-is-not-canonical-index.js {unsupported: [Reflect]}
@@ -1931,13 +1931,13 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     internals/Set/tonumber-value-throws.js
     *of/BigInt 12/12 (100.0%)
     of/argument-number-value-throws.js
-    of/custom-ctor-returns-other-instance.js
     of/custom-ctor.js
+    of/custom-ctor-returns-other-instance.js
     of/nan-conversion.js
+    of/new-instance.js
     of/new-instance-empty.js
     of/new-instance-from-zero.js
     of/new-instance-using-custom-ctor.js
-    of/new-instance.js
     *prototype/buffer 2/2 (100.0%)
     *prototype/byteLength 2/2 (100.0%)
     *prototype/byteOffset 2/2 (100.0%)
@@ -2189,8 +2189,8 @@ language/block-scope 82/145 (56.55%)
     syntax/for-in/mixed-values-in-iteration.js
     syntax/function-declarations/in-statement-position-do-statement-while-expression.js strict
     syntax/function-declarations/in-statement-position-for-statement.js strict
-    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
     syntax/function-declarations/in-statement-position-if-expression-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
     syntax/function-declarations/in-statement-position-while-expression-statement.js strict
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
@@ -2268,8 +2268,8 @@ language/block-scope 82/145 (56.55%)
 language/comments 37/52 (71.15%)
     *hashbang 29/29 (100.0%)
     mongolian-vowel-separator-multi.js {unsupported: [u180e]}
-    mongolian-vowel-separator-single-eval.js {unsupported: [u180e]}
     mongolian-vowel-separator-single.js {unsupported: [u180e]}
+    mongolian-vowel-separator-single-eval.js {unsupported: [u180e]}
     multi-line-asi-carriage-return.js
     multi-line-asi-line-feed.js
     multi-line-asi-line-separator.js
@@ -2321,20 +2321,20 @@ language/eval-code 65/151 (43.05%)
     direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
+    direct/new.target.js {unsupported: [new.target]}
     direct/new.target-arrow.js {unsupported: [new.target]}
     direct/new.target-fn.js {unsupported: [new.target]}
-    direct/new.target.js {unsupported: [new.target]}
     direct/non-definable-global-var.js non-strict
+    direct/super-call.js {unsupported: [super]}
     direct/super-call-arrow.js {unsupported: [super]}
     direct/super-call-fn.js {unsupported: [super]}
     direct/super-call-method.js {unsupported: [super]}
-    direct/super-call.js {unsupported: [super]}
+    direct/super-prop.js {unsupported: [super]}
     direct/super-prop-arrow.js {unsupported: [super]}
     direct/super-prop-dot-no-home.js {unsupported: [super]}
-    direct/super-prop-expr-no-home-no-eval.js {unsupported: [super]}
     direct/super-prop-expr-no-home.js {unsupported: [super]}
+    direct/super-prop-expr-no-home-no-eval.js {unsupported: [super]}
     direct/super-prop-method.js {unsupported: [super]}
-    direct/super-prop.js {unsupported: [super]}
     direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
     direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
     direct/switch-case-decl-onlystrict.js strict
@@ -2343,14 +2343,14 @@ language/eval-code 65/151 (43.05%)
     direct/switch-dflt-decl-onlystrict.js strict
     direct/this-value-func-strict-caller.js strict
     direct/var-env-func-init-global-update-configurable.js non-strict
-    direct/var-env-func-strict-caller-2.js strict
     direct/var-env-func-strict-caller.js strict
+    direct/var-env-func-strict-caller-2.js strict
     direct/var-env-func-strict-source.js
     direct/var-env-global-lex-non-strict.js non-strict
     direct/var-env-lower-lex-non-strict.js non-strict
+    direct/var-env-var-strict-caller.js strict
     direct/var-env-var-strict-caller-2.js strict
     direct/var-env-var-strict-caller-3.js strict
-    direct/var-env-var-strict-caller.js strict
     direct/var-env-var-strict-source.js
     indirect/always-non-strict.js strict
     indirect/block-decl-strict.js
@@ -2413,22 +2413,22 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
-    dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-id.js
-    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-prop-id.js
-    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
     dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
     dstr/ary-ptrn-rest-ary-elem.js
     dstr/ary-ptrn-rest-ary-elision.js
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
-    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
     dstr/ary-ptrn-rest-id-iter-step-err.js
     dstr/ary-ptrn-rest-id-iter-val-err.js
-    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-init-ary.js
     dstr/ary-ptrn-rest-init-id.js
     dstr/ary-ptrn-rest-init-obj.js
@@ -2464,28 +2464,28 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
@@ -2508,22 +2508,22 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
@@ -2538,19 +2538,19 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
-    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
-    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -2561,17 +2561,17 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/syntax-error-ident-ref-const-escaped.js
     dstr/syntax-error-ident-ref-continue-escaped.js
     dstr/syntax-error-ident-ref-debugger-escaped.js
-    dstr/syntax-error-ident-ref-default-escaped-ext.js
-    dstr/syntax-error-ident-ref-default-escaped.js
     dstr/syntax-error-ident-ref-default.js
+    dstr/syntax-error-ident-ref-default-escaped.js
+    dstr/syntax-error-ident-ref-default-escaped-ext.js
     dstr/syntax-error-ident-ref-delete-escaped.js
     dstr/syntax-error-ident-ref-do-escaped.js
     dstr/syntax-error-ident-ref-else-escaped.js
     dstr/syntax-error-ident-ref-enum-escaped.js
     dstr/syntax-error-ident-ref-export-escaped.js
-    dstr/syntax-error-ident-ref-extends-escaped-ext.js
-    dstr/syntax-error-ident-ref-extends-escaped.js
     dstr/syntax-error-ident-ref-extends.js
+    dstr/syntax-error-ident-ref-extends-escaped.js
+    dstr/syntax-error-ident-ref-extends-escaped-ext.js
     dstr/syntax-error-ident-ref-finally-escaped.js
     dstr/syntax-error-ident-ref-for-escaped.js
     dstr/syntax-error-ident-ref-function-escaped.js
@@ -2619,11 +2619,11 @@ language/expressions/arrow-function 276/326 (84.66%)
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
     length-dflt.js {unsupported: [default-parameters]}
-    lexical-new.target-closure-returned.js {unsupported: [new.target]}
     lexical-new.target.js {unsupported: [new.target]}
+    lexical-new.target-closure-returned.js {unsupported: [new.target]}
     lexical-super-call-from-within-constructor.js
-    lexical-super-property-from-within-constructor.js
     lexical-super-property.js
+    lexical-super-property-from-within-constructor.js
     lexical-supercall-from-immediately-invoked-arrow.js
     name.js
     object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
@@ -2676,10 +2676,10 @@ language/expressions/call 64/96 (66.67%)
     11.2.3-3_7.js
     11.2.3-3_8.js non-strict
     eval-realm-indirect.js {unsupported: [cross-realm]}
+    eval-spread.js
+    eval-spread-empty.js
     eval-spread-empty-leading.js
     eval-spread-empty-trailing.js
-    eval-spread-empty.js
-    eval-spread.js
     spread-err-mult-err-expr-throws.js
     spread-err-mult-err-iter-get-value.js
     spread-err-mult-err-itr-get-call.js
@@ -2706,8 +2706,8 @@ language/expressions/call 64/96 (66.67%)
     spread-obj-getter-descriptor.js
     spread-obj-getter-init.js
     spread-obj-manipulate-outter-obj-in-getter.js
-    spread-obj-mult-spread-getter.js
     spread-obj-mult-spread.js
+    spread-obj-mult-spread-getter.js
     spread-obj-null.js
     spread-obj-override-immutable.js
     spread-obj-overrides-prev-properties.js
@@ -2727,8 +2727,8 @@ language/expressions/call 64/96 (66.67%)
     tco-cross-realm-fun-call.js {unsupported: [tail-call-optimization, cross-realm, class]}
     tco-cross-realm-fun-construct.js {unsupported: [tail-call-optimization, cross-realm, class]}
     tco-member-args.js {unsupported: [tail-call-optimization]}
-    tco-non-eval-function-dynamic.js {unsupported: [tail-call-optimization]}
     tco-non-eval-function.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-function-dynamic.js {unsupported: [tail-call-optimization]}
     tco-non-eval-global.js {unsupported: [tail-call-optimization]}
     tco-non-eval-with.js {unsupported: [tail-call-optimization]}
     trailing-comma.js
@@ -2875,22 +2875,22 @@ language/expressions/function 205/241 (85.06%)
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
-    dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-id.js
-    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-prop-id.js
-    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
     dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
     dstr/ary-ptrn-rest-ary-elem.js
     dstr/ary-ptrn-rest-ary-elision.js
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
-    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
     dstr/ary-ptrn-rest-id-iter-step-err.js
     dstr/ary-ptrn-rest-id-iter-val-err.js
-    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-init-ary.js
     dstr/ary-ptrn-rest-init-id.js
     dstr/ary-ptrn-rest-init-obj.js
@@ -2926,28 +2926,28 @@ language/expressions/function 205/241 (85.06%)
     dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
@@ -2970,22 +2970,22 @@ language/expressions/function 205/241 (85.06%)
     dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
@@ -3000,19 +3000,19 @@ language/expressions/function 205/241 (85.06%)
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
-    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
-    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -3030,9 +3030,9 @@ language/expressions/function 205/241 (85.06%)
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
     length-dflt.js {unsupported: [default-parameters]}
+    name.js
     name-arguments-strict-body.js non-strict
     name-eval-strict-body.js non-strict
-    name.js
     object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     param-dflt-yield-non-strict.js {unsupported: [default-parameters]}
     param-dflt-yield-strict.js {unsupported: [default-parameters]}
@@ -3081,26 +3081,26 @@ language/expressions/generators 228/268 (85.07%)
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
-    dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
-    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
-    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
     dstr/ary-ptrn-elem-obj-val-null.js
     dstr/ary-ptrn-elem-obj-val-undef.js
-    dstr/ary-ptrn-elision-step-err.js
     dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
     dstr/ary-ptrn-rest-ary-elem.js
     dstr/ary-ptrn-rest-ary-elision.js
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
-    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
     dstr/ary-ptrn-rest-id-iter-step-err.js
     dstr/ary-ptrn-rest-id-iter-val-err.js
-    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
@@ -3130,28 +3130,28 @@ language/expressions/generators 228/268 (85.07%)
     dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
@@ -3174,22 +3174,22 @@ language/expressions/generators 228/268 (85.07%)
     dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
@@ -3206,20 +3206,20 @@ language/expressions/generators 228/268 (85.07%)
     dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-id-trailing-comma.js non-interpreted
     dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-trailing-comma.js non-interpreted
     dstr/obj-ptrn-prop-ary-value-null.js
-    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
-    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -3367,28 +3367,28 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-init-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration, async]}
@@ -3424,28 +3424,28 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration, async]}
@@ -3468,22 +3468,22 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
     dstr/async-gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
@@ -3501,22 +3501,22 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-list-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
     dstr/async-gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
     dstr/async-gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
@@ -3547,28 +3547,28 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-ary-ptrn-elem-id-iter-complete.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-done.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-step-err.js
-    dstr/gen-meth-ary-ptrn-elem-id-iter-val-err.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-val.js
-    dstr/gen-meth-ary-ptrn-elem-obj-id-init.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-val-err.js
     dstr/gen-meth-ary-ptrn-elem-obj-id.js
-    dstr/gen-meth-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/gen-meth-ary-ptrn-elem-obj-id-init.js
     dstr/gen-meth-ary-ptrn-elem-obj-prop-id.js
+    dstr/gen-meth-ary-ptrn-elem-obj-prop-id-init.js
     dstr/gen-meth-ary-ptrn-elem-obj-val-null.js
     dstr/gen-meth-ary-ptrn-elem-obj-val-undef.js
+    dstr/gen-meth-ary-ptrn-elision.js
     dstr/gen-meth-ary-ptrn-elision-exhausted.js
     dstr/gen-meth-ary-ptrn-elision-step-err.js
-    dstr/gen-meth-ary-ptrn-elision.js
     dstr/gen-meth-ary-ptrn-empty.js
     dstr/gen-meth-ary-ptrn-rest-ary-elem.js
     dstr/gen-meth-ary-ptrn-rest-ary-elision.js
     dstr/gen-meth-ary-ptrn-rest-ary-empty.js
     dstr/gen-meth-ary-ptrn-rest-ary-rest.js
-    dstr/gen-meth-ary-ptrn-rest-id-elision-next-err.js
+    dstr/gen-meth-ary-ptrn-rest-id.js
     dstr/gen-meth-ary-ptrn-rest-id-elision.js
+    dstr/gen-meth-ary-ptrn-rest-id-elision-next-err.js
     dstr/gen-meth-ary-ptrn-rest-id-exhausted.js
     dstr/gen-meth-ary-ptrn-rest-id-iter-step-err.js
     dstr/gen-meth-ary-ptrn-rest-id-iter-val-err.js
-    dstr/gen-meth-ary-ptrn-rest-id.js
     dstr/gen-meth-ary-ptrn-rest-obj-id.js
     dstr/gen-meth-ary-ptrn-rest-obj-prop-id.js
     dstr/gen-meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
@@ -3598,28 +3598,28 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
@@ -3642,22 +3642,22 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
     dstr/gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
     dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
@@ -3675,22 +3675,22 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-obj-ptrn-id-init-unresolvable.js
     dstr/gen-meth-obj-ptrn-id-trailing-comma.js
     dstr/gen-meth-obj-ptrn-list-err.js
+    dstr/gen-meth-obj-ptrn-prop-ary.js
     dstr/gen-meth-obj-ptrn-prop-ary-init.js
     dstr/gen-meth-obj-ptrn-prop-ary-trailing-comma.js
     dstr/gen-meth-obj-ptrn-prop-ary-value-null.js
-    dstr/gen-meth-obj-ptrn-prop-ary.js
     dstr/gen-meth-obj-ptrn-prop-eval-err.js
+    dstr/gen-meth-obj-ptrn-prop-id.js
     dstr/gen-meth-obj-ptrn-prop-id-get-value-err.js
+    dstr/gen-meth-obj-ptrn-prop-id-init.js
     dstr/gen-meth-obj-ptrn-prop-id-init-skipped.js
     dstr/gen-meth-obj-ptrn-prop-id-init-throws.js
     dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/gen-meth-obj-ptrn-prop-id-init.js
     dstr/gen-meth-obj-ptrn-prop-id-trailing-comma.js
-    dstr/gen-meth-obj-ptrn-prop-id.js
+    dstr/gen-meth-obj-ptrn-prop-obj.js
     dstr/gen-meth-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-undef.js
-    dstr/gen-meth-obj-ptrn-prop-obj.js
     dstr/gen-meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -3717,22 +3717,22 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-ary-ptrn-elem-id-init-unresolvable.js
     dstr/meth-ary-ptrn-elem-id-iter-step-err.js
     dstr/meth-ary-ptrn-elem-id-iter-val-err.js
-    dstr/meth-ary-ptrn-elem-obj-id-init.js
     dstr/meth-ary-ptrn-elem-obj-id.js
-    dstr/meth-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/meth-ary-ptrn-elem-obj-id-init.js
     dstr/meth-ary-ptrn-elem-obj-prop-id.js
-    dstr/meth-ary-ptrn-elision-step-err.js
+    dstr/meth-ary-ptrn-elem-obj-prop-id-init.js
     dstr/meth-ary-ptrn-elision.js
+    dstr/meth-ary-ptrn-elision-step-err.js
     dstr/meth-ary-ptrn-rest-ary-elem.js
     dstr/meth-ary-ptrn-rest-ary-elision.js
     dstr/meth-ary-ptrn-rest-ary-empty.js
     dstr/meth-ary-ptrn-rest-ary-rest.js
-    dstr/meth-ary-ptrn-rest-id-elision-next-err.js
+    dstr/meth-ary-ptrn-rest-id.js
     dstr/meth-ary-ptrn-rest-id-elision.js
+    dstr/meth-ary-ptrn-rest-id-elision-next-err.js
     dstr/meth-ary-ptrn-rest-id-exhausted.js
     dstr/meth-ary-ptrn-rest-id-iter-step-err.js
     dstr/meth-ary-ptrn-rest-id-iter-val-err.js
-    dstr/meth-ary-ptrn-rest-id.js
     dstr/meth-ary-ptrn-rest-obj-id.js
     dstr/meth-ary-ptrn-rest-obj-prop-id.js
     dstr/meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
@@ -3762,28 +3762,28 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
@@ -3806,22 +3806,22 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/meth-dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
     dstr/meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
     dstr/meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
@@ -3836,34 +3836,34 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-obj-ptrn-id-init-throws.js
     dstr/meth-obj-ptrn-id-init-unresolvable.js
     dstr/meth-obj-ptrn-list-err.js
+    dstr/meth-obj-ptrn-prop-ary.js
     dstr/meth-obj-ptrn-prop-ary-init.js
     dstr/meth-obj-ptrn-prop-ary-value-null.js
-    dstr/meth-obj-ptrn-prop-ary.js
     dstr/meth-obj-ptrn-prop-eval-err.js
     dstr/meth-obj-ptrn-prop-id-get-value-err.js
+    dstr/meth-obj-ptrn-prop-id-init.js
     dstr/meth-obj-ptrn-prop-id-init-skipped.js
     dstr/meth-obj-ptrn-prop-id-init-throws.js
     dstr/meth-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/meth-obj-ptrn-prop-id-init.js
+    dstr/meth-obj-ptrn-prop-obj.js
     dstr/meth-obj-ptrn-prop-obj-init.js
     dstr/meth-obj-ptrn-prop-obj-value-null.js
     dstr/meth-obj-ptrn-prop-obj-value-undef.js
-    dstr/meth-obj-ptrn-prop-obj.js
     dstr/meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
     method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
-    method-definition/async-await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
     method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
-    method-definition/async-await-as-label-identifier-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
     method-definition/async-await-as-label-identifier.js {unsupported: [async-functions]}
-    method-definition/async-gen-await-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-await-as-label-identifier-escaped.js {unsupported: [async-functions]}
     method-definition/async-gen-await-as-binding-identifier.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-await-as-identifier-reference.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-label-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-await-as-label-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-label-identifier-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-meth-array-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
     method-definition/async-gen-meth-dflt-params-abrupt.js {unsupported: [default-parameters, async-iteration]}
     method-definition/async-gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-iteration, async]}
@@ -3880,22 +3880,22 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/async-gen-meth-params-trailing-comma-single.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-meth-rest-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
     method-definition/async-gen-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-yield-as-binding-identifier.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-yield-as-identifier-reference.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-label-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-yield-as-label-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-label-identifier-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-yield-identifier-non-strict.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-identifier-spread-non-strict.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-identifier-spread-strict.js {unsupported: [async-iteration]}
     method-definition/async-gen-yield-identifier-strict.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-promise-reject-next.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-promise-reject-next-catch.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-promise-reject-next-for-await-of-async-iterator.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-promise-reject-next-for-await-of-sync-iterator.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-promise-reject-next-yield-star-sync-iterator.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-promise-reject-next.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-spread-arr-multiple.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-spread-arr-single.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-spread-obj.js {unsupported: [async-iteration, async]}
@@ -4000,8 +4000,8 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/generator-invoke-ctor.js
     method-definition/generator-invoke-fn-no-strict.js non-strict
     method-definition/generator-invoke-fn-strict.js non-strict
-    method-definition/generator-length-dflt.js {unsupported: [default-parameters]}
     method-definition/generator-length.js
+    method-definition/generator-length-dflt.js {unsupported: [default-parameters]}
     method-definition/generator-name-prop-string.js
     method-definition/generator-name-prop-symbol.js
     method-definition/generator-no-yield.js
@@ -4010,8 +4010,8 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/generator-prop-name-yield-expr.js non-strict
     method-definition/generator-prop-name-yield-id.js non-strict
     method-definition/generator-property-desc.js
-    method-definition/generator-prototype-prop.js
     method-definition/generator-prototype.js
+    method-definition/generator-prototype-prop.js
     method-definition/generator-return.js
     method-definition/generator-super-prop-body.js
     method-definition/generator-super-prop-param.js {unsupported: [super, default-parameters]}
@@ -4031,8 +4031,8 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/meth-rest-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/name-invoke-ctor.js
     method-definition/name-invoke-fn-strict.js non-strict
-    method-definition/name-length-dflt.js {unsupported: [default-parameters]}
     method-definition/name-length.js
+    method-definition/name-length-dflt.js {unsupported: [default-parameters]}
     method-definition/name-name-prop-string.js
     method-definition/name-name-prop-symbol.js
     method-definition/name-param-id-yield.js non-strict
@@ -4049,10 +4049,10 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/params-dflt-gen-meth-ref-arguments.js {unsupported: [default-parameters]}
     method-definition/params-dflt-meth-args-unmapped.js {unsupported: [default-parameters]}
     method-definition/params-dflt-meth-ref-arguments.js {unsupported: [default-parameters]}
-    method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
     method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
-    method-definition/private-name-early-error-async-gen-inside-class.js {unsupported: [class-fields-public, async-iteration, class]}
+    method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
     method-definition/private-name-early-error-async-gen.js {unsupported: [async-iteration]}
+    method-definition/private-name-early-error-async-gen-inside-class.js {unsupported: [class-fields-public, async-iteration, class]}
     method-definition/private-name-early-error-gen-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/private-name-early-error-get-method-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/private-name-early-error-method-inside-class.js {unsupported: [class-fields-public, class]}
@@ -4073,13 +4073,13 @@ language/expressions/object 939/1049 (89.51%)
     11.1.5_4-4-a-3.js strict
     11.1.5_4-4-b-1.js strict
     __proto__-permitted-dup.js
+    accessor-name-computed.js
     accessor-name-computed-err-evaluation.js
     accessor-name-computed-err-to-prop-key.js
     accessor-name-computed-err-unresolvable.js
     accessor-name-computed-in.js
     accessor-name-computed-yield-expr.js
     accessor-name-computed-yield-id.js non-strict
-    accessor-name-computed.js
     accessor-name-literal-numeric-binary.js
     accessor-name-literal-numeric-exponent.js
     accessor-name-literal-numeric-hex.js
@@ -4088,9 +4088,9 @@ language/expressions/object 939/1049 (89.51%)
     accessor-name-literal-numeric-octal.js
     accessor-name-literal-numeric-zero.js
     accessor-name-literal-string-char-escape.js
-    accessor-name-literal-string-default-escaped-ext.js
-    accessor-name-literal-string-default-escaped.js
     accessor-name-literal-string-default.js
+    accessor-name-literal-string-default-escaped.js
+    accessor-name-literal-string-default-escaped-ext.js
     accessor-name-literal-string-double-quote.js
     accessor-name-literal-string-empty.js
     accessor-name-literal-string-hex-escape.js
@@ -4107,15 +4107,15 @@ language/expressions/object 939/1049 (89.51%)
     covered-ident-name-prop-name-literal-const-escaped.js
     covered-ident-name-prop-name-literal-continue-escaped.js
     covered-ident-name-prop-name-literal-debugger-escaped.js
-    covered-ident-name-prop-name-literal-default-escaped-ext.js
     covered-ident-name-prop-name-literal-default-escaped.js
+    covered-ident-name-prop-name-literal-default-escaped-ext.js
     covered-ident-name-prop-name-literal-delete-escaped.js
     covered-ident-name-prop-name-literal-do-escaped.js
     covered-ident-name-prop-name-literal-else-escaped.js
     covered-ident-name-prop-name-literal-enum-escaped.js
     covered-ident-name-prop-name-literal-export-escaped.js
-    covered-ident-name-prop-name-literal-extends-escaped-ext.js
     covered-ident-name-prop-name-literal-extends-escaped.js
+    covered-ident-name-prop-name-literal-extends-escaped-ext.js
     covered-ident-name-prop-name-literal-finally-escaped.js
     covered-ident-name-prop-name-literal-for-escaped.js
     covered-ident-name-prop-name-literal-function-escaped.js
@@ -4161,15 +4161,15 @@ language/expressions/object 939/1049 (89.51%)
     ident-name-method-def-const-escaped.js
     ident-name-method-def-continue-escaped.js
     ident-name-method-def-debugger-escaped.js
-    ident-name-method-def-default-escaped-ext.js
     ident-name-method-def-default-escaped.js
+    ident-name-method-def-default-escaped-ext.js
     ident-name-method-def-delete-escaped.js
     ident-name-method-def-do-escaped.js
     ident-name-method-def-else-escaped.js
     ident-name-method-def-enum-escaped.js
     ident-name-method-def-export-escaped.js
-    ident-name-method-def-extends-escaped-ext.js
     ident-name-method-def-extends-escaped.js
+    ident-name-method-def-extends-escaped-ext.js
     ident-name-method-def-finally-escaped.js
     ident-name-method-def-for-escaped.js
     ident-name-method-def-function-escaped.js
@@ -4204,15 +4204,15 @@ language/expressions/object 939/1049 (89.51%)
     ident-name-prop-name-literal-const-escaped.js
     ident-name-prop-name-literal-continue-escaped.js
     ident-name-prop-name-literal-debugger-escaped.js
-    ident-name-prop-name-literal-default-escaped-ext.js
     ident-name-prop-name-literal-default-escaped.js
+    ident-name-prop-name-literal-default-escaped-ext.js
     ident-name-prop-name-literal-delete-escaped.js
     ident-name-prop-name-literal-do-escaped.js
     ident-name-prop-name-literal-else-escaped.js
     ident-name-prop-name-literal-enum-escaped.js
     ident-name-prop-name-literal-export-escaped.js
-    ident-name-prop-name-literal-extends-escaped-ext.js
     ident-name-prop-name-literal-extends-escaped.js
+    ident-name-prop-name-literal-extends-escaped-ext.js
     ident-name-prop-name-literal-finally-escaped.js
     ident-name-prop-name-literal-for-escaped.js
     ident-name-prop-name-literal-function-escaped.js
@@ -4243,8 +4243,8 @@ language/expressions/object 939/1049 (89.51%)
     let-non-strict-access.js non-strict
     let-non-strict-syntax.js non-strict
     method.js
-    prop-def-id-eval-error-2.js {unsupported: [Proxy]}
     prop-def-id-eval-error.js non-strict
+    prop-def-id-eval-error-2.js {unsupported: [Proxy]}
     prop-dup-data-data.js strict
     prop-dup-data-set.js strict
     prop-dup-get-data.js strict
@@ -4352,8 +4352,8 @@ language/expressions/tagged-template 4/27 (14.81%)
     tco-member.js {unsupported: [tail-call-optimization]}
 
 language/expressions/template-literal 2/54 (3.7%)
-    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     mongolian-vowel-separator.js {unsupported: [u180e]}
+    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
 
 language/expressions/this 1/6 (16.67%)
     S11.1.1_A1.js
@@ -4511,35 +4511,35 @@ language/function-code 125/219 (57.08%)
 
 language/global-code 34/41 (82.93%)
     block-decl-strict.js strict
+    decl-lex.js
     decl-lex-configurable-global.js
     decl-lex-deletion.js non-strict
     decl-lex-restricted-global.js
-    decl-lex.js
     export.js
     import.js
     invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
     invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
     invalid-private-names-member-expression-bad-reference.js {unsupported: [class-fields-private]}
     invalid-private-names-member-expression-this.js {unsupported: [class-fields-private]}
-    new.target-arrow.js {unsupported: [new.target]}
     new.target.js {unsupported: [new.target]}
+    new.target-arrow.js {unsupported: [new.target]}
     return.js
+    script-decl-func.js
     script-decl-func-dups.js
     script-decl-func-err-non-configurable.js
     script-decl-func-err-non-extensible.js
-    script-decl-func.js
+    script-decl-lex.js
     script-decl-lex-deletion.js non-strict
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
-    script-decl-lex.js
+    script-decl-var.js
     script-decl-var-collision.js
     script-decl-var-err.js
-    script-decl-var.js
-    super-call-arrow.js {unsupported: [super]}
     super-call.js {unsupported: [super]}
-    super-prop-arrow.js {unsupported: [super]}
+    super-call-arrow.js {unsupported: [super]}
     super-prop.js {unsupported: [super]}
+    super-prop-arrow.js {unsupported: [super]}
     switch-case-decl-strict.js strict
     switch-dflt-decl-strict.js strict
     yield-non-strict.js non-strict
@@ -4551,125 +4551,125 @@ language/identifiers 122/145 (84.14%)
     other_id_continue.js
     other_id_start.js
     part-digits-via-escape-hex.js
+    val-break.js
     val-break-via-escape-hex.js
     val-break-via-escape-hex4.js
-    val-break.js
+    val-case.js
     val-case-via-escape-hex.js
     val-case-via-escape-hex4.js
-    val-case.js
+    val-catch.js
     val-catch-via-escape-hex.js
     val-catch-via-escape-hex4.js
-    val-catch.js
+    val-class.js
     val-class-via-escape-hex.js
     val-class-via-escape-hex4.js
-    val-class.js
+    val-const.js
     val-const-via-escape-hex.js
     val-const-via-escape-hex4.js
-    val-const.js
+    val-continue.js
     val-continue-via-escape-hex.js
     val-continue-via-escape-hex4.js
-    val-continue.js
+    val-debugger.js
     val-debugger-via-escape-hex.js
     val-debugger-via-escape-hex4.js
-    val-debugger.js
+    val-default.js
     val-default-via-escape-hex.js
     val-default-via-escape-hex4.js
-    val-default.js
+    val-delete.js
     val-delete-via-escape-hex.js
     val-delete-via-escape-hex4.js
-    val-delete.js
+    val-do.js
     val-do-via-escape-hex.js
     val-do-via-escape-hex4.js
-    val-do.js
     val-dollar-sign-via-escape-hex.js
+    val-else.js
     val-else-via-escape-hex.js
     val-else-via-escape-hex4.js
-    val-else.js
+    val-enum.js
     val-enum-via-escape-hex.js
     val-enum-via-escape-hex4.js
-    val-enum.js
+    val-export.js
     val-export-via-escape-hex.js
     val-export-via-escape-hex4.js
-    val-export.js
+    val-extends.js
     val-extends-via-escape-hex.js
     val-extends-via-escape-hex4.js
-    val-extends.js
+    val-false.js
     val-false-via-escape-hex.js
     val-false-via-escape-hex4.js
-    val-false.js
+    val-finally.js
     val-finally-via-escape-hex.js
     val-finally-via-escape-hex4.js
-    val-finally.js
+    val-for.js
     val-for-via-escape-hex.js
     val-for-via-escape-hex4.js
-    val-for.js
+    val-function.js
     val-function-via-escape-hex.js
     val-function-via-escape-hex4.js
-    val-function.js
+    val-if.js
     val-if-via-escape-hex.js
     val-if-via-escape-hex4.js
-    val-if.js
+    val-import.js
     val-import-via-escape-hex.js
     val-import-via-escape-hex4.js
-    val-import.js
+    val-in.js
     val-in-via-escape-hex.js
     val-in-via-escape-hex4.js
-    val-in.js
+    val-instanceof.js
     val-instanceof-via-escape-hex.js
     val-instanceof-via-escape-hex4.js
-    val-instanceof.js
+    val-new.js
     val-new-via-escape-hex.js
     val-new-via-escape-hex4.js
-    val-new.js
+    val-null.js
     val-null-via-escape-hex.js
     val-null-via-escape-hex4.js
-    val-null.js
+    val-return.js
     val-return-via-escape-hex.js
     val-return-via-escape-hex4.js
-    val-return.js
+    val-super.js
     val-super-via-escape-hex.js
     val-super-via-escape-hex4.js
-    val-super.js
+    val-switch.js
     val-switch-via-escape-hex.js
     val-switch-via-escape-hex4.js
-    val-switch.js
+    val-this.js
     val-this-via-escape-hex.js
     val-this-via-escape-hex4.js
-    val-this.js
+    val-throw.js
     val-throw-via-escape-hex.js
     val-throw-via-escape-hex4.js
-    val-throw.js
+    val-true.js
     val-true-via-escape-hex.js
     val-true-via-escape-hex4.js
-    val-true.js
+    val-try.js
     val-try-via-escape-hex.js
     val-try-via-escape-hex4.js
-    val-try.js
+    val-typeof.js
     val-typeof-via-escape-hex.js
     val-typeof-via-escape-hex4.js
-    val-typeof.js
     val-underscore-via-escape-hex.js
+    val-var.js
     val-var-via-escape-hex.js
     val-var-via-escape-hex4.js
-    val-var.js
+    val-void.js
     val-void-via-escape-hex.js
     val-void-via-escape-hex4.js
-    val-void.js
+    val-while.js
     val-while-via-escape-hex.js
     val-while-via-escape-hex4.js
-    val-while.js
+    val-with.js
     val-with-via-escape-hex.js
     val-with-via-escape-hex4.js
-    val-with.js
     val-yield-strict.js strict
     vals-eng-alpha-lower-via-escape-hex.js
     vals-eng-alpha-upper-via-escape-hex.js
     vals-rus-alpha-lower-via-escape-hex.js
     vals-rus-alpha-upper-via-escape-hex.js
-    vertical-tilde-continue-escaped.js
     vertical-tilde-continue.js
-    vertical-tilde-start-escaped.js
+    vertical-tilde-continue-escaped.js
     vertical-tilde-start.js
+    vertical-tilde-start-escaped.js
 
 ~language/import
 
@@ -4699,8 +4699,8 @@ language/literals 113/430 (26.28%)
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
     regexp/invalid-braced-quantifier-range.js
-    regexp/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     regexp/mongolian-vowel-separator.js {unsupported: [u180e]}
+    regexp/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     regexp/S7.8.5_A1.1_T2.js
     regexp/S7.8.5_A1.4_T2.js
     regexp/S7.8.5_A1.5_T1.js
@@ -4711,22 +4711,22 @@ language/literals 113/430 (26.28%)
     regexp/S7.8.5_A2.5_T3.js
     regexp/u-astral.js
     regexp/u-case-mapping.js
+    regexp/u-surrogate-pairs.js
     regexp/u-surrogate-pairs-atom-char-class.js
     regexp/u-surrogate-pairs-atom-dot.js
     regexp/u-surrogate-pairs-atom-escape-char-class.js
     regexp/u-surrogate-pairs-atom-escape-decimal.js
-    regexp/u-surrogate-pairs.js
     regexp/u-unicode-esc.js
     regexp/y-assertion-start.js
     string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
     string/legacy-octal-escape-sequence-strict.js strict
-    string/line-separator-eval.js {unsupported: [json-superset]}
     string/line-separator.js {unsupported: [json-superset]}
-    string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+    string/line-separator-eval.js {unsupported: [json-superset]}
     string/mongolian-vowel-separator.js {unsupported: [u180e]}
-    string/paragraph-separator-eval.js {unsupported: [json-superset]}
+    string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     string/paragraph-separator.js {unsupported: [json-superset]}
+    string/paragraph-separator-eval.js {unsupported: [json-superset]}
     string/S7.8.4_A4.3_T1.js strict
     string/S7.8.4_A4.3_T2.js strict
     string/S7.8.4_A7.1_T4.js
@@ -4800,30 +4800,30 @@ language/statements/for 254/375 (67.73%)
     dstr/const-ary-ptrn-elem-id-iter-complete.js
     dstr/const-ary-ptrn-elem-id-iter-done.js
     dstr/const-ary-ptrn-elem-id-iter-step-err.js
-    dstr/const-ary-ptrn-elem-id-iter-val-err.js
     dstr/const-ary-ptrn-elem-id-iter-val.js
-    dstr/const-ary-ptrn-elem-obj-id-init.js
+    dstr/const-ary-ptrn-elem-id-iter-val-err.js
     dstr/const-ary-ptrn-elem-obj-id.js
-    dstr/const-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/const-ary-ptrn-elem-obj-id-init.js
     dstr/const-ary-ptrn-elem-obj-prop-id.js
+    dstr/const-ary-ptrn-elem-obj-prop-id-init.js
     dstr/const-ary-ptrn-elem-obj-val-null.js
     dstr/const-ary-ptrn-elem-obj-val-undef.js
+    dstr/const-ary-ptrn-elision.js
     dstr/const-ary-ptrn-elision-exhausted.js
     dstr/const-ary-ptrn-elision-iter-close.js
     dstr/const-ary-ptrn-elision-step-err.js
-    dstr/const-ary-ptrn-elision.js
     dstr/const-ary-ptrn-empty.js
     dstr/const-ary-ptrn-rest-ary-elem.js
     dstr/const-ary-ptrn-rest-ary-elision.js
     dstr/const-ary-ptrn-rest-ary-empty.js
     dstr/const-ary-ptrn-rest-ary-rest.js
-    dstr/const-ary-ptrn-rest-id-elision-next-err.js
+    dstr/const-ary-ptrn-rest-id.js
     dstr/const-ary-ptrn-rest-id-elision.js
+    dstr/const-ary-ptrn-rest-id-elision-next-err.js
     dstr/const-ary-ptrn-rest-id-exhausted.js
     dstr/const-ary-ptrn-rest-id-iter-close.js
     dstr/const-ary-ptrn-rest-id-iter-step-err.js
     dstr/const-ary-ptrn-rest-id-iter-val-err.js
-    dstr/const-ary-ptrn-rest-id.js
     dstr/const-ary-ptrn-rest-obj-id.js
     dstr/const-ary-ptrn-rest-obj-prop-id.js
     dstr/const-obj-init-null.js
@@ -4840,22 +4840,22 @@ language/statements/for 254/375 (67.73%)
     dstr/const-obj-ptrn-id-init-unresolvable.js
     dstr/const-obj-ptrn-id-trailing-comma.js
     dstr/const-obj-ptrn-list-err.js
+    dstr/const-obj-ptrn-prop-ary.js
     dstr/const-obj-ptrn-prop-ary-init.js
     dstr/const-obj-ptrn-prop-ary-trailing-comma.js
     dstr/const-obj-ptrn-prop-ary-value-null.js
-    dstr/const-obj-ptrn-prop-ary.js
     dstr/const-obj-ptrn-prop-eval-err.js
+    dstr/const-obj-ptrn-prop-id.js
     dstr/const-obj-ptrn-prop-id-get-value-err.js
+    dstr/const-obj-ptrn-prop-id-init.js
     dstr/const-obj-ptrn-prop-id-init-skipped.js
     dstr/const-obj-ptrn-prop-id-init-throws.js
     dstr/const-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/const-obj-ptrn-prop-id-init.js
     dstr/const-obj-ptrn-prop-id-trailing-comma.js
-    dstr/const-obj-ptrn-prop-id.js
+    dstr/const-obj-ptrn-prop-obj.js
     dstr/const-obj-ptrn-prop-obj-init.js
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
-    dstr/const-obj-ptrn-prop-obj.js
     dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -4882,24 +4882,24 @@ language/statements/for 254/375 (67.73%)
     dstr/let-ary-ptrn-elem-id-init-unresolvable.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
-    dstr/let-ary-ptrn-elem-obj-id-init.js
     dstr/let-ary-ptrn-elem-obj-id.js
-    dstr/let-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/let-ary-ptrn-elem-obj-id-init.js
     dstr/let-ary-ptrn-elem-obj-prop-id.js
+    dstr/let-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/let-ary-ptrn-elision.js
     dstr/let-ary-ptrn-elision-iter-close.js
     dstr/let-ary-ptrn-elision-step-err.js
-    dstr/let-ary-ptrn-elision.js
     dstr/let-ary-ptrn-rest-ary-elem.js
     dstr/let-ary-ptrn-rest-ary-elision.js
     dstr/let-ary-ptrn-rest-ary-empty.js
     dstr/let-ary-ptrn-rest-ary-rest.js
-    dstr/let-ary-ptrn-rest-id-elision-next-err.js
+    dstr/let-ary-ptrn-rest-id.js
     dstr/let-ary-ptrn-rest-id-elision.js
+    dstr/let-ary-ptrn-rest-id-elision-next-err.js
     dstr/let-ary-ptrn-rest-id-exhausted.js
     dstr/let-ary-ptrn-rest-id-iter-close.js
     dstr/let-ary-ptrn-rest-id-iter-step-err.js
     dstr/let-ary-ptrn-rest-id-iter-val-err.js
-    dstr/let-ary-ptrn-rest-id.js
     dstr/let-ary-ptrn-rest-obj-id.js
     dstr/let-ary-ptrn-rest-obj-prop-id.js
     dstr/let-obj-init-null.js
@@ -4913,20 +4913,20 @@ language/statements/for 254/375 (67.73%)
     dstr/let-obj-ptrn-id-init-throws.js
     dstr/let-obj-ptrn-id-init-unresolvable.js
     dstr/let-obj-ptrn-list-err.js
+    dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
     dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
     dstr/let-obj-ptrn-prop-ary-value-null.js
-    dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-eval-err.js
     dstr/let-obj-ptrn-prop-id-get-value-err.js
+    dstr/let-obj-ptrn-prop-id-init.js
     dstr/let-obj-ptrn-prop-id-init-skipped.js
     dstr/let-obj-ptrn-prop-id-init-throws.js
     dstr/let-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/let-obj-ptrn-prop-id-init.js
+    dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
-    dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -4953,24 +4953,24 @@ language/statements/for 254/375 (67.73%)
     dstr/var-ary-ptrn-elem-id-init-unresolvable.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
-    dstr/var-ary-ptrn-elem-obj-id-init.js
     dstr/var-ary-ptrn-elem-obj-id.js
-    dstr/var-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/var-ary-ptrn-elem-obj-id-init.js
     dstr/var-ary-ptrn-elem-obj-prop-id.js
+    dstr/var-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/var-ary-ptrn-elision.js
     dstr/var-ary-ptrn-elision-iter-close.js
     dstr/var-ary-ptrn-elision-step-err.js
-    dstr/var-ary-ptrn-elision.js
     dstr/var-ary-ptrn-rest-ary-elem.js
     dstr/var-ary-ptrn-rest-ary-elision.js
     dstr/var-ary-ptrn-rest-ary-empty.js
     dstr/var-ary-ptrn-rest-ary-rest.js
-    dstr/var-ary-ptrn-rest-id-elision-next-err.js
+    dstr/var-ary-ptrn-rest-id.js
     dstr/var-ary-ptrn-rest-id-elision.js
+    dstr/var-ary-ptrn-rest-id-elision-next-err.js
     dstr/var-ary-ptrn-rest-id-exhausted.js
     dstr/var-ary-ptrn-rest-id-iter-close.js
     dstr/var-ary-ptrn-rest-id-iter-step-err.js
     dstr/var-ary-ptrn-rest-id-iter-val-err.js
-    dstr/var-ary-ptrn-rest-id.js
     dstr/var-ary-ptrn-rest-obj-id.js
     dstr/var-ary-ptrn-rest-obj-prop-id.js
     dstr/var-obj-init-null.js
@@ -4984,19 +4984,19 @@ language/statements/for 254/375 (67.73%)
     dstr/var-obj-ptrn-id-init-throws.js
     dstr/var-obj-ptrn-id-init-unresolvable.js
     dstr/var-obj-ptrn-list-err.js
+    dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-ary-init.js
     dstr/var-obj-ptrn-prop-ary-value-null.js
-    dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-eval-err.js
     dstr/var-obj-ptrn-prop-id-get-value-err.js
+    dstr/var-obj-ptrn-prop-id-init.js
     dstr/var-obj-ptrn-prop-id-init-skipped.js
     dstr/var-obj-ptrn-prop-id-init-throws.js
     dstr/var-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/var-obj-ptrn-prop-id-init.js
+    dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
-    dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -5085,16 +5085,16 @@ language/statements/for-of 466/716 (65.08%)
     dstr/array-elem-init-yield-ident-invalid.js strict
     dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
+    dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
     dstr/array-elem-iter-nrml-close-null.js
     dstr/array-elem-iter-nrml-close-skip.js
-    dstr/array-elem-iter-nrml-close.js
+    dstr/array-elem-iter-rtrn-close.js
     dstr/array-elem-iter-rtrn-close-err.js
     dstr/array-elem-iter-rtrn-close-null.js
-    dstr/array-elem-iter-rtrn-close.js
+    dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-nested-array-yield-ident-valid.js non-strict
     dstr/array-elem-nested-obj-invalid.js
     dstr/array-elem-nested-obj-yield-expr.js
@@ -5102,48 +5102,48 @@ language/statements/for-of 466/716 (65.08%)
     dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
     dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
-    dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref.js
+    dstr/array-elem-put-obj-literal-prop-ref-init.js
+    dstr/array-elem-put-obj-literal-prop-ref-init-active.js
     dstr/array-elem-target-simple-strict.js strict
     dstr/array-elem-target-yield-valid.js non-strict
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
+    dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-null.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-skip.js
-    dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-get-err.js
+    dstr/array-elem-trlg-iter-list-nrml-close.js
     dstr/array-elem-trlg-iter-list-nrml-close-err.js
     dstr/array-elem-trlg-iter-list-nrml-close-null.js
     dstr/array-elem-trlg-iter-list-nrml-close-skip.js
-    dstr/array-elem-trlg-iter-list-nrml-close.js
+    dstr/array-elem-trlg-iter-list-rtrn-close.js
     dstr/array-elem-trlg-iter-list-rtrn-close-err.js
     dstr/array-elem-trlg-iter-list-rtrn-close-null.js
-    dstr/array-elem-trlg-iter-list-rtrn-close.js
+    dstr/array-elem-trlg-iter-list-thrw-close.js
     dstr/array-elem-trlg-iter-list-thrw-close-err.js
     dstr/array-elem-trlg-iter-list-thrw-close-skip.js
-    dstr/array-elem-trlg-iter-list-thrw-close.js
     dstr/array-elem-trlg-iter-rest-nrml-close-skip.js
+    dstr/array-elem-trlg-iter-rest-rtrn-close.js
     dstr/array-elem-trlg-iter-rest-rtrn-close-err.js
     dstr/array-elem-trlg-iter-rest-rtrn-close-null.js
-    dstr/array-elem-trlg-iter-rest-rtrn-close.js
+    dstr/array-elem-trlg-iter-rest-thrw-close.js
     dstr/array-elem-trlg-iter-rest-thrw-close-err.js
     dstr/array-elem-trlg-iter-rest-thrw-close-skip.js
-    dstr/array-elem-trlg-iter-rest-thrw-close.js
     dstr/array-elision-iter-abpt.js
     dstr/array-elision-iter-get-err.js
+    dstr/array-elision-iter-nrml-close.js
     dstr/array-elision-iter-nrml-close-err.js
     dstr/array-elision-iter-nrml-close-null.js
     dstr/array-elision-iter-nrml-close-skip.js
-    dstr/array-elision-iter-nrml-close.js
     dstr/array-elision-val-bool.js
     dstr/array-elision-val-null.js
     dstr/array-elision-val-num.js
     dstr/array-elision-val-symbol.js
     dstr/array-elision-val-undef.js
+    dstr/array-empty-iter-close.js
     dstr/array-empty-iter-close-err.js
     dstr/array-empty-iter-close-null.js
-    dstr/array-empty-iter-close.js
     dstr/array-empty-iter-get-err.js
     dstr/array-empty-val-bool.js
     dstr/array-empty-val-null.js
@@ -5153,40 +5153,40 @@ language/statements/for-of 466/716 (65.08%)
     dstr/array-iteration.js
     dstr/array-rest-after-element.js
     dstr/array-rest-after-elision.js
-    dstr/array-rest-elision-iter-abpt.js
     dstr/array-rest-elision.js
+    dstr/array-rest-elision-iter-abpt.js
     dstr/array-rest-iter-get-err.js
     dstr/array-rest-iter-nrml-close-skip.js
+    dstr/array-rest-iter-rtrn-close.js
     dstr/array-rest-iter-rtrn-close-err.js
     dstr/array-rest-iter-rtrn-close-null.js
-    dstr/array-rest-iter-rtrn-close.js
+    dstr/array-rest-iter-thrw-close.js
     dstr/array-rest-iter-thrw-close-err.js
     dstr/array-rest-iter-thrw-close-skip.js
-    dstr/array-rest-iter-thrw-close.js
     dstr/array-rest-iteration.js
-    dstr/array-rest-lref-err.js
     dstr/array-rest-lref.js
+    dstr/array-rest-lref-err.js
+    dstr/array-rest-nested-array.js
     dstr/array-rest-nested-array-iter-thrw-close-skip.js
     dstr/array-rest-nested-array-null.js
+    dstr/array-rest-nested-array-undefined.js
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
-    dstr/array-rest-nested-array-undefined.js
     dstr/array-rest-nested-array-yield-expr.js
     dstr/array-rest-nested-array-yield-ident-valid.js non-strict
-    dstr/array-rest-nested-array.js
+    dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
+    dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
-    dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-yield-expr.js
     dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
-    dstr/array-rest-nested-obj.js
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
-    dstr/array-rest-put-prop-ref-no-get.js
-    dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref.js
+    dstr/array-rest-put-prop-ref-no-get.js
+    dstr/array-rest-put-prop-ref-user-err.js
+    dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
     dstr/array-rest-put-unresolvable-no-strict.js non-strict
     dstr/array-rest-put-unresolvable-strict.js strict
     dstr/array-rest-yield-expr.js
@@ -5218,30 +5218,30 @@ language/statements/for-of 466/716 (65.08%)
     dstr/const-ary-ptrn-elem-id-iter-complete.js
     dstr/const-ary-ptrn-elem-id-iter-done.js
     dstr/const-ary-ptrn-elem-id-iter-step-err.js
-    dstr/const-ary-ptrn-elem-id-iter-val-err.js
     dstr/const-ary-ptrn-elem-id-iter-val.js
-    dstr/const-ary-ptrn-elem-obj-id-init.js
+    dstr/const-ary-ptrn-elem-id-iter-val-err.js
     dstr/const-ary-ptrn-elem-obj-id.js
-    dstr/const-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/const-ary-ptrn-elem-obj-id-init.js
     dstr/const-ary-ptrn-elem-obj-prop-id.js
+    dstr/const-ary-ptrn-elem-obj-prop-id-init.js
     dstr/const-ary-ptrn-elem-obj-val-null.js
     dstr/const-ary-ptrn-elem-obj-val-undef.js
+    dstr/const-ary-ptrn-elision.js
     dstr/const-ary-ptrn-elision-exhausted.js
     dstr/const-ary-ptrn-elision-iter-close.js
     dstr/const-ary-ptrn-elision-step-err.js
-    dstr/const-ary-ptrn-elision.js
     dstr/const-ary-ptrn-empty.js
     dstr/const-ary-ptrn-rest-ary-elem.js
     dstr/const-ary-ptrn-rest-ary-elision.js
     dstr/const-ary-ptrn-rest-ary-empty.js
     dstr/const-ary-ptrn-rest-ary-rest.js
-    dstr/const-ary-ptrn-rest-id-elision-next-err.js
+    dstr/const-ary-ptrn-rest-id.js
     dstr/const-ary-ptrn-rest-id-elision.js
+    dstr/const-ary-ptrn-rest-id-elision-next-err.js
     dstr/const-ary-ptrn-rest-id-exhausted.js
     dstr/const-ary-ptrn-rest-id-iter-close.js
     dstr/const-ary-ptrn-rest-id-iter-step-err.js
     dstr/const-ary-ptrn-rest-id-iter-val-err.js
-    dstr/const-ary-ptrn-rest-id.js
     dstr/const-ary-ptrn-rest-obj-id.js
     dstr/const-ary-ptrn-rest-obj-prop-id.js
     dstr/const-obj-init-null.js
@@ -5258,22 +5258,22 @@ language/statements/for-of 466/716 (65.08%)
     dstr/const-obj-ptrn-id-init-unresolvable.js
     dstr/const-obj-ptrn-id-trailing-comma.js
     dstr/const-obj-ptrn-list-err.js
+    dstr/const-obj-ptrn-prop-ary.js
     dstr/const-obj-ptrn-prop-ary-init.js
     dstr/const-obj-ptrn-prop-ary-trailing-comma.js
     dstr/const-obj-ptrn-prop-ary-value-null.js
-    dstr/const-obj-ptrn-prop-ary.js
     dstr/const-obj-ptrn-prop-eval-err.js
+    dstr/const-obj-ptrn-prop-id.js
     dstr/const-obj-ptrn-prop-id-get-value-err.js
+    dstr/const-obj-ptrn-prop-id-init.js
     dstr/const-obj-ptrn-prop-id-init-skipped.js
     dstr/const-obj-ptrn-prop-id-init-throws.js
     dstr/const-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/const-obj-ptrn-prop-id-init.js
     dstr/const-obj-ptrn-prop-id-trailing-comma.js
-    dstr/const-obj-ptrn-prop-id.js
+    dstr/const-obj-ptrn-prop-obj.js
     dstr/const-obj-ptrn-prop-obj-init.js
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
-    dstr/const-obj-ptrn-prop-obj.js
     dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -5300,24 +5300,24 @@ language/statements/for-of 466/716 (65.08%)
     dstr/let-ary-ptrn-elem-id-init-unresolvable.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
-    dstr/let-ary-ptrn-elem-obj-id-init.js
     dstr/let-ary-ptrn-elem-obj-id.js
-    dstr/let-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/let-ary-ptrn-elem-obj-id-init.js
     dstr/let-ary-ptrn-elem-obj-prop-id.js
+    dstr/let-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/let-ary-ptrn-elision.js
     dstr/let-ary-ptrn-elision-iter-close.js
     dstr/let-ary-ptrn-elision-step-err.js
-    dstr/let-ary-ptrn-elision.js
     dstr/let-ary-ptrn-rest-ary-elem.js
     dstr/let-ary-ptrn-rest-ary-elision.js
     dstr/let-ary-ptrn-rest-ary-empty.js
     dstr/let-ary-ptrn-rest-ary-rest.js
-    dstr/let-ary-ptrn-rest-id-elision-next-err.js
+    dstr/let-ary-ptrn-rest-id.js
     dstr/let-ary-ptrn-rest-id-elision.js
+    dstr/let-ary-ptrn-rest-id-elision-next-err.js
     dstr/let-ary-ptrn-rest-id-exhausted.js
     dstr/let-ary-ptrn-rest-id-iter-close.js
     dstr/let-ary-ptrn-rest-id-iter-step-err.js
     dstr/let-ary-ptrn-rest-id-iter-val-err.js
-    dstr/let-ary-ptrn-rest-id.js
     dstr/let-ary-ptrn-rest-obj-id.js
     dstr/let-ary-ptrn-rest-obj-prop-id.js
     dstr/let-obj-init-null.js
@@ -5331,19 +5331,19 @@ language/statements/for-of 466/716 (65.08%)
     dstr/let-obj-ptrn-id-init-throws.js
     dstr/let-obj-ptrn-id-init-unresolvable.js
     dstr/let-obj-ptrn-list-err.js
+    dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
     dstr/let-obj-ptrn-prop-ary-value-null.js
-    dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-eval-err.js
     dstr/let-obj-ptrn-prop-id-get-value-err.js
+    dstr/let-obj-ptrn-prop-id-init.js
     dstr/let-obj-ptrn-prop-id-init-skipped.js
     dstr/let-obj-ptrn-prop-id-init-throws.js
     dstr/let-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/let-obj-ptrn-prop-id-init.js
+    dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
-    dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -5383,24 +5383,24 @@ language/statements/for-of 466/716 (65.08%)
     dstr/obj-prop-elem-init-let.js
     dstr/obj-prop-elem-init-yield-expr.js
     dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
-    dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref.js
+    dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
+    dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
     dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
-    dstr/obj-prop-name-evaluation-error.js
     dstr/obj-prop-name-evaluation.js
+    dstr/obj-prop-name-evaluation-error.js
     dstr/obj-prop-nested-array-yield-expr.js
     dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
     dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
     dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
-    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
     dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
     dstr/obj-rest-descriptors.js {unsupported: [object-rest]}
     dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
-    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
     dstr/obj-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     dstr/obj-rest-number.js {unsupported: [object-rest]}
     dstr/obj-rest-order.js {unsupported: [object-rest]}
@@ -5409,8 +5409,8 @@ language/statements/for-of 466/716 (65.08%)
     dstr/obj-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-rest-str-val.js {unsupported: [object-rest]}
     dstr/obj-rest-symbol-val.js {unsupported: [object-rest]}
-    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
     dstr/obj-rest-to-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
     dstr/obj-rest-val-null.js {unsupported: [object-rest]}
     dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
     dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
@@ -5437,24 +5437,24 @@ language/statements/for-of 466/716 (65.08%)
     dstr/var-ary-ptrn-elem-id-init-unresolvable.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
-    dstr/var-ary-ptrn-elem-obj-id-init.js
     dstr/var-ary-ptrn-elem-obj-id.js
-    dstr/var-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/var-ary-ptrn-elem-obj-id-init.js
     dstr/var-ary-ptrn-elem-obj-prop-id.js
+    dstr/var-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/var-ary-ptrn-elision.js
     dstr/var-ary-ptrn-elision-iter-close.js
     dstr/var-ary-ptrn-elision-step-err.js
-    dstr/var-ary-ptrn-elision.js
     dstr/var-ary-ptrn-rest-ary-elem.js
     dstr/var-ary-ptrn-rest-ary-elision.js
     dstr/var-ary-ptrn-rest-ary-empty.js
     dstr/var-ary-ptrn-rest-ary-rest.js
-    dstr/var-ary-ptrn-rest-id-elision-next-err.js
+    dstr/var-ary-ptrn-rest-id.js
     dstr/var-ary-ptrn-rest-id-elision.js
+    dstr/var-ary-ptrn-rest-id-elision-next-err.js
     dstr/var-ary-ptrn-rest-id-exhausted.js
     dstr/var-ary-ptrn-rest-id-iter-close.js
     dstr/var-ary-ptrn-rest-id-iter-step-err.js
     dstr/var-ary-ptrn-rest-id-iter-val-err.js
-    dstr/var-ary-ptrn-rest-id.js
     dstr/var-ary-ptrn-rest-obj-id.js
     dstr/var-ary-ptrn-rest-obj-prop-id.js
     dstr/var-obj-init-null.js
@@ -5468,19 +5468,19 @@ language/statements/for-of 466/716 (65.08%)
     dstr/var-obj-ptrn-id-init-throws.js
     dstr/var-obj-ptrn-id-init-unresolvable.js
     dstr/var-obj-ptrn-list-err.js
+    dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-ary-init.js
     dstr/var-obj-ptrn-prop-ary-value-null.js
-    dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-eval-err.js
     dstr/var-obj-ptrn-prop-id-get-value-err.js
+    dstr/var-obj-ptrn-prop-id-init.js
     dstr/var-obj-ptrn-prop-id-init-skipped.js
     dstr/var-obj-ptrn-prop-id-init-throws.js
     dstr/var-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/var-obj-ptrn-prop-id-init.js
+    dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
-    dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -5563,26 +5563,26 @@ language/statements/generators 218/252 (86.51%)
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
-    dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
-    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
-    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
     dstr/ary-ptrn-elem-obj-val-null.js
     dstr/ary-ptrn-elem-obj-val-undef.js
-    dstr/ary-ptrn-elision-step-err.js
     dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
     dstr/ary-ptrn-rest-ary-elem.js
     dstr/ary-ptrn-rest-ary-elision.js
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
-    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
     dstr/ary-ptrn-rest-id-iter-step-err.js
     dstr/ary-ptrn-rest-id-iter-val-err.js
-    dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
@@ -5612,28 +5612,28 @@ language/statements/generators 218/252 (86.51%)
     dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
@@ -5656,22 +5656,22 @@ language/statements/generators 218/252 (86.51%)
     dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
     dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
     dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
@@ -5688,20 +5688,20 @@ language/statements/generators 218/252 (86.51%)
     dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-id-trailing-comma.js non-interpreted
     dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-trailing-comma.js non-interpreted
     dstr/obj-ptrn-prop-ary-value-null.js
-    dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
-    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -5765,16 +5765,16 @@ language/types 13/113 (11.5%)
     number/S8.5_A4_T1.js
     number/S8.5_A4_T2.js non-strict
     reference/get-value-prop-base-primitive-realm.js {unsupported: [cross-realm]}
-    reference/put-value-prop-base-primitive-realm.js {unsupported: [Proxy, cross-realm]}
     reference/put-value-prop-base-primitive.js {unsupported: [Proxy]}
+    reference/put-value-prop-base-primitive-realm.js {unsupported: [Proxy, cross-realm]}
     reference/S8.7.2_A1_T1.js
     reference/S8.7.2_A1_T2.js
     undefined/S8.1_A3_T1.js
     undefined/S8.1_A3_T2.js non-strict
 
 language/white-space 7/42 (16.67%)
-    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     mongolian-vowel-separator.js {unsupported: [u180e]}
+    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     S7.2_A5_T1.js
     S7.2_A5_T2.js
     S7.2_A5_T3.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,23 +1,46 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array 161/2624 (6.14%)
+built-ins/Array 239/2670 (8.95%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
-    from/iter-set-elem-prop-err.js non-strict Error propagation needs work in general
+    from/iter-set-elem-prop-err.js Error propagation needs work in general
+    from/iter-set-elem-prop-non-writable.js
     from/proto-from-ctor-realm.js {unsupported: [cross-realm]}
     from/source-object-constructor.js Error propagation needs work in general
     from/source-object-iterator-1.js Uses "get" syntax that's not implemented
     from/source-object-iterator-2.js Uses "get" syntax that's not implemented
+    from/source-object-length-set-elem-prop-err.js
+    from/source-object-length-set-elem-prop-non-writable.js
     isArray/proxy.js {unsupported: [Proxy]}
     isArray/proxy-revoked.js {unsupported: [Proxy]}
+    length/define-own-prop-length-coercion-order.js {unsupported: [Reflect]}
+    length/define-own-prop-length-coercion-order-set.js {unsupported: [Reflect, Reflect.set]}
+    length/define-own-prop-length-no-value-order.js {unsupported: [Reflect]}
+    length/define-own-prop-length-overflow-order.js
     length/define-own-prop-length-overflow-realm.js {unsupported: [cross-realm]}
+    of/does-not-use-set-for-indices.js
     of/proto-from-ctor-realm.js {unsupported: [cross-realm]}
     of/return-abrupt-from-data-property.js Object.preventExtensions doesn't seem to throw
     of/return-abrupt-from-data-property-using-proxy.js {unsupported: [Proxy]}
+    prototype/concat/arg-length-exceeding-integer-limit.js {unsupported: [Proxy]}
+    prototype/concat/Array.prototype.concat_array-like.js
+    prototype/concat/Array.prototype.concat_array-like-negative-length.js
+    prototype/concat/Array.prototype.concat_array-like-primitive-non-number-length.js
+    prototype/concat/Array.prototype.concat_array-like-string-length.js
+    prototype/concat/Array.prototype.concat_holey-sloppy-arguments.js
     prototype/concat/Array.prototype.concat_large-typed-array.js new
     prototype/concat/Array.prototype.concat_non-array.js
+    prototype/concat/Array.prototype.concat_sloppy-arguments.js
+    prototype/concat/Array.prototype.concat_sloppy-arguments-with-dupes.js non-strict
     prototype/concat/Array.prototype.concat_small-typed-array.js
+    prototype/concat/Array.prototype.concat_spreadable-boolean-wrapper.js
+    prototype/concat/Array.prototype.concat_spreadable-function.js
+    prototype/concat/Array.prototype.concat_spreadable-number-wrapper.js
+    prototype/concat/Array.prototype.concat_spreadable-reg-exp.js
+    prototype/concat/Array.prototype.concat_spreadable-sparse-object.js
+    prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
+    prototype/concat/Array.prototype.concat_strict-arguments.js
     prototype/concat/create-ctor-non-object.js
     prototype/concat/create-ctor-poisoned.js
     prototype/concat/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
@@ -27,16 +50,44 @@ built-ins/Array 161/2624 (6.14%)
     prototype/concat/create-species.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-abrupt.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-non-extensible.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-non-extensible-spreadable.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-null.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/concat/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-with-non-configurable-property.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-with-non-configurable-property-spreadable.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-with-non-writable-property-spreadable.js {unsupported: [Symbol.species]}
+    prototype/concat/is-concat-spreadable-get-order.js
     prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js {unsupported: [Proxy]}
     prototype/concat/is-concat-spreadable-proxy.js {unsupported: [Proxy]}
     prototype/concat/is-concat-spreadable-proxy-revoked.js {unsupported: [Proxy]}
+    prototype/copyWithin/coerced-values-end.js
+    prototype/copyWithin/coerced-values-start.js
+    prototype/copyWithin/coerced-values-start-change-start.js
+    prototype/copyWithin/coerced-values-start-change-target.js
+    prototype/copyWithin/coerced-values-target.js
+    prototype/copyWithin/negative-end.js
+    prototype/copyWithin/negative-out-of-bounds-end.js
+    prototype/copyWithin/negative-out-of-bounds-start.js
+    prototype/copyWithin/negative-out-of-bounds-target.js
+    prototype/copyWithin/negative-start.js
+    prototype/copyWithin/negative-target.js
+    prototype/copyWithin/non-negative-out-of-bounds-end.js
+    prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
+    prototype/copyWithin/non-negative-target-and-start.js
+    prototype/copyWithin/non-negative-target-start-and-end.js
     prototype/copyWithin/return-abrupt-from-delete-proxy-target.js {unsupported: [Proxy]}
     prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
     prototype/copyWithin/return-abrupt-from-has-start.js {unsupported: [Proxy]}
+    prototype/copyWithin/undefined-end.js
     prototype/every/15.4.4.16-5-1-s.js non-strict
+    prototype/fill/coerced-indexes.js
+    prototype/fill/fill-values.js
+    prototype/fill/fill-values-custom-start-and-end.js
+    prototype/fill/fill-values-relative-end.js
+    prototype/fill/fill-values-relative-start.js
     prototype/filter/15.4.4.20-5-1-s.js non-strict
     prototype/filter/create-ctor-non-object.js
     prototype/filter/create-ctor-poisoned.js
@@ -50,15 +101,19 @@ built-ins/Array 161/2624 (6.14%)
     prototype/filter/create-species-null.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/filter/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/filter/target-array-non-extensible.js {unsupported: [Symbol.species]}
+    prototype/filter/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
     prototype/filter/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
-    *prototype/flatMap 18/18 (100.0%)
-    *prototype/flat 14/14 (100.0%)
+    *prototype/flatMap 21/21 (100.0%)
+    *prototype/flat 17/17 (100.0%)
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
     prototype/includes/get-prop.js {unsupported: [Proxy]}
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
+    prototype/indexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
+    prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/map/15.4.4.19-5-1-s.js non-strict
     prototype/map/create-ctor-non-object.js
     prototype/map/create-ctor-poisoned.js
@@ -73,12 +128,19 @@ built-ins/Array 161/2624 (6.14%)
     prototype/map/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/map/create-species-undef.js {unsupported: [Symbol.species]}
     prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
+    prototype/map/target-array-non-extensible.js {unsupported: [Symbol.species]}
+    prototype/map/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
     prototype/map/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/pop/throws-with-string-receiver.js
+    prototype/push/length-near-integer-limit-set-failure.js non-strict
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
+    prototype/push/throws-with-string-receiver.js
     prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
+    prototype/reduceRight/length-near-integer-limit.js
     prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+    prototype/shift/throws-when-this-value-length-is-writable-false.js
     prototype/slice/create-ctor-non-object.js
     prototype/slice/create-ctor-poisoned.js
     prototype/slice/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
@@ -93,7 +155,10 @@ built-ins/Array 161/2624 (6.14%)
     prototype/slice/create-species-null.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/slice/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/slice/length-exceeding-integer-limit.js
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
+    prototype/slice/target-array-non-extensible.js {unsupported: [Symbol.species]}
+    prototype/slice/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
     prototype/slice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/some/15.4.4.17-5-1-s.js non-strict
     prototype/sort/S15.4.4.11_A8.js non-strict
@@ -115,14 +180,21 @@ built-ins/Array 161/2624 (6.14%)
     prototype/splice/create-species-poisoned.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-undef.js {unsupported: [Symbol.species]}
     prototype/splice/create-species-undef-invalid-len.js {unsupported: [Proxy]}
+    prototype/splice/length-and-deleteCount-exceeding-integer-limit.js
+    prototype/splice/length-exceeding-integer-limit-shrink-array.js
+    prototype/splice/length-near-integer-limit-grow-array.js
     prototype/splice/property-traps-order-with-species.js {unsupported: [Proxy, Symbol.species]}
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
     prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
+    prototype/splice/target-array-non-extensible.js {unsupported: [Symbol.species]}
+    prototype/splice/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
     prototype/splice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     *prototype/Symbol.unscopables 2/2 (100.0%)
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/unshift/throws-with-string-receiver.js
+    prototype/methods-called-as-functions.js {unsupported: [Symbol.species, Array.prototype.flat, Array.prototype.flatMap]}
     prototype/Symbol.iterator.js Expects a particular string value
     *Symbol.species 4/4 (100.0%)
     proto-from-ctor-realm-one.js {unsupported: [Reflect, cross-realm]}
@@ -165,7 +237,7 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 15/67 (22.39%)
+built-ins/BigInt 15/68 (22.06%)
     asIntN/bigint-tobigint-errors.js {unsupported: [computed-property-names]}
     asIntN/bigint-tobigint-toprimitive.js {unsupported: [computed-property-names]}
     asIntN/bigint-tobigint-wrapped-values.js {unsupported: [computed-property-names]}
@@ -182,7 +254,7 @@ built-ins/BigInt 15/67 (22.39%)
     prototype/toString/thisbigintvalue-not-valid-throws.js Computed property is not support
     prototype/valueOf/cross-realm.js {unsupported: [cross-realm]}
 
-built-ins/Boolean 1/48 (2.08%)
+built-ins/Boolean 1/49 (2.04%)
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
 built-ins/DataView 166/455 (36.48%)
@@ -353,7 +425,8 @@ built-ins/DataView 166/455 (36.48%)
     toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
 
-built-ins/Date 37/702 (5.27%)
+built-ins/Date 40/707 (5.66%)
+    parse/without-utc-offset.js
     prototype/setFullYear/15.9.5.40_1.js
     prototype/Symbol.toPrimitive/hint-default-first-invalid.js
     prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
@@ -370,10 +443,12 @@ built-ins/Date 37/702 (5.27%)
     prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/this-val-non-obj.js
     prototype/toJSON/builtin.js {unsupported: [Reflect.construct]}
+    prototype/toJSON/called-as-function.js
     prototype/toJSON/invoke-result.js
     prototype/toJSON/to-primitive-symbol.js
     prototype/toJSON/to-primitive-value-of.js
     prototype/toString/non-date-receiver.js
+    prototype/no-date-value.js
     UTC/coercion-order.js
     coercion-order.js
     proto-from-ctor-realm-one.js {unsupported: [Reflect, cross-realm]}
@@ -402,15 +477,18 @@ built-ins/Date 37/702 (5.27%)
     S15.1.3.2_A2.4_T1.js
     S15.1.3.2_A5.2.js
 
-built-ins/encodeURI 2/29 (6.9%)
+built-ins/encodeURI 2/30 (6.67%)
     name.js
     S15.1.3.3_A5.2.js
 
-built-ins/encodeURIComponent 2/29 (6.9%)
+built-ins/encodeURIComponent 2/30 (6.67%)
     name.js
     S15.1.3.4_A5.2.js
 
-built-ins/Error 3/37 (8.11%)
+built-ins/Error 6/42 (14.29%)
+    prototype/toString/called-as-function.js
+    prototype/toString/invalid-receiver.js
+    prototype/no-error-data.js
     prototype/S15.11.4_A2.js
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
@@ -419,7 +497,7 @@ built-ins/eval 3/9 (33.33%)
     name.js
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
-built-ins/Function 195/509 (38.31%)
+built-ins/Function 199/505 (39.41%)
     *internals/Call 2/2 (100.0%)
     *internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -448,20 +526,21 @@ built-ins/Function 195/509 (38.31%)
     prototype/apply/S15.3.4.3_A7_T7.js non-interpreted
     prototype/apply/this-not-callable.js
     prototype/apply/this-not-callable-realm.js {unsupported: [cross-realm]}
-    prototype/bind/15.3.4.5-15-2.js
-    prototype/bind/15.3.4.5-15-5.js
     prototype/bind/BoundFunction_restricted-properties.js
-    prototype/bind/get-fn-realm.js {unsupported: [cross-realm]}
-    prototype/bind/get-fn-realm-recursive.js {unsupported: [cross-realm]}
+    prototype/bind/get-fn-realm.js {unsupported: [Reflect, cross-realm]}
+    prototype/bind/get-fn-realm-recursive.js {unsupported: [Reflect, cross-realm]}
     prototype/bind/instance-construct-newtarget-boundtarget.js {unsupported: [Reflect, new.target]}
     prototype/bind/instance-construct-newtarget-boundtarget-bound.js {unsupported: [Reflect, new.target]}
     prototype/bind/instance-construct-newtarget-self-new.js {unsupported: [new.target]}
     prototype/bind/instance-construct-newtarget-self-reflect.js {unsupported: [Reflect, new.target]}
+    prototype/bind/instance-length-default-value.js
+    prototype/bind/instance-length-exceeds-int32.js
+    prototype/bind/instance-length-prop-desc.js
+    prototype/bind/instance-length-tointeger.js
     prototype/bind/instance-name.js
     prototype/bind/instance-name-chained.js
     prototype/bind/instance-name-error.js
     prototype/bind/instance-name-non-string.js
-    prototype/bind/length-exceeds-int32.js
     prototype/bind/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     prototype/call/15.3.4.4-1-s.js strict
     prototype/call/15.3.4.4-2-s.js strict
@@ -509,6 +588,8 @@ built-ins/Function 195/509 (38.31%)
     prototype/toString/async-method-object.js {unsupported: [async-functions]}
     prototype/toString/AsyncFunction.js {unsupported: [async-functions]}
     prototype/toString/AsyncGenerator.js {unsupported: [async-iteration]}
+    prototype/toString/bound-function.js
+    prototype/toString/built-in-function-object.js {unsupported: [Reflect]}
     prototype/toString/class-declaration-complex-heritage.js
     prototype/toString/class-declaration-explicit-ctor.js
     prototype/toString/class-declaration-implicit-ctor.js
@@ -560,7 +641,7 @@ built-ins/Function 195/509 (38.31%)
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
     prototype/toString/unicode.js
-    prototype/toString/well-known-intrinsic-object-functions.js
+    prototype/length.js
     prototype/name.js
     prototype/restricted-property-arguments.js
     prototype/restricted-property-caller.js
@@ -608,6 +689,7 @@ built-ins/Function 195/509 (38.31%)
     instance-name.js
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    proto-from-ctor-realm-prototype.js {unsupported: [Reflect, cross-realm]}
     StrictFunction_restricted-properties.js strict
 
 ~built-ins/GeneratorFunction
@@ -629,11 +711,11 @@ built-ins/GeneratorPrototype 35/57 (61.4%)
     constructor.js
     Symbol.toStringTag.js
 
-built-ins/global 2/33 (6.06%)
+built-ins/global 2/29 (6.9%)
     global-object.js
     property-descriptor.js
 
-built-ins/Infinity 0/7 (0.0%)
+built-ins/Infinity 0/6 (0.0%)
 
 built-ins/isFinite 8/16 (50.0%)
     length.js
@@ -657,18 +739,22 @@ built-ins/isNaN 8/16 (50.0%)
 
 ~built-ins/IteratorPrototype
 
-built-ins/JSON 33/131 (25.19%)
+built-ins/JSON 38/140 (27.14%)
     parse/builtin.js {unsupported: [Reflect.construct]}
     parse/revived-proxy.js {unsupported: [Proxy]}
     parse/revived-proxy-revoked.js {unsupported: [Proxy]}
     parse/reviver-array-define-prop-err.js {unsupported: [Proxy]}
     parse/reviver-array-delete-err.js {unsupported: [Proxy]}
+    parse/reviver-array-get-prop-from-prototype.js
     parse/reviver-array-length-coerce-err.js {unsupported: [Proxy]}
     parse/reviver-array-length-get-err.js {unsupported: [Proxy]}
+    parse/reviver-call-order.js
     parse/reviver-object-define-prop-err.js {unsupported: [Proxy]}
     parse/reviver-object-delete-err.js {unsupported: [Proxy]}
+    parse/reviver-object-get-prop-from-prototype.js
+    parse/reviver-object-non-configurable-prop-create.js
+    parse/reviver-object-non-configurable-prop-delete.js strict
     parse/reviver-object-own-keys-err.js {unsupported: [Proxy]}
-    parse/S15.12.2_A1.js
     parse/text-negative-zero.js
     stringify/builtin.js {unsupported: [Reflect.construct]}
     stringify/replacer-array-abrupt.js {unsupported: [Proxy]}
@@ -678,6 +764,7 @@ built-ins/JSON 33/131 (25.19%)
     stringify/replacer-array-proxy-revoked-realm.js {unsupported: [Proxy, cross-realm]}
     stringify/replacer-array-wrong-type.js {unsupported: [Proxy]}
     stringify/replacer-function-arguments.js
+    stringify/replacer-function-object-deleted-property.js
     stringify/replacer-function-result.js
     stringify/value-array-abrupt.js {unsupported: [Proxy]}
     stringify/value-array-proxy.js {unsupported: [Proxy]}
@@ -692,8 +779,9 @@ built-ins/JSON 33/131 (25.19%)
     stringify/value-tojson-arguments.js
     Symbol.toStringTag.js
 
-built-ins/Map 6/144 (4.17%)
+built-ins/Map 7/145 (4.83%)
     *Symbol.species 4/4 (100.0%)
+    iterable-calls-set.js
     iterator-is-undefined-throws.js
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
@@ -703,9 +791,11 @@ built-ins/Math 2/273 (0.73%)
     log2/log2-basicTests.js calculation is not exact
     Symbol.toStringTag.js
 
-built-ins/NaN 0/7 (0.0%)
+built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors 43/79 (54.43%)
+built-ins/NativeErrors 66/108 (61.11%)
+    *AggregateError/prototype 6/6 (100.0%)
+    *AggregateError 17/17 (100.0%)
     EvalError/prototype/not-error-object.js
     EvalError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     RangeError/prototype/not-error-object.js
@@ -719,7 +809,7 @@ built-ins/NativeErrors 43/79 (54.43%)
     URIError/prototype/not-error-object.js
     URIError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-built-ins/Number 9/281 (3.2%)
+built-ins/Number 9/283 (3.18%)
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/undefined-fractiondigits.js
@@ -730,11 +820,12 @@ built-ins/Number 9/281 (3.2%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 118/3115 (3.79%)
+built-ins/Object 161/3150 (5.11%)
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
     assign/source-own-prop-error.js {unsupported: [Proxy]}
     assign/source-own-prop-keys-error.js {unsupported: [Proxy]}
     assign/strings-and-symbol-order.js
+    assign/strings-and-symbol-order-proxy.js {unsupported: [Proxy]}
     create/15.2.3.5-4-311.js
     defineProperties/15.2.3.7-6-a-112.js non-strict
     defineProperties/15.2.3.7-6-a-113.js non-strict
@@ -752,6 +843,7 @@ built-ins/Object 118/3115 (3.79%)
     defineProperties/15.2.3.7-6-a-184.js
     defineProperties/15.2.3.7-6-a-185.js
     defineProperties/15.2.3.7-6-a-282.js
+    defineProperties/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
     defineProperty/15.2.3.6-4-116.js non-strict
     defineProperty/15.2.3.6-4-117.js non-strict
     defineProperty/15.2.3.6-4-122.js
@@ -774,6 +866,11 @@ built-ins/Object 118/3115 (3.79%)
     defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
     entries/observable-operations.js {unsupported: [Proxy]}
+    entries/order-after-define-property.js
+    entries/return-order.js
+    freeze/abrupt-completion.js {unsupported: [Proxy]}
+    freeze/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    freeze/throws-when-false.js
     fromEntries/evaluation-order.js
     fromEntries/iterator-closed-for-null-entry.js
     fromEntries/iterator-closed-for-string-entry.js
@@ -784,6 +881,7 @@ built-ins/Object 118/3115 (3.79%)
     fromEntries/iterator-not-closed-for-throwing-done-accessor.js
     fromEntries/iterator-not-closed-for-throwing-next.js
     fromEntries/iterator-not-closed-for-uncallable-next.js
+    fromEntries/key-order.js
     fromEntries/to-property-key.js
     fromEntries/uses-keys-not-iterator.js
     getOwnPropertyDescriptors/function-length.js
@@ -792,10 +890,12 @@ built-ins/Object 118/3115 (3.79%)
     getOwnPropertyDescriptors/inherited-properties-omitted.js
     getOwnPropertyDescriptors/normal-object.js
     getOwnPropertyDescriptors/observable-operations.js {unsupported: [Proxy]}
+    getOwnPropertyDescriptors/order-after-define-property.js {unsupported: [Reflect]}
     getOwnPropertyDescriptors/primitive-booleans.js
     getOwnPropertyDescriptors/primitive-numbers.js
     getOwnPropertyDescriptors/primitive-strings.js
     getOwnPropertyDescriptors/primitive-symbols.js
+    getOwnPropertyDescriptors/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
     getOwnPropertyDescriptors/proxy-undefined-descriptor.js {unsupported: [Proxy]}
     getOwnPropertyDescriptors/symbols-included.js
     getOwnPropertyDescriptors/tamper-with-global-object.js
@@ -807,6 +907,19 @@ built-ins/Object 118/3115 (3.79%)
     getOwnPropertyDescriptor/15.2.3.3-4-215.js
     getOwnPropertyDescriptor/15.2.3.3-4-249.js
     getOwnPropertyDescriptor/15.2.3.3-4-250.js
+    getOwnPropertyNames/15.2.3.4-4-44.js
+    getOwnPropertyNames/15.2.3.4-4-49.js
+    getOwnPropertyNames/15.2.3.4-4-b-2.js
+    getOwnPropertyNames/order-after-define-property.js
+    getOwnPropertyNames/proxy-invariant-absent-not-configurable-symbol-key.js {unsupported: [Proxy]}
+    getOwnPropertyNames/proxy-invariant-duplicate-symbol-entry.js {unsupported: [Proxy]}
+    getOwnPropertyNames/proxy-invariant-not-extensible-absent-symbol-key.js {unsupported: [Proxy]}
+    getOwnPropertyNames/proxy-invariant-not-extensible-extra-symbol-key.js {unsupported: [Proxy]}
+    getOwnPropertySymbols/order-after-define-property.js
+    getOwnPropertySymbols/proxy-invariant-absent-not-configurable-string-key.js {unsupported: [Proxy]}
+    getOwnPropertySymbols/proxy-invariant-duplicate-string-entry.js {unsupported: [Proxy]}
+    getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js {unsupported: [Proxy]}
+    getOwnPropertySymbols/proxy-invariant-not-extensible-extra-string-key.js {unsupported: [Proxy]}
     getPrototypeOf/15.2.3.2-2-12.js
     getPrototypeOf/15.2.3.2-2-13.js
     getPrototypeOf/15.2.3.2-2-14.js
@@ -817,11 +930,25 @@ built-ins/Object 118/3115 (3.79%)
     internals/DefineOwnProperty/consistent-value-function-caller.js
     internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
     internals/DefineOwnProperty/consistent-writable-regexp-dollar1.js
+    isFrozen/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    isSealed/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    keys/order-after-define-property.js {unsupported: [Proxy]}
     keys/property-traps-order-with-proxied-array.js {unsupported: [Proxy]}
     keys/proxy-keys.js
+    keys/proxy-non-enumerable-prop-invariant-1.js {unsupported: [Proxy]}
+    keys/proxy-non-enumerable-prop-invariant-2.js {unsupported: [Proxy]}
+    keys/proxy-non-enumerable-prop-invariant-3.js {unsupported: [Proxy]}
+    keys/return-order.js
+    preventExtensions/abrupt-completion.js {unsupported: [Proxy]}
+    preventExtensions/throws-when-false.js
     prototype/hasOwnProperty/symbol_property_toPrimitive.js
     prototype/hasOwnProperty/symbol_property_toString.js
     prototype/hasOwnProperty/symbol_property_valueOf.js
+    prototype/hasOwnProperty/topropertykey_before_toobject.js
+    prototype/isPrototypeOf/arg-is-proxy.js {unsupported: [Proxy]}
+    prototype/isPrototypeOf/builtin.js {unsupported: [Reflect.construct]}
+    prototype/isPrototypeOf/null-this-and-primitive-arg-returns-false.js
+    prototype/isPrototypeOf/undefined-this-and-primitive-arg-returns-false.js
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
@@ -834,6 +961,7 @@ built-ins/Object 118/3115 (3.79%)
     prototype/toString/proxy-function.js {unsupported: [Proxy, async-functions]}
     prototype/toString/proxy-function-async.js {unsupported: [Proxy, async-functions]}
     prototype/toString/proxy-revoked.js {unsupported: [Proxy]}
+    prototype/toString/proxy-revoked-during-get-call.js {unsupported: [Proxy]}
     prototype/toString/symbol-tag-non-str-bigint.js
     prototype/toString/symbol-tag-non-str-builtin.js
     prototype/toString/symbol-tag-non-str-proxy-function.js {unsupported: [Proxy, async-functions]}
@@ -845,17 +973,22 @@ built-ins/Object 118/3115 (3.79%)
     prototype/valueOf/S15.2.4.4_A15.js
     prototype/setPrototypeOf-with-different-values.js {unsupported: [Reflect.setPrototypeOf]}
     prototype/setPrototypeOf-with-same-value.js {unsupported: [Reflect.setPrototypeOf]}
+    seal/abrupt-completion.js {unsupported: [Proxy]}
+    seal/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    seal/throws-when-false.js
     setPrototypeOf/set-error.js {unsupported: [Proxy]}
     values/observable-operations.js {unsupported: [Proxy]}
+    values/order-after-define-property.js
+    values/return-order.js
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     subclass-object-arg.js {unsupported: [Reflect.construct, Reflect, class]}
 
-built-ins/parseFloat 3/57 (5.26%)
+built-ins/parseFloat 3/58 (5.17%)
     name.js
     S15.1.2.3_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.3_A7.2.js
 
-built-ins/parseInt 3/59 (5.08%)
+built-ins/parseInt 3/60 (5.0%)
     name.js
     S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.2_A9.2.js
@@ -866,13 +999,13 @@ built-ins/parseInt 3/59 (5.08%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 896/1432 (62.57%)
+built-ins/RegExp 926/1464 (63.25%)
     *CharacterClassEscapes 24/24 (100.0%)
     *dotall 4/4 (100.0%)
     *lookBehind 17/17 (100.0%)
     *match-indices 13/13 (100.0%)
-    *named-groups 22/22 (100.0%)
-    *property-escapes/generated 395/395 (100.0%)
+    *named-groups 26/26 (100.0%)
+    *property-escapes/generated 403/403 (100.0%)
     *property-escapes 143/143 (100.0%)
     *prototype/dotAll 8/8 (100.0%)
     prototype/exec/failure-lastindex-access.js
@@ -955,6 +1088,8 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.replace/arg-2-coerce.js
     prototype/Symbol.replace/arg-2-coerce-err.js
     prototype/Symbol.replace/coerce-global.js
+    prototype/Symbol.replace/coerce-lastindex.js
+    prototype/Symbol.replace/coerce-lastindex-err.js
     prototype/Symbol.replace/coerce-unicode.js
     prototype/Symbol.replace/exec-err.js
     prototype/Symbol.replace/exec-invocation.js
@@ -962,6 +1097,7 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.replace/fn-coerce-replacement-err.js
     prototype/Symbol.replace/fn-err.js
     prototype/Symbol.replace/fn-invoke-args.js
+    prototype/Symbol.replace/fn-invoke-args-empty-result.js
     prototype/Symbol.replace/fn-invoke-this-no-strict.js non-strict
     prototype/Symbol.replace/fn-invoke-this-strict.js strict
     prototype/Symbol.replace/g-init-lastindex.js
@@ -974,18 +1110,29 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.replace/length.js
     prototype/Symbol.replace/match-failure.js
     prototype/Symbol.replace/name.js
+    prototype/Symbol.replace/named-groups.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/named-groups-fn.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/poisoned-stdlib.js {unsupported: [regexp-named-groups]}
     prototype/Symbol.replace/prop-desc.js
     prototype/Symbol.replace/replace-with-trailing.js
     prototype/Symbol.replace/replace-without-trailing.js
     prototype/Symbol.replace/result-coerce-capture.js
     prototype/Symbol.replace/result-coerce-capture-err.js
+    prototype/Symbol.replace/result-coerce-groups.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/result-coerce-groups-err.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/result-coerce-groups-prop.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/result-coerce-groups-prop-err.js {unsupported: [regexp-named-groups]}
     prototype/Symbol.replace/result-coerce-index.js
     prototype/Symbol.replace/result-coerce-index-err.js
+    prototype/Symbol.replace/result-coerce-index-undefined.js
     prototype/Symbol.replace/result-coerce-length.js
     prototype/Symbol.replace/result-coerce-length-err.js
     prototype/Symbol.replace/result-coerce-matched.js
     prototype/Symbol.replace/result-coerce-matched-err.js
+    prototype/Symbol.replace/result-coerce-matched-global.js
     prototype/Symbol.replace/result-get-capture-err.js
+    prototype/Symbol.replace/result-get-groups-err.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/result-get-groups-prop-err.js {unsupported: [regexp-named-groups]}
     prototype/Symbol.replace/result-get-index-err.js
     prototype/Symbol.replace/result-get-length-err.js
     prototype/Symbol.replace/result-get-matched-err.js
@@ -1009,8 +1156,10 @@ built-ins/RegExp 896/1432 (62.57%)
     prototype/Symbol.search/match-err.js
     prototype/Symbol.search/set-lastindex-init.js
     prototype/Symbol.search/set-lastindex-init-err.js
+    prototype/Symbol.search/set-lastindex-init-samevalue.js
     prototype/Symbol.search/set-lastindex-restore.js
     prototype/Symbol.search/set-lastindex-restore-err.js
+    prototype/Symbol.search/set-lastindex-restore-samevalue.js
     prototype/Symbol.search/success-get-index-err.js
     prototype/Symbol.search/u-lastindex-advance.js
     prototype/Symbol.search/y-fail-return.js
@@ -1079,6 +1228,7 @@ built-ins/RegExp 896/1432 (62.57%)
     from-regexp-like-get-source-err.js
     from-regexp-like-short-circuit.js
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    quantifier-integer-limit.js
     S15.10.1_A1_T13.js
     S15.10.1_A1_T14.js
     S15.10.1_A1_T15.js
@@ -1088,6 +1238,7 @@ built-ins/RegExp 896/1432 (62.57%)
     S15.10.4.1_A2_T1.js
     S15.10.4.1_A2_T2.js
     u180e.js {unsupported: [u180e]}
+    unicode_character_class_backspace_escape.js
     unicode_identity_escape.js
     valid-flags-y.js
 
@@ -1099,7 +1250,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 75/1064 (7.05%)
+built-ins/String 121/1114 (10.86%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-bigint.js {unsupported: [computed-property-names]}
@@ -1110,10 +1261,11 @@ built-ins/String 75/1064 (7.05%)
     prototype/indexOf/searchstring-tostring-errors.js {unsupported: [computed-property-names]}
     prototype/indexOf/searchstring-tostring-toprimitive.js {unsupported: [computed-property-names]}
     prototype/indexOf/searchstring-tostring-wrapped-values.js {unsupported: [computed-property-names]}
-    *prototype/matchAll 17/17 (100.0%)
+    *prototype/matchAll 19/19 (100.0%)
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/invoke-builtin-match.js
+    *prototype/replaceAll 40/40 (100.0%)
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
     prototype/replace/S15.5.4.11_A12.js non-strict
@@ -1123,6 +1275,10 @@ built-ins/String 75/1064 (7.05%)
     prototype/search/invoke-builtin-search-searcher-undef.js
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js
+    prototype/split/cstm-split-is-null.js
+    prototype/split/limit-touint32-error.js
+    prototype/split/separator-tostring-error.js
+    prototype/split/this-value-tostring-error.js
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/substring/S15.5.4.15_A1_T5.js
     prototype/toLocaleLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
@@ -1162,7 +1318,7 @@ built-ins/String 75/1064 (7.05%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 31/84 (36.9%)
+built-ins/Symbol 32/85 (37.65%)
     *asyncIterator 2/2 (100.0%)
     for/cross-realm.js {unsupported: [cross-realm]}
     hasInstance/cross-realm.js {unsupported: [cross-realm]}
@@ -1189,6 +1345,7 @@ built-ins/Symbol 31/84 (36.9%)
     toPrimitive/cross-realm.js {unsupported: [cross-realm]}
     toStringTag/cross-realm.js {unsupported: [cross-realm]}
     unscopables/cross-realm.js {unsupported: [cross-realm]}
+    is-constructor.js {unsupported: [Reflect.construct]}
 
 built-ins/ThrowTypeError 8/13 (61.54%)
     distinct-cross-realm.js {unsupported: [cross-realm]}
@@ -1200,7 +1357,7 @@ built-ins/ThrowTypeError 8/13 (61.54%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 984/1054 (93.36%)
+built-ins/TypedArray 1006/1070 (94.02%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/iter-access-error.js
@@ -1220,6 +1377,7 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/buffer/name.js
     prototype/buffer/prop-desc.js
     prototype/buffer/this-has-no-typedarrayname-internal.js
+    prototype/buffer/this-inherits-typedarray.js
     prototype/buffer/this-is-not-object.js
     *prototype/byteLength/BigInt 2/2 (100.0%)
     prototype/byteLength/detached-buffer.js
@@ -1427,10 +1585,11 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/includes/samevaluezero.js
     prototype/includes/search-found-returns-true.js
     prototype/includes/search-not-found-returns-false.js
+    prototype/includes/searchelement-not-integer.js
     prototype/includes/this-is-not-object.js
     prototype/includes/this-is-not-typedarray-instance.js
     prototype/includes/tointeger-fromindex.js
-    *prototype/indexOf/BigInt 11/11 (100.0%)
+    *prototype/indexOf/BigInt 12/12 (100.0%)
     prototype/indexOf/detached-buffer.js
     prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
     prototype/indexOf/fromIndex-infinity.js
@@ -1441,6 +1600,7 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/indexOf/length.js
     prototype/indexOf/length-zero-returns-minus-one.js
     prototype/indexOf/name.js
+    prototype/indexOf/no-arg.js
     prototype/indexOf/prop-desc.js
     prototype/indexOf/return-abrupt-tointeger-fromindex.js
     prototype/indexOf/search-found-returns-index.js
@@ -1467,7 +1627,7 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/join/this-is-not-typedarray-instance.js
     *prototype/keys/BigInt 3/3 (100.0%)
     *prototype/keys 10/10 (100.0%)
-    *prototype/lastIndexOf/BigInt 10/10 (100.0%)
+    *prototype/lastIndexOf/BigInt 11/11 (100.0%)
     prototype/lastIndexOf/detached-buffer.js
     prototype/lastIndexOf/fromIndex-infinity.js
     prototype/lastIndexOf/fromIndex-minus-zero.js
@@ -1477,6 +1637,7 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/lastIndexOf/length.js
     prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/name.js
+    prototype/lastIndexOf/no-arg.js
     prototype/lastIndexOf/prop-desc.js
     prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
     prototype/lastIndexOf/search-found-returns-index.js
@@ -1582,8 +1743,10 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/reduce/values-are-not-cached.js
     *prototype/reverse/BigInt 5/5 (100.0%)
     *prototype/reverse 12/12 (100.0%)
-    *prototype/set/BigInt 47/47 (100.0%)
+    *prototype/set/BigInt 48/48 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
+    prototype/set/array-arg-offset-tointeger.js
+    prototype/set/array-arg-primitive-toobject.js
     prototype/set/array-arg-return-abrupt-from-src-get-length.js
     prototype/set/array-arg-return-abrupt-from-src-get-value.js
     prototype/set/array-arg-return-abrupt-from-src-length.js
@@ -1594,11 +1757,13 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/set/array-arg-set-values.js
     prototype/set/array-arg-set-values-in-order.js
     prototype/set/array-arg-src-tonumber-value-conversions.js
+    prototype/set/array-arg-src-tonumber-value-type-conversions.js
     prototype/set/array-arg-src-values-are-not-cached.js
     prototype/set/array-arg-target-arraylength-internal.js
     prototype/set/array-arg-targetbuffer-detached-on-get-src-value-throws.js
     prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
     prototype/set/array-arg-targetbuffer-detached-throws.js
+    prototype/set/bit-precision.js
     prototype/set/invoked-as-func.js
     prototype/set/invoked-as-method.js
     prototype/set/length.js
@@ -1608,10 +1773,14 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/set/this-is-not-object.js
     prototype/set/this-is-not-typedarray-instance.js
     prototype/set/typedarray-arg-negative-integer-offset-throws.js
+    prototype/set/typedarray-arg-offset-tointeger.js
+    prototype/set/typedarray-arg-set-values-diff-buffer-other-type.js
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/typedarray-arg-set-values-diff-buffer-same-type.js
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type.js
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-arraylength-internal.js
     prototype/set/typedarray-arg-src-byteoffset-internal.js
@@ -1688,6 +1857,7 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/sort/comparefn-calls.js
     prototype/sort/detached-buffer.js
     prototype/sort/detached-buffer-comparefn.js
+    prototype/sort/detached-buffer-comparefn-coerce.js
     prototype/sort/invoked-as-func.js
     prototype/sort/invoked-as-method.js
     prototype/sort/length.js
@@ -1707,8 +1877,12 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/subarray/invoked-as-func.js
     prototype/subarray/invoked-as-method.js
     prototype/subarray/length.js
+    prototype/subarray/minus-zero.js
     prototype/subarray/name.js
     prototype/subarray/prop-desc.js
+    prototype/subarray/result-is-new-instance-from-same-ctor.js
+    prototype/subarray/result-is-new-instance-with-shared-buffer.js
+    prototype/subarray/results-with-different-length.js
     prototype/subarray/speciesctor-get-ctor.js
     prototype/subarray/speciesctor-get-ctor-abrupt.js
     prototype/subarray/speciesctor-get-ctor-inherited.js
@@ -1723,6 +1897,8 @@ built-ins/TypedArray 984/1054 (93.36%)
     prototype/subarray/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
     prototype/subarray/this-is-not-object.js
     prototype/subarray/this-is-not-typedarray-instance.js
+    prototype/subarray/tointeger-begin.js
+    prototype/subarray/tointeger-end.js
     *prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
     *prototype/Symbol.toStringTag 9/9 (100.0%)
     *prototype/toLocaleString/BigInt 13/13 (100.0%)
@@ -1755,7 +1931,7 @@ built-ins/TypedArray 984/1054 (93.36%)
     name.js
     prototype.js
 
-built-ins/TypedArrayConstructors 528/683 (77.31%)
+built-ins/TypedArrayConstructors 530/684 (77.49%)
     *BigInt64Array/prototype 4/4 (100.0%)
     *BigInt64Array 7/7 (100.0%)
     *BigUint64Array/prototype 4/4 (100.0%)
@@ -1812,8 +1988,10 @@ built-ins/TypedArrayConstructors 528/683 (77.31%)
     ctors/no-args/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/no-args/use-default-proto-if-custom-proto-is-not-object.js
     ctors/object-arg/as-generator-iterable-returns.js
+    ctors/object-arg/conversion-operation-consistent-nan.js
     ctors/object-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
     ctors/object-arg/iterating-throws.js
+    ctors/object-arg/iterator-is-null-as-array-like.js
     ctors/object-arg/iterator-not-callable-throws.js
     ctors/object-arg/iterator-throws.js
     ctors/object-arg/length-excessive-throws.js
@@ -1985,7 +2163,7 @@ built-ins/WeakMap 1/88 (1.14%)
 built-ins/WeakSet 1/75 (1.33%)
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-language/arguments-object 191/262 (72.9%)
+language/arguments-object 191/260 (73.46%)
     mapped/mapped-arguments-nonconfigurable-3.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
@@ -2178,7 +2356,7 @@ language/arguments-object 191/262 (72.9%)
     gen-meth-args-trailing-comma-undefined.js
     meth-args-trailing-comma-spread-operator.js
 
-language/asi 1/101 (0.99%)
+language/asi 1/102 (0.98%)
     S7.9_A5.7_T1.js
 
 language/block-scope 82/145 (56.55%)
@@ -2187,11 +2365,11 @@ language/block-scope 82/145 (56.55%)
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
     syntax/for-in/disallow-initialization-assignment.js
     syntax/for-in/mixed-values-in-iteration.js
-    syntax/function-declarations/in-statement-position-do-statement-while-expression.js strict
-    syntax/function-declarations/in-statement-position-for-statement.js strict
+    syntax/function-declarations/in-statement-position-do-statement-while-expression.js
+    syntax/function-declarations/in-statement-position-for-statement.js
     syntax/function-declarations/in-statement-position-if-expression-statement.js strict
     syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
-    syntax/function-declarations/in-statement-position-while-expression-statement.js strict
+    syntax/function-declarations/in-statement-position-while-expression-statement.js
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
@@ -2309,11 +2487,193 @@ language/directive-prologue 18/62 (29.03%)
     14.1-9-s.js {non-strict: [-1]}
     func-decl-inside-func-decl-parse.js non-strict
 
-language/eval-code 65/151 (43.05%)
+language/eval-code 259/349 (74.21%)
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
     direct/block-decl-eval-source-is-strict-nostrict.js non-strict
     direct/block-decl-eval-source-is-strict-onlystrict.js strict
     direct/block-decl-onlystrict.js strict
     direct/export.js {unsupported: [module]}
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
     direct/import.js {unsupported: [module]}
     direct/lex-env-distinct-cls.js {unsupported: [class]}
     direct/lex-env-distinct-const.js
@@ -2321,6 +2681,18 @@ language/eval-code 65/151 (43.05%)
     direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
     direct/new.target.js {unsupported: [new.target]}
     direct/new.target-arrow.js {unsupported: [new.target]}
     direct/new.target-fn.js {unsupported: [new.target]}
@@ -2389,9 +2761,10 @@ language/expressions/addition 9/48 (18.75%)
     get-symbol-to-prim-err.js
     order-of-evaluation.js
 
-language/expressions/arrow-function 276/326 (84.66%)
+language/expressions/arrow-function 283/333 (84.98%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
@@ -2412,6 +2785,7 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-id-init.js
@@ -2424,6 +2798,7 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
     dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
     dstr/ary-ptrn-rest-id-elision.js
     dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
@@ -2439,6 +2814,7 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
@@ -2465,6 +2841,7 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
@@ -2481,6 +2858,7 @@ language/expressions/arrow-function 276/326 (84.66%)
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
@@ -2618,6 +2996,7 @@ language/expressions/arrow-function 276/326 (84.66%)
     dflt-params-ref-self.js {unsupported: [default-parameters]}
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
+    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
     length-dflt.js {unsupported: [default-parameters]}
     lexical-new.target.js {unsupported: [new.target]}
     lexical-new.target-closure-returned.js {unsupported: [new.target]}
@@ -2738,7 +3117,7 @@ language/expressions/call 64/96 (66.67%)
 language/expressions/comma 1/6 (16.67%)
     tco-final.js {unsupported: [tail-call-optimization]}
 
-language/expressions/compound-assignment 77/408 (18.87%)
+language/expressions/compound-assignment 99/406 (24.38%)
     11.13.2-34-s.js strict
     11.13.2-35-s.js strict
     11.13.2-36-s.js strict
@@ -2759,6 +3138,28 @@ language/expressions/compound-assignment 77/408 (18.87%)
     btws-and-non-simple.js
     btws-or-non-simple.js
     btws-xor-non-simple.js
+    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
     div-arguments-strict.js strict
     div-eval-strict.js strict
     div-non-simple.js
@@ -2819,15 +3220,16 @@ language/expressions/compound-assignment 77/408 (18.87%)
 
 language/expressions/concatenation 0/5 (0.0%)
 
-language/expressions/conditional 2/21 (9.52%)
+language/expressions/conditional 3/22 (13.64%)
+    coalesce-expr-ternary.js
     tco-cond.js {unsupported: [tail-call-optimization]}
     tco-pos.js {unsupported: [tail-call-optimization]}
 
-language/expressions/delete 4/60 (6.67%)
+language/expressions/delete 4/61 (6.56%)
     11.4.1-5-a-28-s.js strict
-    11.4.1-5-a-5gs.js strict
     identifier-strict.js strict
     super-property.js {unsupported: [class]}
+    super-property-method.js {unsupported: [class]}
 
 language/expressions/division 4/45 (8.89%)
     bigint-errors.js {unsupported: [computed-property-names]}
@@ -2851,9 +3253,10 @@ language/expressions/exponentiation 4/44 (9.09%)
     bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/function 205/241 (85.06%)
+language/expressions/function 212/248 (85.48%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
@@ -2874,6 +3277,7 @@ language/expressions/function 205/241 (85.06%)
     dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-id-init.js
@@ -2886,6 +3290,7 @@ language/expressions/function 205/241 (85.06%)
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
     dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
     dstr/ary-ptrn-rest-id-elision.js
     dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
@@ -2901,6 +3306,7 @@ language/expressions/function 205/241 (85.06%)
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
@@ -2927,6 +3333,7 @@ language/expressions/function 205/241 (85.06%)
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
@@ -2943,6 +3350,7 @@ language/expressions/function 205/241 (85.06%)
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
@@ -3029,6 +3437,7 @@ language/expressions/function 205/241 (85.06%)
     dflt-params-ref-self.js {unsupported: [default-parameters]}
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
+    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
     length-dflt.js {unsupported: [default-parameters]}
     name.js
     name-arguments-strict-body.js non-strict
@@ -3055,9 +3464,10 @@ language/expressions/function 205/241 (85.06%)
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/generators 228/268 (85.07%)
+language/expressions/generators 235/275 (85.45%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-name-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
@@ -3082,6 +3492,7 @@ language/expressions/generators 228/268 (85.07%)
     dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-id-init.js
@@ -3096,6 +3507,7 @@ language/expressions/generators 228/268 (85.07%)
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
     dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
     dstr/ary-ptrn-rest-id-elision.js
     dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
@@ -3105,6 +3517,7 @@ language/expressions/generators 228/268 (85.07%)
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
@@ -3131,6 +3544,7 @@ language/expressions/generators 228/268 (85.07%)
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
@@ -3147,6 +3561,7 @@ language/expressions/generators 228/268 (85.07%)
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
@@ -3237,6 +3652,7 @@ language/expressions/generators 228/268 (85.07%)
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
     eval-body-proto-realm.js {unsupported: [cross-realm]}
+    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
     generator-created-after-decl-inst.js
     has-instance.js
     implicit-name.js
@@ -3339,9 +3755,10 @@ language/expressions/multiplication 4/40 (10.0%)
     bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/object 939/1049 (89.51%)
+language/expressions/object 971/1081 (89.82%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-name-iter-val.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
@@ -3368,6 +3785,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
@@ -3384,21 +3802,23 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-direct.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-init-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-name-iter-val.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
@@ -3425,6 +3845,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
@@ -3441,17 +3862,18 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-dflt-obj-init-null.js {unsupported: [async-iteration]}
@@ -3522,6 +3944,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/async-gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
     dstr/gen-meth-ary-init-iter-close.js
     dstr/gen-meth-ary-init-iter-get-err.js
+    dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
     dstr/gen-meth-ary-init-iter-no-close.js
     dstr/gen-meth-ary-name-iter-val.js
     dstr/gen-meth-ary-ptrn-elem-ary-elem-init.js
@@ -3548,6 +3971,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-ary-ptrn-elem-id-iter-done.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-step-err.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-val.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-val-err.js
     dstr/gen-meth-ary-ptrn-elem-obj-id.js
     dstr/gen-meth-ary-ptrn-elem-obj-id-init.js
@@ -3564,6 +3988,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-ary-ptrn-rest-ary-empty.js
     dstr/gen-meth-ary-ptrn-rest-ary-rest.js
     dstr/gen-meth-ary-ptrn-rest-id.js
+    dstr/gen-meth-ary-ptrn-rest-id-direct.js
     dstr/gen-meth-ary-ptrn-rest-id-elision.js
     dstr/gen-meth-ary-ptrn-rest-id-elision-next-err.js
     dstr/gen-meth-ary-ptrn-rest-id-exhausted.js
@@ -3573,6 +3998,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-ary-ptrn-rest-obj-prop-id.js
     dstr/gen-meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
@@ -3599,6 +4025,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
@@ -3615,6 +4042,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
@@ -3696,6 +4124,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-ary-init-iter-close.js
     dstr/meth-ary-init-iter-get-err.js
+    dstr/meth-ary-init-iter-get-err-array-prototype.js
     dstr/meth-ary-ptrn-elem-ary-elem-init.js
     dstr/meth-ary-ptrn-elem-ary-elem-iter.js
     dstr/meth-ary-ptrn-elem-ary-elision-init.js
@@ -3716,6 +4145,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-ary-ptrn-elem-id-init-undef.js
     dstr/meth-ary-ptrn-elem-id-init-unresolvable.js
     dstr/meth-ary-ptrn-elem-id-iter-step-err.js
+    dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/meth-ary-ptrn-elem-id-iter-val-err.js
     dstr/meth-ary-ptrn-elem-obj-id.js
     dstr/meth-ary-ptrn-elem-obj-id-init.js
@@ -3728,6 +4158,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-ary-ptrn-rest-ary-empty.js
     dstr/meth-ary-ptrn-rest-ary-rest.js
     dstr/meth-ary-ptrn-rest-id.js
+    dstr/meth-ary-ptrn-rest-id-direct.js
     dstr/meth-ary-ptrn-rest-id-elision.js
     dstr/meth-ary-ptrn-rest-id-elision-next-err.js
     dstr/meth-ary-ptrn-rest-id-exhausted.js
@@ -3737,6 +4168,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-ary-ptrn-rest-obj-prop-id.js
     dstr/meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
@@ -3763,6 +4195,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
@@ -3779,6 +4212,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
@@ -3852,6 +4286,7 @@ language/expressions/object 939/1049 (89.51%)
     dstr/meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    dstr/object-rest-proxy-ownkeys-returned-keys-order.js {unsupported: [Proxy, object-rest]}
     method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
     method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
     method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
@@ -3875,6 +4310,7 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/async-gen-meth-dflt-params-rest.js {unsupported: [default-parameters, async-iteration]}
     method-definition/async-gen-meth-dflt-params-trailing-comma.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-meth-escaped-async.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters, async-iteration]}
     method-definition/async-gen-meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
     method-definition/async-gen-meth-params-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-meth-params-trailing-comma-single.js {unsupported: [async-iteration, async]}
@@ -3966,6 +4402,7 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/async-meth-dflt-params-rest.js {unsupported: [default-parameters, async-iteration]}
     method-definition/async-meth-dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
     method-definition/async-meth-escaped-async.js {unsupported: [async-functions]}
+    method-definition/async-meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters, async-functions, async]}
     method-definition/async-meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
     method-definition/async-meth-params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
     method-definition/async-meth-params-trailing-comma-single.js {unsupported: [async-functions, async]}
@@ -3975,7 +4412,13 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/async-super-call-param.js {unsupported: [async]}
     method-definition/early-errors-object-method-duplicate-parameters.js
     method-definition/escaped-get.js
+    method-definition/escaped-get-e.js
+    method-definition/escaped-get-g.js
+    method-definition/escaped-get-t.js
     method-definition/escaped-set.js
+    method-definition/escaped-set-e.js
+    method-definition/escaped-set-s.js
+    method-definition/escaped-set-t.js
     method-definition/fn-name-fn.js
     method-definition/fn-name-gen.js
     method-definition/gen-meth-array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
@@ -3988,6 +4431,7 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/gen-meth-dflt-params-ref-self.js {unsupported: [default-parameters]}
     method-definition/gen-meth-dflt-params-rest.js {unsupported: [default-parameters]}
     method-definition/gen-meth-dflt-params-trailing-comma.js
+    method-definition/gen-meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
     method-definition/gen-meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/gen-meth-params-trailing-comma-multiple.js
     method-definition/gen-meth-params-trailing-comma-single.js
@@ -4025,6 +4469,7 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/meth-dflt-params-ref-self.js {unsupported: [default-parameters]}
     method-definition/meth-dflt-params-rest.js {unsupported: [default-parameters]}
     method-definition/meth-dflt-params-trailing-comma.js
+    method-definition/meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
     method-definition/meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/meth-params-trailing-comma-multiple.js
     method-definition/meth-params-trailing-comma-single.js
@@ -4060,7 +4505,7 @@ language/expressions/object 939/1049 (89.51%)
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
     method-definition/yield-as-function-expression-binding-identifier.js non-strict
-    method-definition/yield-as-generator-method-binding-identifier.js non-strict
+    method-definition/yield-as-generator-method-binding-identifier.js
     method-definition/yield-as-identifier-in-nested-function.js non-strict
     method-definition/yield-as-literal-property-name.js
     method-definition/yield-as-property-name.js
@@ -4072,7 +4517,8 @@ language/expressions/object 939/1049 (89.51%)
     11.1.5-2gs.js strict
     11.1.5_4-4-a-3.js strict
     11.1.5_4-4-b-1.js strict
-    __proto__-permitted-dup.js
+    __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
+    __proto__-permitted-dup-shorthand.js
     accessor-name-computed.js
     accessor-name-computed-err-evaluation.js
     accessor-name-computed-err-to-prop-key.js
@@ -4242,7 +4688,9 @@ language/expressions/object 939/1049 (89.51%)
     ident-name-prop-name-literal-with-escaped.js
     let-non-strict-access.js non-strict
     let-non-strict-syntax.js non-strict
+    literal-property-name-bigint.js {unsupported: [class]}
     method.js
+    object-spread-proxy-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
     prop-def-id-eval-error.js non-strict
     prop-def-id-eval-error-2.js {unsupported: [Proxy]}
     prop-dup-data-data.js strict
@@ -4280,9 +4728,11 @@ language/expressions/object 939/1049 (89.51%)
     yield-non-strict-access.js non-strict
     yield-non-strict-syntax.js non-strict
 
-language/expressions/postfix-decrement 8/36 (22.22%)
+language/expressions/postfix-decrement 10/36 (27.78%)
     arguments.js strict
     eval.js strict
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
@@ -4290,10 +4740,12 @@ language/expressions/postfix-decrement 8/36 (22.22%)
     target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/postfix-increment 9/37 (24.32%)
+language/expressions/postfix-increment 11/37 (29.73%)
     11.3.1-2-1gs.js strict
     arguments.js strict
     eval.js strict
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
@@ -4301,10 +4753,12 @@ language/expressions/postfix-increment 9/37 (24.32%)
     target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-decrement 9/33 (27.27%)
+language/expressions/prefix-decrement 11/33 (33.33%)
     11.4.5-2-2gs.js strict
     arguments.js strict
     eval.js strict
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
@@ -4312,9 +4766,11 @@ language/expressions/prefix-decrement 9/33 (27.27%)
     target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-increment 8/32 (25.0%)
+language/expressions/prefix-increment 10/32 (31.25%)
     arguments.js strict
     eval.js strict
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
@@ -4351,15 +4807,16 @@ language/expressions/tagged-template 4/27 (14.81%)
     tco-call.js {unsupported: [tail-call-optimization]}
     tco-member.js {unsupported: [tail-call-optimization]}
 
-language/expressions/template-literal 2/54 (3.7%)
+language/expressions/template-literal 2/57 (3.51%)
     mongolian-vowel-separator.js {unsupported: [u180e]}
     mongolian-vowel-separator-eval.js {unsupported: [u180e]}
 
 language/expressions/this 1/6 (16.67%)
     S11.1.1_A1.js
 
-language/expressions/typeof 1/15 (6.67%)
+language/expressions/typeof 2/16 (12.5%)
     built-in-ordinary-objects-no-call.js
+    proxy.js {unsupported: [Proxy]}
 
 language/expressions/unary-minus 1/14 (7.14%)
     bigint-non-primitive.js
@@ -4375,12 +4832,13 @@ language/expressions/unsigned-right-shift 5/45 (11.11%)
 
 language/expressions/void 0/9 (0.0%)
 
-language/expressions/yield 3/61 (4.92%)
+language/expressions/yield 4/63 (6.35%)
     rhs-omitted.js
     rhs-primitive.js
+    star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 125/219 (57.08%)
+language/function-code 123/217 (56.68%)
     10.4.3-1-1-s.js non-strict
     10.4.3-1-10-s.js non-strict
     10.4.3-1-100-s.js
@@ -4499,10 +4957,8 @@ language/function-code 125/219 (57.08%)
     10.4.3-1-92gs.js {non-strict: [0, 9]}
     10.4.3-1-9gs.js strict
     block-decl-onlystrict.js strict
-    each-param-has-own-non-shared-eval-scope.js {unsupported: [default-parameters]}
-    each-param-has-own-scope.js {unsupported: [default-parameters]}
-    eval-param-env-with-computed-key.js
-    eval-param-env-with-prop-initializer.js
+    eval-param-env-with-computed-key.js non-strict
+    eval-param-env-with-prop-initializer.js non-strict
     S10.4.3_A1.js strict
     switch-case-decl-onlystrict.js strict
     switch-dflt-decl-onlystrict.js strict
@@ -4545,12 +5001,54 @@ language/global-code 34/41 (82.93%)
     yield-non-strict.js non-strict
     yield-strict.js strict
 
-language/identifier-resolution 0/12 (0.0%)
+language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 122/145 (84.14%)
+language/identifiers 164/188 (87.23%)
     other_id_continue.js
     other_id_start.js
     part-digits-via-escape-hex.js
+    part-unicode-10.0.0.js
+    part-unicode-10.0.0-escaped.js
+    part-unicode-11.0.0.js
+    part-unicode-11.0.0-escaped.js
+    part-unicode-12.0.0.js
+    part-unicode-12.0.0-escaped.js
+    part-unicode-13.0.0.js
+    part-unicode-13.0.0-escaped.js
+    part-unicode-5.2.0.js
+    part-unicode-5.2.0-escaped.js
+    part-unicode-6.0.0.js
+    part-unicode-6.0.0-escaped.js
+    part-unicode-6.1.0.js
+    part-unicode-6.1.0-escaped.js
+    part-unicode-7.0.0.js
+    part-unicode-7.0.0-escaped.js
+    part-unicode-8.0.0.js
+    part-unicode-8.0.0-escaped.js
+    part-unicode-9.0.0.js
+    part-unicode-9.0.0-escaped.js
+    start-unicode-10.0.0.js
+    start-unicode-10.0.0-escaped.js
+    start-unicode-11.0.0.js
+    start-unicode-11.0.0-escaped.js
+    start-unicode-12.0.0.js
+    start-unicode-12.0.0-escaped.js
+    start-unicode-13.0.0.js
+    start-unicode-13.0.0-escaped.js
+    start-unicode-5.2.0.js
+    start-unicode-5.2.0-escaped.js
+    start-unicode-6.0.0.js
+    start-unicode-6.0.0-escaped.js
+    start-unicode-6.1.0.js
+    start-unicode-6.1.0-escaped.js
+    start-unicode-7.0.0.js
+    start-unicode-7.0.0-escaped.js
+    start-unicode-8.0.0.js
+    start-unicode-8.0.0-escaped.js
+    start-unicode-9.0.0.js
+    start-unicode-9.0.0-escaped.js
+    start-zwj-escaped.js
+    start-zwnj-escaped.js
     val-break.js
     val-break-via-escape-hex.js
     val-break-via-escape-hex4.js
@@ -4681,7 +5179,7 @@ language/line-terminators 4/41 (9.76%)
     S7.3_A6_T3.js
     S7.3_A6_T4.js
 
-language/literals 113/430 (26.28%)
+language/literals 117/434 (26.96%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     bigint/legacy-octal-like-invalid-00n.js
@@ -4694,7 +5192,7 @@ language/literals 113/430 (26.28%)
     numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     numeric/numeric-followed-by-ident.js
-    *regexp/named-groups 58/58 (100.0%)
+    *regexp/named-groups 56/56 (100.0%)
     regexp/early-err-pattern.js Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
@@ -4710,7 +5208,9 @@ language/literals 113/430 (26.28%)
     regexp/S7.8.5_A2.5_T1.js
     regexp/S7.8.5_A2.5_T3.js
     regexp/u-astral.js
+    regexp/u-astral-char-class-invert.js
     regexp/u-case-mapping.js
+    regexp/u-null-character-escape.js
     regexp/u-surrogate-pairs.js
     regexp/u-surrogate-pairs-atom-char-class.js
     regexp/u-surrogate-pairs-atom-dot.js
@@ -4718,6 +5218,8 @@ language/literals 113/430 (26.28%)
     regexp/u-surrogate-pairs-atom-escape-decimal.js
     regexp/u-unicode-esc.js
     regexp/y-assertion-start.js
+    string/legacy-non-octal-escape-sequence-8-strict.js strict
+    string/legacy-non-octal-escape-sequence-9-strict.js strict
     string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
     string/legacy-octal-escape-sequence-strict.js strict
@@ -4738,6 +5240,8 @@ language/literals 113/430 (26.28%)
     string/S7.8.4_A7.2_T6.js
     string/unicode-escape-nls-err-double.js
     string/unicode-escape-nls-err-single.js
+    string/unicode-escape-no-hex-err-double.js
+    string/unicode-escape-no-hex-err-single.js
 
 ~language/module-code
 
@@ -4772,9 +5276,10 @@ language/rest-parameters 10/11 (90.91%)
 
 language/source-text 0/1 (0.0%)
 
-language/statements/for 254/375 (67.73%)
+language/statements/for 263/384 (68.49%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
+    dstr/const-ary-init-iter-get-err-array-prototype.js
     dstr/const-ary-init-iter-no-close.js
     dstr/const-ary-name-iter-val.js
     dstr/const-ary-ptrn-elem-ary-elem-init.js
@@ -4801,6 +5306,7 @@ language/statements/for 254/375 (67.73%)
     dstr/const-ary-ptrn-elem-id-iter-done.js
     dstr/const-ary-ptrn-elem-id-iter-step-err.js
     dstr/const-ary-ptrn-elem-id-iter-val.js
+    dstr/const-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/const-ary-ptrn-elem-id-iter-val-err.js
     dstr/const-ary-ptrn-elem-obj-id.js
     dstr/const-ary-ptrn-elem-obj-id-init.js
@@ -4818,6 +5324,7 @@ language/statements/for 254/375 (67.73%)
     dstr/const-ary-ptrn-rest-ary-empty.js
     dstr/const-ary-ptrn-rest-ary-rest.js
     dstr/const-ary-ptrn-rest-id.js
+    dstr/const-ary-ptrn-rest-id-direct.js
     dstr/const-ary-ptrn-rest-id-elision.js
     dstr/const-ary-ptrn-rest-id-elision-next-err.js
     dstr/const-ary-ptrn-rest-id-exhausted.js
@@ -4861,6 +5368,7 @@ language/statements/for 254/375 (67.73%)
     dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
+    dstr/let-ary-init-iter-get-err-array-prototype.js
     dstr/let-ary-ptrn-elem-ary-elem-init.js
     dstr/let-ary-ptrn-elem-ary-elem-iter.js
     dstr/let-ary-ptrn-elem-ary-elision-init.js
@@ -4881,6 +5389,7 @@ language/statements/for 254/375 (67.73%)
     dstr/let-ary-ptrn-elem-id-init-undef.js
     dstr/let-ary-ptrn-elem-id-init-unresolvable.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
+    dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
     dstr/let-ary-ptrn-elem-obj-id.js
     dstr/let-ary-ptrn-elem-obj-id-init.js
@@ -4894,6 +5403,7 @@ language/statements/for 254/375 (67.73%)
     dstr/let-ary-ptrn-rest-ary-empty.js
     dstr/let-ary-ptrn-rest-ary-rest.js
     dstr/let-ary-ptrn-rest-id.js
+    dstr/let-ary-ptrn-rest-id-direct.js
     dstr/let-ary-ptrn-rest-id-elision.js
     dstr/let-ary-ptrn-rest-id-elision-next-err.js
     dstr/let-ary-ptrn-rest-id-exhausted.js
@@ -4932,6 +5442,7 @@ language/statements/for 254/375 (67.73%)
     dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
+    dstr/var-ary-init-iter-get-err-array-prototype.js
     dstr/var-ary-ptrn-elem-ary-elem-init.js
     dstr/var-ary-ptrn-elem-ary-elem-iter.js
     dstr/var-ary-ptrn-elem-ary-elision-init.js
@@ -4952,6 +5463,7 @@ language/statements/for 254/375 (67.73%)
     dstr/var-ary-ptrn-elem-id-init-undef.js
     dstr/var-ary-ptrn-elem-id-init-unresolvable.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
+    dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
     dstr/var-ary-ptrn-elem-obj-id.js
     dstr/var-ary-ptrn-elem-obj-id-init.js
@@ -4965,6 +5477,7 @@ language/statements/for 254/375 (67.73%)
     dstr/var-ary-ptrn-rest-ary-empty.js
     dstr/var-ary-ptrn-rest-ary-rest.js
     dstr/var-ary-ptrn-rest-id.js
+    dstr/var-ary-ptrn-rest-id-direct.js
     dstr/var-ary-ptrn-rest-id-elision.js
     dstr/var-ary-ptrn-rest-id-elision-next-err.js
     dstr/var-ary-ptrn-rest-id-exhausted.js
@@ -5028,7 +5541,7 @@ language/statements/for 254/375 (67.73%)
     tco-lhs-body.js {unsupported: [tail-call-optimization]}
     tco-var-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/for-in 39/113 (34.51%)
+language/statements/for-in 44/114 (38.6%)
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
@@ -5061,6 +5574,11 @@ language/statements/for-in 39/113 (34.51%)
     let-array-with-newline.js non-strict
     let-block-with-newline.js non-strict
     let-identifier-with-newline.js non-strict
+    order-after-define-property.js
+    order-enumerable-shadowed.js
+    order-property-added.js
+    order-property-on-prototype.js
+    order-simple-object.js
     scope-body-lex-boundary.js
     scope-body-lex-close.js
     scope-body-lex-open.js
@@ -5069,7 +5587,7 @@ language/statements/for-in 39/113 (34.51%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 466/716 (65.08%)
+language/statements/for-of 475/725 (65.52%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -5193,6 +5711,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/array-rest-yield-ident-valid.js non-strict
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
+    dstr/const-ary-init-iter-get-err-array-prototype.js
     dstr/const-ary-init-iter-no-close.js
     dstr/const-ary-name-iter-val.js
     dstr/const-ary-ptrn-elem-ary-elem-init.js
@@ -5219,6 +5738,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/const-ary-ptrn-elem-id-iter-done.js
     dstr/const-ary-ptrn-elem-id-iter-step-err.js
     dstr/const-ary-ptrn-elem-id-iter-val.js
+    dstr/const-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/const-ary-ptrn-elem-id-iter-val-err.js
     dstr/const-ary-ptrn-elem-obj-id.js
     dstr/const-ary-ptrn-elem-obj-id-init.js
@@ -5236,6 +5756,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/const-ary-ptrn-rest-ary-empty.js
     dstr/const-ary-ptrn-rest-ary-rest.js
     dstr/const-ary-ptrn-rest-id.js
+    dstr/const-ary-ptrn-rest-id-direct.js
     dstr/const-ary-ptrn-rest-id-elision.js
     dstr/const-ary-ptrn-rest-id-elision-next-err.js
     dstr/const-ary-ptrn-rest-id-exhausted.js
@@ -5299,6 +5820,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/let-ary-ptrn-elem-id-init-undef.js
     dstr/let-ary-ptrn-elem-id-init-unresolvable.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
+    dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
     dstr/let-ary-ptrn-elem-obj-id.js
     dstr/let-ary-ptrn-elem-obj-id-init.js
@@ -5312,6 +5834,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/let-ary-ptrn-rest-ary-empty.js
     dstr/let-ary-ptrn-rest-ary-rest.js
     dstr/let-ary-ptrn-rest-id.js
+    dstr/let-ary-ptrn-rest-id-direct.js
     dstr/let-ary-ptrn-rest-id-elision.js
     dstr/let-ary-ptrn-rest-id-elision-next-err.js
     dstr/let-ary-ptrn-rest-id-exhausted.js
@@ -5436,6 +5959,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/var-ary-ptrn-elem-id-init-undef.js
     dstr/var-ary-ptrn-elem-id-init-unresolvable.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
+    dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
     dstr/var-ary-ptrn-elem-obj-id.js
     dstr/var-ary-ptrn-elem-obj-id-init.js
@@ -5449,6 +5973,7 @@ language/statements/for-of 466/716 (65.08%)
     dstr/var-ary-ptrn-rest-ary-empty.js
     dstr/var-ary-ptrn-rest-ary-rest.js
     dstr/var-ary-ptrn-rest-id.js
+    dstr/var-ary-ptrn-rest-id-direct.js
     dstr/var-ary-ptrn-rest-id-elision.js
     dstr/var-ary-ptrn-rest-id-elision-next-err.js
     dstr/var-ary-ptrn-rest-id-exhausted.js
@@ -5515,8 +6040,10 @@ language/statements/for-of 466/716 (65.08%)
     head-var-init.js
     head-var-no-expr.js
     iterator-as-proxy.js {unsupported: [Proxy]}
-    iterator-close-get-method-error.js
     iterator-close-non-object.js
+    iterator-close-non-throw-get-method-abrupt.js
+    iterator-close-non-throw-get-method-is-null.js
+    iterator-close-non-throw-get-method-non-callable.js
     iterator-close-via-break.js
     iterator-close-via-continue.js
     iterator-close-via-return.js
@@ -5537,9 +6064,10 @@ language/statements/for-of 466/716 (65.08%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/generators 218/252 (86.51%)
+language/statements/generators 225/259 (86.87%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-name-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
@@ -5564,6 +6092,7 @@ language/statements/generators 218/252 (86.51%)
     dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-id-init.js
@@ -5578,6 +6107,7 @@ language/statements/generators 218/252 (86.51%)
     dstr/ary-ptrn-rest-ary-empty.js
     dstr/ary-ptrn-rest-ary-rest.js
     dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
     dstr/ary-ptrn-rest-id-elision.js
     dstr/ary-ptrn-rest-id-elision-next-err.js
     dstr/ary-ptrn-rest-id-exhausted.js
@@ -5587,6 +6117,7 @@ language/statements/generators 218/252 (86.51%)
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
     dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
@@ -5613,6 +6144,7 @@ language/statements/generators 218/252 (86.51%)
     dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
@@ -5629,6 +6161,7 @@ language/statements/generators 218/252 (86.51%)
     dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
     dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
@@ -5719,6 +6252,7 @@ language/statements/generators 218/252 (86.51%)
     dflt-params-ref-self.js {unsupported: [default-parameters]}
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
+    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
     generator-created-after-decl-inst.js
     has-instance.js
     invoke-as-constructor.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -106,8 +106,8 @@ built-ins/Array 239/2670 (8.95%)
     prototype/filter/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
-    *prototype/flatMap 21/21 (100.0%)
-    *prototype/flat 17/17 (100.0%)
+    prototype/flatMap 21/21 (100.0%)
+    prototype/flat 17/17 (100.0%)
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
     prototype/includes/get-prop.js {unsupported: [Proxy]}
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
@@ -190,13 +190,13 @@ built-ins/Array 239/2670 (8.95%)
     prototype/splice/target-array-non-extensible.js {unsupported: [Symbol.species]}
     prototype/splice/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
     prototype/splice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
-    *prototype/Symbol.unscopables 2/2 (100.0%)
+    prototype/Symbol.unscopables 2/2 (100.0%)
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/unshift/throws-with-string-receiver.js
     prototype/methods-called-as-functions.js {unsupported: [Symbol.species, Array.prototype.flat, Array.prototype.flatMap]}
     prototype/Symbol.iterator.js Expects a particular string value
-    *Symbol.species 4/4 (100.0%)
+    Symbol.species 4/4 (100.0%)
     proto-from-ctor-realm-one.js {unsupported: [Reflect, cross-realm]}
     proto-from-ctor-realm-two.js {unsupported: [Reflect, cross-realm]}
     proto-from-ctor-realm-zero.js {unsupported: [Reflect, cross-realm]}
@@ -223,7 +223,7 @@ built-ins/ArrayBuffer 30/80 (37.5%)
     prototype/slice/species-returns-smaller-arraybuffer.js {unsupported: [Symbol.species]}
     prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/Symbol.toStringTag.js
-    *Symbol.species 4/4 (100.0%)
+    Symbol.species 4/4 (100.0%)
     data-allocation-after-object-creation.js {unsupported: [Reflect.construct]}
     newtarget-prototype-is-not-object.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
@@ -498,8 +498,8 @@ built-ins/eval 3/9 (33.33%)
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
 built-ins/Function 199/505 (39.41%)
-    *internals/Call 2/2 (100.0%)
-    *internals/Construct 6/6 (100.0%)
+    internals/Call 2/2 (100.0%)
+    internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
     length/S15.3.5.1_A2_T1.js
     length/S15.3.5.1_A2_T2.js
@@ -701,7 +701,7 @@ built-ins/GeneratorPrototype 35/57 (61.4%)
     next/property-descriptor.js
     next/this-val-not-generator.js
     next/this-val-not-object.js
-    *return 21/21 (100.0%)
+    return 21/21 (100.0%)
     throw/from-state-executing.js non-interpreted
     throw/length.js
     throw/name.js
@@ -780,7 +780,7 @@ built-ins/JSON 38/140 (27.14%)
     Symbol.toStringTag.js
 
 built-ins/Map 7/145 (4.83%)
-    *Symbol.species 4/4 (100.0%)
+    Symbol.species 4/4 (100.0%)
     iterable-calls-set.js
     iterator-is-undefined-throws.js
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
@@ -794,8 +794,8 @@ built-ins/Math 2/273 (0.73%)
 built-ins/NaN 0/6 (0.0%)
 
 built-ins/NativeErrors 66/108 (61.11%)
-    *AggregateError/prototype 6/6 (100.0%)
-    *AggregateError 17/17 (100.0%)
+    AggregateError/prototype 6/6 (100.0%)
+    AggregateError 17/17 (100.0%)
     EvalError/prototype/not-error-object.js
     EvalError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     RangeError/prototype/not-error-object.js
@@ -1000,14 +1000,14 @@ built-ins/parseInt 3/60 (5.0%)
 ~built-ins/Reflect
 
 built-ins/RegExp 926/1464 (63.25%)
-    *CharacterClassEscapes 24/24 (100.0%)
-    *dotall 4/4 (100.0%)
-    *lookBehind 17/17 (100.0%)
-    *match-indices 13/13 (100.0%)
-    *named-groups 26/26 (100.0%)
-    *property-escapes/generated 403/403 (100.0%)
-    *property-escapes 143/143 (100.0%)
-    *prototype/dotAll 8/8 (100.0%)
+    CharacterClassEscapes 24/24 (100.0%)
+    dotall 4/4 (100.0%)
+    lookBehind 17/17 (100.0%)
+    match-indices 13/13 (100.0%)
+    named-groups 26/26 (100.0%)
+    property-escapes/generated 403/403 (100.0%)
+    property-escapes 143/143 (100.0%)
+    prototype/dotAll 8/8 (100.0%)
     prototype/exec/failure-lastindex-access.js
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
@@ -1019,7 +1019,7 @@ built-ins/RegExp 926/1464 (63.25%)
     prototype/exec/y-fail-return.js
     prototype/exec/y-init-lastindex.js
     prototype/exec/y-set-lastindex.js
-    *prototype/flags 15/15 (100.0%)
+    prototype/flags 15/15 (100.0%)
     prototype/global/15.10.7.2-2.js
     prototype/global/cross-realm.js {unsupported: [cross-realm]}
     prototype/global/length.js
@@ -1046,8 +1046,8 @@ built-ins/RegExp 926/1464 (63.25%)
     prototype/source/value-empty.js
     prototype/source/value-line-terminator.js
     prototype/source/value-u.js
-    *prototype/sticky 8/8 (100.0%)
-    *prototype/Symbol.matchAll 25/25 (100.0%)
+    prototype/sticky 8/8 (100.0%)
+    prototype/Symbol.matchAll 25/25 (100.0%)
     prototype/Symbol.match/builtin-coerce-lastindex.js
     prototype/Symbol.match/builtin-failure-y-return-val.js
     prototype/Symbol.match/builtin-failure-y-set-lastindex.js
@@ -1211,10 +1211,10 @@ built-ins/RegExp 926/1464 (63.25%)
     prototype/test/y-fail-return.js
     prototype/test/y-init-lastindex.js
     prototype/test/y-set-lastindex.js
-    *prototype/unicode 8/8 (100.0%)
+    prototype/unicode 8/8 (100.0%)
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
-    *Symbol.species 4/4 (100.0%)
+    Symbol.species 4/4 (100.0%)
     15.10.4.1-1.js
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
@@ -1243,7 +1243,7 @@ built-ins/RegExp 926/1464 (63.25%)
     valid-flags-y.js
 
 built-ins/Set 5/188 (2.66%)
-    *Symbol.species 4/4 (100.0%)
+    Symbol.species 4/4 (100.0%)
     proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
 built-ins/SetIteratorPrototype 0/11 (0.0%)
@@ -1261,11 +1261,11 @@ built-ins/String 121/1114 (10.86%)
     prototype/indexOf/searchstring-tostring-errors.js {unsupported: [computed-property-names]}
     prototype/indexOf/searchstring-tostring-toprimitive.js {unsupported: [computed-property-names]}
     prototype/indexOf/searchstring-tostring-wrapped-values.js {unsupported: [computed-property-names]}
-    *prototype/matchAll 19/19 (100.0%)
+    prototype/matchAll 19/19 (100.0%)
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/invoke-builtin-match.js
-    *prototype/replaceAll 40/40 (100.0%)
+    prototype/replaceAll 40/40 (100.0%)
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
     prototype/replace/S15.5.4.11_A12.js non-strict
@@ -1319,14 +1319,14 @@ built-ins/String 121/1114 (10.86%)
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
 built-ins/Symbol 32/85 (37.65%)
-    *asyncIterator 2/2 (100.0%)
+    asyncIterator 2/2 (100.0%)
     for/cross-realm.js {unsupported: [cross-realm]}
     hasInstance/cross-realm.js {unsupported: [cross-realm]}
     isConcatSpreadable/cross-realm.js {unsupported: [cross-realm]}
     iterator/cross-realm.js {unsupported: [cross-realm]}
     keyFor/arg-non-symbol.js
     keyFor/cross-realm.js {unsupported: [cross-realm]}
-    *matchAll 2/2 (100.0%)
+    matchAll 2/2 (100.0%)
     match/cross-realm.js {unsupported: [cross-realm]}
     prototype/description/description-symboldescriptivestring.js
     prototype/description/descriptor.js
@@ -1340,7 +1340,7 @@ built-ins/Symbol 32/85 (37.65%)
     prototype/valueOf/this-val-non-obj.js
     replace/cross-realm.js {unsupported: [cross-realm]}
     search/cross-realm.js {unsupported: [cross-realm]}
-    *species 4/4 (100.0%)
+    species 4/4 (100.0%)
     split/cross-realm.js {unsupported: [cross-realm]}
     toPrimitive/cross-realm.js {unsupported: [cross-realm]}
     toStringTag/cross-realm.js {unsupported: [cross-realm]}
@@ -1370,7 +1370,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     of/length.js
     of/name.js
     of/prop-desc.js
-    *prototype/buffer/BigInt 2/2 (100.0%)
+    prototype/buffer/BigInt 2/2 (100.0%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-func.js
     prototype/buffer/length.js
@@ -1379,7 +1379,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/buffer/this-has-no-typedarrayname-internal.js
     prototype/buffer/this-inherits-typedarray.js
     prototype/buffer/this-is-not-object.js
-    *prototype/byteLength/BigInt 2/2 (100.0%)
+    prototype/byteLength/BigInt 2/2 (100.0%)
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-func.js
     prototype/byteLength/length.js
@@ -1387,7 +1387,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/byteLength/prop-desc.js
     prototype/byteLength/this-has-no-typedarrayname-internal.js
     prototype/byteLength/this-is-not-object.js
-    *prototype/byteOffset/BigInt 2/2 (100.0%)
+    prototype/byteOffset/BigInt 2/2 (100.0%)
     prototype/byteOffset/detached-buffer.js
     prototype/byteOffset/invoked-as-func.js
     prototype/byteOffset/length.js
@@ -1395,7 +1395,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/byteOffset/prop-desc.js
     prototype/byteOffset/this-has-no-typedarrayname-internal.js
     prototype/byteOffset/this-is-not-object.js
-    *prototype/copyWithin/BigInt 23/23 (100.0%)
+    prototype/copyWithin/BigInt 23/23 (100.0%)
     prototype/copyWithin/bit-precision.js
     prototype/copyWithin/coerced-values-end.js
     prototype/copyWithin/coerced-values-start.js
@@ -1424,9 +1424,9 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/copyWithin/this-is-not-object.js
     prototype/copyWithin/this-is-not-typedarray-instance.js
     prototype/copyWithin/undefined-end.js
-    *prototype/entries/BigInt 3/3 (100.0%)
-    *prototype/entries 10/10 (100.0%)
-    *prototype/every/BigInt 15/15 (100.0%)
+    prototype/entries/BigInt 3/3 (100.0%)
+    prototype/entries 10/10 (100.0%)
+    prototype/every/BigInt 15/15 (100.0%)
     prototype/every/callbackfn-arguments-with-thisarg.js
     prototype/every/callbackfn-arguments-without-thisarg.js
     prototype/every/callbackfn-detachbuffer.js
@@ -1448,7 +1448,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/every/this-is-not-object.js
     prototype/every/this-is-not-typedarray-instance.js
     prototype/every/values-are-not-cached.js
-    *prototype/fill/BigInt 17/17 (100.0%)
+    prototype/fill/BigInt 17/17 (100.0%)
     prototype/fill/coerced-indexes.js
     prototype/fill/detached-buffer.js
     prototype/fill/fill-values.js
@@ -1471,7 +1471,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/fill/return-this.js
     prototype/fill/this-is-not-object.js
     prototype/fill/this-is-not-typedarray-instance.js
-    *prototype/filter/BigInt 33/33 (100.0%)
+    prototype/filter/BigInt 33/33 (100.0%)
     prototype/filter/arraylength-internal.js
     prototype/filter/callbackfn-arguments-with-thisarg.js
     prototype/filter/callbackfn-arguments-without-thisarg.js
@@ -1510,8 +1510,8 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/filter/values-are-not-cached.js
     prototype/filter/values-are-set.js
-    *prototype/find/BigInt 12/12 (100.0%)
-    *prototype/findIndex/BigInt 12/12 (100.0%)
+    prototype/find/BigInt 12/12 (100.0%)
+    prototype/findIndex/BigInt 12/12 (100.0%)
     prototype/findIndex/detached-buffer.js
     prototype/findIndex/get-length-ignores-length-prop.js
     prototype/findIndex/invoked-as-func.js
@@ -1548,7 +1548,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/find/return-undefined-if-predicate-returns-false-value.js
     prototype/find/this-is-not-object.js
     prototype/find/this-is-not-typedarray-instance.js
-    *prototype/forEach/BigInt 14/14 (100.0%)
+    prototype/forEach/BigInt 14/14 (100.0%)
     prototype/forEach/arraylength-internal.js
     prototype/forEach/callbackfn-arguments-with-thisarg.js
     prototype/forEach/callbackfn-arguments-without-thisarg.js
@@ -1569,7 +1569,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/forEach/this-is-not-object.js
     prototype/forEach/this-is-not-typedarray-instance.js
     prototype/forEach/values-are-not-cached.js
-    *prototype/includes/BigInt 11/11 (100.0%)
+    prototype/includes/BigInt 11/11 (100.0%)
     prototype/includes/detached-buffer.js
     prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
     prototype/includes/fromIndex-infinity.js
@@ -1589,7 +1589,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/includes/this-is-not-object.js
     prototype/includes/this-is-not-typedarray-instance.js
     prototype/includes/tointeger-fromindex.js
-    *prototype/indexOf/BigInt 12/12 (100.0%)
+    prototype/indexOf/BigInt 12/12 (100.0%)
     prototype/indexOf/detached-buffer.js
     prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
     prototype/indexOf/fromIndex-infinity.js
@@ -1609,7 +1609,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/indexOf/this-is-not-object.js
     prototype/indexOf/this-is-not-typedarray-instance.js
     prototype/indexOf/tointeger-fromindex.js
-    *prototype/join/BigInt 7/7 (100.0%)
+    prototype/join/BigInt 7/7 (100.0%)
     prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
     prototype/join/custom-separator-result-from-tostring-on-each-value.js
     prototype/join/detached-buffer.js
@@ -1625,9 +1625,9 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/join/return-abrupt-from-separator.js
     prototype/join/this-is-not-object.js
     prototype/join/this-is-not-typedarray-instance.js
-    *prototype/keys/BigInt 3/3 (100.0%)
-    *prototype/keys 10/10 (100.0%)
-    *prototype/lastIndexOf/BigInt 11/11 (100.0%)
+    prototype/keys/BigInt 3/3 (100.0%)
+    prototype/keys 10/10 (100.0%)
+    prototype/lastIndexOf/BigInt 11/11 (100.0%)
     prototype/lastIndexOf/detached-buffer.js
     prototype/lastIndexOf/fromIndex-infinity.js
     prototype/lastIndexOf/fromIndex-minus-zero.js
@@ -1646,7 +1646,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/lastIndexOf/this-is-not-object.js
     prototype/lastIndexOf/this-is-not-typedarray-instance.js
     prototype/lastIndexOf/tointeger-fromindex.js
-    *prototype/length/BigInt 2/2 (100.0%)
+    prototype/length/BigInt 2/2 (100.0%)
     prototype/length/detached-buffer.js
     prototype/length/invoked-as-func.js
     prototype/length/length.js
@@ -1654,7 +1654,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/length/prop-desc.js
     prototype/length/this-has-no-typedarrayname-internal.js
     prototype/length/this-is-not-object.js
-    *prototype/map/BigInt 31/31 (100.0%)
+    prototype/map/BigInt 31/31 (100.0%)
     prototype/map/arraylength-internal.js
     prototype/map/callbackfn-arguments-with-thisarg.js
     prototype/map/callbackfn-arguments-without-thisarg.js
@@ -1693,8 +1693,8 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/map/values-are-not-cached.js
-    *prototype/reduce/BigInt 18/18 (100.0%)
-    *prototype/reduceRight/BigInt 18/18 (100.0%)
+    prototype/reduce/BigInt 18/18 (100.0%)
+    prototype/reduceRight/BigInt 18/18 (100.0%)
     prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
     prototype/reduceRight/callbackfn-arguments-default-accumulator.js
     prototype/reduceRight/callbackfn-detachbuffer.js
@@ -1741,9 +1741,9 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/reduce/this-is-not-object.js
     prototype/reduce/this-is-not-typedarray-instance.js
     prototype/reduce/values-are-not-cached.js
-    *prototype/reverse/BigInt 5/5 (100.0%)
-    *prototype/reverse 12/12 (100.0%)
-    *prototype/set/BigInt 48/48 (100.0%)
+    prototype/reverse/BigInt 5/5 (100.0%)
+    prototype/reverse 12/12 (100.0%)
+    prototype/set/BigInt 48/48 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-offset-tointeger.js
     prototype/set/array-arg-primitive-toobject.js
@@ -1789,7 +1789,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/set/typedarray-arg-target-arraylength-internal.js
     prototype/set/typedarray-arg-target-byteoffset-internal.js
     prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    *prototype/slice/BigInt 35/35 (100.0%)
+    prototype/slice/BigInt 35/35 (100.0%)
     prototype/slice/arraylength-internal.js
     prototype/slice/bit-precision.js
     prototype/slice/detached-buffer.js
@@ -1829,7 +1829,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/slice/tointeger-end.js
     prototype/slice/tointeger-start.js
-    *prototype/some/BigInt 15/15 (100.0%)
+    prototype/some/BigInt 15/15 (100.0%)
     prototype/some/callbackfn-arguments-with-thisarg.js
     prototype/some/callbackfn-arguments-without-thisarg.js
     prototype/some/callbackfn-detachbuffer.js
@@ -1851,7 +1851,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/some/this-is-not-object.js
     prototype/some/this-is-not-typedarray-instance.js
     prototype/some/values-are-not-cached.js
-    *prototype/sort/BigInt 9/9 (100.0%)
+    prototype/sort/BigInt 9/9 (100.0%)
     prototype/sort/arraylength-internal.js
     prototype/sort/comparefn-call-throws.js
     prototype/sort/comparefn-calls.js
@@ -1871,7 +1871,7 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/sort/stability.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
-    *prototype/subarray/BigInt 27/27 (100.0%)
+    prototype/subarray/BigInt 27/27 (100.0%)
     prototype/subarray/detached-buffer.js
     prototype/subarray/infinity.js
     prototype/subarray/invoked-as-func.js
@@ -1899,9 +1899,9 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/subarray/this-is-not-typedarray-instance.js
     prototype/subarray/tointeger-begin.js
     prototype/subarray/tointeger-end.js
-    *prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
-    *prototype/Symbol.toStringTag 9/9 (100.0%)
-    *prototype/toLocaleString/BigInt 13/13 (100.0%)
+    prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
+    prototype/Symbol.toStringTag 9/9 (100.0%)
+    prototype/toLocaleString/BigInt 13/13 (100.0%)
     prototype/toLocaleString/calls-tolocalestring-from-each-value.js
     prototype/toLocaleString/calls-tostring-from-each-value.js
     prototype/toLocaleString/calls-valueof-from-each-value.js
@@ -1922,25 +1922,25 @@ built-ins/TypedArray 1006/1070 (94.02%)
     prototype/toLocaleString/this-is-not-typedarray-instance.js
     prototype/toString/BigInt/detached-buffer.js
     prototype/toString/detached-buffer.js
-    *prototype/values/BigInt 3/3 (100.0%)
-    *prototype/values 10/10 (100.0%)
-    *prototype 3/3 (100.0%)
-    *Symbol.species 4/4 (100.0%)
+    prototype/values/BigInt 3/3 (100.0%)
+    prototype/values 10/10 (100.0%)
+    prototype 3/3 (100.0%)
+    Symbol.species 4/4 (100.0%)
     invoked.js
     length.js
     name.js
     prototype.js
 
 built-ins/TypedArrayConstructors 530/684 (77.49%)
-    *BigInt64Array/prototype 4/4 (100.0%)
-    *BigInt64Array 7/7 (100.0%)
-    *BigUint64Array/prototype 4/4 (100.0%)
-    *BigUint64Array 7/7 (100.0%)
-    *ctors-bigint/buffer-arg 52/52 (100.0%)
-    *ctors-bigint/length-arg 12/12 (100.0%)
-    *ctors-bigint/no-args 7/7 (100.0%)
-    *ctors-bigint/object-arg 31/31 (100.0%)
-    *ctors-bigint/typedarray-arg 27/27 (100.0%)
+    BigInt64Array/prototype 4/4 (100.0%)
+    BigInt64Array 7/7 (100.0%)
+    BigUint64Array/prototype 4/4 (100.0%)
+    BigUint64Array 7/7 (100.0%)
+    ctors-bigint/buffer-arg 52/52 (100.0%)
+    ctors-bigint/length-arg 12/12 (100.0%)
+    ctors-bigint/no-args 7/7 (100.0%)
+    ctors-bigint/object-arg 31/31 (100.0%)
+    ctors-bigint/typedarray-arg 27/27 (100.0%)
     ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-throws.js
     ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2036,7 +2036,7 @@ built-ins/TypedArrayConstructors 530/684 (77.49%)
     Float32Array/prototype/proto.js
     Float64Array/prototype/not-typedarray-object.js
     Float64Array/prototype/proto.js
-    *from/BigInt 28/28 (100.0%)
+    from/BigInt 28/28 (100.0%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/custom-ctor.js
@@ -2066,10 +2066,10 @@ built-ins/TypedArrayConstructors 530/684 (77.49%)
     Int32Array/prototype/proto.js
     Int8Array/prototype/not-typedarray-object.js
     Int8Array/prototype/proto.js
-    *internals/DefineOwnProperty/BigInt 20/20 (100.0%)
-    *internals/DefineOwnProperty 22/22 (100.0%)
-    *internals/Get/BigInt 14/14 (100.0%)
-    *internals/GetOwnProperty/BigInt 12/12 (100.0%)
+    internals/DefineOwnProperty/BigInt 20/20 (100.0%)
+    internals/DefineOwnProperty 22/22 (100.0%)
+    internals/Get/BigInt 14/14 (100.0%)
+    internals/GetOwnProperty/BigInt 12/12 (100.0%)
     internals/GetOwnProperty/detached-buffer.js
     internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     internals/GetOwnProperty/detached-buffer-key-is-symbol.js
@@ -2089,11 +2089,11 @@ built-ins/TypedArrayConstructors 530/684 (77.49%)
     internals/Get/key-is-not-numeric-index.js
     internals/Get/key-is-out-of-bounds.js
     internals/Get/key-is-symbol.js
-    *internals/HasProperty/BigInt 15/15 (100.0%)
-    *internals/HasProperty 15/15 (100.0%)
-    *internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
-    *internals/OwnPropertyKeys 4/4 (100.0%)
-    *internals/Set/BigInt 23/23 (100.0%)
+    internals/HasProperty/BigInt 15/15 (100.0%)
+    internals/HasProperty 15/15 (100.0%)
+    internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
+    internals/OwnPropertyKeys 4/4 (100.0%)
+    internals/Set/BigInt 23/23 (100.0%)
     internals/Set/detached-buffer.js
     internals/Set/detached-buffer-key-is-not-numeric-index.js {unsupported: [Reflect]}
     internals/Set/detached-buffer-key-is-symbol.js {unsupported: [Reflect]}
@@ -2107,7 +2107,7 @@ built-ins/TypedArrayConstructors 530/684 (77.49%)
     internals/Set/key-is-symbol.js {unsupported: [Reflect]}
     internals/Set/tonumber-value-detached-buffer.js {unsupported: [Reflect]}
     internals/Set/tonumber-value-throws.js
-    *of/BigInt 12/12 (100.0%)
+    of/BigInt 12/12 (100.0%)
     of/argument-number-value-throws.js
     of/custom-ctor.js
     of/custom-ctor-returns-other-instance.js
@@ -2116,9 +2116,9 @@ built-ins/TypedArrayConstructors 530/684 (77.49%)
     of/new-instance-empty.js
     of/new-instance-from-zero.js
     of/new-instance-using-custom-ctor.js
-    *prototype/buffer 2/2 (100.0%)
-    *prototype/byteLength 2/2 (100.0%)
-    *prototype/byteOffset 2/2 (100.0%)
+    prototype/buffer 2/2 (100.0%)
+    prototype/byteLength 2/2 (100.0%)
+    prototype/byteOffset 2/2 (100.0%)
     prototype/copyWithin/bigint-inherited.js
     prototype/entries/bigint-inherited.js
     prototype/every/bigint-inherited.js
@@ -2131,21 +2131,21 @@ built-ins/TypedArrayConstructors 530/684 (77.49%)
     prototype/join/bigint-inherited.js
     prototype/keys/bigint-inherited.js
     prototype/lastIndexOf/bigint-inherited.js
-    *prototype/length 2/2 (100.0%)
+    prototype/length 2/2 (100.0%)
     prototype/map/bigint-inherited.js
     prototype/reduceRight/bigint-inherited.js
     prototype/reduce/bigint-inherited.js
     prototype/reverse/bigint-inherited.js
-    *prototype/set 2/2 (100.0%)
+    prototype/set 2/2 (100.0%)
     prototype/slice/bigint-inherited.js
     prototype/some/bigint-inherited.js
     prototype/sort/bigint-inherited.js
-    *prototype/subarray 2/2 (100.0%)
+    prototype/subarray 2/2 (100.0%)
     prototype/Symbol.toStringTag/bigint-inherited.js
     prototype/toLocaleString/bigint-inherited.js
-    *prototype/toString 2/2 (100.0%)
+    prototype/toString 2/2 (100.0%)
     prototype/values/bigint-inherited.js
-    *prototype 2/2 (100.0%)
+    prototype 2/2 (100.0%)
     Uint16Array/prototype/not-typedarray-object.js
     Uint16Array/prototype/proto.js
     Uint32Array/prototype/not-typedarray-object.js
@@ -2444,7 +2444,7 @@ language/block-scope 82/145 (56.55%)
     syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
 language/comments 37/52 (71.15%)
-    *hashbang 29/29 (100.0%)
+    hashbang 29/29 (100.0%)
     mongolian-vowel-separator-multi.js {unsupported: [u180e]}
     mongolian-vowel-separator-single.js {unsupported: [u180e]}
     mongolian-vowel-separator-single-eval.js {unsupported: [u180e]}
@@ -2977,7 +2977,7 @@ language/expressions/arrow-function 283/333 (84.98%)
     dstr/syntax-error-ident-ref-void-escaped.js
     dstr/syntax-error-ident-ref-while-escaped.js
     dstr/syntax-error-ident-ref-with-escaped.js
-    *syntax/early-errors 25/25 (100.0%)
+    syntax/early-errors 25/25 (100.0%)
     syntax/arrowparameters-bindingidentifier-yield.js non-strict
     syntax/arrowparameters-cover-formalparameters-yield.js non-strict
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
@@ -3424,7 +3424,7 @@ language/expressions/function 212/248 (85.48%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    *early-errors 4/4 (100.0%)
+    early-errors 4/4 (100.0%)
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
@@ -5192,7 +5192,7 @@ language/literals 117/434 (26.96%)
     numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     numeric/numeric-followed-by-ident.js
-    *regexp/named-groups 56/56 (100.0%)
+    regexp/named-groups 56/56 (100.0%)
     regexp/early-err-pattern.js Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,44 +1,79 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array 106/2583 (4.1%)
+built-ins/Array 161/2624 (6.14%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
     from/iter-set-elem-prop-err.js non-strict Error propagation needs work in general
+    from/proto-from-ctor-realm.js {unsupported: [cross-realm]}
     from/source-object-constructor.js Error propagation needs work in general
     from/source-object-iterator-1.js Uses "get" syntax that's not implemented
     from/source-object-iterator-2.js Uses "get" syntax that's not implemented
+    isArray/proxy-revoked.js {unsupported: [Proxy]}
+    isArray/proxy.js {unsupported: [Proxy]}
+    length/define-own-prop-length-overflow-realm.js {unsupported: [cross-realm]}
+    of/proto-from-ctor-realm.js {unsupported: [cross-realm]}
+    of/return-abrupt-from-data-property-using-proxy.js {unsupported: [Proxy]}
     of/return-abrupt-from-data-property.js Object.preventExtensions doesn't seem to throw
     prototype/concat/Array.prototype.concat_large-typed-array.js new
     prototype/concat/Array.prototype.concat_non-array.js
     prototype/concat/Array.prototype.concat_small-typed-array.js
     prototype/concat/create-ctor-non-object.js
     prototype/concat/create-ctor-poisoned.js
-    prototype/concat/create-species-abrupt.js
-    prototype/concat/create-species-non-ctor.js
-    prototype/concat/create-species-poisoned.js
-    prototype/concat/create-species.js
+    prototype/concat/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/concat/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/concat/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/concat/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/concat/create-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-null.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-poisoned.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species.js {unsupported: [Symbol.species]}
+    prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js {unsupported: [Proxy]}
+    prototype/concat/is-concat-spreadable-proxy-revoked.js {unsupported: [Proxy]}
+    prototype/concat/is-concat-spreadable-proxy.js {unsupported: [Proxy]}
+    prototype/copyWithin/return-abrupt-from-delete-proxy-target.js {unsupported: [Proxy]}
     prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
+    prototype/copyWithin/return-abrupt-from-has-start.js {unsupported: [Proxy]}
     prototype/every/15.4.4.16-5-1-s.js non-strict
     prototype/filter/15.4.4.20-5-1-s.js non-strict
     prototype/filter/create-ctor-non-object.js
     prototype/filter/create-ctor-poisoned.js
-    prototype/filter/create-species-abrupt.js
-    prototype/filter/create-species-non-ctor.js
-    prototype/filter/create-species-poisoned.js
-    prototype/filter/create-species.js
+    prototype/filter/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/filter/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/filter/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/filter/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/filter/create-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/filter/create-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/filter/create-species-null.js {unsupported: [Symbol.species]}
+    prototype/filter/create-species-poisoned.js {unsupported: [Symbol.species]}
+    prototype/filter/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/filter/create-species.js {unsupported: [Symbol.species]}
+    prototype/filter/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
     *prototype/flatMap 18/18 (100.0%)
     *prototype/flat 14/14 (100.0%)
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
+    prototype/includes/get-prop.js {unsupported: [Proxy]}
+    prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
+    prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
     prototype/map/15.4.4.19-5-1-s.js non-strict
     prototype/map/create-ctor-non-object.js
     prototype/map/create-ctor-poisoned.js
-    prototype/map/create-species-abrupt.js
-    prototype/map/create-species-non-ctor.js
-    prototype/map/create-species-poisoned.js
-    prototype/map/create-species.js
+    prototype/map/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/map/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/map/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/map/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/map/create-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/map/create-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/map/create-species-null.js {unsupported: [Symbol.species]}
+    prototype/map/create-species-poisoned.js {unsupported: [Symbol.species]}
+    prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
+    prototype/map/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/map/create-species.js {unsupported: [Symbol.species]}
+    prototype/map/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
     prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
@@ -46,12 +81,20 @@ built-ins/Array 106/2583 (4.1%)
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
     prototype/slice/create-ctor-non-object.js
     prototype/slice/create-ctor-poisoned.js
-    prototype/slice/create-species-abrupt.js
-    prototype/slice/create-species-neg-zero.js
-    prototype/slice/create-species-non-ctor.js
-    prototype/slice/create-species-poisoned.js
-    prototype/slice/create-species.js
+    prototype/slice/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/slice/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/slice/create-proxied-array-invalid-len.js {unsupported: [Proxy]}
+    prototype/slice/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/slice/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/slice/create-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species-neg-zero.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species-null.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species-poisoned.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species.js {unsupported: [Symbol.species]}
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
+    prototype/slice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/some/15.4.4.17-5-1-s.js non-strict
     prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/sort/stability-2048-elements.js
@@ -59,40 +102,60 @@ built-ins/Array 106/2583 (4.1%)
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-ctor-non-object.js
     prototype/splice/create-ctor-poisoned.js
-    prototype/splice/create-species-abrupt.js
-    prototype/splice/create-species-length-exceeding-integer-limit.js
-    prototype/splice/create-species-neg-zero.js
-    prototype/splice/create-species-non-ctor.js
-    prototype/splice/create-species-poisoned.js
-    prototype/splice/create-species.js
+    prototype/splice/create-proto-from-ctor-realm-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/splice/create-proto-from-ctor-realm-non-array.js {unsupported: [cross-realm, Symbol.species]}
+    prototype/splice/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/splice/create-revoked-proxy.js {unsupported: [Proxy]}
+    prototype/splice/create-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-length-exceeding-integer-limit.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-neg-zero.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-null.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-poisoned.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species-undef-invalid-len.js {unsupported: [Proxy]}
+    prototype/splice/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species.js {unsupported: [Symbol.species]}
+    prototype/splice/property-traps-order-with-species.js {unsupported: [Proxy, Symbol.species]}
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
     prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
+    prototype/splice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     *prototype/Symbol.unscopables 2/2 (100.0%)
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/Symbol.iterator.js Expects a particular string value
     *Symbol.species 4/4 (100.0%)
+    proto-from-ctor-realm-one.js {unsupported: [Reflect, cross-realm]}
+    proto-from-ctor-realm-two.js {unsupported: [Reflect, cross-realm]}
+    proto-from-ctor-realm-zero.js {unsupported: [Reflect, cross-realm]}
 
-built-ins/ArrayBuffer 22/72 (30.56%)
+built-ins/ArrayBuffer 30/80 (37.5%)
+    isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
+    isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-accessor.js
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
+    prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/slice/species-constructor-is-not-object.js
     prototype/slice/species-constructor-is-undefined.js
-    prototype/slice/species-is-not-constructor.js
-    prototype/slice/species-is-not-object.js
-    prototype/slice/species-is-null.js
-    prototype/slice/species-is-undefined.js
-    prototype/slice/species-returns-larger-arraybuffer.js
-    prototype/slice/species-returns-not-arraybuffer.js
-    prototype/slice/species-returns-same-arraybuffer.js
-    prototype/slice/species-returns-smaller-arraybuffer.js
-    prototype/slice/species.js
+    prototype/slice/species-is-not-constructor.js {unsupported: [Symbol.species]}
+    prototype/slice/species-is-not-object.js {unsupported: [Symbol.species]}
+    prototype/slice/species-is-null.js {unsupported: [Symbol.species]}
+    prototype/slice/species-is-undefined.js {unsupported: [Symbol.species]}
+    prototype/slice/species-returns-larger-arraybuffer.js {unsupported: [Symbol.species]}
+    prototype/slice/species-returns-not-arraybuffer.js {unsupported: [Symbol.species]}
+    prototype/slice/species-returns-same-arraybuffer.js {unsupported: [Symbol.species]}
+    prototype/slice/species-returns-smaller-arraybuffer.js {unsupported: [Symbol.species]}
+    prototype/slice/species.js {unsupported: [Symbol.species]}
+    prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/Symbol.toStringTag.js
     *Symbol.species 4/4 (100.0%)
+    data-allocation-after-object-creation.js {unsupported: [Reflect.construct]}
+    newtarget-prototype-is-not-object.js {unsupported: [Reflect.construct]}
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    prototype-from-newtarget.js {unsupported: [Reflect.construct]}
     undefined-newtarget-throws.js
 
 built-ins/ArrayIteratorPrototype 1/27 (3.7%)
@@ -102,28 +165,48 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 2/54 (3.7%)
+built-ins/BigInt 15/67 (22.39%)
+    asIntN/bigint-tobigint-errors.js {unsupported: [computed-property-names]}
+    asIntN/bigint-tobigint-toprimitive.js {unsupported: [computed-property-names]}
+    asIntN/bigint-tobigint-wrapped-values.js {unsupported: [computed-property-names]}
+    asIntN/bits-toindex-errors.js {unsupported: [computed-property-names]}
+    asIntN/bits-toindex-toprimitive.js {unsupported: [computed-property-names]}
+    asIntN/bits-toindex-wrapped-values.js {unsupported: [computed-property-names]}
+    asUintN/bigint-tobigint-errors.js {unsupported: [computed-property-names]}
+    asUintN/bigint-tobigint-toprimitive.js {unsupported: [computed-property-names]}
+    asUintN/bigint-tobigint-wrapped-values.js {unsupported: [computed-property-names]}
+    asUintN/bits-toindex-errors.js {unsupported: [computed-property-names]}
+    asUintN/bits-toindex-toprimitive.js {unsupported: [computed-property-names]}
+    asUintN/bits-toindex-wrapped-values.js {unsupported: [computed-property-names]}
     prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     prototype/toString/thisbigintvalue-not-valid-throws.js Computed property is not support
+    prototype/valueOf/cross-realm.js {unsupported: [cross-realm]}
 
-built-ins/Boolean 0/47 (0.0%)
+built-ins/Boolean 1/48 (2.08%)
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-built-ins/DataView 116/405 (28.64%)
+built-ins/DataView 166/455 (36.48%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-accessor.js
     prototype/buffer/length.js
     prototype/buffer/name.js
     prototype/buffer/prop-desc.js
+    prototype/buffer/return-buffer-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/buffer/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-accessor.js
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
+    prototype/byteLength/return-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/byteLength/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/detached-buffer.js
     prototype/byteOffset/invoked-as-accessor.js
     prototype/byteOffset/length.js
     prototype/byteOffset/name.js
     prototype/byteOffset/prop-desc.js
+    prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigInt64/detached-buffer-before-outofrange-byteoffset.js
     prototype/getBigInt64/detached-buffer.js
@@ -136,6 +219,9 @@ built-ins/DataView 116/405 (28.64%)
     prototype/getBigInt64/return-values-custom-offset.js
     prototype/getBigInt64/return-values.js
     prototype/getBigInt64/to-boolean-littleendian.js
+    prototype/getBigInt64/toindex-byteoffset-errors.js {unsupported: [computed-property-names]}
+    prototype/getBigInt64/toindex-byteoffset-toprimitive.js {unsupported: [computed-property-names]}
+    prototype/getBigInt64/toindex-byteoffset-wrapped-values.js {unsupported: [computed-property-names]}
     prototype/getBigInt64/toindex-byteoffset.js
     prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
@@ -149,6 +235,9 @@ built-ins/DataView 116/405 (28.64%)
     prototype/getBigUint64/return-values-custom-offset.js
     prototype/getBigUint64/return-values.js
     prototype/getBigUint64/to-boolean-littleendian.js
+    prototype/getBigUint64/toindex-byteoffset-errors.js {unsupported: [computed-property-names]}
+    prototype/getBigUint64/toindex-byteoffset-toprimitive.js {unsupported: [computed-property-names]}
+    prototype/getBigUint64/toindex-byteoffset-wrapped-values.js {unsupported: [computed-property-names]}
     prototype/getBigUint64/toindex-byteoffset.js
     prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
@@ -162,6 +251,16 @@ built-ins/DataView 116/405 (28.64%)
     prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt32/detached-buffer.js
+    prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-value-clean-arraybuffer-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-values-custom-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-values-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/to-boolean-littleendian-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt8/detached-buffer.js
@@ -223,10 +322,38 @@ built-ins/DataView 116/405 (28.64%)
     prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint8/detached-buffer.js
     prototype/Symbol.toStringTag.js
+    buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
+    byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    custom-proto-access-detaches-buffer.js {unsupported: [Reflect.construct]}
+    custom-proto-access-throws-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
+    custom-proto-access-throws.js {unsupported: [Reflect.construct]}
+    custom-proto-if-not-object-fallbacks-to-default-prototype-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
+    custom-proto-if-not-object-fallbacks-to-default-prototype.js {unsupported: [Reflect.construct]}
+    custom-proto-if-object-is-used-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
+    custom-proto-if-object-is-used.js {unsupported: [Reflect.construct]}
+    defined-bytelength-and-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    defined-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    defined-byteoffset-undefined-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     detached-buffer.js
+    excessive-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    excessive-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
+    negative-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    newtarget-undefined-throws-sab.js {unsupported: [SharedArrayBuffer]}
     newtarget-undefined-throws.js
+    proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect, cross-realm]}
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    return-abrupt-tonumber-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-bytelength-symbol-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
+    return-instance-sab.js {unsupported: [SharedArrayBuffer]}
+    toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
 
-built-ins/Date 32/697 (4.59%)
+built-ins/Date 37/702 (5.27%)
     prototype/setFullYear/15.9.5.40_1.js
     prototype/Symbol.toPrimitive/hint-default-first-invalid.js
     prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
@@ -242,12 +369,17 @@ built-ins/Date 32/697 (4.59%)
     prototype/Symbol.toPrimitive/name.js
     prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/this-val-non-obj.js
+    prototype/toJSON/builtin.js {unsupported: [Reflect.construct]}
     prototype/toJSON/invoke-result.js
     prototype/toJSON/to-primitive-symbol.js
     prototype/toJSON/to-primitive-value-of.js
     prototype/toString/non-date-receiver.js
     UTC/coercion-order.js
     coercion-order.js
+    proto-from-ctor-realm-one.js {unsupported: [Reflect, cross-realm]}
+    proto-from-ctor-realm-two.js {unsupported: [Reflect, cross-realm]}
+    proto-from-ctor-realm-zero.js {unsupported: [Reflect, cross-realm]}
+    subclassing.js {unsupported: [Reflect]}
     value-get-symbol-to-prim-err.js
     value-symbol-to-prim-err.js
     value-symbol-to-prim-invocation.js
@@ -278,14 +410,18 @@ built-ins/encodeURIComponent 2/29 (6.9%)
     name.js
     S15.1.3.4_A5.2.js
 
-built-ins/Error 2/36 (5.56%)
+built-ins/Error 3/37 (8.11%)
     prototype/S15.11.4_A2.js
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-built-ins/eval 2/8 (25.0%)
+built-ins/eval 3/9 (33.33%)
     length-non-configurable.js
     name.js
+    private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
-built-ins/Function 145/459 (31.59%)
+built-ins/Function 195/509 (38.31%)
+    *internals/Call 2/2 (100.0%)
+    *internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
     length/S15.3.5.1_A2_T1.js
     length/S15.3.5.1_A2_T2.js
@@ -295,6 +431,7 @@ built-ins/Function 145/459 (31.59%)
     prototype/apply/15.3.4.3-1-s.js strict
     prototype/apply/15.3.4.3-2-s.js strict
     prototype/apply/15.3.4.3-3-s.js strict
+    prototype/apply/argarray-not-object-realm.js {unsupported: [cross-realm]}
     prototype/apply/argarray-not-object.js
     prototype/apply/S15.3.4.3_A3_T1.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T2.js non-interpreted
@@ -309,15 +446,23 @@ built-ins/Function 145/459 (31.59%)
     prototype/apply/S15.3.4.3_A7_T2.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T5.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T7.js non-interpreted
+    prototype/apply/this-not-callable-realm.js {unsupported: [cross-realm]}
     prototype/apply/this-not-callable.js
     prototype/bind/15.3.4.5-15-2.js
     prototype/bind/15.3.4.5-15-5.js
     prototype/bind/BoundFunction_restricted-properties.js
+    prototype/bind/get-fn-realm-recursive.js {unsupported: [cross-realm]}
+    prototype/bind/get-fn-realm.js {unsupported: [cross-realm]}
+    prototype/bind/instance-construct-newtarget-boundtarget-bound.js {unsupported: [Reflect, new.target]}
+    prototype/bind/instance-construct-newtarget-boundtarget.js {unsupported: [Reflect, new.target]}
+    prototype/bind/instance-construct-newtarget-self-new.js {unsupported: [new.target]}
+    prototype/bind/instance-construct-newtarget-self-reflect.js {unsupported: [Reflect, new.target]}
     prototype/bind/instance-name-chained.js
     prototype/bind/instance-name-error.js
     prototype/bind/instance-name-non-string.js
     prototype/bind/instance-name.js
     prototype/bind/length-exceeds-int32.js
+    prototype/bind/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     prototype/call/15.3.4.4-1-s.js strict
     prototype/call/15.3.4.4-2-s.js strict
     prototype/call/15.3.4.4-3-s.js strict
@@ -342,10 +487,28 @@ built-ins/Function 145/459 (31.59%)
     prototype/Symbol.hasInstance/this-val-bound-target.js
     prototype/Symbol.hasInstance/this-val-not-callable.js
     prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
+    prototype/Symbol.hasInstance/value-get-prototype-of-err.js {unsupported: [Proxy]}
     prototype/Symbol.hasInstance/value-negative.js
     prototype/Symbol.hasInstance/value-non-obj.js
     prototype/Symbol.hasInstance/value-positive.js
     prototype/toString/arrow-function.js
+    prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
+    prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
+    prototype/toString/async-function-expression.js {unsupported: [async-functions]}
+    prototype/toString/async-generator-declaration.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-expression.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-expression-static.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-expression.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-statement-static.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-statement.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-object.js {unsupported: [async-iteration]}
+    prototype/toString/async-method-class-expression-static.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-expression.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-statement-static.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-statement.js {unsupported: [async-functions]}
+    prototype/toString/async-method-object.js {unsupported: [async-functions]}
+    prototype/toString/AsyncFunction.js {unsupported: [async-functions]}
+    prototype/toString/AsyncGenerator.js {unsupported: [async-iteration]}
     prototype/toString/class-declaration-complex-heritage.js
     prototype/toString/class-declaration-explicit-ctor.js
     prototype/toString/class-declaration-implicit-ctor.js
@@ -377,6 +540,17 @@ built-ins/Function 145/459 (31.59%)
     prototype/toString/private-method-class-statement.js
     prototype/toString/private-static-method-class-expression.js
     prototype/toString/private-static-method-class-statement.js
+    prototype/toString/proxy-arrow-function.js {unsupported: [Proxy]}
+    prototype/toString/proxy-async-function.js {unsupported: [Proxy, async-functions]}
+    prototype/toString/proxy-async-generator-function.js {unsupported: [Proxy, async-iteration]}
+    prototype/toString/proxy-async-generator-method-definition.js {unsupported: [Proxy, async-iteration]}
+    prototype/toString/proxy-async-method-definition.js {unsupported: [Proxy, async-functions]}
+    prototype/toString/proxy-bound-function.js {unsupported: [Proxy]}
+    prototype/toString/proxy-class.js {unsupported: [Proxy, class]}
+    prototype/toString/proxy-function-expression.js {unsupported: [Proxy]}
+    prototype/toString/proxy-generator-function.js {unsupported: [Proxy]}
+    prototype/toString/proxy-method-definition.js {unsupported: [Proxy]}
+    prototype/toString/proxy-non-callable-throws.js {unsupported: [Proxy]}
     prototype/toString/S15.3.4.2_A12.js
     prototype/toString/S15.3.4.2_A13.js
     prototype/toString/setter-class-expression-static.js
@@ -429,7 +603,11 @@ built-ins/Function 145/459 (31.59%)
     15.3.5.4_2-5gs.js strict
     15.3.5.4_2-7gs.js strict
     15.3.5.4_2-9gs.js strict
+    call-bind-this-realm-undef.js {unsupported: [cross-realm]}
+    call-bind-this-realm-value.js {unsupported: [cross-realm]}
     instance-name.js
+    private-identifiers-not-empty.js {unsupported: [class-fields-private]}
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     StrictFunction_restricted-properties.js strict
 
 ~built-ins/GeneratorFunction
@@ -479,22 +657,45 @@ built-ins/isNaN 8/16 (50.0%)
 
 ~built-ins/IteratorPrototype
 
-built-ins/JSON 11/109 (10.09%)
+built-ins/JSON 33/131 (25.19%)
+    parse/builtin.js {unsupported: [Reflect.construct]}
+    parse/revived-proxy-revoked.js {unsupported: [Proxy]}
+    parse/revived-proxy.js {unsupported: [Proxy]}
+    parse/reviver-array-define-prop-err.js {unsupported: [Proxy]}
+    parse/reviver-array-delete-err.js {unsupported: [Proxy]}
+    parse/reviver-array-length-coerce-err.js {unsupported: [Proxy]}
+    parse/reviver-array-length-get-err.js {unsupported: [Proxy]}
+    parse/reviver-object-define-prop-err.js {unsupported: [Proxy]}
+    parse/reviver-object-delete-err.js {unsupported: [Proxy]}
+    parse/reviver-object-own-keys-err.js {unsupported: [Proxy]}
     parse/S15.12.2_A1.js
     parse/text-negative-zero.js
+    stringify/builtin.js {unsupported: [Reflect.construct]}
+    stringify/replacer-array-abrupt.js {unsupported: [Proxy]}
     stringify/replacer-array-number.js
+    stringify/replacer-array-proxy-revoked-realm.js {unsupported: [Proxy, cross-realm]}
+    stringify/replacer-array-proxy-revoked.js {unsupported: [Proxy]}
+    stringify/replacer-array-proxy.js {unsupported: [Proxy]}
+    stringify/replacer-array-wrong-type.js {unsupported: [Proxy]}
     stringify/replacer-function-arguments.js
     stringify/replacer-function-result.js
+    stringify/value-array-abrupt.js {unsupported: [Proxy]}
+    stringify/value-array-proxy-revoked.js {unsupported: [Proxy]}
+    stringify/value-array-proxy.js {unsupported: [Proxy]}
+    stringify/value-bigint-cross-realm.js {unsupported: [cross-realm]}
     stringify/value-bigint-tojson-receiver.js
+    stringify/value-object-proxy-revoked.js {unsupported: [Proxy]}
+    stringify/value-object-proxy.js {unsupported: [Proxy]}
     stringify/value-string-escape-ascii.js
     stringify/value-string-escape-unicode.js
     stringify/value-symbol.js
     stringify/value-tojson-arguments.js
     Symbol.toStringTag.js
 
-built-ins/Map 5/143 (3.5%)
+built-ins/Map 6/144 (4.17%)
     *Symbol.species 4/4 (100.0%)
     iterator-is-undefined-throws.js
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
 built-ins/MapIteratorPrototype 0/11 (0.0%)
 
@@ -504,22 +705,35 @@ built-ins/Math 2/273 (0.73%)
 
 built-ins/NaN 0/7 (0.0%)
 
-built-ins/NativeErrors 37/73 (50.68%)
+built-ins/NativeErrors 43/79 (54.43%)
     EvalError/prototype/not-error-object.js
+    EvalError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     RangeError/prototype/not-error-object.js
+    RangeError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     ReferenceError/prototype/not-error-object.js
+    ReferenceError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     SyntaxError/prototype/not-error-object.js
+    SyntaxError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     TypeError/prototype/not-error-object.js
+    TypeError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     URIError/prototype/not-error-object.js
+    URIError/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-built-ins/Number 5/277 (1.81%)
+built-ins/Number 9/281 (3.2%)
     prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     prototype/toExponential/undefined-fractiondigits.js
     prototype/toLocaleString/length.js
     prototype/toPrecision/nan.js
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    S9.3.1_A2_U180E.js {unsupported: [u180e]}
+    S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
+    S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 100/3097 (3.23%)
+built-ins/Object 118/3115 (3.79%)
+    assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
+    assign/source-own-prop-error.js {unsupported: [Proxy]}
+    assign/source-own-prop-keys-error.js {unsupported: [Proxy]}
     assign/strings-and-symbol-order.js
     create/15.2.3.5-4-311.js
     defineProperties/15.2.3.7-6-a-112.js non-strict
@@ -559,6 +773,7 @@ built-ins/Object 100/3097 (3.23%)
     defineProperty/15.2.3.6-4-293-3.js non-strict
     defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
+    entries/observable-operations.js {unsupported: [Proxy]}
     fromEntries/evaluation-order.js
     fromEntries/iterator-closed-for-null-entry.js
     fromEntries/iterator-closed-for-string-entry.js
@@ -576,10 +791,12 @@ built-ins/Object 100/3097 (3.23%)
     getOwnPropertyDescriptors/function-property-descriptor.js
     getOwnPropertyDescriptors/inherited-properties-omitted.js
     getOwnPropertyDescriptors/normal-object.js
+    getOwnPropertyDescriptors/observable-operations.js {unsupported: [Proxy]}
     getOwnPropertyDescriptors/primitive-booleans.js
     getOwnPropertyDescriptors/primitive-numbers.js
     getOwnPropertyDescriptors/primitive-strings.js
     getOwnPropertyDescriptors/primitive-symbols.js
+    getOwnPropertyDescriptors/proxy-undefined-descriptor.js {unsupported: [Proxy]}
     getOwnPropertyDescriptors/symbols-included.js
     getOwnPropertyDescriptors/tamper-with-global-object.js
     getOwnPropertyDescriptors/tamper-with-object-keys.js
@@ -600,6 +817,7 @@ built-ins/Object 100/3097 (3.23%)
     internals/DefineOwnProperty/consistent-value-function-caller.js
     internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
     internals/DefineOwnProperty/consistent-writable-regexp-dollar1.js
+    keys/property-traps-order-with-proxied-array.js {unsupported: [Proxy]}
     keys/proxy-keys.js
     prototype/hasOwnProperty/symbol_property_toPrimitive.js
     prototype/hasOwnProperty/symbol_property_toString.js
@@ -612,21 +830,34 @@ built-ins/Object 100/3097 (3.23%)
     prototype/toLocaleString/S15.2.4.3_A12.js
     prototype/toLocaleString/S15.2.4.3_A13.js
     prototype/toString/get-symbol-tag-err.js
+    prototype/toString/proxy-array.js {unsupported: [Proxy]}
+    prototype/toString/proxy-function-async.js {unsupported: [Proxy, async-functions]}
+    prototype/toString/proxy-function.js {unsupported: [Proxy, async-functions]}
+    prototype/toString/proxy-revoked.js {unsupported: [Proxy]}
     prototype/toString/symbol-tag-non-str-bigint.js
     prototype/toString/symbol-tag-non-str-builtin.js
+    prototype/toString/symbol-tag-non-str-proxy-function.js {unsupported: [Proxy, async-functions]}
     prototype/toString/symbol-tag-override-bigint.js
     prototype/toString/symbol-tag-override-instances.js
     prototype/toString/symbol-tag-override-primitives.js
     prototype/toString/symbol-tag-str.js
     prototype/valueOf/S15.2.4.4_A14.js
     prototype/valueOf/S15.2.4.4_A15.js
+    prototype/setPrototypeOf-with-different-values.js {unsupported: [Reflect.setPrototypeOf]}
+    prototype/setPrototypeOf-with-same-value.js {unsupported: [Reflect.setPrototypeOf]}
+    setPrototypeOf/set-error.js {unsupported: [Proxy]}
+    values/observable-operations.js {unsupported: [Proxy]}
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    subclass-object-arg.js {unsupported: [Reflect.construct, Reflect, class]}
 
-built-ins/parseFloat 2/56 (3.57%)
+built-ins/parseFloat 3/57 (5.26%)
     name.js
+    S15.1.2.3_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.3_A7.2.js
 
-built-ins/parseInt 2/58 (3.45%)
+built-ins/parseInt 3/59 (5.08%)
     name.js
+    S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.2_A9.2.js
 
 ~built-ins/Promise
@@ -635,9 +866,15 @@ built-ins/parseInt 2/58 (3.45%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 262/798 (32.83%)
+built-ins/RegExp 896/1432 (62.57%)
     *CharacterClassEscapes 24/24 (100.0%)
-    *match-indices 9/9 (100.0%)
+    *dotall 4/4 (100.0%)
+    *lookBehind 17/17 (100.0%)
+    *match-indices 13/13 (100.0%)
+    *named-groups 22/22 (100.0%)
+    *property-escapes/generated 395/395 (100.0%)
+    *property-escapes 143/143 (100.0%)
+    *prototype/dotAll 8/8 (100.0%)
     prototype/exec/failure-lastindex-access.js
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
@@ -649,22 +886,26 @@ built-ins/RegExp 262/798 (32.83%)
     prototype/exec/y-fail-return.js
     prototype/exec/y-init-lastindex.js
     prototype/exec/y-set-lastindex.js
-    *prototype/flags 10/10 (100.0%)
+    *prototype/flags 15/15 (100.0%)
     prototype/global/15.10.7.2-2.js
+    prototype/global/cross-realm.js {unsupported: [cross-realm]}
     prototype/global/length.js
     prototype/global/name.js
     prototype/global/S15.10.7.2_A9.js
     prototype/global/this-val-regexp-prototype.js
     prototype/ignoreCase/15.10.7.3-2.js
+    prototype/ignoreCase/cross-realm.js {unsupported: [cross-realm]}
     prototype/ignoreCase/length.js
     prototype/ignoreCase/name.js
     prototype/ignoreCase/S15.10.7.3_A9.js
     prototype/ignoreCase/this-val-regexp-prototype.js
     prototype/multiline/15.10.7.4-2.js
+    prototype/multiline/cross-realm.js {unsupported: [cross-realm]}
     prototype/multiline/length.js
     prototype/multiline/name.js
     prototype/multiline/S15.10.7.4_A9.js
     prototype/multiline/this-val-regexp-prototype.js
+    prototype/source/cross-realm.js {unsupported: [cross-realm]}
     prototype/source/length.js
     prototype/source/name.js
     prototype/source/prop-desc.js
@@ -672,7 +913,8 @@ built-ins/RegExp 262/798 (32.83%)
     prototype/source/value-empty.js
     prototype/source/value-line-terminator.js
     prototype/source/value-u.js
-    *prototype/sticky 7/7 (100.0%)
+    *prototype/sticky 8/8 (100.0%)
+    *prototype/Symbol.matchAll 25/25 (100.0%)
     prototype/Symbol.match/builtin-coerce-lastindex.js
     prototype/Symbol.match/builtin-failure-y-return-val.js
     prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
@@ -773,7 +1015,7 @@ built-ins/RegExp 262/798 (32.83%)
     prototype/Symbol.search/u-lastindex-advance.js
     prototype/Symbol.search/y-fail-return.js
     prototype/Symbol.split/coerce-flags-err.js
-    prototype/Symbol.split/coerce-flags.js
+    prototype/Symbol.split/coerce-flags.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/coerce-limit-err.js
     prototype/Symbol.split/coerce-limit.js
     prototype/Symbol.split/coerce-string-err.js
@@ -781,35 +1023,36 @@ built-ins/RegExp 262/798 (32.83%)
     prototype/Symbol.split/get-flags-err.js
     prototype/Symbol.split/last-index-exceeds-str-size.js
     prototype/Symbol.split/length.js
-    prototype/Symbol.split/limit-0-bail.js
+    prototype/Symbol.split/limit-0-bail.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/name.js
     prototype/Symbol.split/prop-desc.js
     prototype/Symbol.split/species-ctor-ctor-get-err.js
     prototype/Symbol.split/species-ctor-ctor-non-obj.js
     prototype/Symbol.split/species-ctor-ctor-undef.js
-    prototype/Symbol.split/species-ctor-err.js
-    prototype/Symbol.split/species-ctor-species-get-err.js
-    prototype/Symbol.split/species-ctor-species-non-ctor.js
-    prototype/Symbol.split/species-ctor-species-undef.js
-    prototype/Symbol.split/species-ctor-y.js
-    prototype/Symbol.split/species-ctor.js
+    prototype/Symbol.split/species-ctor-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor-species-get-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor-species-non-ctor.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor-species-undef.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor-y.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/splitter-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
     prototype/Symbol.split/str-adv-thru-empty-match.js
-    prototype/Symbol.split/str-coerce-lastindex-err.js
-    prototype/Symbol.split/str-coerce-lastindex.js
-    prototype/Symbol.split/str-empty-match-err.js
+    prototype/Symbol.split/str-coerce-lastindex-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-coerce-lastindex.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-empty-match-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-empty-match.js
     prototype/Symbol.split/str-empty-no-match.js
-    prototype/Symbol.split/str-get-lastindex-err.js
+    prototype/Symbol.split/str-get-lastindex-err.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-limit-capturing.js
     prototype/Symbol.split/str-limit.js
-    prototype/Symbol.split/str-match-err.js
-    prototype/Symbol.split/str-result-coerce-length-err.js
-    prototype/Symbol.split/str-result-coerce-length.js
-    prototype/Symbol.split/str-result-get-capture-err.js
-    prototype/Symbol.split/str-result-get-length-err.js
-    prototype/Symbol.split/str-set-lastindex-err.js
-    prototype/Symbol.split/str-set-lastindex-match.js
-    prototype/Symbol.split/str-set-lastindex-no-match.js
+    prototype/Symbol.split/str-match-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-result-coerce-length-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-result-coerce-length.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-result-get-capture-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-result-get-length-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-set-lastindex-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-set-lastindex-match.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-set-lastindex-no-match.js {unsupported: [Symbol.species]}
     prototype/Symbol.split/str-trailing-chars.js
     prototype/Symbol.split/u-lastindex-adv-thru-failure.js
     prototype/Symbol.split/u-lastindex-adv-thru-match.js
@@ -819,7 +1062,7 @@ built-ins/RegExp 262/798 (32.83%)
     prototype/test/y-fail-return.js
     prototype/test/y-init-lastindex.js
     prototype/test/y-set-lastindex.js
-    *prototype/unicode 7/7 (100.0%)
+    *prototype/unicode 8/8 (100.0%)
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
     *Symbol.species 4/4 (100.0%)
@@ -827,12 +1070,15 @@ built-ins/RegExp 262/798 (32.83%)
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
     call_with_regexp_not_same_constructor.js
+    character-class-escape-non-whitespace-u180e.js {unsupported: [u180e]}
+    duplicate-flags.js {unsupported: [regexp-dotall]}
     from-regexp-like-flag-override.js
     from-regexp-like-get-ctor-err.js
     from-regexp-like-get-flags-err.js
     from-regexp-like-get-source-err.js
     from-regexp-like-short-circuit.js
     from-regexp-like.js
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     S15.10.1_A1_T13.js
     S15.10.1_A1_T14.js
     S15.10.1_A1_T15.js
@@ -841,19 +1087,30 @@ built-ins/RegExp 262/798 (32.83%)
     S15.10.3.1_A2_T2.js
     S15.10.4.1_A2_T1.js
     S15.10.4.1_A2_T2.js
+    u180e.js {unsupported: [u180e]}
     unicode_identity_escape.js
     valid-flags-y.js
 
-built-ins/Set 4/187 (2.14%)
+built-ins/Set 5/188 (2.66%)
     *Symbol.species 4/4 (100.0%)
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
 built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 44/1033 (4.26%)
+built-ins/String 75/1064 (7.05%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
+    prototype/indexOf/position-tointeger-bigint.js {unsupported: [computed-property-names]}
+    prototype/indexOf/position-tointeger-errors.js {unsupported: [computed-property-names]}
+    prototype/indexOf/position-tointeger-toprimitive.js {unsupported: [computed-property-names]}
+    prototype/indexOf/position-tointeger-wrapped-values.js {unsupported: [computed-property-names]}
+    prototype/indexOf/searchstring-tostring-bigint.js {unsupported: [computed-property-names]}
+    prototype/indexOf/searchstring-tostring-errors.js {unsupported: [computed-property-names]}
+    prototype/indexOf/searchstring-tostring-toprimitive.js {unsupported: [computed-property-names]}
+    prototype/indexOf/searchstring-tostring-wrapped-values.js {unsupported: [computed-property-names]}
+    *prototype/matchAll 17/17 (100.0%)
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/invoke-builtin-match.js
@@ -868,8 +1125,11 @@ built-ins/String 44/1033 (4.26%)
     prototype/split/cstm-split-invocation.js
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/substring/S15.5.4.15_A1_T5.js
+    prototype/toLocaleLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLocaleLowerCase/special_casing_conditional.js
+    prototype/toLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLowerCase/special_casing_conditional.js
+    prototype/toString/non-generic-realm.js {unsupported: [cross-realm]}
     prototype/trimEnd/this-value-object-cannot-convert-to-primitive-err.js
     prototype/trimEnd/this-value-object-toprimitive-call-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-err.js
@@ -896,12 +1156,22 @@ built-ins/String 44/1033 (4.26%)
     prototype/trimStart/this-value-object-valueof-meth-err.js
     prototype/trimStart/this-value-object-valueof-meth-priority.js
     prototype/trimStart/this-value-object-valueof-returns-object-err.js
+    prototype/trim/u180e.js {unsupported: [u180e]}
+    prototype/valueOf/non-generic-realm.js {unsupported: [cross-realm]}
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 14/68 (20.59%)
-    asyncIterator/prop-desc.js
+built-ins/Symbol 31/84 (36.9%)
+    *asyncIterator 2/2 (100.0%)
+    for/cross-realm.js {unsupported: [cross-realm]}
+    hasInstance/cross-realm.js {unsupported: [cross-realm]}
+    isConcatSpreadable/cross-realm.js {unsupported: [cross-realm]}
+    iterator/cross-realm.js {unsupported: [cross-realm]}
     keyFor/arg-non-symbol.js
+    keyFor/cross-realm.js {unsupported: [cross-realm]}
+    *matchAll 2/2 (100.0%)
+    match/cross-realm.js {unsupported: [cross-realm]}
     prototype/description/description-symboldescriptivestring.js
     prototype/description/descriptor.js
     prototype/description/get.js
@@ -912,10 +1182,16 @@ built-ins/Symbol 14/68 (20.59%)
     prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/this-val-non-obj.js
     prototype/valueOf/this-val-non-obj.js
-    species/builtin-getter-name.js
-    species/subclassing.js
+    replace/cross-realm.js {unsupported: [cross-realm]}
+    search/cross-realm.js {unsupported: [cross-realm]}
+    *species 4/4 (100.0%)
+    split/cross-realm.js {unsupported: [cross-realm]}
+    toPrimitive/cross-realm.js {unsupported: [cross-realm]}
+    toStringTag/cross-realm.js {unsupported: [cross-realm]}
+    unscopables/cross-realm.js {unsupported: [cross-realm]}
 
-built-ins/ThrowTypeError 7/12 (58.33%)
+built-ins/ThrowTypeError 8/13 (61.54%)
+    distinct-cross-realm.js {unsupported: [cross-realm]}
     extensible.js
     forbidden-arguments.js
     frozen.js
@@ -924,7 +1200,7 @@ built-ins/ThrowTypeError 7/12 (58.33%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 950/1033 (91.97%)
+built-ins/TypedArray 984/1054 (93.36%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/iter-access-error.js
@@ -992,7 +1268,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/copyWithin/undefined-end.js
     *prototype/entries/BigInt 3/3 (100.0%)
     *prototype/entries 10/10 (100.0%)
-    *prototype/every/BigInt 14/14 (100.0%)
+    *prototype/every/BigInt 15/15 (100.0%)
     prototype/every/callbackfn-arguments-with-thisarg.js
     prototype/every/callbackfn-arguments-without-thisarg.js
     prototype/every/callbackfn-detachbuffer.js
@@ -1000,6 +1276,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/every/callbackfn-not-called-on-empty.js
     prototype/every/callbackfn-return-does-not-change-instance.js
     prototype/every/callbackfn-returns-abrupt.js
+    prototype/every/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/every/callbackfn-this.js
     prototype/every/detached-buffer.js
     prototype/every/get-length-uses-internal-arraylength.js
@@ -1036,17 +1313,18 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/fill/return-this.js
     prototype/fill/this-is-not-object.js
     prototype/fill/this-is-not-typedarray-instance.js
-    *prototype/filter/BigInt 32/32 (100.0%)
+    *prototype/filter/BigInt 33/33 (100.0%)
     prototype/filter/arraylength-internal.js
     prototype/filter/callbackfn-arguments-with-thisarg.js
     prototype/filter/callbackfn-arguments-without-thisarg.js
-    prototype/filter/callbackfn-called-before-ctor.js
-    prototype/filter/callbackfn-called-before-species.js
+    prototype/filter/callbackfn-called-before-ctor.js {unsupported: [Symbol.species]}
+    prototype/filter/callbackfn-called-before-species.js {unsupported: [Symbol.species]}
     prototype/filter/callbackfn-detachbuffer.js
     prototype/filter/callbackfn-no-iteration-over-non-integer.js
     prototype/filter/callbackfn-not-called-on-empty.js
     prototype/filter/callbackfn-return-does-not-change-instance.js
     prototype/filter/callbackfn-returns-abrupt.js
+    prototype/filter/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/filter/callbackfn-this.js
     prototype/filter/detached-buffer.js
     prototype/filter/invoked-as-func.js
@@ -1060,13 +1338,16 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/filter/speciesctor-get-ctor-abrupt.js
     prototype/filter/speciesctor-get-ctor-inherited.js
     prototype/filter/speciesctor-get-ctor.js
-    prototype/filter/speciesctor-get-species-abrupt.js
-    prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/filter/speciesctor-get-species-custom-ctor-length.js
-    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/filter/speciesctor-get-species-custom-ctor.js
-    prototype/filter/speciesctor-get-species-use-default-ctor.js
-    prototype/filter/speciesctor-get-species.js
+    prototype/filter/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/filter/values-are-not-cached.js
@@ -1109,7 +1390,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/find/return-undefined-if-predicate-returns-false-value.js
     prototype/find/this-is-not-object.js
     prototype/find/this-is-not-typedarray-instance.js
-    *prototype/forEach/BigInt 13/13 (100.0%)
+    *prototype/forEach/BigInt 14/14 (100.0%)
     prototype/forEach/arraylength-internal.js
     prototype/forEach/callbackfn-arguments-with-thisarg.js
     prototype/forEach/callbackfn-arguments-without-thisarg.js
@@ -1118,6 +1399,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/forEach/callbackfn-not-called-on-empty.js
     prototype/forEach/callbackfn-return-does-not-change-instance.js
     prototype/forEach/callbackfn-returns-abrupt.js
+    prototype/forEach/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/forEach/callbackfn-this.js
     prototype/forEach/detached-buffer.js
     prototype/forEach/invoked-as-func.js
@@ -1211,7 +1493,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/length/prop-desc.js
     prototype/length/this-has-no-typedarrayname-internal.js
     prototype/length/this-is-not-object.js
-    *prototype/map/BigInt 30/30 (100.0%)
+    *prototype/map/BigInt 31/31 (100.0%)
     prototype/map/arraylength-internal.js
     prototype/map/callbackfn-arguments-with-thisarg.js
     prototype/map/callbackfn-arguments-without-thisarg.js
@@ -1222,6 +1504,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/map/callbackfn-return-does-not-change-instance.js
     prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
     prototype/map/callbackfn-returns-abrupt.js
+    prototype/map/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/map/callbackfn-this.js
     prototype/map/detached-buffer.js
     prototype/map/invoked-as-func.js
@@ -1236,18 +1519,21 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-ctor-inherited.js
     prototype/map/speciesctor-get-ctor.js
-    prototype/map/speciesctor-get-species-abrupt.js
-    prototype/map/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/map/speciesctor-get-species-custom-ctor-length.js
-    prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/speciesctor-get-species-custom-ctor.js
-    prototype/map/speciesctor-get-species-use-default-ctor.js
-    prototype/map/speciesctor-get-species.js
+    prototype/map/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/map/values-are-not-cached.js
-    *prototype/reduce/BigInt 17/17 (100.0%)
-    *prototype/reduceRight/BigInt 17/17 (100.0%)
+    *prototype/reduce/BigInt 18/18 (100.0%)
+    *prototype/reduceRight/BigInt 18/18 (100.0%)
     prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
     prototype/reduceRight/callbackfn-arguments-default-accumulator.js
     prototype/reduceRight/callbackfn-detachbuffer.js
@@ -1255,6 +1541,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/reduceRight/callbackfn-not-called-on-empty.js
     prototype/reduceRight/callbackfn-return-does-not-change-instance.js
     prototype/reduceRight/callbackfn-returns-abrupt.js
+    prototype/reduceRight/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/reduceRight/callbackfn-this.js
     prototype/reduceRight/detached-buffer.js
     prototype/reduceRight/empty-instance-return-initialvalue.js
@@ -1277,6 +1564,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/reduce/callbackfn-not-called-on-empty.js
     prototype/reduce/callbackfn-return-does-not-change-instance.js
     prototype/reduce/callbackfn-returns-abrupt.js
+    prototype/reduce/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/reduce/callbackfn-this.js
     prototype/reduce/detached-buffer.js
     prototype/reduce/empty-instance-return-initialvalue.js
@@ -1294,7 +1582,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/reduce/values-are-not-cached.js
     *prototype/reverse/BigInt 5/5 (100.0%)
     *prototype/reverse 12/12 (100.0%)
-    *prototype/set/BigInt 44/44 (100.0%)
+    *prototype/set/BigInt 47/47 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-return-abrupt-from-src-get-length.js
     prototype/set/array-arg-return-abrupt-from-src-get-value.js
@@ -1320,7 +1608,11 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/set/this-is-not-object.js
     prototype/set/this-is-not-typedarray-instance.js
     prototype/set/typedarray-arg-negative-integer-offset-throws.js
+    prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-arraylength-internal.js
     prototype/set/typedarray-arg-src-byteoffset-internal.js
     prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
@@ -1331,8 +1623,11 @@ built-ins/TypedArray 950/1033 (91.97%)
     *prototype/slice/BigInt 35/35 (100.0%)
     prototype/slice/arraylength-internal.js
     prototype/slice/bit-precision.js
-    prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
-    prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
+    prototype/slice/detached-buffer-custom-ctor-other-targettype.js {unsupported: [Symbol.species]}
+    prototype/slice/detached-buffer-custom-ctor-same-targettype.js {unsupported: [Symbol.species]}
+    prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
+    prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js {unsupported: [Symbol.species]}
+    prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js {unsupported: [Symbol.species]}
     prototype/slice/detached-buffer.js
     prototype/slice/infinity.js
     prototype/slice/invoked-as-func.js
@@ -1347,22 +1642,25 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/slice/results-with-same-length.js
     prototype/slice/return-abrupt-from-end.js
     prototype/slice/return-abrupt-from-start.js
-    prototype/slice/set-values-from-different-ctor-type.js
+    prototype/slice/set-values-from-different-ctor-type.js {unsupported: [Symbol.species]}
     prototype/slice/speciesctor-get-ctor-abrupt.js
     prototype/slice/speciesctor-get-ctor-inherited.js
     prototype/slice/speciesctor-get-ctor.js
-    prototype/slice/speciesctor-get-species-abrupt.js
-    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length.js
-    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/slice/speciesctor-get-species-custom-ctor.js
-    prototype/slice/speciesctor-get-species-use-default-ctor.js
-    prototype/slice/speciesctor-get-species.js
+    prototype/slice/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/slice/tointeger-end.js
     prototype/slice/tointeger-start.js
-    *prototype/some/BigInt 14/14 (100.0%)
+    *prototype/some/BigInt 15/15 (100.0%)
     prototype/some/callbackfn-arguments-with-thisarg.js
     prototype/some/callbackfn-arguments-without-thisarg.js
     prototype/some/callbackfn-detachbuffer.js
@@ -1370,6 +1668,7 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/some/callbackfn-not-called-on-empty.js
     prototype/some/callbackfn-return-does-not-change-instance.js
     prototype/some/callbackfn-returns-abrupt.js
+    prototype/some/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/some/callbackfn-this.js
     prototype/some/detached-buffer.js
     prototype/some/get-length-uses-internal-arraylength.js
@@ -1414,13 +1713,14 @@ built-ins/TypedArray 950/1033 (91.97%)
     prototype/subarray/speciesctor-get-ctor-inherited.js
     prototype/subarray/speciesctor-get-ctor-returns-throws.js
     prototype/subarray/speciesctor-get-ctor.js
-    prototype/subarray/speciesctor-get-species-abrupt.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-throws.js
-    prototype/subarray/speciesctor-get-species-custom-ctor.js
-    prototype/subarray/speciesctor-get-species-returns-throws.js
-    prototype/subarray/speciesctor-get-species.js
+    prototype/subarray/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species.js {unsupported: [Symbol.species]}
     prototype/subarray/this-is-not-object.js
     prototype/subarray/this-is-not-typedarray-instance.js
     *prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
@@ -1455,29 +1755,64 @@ built-ins/TypedArray 950/1033 (91.97%)
     name.js
     prototype.js
 
-built-ins/TypedArrayConstructors 339/498 (68.07%)
+built-ins/TypedArrayConstructors 528/683 (77.31%)
     *BigInt64Array/prototype 4/4 (100.0%)
     *BigInt64Array 7/7 (100.0%)
     *BigUint64Array/prototype 4/4 (100.0%)
     *BigUint64Array 7/7 (100.0%)
-    *ctors-bigint/buffer-arg 24/24 (100.0%)
-    *ctors-bigint/length-arg 9/9 (100.0%)
-    *ctors-bigint/no-args 4/4 (100.0%)
-    *ctors-bigint/object-arg 28/28 (100.0%)
-    *ctors-bigint/typedarray-arg 23/23 (100.0%)
+    *ctors-bigint/buffer-arg 52/52 (100.0%)
+    *ctors-bigint/length-arg 12/12 (100.0%)
+    *ctors-bigint/no-args 7/7 (100.0%)
+    *ctors-bigint/object-arg 31/31 (100.0%)
+    *ctors-bigint/typedarray-arg 27/27 (100.0%)
+    ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-throws.js
+    ctors/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
+    ctors/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
+    ctors/buffer-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
+    ctors/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-negative-length.js
+    ctors/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/detachedbuffer.js
+    ctors/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/length-to-number-detachbuffer.js
+    ctors/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect, cross-realm]}
+    ctors/buffer-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    ctors/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
+    ctors/buffer-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
+    ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/length-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
     ctors/length-arg/is-infinity-throws-rangeerror.js
     ctors/length-arg/is-negative-integer-throws-rangeerror.js
     ctors/length-arg/is-symbol-throws.js
+    ctors/length-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     ctors/length-arg/toindex-length.js
+    ctors/length-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/length-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/no-args/custom-proto-access-throws.js {unsupported: [Reflect]}
+    ctors/no-args/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    ctors/no-args/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/no-args/use-default-proto-if-custom-proto-is-not-object.js
     ctors/object-arg/as-generator-iterable-returns.js
+    ctors/object-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
     ctors/object-arg/iterating-throws.js
     ctors/object-arg/iterator-not-callable-throws.js
     ctors/object-arg/iterator-throws.js
@@ -1485,28 +1820,39 @@ built-ins/TypedArrayConstructors 339/498 (68.07%)
     ctors/object-arg/length-is-symbol-throws.js
     ctors/object-arg/length-throws.js
     ctors/object-arg/new-instance-extensibility.js
+    ctors/object-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     ctors/object-arg/returns.js
     ctors/object-arg/throws-from-property.js
     ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
     ctors/object-arg/throws-setting-obj-to-primitive.js
     ctors/object-arg/throws-setting-property.js
     ctors/object-arg/throws-setting-symbol-property.js
+    ctors/object-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/object-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
-    ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
+    ctors/typedarray-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
+    ctors/typedarray-arg/detached-when-species-retrieved-different-type.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/detached-when-species-retrieved-same-type.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-null.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js {unsupported: [cross-realm, Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-null.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js {unsupported: [Symbol.species]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
     ctors/typedarray-arg/src-typedarray-big-throws.js
+    ctors/typedarray-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
     Float32Array/prototype/not-typedarray-object.js
     Float32Array/prototype/proto.js
@@ -1542,18 +1888,21 @@ built-ins/TypedArrayConstructors 339/498 (68.07%)
     Int32Array/prototype/proto.js
     Int8Array/prototype/not-typedarray-object.js
     Int8Array/prototype/proto.js
-    internals/DefineOwnProperty/BigInt/desc-value-throws.js
-    *internals/DefineOwnProperty 3/3 (100.0%)
-    *internals/Get/BigInt 12/12 (100.0%)
-    *internals/GetOwnProperty/BigInt 11/11 (100.0%)
+    *internals/DefineOwnProperty/BigInt 20/20 (100.0%)
+    *internals/DefineOwnProperty 22/22 (100.0%)
+    *internals/Get/BigInt 14/14 (100.0%)
+    *internals/GetOwnProperty/BigInt 12/12 (100.0%)
     internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     internals/GetOwnProperty/detached-buffer-key-is-symbol.js
+    internals/GetOwnProperty/detached-buffer-realm.js {unsupported: [cross-realm]}
     internals/GetOwnProperty/detached-buffer.js
     internals/GetOwnProperty/enumerate-detached-buffer.js
     internals/GetOwnProperty/index-prop-desc.js
     internals/Get/detached-buffer-key-is-not-numeric-index.js
     internals/Get/detached-buffer-key-is-symbol.js
+    internals/Get/detached-buffer-realm.js {unsupported: [cross-realm]}
     internals/Get/detached-buffer.js
+    internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/indexed-value.js
     internals/Get/infinity-detached-buffer.js
     internals/Get/key-is-not-canonical-index.js
@@ -1562,10 +1911,23 @@ built-ins/TypedArrayConstructors 339/498 (68.07%)
     internals/Get/key-is-not-numeric-index.js
     internals/Get/key-is-out-of-bounds.js
     internals/Get/key-is-symbol.js
-    internals/HasProperty/BigInt/infinity-with-detached-buffer.js non-strict
-    internals/HasProperty/infinity-with-detached-buffer.js non-strict
-    *internals/Set/BigInt 12/12 (100.0%)
+    *internals/HasProperty/BigInt 15/15 (100.0%)
+    *internals/HasProperty 15/15 (100.0%)
+    *internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
+    *internals/OwnPropertyKeys 4/4 (100.0%)
+    *internals/Set/BigInt 23/23 (100.0%)
+    internals/Set/detached-buffer-key-is-not-numeric-index.js {unsupported: [Reflect]}
+    internals/Set/detached-buffer-key-is-symbol.js {unsupported: [Reflect]}
+    internals/Set/detached-buffer-realm.js {unsupported: [cross-realm]}
     internals/Set/detached-buffer.js
+    internals/Set/indexed-value.js {unsupported: [Reflect]}
+    internals/Set/key-is-minus-zero.js {unsupported: [Reflect]}
+    internals/Set/key-is-not-canonical-index.js {unsupported: [Reflect]}
+    internals/Set/key-is-not-integer.js {unsupported: [Reflect]}
+    internals/Set/key-is-not-numeric-index.js {unsupported: [Reflect]}
+    internals/Set/key-is-out-of-bounds.js {unsupported: [Reflect]}
+    internals/Set/key-is-symbol.js {unsupported: [Reflect]}
+    internals/Set/tonumber-value-detached-buffer.js {unsupported: [Reflect]}
     internals/Set/tonumber-value-throws.js
     *of/BigInt 12/12 (100.0%)
     of/argument-number-value-throws.js
@@ -1617,11 +1979,13 @@ built-ins/TypedArrayConstructors 339/498 (68.07%)
 
 built-ins/undefined 0/8 (0.0%)
 
-built-ins/WeakMap 0/87 (0.0%)
+built-ins/WeakMap 1/88 (1.14%)
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-built-ins/WeakSet 0/74 (0.0%)
+built-ins/WeakSet 1/75 (1.33%)
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
 
-language/arguments-object 91/162 (56.17%)
+language/arguments-object 191/262 (72.9%)
     mapped/mapped-arguments-nonconfigurable-3.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
@@ -1663,6 +2027,41 @@ language/arguments-object 91/162 (56.17%)
     unmapped/via-params-dstr.js non-strict
     unmapped/via-params-rest.js
     arguments-caller.js
+    async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
     cls-decl-gen-meth-args-trailing-comma-multiple.js
     cls-decl-gen-meth-args-trailing-comma-null.js
     cls-decl-gen-meth-args-trailing-comma-single-args.js
@@ -1683,6 +2082,51 @@ language/arguments-object 91/162 (56.17%)
     cls-decl-meth-static-args-trailing-comma-single-args.js
     cls-decl-meth-static-args-trailing-comma-spread-operator.js
     cls-decl-meth-static-args-trailing-comma-undefined.js
+    cls-decl-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-async-gen-func-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
     cls-expr-gen-meth-args-trailing-comma-multiple.js
     cls-expr-gen-meth-args-trailing-comma-null.js
     cls-expr-gen-meth-args-trailing-comma-single-args.js
@@ -1703,6 +2147,26 @@ language/arguments-object 91/162 (56.17%)
     cls-expr-meth-static-args-trailing-comma-single-args.js
     cls-expr-meth-static-args-trailing-comma-spread-operator.js
     cls-expr-meth-static-args-trailing-comma-undefined.js
+    cls-expr-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
     func-decl-args-trailing-comma-spread-operator.js
     func-expr-args-trailing-comma-spread-operator.js
     gen-func-decl-args-trailing-comma-spread-operator.js
@@ -1717,7 +2181,7 @@ language/arguments-object 91/162 (56.17%)
 language/asi 1/101 (0.99%)
     S7.9_A5.7_T1.js
 
-language/block-scope 46/109 (42.2%)
+language/block-scope 82/145 (56.55%)
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -1728,44 +2192,84 @@ language/block-scope 46/109 (42.2%)
     syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
     syntax/function-declarations/in-statement-position-if-expression-statement.js strict
     syntax/function-declarations/in-statement-position-while-expression-statement.js strict
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js {unsupported: [async-iteration]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-class.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-class.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-class.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-class.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-redeclaration-attempt-after-class.js
     syntax/redeclaration/var-redeclaration-attempt-after-const.js
     syntax/redeclaration/var-redeclaration-attempt-after-function.js
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
-language/comments 5/20 (25.0%)
+language/comments 37/52 (71.15%)
+    *hashbang 29/29 (100.0%)
+    mongolian-vowel-separator-multi.js {unsupported: [u180e]}
+    mongolian-vowel-separator-single-eval.js {unsupported: [u180e]}
+    mongolian-vowel-separator-single.js {unsupported: [u180e]}
     multi-line-asi-carriage-return.js
     multi-line-asi-line-feed.js
     multi-line-asi-line-separator.js
@@ -1805,15 +2309,32 @@ language/directive-prologue 18/62 (29.03%)
     14.1-9-s.js {non-strict: [-1]}
     func-decl-inside-func-decl-parse.js non-strict
 
-language/eval-code 40/126 (31.75%)
+language/eval-code 65/151 (43.05%)
     direct/block-decl-eval-source-is-strict-nostrict.js non-strict
     direct/block-decl-eval-source-is-strict-onlystrict.js strict
     direct/block-decl-onlystrict.js strict
+    direct/export.js {unsupported: [module]}
+    direct/import.js {unsupported: [module]}
+    direct/lex-env-distinct-cls.js {unsupported: [class]}
     direct/lex-env-distinct-const.js
     direct/lex-env-distinct-let.js
+    direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
+    direct/new.target-arrow.js {unsupported: [new.target]}
+    direct/new.target-fn.js {unsupported: [new.target]}
+    direct/new.target.js {unsupported: [new.target]}
     direct/non-definable-global-var.js non-strict
+    direct/super-call-arrow.js {unsupported: [super]}
+    direct/super-call-fn.js {unsupported: [super]}
+    direct/super-call-method.js {unsupported: [super]}
+    direct/super-call.js {unsupported: [super]}
+    direct/super-prop-arrow.js {unsupported: [super]}
+    direct/super-prop-dot-no-home.js {unsupported: [super]}
+    direct/super-prop-expr-no-home-no-eval.js {unsupported: [super]}
+    direct/super-prop-expr-no-home.js {unsupported: [super]}
+    direct/super-prop-method.js {unsupported: [super]}
+    direct/super-prop.js {unsupported: [super]}
     direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
     direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
     direct/switch-case-decl-onlystrict.js strict
@@ -1833,13 +2354,21 @@ language/eval-code 40/126 (31.75%)
     direct/var-env-var-strict-source.js
     indirect/always-non-strict.js strict
     indirect/block-decl-strict.js
+    indirect/export.js {unsupported: [module]}
+    indirect/import.js {unsupported: [module]}
+    indirect/lex-env-distinct-cls.js {unsupported: [class]}
     indirect/lex-env-distinct-const.js
     indirect/lex-env-distinct-let.js
+    indirect/lex-env-no-init-cls.js {unsupported: [class]}
     indirect/lex-env-no-init-const.js
     indirect/lex-env-no-init-let.js
+    indirect/new.target.js {unsupported: [new.target]}
     indirect/non-definable-function-with-function.js
     indirect/non-definable-function-with-variable.js
     indirect/non-definable-global-var.js non-strict
+    indirect/realm.js {unsupported: [cross-realm]}
+    indirect/super-call.js {unsupported: [super]}
+    indirect/super-prop.js {unsupported: [super]}
     indirect/switch-case-decl-strict.js
     indirect/switch-dflt-decl-strict.js
     indirect/var-env-func-init-global-update-configurable.js
@@ -1849,7 +2378,10 @@ language/eval-code 40/126 (31.75%)
 
 ~language/export
 
-language/expressions/addition 6/45 (13.33%)
+language/expressions/addition 9/48 (18.75%)
+    bigint-errors.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     coerce-symbol-to-prim-err.js
     coerce-symbol-to-prim-invocation.js
     coerce-symbol-to-prim-return-obj.js
@@ -1857,7 +2389,7 @@ language/expressions/addition 6/45 (13.33%)
     get-symbol-to-prim-err.js
     order-of-evaluation.js
 
-language/expressions/arrow-function 168/219 (76.71%)
+language/expressions/arrow-function 276/326 (84.66%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-ptrn-elem-ary-elem-init.js
@@ -1905,6 +2437,96 @@ language/expressions/arrow-function 168/219 (76.71%)
     dstr/ary-ptrn-rest-not-final-obj.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -1929,6 +2551,9 @@ language/expressions/arrow-function 168/219 (76.71%)
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/syntax-error-ident-ref-break-escaped.js
     dstr/syntax-error-ident-ref-case-escaped.js
     dstr/syntax-error-ident-ref-catch-escaped.js
@@ -1982,18 +2607,33 @@ language/expressions/arrow-function 168/219 (76.71%)
     syntax/arrowparameters-cover-initialize-2.js
     syntax/arrowparameters-cover-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
-    array-destructuring-param-strict-body.js
+    array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     ArrowFunction_restricted-properties.js
+    dflt-params-abrupt.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js {unsupported: [default-parameters]}
+    dflt-params-ref-later.js {unsupported: [default-parameters]}
+    dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    dflt-params-ref-self.js {unsupported: [default-parameters]}
+    dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
+    length-dflt.js {unsupported: [default-parameters]}
+    lexical-new.target-closure-returned.js {unsupported: [new.target]}
+    lexical-new.target.js {unsupported: [new.target]}
     lexical-super-call-from-within-constructor.js
     lexical-super-property-from-within-constructor.js
     lexical-super-property.js
     lexical-supercall-from-immediately-invoked-arrow.js
     name.js
-    object-destructuring-param-strict-body.js
+    object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    param-dflt-yield-expr.js {unsupported: [default-parameters]}
+    param-dflt-yield-id-non-strict.js {unsupported: [default-parameters]}
+    param-dflt-yield-id-strict.js {unsupported: [default-parameters]}
     params-duplicate.js
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
+    rest-param-strict-body.js {unsupported: [rest-parameters]}
     rest-params-trailing-comma-early-error.js
     scope-body-lex-distinct.js non-strict
     scope-param-elem-var-close.js non-strict
@@ -2003,22 +2643,31 @@ language/expressions/arrow-function 168/219 (76.71%)
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/bitwise-and 2/27 (7.41%)
+language/expressions/bitwise-and 5/30 (16.67%)
+    bigint-errors.js {unsupported: [computed-property-names]}
     bigint-non-primitive.js
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
 language/expressions/bitwise-not 1/16 (6.25%)
     bigint-non-primitive.js
 
-language/expressions/bitwise-or 2/27 (7.41%)
+language/expressions/bitwise-or 5/30 (16.67%)
+    bigint-errors.js {unsupported: [computed-property-names]}
     bigint-non-primitive.js
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/bitwise-xor 2/27 (7.41%)
+language/expressions/bitwise-xor 5/30 (16.67%)
+    bigint-errors.js {unsupported: [computed-property-names]}
     bigint-non-primitive.js
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/call 53/85 (62.35%)
+language/expressions/call 64/96 (66.67%)
     11.2.3-3_1.js
     11.2.3-3_2.js
     11.2.3-3_4.js
@@ -2026,6 +2675,7 @@ language/expressions/call 53/85 (62.35%)
     11.2.3-3_6.js
     11.2.3-3_7.js
     11.2.3-3_8.js non-strict
+    eval-realm-indirect.js {unsupported: [cross-realm]}
     eval-spread-empty-leading.js
     eval-spread-empty-trailing.js
     eval-spread-empty.js
@@ -2071,11 +2721,22 @@ language/expressions/call 53/85 (62.35%)
     spread-sngl-iter.js
     spread-sngl-literal.js
     spread-sngl-obj-ident.js
+    tco-call-args.js {unsupported: [tail-call-optimization]}
+    tco-cross-realm-class-construct.js {unsupported: [tail-call-optimization, cross-realm, class]}
+    tco-cross-realm-class-derived-construct.js {unsupported: [tail-call-optimization, cross-realm, class]}
+    tco-cross-realm-fun-call.js {unsupported: [tail-call-optimization, cross-realm, class]}
+    tco-cross-realm-fun-construct.js {unsupported: [tail-call-optimization, cross-realm, class]}
+    tco-member-args.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-function-dynamic.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-function.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-global.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-with.js {unsupported: [tail-call-optimization]}
     trailing-comma.js
 
 ~language/expressions/class
 
-language/expressions/comma 0/5 (0.0%)
+language/expressions/comma 1/6 (16.67%)
+    tco-final.js {unsupported: [tail-call-optimization]}
 
 language/expressions/compound-assignment 77/408 (18.87%)
     11.13.2-34-s.js strict
@@ -2158,14 +2819,20 @@ language/expressions/compound-assignment 77/408 (18.87%)
 
 language/expressions/concatenation 0/5 (0.0%)
 
-language/expressions/conditional 0/19 (0.0%)
+language/expressions/conditional 2/21 (9.52%)
+    tco-cond.js {unsupported: [tail-call-optimization]}
+    tco-pos.js {unsupported: [tail-call-optimization]}
 
-language/expressions/delete 3/59 (5.08%)
+language/expressions/delete 4/60 (6.67%)
     11.4.1-5-a-28-s.js strict
     11.4.1-5-a-5gs.js strict
     identifier-strict.js strict
+    super-property.js {unsupported: [class]}
 
-language/expressions/division 1/42 (2.38%)
+language/expressions/division 4/45 (8.89%)
+    bigint-errors.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
 language/expressions/does-not-equals 0/38 (0.0%)
@@ -2178,10 +2845,13 @@ language/expressions/equals 6/47 (12.77%)
     get-symbol-to-prim-err.js
     to-prim-hint.js
 
-language/expressions/exponentiation 1/41 (2.44%)
+language/expressions/exponentiation 4/44 (9.09%)
+    bigint-errors.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/function 94/131 (71.76%)
+language/expressions/function 205/241 (85.06%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-ptrn-elem-ary-elem-init.js
@@ -2229,6 +2899,96 @@ language/expressions/function 94/131 (71.76%)
     dstr/ary-ptrn-rest-not-final-obj.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -2253,20 +3013,38 @@ language/expressions/function 94/131 (71.76%)
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    *early-errors 4/4 (100.0%)
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
-    array-destructuring-param-strict-body.js
+    array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    dflt-params-abrupt.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js {unsupported: [default-parameters]}
+    dflt-params-ref-later.js {unsupported: [default-parameters]}
+    dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    dflt-params-ref-self.js {unsupported: [default-parameters]}
+    dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
+    length-dflt.js {unsupported: [default-parameters]}
     name-arguments-strict-body.js non-strict
     name-eval-strict-body.js non-strict
     name.js
-    object-destructuring-param-strict-body.js
+    object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    param-dflt-yield-non-strict.js {unsupported: [default-parameters]}
+    param-dflt-yield-strict.js {unsupported: [default-parameters]}
     param-duplicated-strict-body-1.js non-strict
     param-duplicated-strict-body-2.js non-strict
     param-duplicated-strict-body-3.js non-strict
     param-eval-strict-body.js non-strict
+    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
+    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
+    rest-param-strict-body.js {unsupported: [rest-parameters]}
     scope-body-lex-distinct.js non-strict
     scope-name-var-open-non-strict.js non-strict
     scope-name-var-open-strict.js strict
@@ -2277,7 +3055,7 @@ language/expressions/function 94/131 (71.76%)
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/generators 121/162 (74.69%)
+language/expressions/generators 228/268 (85.07%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-name-iter-val.js non-interpreted
@@ -2325,6 +3103,96 @@ language/expressions/generators 121/162 (74.69%)
     dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -2352,15 +3220,28 @@ language/expressions/generators 121/162 (74.69%)
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
-    array-destructuring-param-strict-body.js
+    array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     default-proto.js
+    dflt-params-abrupt.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js {unsupported: [default-parameters]}
+    dflt-params-ref-later.js {unsupported: [default-parameters]}
+    dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    dflt-params-ref-self.js {unsupported: [default-parameters]}
+    dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
+    eval-body-proto-realm.js {unsupported: [cross-realm]}
     generator-created-after-decl-inst.js
     has-instance.js
     implicit-name.js
     invoke-as-constructor.js
+    length-dflt.js {unsupported: [default-parameters]}
     length-property-descriptor.js
     name.js
     named-yield-as-binding-identifier-escaped.js
@@ -2371,12 +3252,16 @@ language/expressions/generators 121/162 (74.69%)
     named-yield-spread-arr-multiple.js
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
-    object-destructuring-param-strict-body.js
+    object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    param-dflt-yield.js {unsupported: [default-parameters]}
+    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
+    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js
+    rest-param-strict-body.js {unsupported: [rest-parameters]}
     scope-body-lex-distinct.js non-strict
     scope-name-var-close.js non-interpreted
     scope-name-var-open-non-strict.js non-strict
@@ -2420,8 +3305,11 @@ language/expressions/instanceof 7/43 (16.28%)
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift 2/42 (4.76%)
+language/expressions/left-shift 5/45 (11.11%)
+    bigint-errors.js {unsupported: [computed-property-names]}
     bigint-non-primitive.js
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
 language/expressions/less-than 1/45 (2.22%)
@@ -2431,19 +3319,207 @@ language/expressions/less-than-or-equal 2/47 (4.26%)
     bigint-and-incomparable-string.js
     bigint-and-string.js
 
-language/expressions/logical-and 0/17 (0.0%)
+language/expressions/logical-and 1/18 (5.56%)
+    tco-right.js {unsupported: [tail-call-optimization]}
 
 language/expressions/logical-not 0/19 (0.0%)
 
-language/expressions/logical-or 0/17 (0.0%)
+language/expressions/logical-or 1/18 (5.56%)
+    tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/modulus 1/37 (2.7%)
+language/expressions/modulus 4/40 (10.0%)
+    bigint-errors.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/multiplication 1/37 (2.7%)
+language/expressions/multiplication 4/40 (10.0%)
+    bigint-errors.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/object 411/525 (78.29%)
+language/expressions/object 939/1049 (89.51%)
+    dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-name-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elem-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elision-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elision-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-empty-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-empty-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-rest-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-rest-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-hole.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-undef.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-init-iter-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-name-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-init-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-init-undefined.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-obj-init-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-init-undefined.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-list-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
     dstr/gen-meth-ary-init-iter-close.js
     dstr/gen-meth-ary-init-iter-get-err.js
     dstr/gen-meth-ary-init-iter-no-close.js
@@ -2495,6 +3571,96 @@ language/expressions/object 411/525 (78.29%)
     dstr/gen-meth-ary-ptrn-rest-id.js
     dstr/gen-meth-ary-ptrn-rest-obj-id.js
     dstr/gen-meth-ary-ptrn-rest-obj-prop-id.js
+    dstr/gen-meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
     dstr/gen-meth-obj-init-null.js
     dstr/gen-meth-obj-init-undefined.js
     dstr/gen-meth-obj-ptrn-empty.js
@@ -2525,6 +3691,9 @@ language/expressions/object 411/525 (78.29%)
     dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-undef.js
     dstr/gen-meth-obj-ptrn-prop-obj.js
+    dstr/gen-meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-ary-init-iter-close.js
     dstr/meth-ary-init-iter-get-err.js
     dstr/meth-ary-ptrn-elem-ary-elem-init.js
@@ -2566,6 +3735,96 @@ language/expressions/object 411/525 (78.29%)
     dstr/meth-ary-ptrn-rest-id.js
     dstr/meth-ary-ptrn-rest-obj-id.js
     dstr/meth-ary-ptrn-rest-obj-prop-id.js
+    dstr/meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/meth-dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
     dstr/meth-obj-init-null.js
     dstr/meth-obj-init-undefined.js
     dstr/meth-obj-ptrn-id-init-fn-name-arrow.js
@@ -2590,14 +3849,149 @@ language/expressions/object 411/525 (78.29%)
     dstr/meth-obj-ptrn-prop-obj-value-null.js
     dstr/meth-obj-ptrn-prop-obj-value-undef.js
     dstr/meth-obj-ptrn-prop-obj.js
+    dstr/meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
+    method-definition/async-await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
+    method-definition/async-await-as-label-identifier-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-label-identifier.js {unsupported: [async-functions]}
+    method-definition/async-gen-await-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-binding-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-identifier-reference.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-label-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-label-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-array-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-abrupt.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters, async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-duplicates.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-ref-later.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-ref-prior.js {unsupported: [default-parameters, async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-ref-self.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-rest.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-trailing-comma.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-escaped-async.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
+    method-definition/async-gen-meth-params-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-params-trailing-comma-single.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-rest-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
+    method-definition/async-gen-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-binding-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-identifier-reference.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-label-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-label-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-identifier-non-strict.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-identifier-spread-non-strict.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-identifier-spread-strict.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-identifier-strict.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-promise-reject-next-catch.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-for-await-of-async-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-for-await-of-sync-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-yield-star-sync-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-spread-arr-multiple.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-spread-arr-single.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-spread-obj.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-async-next.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-async-return.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-async-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-expr-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-object-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-null-sync-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-null-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-undefined-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-undefined-sync-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-object-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-null-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-undefined-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-call-done-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-call-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-call-value-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-non-object-ignores-then.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-null-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-object-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-undefined-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-boolean-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-null-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-number-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-object-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-string-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-symbol-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-undefined-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-sync-next.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-sync-return.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-sync-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-meth-array-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
+    method-definition/async-meth-dflt-params-abrupt.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-dflt-params-duplicates.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-meth-dflt-params-ref-later.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-dflt-params-ref-prior.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-dflt-params-ref-self.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-dflt-params-rest.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-meth-dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-escaped-async.js {unsupported: [async-functions]}
+    method-definition/async-meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
+    method-definition/async-meth-params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-params-trailing-comma-single.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-rest-param-strict-body.js {unsupported: [rest-parameters, async-iteration]}
+    method-definition/async-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
+    method-definition/async-super-call-body.js {unsupported: [async]}
+    method-definition/async-super-call-param.js {unsupported: [async]}
     method-definition/early-errors-object-method-duplicate-parameters.js
     method-definition/escaped-get.js
     method-definition/escaped-set.js
     method-definition/fn-name-fn.js
     method-definition/fn-name-gen.js
+    method-definition/gen-meth-array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    method-definition/gen-meth-dflt-params-abrupt.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-duplicates.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-ref-later.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-ref-self.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-rest.js {unsupported: [default-parameters]}
     method-definition/gen-meth-dflt-params-trailing-comma.js
+    method-definition/gen-meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/gen-meth-params-trailing-comma-multiple.js
     method-definition/gen-meth-params-trailing-comma-single.js
+    method-definition/gen-meth-rest-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/gen-yield-identifier-non-strict.js non-strict
     method-definition/gen-yield-identifier-spread-non-strict.js non-strict
     method-definition/gen-yield-spread-arr-multiple.js
@@ -2606,6 +4000,7 @@ language/expressions/object 411/525 (78.29%)
     method-definition/generator-invoke-ctor.js
     method-definition/generator-invoke-fn-no-strict.js non-strict
     method-definition/generator-invoke-fn-strict.js non-strict
+    method-definition/generator-length-dflt.js {unsupported: [default-parameters]}
     method-definition/generator-length.js
     method-definition/generator-name-prop-string.js
     method-definition/generator-name-prop-symbol.js
@@ -2619,13 +4014,24 @@ language/expressions/object 411/525 (78.29%)
     method-definition/generator-prototype.js
     method-definition/generator-return.js
     method-definition/generator-super-prop-body.js
-    method-definition/meth-array-destructuring-param-strict-body.js
+    method-definition/generator-super-prop-param.js {unsupported: [super, default-parameters]}
+    method-definition/meth-array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    method-definition/meth-dflt-params-abrupt.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-duplicates.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-ref-later.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-ref-self.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-rest.js {unsupported: [default-parameters]}
     method-definition/meth-dflt-params-trailing-comma.js
-    method-definition/meth-object-destructuring-param-strict-body.js
+    method-definition/meth-object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/meth-params-trailing-comma-multiple.js
     method-definition/meth-params-trailing-comma-single.js
+    method-definition/meth-rest-param-strict-body.js {unsupported: [rest-parameters]}
     method-definition/name-invoke-ctor.js
     method-definition/name-invoke-fn-strict.js non-strict
+    method-definition/name-length-dflt.js {unsupported: [default-parameters]}
     method-definition/name-length.js
     method-definition/name-name-prop-string.js
     method-definition/name-name-prop-symbol.js
@@ -2636,7 +4042,21 @@ language/expressions/object 411/525 (78.29%)
     method-definition/name-prop-name-yield-expr.js non-strict
     method-definition/name-prop-name-yield-id.js non-strict
     method-definition/name-prototype-prop.js
+    method-definition/name-super-prop-body.js {unsupported: [super]}
+    method-definition/name-super-prop-param.js {unsupported: [super]}
     method-definition/object-method-returns-promise.js
+    method-definition/params-dflt-gen-meth-args-unmapped.js {unsupported: [default-parameters]}
+    method-definition/params-dflt-gen-meth-ref-arguments.js {unsupported: [default-parameters]}
+    method-definition/params-dflt-meth-args-unmapped.js {unsupported: [default-parameters]}
+    method-definition/params-dflt-meth-ref-arguments.js {unsupported: [default-parameters]}
+    method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
+    method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
+    method-definition/private-name-early-error-async-gen-inside-class.js {unsupported: [class-fields-public, async-iteration, class]}
+    method-definition/private-name-early-error-async-gen.js {unsupported: [async-iteration]}
+    method-definition/private-name-early-error-gen-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/private-name-early-error-get-method-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/private-name-early-error-method-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/private-name-early-error-set-method-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
     method-definition/yield-as-function-expression-binding-identifier.js non-strict
@@ -2726,11 +4146,13 @@ language/expressions/object 411/525 (78.29%)
     fn-name-accessor-get.js
     fn-name-accessor-set.js
     fn-name-arrow.js
+    fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
     fn-name-fn.js
     fn-name-gen.js
     getter-body-strict-inside.js non-strict
     getter-body-strict-outside.js strict
+    getter-param-dflt.js {unsupported: [default-parameters]}
     getter-super-prop.js
     ident-name-method-def-break-escaped.js
     ident-name-method-def-case-escaped.js
@@ -2821,6 +4243,7 @@ language/expressions/object 411/525 (78.29%)
     let-non-strict-access.js non-strict
     let-non-strict-syntax.js non-strict
     method.js
+    prop-def-id-eval-error-2.js {unsupported: [Proxy]}
     prop-def-id-eval-error.js non-strict
     prop-dup-data-data.js strict
     prop-dup-data-set.js strict
@@ -2850,67 +4273,87 @@ language/expressions/object 411/525 (78.29%)
     scope-setter-paramsbody-var-open.js
     setter-body-strict-inside.js non-strict
     setter-body-strict-outside.js strict
+    setter-length-dflt.js {unsupported: [default-parameters]}
     setter-param-arguments-strict-inside.js non-strict
     setter-param-eval-strict-inside.js non-strict
     setter-super-prop.js
     yield-non-strict-access.js non-strict
     yield-non-strict-syntax.js non-strict
 
-language/expressions/postfix-decrement 6/34 (17.65%)
+language/expressions/postfix-decrement 8/36 (22.22%)
     arguments.js strict
     eval.js strict
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
     target-cover-yieldexpr.js
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/postfix-increment 7/35 (20.0%)
+language/expressions/postfix-increment 9/37 (24.32%)
     11.3.1-2-1gs.js strict
     arguments.js strict
     eval.js strict
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
     target-cover-yieldexpr.js
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-decrement 7/31 (22.58%)
+language/expressions/prefix-decrement 9/33 (27.27%)
     11.4.5-2-2gs.js strict
     arguments.js strict
     eval.js strict
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
     target-cover-yieldexpr.js
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-increment 6/30 (20.0%)
+language/expressions/prefix-increment 8/32 (25.0%)
     arguments.js strict
     eval.js strict
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
     target-cover-yieldexpr.js
+    target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/property-accessors 0/21 (0.0%)
 
 language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift 2/34 (5.88%)
+language/expressions/right-shift 5/37 (13.51%)
+    bigint-errors.js {unsupported: [computed-property-names]}
     bigint-non-primitive.js
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
 language/expressions/strict-does-not-equals 0/30 (0.0%)
 
 language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction 1/35 (2.86%)
+language/expressions/subtraction 4/38 (10.53%)
+    bigint-errors.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
 ~language/expressions/super
 
-language/expressions/tagged-template 1/24 (4.17%)
+language/expressions/tagged-template 4/27 (14.81%)
+    cache-realm.js {unsupported: [cross-realm]}
     call-expression-context-strict.js strict
+    tco-call.js {unsupported: [tail-call-optimization]}
+    tco-member.js {unsupported: [tail-call-optimization]}
 
-language/expressions/template-literal 0/52 (0.0%)
+language/expressions/template-literal 2/54 (3.7%)
+    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+    mongolian-vowel-separator.js {unsupported: [u180e]}
 
 language/expressions/this 1/6 (16.67%)
     S11.1.1_A1.js
@@ -2923,8 +4366,11 @@ language/expressions/unary-minus 1/14 (7.14%)
 
 language/expressions/unary-plus 0/17 (0.0%)
 
-language/expressions/unsigned-right-shift 2/42 (4.76%)
+language/expressions/unsigned-right-shift 5/45 (11.11%)
+    bigint-errors.js {unsupported: [computed-property-names]}
     bigint-non-primitive.js
+    bigint-toprimitive.js {unsupported: [computed-property-names]}
+    bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
 language/expressions/void 0/9 (0.0%)
@@ -2934,7 +4380,7 @@ language/expressions/yield 3/61 (4.92%)
     rhs-primitive.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 123/217 (56.68%)
+language/function-code 125/219 (57.08%)
     10.4.3-1-1-s.js non-strict
     10.4.3-1-10-s.js non-strict
     10.4.3-1-100-s.js
@@ -3053,6 +4499,8 @@ language/function-code 123/217 (56.68%)
     10.4.3-1-92gs.js {non-strict: [0, 9]}
     10.4.3-1-9gs.js strict
     block-decl-onlystrict.js strict
+    each-param-has-own-non-shared-eval-scope.js {unsupported: [default-parameters]}
+    each-param-has-own-scope.js {unsupported: [default-parameters]}
     eval-param-env-with-computed-key.js
     eval-param-env-with-prop-initializer.js
     S10.4.3_A1.js strict
@@ -3061,7 +4509,7 @@ language/function-code 123/217 (56.68%)
 
 ~language/future-reserved-words
 
-language/global-code 24/31 (77.42%)
+language/global-code 34/41 (82.93%)
     block-decl-strict.js strict
     decl-lex-configurable-global.js
     decl-lex-deletion.js non-strict
@@ -3069,6 +4517,12 @@ language/global-code 24/31 (77.42%)
     decl-lex.js
     export.js
     import.js
+    invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
+    invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
+    invalid-private-names-member-expression-bad-reference.js {unsupported: [class-fields-private]}
+    invalid-private-names-member-expression-this.js {unsupported: [class-fields-private]}
+    new.target-arrow.js {unsupported: [new.target]}
+    new.target.js {unsupported: [new.target]}
     return.js
     script-decl-func-dups.js
     script-decl-func-err-non-configurable.js
@@ -3082,6 +4536,10 @@ language/global-code 24/31 (77.42%)
     script-decl-var-collision.js
     script-decl-var-err.js
     script-decl-var.js
+    super-call-arrow.js {unsupported: [super]}
+    super-call.js {unsupported: [super]}
+    super-prop-arrow.js {unsupported: [super]}
+    super-prop.js {unsupported: [super]}
     switch-case-decl-strict.js strict
     switch-dflt-decl-strict.js strict
     yield-non-strict.js non-strict
@@ -3223,7 +4681,7 @@ language/line-terminators 4/41 (9.76%)
     S7.3_A6_T3.js
     S7.3_A6_T4.js
 
-language/literals 47/364 (12.91%)
+language/literals 113/430 (26.28%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     bigint/legacy-octal-like-invalid-00n.js
@@ -3236,10 +4694,13 @@ language/literals 47/364 (12.91%)
     numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     numeric/numeric-followed-by-ident.js
+    *regexp/named-groups 58/58 (100.0%)
     regexp/early-err-pattern.js Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
     regexp/invalid-braced-quantifier-range.js
+    regexp/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+    regexp/mongolian-vowel-separator.js {unsupported: [u180e]}
     regexp/S7.8.5_A1.1_T2.js
     regexp/S7.8.5_A1.4_T2.js
     regexp/S7.8.5_A1.5_T1.js
@@ -3260,6 +4721,12 @@ language/literals 47/364 (12.91%)
     string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
     string/legacy-octal-escape-sequence-strict.js strict
+    string/line-separator-eval.js {unsupported: [json-superset]}
+    string/line-separator.js {unsupported: [json-superset]}
+    string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+    string/mongolian-vowel-separator.js {unsupported: [u180e]}
+    string/paragraph-separator-eval.js {unsupported: [json-superset]}
+    string/paragraph-separator.js {unsupported: [json-superset]}
     string/S7.8.4_A4.3_T1.js strict
     string/S7.8.4_A4.3_T2.js strict
     string/S7.8.4_A7.1_T4.js
@@ -3281,7 +4748,8 @@ language/punctuators 5/11 (45.45%)
     S7.7_A2_T4.js
     S7.7_A2_T5.js
 
-language/reserved-words 7/26 (26.92%)
+language/reserved-words 8/27 (29.63%)
+    await-module.js {unsupported: [module]}
     await-script.js
     ident-reference-false-escaped.js
     ident-reference-null-escaped.js
@@ -3304,7 +4772,7 @@ language/rest-parameters 10/11 (90.91%)
 
 language/source-text 0/1 (0.0%)
 
-language/statements/for 239/360 (66.39%)
+language/statements/for 254/375 (67.73%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-no-close.js
@@ -3388,6 +4856,9 @@ language/statements/for 239/360 (66.39%)
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
     dstr/const-obj-ptrn-prop-obj.js
+    dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
     dstr/let-ary-ptrn-elem-ary-elem-init.js
@@ -3456,6 +4927,9 @@ language/statements/for 239/360 (66.39%)
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
     dstr/let-obj-ptrn-prop-obj.js
+    dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
     dstr/var-ary-ptrn-elem-ary-elem-init.js
@@ -3523,10 +4997,15 @@ language/statements/for 239/360 (66.39%)
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
     dstr/var-obj-ptrn-prop-obj.js
+    dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     cptn-decl-expr-iter.js
     cptn-decl-expr-no-iter.js
     cptn-expr-expr-iter.js
     cptn-expr-expr-no-iter.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -3544,8 +5023,13 @@ language/statements/for 239/360 (66.39%)
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-open.js
+    tco-const-body.js {unsupported: [tail-call-optimization]}
+    tco-let-body.js {unsupported: [tail-call-optimization]}
+    tco-lhs-body.js {unsupported: [tail-call-optimization]}
+    tco-var-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/for-in 36/110 (32.73%)
+language/statements/for-in 39/113 (34.51%)
+    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
     cptn-decl-itr.js
@@ -3555,6 +5039,8 @@ language/statements/for-in 36/110 (32.73%)
     cptn-expr-itr.js
     cptn-expr-skip-itr.js
     cptn-expr-zero-itr.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -3583,11 +5069,13 @@ language/statements/for-in 36/110 (32.73%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 431/681 (63.29%)
+language/statements/for-of 466/716 (65.08%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
+    dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-cover.js
+    dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
@@ -3786,6 +5274,9 @@ language/statements/for-of 431/681 (63.29%)
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
     dstr/const-obj-ptrn-prop-obj.js
+    dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
     dstr/let-ary-ptrn-elem-ary-elem-init.js
@@ -3853,6 +5344,9 @@ language/statements/for-of 431/681 (63.29%)
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
     dstr/let-obj-ptrn-prop-obj.js
+    dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
     dstr/obj-id-identifier-yield-ident-valid.js non-strict
@@ -3862,6 +5356,7 @@ language/statements/for-of 431/681 (63.29%)
     dstr/obj-id-init-assignment-undef.js
     dstr/obj-id-init-evaluation.js
     dstr/obj-id-init-fn-name-arrow.js
+    dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
@@ -3880,6 +5375,7 @@ language/statements/for-of 431/681 (63.29%)
     dstr/obj-prop-elem-init-assignment-undef.js
     dstr/obj-prop-elem-init-evaluation.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
+    dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
@@ -3899,6 +5395,25 @@ language/statements/for-of 431/681 (63.29%)
     dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
     dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
+    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
+    dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-descriptors.js {unsupported: [object-rest]}
+    dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
+    dstr/obj-rest-number.js {unsupported: [object-rest]}
+    dstr/obj-rest-order.js {unsupported: [object-rest]}
+    dstr/obj-rest-put-const.js {unsupported: [object-rest]}
+    dstr/obj-rest-same-name.js {unsupported: [object-rest]}
+    dstr/obj-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-rest-str-val.js {unsupported: [object-rest]}
+    dstr/obj-rest-symbol-val.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-val-null.js {unsupported: [object-rest]}
+    dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
+    dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
     dstr/var-ary-ptrn-elem-ary-elem-init.js
@@ -3966,6 +5481,9 @@ language/statements/for-of 431/681 (63.29%)
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
     dstr/var-obj-ptrn-prop-obj.js
+    dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     body-dstr-assign-error.js
     body-put-error.js
     cptn-decl-abrupt-empty.js
@@ -3974,6 +5492,8 @@ language/statements/for-of 431/681 (63.29%)
     cptn-expr-abrupt-empty.js
     cptn-expr-itr.js
     cptn-expr-no-itr.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -3994,6 +5514,7 @@ language/statements/for-of 431/681 (63.29%)
     head-var-bound-names-let.js non-strict
     head-var-init.js
     head-var-no-expr.js
+    iterator-as-proxy.js {unsupported: [Proxy]}
     iterator-close-get-method-error.js
     iterator-close-non-object.js
     iterator-close-via-break.js
@@ -4016,7 +5537,7 @@ language/statements/for-of 431/681 (63.29%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/generators 112/147 (76.19%)
+language/statements/generators 218/252 (86.51%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-name-iter-val.js non-interpreted
@@ -4064,6 +5585,96 @@ language/statements/generators 112/147 (76.19%)
     dstr/ary-ptrn-rest-id.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -4091,23 +5702,39 @@ language/statements/generators 112/147 (76.19%)
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
-    array-destructuring-param-strict-body.js
+    array-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
     cptn-decl.js
     default-proto.js
+    dflt-params-abrupt.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js {unsupported: [default-parameters]}
+    dflt-params-ref-later.js {unsupported: [default-parameters]}
+    dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    dflt-params-ref-self.js {unsupported: [default-parameters]}
+    dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js
     generator-created-after-decl-inst.js
     has-instance.js
     invoke-as-constructor.js
+    length-dflt.js {unsupported: [default-parameters]}
     length-property-descriptor.js
     name.js
-    object-destructuring-param-strict-body.js
+    object-destructuring-param-strict-body.js {unsupported: [rest-parameters]}
+    param-dflt-yield.js {unsupported: [default-parameters]}
+    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
+    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js
+    rest-param-strict-body.js {unsupported: [rest-parameters]}
     restricted-properties.js
     scope-body-lex-distinct.js non-strict
     scope-param-elem-var-close.js non-strict
@@ -4130,19 +5757,24 @@ language/statements/generators 112/147 (76.19%)
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/types 10/110 (9.09%)
+language/types 13/113 (11.5%)
     boolean/S8.3_A2.1.js
     boolean/S8.3_A2.2.js
     number/S8.5_A10_T1.js
     number/S8.5_A10_T2.js non-strict
     number/S8.5_A4_T1.js
     number/S8.5_A4_T2.js non-strict
+    reference/get-value-prop-base-primitive-realm.js {unsupported: [cross-realm]}
+    reference/put-value-prop-base-primitive-realm.js {unsupported: [Proxy, cross-realm]}
+    reference/put-value-prop-base-primitive.js {unsupported: [Proxy]}
     reference/S8.7.2_A1_T1.js
     reference/S8.7.2_A1_T2.js
     undefined/S8.1_A3_T1.js
     undefined/S8.1_A3_T2.js non-strict
 
-language/white-space 5/40 (12.5%)
+language/white-space 7/42 (16.67%)
+    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+    mongolian-vowel-separator.js {unsupported: [u180e]}
     S7.2_A5_T1.js
     S7.2_A5_T2.js
     S7.2_A5_T3.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -485,7 +485,7 @@ built-ins/encodeURIComponent 2/30 (6.67%)
     name.js
     S15.1.3.4_A5.2.js
 
-built-ins/Error 6/42 (14.29%)
+built-ins/Error 5/42 (11.9%)
     prototype/toString/called-as-function.js
     prototype/toString/invalid-receiver.js
     prototype/no-error-data.js
@@ -793,7 +793,7 @@ built-ins/Math 2/273 (0.73%)
 
 built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors 66/108 (61.11%)
+built-ins/NativeErrors 35/108 (32.41%)
     AggregateError/prototype 6/6 (100.0%)
     AggregateError 17/17 (100.0%)
     EvalError/prototype/not-error-object.js
@@ -820,7 +820,7 @@ built-ins/Number 9/283 (3.18%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 161/3150 (5.11%)
+built-ins/Object 155/3150 (4.92%)
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
     assign/source-own-prop-error.js {unsupported: [Proxy]}
     assign/source-own-prop-keys-error.js {unsupported: [Proxy]}
@@ -920,12 +920,6 @@ built-ins/Object 161/3150 (5.11%)
     getOwnPropertySymbols/proxy-invariant-duplicate-string-entry.js {unsupported: [Proxy]}
     getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js {unsupported: [Proxy]}
     getOwnPropertySymbols/proxy-invariant-not-extensible-extra-string-key.js {unsupported: [Proxy]}
-    getPrototypeOf/15.2.3.2-2-12.js
-    getPrototypeOf/15.2.3.2-2-13.js
-    getPrototypeOf/15.2.3.2-2-14.js
-    getPrototypeOf/15.2.3.2-2-15.js
-    getPrototypeOf/15.2.3.2-2-16.js
-    getPrototypeOf/15.2.3.2-2-17.js
     internals/DefineOwnProperty/consistent-value-function-arguments.js
     internals/DefineOwnProperty/consistent-value-function-caller.js
     internals/DefineOwnProperty/consistent-value-regexp-dollar1.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,2374 +1,2339 @@
-# This is a configuration file for Test262SuiteTest.java.
-#
-# Lines that start with a # (like this one) are comments.
-# There is no support for inline comments.
-#
-# Each non-commented out line adds either an inclusion or exclusion:
-# * inclusions are lines that don't have any special syntax.
-#   They are paths relative to '/test262/tests' directory
-#   of either a single file or a directory that will be executed
-#   as part of the test
-#
-# * exclusions start with a ! (with optional spaces around it)
-#   Each exclusion defines a substring that will make test ignore files
-#   that contain it in their paths. It affects only files added
-#   by directory inclusion defined on a closest line above it
+# This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
 built-ins/Array
-    # Spec pretty clearly says this should be undefined
-    ! from/calling-from-valid-1-noStrict.js
-    # Checking to see if length changed, but spec says it should not
-    ! from/elements-deleted-after.js
-    # Error propagation needs work in general
-    ! from/iter-map-fn-this-non-strict.js
-    # Error propagation needs work in general
-    ! from/iter-set-elem-prop-err.js
-    # Error propagation needs work in general
-    ! from/source-object-constructor.js
-    # Uses "get" syntax that's not implemented
-    ! from/source-object-iterator-1.js
-    # Uses "get" syntax that's not implemented
-    ! from/source-object-iterator-2.js
-    # Object.preventExtensions doesn't seem to throw
-    ! of/return-abrupt-from-data-property.js
-    # new
-    ! prototype/concat/Array.prototype.concat_large-typed-array.js
-    ! prototype/concat/Array.prototype.concat_non-array.js
-    ! prototype/concat/Array.prototype.concat_small-typed-array.js
-    ! prototype/concat/create-ctor-non-object.js
-    ! prototype/concat/create-ctor-poisoned.js
-    ! prototype/concat/create-species-abrupt.js
-    ! prototype/concat/create-species-non-ctor.js
-    ! prototype/concat/create-species-poisoned.js
-    ! prototype/concat/create-species.js
-    # Not throwing properly on unwritable
-    ! prototype/copyWithin/return-abrupt-from-delete-target.js
-    ! prototype/every/15.4.4.16-5-1-s.js
-    ! prototype/filter/15.4.4.20-5-1-s.js
-    ! prototype/filter/create-ctor-non-object.js
-    ! prototype/filter/create-ctor-poisoned.js
-    ! prototype/filter/create-species-abrupt.js
-    ! prototype/filter/create-species-non-ctor.js
-    ! prototype/filter/create-species-poisoned.js
-    ! prototype/filter/create-species.js
-    ! prototype/findIndex/predicate-call-this-strict.js
-    ! prototype/find/predicate-call-this-strict.js
-    ! prototype/flatMap/array-like-objects-nested.js
-    ! prototype/flatMap/array-like-objects-poisoned-length.js
-    ! prototype/flatMap/array-like-objects-typedarrays.js
-    ! prototype/flatMap/array-like-objects.js
-    ! prototype/flatMap/bound-function-argument.js
-    ! prototype/flatMap/depth-always-one.js
-    ! prototype/flatMap/length.js
-    ! prototype/flatMap/name.js
-    ! prototype/flatMap/non-callable-argument-throws.js
-    ! prototype/flatMap/prop-desc.js
-    ! prototype/flatMap/proxy-access-count.js
-    ! prototype/flatMap/this-value-ctor-non-object.js
-    ! prototype/flatMap/this-value-ctor-object-species-bad-throws.js
-    ! prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    ! prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
-    ! prototype/flatMap/this-value-ctor-object-species.js
-    ! prototype/flatMap/this-value-null-undefined-throws.js
-    ! prototype/flatMap/thisArg-argument.js
-    ! prototype/flat/array-like-objects.js
-    ! prototype/flat/bound-function-call.js
-    ! prototype/flat/empty-array-elements.js
-    ! prototype/flat/empty-object-elements.js
-    ! prototype/flat/length.js
-    ! prototype/flat/name.js
-    ! prototype/flat/non-numeric-depth-should-not-throw.js
-    ! prototype/flat/non-object-ctor-throws.js
-    ! prototype/flat/null-undefined-elements.js
-    ! prototype/flat/null-undefined-input-throws.js
-    ! prototype/flat/positive-infinity.js
-    ! prototype/flat/prop-desc.js
-    ! prototype/flat/proxy-access-count.js
-    ! prototype/flat/symbol-object-create-null-depth-throws.js
-    ! prototype/forEach/15.4.4.18-5-1-s.js
-    ! prototype/map/15.4.4.19-5-1-s.js
-    ! prototype/map/create-ctor-non-object.js
-    ! prototype/map/create-ctor-poisoned.js
-    ! prototype/map/create-species-abrupt.js
-    ! prototype/map/create-species-non-ctor.js
-    ! prototype/map/create-species-poisoned.js
-    ! prototype/map/create-species.js
-    # incorrect length handling
-    ! prototype/push/S15.4.4.7_A2_T2.js
-    # incorrect length handling
-    ! prototype/push/throws-if-integer-limit-exceeded.js
-    ! prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js
-    ! prototype/reduce/15.4.4.21-9-c-ii-4-s.js
-    ! prototype/reverse/length-exceeding-integer-limit-with-proxy.js
-    ! prototype/slice/create-ctor-non-object.js
-    ! prototype/slice/create-ctor-poisoned.js
-    ! prototype/slice/create-species-abrupt.js
-    ! prototype/slice/create-species-neg-zero.js
-    ! prototype/slice/create-species-non-ctor.js
-    ! prototype/slice/create-species-poisoned.js
-    ! prototype/slice/create-species.js
-    ! prototype/slice/length-exceeding-integer-limit-proxied-array.js
-    ! prototype/some/15.4.4.17-5-1-s.js
-    ! prototype/sort/S15.4.4.11_A8.js
-    ! prototype/sort/stability-2048-elements.js
-    ! prototype/sort/stability-513-elements.js
-    ! prototype/splice/clamps-length-to-integer-limit.js
-    ! prototype/splice/create-ctor-non-object.js
-    ! prototype/splice/create-ctor-poisoned.js
-    ! prototype/splice/create-species-abrupt.js
-    ! prototype/splice/create-species-length-exceeding-integer-limit.js
-    ! prototype/splice/create-species-neg-zero.js
-    ! prototype/splice/create-species-non-ctor.js
-    ! prototype/splice/create-species-poisoned.js
-    ! prototype/splice/create-species.js
-    # incorrect length handling
-    ! prototype/splice/S15.4.4.12_A6.1_T2.js
-    ! prototype/splice/S15.4.4.12_A6.1_T3.js
-    ! prototype/splice/set_length_no_args.js
-    # Object.preventExtensions doesn't seem to throw
-    ! prototype/Symbol.unscopables/prop-desc.js
-    # Object.preventExtensions doesn't seem to throw
-    ! prototype/Symbol.unscopables/value.js
-    ! prototype/toLocaleString/primitive_this_value.js
-    ! prototype/toLocaleString/primitive_this_value_getter.js
-    # Expects a particular string value
-    ! prototype/Symbol.iterator.js
-    ! Symbol.species/length.js
-    ! Symbol.species/return-value.js
-    ! Symbol.species/symbol-species-name.js
-    ! Symbol.species/symbol-species.js
+    from/calling-from-valid-1-noStrict.js Spec pretty clearly says this should be undefined
+    from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
+    from/iter-map-fn-this-non-strict.js Error propagation needs work in general
+    from/iter-set-elem-prop-err.js Error propagation needs work in general
+    from/source-object-constructor.js Error propagation needs work in general
+    from/source-object-iterator-1.js Uses "get" syntax that's not implemented
+    from/source-object-iterator-2.js Uses "get" syntax that's not implemented
+    of/return-abrupt-from-data-property.js Object.preventExtensions doesn't seem to throw
+    prototype/concat/Array.prototype.concat_large-typed-array.js new
+    prototype/concat/Array.prototype.concat_non-array.js
+    prototype/concat/Array.prototype.concat_small-typed-array.js
+    prototype/concat/create-ctor-non-object.js
+    prototype/concat/create-ctor-poisoned.js
+    prototype/concat/create-species-abrupt.js
+    prototype/concat/create-species-non-ctor.js
+    prototype/concat/create-species-poisoned.js
+    prototype/concat/create-species.js
+    prototype/copyWithin/return-abrupt-from-delete-target.js Not throwing properly on unwritable
+    prototype/every/15.4.4.16-5-1-s.js
+    prototype/filter/15.4.4.20-5-1-s.js
+    prototype/filter/create-ctor-non-object.js
+    prototype/filter/create-ctor-poisoned.js
+    prototype/filter/create-species-abrupt.js
+    prototype/filter/create-species-non-ctor.js
+    prototype/filter/create-species-poisoned.js
+    prototype/filter/create-species.js
+    prototype/findIndex/predicate-call-this-strict.js
+    prototype/find/predicate-call-this-strict.js
+    prototype/flatMap/array-like-objects-nested.js
+    prototype/flatMap/array-like-objects-poisoned-length.js
+    prototype/flatMap/array-like-objects-typedarrays.js
+    prototype/flatMap/array-like-objects.js
+    prototype/flatMap/bound-function-argument.js
+    prototype/flatMap/depth-always-one.js
+    prototype/flatMap/length.js
+    prototype/flatMap/name.js
+    prototype/flatMap/non-callable-argument-throws.js
+    prototype/flatMap/prop-desc.js
+    prototype/flatMap/proxy-access-count.js
+    prototype/flatMap/this-value-ctor-non-object.js
+    prototype/flatMap/this-value-ctor-object-species-bad-throws.js
+    prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
+    prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
+    prototype/flatMap/this-value-ctor-object-species.js
+    prototype/flatMap/this-value-null-undefined-throws.js
+    prototype/flatMap/thisArg-argument.js
+    prototype/flat/array-like-objects.js
+    prototype/flat/bound-function-call.js
+    prototype/flat/empty-array-elements.js
+    prototype/flat/empty-object-elements.js
+    prototype/flat/length.js
+    prototype/flat/name.js
+    prototype/flat/non-numeric-depth-should-not-throw.js
+    prototype/flat/non-object-ctor-throws.js
+    prototype/flat/null-undefined-elements.js
+    prototype/flat/null-undefined-input-throws.js
+    prototype/flat/positive-infinity.js
+    prototype/flat/prop-desc.js
+    prototype/flat/proxy-access-count.js
+    prototype/flat/symbol-object-create-null-depth-throws.js
+    prototype/forEach/15.4.4.18-5-1-s.js
+    prototype/map/15.4.4.19-5-1-s.js
+    prototype/map/create-ctor-non-object.js
+    prototype/map/create-ctor-poisoned.js
+    prototype/map/create-species-abrupt.js
+    prototype/map/create-species-non-ctor.js
+    prototype/map/create-species-poisoned.js
+    prototype/map/create-species.js
+    prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
+    prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
+    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js
+    prototype/reduce/15.4.4.21-9-c-ii-4-s.js
+    prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+    prototype/slice/create-ctor-non-object.js
+    prototype/slice/create-ctor-poisoned.js
+    prototype/slice/create-species-abrupt.js
+    prototype/slice/create-species-neg-zero.js
+    prototype/slice/create-species-non-ctor.js
+    prototype/slice/create-species-poisoned.js
+    prototype/slice/create-species.js
+    prototype/slice/length-exceeding-integer-limit-proxied-array.js
+    prototype/some/15.4.4.17-5-1-s.js
+    prototype/sort/S15.4.4.11_A8.js
+    prototype/sort/stability-2048-elements.js
+    prototype/sort/stability-513-elements.js
+    prototype/splice/clamps-length-to-integer-limit.js
+    prototype/splice/create-ctor-non-object.js
+    prototype/splice/create-ctor-poisoned.js
+    prototype/splice/create-species-abrupt.js
+    prototype/splice/create-species-length-exceeding-integer-limit.js
+    prototype/splice/create-species-neg-zero.js
+    prototype/splice/create-species-non-ctor.js
+    prototype/splice/create-species-poisoned.js
+    prototype/splice/create-species.js
+    prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
+    prototype/splice/S15.4.4.12_A6.1_T3.js
+    prototype/splice/set_length_no_args.js
+    prototype/Symbol.unscopables/prop-desc.js Object.preventExtensions doesn't seem to throw
+    prototype/Symbol.unscopables/value.js Object.preventExtensions doesn't seem to throw
+    prototype/toLocaleString/primitive_this_value.js
+    prototype/toLocaleString/primitive_this_value_getter.js
+    prototype/Symbol.iterator.js Expects a particular string value
+    Symbol.species/length.js
+    Symbol.species/return-value.js
+    Symbol.species/symbol-species-name.js
+    Symbol.species/symbol-species.js
 
 built-ins/ArrayBuffer
-    ! prototype/byteLength/detached-buffer.js
-    ! prototype/byteLength/invoked-as-accessor.js
-    ! prototype/byteLength/length.js
-    ! prototype/byteLength/name.js
-    ! prototype/byteLength/prop-desc.js
-    ! prototype/slice/species-constructor-is-not-object.js
-    ! prototype/slice/species-constructor-is-undefined.js
-    ! prototype/slice/species-is-not-constructor.js
-    ! prototype/slice/species-is-not-object.js
-    ! prototype/slice/species-is-null.js
-    ! prototype/slice/species-is-undefined.js
-    ! prototype/slice/species-returns-larger-arraybuffer.js
-    ! prototype/slice/species-returns-not-arraybuffer.js
-    ! prototype/slice/species-returns-same-arraybuffer.js
-    ! prototype/slice/species-returns-smaller-arraybuffer.js
-    ! prototype/slice/species.js
-    ! prototype/Symbol.toStringTag.js
-    ! Symbol.species/length.js
-    ! Symbol.species/return-value.js
-    ! Symbol.species/symbol-species-name.js
-    ! Symbol.species/symbol-species.js
-    ! undefined-newtarget-throws.js
+    prototype/byteLength/detached-buffer.js
+    prototype/byteLength/invoked-as-accessor.js
+    prototype/byteLength/length.js
+    prototype/byteLength/name.js
+    prototype/byteLength/prop-desc.js
+    prototype/slice/species-constructor-is-not-object.js
+    prototype/slice/species-constructor-is-undefined.js
+    prototype/slice/species-is-not-constructor.js
+    prototype/slice/species-is-not-object.js
+    prototype/slice/species-is-null.js
+    prototype/slice/species-is-undefined.js
+    prototype/slice/species-returns-larger-arraybuffer.js
+    prototype/slice/species-returns-not-arraybuffer.js
+    prototype/slice/species-returns-same-arraybuffer.js
+    prototype/slice/species-returns-smaller-arraybuffer.js
+    prototype/slice/species.js
+    prototype/Symbol.toStringTag.js
+    Symbol.species/length.js
+    Symbol.species/return-value.js
+    Symbol.species/symbol-species-name.js
+    Symbol.species/symbol-species.js
+    undefined-newtarget-throws.js
 
 built-ins/ArrayIteratorPrototype
-    ! next/detach-typedarray-in-progress.js
+    next/detach-typedarray-in-progress.js
 
-#built-ins/AsyncFunction
+~built-ins/AsyncFunction
 
-#built-ins/Atomics
+~built-ins/Atomics
 
 built-ins/BigInt
-    # Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
-    ! prototype/toString/prototype-call.js
-    # Computed property is not support
-    ! prototype/toString/thisbigintvalue-not-valid-throws.js
+    prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
+    prototype/toString/thisbigintvalue-not-valid-throws.js Computed property is not support
 
 built-ins/Boolean
 
 built-ins/DataView
-    ! prototype/buffer/detached-buffer.js
-    ! prototype/buffer/invoked-as-accessor.js
-    ! prototype/buffer/length.js
-    ! prototype/buffer/name.js
-    ! prototype/buffer/prop-desc.js
-    ! prototype/byteLength/detached-buffer.js
-    ! prototype/byteLength/invoked-as-accessor.js
-    ! prototype/byteLength/length.js
-    ! prototype/byteLength/name.js
-    ! prototype/byteLength/prop-desc.js
-    ! prototype/byteOffset/detached-buffer.js
-    ! prototype/byteOffset/invoked-as-accessor.js
-    ! prototype/byteOffset/length.js
-    ! prototype/byteOffset/name.js
-    ! prototype/byteOffset/prop-desc.js
-    ! prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getBigInt64/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getBigInt64/detached-buffer.js
-    ! prototype/getBigInt64/index-is-out-of-range.js
-    ! prototype/getBigInt64/length.js
-    ! prototype/getBigInt64/name.js
-    ! prototype/getBigInt64/negative-byteoffset-throws.js
-    ! prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
-    ! prototype/getBigInt64/return-value-clean-arraybuffer.js
-    ! prototype/getBigInt64/return-values-custom-offset.js
-    ! prototype/getBigInt64/return-values.js
-    ! prototype/getBigInt64/to-boolean-littleendian.js
-    ! prototype/getBigInt64/toindex-byteoffset.js
-    ! prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getBigUint64/detached-buffer.js
-    ! prototype/getBigUint64/index-is-out-of-range.js
-    ! prototype/getBigUint64/length.js
-    ! prototype/getBigUint64/name.js
-    ! prototype/getBigUint64/negative-byteoffset-throws.js
-    ! prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
-    ! prototype/getBigUint64/return-value-clean-arraybuffer.js
-    ! prototype/getBigUint64/return-values-custom-offset.js
-    ! prototype/getBigUint64/return-values.js
-    ! prototype/getBigUint64/to-boolean-littleendian.js
-    ! prototype/getBigUint64/toindex-byteoffset.js
-    ! prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getFloat32/detached-buffer.js
-    ! prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getFloat64/detached-buffer.js
-    ! prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getInt16/detached-buffer.js
-    ! prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getInt32/detached-buffer.js
-    ! prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getInt8/detached-buffer.js
-    ! prototype/getUint16/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getUint16/detached-buffer.js
-    ! prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getUint32/detached-buffer.js
-    ! prototype/getUint8/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getUint8/detached-buffer.js
-    ! prototype/setBigInt64/detached-buffer-after-bigint-value.js
-    ! prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setBigInt64/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setBigInt64/detached-buffer.js
-    ! prototype/setBigInt64/index-check-before-value-conversion.js
-    ! prototype/setBigInt64/index-is-out-of-range.js
-    ! prototype/setBigInt64/length.js
-    ! prototype/setBigInt64/name.js
-    ! prototype/setBigInt64/negative-byteoffset-throws.js
-    ! prototype/setBigInt64/range-check-after-value-conversion.js
-    ! prototype/setBigInt64/return-abrupt-from-tobigint-value.js
-    ! prototype/setBigInt64/return-abrupt-from-tonumber-byteoffset.js
-    ! prototype/setBigInt64/set-values-little-endian-order.js
-    ! prototype/setBigInt64/set-values-return-undefined.js
-    ! prototype/setBigInt64/to-boolean-littleendian.js
-    ! prototype/setBigInt64/toindex-byteoffset.js
-    ! prototype/setFloat32/detached-buffer-after-number-value.js
-    ! prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setFloat32/detached-buffer.js
-    ! prototype/setFloat64/detached-buffer-after-number-value.js
-    ! prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setFloat64/detached-buffer.js
-    ! prototype/setInt16/detached-buffer-after-number-value.js
-    ! prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setInt16/detached-buffer.js
-    ! prototype/setInt32/detached-buffer-after-number-value.js
-    ! prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setInt32/detached-buffer.js
-    ! prototype/setInt8/detached-buffer-after-number-value.js
-    ! prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setInt8/detached-buffer.js
-    ! prototype/setUint16/detached-buffer-after-number-value.js
-    ! prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setUint16/detached-buffer.js
-    ! prototype/setUint32/detached-buffer-after-number-value.js
-    ! prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setUint32/detached-buffer.js
-    ! prototype/setUint8/detached-buffer-after-number-value.js
-    ! prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
-    ! prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/setUint8/detached-buffer.js
-    ! prototype/Symbol.toStringTag.js
-    ! detached-buffer.js
-    ! newtarget-undefined-throws.js
+    prototype/buffer/detached-buffer.js
+    prototype/buffer/invoked-as-accessor.js
+    prototype/buffer/length.js
+    prototype/buffer/name.js
+    prototype/buffer/prop-desc.js
+    prototype/byteLength/detached-buffer.js
+    prototype/byteLength/invoked-as-accessor.js
+    prototype/byteLength/length.js
+    prototype/byteLength/name.js
+    prototype/byteLength/prop-desc.js
+    prototype/byteOffset/detached-buffer.js
+    prototype/byteOffset/invoked-as-accessor.js
+    prototype/byteOffset/length.js
+    prototype/byteOffset/name.js
+    prototype/byteOffset/prop-desc.js
+    prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
+    prototype/getBigInt64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getBigInt64/detached-buffer.js
+    prototype/getBigInt64/index-is-out-of-range.js
+    prototype/getBigInt64/length.js
+    prototype/getBigInt64/name.js
+    prototype/getBigInt64/negative-byteoffset-throws.js
+    prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
+    prototype/getBigInt64/return-value-clean-arraybuffer.js
+    prototype/getBigInt64/return-values-custom-offset.js
+    prototype/getBigInt64/return-values.js
+    prototype/getBigInt64/to-boolean-littleendian.js
+    prototype/getBigInt64/toindex-byteoffset.js
+    prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
+    prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getBigUint64/detached-buffer.js
+    prototype/getBigUint64/index-is-out-of-range.js
+    prototype/getBigUint64/length.js
+    prototype/getBigUint64/name.js
+    prototype/getBigUint64/negative-byteoffset-throws.js
+    prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
+    prototype/getBigUint64/return-value-clean-arraybuffer.js
+    prototype/getBigUint64/return-values-custom-offset.js
+    prototype/getBigUint64/return-values.js
+    prototype/getBigUint64/to-boolean-littleendian.js
+    prototype/getBigUint64/toindex-byteoffset.js
+    prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
+    prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getFloat32/detached-buffer.js
+    prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
+    prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getFloat64/detached-buffer.js
+    prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
+    prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getInt16/detached-buffer.js
+    prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
+    prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getInt32/detached-buffer.js
+    prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
+    prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getInt8/detached-buffer.js
+    prototype/getUint16/detached-buffer-after-toindex-byteoffset.js
+    prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getUint16/detached-buffer.js
+    prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
+    prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getUint32/detached-buffer.js
+    prototype/getUint8/detached-buffer-after-toindex-byteoffset.js
+    prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getUint8/detached-buffer.js
+    prototype/setBigInt64/detached-buffer-after-bigint-value.js
+    prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
+    prototype/setBigInt64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setBigInt64/detached-buffer.js
+    prototype/setBigInt64/index-check-before-value-conversion.js
+    prototype/setBigInt64/index-is-out-of-range.js
+    prototype/setBigInt64/length.js
+    prototype/setBigInt64/name.js
+    prototype/setBigInt64/negative-byteoffset-throws.js
+    prototype/setBigInt64/range-check-after-value-conversion.js
+    prototype/setBigInt64/return-abrupt-from-tobigint-value.js
+    prototype/setBigInt64/return-abrupt-from-tonumber-byteoffset.js
+    prototype/setBigInt64/set-values-little-endian-order.js
+    prototype/setBigInt64/set-values-return-undefined.js
+    prototype/setBigInt64/to-boolean-littleendian.js
+    prototype/setBigInt64/toindex-byteoffset.js
+    prototype/setFloat32/detached-buffer-after-number-value.js
+    prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js
+    prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setFloat32/detached-buffer.js
+    prototype/setFloat64/detached-buffer-after-number-value.js
+    prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
+    prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setFloat64/detached-buffer.js
+    prototype/setInt16/detached-buffer-after-number-value.js
+    prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
+    prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setInt16/detached-buffer.js
+    prototype/setInt32/detached-buffer-after-number-value.js
+    prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
+    prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setInt32/detached-buffer.js
+    prototype/setInt8/detached-buffer-after-number-value.js
+    prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
+    prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setInt8/detached-buffer.js
+    prototype/setUint16/detached-buffer-after-number-value.js
+    prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
+    prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setUint16/detached-buffer.js
+    prototype/setUint32/detached-buffer-after-number-value.js
+    prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
+    prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setUint32/detached-buffer.js
+    prototype/setUint8/detached-buffer-after-number-value.js
+    prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
+    prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setUint8/detached-buffer.js
+    prototype/Symbol.toStringTag.js
+    detached-buffer.js
+    newtarget-undefined-throws.js
 
 built-ins/Date
-    ! prototype/setFullYear/15.9.5.40_1.js
-    ! prototype/Symbol.toPrimitive/hint-default-first-invalid.js
-    ! prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
-    ! prototype/Symbol.toPrimitive/hint-default-first-valid.js
-    ! prototype/Symbol.toPrimitive/hint-invalid.js
-    ! prototype/Symbol.toPrimitive/hint-number-first-invalid.js
-    ! prototype/Symbol.toPrimitive/hint-number-first-non-callable.js
-    ! prototype/Symbol.toPrimitive/hint-number-first-valid.js
-    ! prototype/Symbol.toPrimitive/hint-string-first-invalid.js
-    ! prototype/Symbol.toPrimitive/hint-string-first-non-callable.js
-    ! prototype/Symbol.toPrimitive/hint-string-first-valid.js
-    ! prototype/Symbol.toPrimitive/length.js
-    ! prototype/Symbol.toPrimitive/name.js
-    ! prototype/Symbol.toPrimitive/prop-desc.js
-    ! prototype/Symbol.toPrimitive/this-val-non-obj.js
-    ! prototype/toJSON/invoke-result.js
-    ! prototype/toJSON/to-primitive-symbol.js
-    ! prototype/toJSON/to-primitive-value-of.js
-    ! prototype/toString/non-date-receiver.js
-    ! UTC/coercion-order.js
-    ! coercion-order.js
-    ! value-get-symbol-to-prim-err.js
-    ! value-symbol-to-prim-err.js
-    ! value-symbol-to-prim-invocation.js
-    ! value-symbol-to-prim-return-obj.js
-    ! value-symbol-to-prim-return-prim.js
-    ! value-to-primitive-call-err.js
-    ! value-to-primitive-call.js
-    ! value-to-primitive-get-meth-err.js
-    ! value-to-primitive-result-faulty.js
-    ! value-to-primitive-result-non-string-prim.js
-    ! value-to-primitive-result-string.js
+    prototype/setFullYear/15.9.5.40_1.js
+    prototype/Symbol.toPrimitive/hint-default-first-invalid.js
+    prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
+    prototype/Symbol.toPrimitive/hint-default-first-valid.js
+    prototype/Symbol.toPrimitive/hint-invalid.js
+    prototype/Symbol.toPrimitive/hint-number-first-invalid.js
+    prototype/Symbol.toPrimitive/hint-number-first-non-callable.js
+    prototype/Symbol.toPrimitive/hint-number-first-valid.js
+    prototype/Symbol.toPrimitive/hint-string-first-invalid.js
+    prototype/Symbol.toPrimitive/hint-string-first-non-callable.js
+    prototype/Symbol.toPrimitive/hint-string-first-valid.js
+    prototype/Symbol.toPrimitive/length.js
+    prototype/Symbol.toPrimitive/name.js
+    prototype/Symbol.toPrimitive/prop-desc.js
+    prototype/Symbol.toPrimitive/this-val-non-obj.js
+    prototype/toJSON/invoke-result.js
+    prototype/toJSON/to-primitive-symbol.js
+    prototype/toJSON/to-primitive-value-of.js
+    prototype/toString/non-date-receiver.js
+    UTC/coercion-order.js
+    coercion-order.js
+    value-get-symbol-to-prim-err.js
+    value-symbol-to-prim-err.js
+    value-symbol-to-prim-invocation.js
+    value-symbol-to-prim-return-obj.js
+    value-symbol-to-prim-return-prim.js
+    value-to-primitive-call-err.js
+    value-to-primitive-call.js
+    value-to-primitive-get-meth-err.js
+    value-to-primitive-result-faulty.js
+    value-to-primitive-result-non-string-prim.js
+    value-to-primitive-result-string.js
 
-# this is really; slow disable for now
-#built-ins/decodeURI
-#    name.js
-#    S15.1.3.1_A2.4_T1.js
-#    S15.1.3.1_A5.2.js
+~built-ins/decodeURI this is really; slow disable for now
+    name.js
+    S15.1.3.1_A2.4_T1.js
+    S15.1.3.1_A5.2.js
 
-# this is really; slow disable for now
-#built-ins/decodeURIComponent
-#    name.js
-#    S15.1.3.2_A2.4_T1.js
-#    S15.1.3.2_A5.2.js
+~built-ins/decodeURIComponent this is really; slow disable for now
+    name.js
+    S15.1.3.2_A2.4_T1.js
+    S15.1.3.2_A5.2.js
 
 built-ins/encodeURI
-    ! name.js
-    ! S15.1.3.3_A5.2.js
+    name.js
+    S15.1.3.3_A5.2.js
 
 built-ins/encodeURIComponent
-    ! name.js
-    ! S15.1.3.4_A5.2.js
+    name.js
+    S15.1.3.4_A5.2.js
 
 built-ins/Error
-    ! prototype/S15.11.4_A2.js
+    prototype/S15.11.4_A2.js
 
 built-ins/eval
-    ! length-non-configurable.js
-    ! name.js
+    length-non-configurable.js
+    name.js
 
 built-ins/Function
-    ! length/S15.3.5.1_A1_T3.js
-    ! length/S15.3.5.1_A2_T1.js
-    ! length/S15.3.5.1_A2_T2.js
-    ! length/S15.3.5.1_A2_T3.js
-    ! length/S15.3.5.1_A3_T3.js
-    ! length/S15.3.5.1_A4_T3.js
-    ! prototype/apply/15.3.4.3-1-s.js
-    ! prototype/apply/15.3.4.3-2-s.js
-    ! prototype/apply/15.3.4.3-3-s.js
-    ! prototype/apply/argarray-not-object.js
-    ! prototype/apply/S15.3.4.3_A3_T1.js
-    ! prototype/apply/S15.3.4.3_A3_T2.js
-    ! prototype/apply/S15.3.4.3_A3_T3.js
-    ! prototype/apply/S15.3.4.3_A3_T4.js
-    ! prototype/apply/S15.3.4.3_A3_T5.js
-    ! prototype/apply/S15.3.4.3_A3_T6.js
-    ! prototype/apply/S15.3.4.3_A3_T7.js
-    ! prototype/apply/S15.3.4.3_A3_T8.js
-    ! prototype/apply/S15.3.4.3_A5_T4.js
-    ! prototype/apply/S15.3.4.3_A7_T1.js
-    ! prototype/apply/S15.3.4.3_A7_T2.js
-    ! prototype/apply/S15.3.4.3_A7_T5.js
-    ! prototype/apply/S15.3.4.3_A7_T7.js
-    ! prototype/apply/this-not-callable.js
-    ! prototype/bind/15.3.4.5-15-2.js
-    ! prototype/bind/15.3.4.5-15-5.js
-    ! prototype/bind/BoundFunction_restricted-properties.js
-    ! prototype/bind/instance-name-chained.js
-    ! prototype/bind/instance-name-error.js
-    ! prototype/bind/instance-name-non-string.js
-    ! prototype/bind/instance-name.js
-    ! prototype/bind/length-exceeds-int32.js
-    ! prototype/call/15.3.4.4-1-s.js
-    ! prototype/call/15.3.4.4-2-s.js
-    ! prototype/call/15.3.4.4-3-s.js
-    ! prototype/call/S15.3.4.4_A13.js
-    ! prototype/call/S15.3.4.4_A14.js
-    ! prototype/call/S15.3.4.4_A3_T1.js
-    ! prototype/call/S15.3.4.4_A3_T2.js
-    ! prototype/call/S15.3.4.4_A3_T3.js
-    ! prototype/call/S15.3.4.4_A3_T4.js
-    ! prototype/call/S15.3.4.4_A3_T5.js
-    ! prototype/call/S15.3.4.4_A3_T6.js
-    ! prototype/call/S15.3.4.4_A3_T7.js
-    ! prototype/call/S15.3.4.4_A3_T8.js
-    ! prototype/call/S15.3.4.4_A5_T4.js
-    ! prototype/call/S15.3.4.4_A6_T1.js
-    ! prototype/call/S15.3.4.4_A6_T2.js
-    ! prototype/call/S15.3.4.4_A6_T5.js
-    ! prototype/call/S15.3.4.4_A6_T7.js
-    ! prototype/Symbol.hasInstance/length.js
-    ! prototype/Symbol.hasInstance/name.js
-    ! prototype/Symbol.hasInstance/prop-desc.js
-    ! prototype/Symbol.hasInstance/this-val-bound-target.js
-    ! prototype/Symbol.hasInstance/this-val-not-callable.js
-    ! prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
-    ! prototype/Symbol.hasInstance/value-negative.js
-    ! prototype/Symbol.hasInstance/value-non-obj.js
-    ! prototype/Symbol.hasInstance/value-positive.js
-    ! prototype/toString/arrow-function.js
-    ! prototype/toString/class-declaration-complex-heritage.js
-    ! prototype/toString/class-declaration-explicit-ctor.js
-    ! prototype/toString/class-declaration-implicit-ctor.js
-    ! prototype/toString/class-expression-explicit-ctor.js
-    ! prototype/toString/class-expression-implicit-ctor.js
-    ! prototype/toString/function-declaration-non-simple-parameter-list.js
-    ! prototype/toString/function-declaration.js
-    ! prototype/toString/function-expression.js
-    ! prototype/toString/Function.js
-    ! prototype/toString/generator-function-declaration.js
-    ! prototype/toString/generator-function-expression.js
-    ! prototype/toString/generator-method.js
-    ! prototype/toString/GeneratorFunction.js
-    ! prototype/toString/getter-class-expression-static.js
-    ! prototype/toString/getter-class-expression.js
-    ! prototype/toString/getter-class-statement-static.js
-    ! prototype/toString/getter-class-statement.js
-    ! prototype/toString/getter-object.js
-    ! prototype/toString/line-terminator-normalisation-CR-LF.js
-    ! prototype/toString/line-terminator-normalisation-CR.js
-    ! prototype/toString/line-terminator-normalisation-LF.js
-    ! prototype/toString/method-class-expression-static.js
-    ! prototype/toString/method-class-expression.js
-    ! prototype/toString/method-class-statement-static.js
-    ! prototype/toString/method-class-statement.js
-    ! prototype/toString/method-computed-property-name.js
-    ! prototype/toString/method-object.js
-    ! prototype/toString/private-method-class-expression.js
-    ! prototype/toString/private-method-class-statement.js
-    ! prototype/toString/private-static-method-class-expression.js
-    ! prototype/toString/private-static-method-class-statement.js
-    ! prototype/toString/S15.3.4.2_A12.js
-    ! prototype/toString/S15.3.4.2_A13.js
-    ! prototype/toString/setter-class-expression-static.js
-    ! prototype/toString/setter-class-expression.js
-    ! prototype/toString/setter-class-statement-static.js
-    ! prototype/toString/setter-class-statement.js
-    ! prototype/toString/setter-object.js
-    ! prototype/toString/symbol-named-builtins.js
-    ! prototype/toString/unicode.js
-    ! prototype/toString/well-known-intrinsic-object-functions.js
-    ! prototype/name.js
-    ! prototype/restricted-property-arguments.js
-    ! prototype/restricted-property-caller.js
-    ! prototype/S15.3.4_A5.js
-    ! 15.3.2.1-10-6gs.js
-    ! 15.3.2.1-11-1-s.js
-    ! 15.3.2.1-11-1.js
-    ! 15.3.2.1-11-2-s.js
-    ! 15.3.2.1-11-3-s.js
-    ! 15.3.2.1-11-3.js
-    ! 15.3.2.1-11-4-s.js
-    ! 15.3.2.1-11-5-s.js
-    ! 15.3.2.1-11-5.js
-    ! 15.3.2.1-11-6-s.js
-    ! 15.3.2.1-11-7-s.js
-    ! 15.3.2.1-11-8-s.js
-    ! 15.3.2.1-11-9-s.js
-    ! 15.3.5-1gs.js
-    ! 15.3.5-2gs.js
-    ! 15.3.5.4_2-11gs.js
-    ! 15.3.5.4_2-13gs.js
-    ! 15.3.5.4_2-15gs.js
-    ! 15.3.5.4_2-17gs.js
-    ! 15.3.5.4_2-19gs.js
-    ! 15.3.5.4_2-1gs.js
-    ! 15.3.5.4_2-21gs.js
-    ! 15.3.5.4_2-22gs.js
-    ! 15.3.5.4_2-23gs.js
-    ! 15.3.5.4_2-24gs.js
-    ! 15.3.5.4_2-25gs.js
-    ! 15.3.5.4_2-26gs.js
-    ! 15.3.5.4_2-27gs.js
-    ! 15.3.5.4_2-28gs.js
-    ! 15.3.5.4_2-29gs.js
-    ! 15.3.5.4_2-3gs.js
-    ! 15.3.5.4_2-48gs.js
-    ! 15.3.5.4_2-50gs.js
-    ! 15.3.5.4_2-52gs.js
-    ! 15.3.5.4_2-54gs.js
-    ! 15.3.5.4_2-5gs.js
-    ! 15.3.5.4_2-7gs.js
-    ! 15.3.5.4_2-9gs.js
-    ! instance-name.js
-    ! StrictFunction_restricted-properties.js
+    length/S15.3.5.1_A1_T3.js
+    length/S15.3.5.1_A2_T1.js
+    length/S15.3.5.1_A2_T2.js
+    length/S15.3.5.1_A2_T3.js
+    length/S15.3.5.1_A3_T3.js
+    length/S15.3.5.1_A4_T3.js
+    prototype/apply/15.3.4.3-1-s.js
+    prototype/apply/15.3.4.3-2-s.js
+    prototype/apply/15.3.4.3-3-s.js
+    prototype/apply/argarray-not-object.js
+    prototype/apply/S15.3.4.3_A3_T1.js
+    prototype/apply/S15.3.4.3_A3_T2.js
+    prototype/apply/S15.3.4.3_A3_T3.js
+    prototype/apply/S15.3.4.3_A3_T4.js
+    prototype/apply/S15.3.4.3_A3_T5.js
+    prototype/apply/S15.3.4.3_A3_T6.js
+    prototype/apply/S15.3.4.3_A3_T7.js
+    prototype/apply/S15.3.4.3_A3_T8.js
+    prototype/apply/S15.3.4.3_A5_T4.js
+    prototype/apply/S15.3.4.3_A7_T1.js
+    prototype/apply/S15.3.4.3_A7_T2.js
+    prototype/apply/S15.3.4.3_A7_T5.js
+    prototype/apply/S15.3.4.3_A7_T7.js
+    prototype/apply/this-not-callable.js
+    prototype/bind/15.3.4.5-15-2.js
+    prototype/bind/15.3.4.5-15-5.js
+    prototype/bind/BoundFunction_restricted-properties.js
+    prototype/bind/instance-name-chained.js
+    prototype/bind/instance-name-error.js
+    prototype/bind/instance-name-non-string.js
+    prototype/bind/instance-name.js
+    prototype/bind/length-exceeds-int32.js
+    prototype/call/15.3.4.4-1-s.js
+    prototype/call/15.3.4.4-2-s.js
+    prototype/call/15.3.4.4-3-s.js
+    prototype/call/S15.3.4.4_A13.js
+    prototype/call/S15.3.4.4_A14.js
+    prototype/call/S15.3.4.4_A3_T1.js
+    prototype/call/S15.3.4.4_A3_T2.js
+    prototype/call/S15.3.4.4_A3_T3.js
+    prototype/call/S15.3.4.4_A3_T4.js
+    prototype/call/S15.3.4.4_A3_T5.js
+    prototype/call/S15.3.4.4_A3_T6.js
+    prototype/call/S15.3.4.4_A3_T7.js
+    prototype/call/S15.3.4.4_A3_T8.js
+    prototype/call/S15.3.4.4_A5_T4.js
+    prototype/call/S15.3.4.4_A6_T1.js
+    prototype/call/S15.3.4.4_A6_T2.js
+    prototype/call/S15.3.4.4_A6_T5.js
+    prototype/call/S15.3.4.4_A6_T7.js
+    prototype/Symbol.hasInstance/length.js
+    prototype/Symbol.hasInstance/name.js
+    prototype/Symbol.hasInstance/prop-desc.js
+    prototype/Symbol.hasInstance/this-val-bound-target.js
+    prototype/Symbol.hasInstance/this-val-not-callable.js
+    prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
+    prototype/Symbol.hasInstance/value-negative.js
+    prototype/Symbol.hasInstance/value-non-obj.js
+    prototype/Symbol.hasInstance/value-positive.js
+    prototype/toString/arrow-function.js
+    prototype/toString/class-declaration-complex-heritage.js
+    prototype/toString/class-declaration-explicit-ctor.js
+    prototype/toString/class-declaration-implicit-ctor.js
+    prototype/toString/class-expression-explicit-ctor.js
+    prototype/toString/class-expression-implicit-ctor.js
+    prototype/toString/function-declaration-non-simple-parameter-list.js
+    prototype/toString/function-declaration.js
+    prototype/toString/function-expression.js
+    prototype/toString/Function.js
+    prototype/toString/generator-function-declaration.js
+    prototype/toString/generator-function-expression.js
+    prototype/toString/generator-method.js
+    prototype/toString/GeneratorFunction.js
+    prototype/toString/getter-class-expression-static.js
+    prototype/toString/getter-class-expression.js
+    prototype/toString/getter-class-statement-static.js
+    prototype/toString/getter-class-statement.js
+    prototype/toString/getter-object.js
+    prototype/toString/line-terminator-normalisation-CR-LF.js
+    prototype/toString/line-terminator-normalisation-CR.js
+    prototype/toString/line-terminator-normalisation-LF.js
+    prototype/toString/method-class-expression-static.js
+    prototype/toString/method-class-expression.js
+    prototype/toString/method-class-statement-static.js
+    prototype/toString/method-class-statement.js
+    prototype/toString/method-computed-property-name.js
+    prototype/toString/method-object.js
+    prototype/toString/private-method-class-expression.js
+    prototype/toString/private-method-class-statement.js
+    prototype/toString/private-static-method-class-expression.js
+    prototype/toString/private-static-method-class-statement.js
+    prototype/toString/S15.3.4.2_A12.js
+    prototype/toString/S15.3.4.2_A13.js
+    prototype/toString/setter-class-expression-static.js
+    prototype/toString/setter-class-expression.js
+    prototype/toString/setter-class-statement-static.js
+    prototype/toString/setter-class-statement.js
+    prototype/toString/setter-object.js
+    prototype/toString/symbol-named-builtins.js
+    prototype/toString/unicode.js
+    prototype/toString/well-known-intrinsic-object-functions.js
+    prototype/name.js
+    prototype/restricted-property-arguments.js
+    prototype/restricted-property-caller.js
+    prototype/S15.3.4_A5.js
+    15.3.2.1-10-6gs.js
+    15.3.2.1-11-1-s.js
+    15.3.2.1-11-1.js
+    15.3.2.1-11-2-s.js
+    15.3.2.1-11-3-s.js
+    15.3.2.1-11-3.js
+    15.3.2.1-11-4-s.js
+    15.3.2.1-11-5-s.js
+    15.3.2.1-11-5.js
+    15.3.2.1-11-6-s.js
+    15.3.2.1-11-7-s.js
+    15.3.2.1-11-8-s.js
+    15.3.2.1-11-9-s.js
+    15.3.5-1gs.js
+    15.3.5-2gs.js
+    15.3.5.4_2-11gs.js
+    15.3.5.4_2-13gs.js
+    15.3.5.4_2-15gs.js
+    15.3.5.4_2-17gs.js
+    15.3.5.4_2-19gs.js
+    15.3.5.4_2-1gs.js
+    15.3.5.4_2-21gs.js
+    15.3.5.4_2-22gs.js
+    15.3.5.4_2-23gs.js
+    15.3.5.4_2-24gs.js
+    15.3.5.4_2-25gs.js
+    15.3.5.4_2-26gs.js
+    15.3.5.4_2-27gs.js
+    15.3.5.4_2-28gs.js
+    15.3.5.4_2-29gs.js
+    15.3.5.4_2-3gs.js
+    15.3.5.4_2-48gs.js
+    15.3.5.4_2-50gs.js
+    15.3.5.4_2-52gs.js
+    15.3.5.4_2-54gs.js
+    15.3.5.4_2-5gs.js
+    15.3.5.4_2-7gs.js
+    15.3.5.4_2-9gs.js
+    instance-name.js
+    StrictFunction_restricted-properties.js
 
-#built-ins/GeneratorFunction
+~built-ins/GeneratorFunction
 
 built-ins/GeneratorPrototype
-    ! next/from-state-executing.js
-    ! next/length.js
-    ! next/name.js
-    ! next/property-descriptor.js
-    ! next/this-val-not-generator.js
-    ! next/this-val-not-object.js
-    ! return/from-state-completed.js
-    ! return/from-state-executing.js
-    ! return/from-state-suspended-start.js
-    ! return/length.js
-    ! return/name.js
-    ! return/property-descriptor.js
-    ! return/this-val-not-generator.js
-    ! return/this-val-not-object.js
-    ! return/try-catch-before-try.js
-    ! return/try-catch-following-catch.js
-    ! return/try-catch-within-catch.js
-    ! return/try-catch-within-try.js
-    ! return/try-finally-before-try.js
-    ! return/try-finally-following-finally.js
-    ! return/try-finally-nested-try-catch-within-catch.js
-    ! return/try-finally-nested-try-catch-within-finally.js
-    ! return/try-finally-nested-try-catch-within-inner-try.js
-    ! return/try-finally-nested-try-catch-within-outer-try-after-nested.js
-    ! return/try-finally-nested-try-catch-within-outer-try-before-nested.js
-    ! return/try-finally-within-finally.js
-    ! return/try-finally-within-try.js
-    ! throw/from-state-executing.js
-    ! throw/length.js
-    ! throw/name.js
-    ! throw/property-descriptor.js
-    ! throw/this-val-not-generator.js
-    ! throw/this-val-not-object.js
-    ! constructor.js
-    ! Symbol.toStringTag.js
+    next/from-state-executing.js
+    next/length.js
+    next/name.js
+    next/property-descriptor.js
+    next/this-val-not-generator.js
+    next/this-val-not-object.js
+    return/from-state-completed.js
+    return/from-state-executing.js
+    return/from-state-suspended-start.js
+    return/length.js
+    return/name.js
+    return/property-descriptor.js
+    return/this-val-not-generator.js
+    return/this-val-not-object.js
+    return/try-catch-before-try.js
+    return/try-catch-following-catch.js
+    return/try-catch-within-catch.js
+    return/try-catch-within-try.js
+    return/try-finally-before-try.js
+    return/try-finally-following-finally.js
+    return/try-finally-nested-try-catch-within-catch.js
+    return/try-finally-nested-try-catch-within-finally.js
+    return/try-finally-nested-try-catch-within-inner-try.js
+    return/try-finally-nested-try-catch-within-outer-try-after-nested.js
+    return/try-finally-nested-try-catch-within-outer-try-before-nested.js
+    return/try-finally-within-finally.js
+    return/try-finally-within-try.js
+    throw/from-state-executing.js
+    throw/length.js
+    throw/name.js
+    throw/property-descriptor.js
+    throw/this-val-not-generator.js
+    throw/this-val-not-object.js
+    constructor.js
+    Symbol.toStringTag.js
 
 built-ins/global
-    ! global-object.js
-    ! property-descriptor.js
+    global-object.js
+    property-descriptor.js
 
 built-ins/Infinity
 
 built-ins/isFinite
-    ! length.js
-    ! name.js
-    ! toprimitive-call-abrupt.js
-    ! toprimitive-get-abrupt.js
-    ! toprimitive-not-callable-throws.js
-    ! toprimitive-result-is-object-throws.js
-    ! toprimitive-result-is-symbol-throws.js
-    ! toprimitive-valid-result.js
+    length.js
+    name.js
+    toprimitive-call-abrupt.js
+    toprimitive-get-abrupt.js
+    toprimitive-not-callable-throws.js
+    toprimitive-result-is-object-throws.js
+    toprimitive-result-is-symbol-throws.js
+    toprimitive-valid-result.js
 
 built-ins/isNaN
-    ! length.js
-    ! name.js
-    ! toprimitive-call-abrupt.js
-    ! toprimitive-get-abrupt.js
-    ! toprimitive-not-callable-throws.js
-    ! toprimitive-result-is-object-throws.js
-    ! toprimitive-result-is-symbol-throws.js
-    ! toprimitive-valid-result.js
+    length.js
+    name.js
+    toprimitive-call-abrupt.js
+    toprimitive-get-abrupt.js
+    toprimitive-not-callable-throws.js
+    toprimitive-result-is-object-throws.js
+    toprimitive-result-is-symbol-throws.js
+    toprimitive-valid-result.js
 
-#built-ins/IteratorPrototype
+~built-ins/IteratorPrototype
 
 built-ins/JSON
-    ! parse/S15.12.2_A1.js
-    ! parse/text-negative-zero.js
-    ! stringify/replacer-array-number.js
-    ! stringify/replacer-function-arguments.js
-    ! stringify/replacer-function-result.js
-    ! stringify/value-bigint-tojson-receiver.js
-    ! stringify/value-string-escape-ascii.js
-    ! stringify/value-string-escape-unicode.js
-    ! stringify/value-symbol.js
-    ! stringify/value-tojson-arguments.js
-    ! Symbol.toStringTag.js
+    parse/S15.12.2_A1.js
+    parse/text-negative-zero.js
+    stringify/replacer-array-number.js
+    stringify/replacer-function-arguments.js
+    stringify/replacer-function-result.js
+    stringify/value-bigint-tojson-receiver.js
+    stringify/value-string-escape-ascii.js
+    stringify/value-string-escape-unicode.js
+    stringify/value-symbol.js
+    stringify/value-tojson-arguments.js
+    Symbol.toStringTag.js
 
 built-ins/Map
-    ! Symbol.species/length.js
-    ! Symbol.species/return-value.js
-    ! Symbol.species/symbol-species-name.js
-    ! Symbol.species/symbol-species.js
-    ! iterator-is-undefined-throws.js
+    Symbol.species/length.js
+    Symbol.species/return-value.js
+    Symbol.species/symbol-species-name.js
+    Symbol.species/symbol-species.js
+    iterator-is-undefined-throws.js
 
 built-ins/MapIteratorPrototype
 
 built-ins/Math
-    # calculation is not exact
-    ! log2/log2-basicTests.js
-    ! Symbol.toStringTag.js
+    log2/log2-basicTests.js calculation is not exact
+    Symbol.toStringTag.js
 
 built-ins/NaN
 
 built-ins/NativeErrors
-    ! EvalError/prototype/not-error-object.js
-    ! RangeError/prototype/not-error-object.js
-    ! ReferenceError/prototype/not-error-object.js
-    ! SyntaxError/prototype/not-error-object.js
-    ! TypeError/prototype/not-error-object.js
-    ! URIError/prototype/not-error-object.js
+    EvalError/prototype/not-error-object.js
+    RangeError/prototype/not-error-object.js
+    ReferenceError/prototype/not-error-object.js
+    SyntaxError/prototype/not-error-object.js
+    TypeError/prototype/not-error-object.js
+    URIError/prototype/not-error-object.js
 
 built-ins/Number
-    ! prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
-    ! prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
-    ! prototype/toExponential/undefined-fractiondigits.js
-    ! prototype/toLocaleString/length.js
-    ! prototype/toPrecision/nan.js
+    prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
+    prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
+    prototype/toExponential/undefined-fractiondigits.js
+    prototype/toLocaleString/length.js
+    prototype/toPrecision/nan.js
 
 built-ins/Object
-    ! assign/strings-and-symbol-order.js
-    ! create/15.2.3.5-4-311.js
-    ! defineProperties/15.2.3.7-6-a-112.js
-    ! defineProperties/15.2.3.7-6-a-113.js
-    ! defineProperties/15.2.3.7-6-a-118.js
-    ! defineProperties/15.2.3.7-6-a-164.js
-    ! defineProperties/15.2.3.7-6-a-165.js
-    ! defineProperties/15.2.3.7-6-a-166.js
-    ! defineProperties/15.2.3.7-6-a-168.js
-    ! defineProperties/15.2.3.7-6-a-169.js
-    ! defineProperties/15.2.3.7-6-a-170.js
-    ! defineProperties/15.2.3.7-6-a-172.js
-    ! defineProperties/15.2.3.7-6-a-173.js
-    ! defineProperties/15.2.3.7-6-a-175.js
-    ! defineProperties/15.2.3.7-6-a-176.js
-    ! defineProperties/15.2.3.7-6-a-184.js
-    ! defineProperties/15.2.3.7-6-a-185.js
-    ! defineProperties/15.2.3.7-6-a-282.js
-    ! defineProperty/15.2.3.6-4-116.js
-    ! defineProperty/15.2.3.6-4-117.js
-    ! defineProperty/15.2.3.6-4-122.js
-    ! defineProperty/15.2.3.6-4-168.js
-    ! defineProperty/15.2.3.6-4-169.js
-    ! defineProperty/15.2.3.6-4-170.js
-    ! defineProperty/15.2.3.6-4-172.js
-    ! defineProperty/15.2.3.6-4-173.js
-    ! defineProperty/15.2.3.6-4-174.js
-    ! defineProperty/15.2.3.6-4-176.js
-    ! defineProperty/15.2.3.6-4-177.js
-    ! defineProperty/15.2.3.6-4-188.js
-    ! defineProperty/15.2.3.6-4-189.js
-    ! defineProperty/15.2.3.6-4-206.js
-    ! defineProperty/15.2.3.6-4-254.js
-    ! defineProperty/15.2.3.6-4-255.js
-    ! defineProperty/15.2.3.6-4-256.js
-    ! defineProperty/15.2.3.6-4-293-1.js
-    ! defineProperty/15.2.3.6-4-293-3.js
-    ! defineProperty/15.2.3.6-4-293-4.js
-    ! defineProperty/15.2.3.6-4-336.js
-    ! fromEntries/evaluation-order.js
-    ! fromEntries/iterator-closed-for-null-entry.js
-    ! fromEntries/iterator-closed-for-string-entry.js
-    ! fromEntries/iterator-closed-for-throwing-entry-key-accessor.js
-    ! fromEntries/iterator-closed-for-throwing-entry-key-tostring.js
-    ! fromEntries/iterator-closed-for-throwing-entry-value-accessor.js
-    ! fromEntries/iterator-not-closed-for-next-returning-non-object.js
-    ! fromEntries/iterator-not-closed-for-throwing-done-accessor.js
-    ! fromEntries/iterator-not-closed-for-throwing-next.js
-    ! fromEntries/iterator-not-closed-for-uncallable-next.js
-    ! fromEntries/to-property-key.js
-    ! fromEntries/uses-keys-not-iterator.js
-    ! getOwnPropertyDescriptors/function-length.js
-    ! getOwnPropertyDescriptors/function-name.js
-    ! getOwnPropertyDescriptors/function-property-descriptor.js
-    ! getOwnPropertyDescriptors/inherited-properties-omitted.js
-    ! getOwnPropertyDescriptors/normal-object.js
-    ! getOwnPropertyDescriptors/primitive-booleans.js
-    ! getOwnPropertyDescriptors/primitive-numbers.js
-    ! getOwnPropertyDescriptors/primitive-strings.js
-    ! getOwnPropertyDescriptors/primitive-symbols.js
-    ! getOwnPropertyDescriptors/symbols-included.js
-    ! getOwnPropertyDescriptors/tamper-with-global-object.js
-    ! getOwnPropertyDescriptors/tamper-with-object-keys.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-187.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-212.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-213.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-214.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-215.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-249.js
-    ! getOwnPropertyDescriptor/15.2.3.3-4-250.js
-    ! getPrototypeOf/15.2.3.2-2-12.js
-    ! getPrototypeOf/15.2.3.2-2-13.js
-    ! getPrototypeOf/15.2.3.2-2-14.js
-    ! getPrototypeOf/15.2.3.2-2-15.js
-    ! getPrototypeOf/15.2.3.2-2-16.js
-    ! getPrototypeOf/15.2.3.2-2-17.js
-    ! internals/DefineOwnProperty/consistent-value-function-arguments.js
-    ! internals/DefineOwnProperty/consistent-value-function-caller.js
-    ! internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
-    ! internals/DefineOwnProperty/consistent-writable-regexp-dollar1.js
-    ! keys/proxy-keys.js
-    ! prototype/hasOwnProperty/symbol_property_toPrimitive.js
-    ! prototype/hasOwnProperty/symbol_property_toString.js
-    ! prototype/hasOwnProperty/symbol_property_valueOf.js
-    ! prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
-    ! prototype/propertyIsEnumerable/symbol_property_toString.js
-    ! prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    ! prototype/toLocaleString/primitive_this_value.js
-    ! prototype/toLocaleString/primitive_this_value_getter.js
-    ! prototype/toLocaleString/S15.2.4.3_A12.js
-    ! prototype/toLocaleString/S15.2.4.3_A13.js
-    ! prototype/toString/get-symbol-tag-err.js
-    ! prototype/toString/symbol-tag-non-str-bigint.js
-    ! prototype/toString/symbol-tag-non-str-builtin.js
-    ! prototype/toString/symbol-tag-override-bigint.js
-    ! prototype/toString/symbol-tag-override-instances.js
-    ! prototype/toString/symbol-tag-override-primitives.js
-    ! prototype/toString/symbol-tag-str.js
-    ! prototype/valueOf/S15.2.4.4_A14.js
-    ! prototype/valueOf/S15.2.4.4_A15.js
+    assign/strings-and-symbol-order.js
+    create/15.2.3.5-4-311.js
+    defineProperties/15.2.3.7-6-a-112.js
+    defineProperties/15.2.3.7-6-a-113.js
+    defineProperties/15.2.3.7-6-a-118.js
+    defineProperties/15.2.3.7-6-a-164.js
+    defineProperties/15.2.3.7-6-a-165.js
+    defineProperties/15.2.3.7-6-a-166.js
+    defineProperties/15.2.3.7-6-a-168.js
+    defineProperties/15.2.3.7-6-a-169.js
+    defineProperties/15.2.3.7-6-a-170.js
+    defineProperties/15.2.3.7-6-a-172.js
+    defineProperties/15.2.3.7-6-a-173.js
+    defineProperties/15.2.3.7-6-a-175.js
+    defineProperties/15.2.3.7-6-a-176.js
+    defineProperties/15.2.3.7-6-a-184.js
+    defineProperties/15.2.3.7-6-a-185.js
+    defineProperties/15.2.3.7-6-a-282.js
+    defineProperty/15.2.3.6-4-116.js
+    defineProperty/15.2.3.6-4-117.js
+    defineProperty/15.2.3.6-4-122.js
+    defineProperty/15.2.3.6-4-168.js
+    defineProperty/15.2.3.6-4-169.js
+    defineProperty/15.2.3.6-4-170.js
+    defineProperty/15.2.3.6-4-172.js
+    defineProperty/15.2.3.6-4-173.js
+    defineProperty/15.2.3.6-4-174.js
+    defineProperty/15.2.3.6-4-176.js
+    defineProperty/15.2.3.6-4-177.js
+    defineProperty/15.2.3.6-4-188.js
+    defineProperty/15.2.3.6-4-189.js
+    defineProperty/15.2.3.6-4-206.js
+    defineProperty/15.2.3.6-4-254.js
+    defineProperty/15.2.3.6-4-255.js
+    defineProperty/15.2.3.6-4-256.js
+    defineProperty/15.2.3.6-4-293-1.js
+    defineProperty/15.2.3.6-4-293-3.js
+    defineProperty/15.2.3.6-4-293-4.js
+    defineProperty/15.2.3.6-4-336.js
+    fromEntries/evaluation-order.js
+    fromEntries/iterator-closed-for-null-entry.js
+    fromEntries/iterator-closed-for-string-entry.js
+    fromEntries/iterator-closed-for-throwing-entry-key-accessor.js
+    fromEntries/iterator-closed-for-throwing-entry-key-tostring.js
+    fromEntries/iterator-closed-for-throwing-entry-value-accessor.js
+    fromEntries/iterator-not-closed-for-next-returning-non-object.js
+    fromEntries/iterator-not-closed-for-throwing-done-accessor.js
+    fromEntries/iterator-not-closed-for-throwing-next.js
+    fromEntries/iterator-not-closed-for-uncallable-next.js
+    fromEntries/to-property-key.js
+    fromEntries/uses-keys-not-iterator.js
+    getOwnPropertyDescriptors/function-length.js
+    getOwnPropertyDescriptors/function-name.js
+    getOwnPropertyDescriptors/function-property-descriptor.js
+    getOwnPropertyDescriptors/inherited-properties-omitted.js
+    getOwnPropertyDescriptors/normal-object.js
+    getOwnPropertyDescriptors/primitive-booleans.js
+    getOwnPropertyDescriptors/primitive-numbers.js
+    getOwnPropertyDescriptors/primitive-strings.js
+    getOwnPropertyDescriptors/primitive-symbols.js
+    getOwnPropertyDescriptors/symbols-included.js
+    getOwnPropertyDescriptors/tamper-with-global-object.js
+    getOwnPropertyDescriptors/tamper-with-object-keys.js
+    getOwnPropertyDescriptor/15.2.3.3-4-187.js
+    getOwnPropertyDescriptor/15.2.3.3-4-212.js
+    getOwnPropertyDescriptor/15.2.3.3-4-213.js
+    getOwnPropertyDescriptor/15.2.3.3-4-214.js
+    getOwnPropertyDescriptor/15.2.3.3-4-215.js
+    getOwnPropertyDescriptor/15.2.3.3-4-249.js
+    getOwnPropertyDescriptor/15.2.3.3-4-250.js
+    getPrototypeOf/15.2.3.2-2-12.js
+    getPrototypeOf/15.2.3.2-2-13.js
+    getPrototypeOf/15.2.3.2-2-14.js
+    getPrototypeOf/15.2.3.2-2-15.js
+    getPrototypeOf/15.2.3.2-2-16.js
+    getPrototypeOf/15.2.3.2-2-17.js
+    internals/DefineOwnProperty/consistent-value-function-arguments.js
+    internals/DefineOwnProperty/consistent-value-function-caller.js
+    internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
+    internals/DefineOwnProperty/consistent-writable-regexp-dollar1.js
+    keys/proxy-keys.js
+    prototype/hasOwnProperty/symbol_property_toPrimitive.js
+    prototype/hasOwnProperty/symbol_property_toString.js
+    prototype/hasOwnProperty/symbol_property_valueOf.js
+    prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
+    prototype/propertyIsEnumerable/symbol_property_toString.js
+    prototype/propertyIsEnumerable/symbol_property_valueOf.js
+    prototype/toLocaleString/primitive_this_value.js
+    prototype/toLocaleString/primitive_this_value_getter.js
+    prototype/toLocaleString/S15.2.4.3_A12.js
+    prototype/toLocaleString/S15.2.4.3_A13.js
+    prototype/toString/get-symbol-tag-err.js
+    prototype/toString/symbol-tag-non-str-bigint.js
+    prototype/toString/symbol-tag-non-str-builtin.js
+    prototype/toString/symbol-tag-override-bigint.js
+    prototype/toString/symbol-tag-override-instances.js
+    prototype/toString/symbol-tag-override-primitives.js
+    prototype/toString/symbol-tag-str.js
+    prototype/valueOf/S15.2.4.4_A14.js
+    prototype/valueOf/S15.2.4.4_A15.js
 
 built-ins/parseFloat
-    ! name.js
-    ! S15.1.2.3_A7.2.js
+    name.js
+    S15.1.2.3_A7.2.js
 
 built-ins/parseInt
-    ! name.js
-    ! S15.1.2.2_A9.2.js
+    name.js
+    S15.1.2.2_A9.2.js
 
-#built-ins/Promise
+~built-ins/Promise
 
-#built-ins/Proxy
+~built-ins/Proxy
 
-#built-ins/Reflect
+~built-ins/Reflect
 
 built-ins/RegExp
-    ! CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
-    ! CharacterClassEscapes/character-class-digit-class-escape.js
-    ! CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
-    ! CharacterClassEscapes/character-class-non-digit-class-escape.js
-    ! CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
-    ! CharacterClassEscapes/character-class-non-whitespace-class-escape.js
-    ! CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
-    ! CharacterClassEscapes/character-class-non-word-class-escape.js
-    ! CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
-    ! CharacterClassEscapes/character-class-whitespace-class-escape.js
-    ! CharacterClassEscapes/character-class-word-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
-    ! CharacterClassEscapes/character-class-word-class-escape.js
-    ! match-indices/indices-array-element.js
-    ! match-indices/indices-array-matched.js
-    ! match-indices/indices-array-non-unicode-match.js
-    ! match-indices/indices-array-properties.js
-    ! match-indices/indices-array-unicode-match.js
-    ! match-indices/indices-array-unicode-property-names.js
-    ! match-indices/indices-array-unmatched.js
-    ! match-indices/indices-array.js
-    ! match-indices/indices-property.js
-    ! prototype/exec/failure-lastindex-access.js
-    ! prototype/exec/S15.10.6.2_A5_T3.js
-    ! prototype/exec/success-lastindex-access.js
-    ! prototype/exec/u-captured-value.js
-    ! prototype/exec/u-lastindex-adv.js
-    ! prototype/exec/u-lastindex-value.js
-    ! prototype/exec/y-fail-lastindex-no-write.js
-    ! prototype/exec/y-fail-lastindex.js
-    ! prototype/exec/y-fail-return.js
-    ! prototype/exec/y-init-lastindex.js
-    ! prototype/exec/y-set-lastindex.js
-    ! prototype/flags/coercion-global.js
-    ! prototype/flags/coercion-ignoreCase.js
-    ! prototype/flags/coercion-multiline.js
-    ! prototype/flags/coercion-sticky.js
-    ! prototype/flags/coercion-unicode.js
-    ! prototype/flags/length.js
-    ! prototype/flags/name.js
-    ! prototype/flags/prop-desc.js
-    ! prototype/flags/this-val-non-obj.js
-    ! prototype/flags/this-val-regexp-prototype.js
-    ! prototype/global/15.10.7.2-2.js
-    ! prototype/global/length.js
-    ! prototype/global/name.js
-    ! prototype/global/S15.10.7.2_A9.js
-    ! prototype/global/this-val-regexp-prototype.js
-    ! prototype/ignoreCase/15.10.7.3-2.js
-    ! prototype/ignoreCase/length.js
-    ! prototype/ignoreCase/name.js
-    ! prototype/ignoreCase/S15.10.7.3_A9.js
-    ! prototype/ignoreCase/this-val-regexp-prototype.js
-    ! prototype/multiline/15.10.7.4-2.js
-    ! prototype/multiline/length.js
-    ! prototype/multiline/name.js
-    ! prototype/multiline/S15.10.7.4_A9.js
-    ! prototype/multiline/this-val-regexp-prototype.js
-    ! prototype/source/length.js
-    ! prototype/source/name.js
-    ! prototype/source/prop-desc.js
-    ! prototype/source/this-val-regexp-prototype.js
-    ! prototype/source/value-empty.js
-    ! prototype/source/value-line-terminator.js
-    ! prototype/source/value-u.js
-    ! prototype/sticky/length.js
-    ! prototype/sticky/name.js
-    ! prototype/sticky/prop-desc.js
-    ! prototype/sticky/this-val-invalid-obj.js
-    ! prototype/sticky/this-val-non-obj.js
-    ! prototype/sticky/this-val-regexp-prototype.js
-    ! prototype/sticky/this-val-regexp.js
-    ! prototype/Symbol.match/builtin-coerce-lastindex.js
-    ! prototype/Symbol.match/builtin-failure-y-return-val.js
-    ! prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
-    ! prototype/Symbol.match/builtin-failure-y-set-lastindex.js
-    ! prototype/Symbol.match/builtin-infer-unicode.js
-    ! prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
-    ! prototype/Symbol.match/builtin-success-g-set-lastindex.js
-    ! prototype/Symbol.match/builtin-success-u-return-val-groups.js
-    ! prototype/Symbol.match/builtin-success-y-set-lastindex-err.js
-    ! prototype/Symbol.match/builtin-success-y-set-lastindex.js
-    ! prototype/Symbol.match/builtin-y-coerce-lastindex-err.js
-    ! prototype/Symbol.match/coerce-global.js
-    ! prototype/Symbol.match/exec-err.js
-    ! prototype/Symbol.match/exec-invocation.js
-    ! prototype/Symbol.match/exec-return-type-invalid.js
-    ! prototype/Symbol.match/exec-return-type-valid.js
-    ! prototype/Symbol.match/g-coerce-result-err.js
-    ! prototype/Symbol.match/g-get-exec-err.js
-    ! prototype/Symbol.match/g-get-result-err.js
-    ! prototype/Symbol.match/g-init-lastindex.js
-    ! prototype/Symbol.match/g-match-empty-advance-lastindex.js
-    ! prototype/Symbol.match/g-match-empty-coerce-lastindex-err.js
-    ! prototype/Symbol.match/g-match-empty-set-lastindex-err.js
-    ! prototype/Symbol.match/g-success-return-val.js
-    ! prototype/Symbol.match/get-exec-err.js
-    ! prototype/Symbol.match/get-global-err.js
-    ! prototype/Symbol.match/get-unicode-error.js
-    ! prototype/Symbol.match/this-val-non-regexp.js
-    ! prototype/Symbol.match/u-advance-after-empty.js
-    ! prototype/Symbol.match/y-fail-global-return.js
-    ! prototype/Symbol.match/y-fail-lastindex-no-write.js
-    ! prototype/Symbol.match/y-fail-lastindex.js
-    ! prototype/Symbol.match/y-fail-return.js
-    ! prototype/Symbol.match/y-init-lastindex.js
-    ! prototype/Symbol.match/y-set-lastindex.js
-    ! prototype/Symbol.replace/arg-1-coerce-err.js
-    ! prototype/Symbol.replace/arg-1-coerce.js
-    ! prototype/Symbol.replace/arg-2-coerce-err.js
-    ! prototype/Symbol.replace/arg-2-coerce.js
-    ! prototype/Symbol.replace/coerce-global.js
-    ! prototype/Symbol.replace/coerce-unicode.js
-    ! prototype/Symbol.replace/exec-err.js
-    ! prototype/Symbol.replace/exec-invocation.js
-    ! prototype/Symbol.replace/fn-coerce-replacement-err.js
-    ! prototype/Symbol.replace/fn-coerce-replacement.js
-    ! prototype/Symbol.replace/fn-err.js
-    ! prototype/Symbol.replace/fn-invoke-args.js
-    ! prototype/Symbol.replace/fn-invoke-this-no-strict.js
-    ! prototype/Symbol.replace/fn-invoke-this-strict.js
-    ! prototype/Symbol.replace/g-init-lastindex-err.js
-    ! prototype/Symbol.replace/g-init-lastindex.js
-    ! prototype/Symbol.replace/g-pos-decrement.js
-    ! prototype/Symbol.replace/g-pos-increment.js
-    ! prototype/Symbol.replace/get-exec-err.js
-    ! prototype/Symbol.replace/get-global-err.js
-    ! prototype/Symbol.replace/get-unicode-error.js
-    ! prototype/Symbol.replace/length.js
-    ! prototype/Symbol.replace/match-failure.js
-    ! prototype/Symbol.replace/name.js
-    ! prototype/Symbol.replace/prop-desc.js
-    ! prototype/Symbol.replace/replace-with-trailing.js
-    ! prototype/Symbol.replace/replace-without-trailing.js
-    ! prototype/Symbol.replace/result-coerce-capture-err.js
-    ! prototype/Symbol.replace/result-coerce-capture.js
-    ! prototype/Symbol.replace/result-coerce-index-err.js
-    ! prototype/Symbol.replace/result-coerce-index.js
-    ! prototype/Symbol.replace/result-coerce-length-err.js
-    ! prototype/Symbol.replace/result-coerce-length.js
-    ! prototype/Symbol.replace/result-coerce-matched-err.js
-    ! prototype/Symbol.replace/result-coerce-matched.js
-    ! prototype/Symbol.replace/result-get-capture-err.js
-    ! prototype/Symbol.replace/result-get-index-err.js
-    ! prototype/Symbol.replace/result-get-length-err.js
-    ! prototype/Symbol.replace/result-get-matched-err.js
-    ! prototype/Symbol.replace/subst-after.js
-    ! prototype/Symbol.replace/subst-before.js
-    ! prototype/Symbol.replace/subst-capture-idx-1.js
-    ! prototype/Symbol.replace/subst-capture-idx-2.js
-    ! prototype/Symbol.replace/subst-dollar.js
-    ! prototype/Symbol.replace/subst-matched.js
-    ! prototype/Symbol.replace/u-advance-after-empty.js
-    ! prototype/Symbol.replace/y-fail-global-return.js
-    ! prototype/Symbol.replace/y-fail-lastindex-no-write.js
-    ! prototype/Symbol.replace/y-fail-lastindex.js
-    ! prototype/Symbol.replace/y-fail-return.js
-    ! prototype/Symbol.replace/y-init-lastindex.js
-    ! prototype/Symbol.replace/y-set-lastindex.js
-    ! prototype/Symbol.search/cstm-exec-return-index.js
-    ! prototype/Symbol.search/failure-return-val.js
-    ! prototype/Symbol.search/get-lastindex-err.js
-    ! prototype/Symbol.search/lastindex-no-restore.js
-    ! prototype/Symbol.search/match-err.js
-    ! prototype/Symbol.search/set-lastindex-init-err.js
-    ! prototype/Symbol.search/set-lastindex-init.js
-    ! prototype/Symbol.search/set-lastindex-restore-err.js
-    ! prototype/Symbol.search/set-lastindex-restore.js
-    ! prototype/Symbol.search/success-get-index-err.js
-    ! prototype/Symbol.search/u-lastindex-advance.js
-    ! prototype/Symbol.search/y-fail-return.js
-    ! prototype/Symbol.split/coerce-flags-err.js
-    ! prototype/Symbol.split/coerce-flags.js
-    ! prototype/Symbol.split/coerce-limit-err.js
-    ! prototype/Symbol.split/coerce-limit.js
-    ! prototype/Symbol.split/coerce-string-err.js
-    ! prototype/Symbol.split/coerce-string.js
-    ! prototype/Symbol.split/get-flags-err.js
-    ! prototype/Symbol.split/last-index-exceeds-str-size.js
-    ! prototype/Symbol.split/length.js
-    ! prototype/Symbol.split/limit-0-bail.js
-    ! prototype/Symbol.split/name.js
-    ! prototype/Symbol.split/prop-desc.js
-    ! prototype/Symbol.split/species-ctor-ctor-get-err.js
-    ! prototype/Symbol.split/species-ctor-ctor-non-obj.js
-    ! prototype/Symbol.split/species-ctor-ctor-undef.js
-    ! prototype/Symbol.split/species-ctor-err.js
-    ! prototype/Symbol.split/species-ctor-species-get-err.js
-    ! prototype/Symbol.split/species-ctor-species-non-ctor.js
-    ! prototype/Symbol.split/species-ctor-species-undef.js
-    ! prototype/Symbol.split/species-ctor-y.js
-    ! prototype/Symbol.split/species-ctor.js
-    ! prototype/Symbol.split/str-adv-thru-empty-match.js
-    ! prototype/Symbol.split/str-coerce-lastindex-err.js
-    ! prototype/Symbol.split/str-coerce-lastindex.js
-    ! prototype/Symbol.split/str-empty-match-err.js
-    ! prototype/Symbol.split/str-empty-match.js
-    ! prototype/Symbol.split/str-empty-no-match.js
-    ! prototype/Symbol.split/str-get-lastindex-err.js
-    ! prototype/Symbol.split/str-limit-capturing.js
-    ! prototype/Symbol.split/str-limit.js
-    ! prototype/Symbol.split/str-match-err.js
-    ! prototype/Symbol.split/str-result-coerce-length-err.js
-    ! prototype/Symbol.split/str-result-coerce-length.js
-    ! prototype/Symbol.split/str-result-get-capture-err.js
-    ! prototype/Symbol.split/str-result-get-length-err.js
-    ! prototype/Symbol.split/str-set-lastindex-err.js
-    ! prototype/Symbol.split/str-set-lastindex-match.js
-    ! prototype/Symbol.split/str-set-lastindex-no-match.js
-    ! prototype/Symbol.split/str-trailing-chars.js
-    ! prototype/Symbol.split/u-lastindex-adv-thru-failure.js
-    ! prototype/Symbol.split/u-lastindex-adv-thru-match.js
-    ! prototype/test/S15.10.6.3_A1_T22.js
-    ! prototype/test/y-fail-lastindex-no-write.js
-    ! prototype/test/y-fail-lastindex.js
-    ! prototype/test/y-fail-return.js
-    ! prototype/test/y-init-lastindex.js
-    ! prototype/test/y-set-lastindex.js
-    ! prototype/unicode/length.js
-    ! prototype/unicode/name.js
-    ! prototype/unicode/prop-desc.js
-    ! prototype/unicode/this-val-invalid-obj.js
-    ! prototype/unicode/this-val-non-obj.js
-    ! prototype/unicode/this-val-regexp-prototype.js
-    ! prototype/unicode/this-val-regexp.js
-    ! prototype/15.10.6.js
-    ! prototype/no-regexp-matcher.js
-    ! Symbol.species/length.js
-    ! Symbol.species/return-value.js
-    ! Symbol.species/symbol-species-name.js
-    ! Symbol.species/symbol-species.js
-    ! 15.10.4.1-1.js
-    ! call_with_non_regexp_same_constructor.js
-    ! call_with_regexp_match_falsy.js
-    ! call_with_regexp_not_same_constructor.js
-    ! from-regexp-like-flag-override.js
-    ! from-regexp-like-get-ctor-err.js
-    ! from-regexp-like-get-flags-err.js
-    ! from-regexp-like-get-source-err.js
-    ! from-regexp-like-short-circuit.js
-    ! from-regexp-like.js
-    ! S15.10.1_A1_T13.js
-    ! S15.10.1_A1_T14.js
-    ! S15.10.1_A1_T15.js
-    ! S15.10.1_A1_T16.js
-    ! S15.10.3.1_A2_T1.js
-    ! S15.10.3.1_A2_T2.js
-    ! S15.10.4.1_A2_T1.js
-    ! S15.10.4.1_A2_T2.js
-    ! unicode_identity_escape.js
-    ! valid-flags-y.js
+    CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
+    CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
+    CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+    CharacterClassEscapes/character-class-digit-class-escape.js
+    CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
+    CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
+    CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+    CharacterClassEscapes/character-class-non-digit-class-escape.js
+    CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
+    CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
+    CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+    CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+    CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
+    CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
+    CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+    CharacterClassEscapes/character-class-non-word-class-escape.js
+    CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
+    CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
+    CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+    CharacterClassEscapes/character-class-whitespace-class-escape.js
+    CharacterClassEscapes/character-class-word-class-escape-flags-u.js
+    CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
+    CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+    CharacterClassEscapes/character-class-word-class-escape.js
+    match-indices/indices-array-element.js
+    match-indices/indices-array-matched.js
+    match-indices/indices-array-non-unicode-match.js
+    match-indices/indices-array-properties.js
+    match-indices/indices-array-unicode-match.js
+    match-indices/indices-array-unicode-property-names.js
+    match-indices/indices-array-unmatched.js
+    match-indices/indices-array.js
+    match-indices/indices-property.js
+    prototype/exec/failure-lastindex-access.js
+    prototype/exec/S15.10.6.2_A5_T3.js
+    prototype/exec/success-lastindex-access.js
+    prototype/exec/u-captured-value.js
+    prototype/exec/u-lastindex-adv.js
+    prototype/exec/u-lastindex-value.js
+    prototype/exec/y-fail-lastindex-no-write.js
+    prototype/exec/y-fail-lastindex.js
+    prototype/exec/y-fail-return.js
+    prototype/exec/y-init-lastindex.js
+    prototype/exec/y-set-lastindex.js
+    prototype/flags/coercion-global.js
+    prototype/flags/coercion-ignoreCase.js
+    prototype/flags/coercion-multiline.js
+    prototype/flags/coercion-sticky.js
+    prototype/flags/coercion-unicode.js
+    prototype/flags/length.js
+    prototype/flags/name.js
+    prototype/flags/prop-desc.js
+    prototype/flags/this-val-non-obj.js
+    prototype/flags/this-val-regexp-prototype.js
+    prototype/global/15.10.7.2-2.js
+    prototype/global/length.js
+    prototype/global/name.js
+    prototype/global/S15.10.7.2_A9.js
+    prototype/global/this-val-regexp-prototype.js
+    prototype/ignoreCase/15.10.7.3-2.js
+    prototype/ignoreCase/length.js
+    prototype/ignoreCase/name.js
+    prototype/ignoreCase/S15.10.7.3_A9.js
+    prototype/ignoreCase/this-val-regexp-prototype.js
+    prototype/multiline/15.10.7.4-2.js
+    prototype/multiline/length.js
+    prototype/multiline/name.js
+    prototype/multiline/S15.10.7.4_A9.js
+    prototype/multiline/this-val-regexp-prototype.js
+    prototype/source/length.js
+    prototype/source/name.js
+    prototype/source/prop-desc.js
+    prototype/source/this-val-regexp-prototype.js
+    prototype/source/value-empty.js
+    prototype/source/value-line-terminator.js
+    prototype/source/value-u.js
+    prototype/sticky/length.js
+    prototype/sticky/name.js
+    prototype/sticky/prop-desc.js
+    prototype/sticky/this-val-invalid-obj.js
+    prototype/sticky/this-val-non-obj.js
+    prototype/sticky/this-val-regexp-prototype.js
+    prototype/sticky/this-val-regexp.js
+    prototype/Symbol.match/builtin-coerce-lastindex.js
+    prototype/Symbol.match/builtin-failure-y-return-val.js
+    prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
+    prototype/Symbol.match/builtin-failure-y-set-lastindex.js
+    prototype/Symbol.match/builtin-infer-unicode.js
+    prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
+    prototype/Symbol.match/builtin-success-g-set-lastindex.js
+    prototype/Symbol.match/builtin-success-u-return-val-groups.js
+    prototype/Symbol.match/builtin-success-y-set-lastindex-err.js
+    prototype/Symbol.match/builtin-success-y-set-lastindex.js
+    prototype/Symbol.match/builtin-y-coerce-lastindex-err.js
+    prototype/Symbol.match/coerce-global.js
+    prototype/Symbol.match/exec-err.js
+    prototype/Symbol.match/exec-invocation.js
+    prototype/Symbol.match/exec-return-type-invalid.js
+    prototype/Symbol.match/exec-return-type-valid.js
+    prototype/Symbol.match/g-coerce-result-err.js
+    prototype/Symbol.match/g-get-exec-err.js
+    prototype/Symbol.match/g-get-result-err.js
+    prototype/Symbol.match/g-init-lastindex.js
+    prototype/Symbol.match/g-match-empty-advance-lastindex.js
+    prototype/Symbol.match/g-match-empty-coerce-lastindex-err.js
+    prototype/Symbol.match/g-match-empty-set-lastindex-err.js
+    prototype/Symbol.match/g-success-return-val.js
+    prototype/Symbol.match/get-exec-err.js
+    prototype/Symbol.match/get-global-err.js
+    prototype/Symbol.match/get-unicode-error.js
+    prototype/Symbol.match/this-val-non-regexp.js
+    prototype/Symbol.match/u-advance-after-empty.js
+    prototype/Symbol.match/y-fail-global-return.js
+    prototype/Symbol.match/y-fail-lastindex-no-write.js
+    prototype/Symbol.match/y-fail-lastindex.js
+    prototype/Symbol.match/y-fail-return.js
+    prototype/Symbol.match/y-init-lastindex.js
+    prototype/Symbol.match/y-set-lastindex.js
+    prototype/Symbol.replace/arg-1-coerce-err.js
+    prototype/Symbol.replace/arg-1-coerce.js
+    prototype/Symbol.replace/arg-2-coerce-err.js
+    prototype/Symbol.replace/arg-2-coerce.js
+    prototype/Symbol.replace/coerce-global.js
+    prototype/Symbol.replace/coerce-unicode.js
+    prototype/Symbol.replace/exec-err.js
+    prototype/Symbol.replace/exec-invocation.js
+    prototype/Symbol.replace/fn-coerce-replacement-err.js
+    prototype/Symbol.replace/fn-coerce-replacement.js
+    prototype/Symbol.replace/fn-err.js
+    prototype/Symbol.replace/fn-invoke-args.js
+    prototype/Symbol.replace/fn-invoke-this-no-strict.js
+    prototype/Symbol.replace/fn-invoke-this-strict.js
+    prototype/Symbol.replace/g-init-lastindex-err.js
+    prototype/Symbol.replace/g-init-lastindex.js
+    prototype/Symbol.replace/g-pos-decrement.js
+    prototype/Symbol.replace/g-pos-increment.js
+    prototype/Symbol.replace/get-exec-err.js
+    prototype/Symbol.replace/get-global-err.js
+    prototype/Symbol.replace/get-unicode-error.js
+    prototype/Symbol.replace/length.js
+    prototype/Symbol.replace/match-failure.js
+    prototype/Symbol.replace/name.js
+    prototype/Symbol.replace/prop-desc.js
+    prototype/Symbol.replace/replace-with-trailing.js
+    prototype/Symbol.replace/replace-without-trailing.js
+    prototype/Symbol.replace/result-coerce-capture-err.js
+    prototype/Symbol.replace/result-coerce-capture.js
+    prototype/Symbol.replace/result-coerce-index-err.js
+    prototype/Symbol.replace/result-coerce-index.js
+    prototype/Symbol.replace/result-coerce-length-err.js
+    prototype/Symbol.replace/result-coerce-length.js
+    prototype/Symbol.replace/result-coerce-matched-err.js
+    prototype/Symbol.replace/result-coerce-matched.js
+    prototype/Symbol.replace/result-get-capture-err.js
+    prototype/Symbol.replace/result-get-index-err.js
+    prototype/Symbol.replace/result-get-length-err.js
+    prototype/Symbol.replace/result-get-matched-err.js
+    prototype/Symbol.replace/subst-after.js
+    prototype/Symbol.replace/subst-before.js
+    prototype/Symbol.replace/subst-capture-idx-1.js
+    prototype/Symbol.replace/subst-capture-idx-2.js
+    prototype/Symbol.replace/subst-dollar.js
+    prototype/Symbol.replace/subst-matched.js
+    prototype/Symbol.replace/u-advance-after-empty.js
+    prototype/Symbol.replace/y-fail-global-return.js
+    prototype/Symbol.replace/y-fail-lastindex-no-write.js
+    prototype/Symbol.replace/y-fail-lastindex.js
+    prototype/Symbol.replace/y-fail-return.js
+    prototype/Symbol.replace/y-init-lastindex.js
+    prototype/Symbol.replace/y-set-lastindex.js
+    prototype/Symbol.search/cstm-exec-return-index.js
+    prototype/Symbol.search/failure-return-val.js
+    prototype/Symbol.search/get-lastindex-err.js
+    prototype/Symbol.search/lastindex-no-restore.js
+    prototype/Symbol.search/match-err.js
+    prototype/Symbol.search/set-lastindex-init-err.js
+    prototype/Symbol.search/set-lastindex-init.js
+    prototype/Symbol.search/set-lastindex-restore-err.js
+    prototype/Symbol.search/set-lastindex-restore.js
+    prototype/Symbol.search/success-get-index-err.js
+    prototype/Symbol.search/u-lastindex-advance.js
+    prototype/Symbol.search/y-fail-return.js
+    prototype/Symbol.split/coerce-flags-err.js
+    prototype/Symbol.split/coerce-flags.js
+    prototype/Symbol.split/coerce-limit-err.js
+    prototype/Symbol.split/coerce-limit.js
+    prototype/Symbol.split/coerce-string-err.js
+    prototype/Symbol.split/coerce-string.js
+    prototype/Symbol.split/get-flags-err.js
+    prototype/Symbol.split/last-index-exceeds-str-size.js
+    prototype/Symbol.split/length.js
+    prototype/Symbol.split/limit-0-bail.js
+    prototype/Symbol.split/name.js
+    prototype/Symbol.split/prop-desc.js
+    prototype/Symbol.split/species-ctor-ctor-get-err.js
+    prototype/Symbol.split/species-ctor-ctor-non-obj.js
+    prototype/Symbol.split/species-ctor-ctor-undef.js
+    prototype/Symbol.split/species-ctor-err.js
+    prototype/Symbol.split/species-ctor-species-get-err.js
+    prototype/Symbol.split/species-ctor-species-non-ctor.js
+    prototype/Symbol.split/species-ctor-species-undef.js
+    prototype/Symbol.split/species-ctor-y.js
+    prototype/Symbol.split/species-ctor.js
+    prototype/Symbol.split/str-adv-thru-empty-match.js
+    prototype/Symbol.split/str-coerce-lastindex-err.js
+    prototype/Symbol.split/str-coerce-lastindex.js
+    prototype/Symbol.split/str-empty-match-err.js
+    prototype/Symbol.split/str-empty-match.js
+    prototype/Symbol.split/str-empty-no-match.js
+    prototype/Symbol.split/str-get-lastindex-err.js
+    prototype/Symbol.split/str-limit-capturing.js
+    prototype/Symbol.split/str-limit.js
+    prototype/Symbol.split/str-match-err.js
+    prototype/Symbol.split/str-result-coerce-length-err.js
+    prototype/Symbol.split/str-result-coerce-length.js
+    prototype/Symbol.split/str-result-get-capture-err.js
+    prototype/Symbol.split/str-result-get-length-err.js
+    prototype/Symbol.split/str-set-lastindex-err.js
+    prototype/Symbol.split/str-set-lastindex-match.js
+    prototype/Symbol.split/str-set-lastindex-no-match.js
+    prototype/Symbol.split/str-trailing-chars.js
+    prototype/Symbol.split/u-lastindex-adv-thru-failure.js
+    prototype/Symbol.split/u-lastindex-adv-thru-match.js
+    prototype/test/S15.10.6.3_A1_T22.js
+    prototype/test/y-fail-lastindex-no-write.js
+    prototype/test/y-fail-lastindex.js
+    prototype/test/y-fail-return.js
+    prototype/test/y-init-lastindex.js
+    prototype/test/y-set-lastindex.js
+    prototype/unicode/length.js
+    prototype/unicode/name.js
+    prototype/unicode/prop-desc.js
+    prototype/unicode/this-val-invalid-obj.js
+    prototype/unicode/this-val-non-obj.js
+    prototype/unicode/this-val-regexp-prototype.js
+    prototype/unicode/this-val-regexp.js
+    prototype/15.10.6.js
+    prototype/no-regexp-matcher.js
+    Symbol.species/length.js
+    Symbol.species/return-value.js
+    Symbol.species/symbol-species-name.js
+    Symbol.species/symbol-species.js
+    15.10.4.1-1.js
+    call_with_non_regexp_same_constructor.js
+    call_with_regexp_match_falsy.js
+    call_with_regexp_not_same_constructor.js
+    from-regexp-like-flag-override.js
+    from-regexp-like-get-ctor-err.js
+    from-regexp-like-get-flags-err.js
+    from-regexp-like-get-source-err.js
+    from-regexp-like-short-circuit.js
+    from-regexp-like.js
+    S15.10.1_A1_T13.js
+    S15.10.1_A1_T14.js
+    S15.10.1_A1_T15.js
+    S15.10.1_A1_T16.js
+    S15.10.3.1_A2_T1.js
+    S15.10.3.1_A2_T2.js
+    S15.10.4.1_A2_T1.js
+    S15.10.4.1_A2_T2.js
+    unicode_identity_escape.js
+    valid-flags-y.js
 
 built-ins/Set
-    ! Symbol.species/length.js
-    ! Symbol.species/return-value.js
-    ! Symbol.species/symbol-species-name.js
-    ! Symbol.species/symbol-species.js
+    Symbol.species/length.js
+    Symbol.species/return-value.js
+    Symbol.species/symbol-species-name.js
+    Symbol.species/symbol-species.js
 
 built-ins/SetIteratorPrototype
 
-#built-ins/SharedArrayBuffer
+~built-ins/SharedArrayBuffer
 
 built-ins/String
-    ! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
-    ! prototype/includes/return-abrupt-from-searchstring-regexp-test.js
-    ! prototype/match/cstm-matcher-get-err.js
-    ! prototype/match/cstm-matcher-invocation.js
-    ! prototype/match/invoke-builtin-match.js
-    ! prototype/replace/cstm-replace-get-err.js
-    ! prototype/replace/cstm-replace-invocation.js
-    ! prototype/replace/S15.5.4.11_A12.js
-    ! prototype/search/cstm-search-get-err.js
-    ! prototype/search/cstm-search-invocation.js
-    ! prototype/search/invoke-builtin-search-searcher-undef.js
-    ! prototype/search/invoke-builtin-search.js
-    ! prototype/split/cstm-split-get-err.js
-    ! prototype/split/cstm-split-invocation.js
-    ! prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
-    ! prototype/substring/S15.5.4.15_A1_T5.js
-    ! prototype/toLocaleLowerCase/special_casing_conditional.js
-    ! prototype/toLowerCase/special_casing_conditional.js
-    ! prototype/trimEnd/this-value-object-cannot-convert-to-primitive-err.js
-    ! prototype/trimEnd/this-value-object-toprimitive-call-err.js
-    ! prototype/trimEnd/this-value-object-toprimitive-meth-err.js
-    ! prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
-    ! prototype/trimEnd/this-value-object-toprimitive-returns-object-err.js
-    ! prototype/trimEnd/this-value-object-tostring-call-err.js
-    ! prototype/trimEnd/this-value-object-tostring-meth-err.js
-    ! prototype/trimEnd/this-value-object-tostring-meth-priority.js
-    ! prototype/trimEnd/this-value-object-tostring-returns-object-err.js
-    ! prototype/trimEnd/this-value-object-valueof-call-err.js
-    ! prototype/trimEnd/this-value-object-valueof-meth-err.js
-    ! prototype/trimEnd/this-value-object-valueof-meth-priority.js
-    ! prototype/trimEnd/this-value-object-valueof-returns-object-err.js
-    ! prototype/trimStart/this-value-object-cannot-convert-to-primitive-err.js
-    ! prototype/trimStart/this-value-object-toprimitive-call-err.js
-    ! prototype/trimStart/this-value-object-toprimitive-meth-err.js
-    ! prototype/trimStart/this-value-object-toprimitive-meth-priority.js
-    ! prototype/trimStart/this-value-object-toprimitive-returns-object-err.js
-    ! prototype/trimStart/this-value-object-tostring-call-err.js
-    ! prototype/trimStart/this-value-object-tostring-meth-err.js
-    ! prototype/trimStart/this-value-object-tostring-meth-priority.js
-    ! prototype/trimStart/this-value-object-tostring-returns-object-err.js
-    ! prototype/trimStart/this-value-object-valueof-call-err.js
-    ! prototype/trimStart/this-value-object-valueof-meth-err.js
-    ! prototype/trimStart/this-value-object-valueof-meth-priority.js
-    ! prototype/trimStart/this-value-object-valueof-returns-object-err.js
+    prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
+    prototype/includes/return-abrupt-from-searchstring-regexp-test.js
+    prototype/match/cstm-matcher-get-err.js
+    prototype/match/cstm-matcher-invocation.js
+    prototype/match/invoke-builtin-match.js
+    prototype/replace/cstm-replace-get-err.js
+    prototype/replace/cstm-replace-invocation.js
+    prototype/replace/S15.5.4.11_A12.js
+    prototype/search/cstm-search-get-err.js
+    prototype/search/cstm-search-invocation.js
+    prototype/search/invoke-builtin-search-searcher-undef.js
+    prototype/search/invoke-builtin-search.js
+    prototype/split/cstm-split-get-err.js
+    prototype/split/cstm-split-invocation.js
+    prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
+    prototype/substring/S15.5.4.15_A1_T5.js
+    prototype/toLocaleLowerCase/special_casing_conditional.js
+    prototype/toLowerCase/special_casing_conditional.js
+    prototype/trimEnd/this-value-object-cannot-convert-to-primitive-err.js
+    prototype/trimEnd/this-value-object-toprimitive-call-err.js
+    prototype/trimEnd/this-value-object-toprimitive-meth-err.js
+    prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
+    prototype/trimEnd/this-value-object-toprimitive-returns-object-err.js
+    prototype/trimEnd/this-value-object-tostring-call-err.js
+    prototype/trimEnd/this-value-object-tostring-meth-err.js
+    prototype/trimEnd/this-value-object-tostring-meth-priority.js
+    prototype/trimEnd/this-value-object-tostring-returns-object-err.js
+    prototype/trimEnd/this-value-object-valueof-call-err.js
+    prototype/trimEnd/this-value-object-valueof-meth-err.js
+    prototype/trimEnd/this-value-object-valueof-meth-priority.js
+    prototype/trimEnd/this-value-object-valueof-returns-object-err.js
+    prototype/trimStart/this-value-object-cannot-convert-to-primitive-err.js
+    prototype/trimStart/this-value-object-toprimitive-call-err.js
+    prototype/trimStart/this-value-object-toprimitive-meth-err.js
+    prototype/trimStart/this-value-object-toprimitive-meth-priority.js
+    prototype/trimStart/this-value-object-toprimitive-returns-object-err.js
+    prototype/trimStart/this-value-object-tostring-call-err.js
+    prototype/trimStart/this-value-object-tostring-meth-err.js
+    prototype/trimStart/this-value-object-tostring-meth-priority.js
+    prototype/trimStart/this-value-object-tostring-returns-object-err.js
+    prototype/trimStart/this-value-object-valueof-call-err.js
+    prototype/trimStart/this-value-object-valueof-meth-err.js
+    prototype/trimStart/this-value-object-valueof-meth-priority.js
+    prototype/trimStart/this-value-object-valueof-returns-object-err.js
 
 built-ins/StringIteratorPrototype
 
 built-ins/Symbol
-    ! asyncIterator/prop-desc.js
-    ! keyFor/arg-non-symbol.js
-    ! prototype/description/description-symboldescriptivestring.js
-    ! prototype/description/descriptor.js
-    ! prototype/description/get.js
-    ! prototype/description/this-val-non-symbol.js
-    ! prototype/description/this-val-symbol.js
-    ! prototype/description/wrapper.js
-    ! prototype/Symbol.toPrimitive/name.js
-    ! prototype/Symbol.toPrimitive/prop-desc.js
-    ! prototype/Symbol.toPrimitive/this-val-non-obj.js
-    ! prototype/valueOf/this-val-non-obj.js
-    ! species/builtin-getter-name.js
-    ! species/subclassing.js
+    asyncIterator/prop-desc.js
+    keyFor/arg-non-symbol.js
+    prototype/description/description-symboldescriptivestring.js
+    prototype/description/descriptor.js
+    prototype/description/get.js
+    prototype/description/this-val-non-symbol.js
+    prototype/description/this-val-symbol.js
+    prototype/description/wrapper.js
+    prototype/Symbol.toPrimitive/name.js
+    prototype/Symbol.toPrimitive/prop-desc.js
+    prototype/Symbol.toPrimitive/this-val-non-obj.js
+    prototype/valueOf/this-val-non-obj.js
+    species/builtin-getter-name.js
+    species/subclassing.js
 
 built-ins/ThrowTypeError
-    ! extensible.js
-    ! forbidden-arguments.js
-    ! frozen.js
-    ! prototype.js
-    ! unique-per-realm-function-proto.js
-    ! unique-per-realm-non-simple.js
-    ! unique-per-realm-unmapped-args.js
+    extensible.js
+    forbidden-arguments.js
+    frozen.js
+    prototype.js
+    unique-per-realm-function-proto.js
+    unique-per-realm-non-simple.js
+    unique-per-realm-unmapped-args.js
 
 built-ins/TypedArray
-    ! from/arylk-get-length-error.js
-    ! from/arylk-to-length-error.js
-    ! from/iter-access-error.js
-    ! from/iter-invoke-error.js
-    ! from/iter-next-error.js
-    ! from/iter-next-value-error.js
-    ! from/length.js
-    ! from/name.js
-    ! from/prop-desc.js
-    ! of/length.js
-    ! of/name.js
-    ! of/prop-desc.js
-    ! prototype/buffer/BigInt/detached-buffer.js
-    ! prototype/buffer/BigInt/return-buffer.js
-    ! prototype/buffer/detached-buffer.js
-    ! prototype/buffer/invoked-as-func.js
-    ! prototype/buffer/length.js
-    ! prototype/buffer/name.js
-    ! prototype/buffer/prop-desc.js
-    ! prototype/buffer/this-has-no-typedarrayname-internal.js
-    ! prototype/buffer/this-is-not-object.js
-    ! prototype/byteLength/BigInt/detached-buffer.js
-    ! prototype/byteLength/BigInt/return-bytelength.js
-    ! prototype/byteLength/detached-buffer.js
-    ! prototype/byteLength/invoked-as-func.js
-    ! prototype/byteLength/length.js
-    ! prototype/byteLength/name.js
-    ! prototype/byteLength/prop-desc.js
-    ! prototype/byteLength/this-has-no-typedarrayname-internal.js
-    ! prototype/byteLength/this-is-not-object.js
-    ! prototype/byteOffset/BigInt/detached-buffer.js
-    ! prototype/byteOffset/BigInt/return-byteoffset.js
-    ! prototype/byteOffset/detached-buffer.js
-    ! prototype/byteOffset/invoked-as-func.js
-    ! prototype/byteOffset/length.js
-    ! prototype/byteOffset/name.js
-    ! prototype/byteOffset/prop-desc.js
-    ! prototype/byteOffset/this-has-no-typedarrayname-internal.js
-    ! prototype/byteOffset/this-is-not-object.js
-    ! prototype/copyWithin/BigInt/coerced-values-end.js
-    ! prototype/copyWithin/BigInt/coerced-values-start.js
-    ! prototype/copyWithin/BigInt/coerced-values-target.js
-    ! prototype/copyWithin/BigInt/detached-buffer.js
-    ! prototype/copyWithin/BigInt/get-length-ignores-length-prop.js
-    ! prototype/copyWithin/BigInt/negative-end.js
-    ! prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
-    ! prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
-    ! prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
-    ! prototype/copyWithin/BigInt/negative-start.js
-    ! prototype/copyWithin/BigInt/negative-target.js
-    ! prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
-    ! prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
-    ! prototype/copyWithin/BigInt/non-negative-target-and-start.js
-    ! prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
-    ! prototype/copyWithin/BigInt/return-abrupt-from-end-is-symbol.js
-    ! prototype/copyWithin/BigInt/return-abrupt-from-end.js
-    ! prototype/copyWithin/BigInt/return-abrupt-from-start-is-symbol.js
-    ! prototype/copyWithin/BigInt/return-abrupt-from-start.js
-    ! prototype/copyWithin/BigInt/return-abrupt-from-target-is-symbol.js
-    ! prototype/copyWithin/BigInt/return-abrupt-from-target.js
-    ! prototype/copyWithin/BigInt/return-this.js
-    ! prototype/copyWithin/BigInt/undefined-end.js
-    ! prototype/copyWithin/bit-precision.js
-    ! prototype/copyWithin/coerced-values-end.js
-    ! prototype/copyWithin/coerced-values-start.js
-    ! prototype/copyWithin/coerced-values-target.js
-    ! prototype/copyWithin/detached-buffer.js
-    ! prototype/copyWithin/get-length-ignores-length-prop.js
-    ! prototype/copyWithin/invoked-as-func.js
-    ! prototype/copyWithin/invoked-as-method.js
-    ! prototype/copyWithin/length.js
-    ! prototype/copyWithin/name.js
-    ! prototype/copyWithin/negative-end.js
-    ! prototype/copyWithin/negative-out-of-bounds-end.js
-    ! prototype/copyWithin/negative-out-of-bounds-start.js
-    ! prototype/copyWithin/negative-out-of-bounds-target.js
-    ! prototype/copyWithin/negative-start.js
-    ! prototype/copyWithin/negative-target.js
-    ! prototype/copyWithin/non-negative-out-of-bounds-end.js
-    ! prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
-    ! prototype/copyWithin/non-negative-target-and-start.js
-    ! prototype/copyWithin/non-negative-target-start-and-end.js
-    ! prototype/copyWithin/prop-desc.js
-    ! prototype/copyWithin/return-abrupt-from-end.js
-    ! prototype/copyWithin/return-abrupt-from-start.js
-    ! prototype/copyWithin/return-abrupt-from-target.js
-    ! prototype/copyWithin/return-this.js
-    ! prototype/copyWithin/this-is-not-object.js
-    ! prototype/copyWithin/this-is-not-typedarray-instance.js
-    ! prototype/copyWithin/undefined-end.js
-    ! prototype/entries/BigInt/detached-buffer.js
-    ! prototype/entries/BigInt/iter-prototype.js
-    ! prototype/entries/BigInt/return-itor.js
-    ! prototype/entries/detached-buffer.js
-    ! prototype/entries/invoked-as-func.js
-    ! prototype/entries/invoked-as-method.js
-    ! prototype/entries/iter-prototype.js
-    ! prototype/entries/length.js
-    ! prototype/entries/name.js
-    ! prototype/entries/prop-desc.js
-    ! prototype/entries/return-itor.js
-    ! prototype/entries/this-is-not-object.js
-    ! prototype/entries/this-is-not-typedarray-instance.js
-    ! prototype/every/BigInt/callbackfn-arguments-with-thisarg.js
-    ! prototype/every/BigInt/callbackfn-arguments-without-thisarg.js
-    ! prototype/every/BigInt/callbackfn-detachbuffer.js
-    ! prototype/every/BigInt/callbackfn-no-interaction-over-non-integer.js
-    ! prototype/every/BigInt/callbackfn-not-callable-throws.js
-    ! prototype/every/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/every/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/every/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/every/BigInt/callbackfn-this.js
-    ! prototype/every/BigInt/detached-buffer.js
-    ! prototype/every/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/every/BigInt/returns-false-if-any-cb-returns-false.js
-    ! prototype/every/BigInt/returns-true-if-every-cb-returns-true.js
-    ! prototype/every/BigInt/values-are-not-cached.js
-    ! prototype/every/callbackfn-arguments-with-thisarg.js
-    ! prototype/every/callbackfn-arguments-without-thisarg.js
-    ! prototype/every/callbackfn-detachbuffer.js
-    ! prototype/every/callbackfn-no-interaction-over-non-integer.js
-    ! prototype/every/callbackfn-not-called-on-empty.js
-    ! prototype/every/callbackfn-return-does-not-change-instance.js
-    ! prototype/every/callbackfn-returns-abrupt.js
-    ! prototype/every/callbackfn-this.js
-    ! prototype/every/detached-buffer.js
-    ! prototype/every/get-length-uses-internal-arraylength.js
-    ! prototype/every/invoked-as-func.js
-    ! prototype/every/invoked-as-method.js
-    ! prototype/every/length.js
-    ! prototype/every/name.js
-    ! prototype/every/prop-desc.js
-    ! prototype/every/returns-false-if-any-cb-returns-false.js
-    ! prototype/every/returns-true-if-every-cb-returns-true.js
-    ! prototype/every/this-is-not-object.js
-    ! prototype/every/this-is-not-typedarray-instance.js
-    ! prototype/every/values-are-not-cached.js
-    ! prototype/fill/BigInt/coerced-indexes.js
-    ! prototype/fill/BigInt/detached-buffer.js
-    ! prototype/fill/BigInt/fill-values-conversion-once.js
-    ! prototype/fill/BigInt/fill-values-custom-start-and-end.js
-    ! prototype/fill/BigInt/fill-values-non-numeric-throw.js
-    ! prototype/fill/BigInt/fill-values-non-numeric.js
-    ! prototype/fill/BigInt/fill-values-relative-end.js
-    ! prototype/fill/BigInt/fill-values-relative-start.js
-    ! prototype/fill/BigInt/fill-values-symbol-throws.js
-    ! prototype/fill/BigInt/fill-values.js
-    ! prototype/fill/BigInt/get-length-ignores-length-prop.js
-    ! prototype/fill/BigInt/return-abrupt-from-end-as-symbol.js
-    ! prototype/fill/BigInt/return-abrupt-from-end.js
-    ! prototype/fill/BigInt/return-abrupt-from-set-value.js
-    ! prototype/fill/BigInt/return-abrupt-from-start-as-symbol.js
-    ! prototype/fill/BigInt/return-abrupt-from-start.js
-    ! prototype/fill/BigInt/return-this.js
-    ! prototype/fill/coerced-indexes.js
-    ! prototype/fill/detached-buffer.js
-    ! prototype/fill/fill-values-conversion-once.js
-    ! prototype/fill/fill-values-conversion-operations-consistent-nan.js
-    ! prototype/fill/fill-values-conversion-operations.js
-    ! prototype/fill/fill-values-custom-start-and-end.js
-    ! prototype/fill/fill-values-non-numeric.js
-    ! prototype/fill/fill-values-relative-end.js
-    ! prototype/fill/fill-values-relative-start.js
-    ! prototype/fill/fill-values.js
-    ! prototype/fill/get-length-ignores-length-prop.js
-    ! prototype/fill/invoked-as-func.js
-    ! prototype/fill/invoked-as-method.js
-    ! prototype/fill/length.js
-    ! prototype/fill/name.js
-    ! prototype/fill/prop-desc.js
-    ! prototype/fill/return-abrupt-from-end.js
-    ! prototype/fill/return-abrupt-from-set-value.js
-    ! prototype/fill/return-abrupt-from-start.js
-    ! prototype/fill/return-this.js
-    ! prototype/fill/this-is-not-object.js
-    ! prototype/fill/this-is-not-typedarray-instance.js
-    ! prototype/filter/BigInt/arraylength-internal.js
-    ! prototype/filter/BigInt/callbackfn-arguments-with-thisarg.js
-    ! prototype/filter/BigInt/callbackfn-arguments-without-thisarg.js
-    ! prototype/filter/BigInt/callbackfn-called-before-ctor.js
-    ! prototype/filter/BigInt/callbackfn-called-before-species.js
-    ! prototype/filter/BigInt/callbackfn-detachbuffer.js
-    ! prototype/filter/BigInt/callbackfn-no-iteration-over-non-integer.js
-    ! prototype/filter/BigInt/callbackfn-not-callable-throws.js
-    ! prototype/filter/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/filter/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/filter/BigInt/callbackfn-this.js
-    ! prototype/filter/BigInt/detached-buffer.js
-    ! prototype/filter/BigInt/result-does-not-share-buffer.js
-    ! prototype/filter/BigInt/result-empty-callbackfn-returns-false.js
-    ! prototype/filter/BigInt/result-full-callbackfn-returns-true.js
-    ! prototype/filter/BigInt/speciesctor-get-ctor-abrupt.js
-    ! prototype/filter/BigInt/speciesctor-get-ctor-inherited.js
-    ! prototype/filter/BigInt/speciesctor-get-ctor-returns-throws.js
-    ! prototype/filter/BigInt/speciesctor-get-ctor.js
-    ! prototype/filter/BigInt/speciesctor-get-species-abrupt.js
-    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length.js
-    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    ! prototype/filter/BigInt/speciesctor-get-species-custom-ctor.js
-    ! prototype/filter/BigInt/speciesctor-get-species-returns-throws.js
-    ! prototype/filter/BigInt/speciesctor-get-species-use-default-ctor.js
-    ! prototype/filter/BigInt/speciesctor-get-species.js
-    ! prototype/filter/BigInt/values-are-not-cached.js
-    ! prototype/filter/BigInt/values-are-set.js
-    ! prototype/filter/arraylength-internal.js
-    ! prototype/filter/callbackfn-arguments-with-thisarg.js
-    ! prototype/filter/callbackfn-arguments-without-thisarg.js
-    ! prototype/filter/callbackfn-called-before-ctor.js
-    ! prototype/filter/callbackfn-called-before-species.js
-    ! prototype/filter/callbackfn-detachbuffer.js
-    ! prototype/filter/callbackfn-no-iteration-over-non-integer.js
-    ! prototype/filter/callbackfn-not-called-on-empty.js
-    ! prototype/filter/callbackfn-return-does-not-change-instance.js
-    ! prototype/filter/callbackfn-returns-abrupt.js
-    ! prototype/filter/callbackfn-this.js
-    ! prototype/filter/detached-buffer.js
-    ! prototype/filter/invoked-as-func.js
-    ! prototype/filter/invoked-as-method.js
-    ! prototype/filter/length.js
-    ! prototype/filter/name.js
-    ! prototype/filter/prop-desc.js
-    ! prototype/filter/result-does-not-share-buffer.js
-    ! prototype/filter/result-empty-callbackfn-returns-false.js
-    ! prototype/filter/result-full-callbackfn-returns-true.js
-    ! prototype/filter/speciesctor-get-ctor-abrupt.js
-    ! prototype/filter/speciesctor-get-ctor-inherited.js
-    ! prototype/filter/speciesctor-get-ctor.js
-    ! prototype/filter/speciesctor-get-species-abrupt.js
-    ! prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/filter/speciesctor-get-species-custom-ctor-length.js
-    ! prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/filter/speciesctor-get-species-custom-ctor.js
-    ! prototype/filter/speciesctor-get-species-use-default-ctor.js
-    ! prototype/filter/speciesctor-get-species.js
-    ! prototype/filter/this-is-not-object.js
-    ! prototype/filter/this-is-not-typedarray-instance.js
-    ! prototype/filter/values-are-not-cached.js
-    ! prototype/filter/values-are-set.js
-    ! prototype/find/BigInt/detached-buffer.js
-    ! prototype/find/BigInt/get-length-ignores-length-prop.js
-    ! prototype/find/BigInt/predicate-call-changes-value.js
-    ! prototype/find/BigInt/predicate-call-parameters.js
-    ! prototype/find/BigInt/predicate-call-this-non-strict.js
-    ! prototype/find/BigInt/predicate-call-this-strict.js
-    ! prototype/find/BigInt/predicate-is-not-callable-throws.js
-    ! prototype/find/BigInt/predicate-may-detach-buffer.js
-    ! prototype/find/BigInt/predicate-not-called-on-empty-array.js
-    ! prototype/find/BigInt/return-abrupt-from-predicate-call.js
-    ! prototype/find/BigInt/return-found-value-predicate-result-is-true.js
-    ! prototype/find/BigInt/return-undefined-if-predicate-returns-false-value.js
-    ! prototype/findIndex/BigInt/detached-buffer.js
-    ! prototype/findIndex/BigInt/get-length-ignores-length-prop.js
-    ! prototype/findIndex/BigInt/predicate-call-changes-value.js
-    ! prototype/findIndex/BigInt/predicate-call-parameters.js
-    ! prototype/findIndex/BigInt/predicate-call-this-non-strict.js
-    ! prototype/findIndex/BigInt/predicate-call-this-strict.js
-    ! prototype/findIndex/BigInt/predicate-is-not-callable-throws.js
-    ! prototype/findIndex/BigInt/predicate-may-detach-buffer.js
-    ! prototype/findIndex/BigInt/predicate-not-called-on-empty-array.js
-    ! prototype/findIndex/BigInt/return-abrupt-from-predicate-call.js
-    ! prototype/findIndex/BigInt/return-index-predicate-result-is-true.js
-    ! prototype/findIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
-    ! prototype/findIndex/detached-buffer.js
-    ! prototype/findIndex/get-length-ignores-length-prop.js
-    ! prototype/findIndex/invoked-as-func.js
-    ! prototype/findIndex/invoked-as-method.js
-    ! prototype/findIndex/length.js
-    ! prototype/findIndex/name.js
-    ! prototype/findIndex/predicate-call-changes-value.js
-    ! prototype/findIndex/predicate-call-parameters.js
-    ! prototype/findIndex/predicate-call-this-non-strict.js
-    ! prototype/findIndex/predicate-call-this-strict.js
-    ! prototype/findIndex/predicate-may-detach-buffer.js
-    ! prototype/findIndex/predicate-not-called-on-empty-array.js
-    ! prototype/findIndex/prop-desc.js
-    ! prototype/findIndex/return-abrupt-from-predicate-call.js
-    ! prototype/findIndex/return-index-predicate-result-is-true.js
-    ! prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
-    ! prototype/findIndex/this-is-not-object.js
-    ! prototype/findIndex/this-is-not-typedarray-instance.js
-    ! prototype/find/detached-buffer.js
-    ! prototype/find/get-length-ignores-length-prop.js
-    ! prototype/find/invoked-as-func.js
-    ! prototype/find/invoked-as-method.js
-    ! prototype/find/length.js
-    ! prototype/find/name.js
-    ! prototype/find/predicate-call-changes-value.js
-    ! prototype/find/predicate-call-parameters.js
-    ! prototype/find/predicate-call-this-non-strict.js
-    ! prototype/find/predicate-call-this-strict.js
-    ! prototype/find/predicate-may-detach-buffer.js
-    ! prototype/find/predicate-not-called-on-empty-array.js
-    ! prototype/find/prop-desc.js
-    ! prototype/find/return-abrupt-from-predicate-call.js
-    ! prototype/find/return-found-value-predicate-result-is-true.js
-    ! prototype/find/return-undefined-if-predicate-returns-false-value.js
-    ! prototype/find/this-is-not-object.js
-    ! prototype/find/this-is-not-typedarray-instance.js
-    ! prototype/forEach/BigInt/arraylength-internal.js
-    ! prototype/forEach/BigInt/callbackfn-arguments-with-thisarg.js
-    ! prototype/forEach/BigInt/callbackfn-arguments-without-thisarg.js
-    ! prototype/forEach/BigInt/callbackfn-detachbuffer.js
-    ! prototype/forEach/BigInt/callbackfn-is-not-callable.js
-    ! prototype/forEach/BigInt/callbackfn-no-interaction-over-non-integer.js
-    ! prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/forEach/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/forEach/BigInt/callbackfn-this.js
-    ! prototype/forEach/BigInt/detached-buffer.js
-    ! prototype/forEach/BigInt/returns-undefined.js
-    ! prototype/forEach/BigInt/values-are-not-cached.js
-    ! prototype/forEach/arraylength-internal.js
-    ! prototype/forEach/callbackfn-arguments-with-thisarg.js
-    ! prototype/forEach/callbackfn-arguments-without-thisarg.js
-    ! prototype/forEach/callbackfn-detachbuffer.js
-    ! prototype/forEach/callbackfn-no-interaction-over-non-integer.js
-    ! prototype/forEach/callbackfn-not-called-on-empty.js
-    ! prototype/forEach/callbackfn-return-does-not-change-instance.js
-    ! prototype/forEach/callbackfn-returns-abrupt.js
-    ! prototype/forEach/callbackfn-this.js
-    ! prototype/forEach/detached-buffer.js
-    ! prototype/forEach/invoked-as-func.js
-    ! prototype/forEach/invoked-as-method.js
-    ! prototype/forEach/length.js
-    ! prototype/forEach/name.js
-    ! prototype/forEach/prop-desc.js
-    ! prototype/forEach/returns-undefined.js
-    ! prototype/forEach/this-is-not-object.js
-    ! prototype/forEach/this-is-not-typedarray-instance.js
-    ! prototype/forEach/values-are-not-cached.js
-    ! prototype/includes/BigInt/detached-buffer.js
-    ! prototype/includes/BigInt/fromIndex-equal-or-greater-length-returns-false.js
-    ! prototype/includes/BigInt/fromIndex-infinity.js
-    ! prototype/includes/BigInt/fromIndex-minus-zero.js
-    ! prototype/includes/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/includes/BigInt/length-zero-returns-false.js
-    ! prototype/includes/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    ! prototype/includes/BigInt/return-abrupt-tointeger-fromindex.js
-    ! prototype/includes/BigInt/search-found-returns-true.js
-    ! prototype/includes/BigInt/search-not-found-returns-false.js
-    ! prototype/includes/BigInt/tointeger-fromindex.js
-    ! prototype/includes/detached-buffer.js
-    ! prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
-    ! prototype/includes/fromIndex-infinity.js
-    ! prototype/includes/fromIndex-minus-zero.js
-    ! prototype/includes/get-length-uses-internal-arraylength.js
-    ! prototype/includes/invoked-as-func.js
-    ! prototype/includes/invoked-as-method.js
-    ! prototype/includes/length-zero-returns-false.js
-    ! prototype/includes/length.js
-    ! prototype/includes/name.js
-    ! prototype/includes/prop-desc.js
-    ! prototype/includes/return-abrupt-tointeger-fromindex.js
-    ! prototype/includes/samevaluezero.js
-    ! prototype/includes/search-found-returns-true.js
-    ! prototype/includes/search-not-found-returns-false.js
-    ! prototype/includes/this-is-not-object.js
-    ! prototype/includes/this-is-not-typedarray-instance.js
-    ! prototype/includes/tointeger-fromindex.js
-    ! prototype/indexOf/BigInt/detached-buffer.js
-    ! prototype/indexOf/BigInt/fromIndex-equal-or-greater-length-returns-minus-one.js
-    ! prototype/indexOf/BigInt/fromIndex-infinity.js
-    ! prototype/indexOf/BigInt/fromIndex-minus-zero.js
-    ! prototype/indexOf/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/indexOf/BigInt/length-zero-returns-minus-one.js
-    ! prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    ! prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex.js
-    ! prototype/indexOf/BigInt/search-found-returns-index.js
-    ! prototype/indexOf/BigInt/search-not-found-returns-minus-one.js
-    ! prototype/indexOf/BigInt/tointeger-fromindex.js
-    ! prototype/indexOf/detached-buffer.js
-    ! prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
-    ! prototype/indexOf/fromIndex-infinity.js
-    ! prototype/indexOf/fromIndex-minus-zero.js
-    ! prototype/indexOf/get-length-uses-internal-arraylength.js
-    ! prototype/indexOf/invoked-as-func.js
-    ! prototype/indexOf/invoked-as-method.js
-    ! prototype/indexOf/length-zero-returns-minus-one.js
-    ! prototype/indexOf/length.js
-    ! prototype/indexOf/name.js
-    ! prototype/indexOf/prop-desc.js
-    ! prototype/indexOf/return-abrupt-tointeger-fromindex.js
-    ! prototype/indexOf/search-found-returns-index.js
-    ! prototype/indexOf/search-not-found-returns-minus-one.js
-    ! prototype/indexOf/strict-comparison.js
-    ! prototype/indexOf/this-is-not-object.js
-    ! prototype/indexOf/this-is-not-typedarray-instance.js
-    ! prototype/indexOf/tointeger-fromindex.js
-    ! prototype/join/BigInt/custom-separator-result-from-tostring-on-each-simple-value.js
-    ! prototype/join/BigInt/detached-buffer.js
-    ! prototype/join/BigInt/empty-instance-empty-string.js
-    ! prototype/join/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/join/BigInt/result-from-tostring-on-each-simple-value.js
-    ! prototype/join/BigInt/return-abrupt-from-separator-symbol.js
-    ! prototype/join/BigInt/return-abrupt-from-separator.js
-    ! prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
-    ! prototype/join/custom-separator-result-from-tostring-on-each-value.js
-    ! prototype/join/detached-buffer.js
-    ! prototype/join/empty-instance-empty-string.js
-    ! prototype/join/get-length-uses-internal-arraylength.js
-    ! prototype/join/invoked-as-func.js
-    ! prototype/join/invoked-as-method.js
-    ! prototype/join/length.js
-    ! prototype/join/name.js
-    ! prototype/join/prop-desc.js
-    ! prototype/join/result-from-tostring-on-each-simple-value.js
-    ! prototype/join/result-from-tostring-on-each-value.js
-    ! prototype/join/return-abrupt-from-separator.js
-    ! prototype/join/this-is-not-object.js
-    ! prototype/join/this-is-not-typedarray-instance.js
-    ! prototype/keys/BigInt/detached-buffer.js
-    ! prototype/keys/BigInt/iter-prototype.js
-    ! prototype/keys/BigInt/return-itor.js
-    ! prototype/keys/detached-buffer.js
-    ! prototype/keys/invoked-as-func.js
-    ! prototype/keys/invoked-as-method.js
-    ! prototype/keys/iter-prototype.js
-    ! prototype/keys/length.js
-    ! prototype/keys/name.js
-    ! prototype/keys/prop-desc.js
-    ! prototype/keys/return-itor.js
-    ! prototype/keys/this-is-not-object.js
-    ! prototype/keys/this-is-not-typedarray-instance.js
-    ! prototype/lastIndexOf/BigInt/detached-buffer.js
-    ! prototype/lastIndexOf/BigInt/fromIndex-infinity.js
-    ! prototype/lastIndexOf/BigInt/fromIndex-minus-zero.js
-    ! prototype/lastIndexOf/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/lastIndexOf/BigInt/length-zero-returns-minus-one.js
-    ! prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    ! prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex.js
-    ! prototype/lastIndexOf/BigInt/search-found-returns-index.js
-    ! prototype/lastIndexOf/BigInt/search-not-found-returns-minus-one.js
-    ! prototype/lastIndexOf/BigInt/tointeger-fromindex.js
-    ! prototype/lastIndexOf/detached-buffer.js
-    ! prototype/lastIndexOf/fromIndex-infinity.js
-    ! prototype/lastIndexOf/fromIndex-minus-zero.js
-    ! prototype/lastIndexOf/get-length-uses-internal-arraylength.js
-    ! prototype/lastIndexOf/invoked-as-func.js
-    ! prototype/lastIndexOf/invoked-as-method.js
-    ! prototype/lastIndexOf/length-zero-returns-minus-one.js
-    ! prototype/lastIndexOf/length.js
-    ! prototype/lastIndexOf/name.js
-    ! prototype/lastIndexOf/prop-desc.js
-    ! prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
-    ! prototype/lastIndexOf/search-found-returns-index.js
-    ! prototype/lastIndexOf/search-not-found-returns-minus-one.js
-    ! prototype/lastIndexOf/strict-comparison.js
-    ! prototype/lastIndexOf/this-is-not-object.js
-    ! prototype/lastIndexOf/this-is-not-typedarray-instance.js
-    ! prototype/lastIndexOf/tointeger-fromindex.js
-    ! prototype/length/BigInt/detached-buffer.js
-    ! prototype/length/BigInt/return-length.js
-    ! prototype/length/detached-buffer.js
-    ! prototype/length/invoked-as-func.js
-    ! prototype/length/length.js
-    ! prototype/length/name.js
-    ! prototype/length/prop-desc.js
-    ! prototype/length/this-has-no-typedarrayname-internal.js
-    ! prototype/length/this-is-not-object.js
-    ! prototype/map/BigInt/arraylength-internal.js
-    ! prototype/map/BigInt/callbackfn-arguments-with-thisarg.js
-    ! prototype/map/BigInt/callbackfn-arguments-without-thisarg.js
-    ! prototype/map/BigInt/callbackfn-detachbuffer.js
-    ! prototype/map/BigInt/callbackfn-is-not-callable.js
-    ! prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
-    ! prototype/map/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/map/BigInt/callbackfn-return-affects-returned-object.js
-    ! prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/map/BigInt/callbackfn-return-does-not-copy-non-integer-properties.js
-    ! prototype/map/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/map/BigInt/callbackfn-this.js
-    ! prototype/map/BigInt/detached-buffer.js
-    ! prototype/map/BigInt/return-new-typedarray-from-empty-length.js
-    ! prototype/map/BigInt/return-new-typedarray-from-positive-length.js
-    ! prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
-    ! prototype/map/BigInt/speciesctor-get-ctor-inherited.js
-    ! prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
-    ! prototype/map/BigInt/speciesctor-get-ctor.js
-    ! prototype/map/BigInt/speciesctor-get-species-abrupt.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
-    ! prototype/map/BigInt/speciesctor-get-species-returns-throws.js
-    ! prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
-    ! prototype/map/BigInt/speciesctor-get-species.js
-    ! prototype/map/BigInt/values-are-not-cached.js
-    ! prototype/map/arraylength-internal.js
-    ! prototype/map/callbackfn-arguments-with-thisarg.js
-    ! prototype/map/callbackfn-arguments-without-thisarg.js
-    ! prototype/map/callbackfn-detachbuffer.js
-    ! prototype/map/callbackfn-no-interaction-over-non-integer-properties.js
-    ! prototype/map/callbackfn-not-called-on-empty.js
-    ! prototype/map/callbackfn-return-affects-returned-object.js
-    ! prototype/map/callbackfn-return-does-not-change-instance.js
-    ! prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
-    ! prototype/map/callbackfn-returns-abrupt.js
-    ! prototype/map/callbackfn-this.js
-    ! prototype/map/detached-buffer.js
-    ! prototype/map/invoked-as-func.js
-    ! prototype/map/invoked-as-method.js
-    ! prototype/map/length.js
-    ! prototype/map/name.js
-    ! prototype/map/prop-desc.js
-    ! prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
-    ! prototype/map/return-new-typedarray-conversion-operation.js
-    ! prototype/map/return-new-typedarray-from-empty-length.js
-    ! prototype/map/return-new-typedarray-from-positive-length.js
-    ! prototype/map/speciesctor-get-ctor-abrupt.js
-    ! prototype/map/speciesctor-get-ctor-inherited.js
-    ! prototype/map/speciesctor-get-ctor.js
-    ! prototype/map/speciesctor-get-species-abrupt.js
-    ! prototype/map/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/map/speciesctor-get-species-custom-ctor-length.js
-    ! prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/map/speciesctor-get-species-custom-ctor.js
-    ! prototype/map/speciesctor-get-species-use-default-ctor.js
-    ! prototype/map/speciesctor-get-species.js
-    ! prototype/map/this-is-not-object.js
-    ! prototype/map/this-is-not-typedarray-instance.js
-    ! prototype/map/values-are-not-cached.js
-    ! prototype/reduce/BigInt/callbackfn-arguments-custom-accumulator.js
-    ! prototype/reduce/BigInt/callbackfn-arguments-default-accumulator.js
-    ! prototype/reduce/BigInt/callbackfn-detachbuffer.js
-    ! prototype/reduce/BigInt/callbackfn-is-not-callable-throws.js
-    ! prototype/reduce/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
-    ! prototype/reduce/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/reduce/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/reduce/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/reduce/BigInt/callbackfn-this.js
-    ! prototype/reduce/BigInt/detached-buffer.js
-    ! prototype/reduce/BigInt/empty-instance-return-initialvalue.js
-    ! prototype/reduce/BigInt/empty-instance-with-no-initialvalue-throws.js
-    ! prototype/reduce/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/reduce/BigInt/result-is-last-callbackfn-return.js
-    ! prototype/reduce/BigInt/result-of-any-type.js
-    ! prototype/reduce/BigInt/return-first-value-without-callbackfn.js
-    ! prototype/reduce/BigInt/values-are-not-cached.js
-    ! prototype/reduceRight/BigInt/callbackfn-arguments-custom-accumulator.js
-    ! prototype/reduceRight/BigInt/callbackfn-arguments-default-accumulator.js
-    ! prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
-    ! prototype/reduceRight/BigInt/callbackfn-is-not-callable-throws.js
-    ! prototype/reduceRight/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
-    ! prototype/reduceRight/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/reduceRight/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/reduceRight/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/reduceRight/BigInt/callbackfn-this.js
-    ! prototype/reduceRight/BigInt/detached-buffer.js
-    ! prototype/reduceRight/BigInt/empty-instance-return-initialvalue.js
-    ! prototype/reduceRight/BigInt/empty-instance-with-no-initialvalue-throws.js
-    ! prototype/reduceRight/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/reduceRight/BigInt/result-is-last-callbackfn-return.js
-    ! prototype/reduceRight/BigInt/result-of-any-type.js
-    ! prototype/reduceRight/BigInt/return-first-value-without-callbackfn.js
-    ! prototype/reduceRight/BigInt/values-are-not-cached.js
-    ! prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
-    ! prototype/reduceRight/callbackfn-arguments-default-accumulator.js
-    ! prototype/reduceRight/callbackfn-detachbuffer.js
-    ! prototype/reduceRight/callbackfn-no-iteration-over-non-integer-properties.js
-    ! prototype/reduceRight/callbackfn-not-called-on-empty.js
-    ! prototype/reduceRight/callbackfn-return-does-not-change-instance.js
-    ! prototype/reduceRight/callbackfn-returns-abrupt.js
-    ! prototype/reduceRight/callbackfn-this.js
-    ! prototype/reduceRight/detached-buffer.js
-    ! prototype/reduceRight/empty-instance-return-initialvalue.js
-    ! prototype/reduceRight/get-length-uses-internal-arraylength.js
-    ! prototype/reduceRight/invoked-as-func.js
-    ! prototype/reduceRight/invoked-as-method.js
-    ! prototype/reduceRight/length.js
-    ! prototype/reduceRight/name.js
-    ! prototype/reduceRight/prop-desc.js
-    ! prototype/reduceRight/result-is-last-callbackfn-return.js
-    ! prototype/reduceRight/result-of-any-type.js
-    ! prototype/reduceRight/return-first-value-without-callbackfn.js
-    ! prototype/reduceRight/this-is-not-object.js
-    ! prototype/reduceRight/this-is-not-typedarray-instance.js
-    ! prototype/reduceRight/values-are-not-cached.js
-    ! prototype/reduce/callbackfn-arguments-custom-accumulator.js
-    ! prototype/reduce/callbackfn-arguments-default-accumulator.js
-    ! prototype/reduce/callbackfn-detachbuffer.js
-    ! prototype/reduce/callbackfn-no-iteration-over-non-integer-properties.js
-    ! prototype/reduce/callbackfn-not-called-on-empty.js
-    ! prototype/reduce/callbackfn-return-does-not-change-instance.js
-    ! prototype/reduce/callbackfn-returns-abrupt.js
-    ! prototype/reduce/callbackfn-this.js
-    ! prototype/reduce/detached-buffer.js
-    ! prototype/reduce/empty-instance-return-initialvalue.js
-    ! prototype/reduce/get-length-uses-internal-arraylength.js
-    ! prototype/reduce/invoked-as-func.js
-    ! prototype/reduce/invoked-as-method.js
-    ! prototype/reduce/length.js
-    ! prototype/reduce/name.js
-    ! prototype/reduce/prop-desc.js
-    ! prototype/reduce/result-is-last-callbackfn-return.js
-    ! prototype/reduce/result-of-any-type.js
-    ! prototype/reduce/return-first-value-without-callbackfn.js
-    ! prototype/reduce/this-is-not-object.js
-    ! prototype/reduce/this-is-not-typedarray-instance.js
-    ! prototype/reduce/values-are-not-cached.js
-    ! prototype/reverse/BigInt/detached-buffer.js
-    ! prototype/reverse/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/reverse/BigInt/preserves-non-numeric-properties.js
-    ! prototype/reverse/BigInt/returns-original-object.js
-    ! prototype/reverse/BigInt/reverts.js
-    ! prototype/reverse/detached-buffer.js
-    ! prototype/reverse/get-length-uses-internal-arraylength.js
-    ! prototype/reverse/invoked-as-func.js
-    ! prototype/reverse/invoked-as-method.js
-    ! prototype/reverse/length.js
-    ! prototype/reverse/name.js
-    ! prototype/reverse/preserves-non-numeric-properties.js
-    ! prototype/reverse/prop-desc.js
-    ! prototype/reverse/returns-original-object.js
-    ! prototype/reverse/reverts.js
-    ! prototype/reverse/this-is-not-object.js
-    ! prototype/reverse/this-is-not-typedarray-instance.js
-    ! prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
-    ! prototype/set/BigInt/array-arg-offset-tointeger.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset.js
-    ! prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
-    ! prototype/set/BigInt/array-arg-set-values-in-order.js
-    ! prototype/set/BigInt/array-arg-set-values.js
-    ! prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
-    ! prototype/set/BigInt/array-arg-src-values-are-not-cached.js
-    ! prototype/set/BigInt/array-arg-target-arraylength-internal.js
-    ! prototype/set/BigInt/array-arg-targetbuffer-detached-on-get-src-value-throws.js
-    ! prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
-    ! prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
-    ! prototype/set/BigInt/bigint-tobigint64.js
-    ! prototype/set/BigInt/bigint-tobiguint64.js
-    ! prototype/set/BigInt/boolean-tobigint.js
-    ! prototype/set/BigInt/null-tobigint.js
-    ! prototype/set/BigInt/number-tobigint.js
-    ! prototype/set/BigInt/src-typedarray-big.js
-    ! prototype/set/BigInt/src-typedarray-not-big-throws.js
-    ! prototype/set/BigInt/string-nan-tobigint.js
-    ! prototype/set/BigInt/string-tobigint.js
-    ! prototype/set/BigInt/symbol-tobigint.js
-    ! prototype/set/BigInt/typedarray-arg-negative-integer-offset-throws.js
-    ! prototype/set/BigInt/typedarray-arg-offset-tointeger.js
-    ! prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
-    ! prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset.js
-    ! prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
-    ! prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
-    ! prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
-    ! prototype/set/BigInt/typedarray-arg-src-arraylength-internal.js
-    ! prototype/set/BigInt/typedarray-arg-src-byteoffset-internal.js
-    ! prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
-    ! prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
-    ! prototype/set/BigInt/typedarray-arg-target-arraylength-internal.js
-    ! prototype/set/BigInt/typedarray-arg-target-byteoffset-internal.js
-    ! prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    ! prototype/set/BigInt/undefined-tobigint.js
-    ! prototype/set/array-arg-negative-integer-offset-throws.js
-    ! prototype/set/array-arg-return-abrupt-from-src-get-length.js
-    ! prototype/set/array-arg-return-abrupt-from-src-get-value.js
-    ! prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
-    ! prototype/set/array-arg-return-abrupt-from-src-length.js
-    ! prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
-    ! prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
-    ! prototype/set/array-arg-return-abrupt-from-toobject-offset.js
-    ! prototype/set/array-arg-set-values-in-order.js
-    ! prototype/set/array-arg-set-values.js
-    ! prototype/set/array-arg-src-tonumber-value-conversions.js
-    ! prototype/set/array-arg-src-values-are-not-cached.js
-    ! prototype/set/array-arg-target-arraylength-internal.js
-    ! prototype/set/array-arg-targetbuffer-detached-on-get-src-value-throws.js
-    ! prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
-    ! prototype/set/array-arg-targetbuffer-detached-throws.js
-    ! prototype/set/invoked-as-func.js
-    ! prototype/set/invoked-as-method.js
-    ! prototype/set/length.js
-    ! prototype/set/name.js
-    ! prototype/set/prop-desc.js
-    ! prototype/set/src-typedarray-big-throws.js
-    ! prototype/set/this-is-not-object.js
-    ! prototype/set/this-is-not-typedarray-instance.js
-    ! prototype/set/typedarray-arg-negative-integer-offset-throws.js
-    ! prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
-    ! prototype/set/typedarray-arg-src-arraylength-internal.js
-    ! prototype/set/typedarray-arg-src-byteoffset-internal.js
-    ! prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
-    ! prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
-    ! prototype/set/typedarray-arg-target-arraylength-internal.js
-    ! prototype/set/typedarray-arg-target-byteoffset-internal.js
-    ! prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    ! prototype/slice/BigInt/arraylength-internal.js
-    ! prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
-    ! prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
-    ! prototype/slice/BigInt/detached-buffer-get-ctor.js
-    ! prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
-    ! prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
-    ! prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
-    ! prototype/slice/BigInt/detached-buffer.js
-    ! prototype/slice/BigInt/infinity.js
-    ! prototype/slice/BigInt/minus-zero.js
-    ! prototype/slice/BigInt/result-does-not-copy-ordinary-properties.js
-    ! prototype/slice/BigInt/results-with-different-length.js
-    ! prototype/slice/BigInt/results-with-empty-length.js
-    ! prototype/slice/BigInt/results-with-same-length.js
-    ! prototype/slice/BigInt/return-abrupt-from-end-symbol.js
-    ! prototype/slice/BigInt/return-abrupt-from-end.js
-    ! prototype/slice/BigInt/return-abrupt-from-start-symbol.js
-    ! prototype/slice/BigInt/return-abrupt-from-start.js
-    ! prototype/slice/BigInt/set-values-from-different-ctor-type.js
-    ! prototype/slice/BigInt/speciesctor-get-ctor-abrupt.js
-    ! prototype/slice/BigInt/speciesctor-get-ctor-inherited.js
-    ! prototype/slice/BigInt/speciesctor-get-ctor-returns-throws.js
-    ! prototype/slice/BigInt/speciesctor-get-ctor.js
-    ! prototype/slice/BigInt/speciesctor-get-species-abrupt.js
-    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length.js
-    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    ! prototype/slice/BigInt/speciesctor-get-species-custom-ctor.js
-    ! prototype/slice/BigInt/speciesctor-get-species-returns-throws.js
-    ! prototype/slice/BigInt/speciesctor-get-species-use-default-ctor.js
-    ! prototype/slice/BigInt/speciesctor-get-species.js
-    ! prototype/slice/BigInt/tointeger-end.js
-    ! prototype/slice/BigInt/tointeger-start.js
-    ! prototype/slice/arraylength-internal.js
-    ! prototype/slice/bit-precision.js
-    ! prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
-    ! prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
-    ! prototype/slice/detached-buffer.js
-    ! prototype/slice/infinity.js
-    ! prototype/slice/invoked-as-func.js
-    ! prototype/slice/invoked-as-method.js
-    ! prototype/slice/length.js
-    ! prototype/slice/minus-zero.js
-    ! prototype/slice/name.js
-    ! prototype/slice/prop-desc.js
-    ! prototype/slice/result-does-not-copy-ordinary-properties.js
-    ! prototype/slice/results-with-different-length.js
-    ! prototype/slice/results-with-empty-length.js
-    ! prototype/slice/results-with-same-length.js
-    ! prototype/slice/return-abrupt-from-end.js
-    ! prototype/slice/return-abrupt-from-start.js
-    ! prototype/slice/set-values-from-different-ctor-type.js
-    ! prototype/slice/speciesctor-get-ctor-abrupt.js
-    ! prototype/slice/speciesctor-get-ctor-inherited.js
-    ! prototype/slice/speciesctor-get-ctor.js
-    ! prototype/slice/speciesctor-get-species-abrupt.js
-    ! prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/slice/speciesctor-get-species-custom-ctor-length.js
-    ! prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/slice/speciesctor-get-species-custom-ctor.js
-    ! prototype/slice/speciesctor-get-species-use-default-ctor.js
-    ! prototype/slice/speciesctor-get-species.js
-    ! prototype/slice/this-is-not-object.js
-    ! prototype/slice/this-is-not-typedarray-instance.js
-    ! prototype/slice/tointeger-end.js
-    ! prototype/slice/tointeger-start.js
-    ! prototype/some/BigInt/callbackfn-arguments-with-thisarg.js
-    ! prototype/some/BigInt/callbackfn-arguments-without-thisarg.js
-    ! prototype/some/BigInt/callbackfn-detachbuffer.js
-    ! prototype/some/BigInt/callbackfn-no-interaction-over-non-integer.js
-    ! prototype/some/BigInt/callbackfn-not-callable-throws.js
-    ! prototype/some/BigInt/callbackfn-not-called-on-empty.js
-    ! prototype/some/BigInt/callbackfn-return-does-not-change-instance.js
-    ! prototype/some/BigInt/callbackfn-returns-abrupt.js
-    ! prototype/some/BigInt/callbackfn-this.js
-    ! prototype/some/BigInt/detached-buffer.js
-    ! prototype/some/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/some/BigInt/returns-false-if-every-cb-returns-false.js
-    ! prototype/some/BigInt/returns-true-if-any-cb-returns-true.js
-    ! prototype/some/BigInt/values-are-not-cached.js
-    ! prototype/some/callbackfn-arguments-with-thisarg.js
-    ! prototype/some/callbackfn-arguments-without-thisarg.js
-    ! prototype/some/callbackfn-detachbuffer.js
-    ! prototype/some/callbackfn-no-interaction-over-non-integer.js
-    ! prototype/some/callbackfn-not-called-on-empty.js
-    ! prototype/some/callbackfn-return-does-not-change-instance.js
-    ! prototype/some/callbackfn-returns-abrupt.js
-    ! prototype/some/callbackfn-this.js
-    ! prototype/some/detached-buffer.js
-    ! prototype/some/get-length-uses-internal-arraylength.js
-    ! prototype/some/invoked-as-func.js
-    ! prototype/some/invoked-as-method.js
-    ! prototype/some/length.js
-    ! prototype/some/name.js
-    ! prototype/some/prop-desc.js
-    ! prototype/some/returns-false-if-every-cb-returns-false.js
-    ! prototype/some/returns-true-if-any-cb-returns-true.js
-    ! prototype/some/this-is-not-object.js
-    ! prototype/some/this-is-not-typedarray-instance.js
-    ! prototype/some/values-are-not-cached.js
-    ! prototype/sort/BigInt/arraylength-internal.js
-    ! prototype/sort/BigInt/comparefn-call-throws.js
-    ! prototype/sort/BigInt/comparefn-calls.js
-    ! prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
-    ! prototype/sort/BigInt/detached-buffer-comparefn.js
-    ! prototype/sort/BigInt/detached-buffer.js
-    ! prototype/sort/BigInt/return-same-instance.js
-    ! prototype/sort/BigInt/sortcompare-with-no-tostring.js
-    ! prototype/sort/BigInt/sorted-values.js
-    ! prototype/sort/arraylength-internal.js
-    ! prototype/sort/comparefn-call-throws.js
-    ! prototype/sort/comparefn-calls.js
-    ! prototype/sort/detached-buffer-comparefn.js
-    ! prototype/sort/detached-buffer.js
-    ! prototype/sort/invoked-as-func.js
-    ! prototype/sort/invoked-as-method.js
-    ! prototype/sort/length.js
-    ! prototype/sort/name.js
-    ! prototype/sort/prop-desc.js
-    ! prototype/sort/return-same-instance.js
-    ! prototype/sort/sort-tonumber.js
-    ! prototype/sort/sortcompare-with-no-tostring.js
-    ! prototype/sort/sorted-values-nan.js
-    ! prototype/sort/sorted-values.js
-    ! prototype/sort/stability.js
-    ! prototype/sort/this-is-not-object.js
-    ! prototype/sort/this-is-not-typedarray-instance.js
-    ! prototype/subarray/BigInt/detached-buffer.js
-    ! prototype/subarray/BigInt/infinity.js
-    ! prototype/subarray/BigInt/minus-zero.js
-    ! prototype/subarray/BigInt/result-does-not-copy-ordinary-properties.js
-    ! prototype/subarray/BigInt/result-is-new-instance-from-same-ctor.js
-    ! prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
-    ! prototype/subarray/BigInt/results-with-different-length.js
-    ! prototype/subarray/BigInt/results-with-empty-length.js
-    ! prototype/subarray/BigInt/results-with-same-length.js
-    ! prototype/subarray/BigInt/return-abrupt-from-begin-symbol.js
-    ! prototype/subarray/BigInt/return-abrupt-from-begin.js
-    ! prototype/subarray/BigInt/return-abrupt-from-end-symbol.js
-    ! prototype/subarray/BigInt/return-abrupt-from-end.js
-    ! prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
-    ! prototype/subarray/BigInt/speciesctor-get-ctor-inherited.js
-    ! prototype/subarray/BigInt/speciesctor-get-ctor-returns-throws.js
-    ! prototype/subarray/BigInt/speciesctor-get-ctor.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-custom-ctor.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-returns-throws.js
-    ! prototype/subarray/BigInt/speciesctor-get-species-use-default-ctor.js
-    ! prototype/subarray/BigInt/speciesctor-get-species.js
-    ! prototype/subarray/BigInt/tointeger-begin.js
-    ! prototype/subarray/BigInt/tointeger-end.js
-    ! prototype/subarray/detached-buffer.js
-    ! prototype/subarray/infinity.js
-    ! prototype/subarray/invoked-as-func.js
-    ! prototype/subarray/invoked-as-method.js
-    ! prototype/subarray/length.js
-    ! prototype/subarray/name.js
-    ! prototype/subarray/prop-desc.js
-    ! prototype/subarray/speciesctor-get-ctor-abrupt.js
-    ! prototype/subarray/speciesctor-get-ctor-inherited.js
-    ! prototype/subarray/speciesctor-get-ctor-returns-throws.js
-    ! prototype/subarray/speciesctor-get-ctor.js
-    ! prototype/subarray/speciesctor-get-species-abrupt.js
-    ! prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    ! prototype/subarray/speciesctor-get-species-custom-ctor-throws.js
-    ! prototype/subarray/speciesctor-get-species-custom-ctor.js
-    ! prototype/subarray/speciesctor-get-species-returns-throws.js
-    ! prototype/subarray/speciesctor-get-species.js
-    ! prototype/subarray/this-is-not-object.js
-    ! prototype/subarray/this-is-not-typedarray-instance.js
-    ! prototype/Symbol.toStringTag/BigInt/detached-buffer.js
-    ! prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
-    ! prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
-    ! prototype/Symbol.toStringTag/BigInt/length.js
-    ! prototype/Symbol.toStringTag/BigInt/name.js
-    ! prototype/Symbol.toStringTag/BigInt/prop-desc.js
-    ! prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
-    ! prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
-    ! prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
-    ! prototype/Symbol.toStringTag/detached-buffer.js
-    ! prototype/Symbol.toStringTag/invoked-as-accessor.js
-    ! prototype/Symbol.toStringTag/invoked-as-func.js
-    ! prototype/Symbol.toStringTag/length.js
-    ! prototype/Symbol.toStringTag/name.js
-    ! prototype/Symbol.toStringTag/prop-desc.js
-    ! prototype/Symbol.toStringTag/return-typedarrayname.js
-    ! prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
-    ! prototype/Symbol.toStringTag/this-is-not-object.js
-    ! prototype/toLocaleString/BigInt/calls-tolocalestring-from-each-value.js
-    ! prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
-    ! prototype/toLocaleString/BigInt/calls-valueof-from-each-value.js
-    ! prototype/toLocaleString/BigInt/detached-buffer.js
-    ! prototype/toLocaleString/BigInt/empty-instance-returns-empty-string.js
-    ! prototype/toLocaleString/BigInt/get-length-uses-internal-arraylength.js
-    ! prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tolocalestring.js
-    ! prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tostring.js
-    ! prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-valueof.js
-    ! prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tolocalestring.js
-    ! prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring.js
-    ! prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof.js
-    ! prototype/toLocaleString/BigInt/return-result.js
-    ! prototype/toLocaleString/calls-tolocalestring-from-each-value.js
-    ! prototype/toLocaleString/calls-tostring-from-each-value.js
-    ! prototype/toLocaleString/calls-valueof-from-each-value.js
-    ! prototype/toLocaleString/detached-buffer.js
-    ! prototype/toLocaleString/get-length-uses-internal-arraylength.js
-    ! prototype/toLocaleString/invoked-as-func.js
-    ! prototype/toLocaleString/invoked-as-method.js
-    ! prototype/toLocaleString/length.js
-    ! prototype/toLocaleString/name.js
-    ! prototype/toLocaleString/prop-desc.js
-    ! prototype/toLocaleString/return-abrupt-from-firstelement-tolocalestring.js
-    ! prototype/toLocaleString/return-abrupt-from-firstelement-tostring.js
-    ! prototype/toLocaleString/return-abrupt-from-firstelement-valueof.js
-    ! prototype/toLocaleString/return-abrupt-from-nextelement-tolocalestring.js
-    ! prototype/toLocaleString/return-abrupt-from-nextelement-tostring.js
-    ! prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
-    ! prototype/toLocaleString/this-is-not-object.js
-    ! prototype/toLocaleString/this-is-not-typedarray-instance.js
-    ! prototype/toString/BigInt/detached-buffer.js
-    ! prototype/toString/detached-buffer.js
-    ! prototype/values/BigInt/detached-buffer.js
-    ! prototype/values/BigInt/iter-prototype.js
-    ! prototype/values/BigInt/return-itor.js
-    ! prototype/values/detached-buffer.js
-    ! prototype/values/invoked-as-func.js
-    ! prototype/values/invoked-as-method.js
-    ! prototype/values/iter-prototype.js
-    ! prototype/values/length.js
-    ! prototype/values/name.js
-    ! prototype/values/prop-desc.js
-    ! prototype/values/return-itor.js
-    ! prototype/values/this-is-not-object.js
-    ! prototype/values/this-is-not-typedarray-instance.js
-    ! prototype/constructor.js
-    ! prototype/Symbol.iterator.js
-    ! prototype/toString.js
-    ! Symbol.species/length.js
-    ! Symbol.species/name.js
-    ! Symbol.species/prop-desc.js
-    ! Symbol.species/result.js
-    ! invoked.js
-    ! length.js
-    ! name.js
-    ! prototype.js
+    from/arylk-get-length-error.js
+    from/arylk-to-length-error.js
+    from/iter-access-error.js
+    from/iter-invoke-error.js
+    from/iter-next-error.js
+    from/iter-next-value-error.js
+    from/length.js
+    from/name.js
+    from/prop-desc.js
+    of/length.js
+    of/name.js
+    of/prop-desc.js
+    prototype/buffer/BigInt/detached-buffer.js
+    prototype/buffer/BigInt/return-buffer.js
+    prototype/buffer/detached-buffer.js
+    prototype/buffer/invoked-as-func.js
+    prototype/buffer/length.js
+    prototype/buffer/name.js
+    prototype/buffer/prop-desc.js
+    prototype/buffer/this-has-no-typedarrayname-internal.js
+    prototype/buffer/this-is-not-object.js
+    prototype/byteLength/BigInt/detached-buffer.js
+    prototype/byteLength/BigInt/return-bytelength.js
+    prototype/byteLength/detached-buffer.js
+    prototype/byteLength/invoked-as-func.js
+    prototype/byteLength/length.js
+    prototype/byteLength/name.js
+    prototype/byteLength/prop-desc.js
+    prototype/byteLength/this-has-no-typedarrayname-internal.js
+    prototype/byteLength/this-is-not-object.js
+    prototype/byteOffset/BigInt/detached-buffer.js
+    prototype/byteOffset/BigInt/return-byteoffset.js
+    prototype/byteOffset/detached-buffer.js
+    prototype/byteOffset/invoked-as-func.js
+    prototype/byteOffset/length.js
+    prototype/byteOffset/name.js
+    prototype/byteOffset/prop-desc.js
+    prototype/byteOffset/this-has-no-typedarrayname-internal.js
+    prototype/byteOffset/this-is-not-object.js
+    prototype/copyWithin/BigInt/coerced-values-end.js
+    prototype/copyWithin/BigInt/coerced-values-start.js
+    prototype/copyWithin/BigInt/coerced-values-target.js
+    prototype/copyWithin/BigInt/detached-buffer.js
+    prototype/copyWithin/BigInt/get-length-ignores-length-prop.js
+    prototype/copyWithin/BigInt/negative-end.js
+    prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
+    prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
+    prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
+    prototype/copyWithin/BigInt/negative-start.js
+    prototype/copyWithin/BigInt/negative-target.js
+    prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
+    prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
+    prototype/copyWithin/BigInt/non-negative-target-and-start.js
+    prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
+    prototype/copyWithin/BigInt/return-abrupt-from-end-is-symbol.js
+    prototype/copyWithin/BigInt/return-abrupt-from-end.js
+    prototype/copyWithin/BigInt/return-abrupt-from-start-is-symbol.js
+    prototype/copyWithin/BigInt/return-abrupt-from-start.js
+    prototype/copyWithin/BigInt/return-abrupt-from-target-is-symbol.js
+    prototype/copyWithin/BigInt/return-abrupt-from-target.js
+    prototype/copyWithin/BigInt/return-this.js
+    prototype/copyWithin/BigInt/undefined-end.js
+    prototype/copyWithin/bit-precision.js
+    prototype/copyWithin/coerced-values-end.js
+    prototype/copyWithin/coerced-values-start.js
+    prototype/copyWithin/coerced-values-target.js
+    prototype/copyWithin/detached-buffer.js
+    prototype/copyWithin/get-length-ignores-length-prop.js
+    prototype/copyWithin/invoked-as-func.js
+    prototype/copyWithin/invoked-as-method.js
+    prototype/copyWithin/length.js
+    prototype/copyWithin/name.js
+    prototype/copyWithin/negative-end.js
+    prototype/copyWithin/negative-out-of-bounds-end.js
+    prototype/copyWithin/negative-out-of-bounds-start.js
+    prototype/copyWithin/negative-out-of-bounds-target.js
+    prototype/copyWithin/negative-start.js
+    prototype/copyWithin/negative-target.js
+    prototype/copyWithin/non-negative-out-of-bounds-end.js
+    prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
+    prototype/copyWithin/non-negative-target-and-start.js
+    prototype/copyWithin/non-negative-target-start-and-end.js
+    prototype/copyWithin/prop-desc.js
+    prototype/copyWithin/return-abrupt-from-end.js
+    prototype/copyWithin/return-abrupt-from-start.js
+    prototype/copyWithin/return-abrupt-from-target.js
+    prototype/copyWithin/return-this.js
+    prototype/copyWithin/this-is-not-object.js
+    prototype/copyWithin/this-is-not-typedarray-instance.js
+    prototype/copyWithin/undefined-end.js
+    prototype/entries/BigInt/detached-buffer.js
+    prototype/entries/BigInt/iter-prototype.js
+    prototype/entries/BigInt/return-itor.js
+    prototype/entries/detached-buffer.js
+    prototype/entries/invoked-as-func.js
+    prototype/entries/invoked-as-method.js
+    prototype/entries/iter-prototype.js
+    prototype/entries/length.js
+    prototype/entries/name.js
+    prototype/entries/prop-desc.js
+    prototype/entries/return-itor.js
+    prototype/entries/this-is-not-object.js
+    prototype/entries/this-is-not-typedarray-instance.js
+    prototype/every/BigInt/callbackfn-arguments-with-thisarg.js
+    prototype/every/BigInt/callbackfn-arguments-without-thisarg.js
+    prototype/every/BigInt/callbackfn-detachbuffer.js
+    prototype/every/BigInt/callbackfn-no-interaction-over-non-integer.js
+    prototype/every/BigInt/callbackfn-not-callable-throws.js
+    prototype/every/BigInt/callbackfn-not-called-on-empty.js
+    prototype/every/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/every/BigInt/callbackfn-returns-abrupt.js
+    prototype/every/BigInt/callbackfn-this.js
+    prototype/every/BigInt/detached-buffer.js
+    prototype/every/BigInt/get-length-uses-internal-arraylength.js
+    prototype/every/BigInt/returns-false-if-any-cb-returns-false.js
+    prototype/every/BigInt/returns-true-if-every-cb-returns-true.js
+    prototype/every/BigInt/values-are-not-cached.js
+    prototype/every/callbackfn-arguments-with-thisarg.js
+    prototype/every/callbackfn-arguments-without-thisarg.js
+    prototype/every/callbackfn-detachbuffer.js
+    prototype/every/callbackfn-no-interaction-over-non-integer.js
+    prototype/every/callbackfn-not-called-on-empty.js
+    prototype/every/callbackfn-return-does-not-change-instance.js
+    prototype/every/callbackfn-returns-abrupt.js
+    prototype/every/callbackfn-this.js
+    prototype/every/detached-buffer.js
+    prototype/every/get-length-uses-internal-arraylength.js
+    prototype/every/invoked-as-func.js
+    prototype/every/invoked-as-method.js
+    prototype/every/length.js
+    prototype/every/name.js
+    prototype/every/prop-desc.js
+    prototype/every/returns-false-if-any-cb-returns-false.js
+    prototype/every/returns-true-if-every-cb-returns-true.js
+    prototype/every/this-is-not-object.js
+    prototype/every/this-is-not-typedarray-instance.js
+    prototype/every/values-are-not-cached.js
+    prototype/fill/BigInt/coerced-indexes.js
+    prototype/fill/BigInt/detached-buffer.js
+    prototype/fill/BigInt/fill-values-conversion-once.js
+    prototype/fill/BigInt/fill-values-custom-start-and-end.js
+    prototype/fill/BigInt/fill-values-non-numeric-throw.js
+    prototype/fill/BigInt/fill-values-non-numeric.js
+    prototype/fill/BigInt/fill-values-relative-end.js
+    prototype/fill/BigInt/fill-values-relative-start.js
+    prototype/fill/BigInt/fill-values-symbol-throws.js
+    prototype/fill/BigInt/fill-values.js
+    prototype/fill/BigInt/get-length-ignores-length-prop.js
+    prototype/fill/BigInt/return-abrupt-from-end-as-symbol.js
+    prototype/fill/BigInt/return-abrupt-from-end.js
+    prototype/fill/BigInt/return-abrupt-from-set-value.js
+    prototype/fill/BigInt/return-abrupt-from-start-as-symbol.js
+    prototype/fill/BigInt/return-abrupt-from-start.js
+    prototype/fill/BigInt/return-this.js
+    prototype/fill/coerced-indexes.js
+    prototype/fill/detached-buffer.js
+    prototype/fill/fill-values-conversion-once.js
+    prototype/fill/fill-values-conversion-operations-consistent-nan.js
+    prototype/fill/fill-values-conversion-operations.js
+    prototype/fill/fill-values-custom-start-and-end.js
+    prototype/fill/fill-values-non-numeric.js
+    prototype/fill/fill-values-relative-end.js
+    prototype/fill/fill-values-relative-start.js
+    prototype/fill/fill-values.js
+    prototype/fill/get-length-ignores-length-prop.js
+    prototype/fill/invoked-as-func.js
+    prototype/fill/invoked-as-method.js
+    prototype/fill/length.js
+    prototype/fill/name.js
+    prototype/fill/prop-desc.js
+    prototype/fill/return-abrupt-from-end.js
+    prototype/fill/return-abrupt-from-set-value.js
+    prototype/fill/return-abrupt-from-start.js
+    prototype/fill/return-this.js
+    prototype/fill/this-is-not-object.js
+    prototype/fill/this-is-not-typedarray-instance.js
+    prototype/filter/BigInt/arraylength-internal.js
+    prototype/filter/BigInt/callbackfn-arguments-with-thisarg.js
+    prototype/filter/BigInt/callbackfn-arguments-without-thisarg.js
+    prototype/filter/BigInt/callbackfn-called-before-ctor.js
+    prototype/filter/BigInt/callbackfn-called-before-species.js
+    prototype/filter/BigInt/callbackfn-detachbuffer.js
+    prototype/filter/BigInt/callbackfn-no-iteration-over-non-integer.js
+    prototype/filter/BigInt/callbackfn-not-callable-throws.js
+    prototype/filter/BigInt/callbackfn-not-called-on-empty.js
+    prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/filter/BigInt/callbackfn-returns-abrupt.js
+    prototype/filter/BigInt/callbackfn-this.js
+    prototype/filter/BigInt/detached-buffer.js
+    prototype/filter/BigInt/result-does-not-share-buffer.js
+    prototype/filter/BigInt/result-empty-callbackfn-returns-false.js
+    prototype/filter/BigInt/result-full-callbackfn-returns-true.js
+    prototype/filter/BigInt/speciesctor-get-ctor-abrupt.js
+    prototype/filter/BigInt/speciesctor-get-ctor-inherited.js
+    prototype/filter/BigInt/speciesctor-get-ctor-returns-throws.js
+    prototype/filter/BigInt/speciesctor-get-ctor.js
+    prototype/filter/BigInt/speciesctor-get-species-abrupt.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor.js
+    prototype/filter/BigInt/speciesctor-get-species-returns-throws.js
+    prototype/filter/BigInt/speciesctor-get-species-use-default-ctor.js
+    prototype/filter/BigInt/speciesctor-get-species.js
+    prototype/filter/BigInt/values-are-not-cached.js
+    prototype/filter/BigInt/values-are-set.js
+    prototype/filter/arraylength-internal.js
+    prototype/filter/callbackfn-arguments-with-thisarg.js
+    prototype/filter/callbackfn-arguments-without-thisarg.js
+    prototype/filter/callbackfn-called-before-ctor.js
+    prototype/filter/callbackfn-called-before-species.js
+    prototype/filter/callbackfn-detachbuffer.js
+    prototype/filter/callbackfn-no-iteration-over-non-integer.js
+    prototype/filter/callbackfn-not-called-on-empty.js
+    prototype/filter/callbackfn-return-does-not-change-instance.js
+    prototype/filter/callbackfn-returns-abrupt.js
+    prototype/filter/callbackfn-this.js
+    prototype/filter/detached-buffer.js
+    prototype/filter/invoked-as-func.js
+    prototype/filter/invoked-as-method.js
+    prototype/filter/length.js
+    prototype/filter/name.js
+    prototype/filter/prop-desc.js
+    prototype/filter/result-does-not-share-buffer.js
+    prototype/filter/result-empty-callbackfn-returns-false.js
+    prototype/filter/result-full-callbackfn-returns-true.js
+    prototype/filter/speciesctor-get-ctor-abrupt.js
+    prototype/filter/speciesctor-get-ctor-inherited.js
+    prototype/filter/speciesctor-get-ctor.js
+    prototype/filter/speciesctor-get-species-abrupt.js
+    prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/filter/speciesctor-get-species-custom-ctor-length.js
+    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/filter/speciesctor-get-species-custom-ctor.js
+    prototype/filter/speciesctor-get-species-use-default-ctor.js
+    prototype/filter/speciesctor-get-species.js
+    prototype/filter/this-is-not-object.js
+    prototype/filter/this-is-not-typedarray-instance.js
+    prototype/filter/values-are-not-cached.js
+    prototype/filter/values-are-set.js
+    prototype/find/BigInt/detached-buffer.js
+    prototype/find/BigInt/get-length-ignores-length-prop.js
+    prototype/find/BigInt/predicate-call-changes-value.js
+    prototype/find/BigInt/predicate-call-parameters.js
+    prototype/find/BigInt/predicate-call-this-non-strict.js
+    prototype/find/BigInt/predicate-call-this-strict.js
+    prototype/find/BigInt/predicate-is-not-callable-throws.js
+    prototype/find/BigInt/predicate-may-detach-buffer.js
+    prototype/find/BigInt/predicate-not-called-on-empty-array.js
+    prototype/find/BigInt/return-abrupt-from-predicate-call.js
+    prototype/find/BigInt/return-found-value-predicate-result-is-true.js
+    prototype/find/BigInt/return-undefined-if-predicate-returns-false-value.js
+    prototype/findIndex/BigInt/detached-buffer.js
+    prototype/findIndex/BigInt/get-length-ignores-length-prop.js
+    prototype/findIndex/BigInt/predicate-call-changes-value.js
+    prototype/findIndex/BigInt/predicate-call-parameters.js
+    prototype/findIndex/BigInt/predicate-call-this-non-strict.js
+    prototype/findIndex/BigInt/predicate-call-this-strict.js
+    prototype/findIndex/BigInt/predicate-is-not-callable-throws.js
+    prototype/findIndex/BigInt/predicate-may-detach-buffer.js
+    prototype/findIndex/BigInt/predicate-not-called-on-empty-array.js
+    prototype/findIndex/BigInt/return-abrupt-from-predicate-call.js
+    prototype/findIndex/BigInt/return-index-predicate-result-is-true.js
+    prototype/findIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
+    prototype/findIndex/detached-buffer.js
+    prototype/findIndex/get-length-ignores-length-prop.js
+    prototype/findIndex/invoked-as-func.js
+    prototype/findIndex/invoked-as-method.js
+    prototype/findIndex/length.js
+    prototype/findIndex/name.js
+    prototype/findIndex/predicate-call-changes-value.js
+    prototype/findIndex/predicate-call-parameters.js
+    prototype/findIndex/predicate-call-this-non-strict.js
+    prototype/findIndex/predicate-call-this-strict.js
+    prototype/findIndex/predicate-may-detach-buffer.js
+    prototype/findIndex/predicate-not-called-on-empty-array.js
+    prototype/findIndex/prop-desc.js
+    prototype/findIndex/return-abrupt-from-predicate-call.js
+    prototype/findIndex/return-index-predicate-result-is-true.js
+    prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
+    prototype/findIndex/this-is-not-object.js
+    prototype/findIndex/this-is-not-typedarray-instance.js
+    prototype/find/detached-buffer.js
+    prototype/find/get-length-ignores-length-prop.js
+    prototype/find/invoked-as-func.js
+    prototype/find/invoked-as-method.js
+    prototype/find/length.js
+    prototype/find/name.js
+    prototype/find/predicate-call-changes-value.js
+    prototype/find/predicate-call-parameters.js
+    prototype/find/predicate-call-this-non-strict.js
+    prototype/find/predicate-call-this-strict.js
+    prototype/find/predicate-may-detach-buffer.js
+    prototype/find/predicate-not-called-on-empty-array.js
+    prototype/find/prop-desc.js
+    prototype/find/return-abrupt-from-predicate-call.js
+    prototype/find/return-found-value-predicate-result-is-true.js
+    prototype/find/return-undefined-if-predicate-returns-false-value.js
+    prototype/find/this-is-not-object.js
+    prototype/find/this-is-not-typedarray-instance.js
+    prototype/forEach/BigInt/arraylength-internal.js
+    prototype/forEach/BigInt/callbackfn-arguments-with-thisarg.js
+    prototype/forEach/BigInt/callbackfn-arguments-without-thisarg.js
+    prototype/forEach/BigInt/callbackfn-detachbuffer.js
+    prototype/forEach/BigInt/callbackfn-is-not-callable.js
+    prototype/forEach/BigInt/callbackfn-no-interaction-over-non-integer.js
+    prototype/forEach/BigInt/callbackfn-not-called-on-empty.js
+    prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/forEach/BigInt/callbackfn-returns-abrupt.js
+    prototype/forEach/BigInt/callbackfn-this.js
+    prototype/forEach/BigInt/detached-buffer.js
+    prototype/forEach/BigInt/returns-undefined.js
+    prototype/forEach/BigInt/values-are-not-cached.js
+    prototype/forEach/arraylength-internal.js
+    prototype/forEach/callbackfn-arguments-with-thisarg.js
+    prototype/forEach/callbackfn-arguments-without-thisarg.js
+    prototype/forEach/callbackfn-detachbuffer.js
+    prototype/forEach/callbackfn-no-interaction-over-non-integer.js
+    prototype/forEach/callbackfn-not-called-on-empty.js
+    prototype/forEach/callbackfn-return-does-not-change-instance.js
+    prototype/forEach/callbackfn-returns-abrupt.js
+    prototype/forEach/callbackfn-this.js
+    prototype/forEach/detached-buffer.js
+    prototype/forEach/invoked-as-func.js
+    prototype/forEach/invoked-as-method.js
+    prototype/forEach/length.js
+    prototype/forEach/name.js
+    prototype/forEach/prop-desc.js
+    prototype/forEach/returns-undefined.js
+    prototype/forEach/this-is-not-object.js
+    prototype/forEach/this-is-not-typedarray-instance.js
+    prototype/forEach/values-are-not-cached.js
+    prototype/includes/BigInt/detached-buffer.js
+    prototype/includes/BigInt/fromIndex-equal-or-greater-length-returns-false.js
+    prototype/includes/BigInt/fromIndex-infinity.js
+    prototype/includes/BigInt/fromIndex-minus-zero.js
+    prototype/includes/BigInt/get-length-uses-internal-arraylength.js
+    prototype/includes/BigInt/length-zero-returns-false.js
+    prototype/includes/BigInt/return-abrupt-tointeger-fromindex-symbol.js
+    prototype/includes/BigInt/return-abrupt-tointeger-fromindex.js
+    prototype/includes/BigInt/search-found-returns-true.js
+    prototype/includes/BigInt/search-not-found-returns-false.js
+    prototype/includes/BigInt/tointeger-fromindex.js
+    prototype/includes/detached-buffer.js
+    prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
+    prototype/includes/fromIndex-infinity.js
+    prototype/includes/fromIndex-minus-zero.js
+    prototype/includes/get-length-uses-internal-arraylength.js
+    prototype/includes/invoked-as-func.js
+    prototype/includes/invoked-as-method.js
+    prototype/includes/length-zero-returns-false.js
+    prototype/includes/length.js
+    prototype/includes/name.js
+    prototype/includes/prop-desc.js
+    prototype/includes/return-abrupt-tointeger-fromindex.js
+    prototype/includes/samevaluezero.js
+    prototype/includes/search-found-returns-true.js
+    prototype/includes/search-not-found-returns-false.js
+    prototype/includes/this-is-not-object.js
+    prototype/includes/this-is-not-typedarray-instance.js
+    prototype/includes/tointeger-fromindex.js
+    prototype/indexOf/BigInt/detached-buffer.js
+    prototype/indexOf/BigInt/fromIndex-equal-or-greater-length-returns-minus-one.js
+    prototype/indexOf/BigInt/fromIndex-infinity.js
+    prototype/indexOf/BigInt/fromIndex-minus-zero.js
+    prototype/indexOf/BigInt/get-length-uses-internal-arraylength.js
+    prototype/indexOf/BigInt/length-zero-returns-minus-one.js
+    prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
+    prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex.js
+    prototype/indexOf/BigInt/search-found-returns-index.js
+    prototype/indexOf/BigInt/search-not-found-returns-minus-one.js
+    prototype/indexOf/BigInt/tointeger-fromindex.js
+    prototype/indexOf/detached-buffer.js
+    prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
+    prototype/indexOf/fromIndex-infinity.js
+    prototype/indexOf/fromIndex-minus-zero.js
+    prototype/indexOf/get-length-uses-internal-arraylength.js
+    prototype/indexOf/invoked-as-func.js
+    prototype/indexOf/invoked-as-method.js
+    prototype/indexOf/length-zero-returns-minus-one.js
+    prototype/indexOf/length.js
+    prototype/indexOf/name.js
+    prototype/indexOf/prop-desc.js
+    prototype/indexOf/return-abrupt-tointeger-fromindex.js
+    prototype/indexOf/search-found-returns-index.js
+    prototype/indexOf/search-not-found-returns-minus-one.js
+    prototype/indexOf/strict-comparison.js
+    prototype/indexOf/this-is-not-object.js
+    prototype/indexOf/this-is-not-typedarray-instance.js
+    prototype/indexOf/tointeger-fromindex.js
+    prototype/join/BigInt/custom-separator-result-from-tostring-on-each-simple-value.js
+    prototype/join/BigInt/detached-buffer.js
+    prototype/join/BigInt/empty-instance-empty-string.js
+    prototype/join/BigInt/get-length-uses-internal-arraylength.js
+    prototype/join/BigInt/result-from-tostring-on-each-simple-value.js
+    prototype/join/BigInt/return-abrupt-from-separator-symbol.js
+    prototype/join/BigInt/return-abrupt-from-separator.js
+    prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
+    prototype/join/custom-separator-result-from-tostring-on-each-value.js
+    prototype/join/detached-buffer.js
+    prototype/join/empty-instance-empty-string.js
+    prototype/join/get-length-uses-internal-arraylength.js
+    prototype/join/invoked-as-func.js
+    prototype/join/invoked-as-method.js
+    prototype/join/length.js
+    prototype/join/name.js
+    prototype/join/prop-desc.js
+    prototype/join/result-from-tostring-on-each-simple-value.js
+    prototype/join/result-from-tostring-on-each-value.js
+    prototype/join/return-abrupt-from-separator.js
+    prototype/join/this-is-not-object.js
+    prototype/join/this-is-not-typedarray-instance.js
+    prototype/keys/BigInt/detached-buffer.js
+    prototype/keys/BigInt/iter-prototype.js
+    prototype/keys/BigInt/return-itor.js
+    prototype/keys/detached-buffer.js
+    prototype/keys/invoked-as-func.js
+    prototype/keys/invoked-as-method.js
+    prototype/keys/iter-prototype.js
+    prototype/keys/length.js
+    prototype/keys/name.js
+    prototype/keys/prop-desc.js
+    prototype/keys/return-itor.js
+    prototype/keys/this-is-not-object.js
+    prototype/keys/this-is-not-typedarray-instance.js
+    prototype/lastIndexOf/BigInt/detached-buffer.js
+    prototype/lastIndexOf/BigInt/fromIndex-infinity.js
+    prototype/lastIndexOf/BigInt/fromIndex-minus-zero.js
+    prototype/lastIndexOf/BigInt/get-length-uses-internal-arraylength.js
+    prototype/lastIndexOf/BigInt/length-zero-returns-minus-one.js
+    prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
+    prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex.js
+    prototype/lastIndexOf/BigInt/search-found-returns-index.js
+    prototype/lastIndexOf/BigInt/search-not-found-returns-minus-one.js
+    prototype/lastIndexOf/BigInt/tointeger-fromindex.js
+    prototype/lastIndexOf/detached-buffer.js
+    prototype/lastIndexOf/fromIndex-infinity.js
+    prototype/lastIndexOf/fromIndex-minus-zero.js
+    prototype/lastIndexOf/get-length-uses-internal-arraylength.js
+    prototype/lastIndexOf/invoked-as-func.js
+    prototype/lastIndexOf/invoked-as-method.js
+    prototype/lastIndexOf/length-zero-returns-minus-one.js
+    prototype/lastIndexOf/length.js
+    prototype/lastIndexOf/name.js
+    prototype/lastIndexOf/prop-desc.js
+    prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
+    prototype/lastIndexOf/search-found-returns-index.js
+    prototype/lastIndexOf/search-not-found-returns-minus-one.js
+    prototype/lastIndexOf/strict-comparison.js
+    prototype/lastIndexOf/this-is-not-object.js
+    prototype/lastIndexOf/this-is-not-typedarray-instance.js
+    prototype/lastIndexOf/tointeger-fromindex.js
+    prototype/length/BigInt/detached-buffer.js
+    prototype/length/BigInt/return-length.js
+    prototype/length/detached-buffer.js
+    prototype/length/invoked-as-func.js
+    prototype/length/length.js
+    prototype/length/name.js
+    prototype/length/prop-desc.js
+    prototype/length/this-has-no-typedarrayname-internal.js
+    prototype/length/this-is-not-object.js
+    prototype/map/BigInt/arraylength-internal.js
+    prototype/map/BigInt/callbackfn-arguments-with-thisarg.js
+    prototype/map/BigInt/callbackfn-arguments-without-thisarg.js
+    prototype/map/BigInt/callbackfn-detachbuffer.js
+    prototype/map/BigInt/callbackfn-is-not-callable.js
+    prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
+    prototype/map/BigInt/callbackfn-not-called-on-empty.js
+    prototype/map/BigInt/callbackfn-return-affects-returned-object.js
+    prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/map/BigInt/callbackfn-return-does-not-copy-non-integer-properties.js
+    prototype/map/BigInt/callbackfn-returns-abrupt.js
+    prototype/map/BigInt/callbackfn-this.js
+    prototype/map/BigInt/detached-buffer.js
+    prototype/map/BigInt/return-new-typedarray-from-empty-length.js
+    prototype/map/BigInt/return-new-typedarray-from-positive-length.js
+    prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
+    prototype/map/BigInt/speciesctor-get-ctor-inherited.js
+    prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
+    prototype/map/BigInt/speciesctor-get-ctor.js
+    prototype/map/BigInt/speciesctor-get-species-abrupt.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
+    prototype/map/BigInt/speciesctor-get-species-returns-throws.js
+    prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
+    prototype/map/BigInt/speciesctor-get-species.js
+    prototype/map/BigInt/values-are-not-cached.js
+    prototype/map/arraylength-internal.js
+    prototype/map/callbackfn-arguments-with-thisarg.js
+    prototype/map/callbackfn-arguments-without-thisarg.js
+    prototype/map/callbackfn-detachbuffer.js
+    prototype/map/callbackfn-no-interaction-over-non-integer-properties.js
+    prototype/map/callbackfn-not-called-on-empty.js
+    prototype/map/callbackfn-return-affects-returned-object.js
+    prototype/map/callbackfn-return-does-not-change-instance.js
+    prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
+    prototype/map/callbackfn-returns-abrupt.js
+    prototype/map/callbackfn-this.js
+    prototype/map/detached-buffer.js
+    prototype/map/invoked-as-func.js
+    prototype/map/invoked-as-method.js
+    prototype/map/length.js
+    prototype/map/name.js
+    prototype/map/prop-desc.js
+    prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
+    prototype/map/return-new-typedarray-conversion-operation.js
+    prototype/map/return-new-typedarray-from-empty-length.js
+    prototype/map/return-new-typedarray-from-positive-length.js
+    prototype/map/speciesctor-get-ctor-abrupt.js
+    prototype/map/speciesctor-get-ctor-inherited.js
+    prototype/map/speciesctor-get-ctor.js
+    prototype/map/speciesctor-get-species-abrupt.js
+    prototype/map/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/map/speciesctor-get-species-custom-ctor-length.js
+    prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/map/speciesctor-get-species-custom-ctor.js
+    prototype/map/speciesctor-get-species-use-default-ctor.js
+    prototype/map/speciesctor-get-species.js
+    prototype/map/this-is-not-object.js
+    prototype/map/this-is-not-typedarray-instance.js
+    prototype/map/values-are-not-cached.js
+    prototype/reduce/BigInt/callbackfn-arguments-custom-accumulator.js
+    prototype/reduce/BigInt/callbackfn-arguments-default-accumulator.js
+    prototype/reduce/BigInt/callbackfn-detachbuffer.js
+    prototype/reduce/BigInt/callbackfn-is-not-callable-throws.js
+    prototype/reduce/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
+    prototype/reduce/BigInt/callbackfn-not-called-on-empty.js
+    prototype/reduce/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/reduce/BigInt/callbackfn-returns-abrupt.js
+    prototype/reduce/BigInt/callbackfn-this.js
+    prototype/reduce/BigInt/detached-buffer.js
+    prototype/reduce/BigInt/empty-instance-return-initialvalue.js
+    prototype/reduce/BigInt/empty-instance-with-no-initialvalue-throws.js
+    prototype/reduce/BigInt/get-length-uses-internal-arraylength.js
+    prototype/reduce/BigInt/result-is-last-callbackfn-return.js
+    prototype/reduce/BigInt/result-of-any-type.js
+    prototype/reduce/BigInt/return-first-value-without-callbackfn.js
+    prototype/reduce/BigInt/values-are-not-cached.js
+    prototype/reduceRight/BigInt/callbackfn-arguments-custom-accumulator.js
+    prototype/reduceRight/BigInt/callbackfn-arguments-default-accumulator.js
+    prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
+    prototype/reduceRight/BigInt/callbackfn-is-not-callable-throws.js
+    prototype/reduceRight/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
+    prototype/reduceRight/BigInt/callbackfn-not-called-on-empty.js
+    prototype/reduceRight/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/reduceRight/BigInt/callbackfn-returns-abrupt.js
+    prototype/reduceRight/BigInt/callbackfn-this.js
+    prototype/reduceRight/BigInt/detached-buffer.js
+    prototype/reduceRight/BigInt/empty-instance-return-initialvalue.js
+    prototype/reduceRight/BigInt/empty-instance-with-no-initialvalue-throws.js
+    prototype/reduceRight/BigInt/get-length-uses-internal-arraylength.js
+    prototype/reduceRight/BigInt/result-is-last-callbackfn-return.js
+    prototype/reduceRight/BigInt/result-of-any-type.js
+    prototype/reduceRight/BigInt/return-first-value-without-callbackfn.js
+    prototype/reduceRight/BigInt/values-are-not-cached.js
+    prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
+    prototype/reduceRight/callbackfn-arguments-default-accumulator.js
+    prototype/reduceRight/callbackfn-detachbuffer.js
+    prototype/reduceRight/callbackfn-no-iteration-over-non-integer-properties.js
+    prototype/reduceRight/callbackfn-not-called-on-empty.js
+    prototype/reduceRight/callbackfn-return-does-not-change-instance.js
+    prototype/reduceRight/callbackfn-returns-abrupt.js
+    prototype/reduceRight/callbackfn-this.js
+    prototype/reduceRight/detached-buffer.js
+    prototype/reduceRight/empty-instance-return-initialvalue.js
+    prototype/reduceRight/get-length-uses-internal-arraylength.js
+    prototype/reduceRight/invoked-as-func.js
+    prototype/reduceRight/invoked-as-method.js
+    prototype/reduceRight/length.js
+    prototype/reduceRight/name.js
+    prototype/reduceRight/prop-desc.js
+    prototype/reduceRight/result-is-last-callbackfn-return.js
+    prototype/reduceRight/result-of-any-type.js
+    prototype/reduceRight/return-first-value-without-callbackfn.js
+    prototype/reduceRight/this-is-not-object.js
+    prototype/reduceRight/this-is-not-typedarray-instance.js
+    prototype/reduceRight/values-are-not-cached.js
+    prototype/reduce/callbackfn-arguments-custom-accumulator.js
+    prototype/reduce/callbackfn-arguments-default-accumulator.js
+    prototype/reduce/callbackfn-detachbuffer.js
+    prototype/reduce/callbackfn-no-iteration-over-non-integer-properties.js
+    prototype/reduce/callbackfn-not-called-on-empty.js
+    prototype/reduce/callbackfn-return-does-not-change-instance.js
+    prototype/reduce/callbackfn-returns-abrupt.js
+    prototype/reduce/callbackfn-this.js
+    prototype/reduce/detached-buffer.js
+    prototype/reduce/empty-instance-return-initialvalue.js
+    prototype/reduce/get-length-uses-internal-arraylength.js
+    prototype/reduce/invoked-as-func.js
+    prototype/reduce/invoked-as-method.js
+    prototype/reduce/length.js
+    prototype/reduce/name.js
+    prototype/reduce/prop-desc.js
+    prototype/reduce/result-is-last-callbackfn-return.js
+    prototype/reduce/result-of-any-type.js
+    prototype/reduce/return-first-value-without-callbackfn.js
+    prototype/reduce/this-is-not-object.js
+    prototype/reduce/this-is-not-typedarray-instance.js
+    prototype/reduce/values-are-not-cached.js
+    prototype/reverse/BigInt/detached-buffer.js
+    prototype/reverse/BigInt/get-length-uses-internal-arraylength.js
+    prototype/reverse/BigInt/preserves-non-numeric-properties.js
+    prototype/reverse/BigInt/returns-original-object.js
+    prototype/reverse/BigInt/reverts.js
+    prototype/reverse/detached-buffer.js
+    prototype/reverse/get-length-uses-internal-arraylength.js
+    prototype/reverse/invoked-as-func.js
+    prototype/reverse/invoked-as-method.js
+    prototype/reverse/length.js
+    prototype/reverse/name.js
+    prototype/reverse/preserves-non-numeric-properties.js
+    prototype/reverse/prop-desc.js
+    prototype/reverse/returns-original-object.js
+    prototype/reverse/reverts.js
+    prototype/reverse/this-is-not-object.js
+    prototype/reverse/this-is-not-typedarray-instance.js
+    prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
+    prototype/set/BigInt/array-arg-offset-tointeger.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
+    prototype/set/BigInt/array-arg-set-values-in-order.js
+    prototype/set/BigInt/array-arg-set-values.js
+    prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
+    prototype/set/BigInt/array-arg-src-values-are-not-cached.js
+    prototype/set/BigInt/array-arg-target-arraylength-internal.js
+    prototype/set/BigInt/array-arg-targetbuffer-detached-on-get-src-value-throws.js
+    prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
+    prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
+    prototype/set/BigInt/bigint-tobigint64.js
+    prototype/set/BigInt/bigint-tobiguint64.js
+    prototype/set/BigInt/boolean-tobigint.js
+    prototype/set/BigInt/null-tobigint.js
+    prototype/set/BigInt/number-tobigint.js
+    prototype/set/BigInt/src-typedarray-big.js
+    prototype/set/BigInt/src-typedarray-not-big-throws.js
+    prototype/set/BigInt/string-nan-tobigint.js
+    prototype/set/BigInt/string-tobigint.js
+    prototype/set/BigInt/symbol-tobigint.js
+    prototype/set/BigInt/typedarray-arg-negative-integer-offset-throws.js
+    prototype/set/BigInt/typedarray-arg-offset-tointeger.js
+    prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset-symbol.js
+    prototype/set/BigInt/typedarray-arg-return-abrupt-from-tointeger-offset.js
+    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
+    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
+    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
+    prototype/set/BigInt/typedarray-arg-src-arraylength-internal.js
+    prototype/set/BigInt/typedarray-arg-src-byteoffset-internal.js
+    prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
+    prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
+    prototype/set/BigInt/typedarray-arg-target-arraylength-internal.js
+    prototype/set/BigInt/typedarray-arg-target-byteoffset-internal.js
+    prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
+    prototype/set/BigInt/undefined-tobigint.js
+    prototype/set/array-arg-negative-integer-offset-throws.js
+    prototype/set/array-arg-return-abrupt-from-src-get-length.js
+    prototype/set/array-arg-return-abrupt-from-src-get-value.js
+    prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
+    prototype/set/array-arg-return-abrupt-from-src-length.js
+    prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+    prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
+    prototype/set/array-arg-return-abrupt-from-toobject-offset.js
+    prototype/set/array-arg-set-values-in-order.js
+    prototype/set/array-arg-set-values.js
+    prototype/set/array-arg-src-tonumber-value-conversions.js
+    prototype/set/array-arg-src-values-are-not-cached.js
+    prototype/set/array-arg-target-arraylength-internal.js
+    prototype/set/array-arg-targetbuffer-detached-on-get-src-value-throws.js
+    prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
+    prototype/set/array-arg-targetbuffer-detached-throws.js
+    prototype/set/invoked-as-func.js
+    prototype/set/invoked-as-method.js
+    prototype/set/length.js
+    prototype/set/name.js
+    prototype/set/prop-desc.js
+    prototype/set/src-typedarray-big-throws.js
+    prototype/set/this-is-not-object.js
+    prototype/set/this-is-not-typedarray-instance.js
+    prototype/set/typedarray-arg-negative-integer-offset-throws.js
+    prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+    prototype/set/typedarray-arg-src-arraylength-internal.js
+    prototype/set/typedarray-arg-src-byteoffset-internal.js
+    prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
+    prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
+    prototype/set/typedarray-arg-target-arraylength-internal.js
+    prototype/set/typedarray-arg-target-byteoffset-internal.js
+    prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
+    prototype/slice/BigInt/arraylength-internal.js
+    prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
+    prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
+    prototype/slice/BigInt/detached-buffer-get-ctor.js
+    prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
+    prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
+    prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
+    prototype/slice/BigInt/detached-buffer.js
+    prototype/slice/BigInt/infinity.js
+    prototype/slice/BigInt/minus-zero.js
+    prototype/slice/BigInt/result-does-not-copy-ordinary-properties.js
+    prototype/slice/BigInt/results-with-different-length.js
+    prototype/slice/BigInt/results-with-empty-length.js
+    prototype/slice/BigInt/results-with-same-length.js
+    prototype/slice/BigInt/return-abrupt-from-end-symbol.js
+    prototype/slice/BigInt/return-abrupt-from-end.js
+    prototype/slice/BigInt/return-abrupt-from-start-symbol.js
+    prototype/slice/BigInt/return-abrupt-from-start.js
+    prototype/slice/BigInt/set-values-from-different-ctor-type.js
+    prototype/slice/BigInt/speciesctor-get-ctor-abrupt.js
+    prototype/slice/BigInt/speciesctor-get-ctor-inherited.js
+    prototype/slice/BigInt/speciesctor-get-ctor-returns-throws.js
+    prototype/slice/BigInt/speciesctor-get-ctor.js
+    prototype/slice/BigInt/speciesctor-get-species-abrupt.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor.js
+    prototype/slice/BigInt/speciesctor-get-species-returns-throws.js
+    prototype/slice/BigInt/speciesctor-get-species-use-default-ctor.js
+    prototype/slice/BigInt/speciesctor-get-species.js
+    prototype/slice/BigInt/tointeger-end.js
+    prototype/slice/BigInt/tointeger-start.js
+    prototype/slice/arraylength-internal.js
+    prototype/slice/bit-precision.js
+    prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
+    prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
+    prototype/slice/detached-buffer.js
+    prototype/slice/infinity.js
+    prototype/slice/invoked-as-func.js
+    prototype/slice/invoked-as-method.js
+    prototype/slice/length.js
+    prototype/slice/minus-zero.js
+    prototype/slice/name.js
+    prototype/slice/prop-desc.js
+    prototype/slice/result-does-not-copy-ordinary-properties.js
+    prototype/slice/results-with-different-length.js
+    prototype/slice/results-with-empty-length.js
+    prototype/slice/results-with-same-length.js
+    prototype/slice/return-abrupt-from-end.js
+    prototype/slice/return-abrupt-from-start.js
+    prototype/slice/set-values-from-different-ctor-type.js
+    prototype/slice/speciesctor-get-ctor-abrupt.js
+    prototype/slice/speciesctor-get-ctor-inherited.js
+    prototype/slice/speciesctor-get-ctor.js
+    prototype/slice/speciesctor-get-species-abrupt.js
+    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/slice/speciesctor-get-species-custom-ctor-length.js
+    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/slice/speciesctor-get-species-custom-ctor.js
+    prototype/slice/speciesctor-get-species-use-default-ctor.js
+    prototype/slice/speciesctor-get-species.js
+    prototype/slice/this-is-not-object.js
+    prototype/slice/this-is-not-typedarray-instance.js
+    prototype/slice/tointeger-end.js
+    prototype/slice/tointeger-start.js
+    prototype/some/BigInt/callbackfn-arguments-with-thisarg.js
+    prototype/some/BigInt/callbackfn-arguments-without-thisarg.js
+    prototype/some/BigInt/callbackfn-detachbuffer.js
+    prototype/some/BigInt/callbackfn-no-interaction-over-non-integer.js
+    prototype/some/BigInt/callbackfn-not-callable-throws.js
+    prototype/some/BigInt/callbackfn-not-called-on-empty.js
+    prototype/some/BigInt/callbackfn-return-does-not-change-instance.js
+    prototype/some/BigInt/callbackfn-returns-abrupt.js
+    prototype/some/BigInt/callbackfn-this.js
+    prototype/some/BigInt/detached-buffer.js
+    prototype/some/BigInt/get-length-uses-internal-arraylength.js
+    prototype/some/BigInt/returns-false-if-every-cb-returns-false.js
+    prototype/some/BigInt/returns-true-if-any-cb-returns-true.js
+    prototype/some/BigInt/values-are-not-cached.js
+    prototype/some/callbackfn-arguments-with-thisarg.js
+    prototype/some/callbackfn-arguments-without-thisarg.js
+    prototype/some/callbackfn-detachbuffer.js
+    prototype/some/callbackfn-no-interaction-over-non-integer.js
+    prototype/some/callbackfn-not-called-on-empty.js
+    prototype/some/callbackfn-return-does-not-change-instance.js
+    prototype/some/callbackfn-returns-abrupt.js
+    prototype/some/callbackfn-this.js
+    prototype/some/detached-buffer.js
+    prototype/some/get-length-uses-internal-arraylength.js
+    prototype/some/invoked-as-func.js
+    prototype/some/invoked-as-method.js
+    prototype/some/length.js
+    prototype/some/name.js
+    prototype/some/prop-desc.js
+    prototype/some/returns-false-if-every-cb-returns-false.js
+    prototype/some/returns-true-if-any-cb-returns-true.js
+    prototype/some/this-is-not-object.js
+    prototype/some/this-is-not-typedarray-instance.js
+    prototype/some/values-are-not-cached.js
+    prototype/sort/BigInt/arraylength-internal.js
+    prototype/sort/BigInt/comparefn-call-throws.js
+    prototype/sort/BigInt/comparefn-calls.js
+    prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
+    prototype/sort/BigInt/detached-buffer-comparefn.js
+    prototype/sort/BigInt/detached-buffer.js
+    prototype/sort/BigInt/return-same-instance.js
+    prototype/sort/BigInt/sortcompare-with-no-tostring.js
+    prototype/sort/BigInt/sorted-values.js
+    prototype/sort/arraylength-internal.js
+    prototype/sort/comparefn-call-throws.js
+    prototype/sort/comparefn-calls.js
+    prototype/sort/detached-buffer-comparefn.js
+    prototype/sort/detached-buffer.js
+    prototype/sort/invoked-as-func.js
+    prototype/sort/invoked-as-method.js
+    prototype/sort/length.js
+    prototype/sort/name.js
+    prototype/sort/prop-desc.js
+    prototype/sort/return-same-instance.js
+    prototype/sort/sort-tonumber.js
+    prototype/sort/sortcompare-with-no-tostring.js
+    prototype/sort/sorted-values-nan.js
+    prototype/sort/sorted-values.js
+    prototype/sort/stability.js
+    prototype/sort/this-is-not-object.js
+    prototype/sort/this-is-not-typedarray-instance.js
+    prototype/subarray/BigInt/detached-buffer.js
+    prototype/subarray/BigInt/infinity.js
+    prototype/subarray/BigInt/minus-zero.js
+    prototype/subarray/BigInt/result-does-not-copy-ordinary-properties.js
+    prototype/subarray/BigInt/result-is-new-instance-from-same-ctor.js
+    prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
+    prototype/subarray/BigInt/results-with-different-length.js
+    prototype/subarray/BigInt/results-with-empty-length.js
+    prototype/subarray/BigInt/results-with-same-length.js
+    prototype/subarray/BigInt/return-abrupt-from-begin-symbol.js
+    prototype/subarray/BigInt/return-abrupt-from-begin.js
+    prototype/subarray/BigInt/return-abrupt-from-end-symbol.js
+    prototype/subarray/BigInt/return-abrupt-from-end.js
+    prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
+    prototype/subarray/BigInt/speciesctor-get-ctor-inherited.js
+    prototype/subarray/BigInt/speciesctor-get-ctor-returns-throws.js
+    prototype/subarray/BigInt/speciesctor-get-ctor.js
+    prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor.js
+    prototype/subarray/BigInt/speciesctor-get-species-returns-throws.js
+    prototype/subarray/BigInt/speciesctor-get-species-use-default-ctor.js
+    prototype/subarray/BigInt/speciesctor-get-species.js
+    prototype/subarray/BigInt/tointeger-begin.js
+    prototype/subarray/BigInt/tointeger-end.js
+    prototype/subarray/detached-buffer.js
+    prototype/subarray/infinity.js
+    prototype/subarray/invoked-as-func.js
+    prototype/subarray/invoked-as-method.js
+    prototype/subarray/length.js
+    prototype/subarray/name.js
+    prototype/subarray/prop-desc.js
+    prototype/subarray/speciesctor-get-ctor-abrupt.js
+    prototype/subarray/speciesctor-get-ctor-inherited.js
+    prototype/subarray/speciesctor-get-ctor-returns-throws.js
+    prototype/subarray/speciesctor-get-ctor.js
+    prototype/subarray/speciesctor-get-species-abrupt.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-throws.js
+    prototype/subarray/speciesctor-get-species-custom-ctor.js
+    prototype/subarray/speciesctor-get-species-returns-throws.js
+    prototype/subarray/speciesctor-get-species.js
+    prototype/subarray/this-is-not-object.js
+    prototype/subarray/this-is-not-typedarray-instance.js
+    prototype/Symbol.toStringTag/BigInt/detached-buffer.js
+    prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
+    prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
+    prototype/Symbol.toStringTag/BigInt/length.js
+    prototype/Symbol.toStringTag/BigInt/name.js
+    prototype/Symbol.toStringTag/BigInt/prop-desc.js
+    prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
+    prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
+    prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
+    prototype/Symbol.toStringTag/detached-buffer.js
+    prototype/Symbol.toStringTag/invoked-as-accessor.js
+    prototype/Symbol.toStringTag/invoked-as-func.js
+    prototype/Symbol.toStringTag/length.js
+    prototype/Symbol.toStringTag/name.js
+    prototype/Symbol.toStringTag/prop-desc.js
+    prototype/Symbol.toStringTag/return-typedarrayname.js
+    prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
+    prototype/Symbol.toStringTag/this-is-not-object.js
+    prototype/toLocaleString/BigInt/calls-tolocalestring-from-each-value.js
+    prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
+    prototype/toLocaleString/BigInt/calls-valueof-from-each-value.js
+    prototype/toLocaleString/BigInt/detached-buffer.js
+    prototype/toLocaleString/BigInt/empty-instance-returns-empty-string.js
+    prototype/toLocaleString/BigInt/get-length-uses-internal-arraylength.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tolocalestring.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tostring.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-valueof.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tolocalestring.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof.js
+    prototype/toLocaleString/BigInt/return-result.js
+    prototype/toLocaleString/calls-tolocalestring-from-each-value.js
+    prototype/toLocaleString/calls-tostring-from-each-value.js
+    prototype/toLocaleString/calls-valueof-from-each-value.js
+    prototype/toLocaleString/detached-buffer.js
+    prototype/toLocaleString/get-length-uses-internal-arraylength.js
+    prototype/toLocaleString/invoked-as-func.js
+    prototype/toLocaleString/invoked-as-method.js
+    prototype/toLocaleString/length.js
+    prototype/toLocaleString/name.js
+    prototype/toLocaleString/prop-desc.js
+    prototype/toLocaleString/return-abrupt-from-firstelement-tolocalestring.js
+    prototype/toLocaleString/return-abrupt-from-firstelement-tostring.js
+    prototype/toLocaleString/return-abrupt-from-firstelement-valueof.js
+    prototype/toLocaleString/return-abrupt-from-nextelement-tolocalestring.js
+    prototype/toLocaleString/return-abrupt-from-nextelement-tostring.js
+    prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
+    prototype/toLocaleString/this-is-not-object.js
+    prototype/toLocaleString/this-is-not-typedarray-instance.js
+    prototype/toString/BigInt/detached-buffer.js
+    prototype/toString/detached-buffer.js
+    prototype/values/BigInt/detached-buffer.js
+    prototype/values/BigInt/iter-prototype.js
+    prototype/values/BigInt/return-itor.js
+    prototype/values/detached-buffer.js
+    prototype/values/invoked-as-func.js
+    prototype/values/invoked-as-method.js
+    prototype/values/iter-prototype.js
+    prototype/values/length.js
+    prototype/values/name.js
+    prototype/values/prop-desc.js
+    prototype/values/return-itor.js
+    prototype/values/this-is-not-object.js
+    prototype/values/this-is-not-typedarray-instance.js
+    prototype/constructor.js
+    prototype/Symbol.iterator.js
+    prototype/toString.js
+    Symbol.species/length.js
+    Symbol.species/name.js
+    Symbol.species/prop-desc.js
+    Symbol.species/result.js
+    invoked.js
+    length.js
+    name.js
+    prototype.js
 
 built-ins/TypedArrayConstructors
-    ! BigInt64Array/prototype/BYTES_PER_ELEMENT.js
-    ! BigInt64Array/prototype/constructor.js
-    ! BigInt64Array/prototype/not-typedarray-object.js
-    ! BigInt64Array/prototype/proto.js
-    ! BigInt64Array/BYTES_PER_ELEMENT.js
-    ! BigInt64Array/constructor.js
-    ! BigInt64Array/length.js
-    ! BigInt64Array/name.js
-    ! BigInt64Array/prop-desc.js
-    ! BigInt64Array/proto.js
-    ! BigInt64Array/prototype.js
-    ! BigUint64Array/prototype/BYTES_PER_ELEMENT.js
-    ! BigUint64Array/prototype/constructor.js
-    ! BigUint64Array/prototype/not-typedarray-object.js
-    ! BigUint64Array/prototype/proto.js
-    ! BigUint64Array/BYTES_PER_ELEMENT.js
-    ! BigUint64Array/constructor.js
-    ! BigUint64Array/length.js
-    ! BigUint64Array/name.js
-    ! BigUint64Array/prop-desc.js
-    ! BigUint64Array/proto.js
-    ! BigUint64Array/prototype.js
-    ! ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
-    ! ctors-bigint/buffer-arg/byteoffset-is-negative-throws.js
-    ! ctors-bigint/buffer-arg/byteoffset-is-negative-zero.js
-    ! ctors-bigint/buffer-arg/byteoffset-is-symbol-throws.js
-    ! ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size.js
-    ! ctors-bigint/buffer-arg/byteoffset-to-number-detachbuffer.js
-    ! ctors-bigint/buffer-arg/byteoffset-to-number-throws.js
-    ! ctors-bigint/buffer-arg/defined-length-and-offset.js
-    ! ctors-bigint/buffer-arg/defined-length.js
-    ! ctors-bigint/buffer-arg/defined-negative-length.js
-    ! ctors-bigint/buffer-arg/defined-offset.js
-    ! ctors-bigint/buffer-arg/detachedbuffer.js
-    ! ctors-bigint/buffer-arg/excessive-length-throws.js
-    ! ctors-bigint/buffer-arg/excessive-offset-throws.js
-    ! ctors-bigint/buffer-arg/invoked-with-undefined-newtarget.js
-    ! ctors-bigint/buffer-arg/is-referenced.js
-    ! ctors-bigint/buffer-arg/length-access-throws.js
-    ! ctors-bigint/buffer-arg/length-is-symbol-throws.js
-    ! ctors-bigint/buffer-arg/length-to-number-detachbuffer.js
-    ! ctors-bigint/buffer-arg/new-instance-extensibility.js
-    ! ctors-bigint/buffer-arg/returns-new-instance.js
-    ! ctors-bigint/buffer-arg/toindex-bytelength.js
-    ! ctors-bigint/buffer-arg/toindex-byteoffset.js
-    ! ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors-bigint/length-arg/init-zeros.js
-    ! ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
-    ! ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
-    ! ctors-bigint/length-arg/is-symbol-throws.js
-    ! ctors-bigint/length-arg/new-instance-extensibility.js
-    ! ctors-bigint/length-arg/returns-object.js
-    ! ctors-bigint/length-arg/toindex-length.js
-    ! ctors-bigint/length-arg/undefined-newtarget-throws.js
-    ! ctors-bigint/length-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors-bigint/no-args/new-instance-extensibility.js
-    ! ctors-bigint/no-args/returns-object.js
-    ! ctors-bigint/no-args/undefined-newtarget-throws.js
-    ! ctors-bigint/no-args/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors-bigint/object-arg/as-array-returns.js
-    ! ctors-bigint/object-arg/as-generator-iterable-returns.js
-    ! ctors-bigint/object-arg/bigint-tobigint64.js
-    ! ctors-bigint/object-arg/bigint-tobiguint64.js
-    ! ctors-bigint/object-arg/boolean-tobigint.js
-    ! ctors-bigint/object-arg/iterating-throws.js
-    ! ctors-bigint/object-arg/iterator-not-callable-throws.js
-    ! ctors-bigint/object-arg/iterator-throws.js
-    ! ctors-bigint/object-arg/length-excessive-throws.js
-    ! ctors-bigint/object-arg/length-is-symbol-throws.js
-    ! ctors-bigint/object-arg/length-throws.js
-    ! ctors-bigint/object-arg/new-instance-extensibility.js
-    ! ctors-bigint/object-arg/null-tobigint.js
-    ! ctors-bigint/object-arg/number-tobigint.js
-    ! ctors-bigint/object-arg/string-nan-tobigint.js
-    ! ctors-bigint/object-arg/string-tobigint.js
-    ! ctors-bigint/object-arg/symbol-tobigint.js
-    ! ctors-bigint/object-arg/throws-from-property.js
-    ! ctors-bigint/object-arg/throws-setting-obj-to-primitive-typeerror.js
-    ! ctors-bigint/object-arg/throws-setting-obj-to-primitive.js
-    ! ctors-bigint/object-arg/throws-setting-obj-tostring.js
-    ! ctors-bigint/object-arg/throws-setting-obj-valueof-typeerror.js
-    ! ctors-bigint/object-arg/throws-setting-obj-valueof.js
-    ! ctors-bigint/object-arg/throws-setting-property.js
-    ! ctors-bigint/object-arg/throws-setting-symbol-property.js
-    ! ctors-bigint/object-arg/undefined-newtarget-throws.js
-    ! ctors-bigint/object-arg/undefined-tobigint.js
-    ! ctors-bigint/object-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors-bigint/typedarray-arg/detached-when-species-retrieved-different-type.js
-    ! ctors-bigint/typedarray-arg/detached-when-species-retrieved-same-type.js
-    ! ctors-bigint/typedarray-arg/new-instance-extensibility.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-null.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
-    ! ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js
-    ! ctors-bigint/typedarray-arg/other-ctor-returns-new-typedarray.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-null.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js
-    ! ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
-    ! ctors-bigint/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
-    ! ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
-    ! ctors-bigint/typedarray-arg/undefined-newtarget-throws.js
-    ! ctors/buffer-arg/byteoffset-is-negative-throws.js
-    ! ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
-    ! ctors/buffer-arg/defined-negative-length.js
-    ! ctors/buffer-arg/detachedbuffer.js
-    ! ctors/buffer-arg/length-to-number-detachbuffer.js
-    ! ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/length-arg/is-infinity-throws-rangeerror.js
-    ! ctors/length-arg/is-negative-integer-throws-rangeerror.js
-    ! ctors/length-arg/is-symbol-throws.js
-    ! ctors/length-arg/toindex-length.js
-    ! ctors/length-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/no-args/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/object-arg/as-generator-iterable-returns.js
-    ! ctors/object-arg/iterating-throws.js
-    ! ctors/object-arg/iterator-not-callable-throws.js
-    ! ctors/object-arg/iterator-throws.js
-    ! ctors/object-arg/length-excessive-throws.js
-    ! ctors/object-arg/length-is-symbol-throws.js
-    ! ctors/object-arg/length-throws.js
-    ! ctors/object-arg/new-instance-extensibility.js
-    ! ctors/object-arg/returns.js
-    ! ctors/object-arg/throws-from-property.js
-    ! ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
-    ! ctors/object-arg/throws-setting-obj-to-primitive.js
-    ! ctors/object-arg/throws-setting-property.js
-    ! ctors/object-arg/throws-setting-symbol-property.js
-    ! ctors/object-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
-    ! ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
-    ! ctors/typedarray-arg/src-typedarray-big-throws.js
-    ! ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! Float32Array/prototype/not-typedarray-object.js
-    ! Float32Array/prototype/proto.js
-    ! Float64Array/prototype/not-typedarray-object.js
-    ! Float64Array/prototype/proto.js
-    ! from/BigInt/arylk-get-length-error.js
-    ! from/BigInt/arylk-to-length-error.js
-    ! from/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
-    ! from/BigInt/custom-ctor-returns-other-instance.js
-    ! from/BigInt/custom-ctor-returns-smaller-instance-throws.js
-    ! from/BigInt/custom-ctor.js
-    ! from/BigInt/inherited.js
-    ! from/BigInt/invoked-as-func.js
-    ! from/BigInt/iter-access-error.js
-    ! from/BigInt/iter-invoke-error.js
-    ! from/BigInt/iter-next-error.js
-    ! from/BigInt/iter-next-value-error.js
-    ! from/BigInt/mapfn-abrupt-completion.js
-    ! from/BigInt/mapfn-arguments.js
-    ! from/BigInt/mapfn-is-not-callable.js
-    ! from/BigInt/mapfn-this-with-thisarg.js
-    ! from/BigInt/mapfn-this-without-thisarg-non-strict.js
-    ! from/BigInt/mapfn-this-without-thisarg-strict.js
-    ! from/BigInt/new-instance-empty.js
-    ! from/BigInt/new-instance-from-ordinary-object.js
-    ! from/BigInt/new-instance-from-sparse-array.js
-    ! from/BigInt/new-instance-using-custom-ctor.js
-    ! from/BigInt/new-instance-with-mapfn.js
-    ! from/BigInt/new-instance-without-mapfn.js
-    ! from/BigInt/property-abrupt-completion.js
-    ! from/BigInt/set-value-abrupt-completion.js
-    ! from/BigInt/source-value-is-symbol-throws.js
-    ! from/BigInt/this-is-not-constructor.js
-    ! from/arylk-get-length-error.js
-    ! from/arylk-to-length-error.js
-    ! from/custom-ctor-returns-other-instance.js
-    ! from/custom-ctor.js
-    ! from/iter-access-error.js
-    ! from/iter-invoke-error.js
-    ! from/iter-next-error.js
-    ! from/iter-next-value-error.js
-    ! from/mapfn-abrupt-completion.js
-    ! from/mapfn-arguments.js
-    ! from/mapfn-this-with-thisarg.js
-    ! from/mapfn-this-without-thisarg-non-strict.js
-    ! from/mapfn-this-without-thisarg-strict.js
-    ! from/nan-conversion.js
-    ! from/new-instance-empty.js
-    ! from/new-instance-from-ordinary-object.js
-    ! from/new-instance-from-sparse-array.js
-    ! from/new-instance-from-zero.js
-    ! from/new-instance-using-custom-ctor.js
-    ! from/new-instance-with-mapfn.js
-    ! from/new-instance-without-mapfn.js
-    ! from/property-abrupt-completion.js
-    ! from/set-value-abrupt-completion.js
-    ! Int16Array/prototype/not-typedarray-object.js
-    ! Int16Array/prototype/proto.js
-    ! Int32Array/prototype/not-typedarray-object.js
-    ! Int32Array/prototype/proto.js
-    ! Int8Array/prototype/not-typedarray-object.js
-    ! Int8Array/prototype/proto.js
-    ! internals/DefineOwnProperty/BigInt/desc-value-throws.js
-    ! internals/DefineOwnProperty/conversion-operation-consistent-nan.js
-    ! internals/DefineOwnProperty/conversion-operation.js
-    ! internals/DefineOwnProperty/desc-value-throws.js
-    ! internals/Get/BigInt/detached-buffer-key-is-not-numeric-index.js
-    ! internals/Get/BigInt/detached-buffer-key-is-symbol.js
-    ! internals/Get/BigInt/detached-buffer.js
-    ! internals/Get/BigInt/indexed-value.js
-    ! internals/Get/BigInt/infinity-detached-buffer.js
-    ! internals/Get/BigInt/key-is-not-canonical-index.js
-    ! internals/Get/BigInt/key-is-not-integer.js
-    ! internals/Get/BigInt/key-is-not-minus-zero.js
-    ! internals/Get/BigInt/key-is-not-numeric-index-get-throws.js
-    ! internals/Get/BigInt/key-is-not-numeric-index.js
-    ! internals/Get/BigInt/key-is-out-of-bounds.js
-    ! internals/Get/BigInt/key-is-symbol.js
-    ! internals/GetOwnProperty/BigInt/detached-buffer-key-is-not-number.js
-    ! internals/GetOwnProperty/BigInt/detached-buffer-key-is-symbol.js
-    ! internals/GetOwnProperty/BigInt/detached-buffer.js
-    ! internals/GetOwnProperty/BigInt/enumerate-detached-buffer.js
-    ! internals/GetOwnProperty/BigInt/index-prop-desc.js
-    ! internals/GetOwnProperty/BigInt/key-is-minus-zero.js
-    ! internals/GetOwnProperty/BigInt/key-is-not-canonical-index.js
-    ! internals/GetOwnProperty/BigInt/key-is-not-integer.js
-    ! internals/GetOwnProperty/BigInt/key-is-not-numeric-index.js
-    ! internals/GetOwnProperty/BigInt/key-is-out-of-bounds.js
-    ! internals/GetOwnProperty/BigInt/key-is-symbol.js
-    ! internals/GetOwnProperty/detached-buffer-key-is-not-number.js
-    ! internals/GetOwnProperty/detached-buffer-key-is-symbol.js
-    ! internals/GetOwnProperty/detached-buffer.js
-    ! internals/GetOwnProperty/enumerate-detached-buffer.js
-    ! internals/GetOwnProperty/index-prop-desc.js
-    ! internals/Get/detached-buffer-key-is-not-numeric-index.js
-    ! internals/Get/detached-buffer-key-is-symbol.js
-    ! internals/Get/detached-buffer.js
-    ! internals/Get/indexed-value.js
-    ! internals/Get/infinity-detached-buffer.js
-    ! internals/Get/key-is-not-canonical-index.js
-    ! internals/Get/key-is-not-integer.js
-    ! internals/Get/key-is-not-minus-zero.js
-    ! internals/Get/key-is-not-numeric-index.js
-    ! internals/Get/key-is-out-of-bounds.js
-    ! internals/Get/key-is-symbol.js
-    ! internals/HasProperty/BigInt/infinity-with-detached-buffer.js
-    ! internals/HasProperty/infinity-with-detached-buffer.js
-    ! internals/Set/BigInt/bigint-tobigint64.js
-    ! internals/Set/BigInt/bigint-tobiguint64.js
-    ! internals/Set/BigInt/boolean-tobigint.js
-    ! internals/Set/BigInt/detached-buffer.js
-    ! internals/Set/BigInt/key-is-not-numeric-index-set-throws.js
-    ! internals/Set/BigInt/null-tobigint.js
-    ! internals/Set/BigInt/number-tobigint.js
-    ! internals/Set/BigInt/string-nan-tobigint.js
-    ! internals/Set/BigInt/string-tobigint.js
-    ! internals/Set/BigInt/symbol-tobigint.js
-    ! internals/Set/BigInt/tonumber-value-throws.js
-    ! internals/Set/BigInt/undefined-tobigint.js
-    ! internals/Set/detached-buffer.js
-    ! internals/Set/tonumber-value-throws.js
-    ! of/BigInt/argument-is-symbol-throws.js
-    ! of/BigInt/argument-number-value-throws.js
-    ! of/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
-    ! of/BigInt/custom-ctor-returns-other-instance.js
-    ! of/BigInt/custom-ctor-returns-smaller-instance-throws.js
-    ! of/BigInt/custom-ctor.js
-    ! of/BigInt/inherited.js
-    ! of/BigInt/invoked-as-func.js
-    ! of/BigInt/new-instance-empty.js
-    ! of/BigInt/new-instance-using-custom-ctor.js
-    ! of/BigInt/new-instance.js
-    ! of/BigInt/this-is-not-constructor.js
-    ! of/argument-number-value-throws.js
-    ! of/custom-ctor-returns-other-instance.js
-    ! of/custom-ctor.js
-    ! of/nan-conversion.js
-    ! of/new-instance-empty.js
-    ! of/new-instance-from-zero.js
-    ! of/new-instance-using-custom-ctor.js
-    ! of/new-instance.js
-    ! prototype/buffer/bigint-inherited.js
-    ! prototype/buffer/inherited.js
-    ! prototype/byteLength/bigint-inherited.js
-    ! prototype/byteLength/inherited.js
-    ! prototype/byteOffset/bigint-inherited.js
-    ! prototype/byteOffset/inherited.js
-    ! prototype/copyWithin/bigint-inherited.js
-    ! prototype/entries/bigint-inherited.js
-    ! prototype/every/bigint-inherited.js
-    ! prototype/fill/bigint-inherited.js
-    ! prototype/filter/bigint-inherited.js
-    ! prototype/findIndex/bigint-inherited.js
-    ! prototype/find/bigint-inherited.js
-    ! prototype/forEach/bigint-inherited.js
-    ! prototype/indexOf/bigint-inherited.js
-    ! prototype/join/bigint-inherited.js
-    ! prototype/keys/bigint-inherited.js
-    ! prototype/lastIndexOf/bigint-inherited.js
-    ! prototype/length/bigint-inherited.js
-    ! prototype/length/inherited.js
-    ! prototype/map/bigint-inherited.js
-    ! prototype/reduceRight/bigint-inherited.js
-    ! prototype/reduce/bigint-inherited.js
-    ! prototype/reverse/bigint-inherited.js
-    ! prototype/set/bigint-inherited.js
-    ! prototype/set/inherited.js
-    ! prototype/slice/bigint-inherited.js
-    ! prototype/some/bigint-inherited.js
-    ! prototype/sort/bigint-inherited.js
-    ! prototype/subarray/bigint-inherited.js
-    ! prototype/subarray/inherited.js
-    ! prototype/Symbol.toStringTag/bigint-inherited.js
-    ! prototype/toLocaleString/bigint-inherited.js
-    ! prototype/toString/bigint-inherited.js
-    ! prototype/toString/inherited.js
-    ! prototype/values/bigint-inherited.js
-    ! prototype/bigint-Symbol.iterator.js
-    ! prototype/Symbol.iterator.js
-    ! Uint16Array/prototype/not-typedarray-object.js
-    ! Uint16Array/prototype/proto.js
-    ! Uint32Array/prototype/not-typedarray-object.js
-    ! Uint32Array/prototype/proto.js
-    ! Uint8Array/prototype/not-typedarray-object.js
-    ! Uint8Array/prototype/proto.js
-    ! Uint8ClampedArray/prototype/not-typedarray-object.js
-    ! Uint8ClampedArray/prototype/proto.js
+    BigInt64Array/prototype/BYTES_PER_ELEMENT.js
+    BigInt64Array/prototype/constructor.js
+    BigInt64Array/prototype/not-typedarray-object.js
+    BigInt64Array/prototype/proto.js
+    BigInt64Array/BYTES_PER_ELEMENT.js
+    BigInt64Array/constructor.js
+    BigInt64Array/length.js
+    BigInt64Array/name.js
+    BigInt64Array/prop-desc.js
+    BigInt64Array/proto.js
+    BigInt64Array/prototype.js
+    BigUint64Array/prototype/BYTES_PER_ELEMENT.js
+    BigUint64Array/prototype/constructor.js
+    BigUint64Array/prototype/not-typedarray-object.js
+    BigUint64Array/prototype/proto.js
+    BigUint64Array/BYTES_PER_ELEMENT.js
+    BigUint64Array/constructor.js
+    BigUint64Array/length.js
+    BigUint64Array/name.js
+    BigUint64Array/prop-desc.js
+    BigUint64Array/proto.js
+    BigUint64Array/prototype.js
+    ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
+    ctors-bigint/buffer-arg/byteoffset-is-negative-throws.js
+    ctors-bigint/buffer-arg/byteoffset-is-negative-zero.js
+    ctors-bigint/buffer-arg/byteoffset-is-symbol-throws.js
+    ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size.js
+    ctors-bigint/buffer-arg/byteoffset-to-number-detachbuffer.js
+    ctors-bigint/buffer-arg/byteoffset-to-number-throws.js
+    ctors-bigint/buffer-arg/defined-length-and-offset.js
+    ctors-bigint/buffer-arg/defined-length.js
+    ctors-bigint/buffer-arg/defined-negative-length.js
+    ctors-bigint/buffer-arg/defined-offset.js
+    ctors-bigint/buffer-arg/detachedbuffer.js
+    ctors-bigint/buffer-arg/excessive-length-throws.js
+    ctors-bigint/buffer-arg/excessive-offset-throws.js
+    ctors-bigint/buffer-arg/invoked-with-undefined-newtarget.js
+    ctors-bigint/buffer-arg/is-referenced.js
+    ctors-bigint/buffer-arg/length-access-throws.js
+    ctors-bigint/buffer-arg/length-is-symbol-throws.js
+    ctors-bigint/buffer-arg/length-to-number-detachbuffer.js
+    ctors-bigint/buffer-arg/new-instance-extensibility.js
+    ctors-bigint/buffer-arg/returns-new-instance.js
+    ctors-bigint/buffer-arg/toindex-bytelength.js
+    ctors-bigint/buffer-arg/toindex-byteoffset.js
+    ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors-bigint/length-arg/init-zeros.js
+    ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
+    ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
+    ctors-bigint/length-arg/is-symbol-throws.js
+    ctors-bigint/length-arg/new-instance-extensibility.js
+    ctors-bigint/length-arg/returns-object.js
+    ctors-bigint/length-arg/toindex-length.js
+    ctors-bigint/length-arg/undefined-newtarget-throws.js
+    ctors-bigint/length-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors-bigint/no-args/new-instance-extensibility.js
+    ctors-bigint/no-args/returns-object.js
+    ctors-bigint/no-args/undefined-newtarget-throws.js
+    ctors-bigint/no-args/use-default-proto-if-custom-proto-is-not-object.js
+    ctors-bigint/object-arg/as-array-returns.js
+    ctors-bigint/object-arg/as-generator-iterable-returns.js
+    ctors-bigint/object-arg/bigint-tobigint64.js
+    ctors-bigint/object-arg/bigint-tobiguint64.js
+    ctors-bigint/object-arg/boolean-tobigint.js
+    ctors-bigint/object-arg/iterating-throws.js
+    ctors-bigint/object-arg/iterator-not-callable-throws.js
+    ctors-bigint/object-arg/iterator-throws.js
+    ctors-bigint/object-arg/length-excessive-throws.js
+    ctors-bigint/object-arg/length-is-symbol-throws.js
+    ctors-bigint/object-arg/length-throws.js
+    ctors-bigint/object-arg/new-instance-extensibility.js
+    ctors-bigint/object-arg/null-tobigint.js
+    ctors-bigint/object-arg/number-tobigint.js
+    ctors-bigint/object-arg/string-nan-tobigint.js
+    ctors-bigint/object-arg/string-tobigint.js
+    ctors-bigint/object-arg/symbol-tobigint.js
+    ctors-bigint/object-arg/throws-from-property.js
+    ctors-bigint/object-arg/throws-setting-obj-to-primitive-typeerror.js
+    ctors-bigint/object-arg/throws-setting-obj-to-primitive.js
+    ctors-bigint/object-arg/throws-setting-obj-tostring.js
+    ctors-bigint/object-arg/throws-setting-obj-valueof-typeerror.js
+    ctors-bigint/object-arg/throws-setting-obj-valueof.js
+    ctors-bigint/object-arg/throws-setting-property.js
+    ctors-bigint/object-arg/throws-setting-symbol-property.js
+    ctors-bigint/object-arg/undefined-newtarget-throws.js
+    ctors-bigint/object-arg/undefined-tobigint.js
+    ctors-bigint/object-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors-bigint/typedarray-arg/detached-when-species-retrieved-different-type.js
+    ctors-bigint/typedarray-arg/detached-when-species-retrieved-same-type.js
+    ctors-bigint/typedarray-arg/new-instance-extensibility.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-null.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
+    ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js
+    ctors-bigint/typedarray-arg/other-ctor-returns-new-typedarray.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-null.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js
+    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
+    ctors-bigint/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
+    ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
+    ctors-bigint/typedarray-arg/undefined-newtarget-throws.js
+    ctors/buffer-arg/byteoffset-is-negative-throws.js
+    ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
+    ctors/buffer-arg/defined-negative-length.js
+    ctors/buffer-arg/detachedbuffer.js
+    ctors/buffer-arg/length-to-number-detachbuffer.js
+    ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/length-arg/is-infinity-throws-rangeerror.js
+    ctors/length-arg/is-negative-integer-throws-rangeerror.js
+    ctors/length-arg/is-symbol-throws.js
+    ctors/length-arg/toindex-length.js
+    ctors/length-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/no-args/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/object-arg/as-generator-iterable-returns.js
+    ctors/object-arg/iterating-throws.js
+    ctors/object-arg/iterator-not-callable-throws.js
+    ctors/object-arg/iterator-throws.js
+    ctors/object-arg/length-excessive-throws.js
+    ctors/object-arg/length-is-symbol-throws.js
+    ctors/object-arg/length-throws.js
+    ctors/object-arg/new-instance-extensibility.js
+    ctors/object-arg/returns.js
+    ctors/object-arg/throws-from-property.js
+    ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
+    ctors/object-arg/throws-setting-obj-to-primitive.js
+    ctors/object-arg/throws-setting-property.js
+    ctors/object-arg/throws-setting-symbol-property.js
+    ctors/object-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
+    ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
+    ctors/typedarray-arg/src-typedarray-big-throws.js
+    ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
+    Float32Array/prototype/not-typedarray-object.js
+    Float32Array/prototype/proto.js
+    Float64Array/prototype/not-typedarray-object.js
+    Float64Array/prototype/proto.js
+    from/BigInt/arylk-get-length-error.js
+    from/BigInt/arylk-to-length-error.js
+    from/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
+    from/BigInt/custom-ctor-returns-other-instance.js
+    from/BigInt/custom-ctor-returns-smaller-instance-throws.js
+    from/BigInt/custom-ctor.js
+    from/BigInt/inherited.js
+    from/BigInt/invoked-as-func.js
+    from/BigInt/iter-access-error.js
+    from/BigInt/iter-invoke-error.js
+    from/BigInt/iter-next-error.js
+    from/BigInt/iter-next-value-error.js
+    from/BigInt/mapfn-abrupt-completion.js
+    from/BigInt/mapfn-arguments.js
+    from/BigInt/mapfn-is-not-callable.js
+    from/BigInt/mapfn-this-with-thisarg.js
+    from/BigInt/mapfn-this-without-thisarg-non-strict.js
+    from/BigInt/mapfn-this-without-thisarg-strict.js
+    from/BigInt/new-instance-empty.js
+    from/BigInt/new-instance-from-ordinary-object.js
+    from/BigInt/new-instance-from-sparse-array.js
+    from/BigInt/new-instance-using-custom-ctor.js
+    from/BigInt/new-instance-with-mapfn.js
+    from/BigInt/new-instance-without-mapfn.js
+    from/BigInt/property-abrupt-completion.js
+    from/BigInt/set-value-abrupt-completion.js
+    from/BigInt/source-value-is-symbol-throws.js
+    from/BigInt/this-is-not-constructor.js
+    from/arylk-get-length-error.js
+    from/arylk-to-length-error.js
+    from/custom-ctor-returns-other-instance.js
+    from/custom-ctor.js
+    from/iter-access-error.js
+    from/iter-invoke-error.js
+    from/iter-next-error.js
+    from/iter-next-value-error.js
+    from/mapfn-abrupt-completion.js
+    from/mapfn-arguments.js
+    from/mapfn-this-with-thisarg.js
+    from/mapfn-this-without-thisarg-non-strict.js
+    from/mapfn-this-without-thisarg-strict.js
+    from/nan-conversion.js
+    from/new-instance-empty.js
+    from/new-instance-from-ordinary-object.js
+    from/new-instance-from-sparse-array.js
+    from/new-instance-from-zero.js
+    from/new-instance-using-custom-ctor.js
+    from/new-instance-with-mapfn.js
+    from/new-instance-without-mapfn.js
+    from/property-abrupt-completion.js
+    from/set-value-abrupt-completion.js
+    Int16Array/prototype/not-typedarray-object.js
+    Int16Array/prototype/proto.js
+    Int32Array/prototype/not-typedarray-object.js
+    Int32Array/prototype/proto.js
+    Int8Array/prototype/not-typedarray-object.js
+    Int8Array/prototype/proto.js
+    internals/DefineOwnProperty/BigInt/desc-value-throws.js
+    internals/DefineOwnProperty/conversion-operation-consistent-nan.js
+    internals/DefineOwnProperty/conversion-operation.js
+    internals/DefineOwnProperty/desc-value-throws.js
+    internals/Get/BigInt/detached-buffer-key-is-not-numeric-index.js
+    internals/Get/BigInt/detached-buffer-key-is-symbol.js
+    internals/Get/BigInt/detached-buffer.js
+    internals/Get/BigInt/indexed-value.js
+    internals/Get/BigInt/infinity-detached-buffer.js
+    internals/Get/BigInt/key-is-not-canonical-index.js
+    internals/Get/BigInt/key-is-not-integer.js
+    internals/Get/BigInt/key-is-not-minus-zero.js
+    internals/Get/BigInt/key-is-not-numeric-index-get-throws.js
+    internals/Get/BigInt/key-is-not-numeric-index.js
+    internals/Get/BigInt/key-is-out-of-bounds.js
+    internals/Get/BigInt/key-is-symbol.js
+    internals/GetOwnProperty/BigInt/detached-buffer-key-is-not-number.js
+    internals/GetOwnProperty/BigInt/detached-buffer-key-is-symbol.js
+    internals/GetOwnProperty/BigInt/detached-buffer.js
+    internals/GetOwnProperty/BigInt/enumerate-detached-buffer.js
+    internals/GetOwnProperty/BigInt/index-prop-desc.js
+    internals/GetOwnProperty/BigInt/key-is-minus-zero.js
+    internals/GetOwnProperty/BigInt/key-is-not-canonical-index.js
+    internals/GetOwnProperty/BigInt/key-is-not-integer.js
+    internals/GetOwnProperty/BigInt/key-is-not-numeric-index.js
+    internals/GetOwnProperty/BigInt/key-is-out-of-bounds.js
+    internals/GetOwnProperty/BigInt/key-is-symbol.js
+    internals/GetOwnProperty/detached-buffer-key-is-not-number.js
+    internals/GetOwnProperty/detached-buffer-key-is-symbol.js
+    internals/GetOwnProperty/detached-buffer.js
+    internals/GetOwnProperty/enumerate-detached-buffer.js
+    internals/GetOwnProperty/index-prop-desc.js
+    internals/Get/detached-buffer-key-is-not-numeric-index.js
+    internals/Get/detached-buffer-key-is-symbol.js
+    internals/Get/detached-buffer.js
+    internals/Get/indexed-value.js
+    internals/Get/infinity-detached-buffer.js
+    internals/Get/key-is-not-canonical-index.js
+    internals/Get/key-is-not-integer.js
+    internals/Get/key-is-not-minus-zero.js
+    internals/Get/key-is-not-numeric-index.js
+    internals/Get/key-is-out-of-bounds.js
+    internals/Get/key-is-symbol.js
+    internals/HasProperty/BigInt/infinity-with-detached-buffer.js
+    internals/HasProperty/infinity-with-detached-buffer.js
+    internals/Set/BigInt/bigint-tobigint64.js
+    internals/Set/BigInt/bigint-tobiguint64.js
+    internals/Set/BigInt/boolean-tobigint.js
+    internals/Set/BigInt/detached-buffer.js
+    internals/Set/BigInt/key-is-not-numeric-index-set-throws.js
+    internals/Set/BigInt/null-tobigint.js
+    internals/Set/BigInt/number-tobigint.js
+    internals/Set/BigInt/string-nan-tobigint.js
+    internals/Set/BigInt/string-tobigint.js
+    internals/Set/BigInt/symbol-tobigint.js
+    internals/Set/BigInt/tonumber-value-throws.js
+    internals/Set/BigInt/undefined-tobigint.js
+    internals/Set/detached-buffer.js
+    internals/Set/tonumber-value-throws.js
+    of/BigInt/argument-is-symbol-throws.js
+    of/BigInt/argument-number-value-throws.js
+    of/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
+    of/BigInt/custom-ctor-returns-other-instance.js
+    of/BigInt/custom-ctor-returns-smaller-instance-throws.js
+    of/BigInt/custom-ctor.js
+    of/BigInt/inherited.js
+    of/BigInt/invoked-as-func.js
+    of/BigInt/new-instance-empty.js
+    of/BigInt/new-instance-using-custom-ctor.js
+    of/BigInt/new-instance.js
+    of/BigInt/this-is-not-constructor.js
+    of/argument-number-value-throws.js
+    of/custom-ctor-returns-other-instance.js
+    of/custom-ctor.js
+    of/nan-conversion.js
+    of/new-instance-empty.js
+    of/new-instance-from-zero.js
+    of/new-instance-using-custom-ctor.js
+    of/new-instance.js
+    prototype/buffer/bigint-inherited.js
+    prototype/buffer/inherited.js
+    prototype/byteLength/bigint-inherited.js
+    prototype/byteLength/inherited.js
+    prototype/byteOffset/bigint-inherited.js
+    prototype/byteOffset/inherited.js
+    prototype/copyWithin/bigint-inherited.js
+    prototype/entries/bigint-inherited.js
+    prototype/every/bigint-inherited.js
+    prototype/fill/bigint-inherited.js
+    prototype/filter/bigint-inherited.js
+    prototype/findIndex/bigint-inherited.js
+    prototype/find/bigint-inherited.js
+    prototype/forEach/bigint-inherited.js
+    prototype/indexOf/bigint-inherited.js
+    prototype/join/bigint-inherited.js
+    prototype/keys/bigint-inherited.js
+    prototype/lastIndexOf/bigint-inherited.js
+    prototype/length/bigint-inherited.js
+    prototype/length/inherited.js
+    prototype/map/bigint-inherited.js
+    prototype/reduceRight/bigint-inherited.js
+    prototype/reduce/bigint-inherited.js
+    prototype/reverse/bigint-inherited.js
+    prototype/set/bigint-inherited.js
+    prototype/set/inherited.js
+    prototype/slice/bigint-inherited.js
+    prototype/some/bigint-inherited.js
+    prototype/sort/bigint-inherited.js
+    prototype/subarray/bigint-inherited.js
+    prototype/subarray/inherited.js
+    prototype/Symbol.toStringTag/bigint-inherited.js
+    prototype/toLocaleString/bigint-inherited.js
+    prototype/toString/bigint-inherited.js
+    prototype/toString/inherited.js
+    prototype/values/bigint-inherited.js
+    prototype/bigint-Symbol.iterator.js
+    prototype/Symbol.iterator.js
+    Uint16Array/prototype/not-typedarray-object.js
+    Uint16Array/prototype/proto.js
+    Uint32Array/prototype/not-typedarray-object.js
+    Uint32Array/prototype/proto.js
+    Uint8Array/prototype/not-typedarray-object.js
+    Uint8Array/prototype/proto.js
+    Uint8ClampedArray/prototype/not-typedarray-object.js
+    Uint8ClampedArray/prototype/proto.js
 
 built-ins/undefined
 
@@ -2377,838 +2342,838 @@ built-ins/WeakMap
 built-ins/WeakSet
 
 language/arguments-object
-    ! mapped/mapped-arguments-nonconfigurable-3.js
-    ! mapped/mapped-arguments-nonconfigurable-delete-1.js
-    ! mapped/mapped-arguments-nonconfigurable-delete-2.js
-    ! mapped/mapped-arguments-nonconfigurable-delete-3.js
-    ! mapped/mapped-arguments-nonconfigurable-delete-4.js
-    ! mapped/mapped-arguments-nonconfigurable-nonwritable-1.js
-    ! mapped/mapped-arguments-nonconfigurable-nonwritable-2.js
-    ! mapped/mapped-arguments-nonconfigurable-nonwritable-3.js
-    ! mapped/mapped-arguments-nonconfigurable-nonwritable-4.js
-    ! mapped/mapped-arguments-nonconfigurable-nonwritable-5.js
-    ! mapped/mapped-arguments-nonconfigurable-strict-delete-1.js
-    ! mapped/mapped-arguments-nonconfigurable-strict-delete-2.js
-    ! mapped/mapped-arguments-nonconfigurable-strict-delete-3.js
-    ! mapped/mapped-arguments-nonconfigurable-strict-delete-4.js
-    ! mapped/mapped-arguments-nonwritable-nonconfigurable-1.js
-    ! mapped/mapped-arguments-nonwritable-nonconfigurable-2.js
-    ! mapped/mapped-arguments-nonwritable-nonconfigurable-3.js
-    ! mapped/mapped-arguments-nonwritable-nonconfigurable-4.js
-    ! mapped/nonconfigurable-descriptors-basic.js
-    ! mapped/nonconfigurable-descriptors-set-value-by-arguments.js
-    ! mapped/nonconfigurable-descriptors-set-value-with-define-property.js
-    ! mapped/nonconfigurable-descriptors-with-param-assign.js
-    ! mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
-    ! mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
-    ! mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
-    ! mapped/nonconfigurable-nonwritable-descriptors-basic.js
-    ! mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
-    ! mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
-    ! mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
-    ! mapped/nonwritable-nonconfigurable-descriptors-basic.js
-    ! mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
-    ! mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
-    ! mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
-    ! mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
-    ! mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
-    ! mapped/Symbol.iterator.js
-    ! unmapped/Symbol.iterator.js
-    ! unmapped/via-params-dflt.js
-    ! unmapped/via-params-dstr.js
-    ! unmapped/via-params-rest.js
-    ! arguments-caller.js
-    ! cls-decl-gen-meth-args-trailing-comma-multiple.js
-    ! cls-decl-gen-meth-args-trailing-comma-null.js
-    ! cls-decl-gen-meth-args-trailing-comma-single-args.js
-    ! cls-decl-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-decl-gen-meth-args-trailing-comma-undefined.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-null.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-decl-meth-args-trailing-comma-multiple.js
-    ! cls-decl-meth-args-trailing-comma-null.js
-    ! cls-decl-meth-args-trailing-comma-single-args.js
-    ! cls-decl-meth-args-trailing-comma-spread-operator.js
-    ! cls-decl-meth-args-trailing-comma-undefined.js
-    ! cls-decl-meth-static-args-trailing-comma-multiple.js
-    ! cls-decl-meth-static-args-trailing-comma-null.js
-    ! cls-decl-meth-static-args-trailing-comma-single-args.js
-    ! cls-decl-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-decl-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-gen-meth-args-trailing-comma-multiple.js
-    ! cls-expr-gen-meth-args-trailing-comma-null.js
-    ! cls-expr-gen-meth-args-trailing-comma-single-args.js
-    ! cls-expr-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-gen-meth-args-trailing-comma-undefined.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-null.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-meth-args-trailing-comma-multiple.js
-    ! cls-expr-meth-args-trailing-comma-null.js
-    ! cls-expr-meth-args-trailing-comma-single-args.js
-    ! cls-expr-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-meth-args-trailing-comma-undefined.js
-    ! cls-expr-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-meth-static-args-trailing-comma-null.js
-    ! cls-expr-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-meth-static-args-trailing-comma-undefined.js
-    ! func-decl-args-trailing-comma-spread-operator.js
-    ! func-expr-args-trailing-comma-spread-operator.js
-    ! gen-func-decl-args-trailing-comma-spread-operator.js
-    ! gen-func-expr-args-trailing-comma-spread-operator.js
-    ! gen-meth-args-trailing-comma-multiple.js
-    ! gen-meth-args-trailing-comma-null.js
-    ! gen-meth-args-trailing-comma-single-args.js
-    ! gen-meth-args-trailing-comma-spread-operator.js
-    ! gen-meth-args-trailing-comma-undefined.js
-    ! meth-args-trailing-comma-spread-operator.js
+    mapped/mapped-arguments-nonconfigurable-3.js
+    mapped/mapped-arguments-nonconfigurable-delete-1.js
+    mapped/mapped-arguments-nonconfigurable-delete-2.js
+    mapped/mapped-arguments-nonconfigurable-delete-3.js
+    mapped/mapped-arguments-nonconfigurable-delete-4.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js
+    mapped/nonconfigurable-descriptors-basic.js
+    mapped/nonconfigurable-descriptors-set-value-by-arguments.js
+    mapped/nonconfigurable-descriptors-set-value-with-define-property.js
+    mapped/nonconfigurable-descriptors-with-param-assign.js
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
+    mapped/nonconfigurable-nonwritable-descriptors-basic.js
+    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
+    mapped/nonwritable-nonconfigurable-descriptors-basic.js
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
+    mapped/Symbol.iterator.js
+    unmapped/Symbol.iterator.js
+    unmapped/via-params-dflt.js
+    unmapped/via-params-dstr.js
+    unmapped/via-params-rest.js
+    arguments-caller.js
+    cls-decl-gen-meth-args-trailing-comma-multiple.js
+    cls-decl-gen-meth-args-trailing-comma-null.js
+    cls-decl-gen-meth-args-trailing-comma-single-args.js
+    cls-decl-gen-meth-args-trailing-comma-spread-operator.js
+    cls-decl-gen-meth-args-trailing-comma-undefined.js
+    cls-decl-gen-meth-static-args-trailing-comma-multiple.js
+    cls-decl-gen-meth-static-args-trailing-comma-null.js
+    cls-decl-gen-meth-static-args-trailing-comma-single-args.js
+    cls-decl-gen-meth-static-args-trailing-comma-spread-operator.js
+    cls-decl-gen-meth-static-args-trailing-comma-undefined.js
+    cls-decl-meth-args-trailing-comma-multiple.js
+    cls-decl-meth-args-trailing-comma-null.js
+    cls-decl-meth-args-trailing-comma-single-args.js
+    cls-decl-meth-args-trailing-comma-spread-operator.js
+    cls-decl-meth-args-trailing-comma-undefined.js
+    cls-decl-meth-static-args-trailing-comma-multiple.js
+    cls-decl-meth-static-args-trailing-comma-null.js
+    cls-decl-meth-static-args-trailing-comma-single-args.js
+    cls-decl-meth-static-args-trailing-comma-spread-operator.js
+    cls-decl-meth-static-args-trailing-comma-undefined.js
+    cls-expr-gen-meth-args-trailing-comma-multiple.js
+    cls-expr-gen-meth-args-trailing-comma-null.js
+    cls-expr-gen-meth-args-trailing-comma-single-args.js
+    cls-expr-gen-meth-args-trailing-comma-spread-operator.js
+    cls-expr-gen-meth-args-trailing-comma-undefined.js
+    cls-expr-gen-meth-static-args-trailing-comma-multiple.js
+    cls-expr-gen-meth-static-args-trailing-comma-null.js
+    cls-expr-gen-meth-static-args-trailing-comma-single-args.js
+    cls-expr-gen-meth-static-args-trailing-comma-spread-operator.js
+    cls-expr-gen-meth-static-args-trailing-comma-undefined.js
+    cls-expr-meth-args-trailing-comma-multiple.js
+    cls-expr-meth-args-trailing-comma-null.js
+    cls-expr-meth-args-trailing-comma-single-args.js
+    cls-expr-meth-args-trailing-comma-spread-operator.js
+    cls-expr-meth-args-trailing-comma-undefined.js
+    cls-expr-meth-static-args-trailing-comma-multiple.js
+    cls-expr-meth-static-args-trailing-comma-null.js
+    cls-expr-meth-static-args-trailing-comma-single-args.js
+    cls-expr-meth-static-args-trailing-comma-spread-operator.js
+    cls-expr-meth-static-args-trailing-comma-undefined.js
+    func-decl-args-trailing-comma-spread-operator.js
+    func-expr-args-trailing-comma-spread-operator.js
+    gen-func-decl-args-trailing-comma-spread-operator.js
+    gen-func-expr-args-trailing-comma-spread-operator.js
+    gen-meth-args-trailing-comma-multiple.js
+    gen-meth-args-trailing-comma-null.js
+    gen-meth-args-trailing-comma-single-args.js
+    gen-meth-args-trailing-comma-spread-operator.js
+    gen-meth-args-trailing-comma-undefined.js
+    meth-args-trailing-comma-spread-operator.js
 
 language/asi
-    ! S7.9_A5.7_T1.js
+    S7.9_A5.7_T1.js
 
 language/block-scope
-    ! shadowing/const-declaration-shadowing-catch-parameter.js
-    ! shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
-    ! shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
-    ! syntax/for-in/disallow-initialization-assignment.js
-    ! syntax/for-in/mixed-values-in-iteration.js
-    ! syntax/function-declarations/in-statement-position-do-statement-while-expression.js
-    ! syntax/function-declarations/in-statement-position-for-statement.js
-    ! syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
-    ! syntax/function-declarations/in-statement-position-if-expression-statement.js
-    ! syntax/function-declarations/in-statement-position-while-expression-statement.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-class.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-class.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-class.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-class.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
-    ! syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
-    ! syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
-    ! syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-class.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-const.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-function.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-generator.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-let.js
+    shadowing/const-declaration-shadowing-catch-parameter.js
+    shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
+    shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
+    syntax/for-in/disallow-initialization-assignment.js
+    syntax/for-in/mixed-values-in-iteration.js
+    syntax/function-declarations/in-statement-position-do-statement-while-expression.js
+    syntax/function-declarations/in-statement-position-for-statement.js
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
+    syntax/function-declarations/in-statement-position-if-expression-statement.js
+    syntax/function-declarations/in-statement-position-while-expression-statement.js
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-class.js
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-class.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-class.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-class.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
+    syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/var-redeclaration-attempt-after-class.js
+    syntax/redeclaration/var-redeclaration-attempt-after-const.js
+    syntax/redeclaration/var-redeclaration-attempt-after-function.js
+    syntax/redeclaration/var-redeclaration-attempt-after-generator.js
+    syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
 language/comments
-    ! multi-line-asi-carriage-return.js
-    ! multi-line-asi-line-feed.js
-    ! multi-line-asi-line-separator.js
-    ! multi-line-asi-paragraph-separator.js
-    ! multi-line-html-close-extra.js
+    multi-line-asi-carriage-return.js
+    multi-line-asi-line-feed.js
+    multi-line-asi-line-separator.js
+    multi-line-asi-paragraph-separator.js
+    multi-line-html-close-extra.js
 
-#language/computed-property-names
+~language/computed-property-names
 
 language/destructuring
-    ! binding/syntax/array-elements-with-initializer.js
-    ! binding/syntax/array-elements-with-object-patterns.js
-    ! binding/syntax/array-rest-elements.js
-    ! binding/syntax/property-list-bindings-elements.js
-    ! binding/syntax/property-list-single-name-bindings.js
-    ! binding/syntax/property-list-with-property-list.js
-    ! binding/syntax/recursive-array-and-object-patterns.js
-    ! binding/initialization-requires-object-coercible-null.js
-    ! binding/initialization-requires-object-coercible-undefined.js
+    binding/syntax/array-elements-with-initializer.js
+    binding/syntax/array-elements-with-object-patterns.js
+    binding/syntax/array-rest-elements.js
+    binding/syntax/property-list-bindings-elements.js
+    binding/syntax/property-list-single-name-bindings.js
+    binding/syntax/property-list-with-property-list.js
+    binding/syntax/recursive-array-and-object-patterns.js
+    binding/initialization-requires-object-coercible-null.js
+    binding/initialization-requires-object-coercible-undefined.js
 
 language/directive-prologue
-    ! 14.1-1-s.js
-    ! 14.1-10-s.js
-    ! 14.1-11-s.js
-    ! 14.1-12-s.js
-    ! 14.1-13-s.js
-    ! 14.1-14-s.js
-    ! 14.1-15-s.js
-    ! 14.1-16-s.js
-    ! 14.1-17-s.js
-    ! 14.1-2-s.js
-    ! 14.1-3-s.js
-    ! 14.1-4-s.js
-    ! 14.1-5-s.js
-    ! 14.1-6-s.js
-    ! 14.1-7-s.js
-    ! 14.1-8-s.js
-    ! 14.1-9-s.js
-    ! func-decl-inside-func-decl-parse.js
+    14.1-1-s.js
+    14.1-10-s.js
+    14.1-11-s.js
+    14.1-12-s.js
+    14.1-13-s.js
+    14.1-14-s.js
+    14.1-15-s.js
+    14.1-16-s.js
+    14.1-17-s.js
+    14.1-2-s.js
+    14.1-3-s.js
+    14.1-4-s.js
+    14.1-5-s.js
+    14.1-6-s.js
+    14.1-7-s.js
+    14.1-8-s.js
+    14.1-9-s.js
+    func-decl-inside-func-decl-parse.js
 
 language/eval-code
-    ! direct/block-decl-eval-source-is-strict-nostrict.js
-    ! direct/block-decl-eval-source-is-strict-onlystrict.js
-    ! direct/block-decl-onlystrict.js
-    ! direct/lex-env-distinct-const.js
-    ! direct/lex-env-distinct-let.js
-    ! direct/lex-env-no-init-const.js
-    ! direct/lex-env-no-init-let.js
-    ! direct/non-definable-global-var.js
-    ! direct/switch-case-decl-eval-source-is-strict-nostrict.js
-    ! direct/switch-case-decl-eval-source-is-strict-onlystrict.js
-    ! direct/switch-case-decl-onlystrict.js
-    ! direct/switch-dflt-decl-eval-source-is-strict-nostrict.js
-    ! direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js
-    ! direct/switch-dflt-decl-onlystrict.js
-    ! direct/this-value-func-strict-caller.js
-    ! direct/var-env-func-init-global-update-configurable.js
-    ! direct/var-env-func-strict-caller-2.js
-    ! direct/var-env-func-strict-caller.js
-    ! direct/var-env-func-strict-source.js
-    ! direct/var-env-global-lex-non-strict.js
-    ! direct/var-env-lower-lex-non-strict.js
-    ! direct/var-env-var-strict-caller-2.js
-    ! direct/var-env-var-strict-caller-3.js
-    ! direct/var-env-var-strict-caller.js
-    ! direct/var-env-var-strict-source.js
-    ! indirect/always-non-strict.js
-    ! indirect/block-decl-strict.js
-    ! indirect/lex-env-distinct-const.js
-    ! indirect/lex-env-distinct-let.js
-    ! indirect/lex-env-no-init-const.js
-    ! indirect/lex-env-no-init-let.js
-    ! indirect/non-definable-function-with-function.js
-    ! indirect/non-definable-function-with-variable.js
-    ! indirect/non-definable-global-var.js
-    ! indirect/switch-case-decl-strict.js
-    ! indirect/switch-dflt-decl-strict.js
-    ! indirect/var-env-func-init-global-update-configurable.js
-    ! indirect/var-env-func-strict.js
-    ! indirect/var-env-global-lex-non-strict.js
-    ! indirect/var-env-var-strict.js
+    direct/block-decl-eval-source-is-strict-nostrict.js
+    direct/block-decl-eval-source-is-strict-onlystrict.js
+    direct/block-decl-onlystrict.js
+    direct/lex-env-distinct-const.js
+    direct/lex-env-distinct-let.js
+    direct/lex-env-no-init-const.js
+    direct/lex-env-no-init-let.js
+    direct/non-definable-global-var.js
+    direct/switch-case-decl-eval-source-is-strict-nostrict.js
+    direct/switch-case-decl-eval-source-is-strict-onlystrict.js
+    direct/switch-case-decl-onlystrict.js
+    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js
+    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js
+    direct/switch-dflt-decl-onlystrict.js
+    direct/this-value-func-strict-caller.js
+    direct/var-env-func-init-global-update-configurable.js
+    direct/var-env-func-strict-caller-2.js
+    direct/var-env-func-strict-caller.js
+    direct/var-env-func-strict-source.js
+    direct/var-env-global-lex-non-strict.js
+    direct/var-env-lower-lex-non-strict.js
+    direct/var-env-var-strict-caller-2.js
+    direct/var-env-var-strict-caller-3.js
+    direct/var-env-var-strict-caller.js
+    direct/var-env-var-strict-source.js
+    indirect/always-non-strict.js
+    indirect/block-decl-strict.js
+    indirect/lex-env-distinct-const.js
+    indirect/lex-env-distinct-let.js
+    indirect/lex-env-no-init-const.js
+    indirect/lex-env-no-init-let.js
+    indirect/non-definable-function-with-function.js
+    indirect/non-definable-function-with-variable.js
+    indirect/non-definable-global-var.js
+    indirect/switch-case-decl-strict.js
+    indirect/switch-dflt-decl-strict.js
+    indirect/var-env-func-init-global-update-configurable.js
+    indirect/var-env-func-strict.js
+    indirect/var-env-global-lex-non-strict.js
+    indirect/var-env-var-strict.js
 
-#language/export
+~language/export
 
 language/expressions/addition
-    ! coerce-symbol-to-prim-err.js
-    ! coerce-symbol-to-prim-invocation.js
-    ! coerce-symbol-to-prim-return-obj.js
-    ! coerce-symbol-to-prim-return-prim.js
-    ! get-symbol-to-prim-err.js
-    ! order-of-evaluation.js
+    coerce-symbol-to-prim-err.js
+    coerce-symbol-to-prim-invocation.js
+    coerce-symbol-to-prim-return-obj.js
+    coerce-symbol-to-prim-return-prim.js
+    get-symbol-to-prim-err.js
+    order-of-evaluation.js
 
 language/expressions/arrow-function
-    ! dstr/ary-init-iter-close.js
-    ! dstr/ary-init-iter-get-err.js
-    ! dstr/ary-ptrn-elem-ary-elem-init.js
-    ! dstr/ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/ary-ptrn-elem-ary-elision-init.js
-    ! dstr/ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/ary-ptrn-elem-ary-empty-init.js
-    ! dstr/ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/ary-ptrn-elem-ary-rest-init.js
-    ! dstr/ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/ary-ptrn-elem-id-init-hole.js
-    ! dstr/ary-ptrn-elem-id-init-skipped.js
-    ! dstr/ary-ptrn-elem-id-init-throws.js
-    ! dstr/ary-ptrn-elem-id-init-undef.js
-    ! dstr/ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/ary-ptrn-elem-obj-id-init.js
-    ! dstr/ary-ptrn-elem-obj-id.js
-    ! dstr/ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/ary-ptrn-elem-obj-prop-id.js
-    ! dstr/ary-ptrn-elision-step-err.js
-    ! dstr/ary-ptrn-elision.js
-    ! dstr/ary-ptrn-rest-ary-elem.js
-    ! dstr/ary-ptrn-rest-ary-elision.js
-    ! dstr/ary-ptrn-rest-ary-empty.js
-    ! dstr/ary-ptrn-rest-ary-rest.js
-    ! dstr/ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/ary-ptrn-rest-id-elision.js
-    ! dstr/ary-ptrn-rest-id-exhausted.js
-    ! dstr/ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/ary-ptrn-rest-id.js
-    ! dstr/ary-ptrn-rest-init-ary.js
-    ! dstr/ary-ptrn-rest-init-id.js
-    ! dstr/ary-ptrn-rest-init-obj.js
-    ! dstr/ary-ptrn-rest-not-final-ary.js
-    ! dstr/ary-ptrn-rest-not-final-id.js
-    ! dstr/ary-ptrn-rest-not-final-obj.js
-    ! dstr/ary-ptrn-rest-obj-id.js
-    ! dstr/ary-ptrn-rest-obj-prop-id.js
-    ! dstr/obj-init-null.js
-    ! dstr/obj-init-undefined.js
-    ! dstr/obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/obj-ptrn-id-init-fn-name-class.js
-    ! dstr/obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/obj-ptrn-id-init-skipped.js
-    ! dstr/obj-ptrn-id-init-throws.js
-    ! dstr/obj-ptrn-id-init-unresolvable.js
-    ! dstr/obj-ptrn-list-err.js
-    ! dstr/obj-ptrn-prop-ary-init.js
-    ! dstr/obj-ptrn-prop-ary-value-null.js
-    ! dstr/obj-ptrn-prop-ary.js
-    ! dstr/obj-ptrn-prop-eval-err.js
-    ! dstr/obj-ptrn-prop-id-get-value-err.js
-    ! dstr/obj-ptrn-prop-id-init-skipped.js
-    ! dstr/obj-ptrn-prop-id-init-throws.js
-    ! dstr/obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/obj-ptrn-prop-id-init.js
-    ! dstr/obj-ptrn-prop-obj-init.js
-    ! dstr/obj-ptrn-prop-obj-value-null.js
-    ! dstr/obj-ptrn-prop-obj-value-undef.js
-    ! dstr/obj-ptrn-prop-obj.js
-    ! dstr/syntax-error-ident-ref-break-escaped.js
-    ! dstr/syntax-error-ident-ref-case-escaped.js
-    ! dstr/syntax-error-ident-ref-catch-escaped.js
-    ! dstr/syntax-error-ident-ref-class-escaped.js
-    ! dstr/syntax-error-ident-ref-const-escaped.js
-    ! dstr/syntax-error-ident-ref-continue-escaped.js
-    ! dstr/syntax-error-ident-ref-debugger-escaped.js
-    ! dstr/syntax-error-ident-ref-default-escaped-ext.js
-    ! dstr/syntax-error-ident-ref-default-escaped.js
-    ! dstr/syntax-error-ident-ref-default.js
-    ! dstr/syntax-error-ident-ref-delete-escaped.js
-    ! dstr/syntax-error-ident-ref-do-escaped.js
-    ! dstr/syntax-error-ident-ref-else-escaped.js
-    ! dstr/syntax-error-ident-ref-enum-escaped.js
-    ! dstr/syntax-error-ident-ref-export-escaped.js
-    ! dstr/syntax-error-ident-ref-extends-escaped-ext.js
-    ! dstr/syntax-error-ident-ref-extends-escaped.js
-    ! dstr/syntax-error-ident-ref-extends.js
-    ! dstr/syntax-error-ident-ref-finally-escaped.js
-    ! dstr/syntax-error-ident-ref-for-escaped.js
-    ! dstr/syntax-error-ident-ref-function-escaped.js
-    ! dstr/syntax-error-ident-ref-if-escaped.js
-    ! dstr/syntax-error-ident-ref-implements-escaped.js
-    ! dstr/syntax-error-ident-ref-import-escaped.js
-    ! dstr/syntax-error-ident-ref-in-escaped.js
-    ! dstr/syntax-error-ident-ref-instanceof-escaped.js
-    ! dstr/syntax-error-ident-ref-interface-escaped.js
-    ! dstr/syntax-error-ident-ref-let-escaped.js
-    ! dstr/syntax-error-ident-ref-new-escaped.js
-    ! dstr/syntax-error-ident-ref-package-escaped.js
-    ! dstr/syntax-error-ident-ref-private-escaped.js
-    ! dstr/syntax-error-ident-ref-protected-escaped.js
-    ! dstr/syntax-error-ident-ref-public-escaped.js
-    ! dstr/syntax-error-ident-ref-return-escaped.js
-    ! dstr/syntax-error-ident-ref-static-escaped.js
-    ! dstr/syntax-error-ident-ref-super-escaped.js
-    ! dstr/syntax-error-ident-ref-switch-escaped.js
-    ! dstr/syntax-error-ident-ref-this-escaped.js
-    ! dstr/syntax-error-ident-ref-throw-escaped.js
-    ! dstr/syntax-error-ident-ref-try-escaped.js
-    ! dstr/syntax-error-ident-ref-typeof-escaped.js
-    ! dstr/syntax-error-ident-ref-var-escaped.js
-    ! dstr/syntax-error-ident-ref-void-escaped.js
-    ! dstr/syntax-error-ident-ref-while-escaped.js
-    ! dstr/syntax-error-ident-ref-with-escaped.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-identifier-futurereservedword.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-identifier-strict-futurereservedword.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-identifier.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-no-arguments.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-no-eval.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-no-yield.js
-    ! syntax/early-errors/arrowparameters-bindingidentifier-rest.js
-    ! syntax/early-errors/arrowparameters-cover-no-arguments.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-3.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-4.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-5.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates-rest.js
-    ! syntax/early-errors/arrowparameters-cover-no-duplicates.js
-    ! syntax/early-errors/arrowparameters-cover-no-eval.js
-    ! syntax/early-errors/arrowparameters-cover-no-yield.js
-    ! syntax/early-errors/asi-restriction-invalid-parenless-parameters-expression-body.js
-    ! syntax/early-errors/asi-restriction-invalid-parenless-parameters.js
-    ! syntax/early-errors/asi-restriction-invalid.js
-    ! syntax/early-errors/use-strict-with-non-simple-param.js
-    ! syntax/arrowparameters-bindingidentifier-yield.js
-    ! syntax/arrowparameters-cover-formalparameters-yield.js
-    ! syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
-    ! syntax/arrowparameters-cover-initialize-1.js
-    ! syntax/arrowparameters-cover-initialize-2.js
-    ! syntax/arrowparameters-cover-rest-concisebody-functionbody.js
-    ! syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
-    ! array-destructuring-param-strict-body.js
-    ! ArrowFunction_restricted-properties.js
-    ! dflt-params-trailing-comma.js
-    ! lexical-super-call-from-within-constructor.js
-    ! lexical-super-property-from-within-constructor.js
-    ! lexical-super-property.js
-    ! lexical-supercall-from-immediately-invoked-arrow.js
-    ! name.js
-    ! object-destructuring-param-strict-body.js
-    ! params-duplicate.js
-    ! params-trailing-comma-multiple.js
-    ! params-trailing-comma-single.js
-    ! rest-params-trailing-comma-early-error.js
-    ! scope-body-lex-distinct.js
-    ! scope-param-elem-var-close.js
-    ! scope-param-elem-var-open.js
-    ! scope-param-rest-elem-var-close.js
-    ! scope-param-rest-elem-var-open.js
-    ! scope-paramsbody-var-close.js
-    ! scope-paramsbody-var-open.js
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-init-ary.js
+    dstr/ary-ptrn-rest-init-id.js
+    dstr/ary-ptrn-rest-init-obj.js
+    dstr/ary-ptrn-rest-not-final-ary.js
+    dstr/ary-ptrn-rest-not-final-id.js
+    dstr/ary-ptrn-rest-not-final-obj.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-prop-obj.js
+    dstr/syntax-error-ident-ref-break-escaped.js
+    dstr/syntax-error-ident-ref-case-escaped.js
+    dstr/syntax-error-ident-ref-catch-escaped.js
+    dstr/syntax-error-ident-ref-class-escaped.js
+    dstr/syntax-error-ident-ref-const-escaped.js
+    dstr/syntax-error-ident-ref-continue-escaped.js
+    dstr/syntax-error-ident-ref-debugger-escaped.js
+    dstr/syntax-error-ident-ref-default-escaped-ext.js
+    dstr/syntax-error-ident-ref-default-escaped.js
+    dstr/syntax-error-ident-ref-default.js
+    dstr/syntax-error-ident-ref-delete-escaped.js
+    dstr/syntax-error-ident-ref-do-escaped.js
+    dstr/syntax-error-ident-ref-else-escaped.js
+    dstr/syntax-error-ident-ref-enum-escaped.js
+    dstr/syntax-error-ident-ref-export-escaped.js
+    dstr/syntax-error-ident-ref-extends-escaped-ext.js
+    dstr/syntax-error-ident-ref-extends-escaped.js
+    dstr/syntax-error-ident-ref-extends.js
+    dstr/syntax-error-ident-ref-finally-escaped.js
+    dstr/syntax-error-ident-ref-for-escaped.js
+    dstr/syntax-error-ident-ref-function-escaped.js
+    dstr/syntax-error-ident-ref-if-escaped.js
+    dstr/syntax-error-ident-ref-implements-escaped.js
+    dstr/syntax-error-ident-ref-import-escaped.js
+    dstr/syntax-error-ident-ref-in-escaped.js
+    dstr/syntax-error-ident-ref-instanceof-escaped.js
+    dstr/syntax-error-ident-ref-interface-escaped.js
+    dstr/syntax-error-ident-ref-let-escaped.js
+    dstr/syntax-error-ident-ref-new-escaped.js
+    dstr/syntax-error-ident-ref-package-escaped.js
+    dstr/syntax-error-ident-ref-private-escaped.js
+    dstr/syntax-error-ident-ref-protected-escaped.js
+    dstr/syntax-error-ident-ref-public-escaped.js
+    dstr/syntax-error-ident-ref-return-escaped.js
+    dstr/syntax-error-ident-ref-static-escaped.js
+    dstr/syntax-error-ident-ref-super-escaped.js
+    dstr/syntax-error-ident-ref-switch-escaped.js
+    dstr/syntax-error-ident-ref-this-escaped.js
+    dstr/syntax-error-ident-ref-throw-escaped.js
+    dstr/syntax-error-ident-ref-try-escaped.js
+    dstr/syntax-error-ident-ref-typeof-escaped.js
+    dstr/syntax-error-ident-ref-var-escaped.js
+    dstr/syntax-error-ident-ref-void-escaped.js
+    dstr/syntax-error-ident-ref-while-escaped.js
+    dstr/syntax-error-ident-ref-with-escaped.js
+    syntax/early-errors/arrowparameters-bindingidentifier-identifier-futurereservedword.js
+    syntax/early-errors/arrowparameters-bindingidentifier-identifier-strict-futurereservedword.js
+    syntax/early-errors/arrowparameters-bindingidentifier-identifier.js
+    syntax/early-errors/arrowparameters-bindingidentifier-no-arguments.js
+    syntax/early-errors/arrowparameters-bindingidentifier-no-eval.js
+    syntax/early-errors/arrowparameters-bindingidentifier-no-yield.js
+    syntax/early-errors/arrowparameters-bindingidentifier-rest.js
+    syntax/early-errors/arrowparameters-cover-no-arguments.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-3.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-4.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-5.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-rest.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates.js
+    syntax/early-errors/arrowparameters-cover-no-eval.js
+    syntax/early-errors/arrowparameters-cover-no-yield.js
+    syntax/early-errors/asi-restriction-invalid-parenless-parameters-expression-body.js
+    syntax/early-errors/asi-restriction-invalid-parenless-parameters.js
+    syntax/early-errors/asi-restriction-invalid.js
+    syntax/early-errors/use-strict-with-non-simple-param.js
+    syntax/arrowparameters-bindingidentifier-yield.js
+    syntax/arrowparameters-cover-formalparameters-yield.js
+    syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
+    syntax/arrowparameters-cover-initialize-1.js
+    syntax/arrowparameters-cover-initialize-2.js
+    syntax/arrowparameters-cover-rest-concisebody-functionbody.js
+    syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
+    array-destructuring-param-strict-body.js
+    ArrowFunction_restricted-properties.js
+    dflt-params-trailing-comma.js
+    lexical-super-call-from-within-constructor.js
+    lexical-super-property-from-within-constructor.js
+    lexical-super-property.js
+    lexical-supercall-from-immediately-invoked-arrow.js
+    name.js
+    object-destructuring-param-strict-body.js
+    params-duplicate.js
+    params-trailing-comma-multiple.js
+    params-trailing-comma-single.js
+    rest-params-trailing-comma-early-error.js
+    scope-body-lex-distinct.js
+    scope-param-elem-var-close.js
+    scope-param-elem-var-open.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
+    scope-paramsbody-var-close.js
+    scope-paramsbody-var-open.js
 
 language/expressions/bitwise-and
-    ! bigint-non-primitive.js
-    ! order-of-evaluation.js
+    bigint-non-primitive.js
+    order-of-evaluation.js
 
 language/expressions/bitwise-not
-    ! bigint-non-primitive.js
+    bigint-non-primitive.js
 
 language/expressions/bitwise-or
-    ! bigint-non-primitive.js
-    ! order-of-evaluation.js
+    bigint-non-primitive.js
+    order-of-evaluation.js
 
 language/expressions/bitwise-xor
-    ! bigint-non-primitive.js
-    ! order-of-evaluation.js
+    bigint-non-primitive.js
+    order-of-evaluation.js
 
 language/expressions/call
-    ! 11.2.3-3_1.js
-    ! 11.2.3-3_2.js
-    ! 11.2.3-3_4.js
-    ! 11.2.3-3_5.js
-    ! 11.2.3-3_6.js
-    ! 11.2.3-3_7.js
-    ! 11.2.3-3_8.js
-    ! eval-spread-empty-leading.js
-    ! eval-spread-empty-trailing.js
-    ! eval-spread-empty.js
-    ! eval-spread.js
-    ! spread-err-mult-err-expr-throws.js
-    ! spread-err-mult-err-iter-get-value.js
-    ! spread-err-mult-err-itr-get-call.js
-    ! spread-err-mult-err-itr-get-get.js
-    ! spread-err-mult-err-itr-step.js
-    ! spread-err-mult-err-itr-value.js
-    ! spread-err-mult-err-obj-unresolvable.js
-    ! spread-err-mult-err-unresolvable.js
-    ! spread-err-sngl-err-expr-throws.js
-    ! spread-err-sngl-err-itr-get-call.js
-    ! spread-err-sngl-err-itr-get-get.js
-    ! spread-err-sngl-err-itr-get-value.js
-    ! spread-err-sngl-err-itr-step.js
-    ! spread-err-sngl-err-itr-value.js
-    ! spread-err-sngl-err-obj-unresolvable.js
-    ! spread-err-sngl-err-unresolvable.js
-    ! spread-mult-empty.js
-    ! spread-mult-expr.js
-    ! spread-mult-iter.js
-    ! spread-mult-literal.js
-    ! spread-mult-obj-ident.js
-    ! spread-mult-obj-null.js
-    ! spread-mult-obj-undefined.js
-    ! spread-obj-getter-descriptor.js
-    ! spread-obj-getter-init.js
-    ! spread-obj-manipulate-outter-obj-in-getter.js
-    ! spread-obj-mult-spread-getter.js
-    ! spread-obj-mult-spread.js
-    ! spread-obj-null.js
-    ! spread-obj-override-immutable.js
-    ! spread-obj-overrides-prev-properties.js
-    ! spread-obj-skip-non-enumerable.js
-    ! spread-obj-spread-order.js
-    ! spread-obj-symbol-property.js
-    ! spread-obj-undefined.js
-    ! spread-obj-with-overrides.js
-    ! spread-sngl-empty.js
-    ! spread-sngl-expr.js
-    ! spread-sngl-iter.js
-    ! spread-sngl-literal.js
-    ! spread-sngl-obj-ident.js
-    ! trailing-comma.js
+    11.2.3-3_1.js
+    11.2.3-3_2.js
+    11.2.3-3_4.js
+    11.2.3-3_5.js
+    11.2.3-3_6.js
+    11.2.3-3_7.js
+    11.2.3-3_8.js
+    eval-spread-empty-leading.js
+    eval-spread-empty-trailing.js
+    eval-spread-empty.js
+    eval-spread.js
+    spread-err-mult-err-expr-throws.js
+    spread-err-mult-err-iter-get-value.js
+    spread-err-mult-err-itr-get-call.js
+    spread-err-mult-err-itr-get-get.js
+    spread-err-mult-err-itr-step.js
+    spread-err-mult-err-itr-value.js
+    spread-err-mult-err-obj-unresolvable.js
+    spread-err-mult-err-unresolvable.js
+    spread-err-sngl-err-expr-throws.js
+    spread-err-sngl-err-itr-get-call.js
+    spread-err-sngl-err-itr-get-get.js
+    spread-err-sngl-err-itr-get-value.js
+    spread-err-sngl-err-itr-step.js
+    spread-err-sngl-err-itr-value.js
+    spread-err-sngl-err-obj-unresolvable.js
+    spread-err-sngl-err-unresolvable.js
+    spread-mult-empty.js
+    spread-mult-expr.js
+    spread-mult-iter.js
+    spread-mult-literal.js
+    spread-mult-obj-ident.js
+    spread-mult-obj-null.js
+    spread-mult-obj-undefined.js
+    spread-obj-getter-descriptor.js
+    spread-obj-getter-init.js
+    spread-obj-manipulate-outter-obj-in-getter.js
+    spread-obj-mult-spread-getter.js
+    spread-obj-mult-spread.js
+    spread-obj-null.js
+    spread-obj-override-immutable.js
+    spread-obj-overrides-prev-properties.js
+    spread-obj-skip-non-enumerable.js
+    spread-obj-spread-order.js
+    spread-obj-symbol-property.js
+    spread-obj-undefined.js
+    spread-obj-with-overrides.js
+    spread-sngl-empty.js
+    spread-sngl-expr.js
+    spread-sngl-iter.js
+    spread-sngl-literal.js
+    spread-sngl-obj-ident.js
+    trailing-comma.js
 
-#language/expressions/class
+~language/expressions/class
 
 language/expressions/comma
 
 language/expressions/compound-assignment
-    ! 11.13.2-34-s.js
-    ! 11.13.2-35-s.js
-    ! 11.13.2-36-s.js
-    ! 11.13.2-37-s.js
-    ! 11.13.2-38-s.js
-    ! 11.13.2-39-s.js
-    ! 11.13.2-40-s.js
-    ! 11.13.2-41-s.js
-    ! 11.13.2-42-s.js
-    ! 11.13.2-43-s.js
-    ! 11.13.2-44-s.js
-    ! 11.13.2-6-1gs.js
-    ! add-arguments-strict.js
-    ! add-eval-strict.js
-    ! add-non-simple.js
-    ! and-arguments-strict.js
-    ! and-eval-strict.js
-    ! btws-and-non-simple.js
-    ! btws-or-non-simple.js
-    ! btws-xor-non-simple.js
-    ! div-arguments-strict.js
-    ! div-eval-strict.js
-    ! div-non-simple.js
-    ! left-shift-non-simple.js
-    ! lshift-arguments-strict.js
-    ! lshift-eval-strict.js
-    ! mod-arguments-strict.js
-    ! mod-div-non-simple.js
-    ! mod-eval-strict.js
-    ! mult-arguments-strict.js
-    ! mult-eval-strict.js
-    ! mult-non-simple.js
-    ! or-arguments-strict.js
-    ! or-eval-strict.js
-    ! right-shift-non-simple.js
-    ! S11.13.2_A7.10_T1.js
-    ! S11.13.2_A7.10_T2.js
-    ! S11.13.2_A7.10_T4.js
-    ! S11.13.2_A7.11_T1.js
-    ! S11.13.2_A7.11_T2.js
-    ! S11.13.2_A7.11_T4.js
-    ! S11.13.2_A7.1_T1.js
-    ! S11.13.2_A7.1_T2.js
-    ! S11.13.2_A7.1_T4.js
-    ! S11.13.2_A7.2_T1.js
-    ! S11.13.2_A7.2_T2.js
-    ! S11.13.2_A7.2_T4.js
-    ! S11.13.2_A7.3_T1.js
-    ! S11.13.2_A7.3_T2.js
-    ! S11.13.2_A7.3_T4.js
-    ! S11.13.2_A7.4_T1.js
-    ! S11.13.2_A7.4_T2.js
-    ! S11.13.2_A7.4_T4.js
-    ! S11.13.2_A7.5_T1.js
-    ! S11.13.2_A7.5_T2.js
-    ! S11.13.2_A7.5_T4.js
-    ! S11.13.2_A7.6_T1.js
-    ! S11.13.2_A7.6_T2.js
-    ! S11.13.2_A7.6_T4.js
-    ! S11.13.2_A7.7_T1.js
-    ! S11.13.2_A7.7_T2.js
-    ! S11.13.2_A7.7_T4.js
-    ! S11.13.2_A7.8_T1.js
-    ! S11.13.2_A7.8_T2.js
-    ! S11.13.2_A7.8_T4.js
-    ! S11.13.2_A7.9_T1.js
-    ! S11.13.2_A7.9_T2.js
-    ! S11.13.2_A7.9_T4.js
-    ! srshift-arguments-strict.js
-    ! srshift-eval-strict.js
-    ! sub-arguments-strict.js
-    ! sub-eval-strict.js
-    ! subtract-non-simple.js
-    ! urshift-arguments-strict.js
-    ! urshift-eval-strict.js
-    ! xor-arguments-strict.js
-    ! xor-eval-strict.js
+    11.13.2-34-s.js
+    11.13.2-35-s.js
+    11.13.2-36-s.js
+    11.13.2-37-s.js
+    11.13.2-38-s.js
+    11.13.2-39-s.js
+    11.13.2-40-s.js
+    11.13.2-41-s.js
+    11.13.2-42-s.js
+    11.13.2-43-s.js
+    11.13.2-44-s.js
+    11.13.2-6-1gs.js
+    add-arguments-strict.js
+    add-eval-strict.js
+    add-non-simple.js
+    and-arguments-strict.js
+    and-eval-strict.js
+    btws-and-non-simple.js
+    btws-or-non-simple.js
+    btws-xor-non-simple.js
+    div-arguments-strict.js
+    div-eval-strict.js
+    div-non-simple.js
+    left-shift-non-simple.js
+    lshift-arguments-strict.js
+    lshift-eval-strict.js
+    mod-arguments-strict.js
+    mod-div-non-simple.js
+    mod-eval-strict.js
+    mult-arguments-strict.js
+    mult-eval-strict.js
+    mult-non-simple.js
+    or-arguments-strict.js
+    or-eval-strict.js
+    right-shift-non-simple.js
+    S11.13.2_A7.10_T1.js
+    S11.13.2_A7.10_T2.js
+    S11.13.2_A7.10_T4.js
+    S11.13.2_A7.11_T1.js
+    S11.13.2_A7.11_T2.js
+    S11.13.2_A7.11_T4.js
+    S11.13.2_A7.1_T1.js
+    S11.13.2_A7.1_T2.js
+    S11.13.2_A7.1_T4.js
+    S11.13.2_A7.2_T1.js
+    S11.13.2_A7.2_T2.js
+    S11.13.2_A7.2_T4.js
+    S11.13.2_A7.3_T1.js
+    S11.13.2_A7.3_T2.js
+    S11.13.2_A7.3_T4.js
+    S11.13.2_A7.4_T1.js
+    S11.13.2_A7.4_T2.js
+    S11.13.2_A7.4_T4.js
+    S11.13.2_A7.5_T1.js
+    S11.13.2_A7.5_T2.js
+    S11.13.2_A7.5_T4.js
+    S11.13.2_A7.6_T1.js
+    S11.13.2_A7.6_T2.js
+    S11.13.2_A7.6_T4.js
+    S11.13.2_A7.7_T1.js
+    S11.13.2_A7.7_T2.js
+    S11.13.2_A7.7_T4.js
+    S11.13.2_A7.8_T1.js
+    S11.13.2_A7.8_T2.js
+    S11.13.2_A7.8_T4.js
+    S11.13.2_A7.9_T1.js
+    S11.13.2_A7.9_T2.js
+    S11.13.2_A7.9_T4.js
+    srshift-arguments-strict.js
+    srshift-eval-strict.js
+    sub-arguments-strict.js
+    sub-eval-strict.js
+    subtract-non-simple.js
+    urshift-arguments-strict.js
+    urshift-eval-strict.js
+    xor-arguments-strict.js
+    xor-eval-strict.js
 
 language/expressions/concatenation
 
 language/expressions/conditional
 
 language/expressions/delete
-    ! 11.4.1-5-a-28-s.js
-    ! 11.4.1-5-a-5gs.js
-    ! identifier-strict.js
+    11.4.1-5-a-28-s.js
+    11.4.1-5-a-5gs.js
+    identifier-strict.js
 
 language/expressions/division
-    ! order-of-evaluation.js
+    order-of-evaluation.js
 
 language/expressions/does-not-equals
 
 language/expressions/equals
-    ! coerce-symbol-to-prim-err.js
-    ! coerce-symbol-to-prim-invocation.js
-    ! coerce-symbol-to-prim-return-obj.js
-    ! coerce-symbol-to-prim-return-prim.js
-    ! get-symbol-to-prim-err.js
-    ! to-prim-hint.js
+    coerce-symbol-to-prim-err.js
+    coerce-symbol-to-prim-invocation.js
+    coerce-symbol-to-prim-return-obj.js
+    coerce-symbol-to-prim-return-prim.js
+    get-symbol-to-prim-err.js
+    to-prim-hint.js
 
 language/expressions/exponentiation
-    ! order-of-evaluation.js
+    order-of-evaluation.js
 
 language/expressions/function
-    ! dstr/ary-init-iter-close.js
-    ! dstr/ary-init-iter-get-err.js
-    ! dstr/ary-ptrn-elem-ary-elem-init.js
-    ! dstr/ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/ary-ptrn-elem-ary-elision-init.js
-    ! dstr/ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/ary-ptrn-elem-ary-empty-init.js
-    ! dstr/ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/ary-ptrn-elem-ary-rest-init.js
-    ! dstr/ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/ary-ptrn-elem-id-init-hole.js
-    ! dstr/ary-ptrn-elem-id-init-skipped.js
-    ! dstr/ary-ptrn-elem-id-init-throws.js
-    ! dstr/ary-ptrn-elem-id-init-undef.js
-    ! dstr/ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/ary-ptrn-elem-obj-id-init.js
-    ! dstr/ary-ptrn-elem-obj-id.js
-    ! dstr/ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/ary-ptrn-elem-obj-prop-id.js
-    ! dstr/ary-ptrn-elision-step-err.js
-    ! dstr/ary-ptrn-elision.js
-    ! dstr/ary-ptrn-rest-ary-elem.js
-    ! dstr/ary-ptrn-rest-ary-elision.js
-    ! dstr/ary-ptrn-rest-ary-empty.js
-    ! dstr/ary-ptrn-rest-ary-rest.js
-    ! dstr/ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/ary-ptrn-rest-id-elision.js
-    ! dstr/ary-ptrn-rest-id-exhausted.js
-    ! dstr/ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/ary-ptrn-rest-id.js
-    ! dstr/ary-ptrn-rest-init-ary.js
-    ! dstr/ary-ptrn-rest-init-id.js
-    ! dstr/ary-ptrn-rest-init-obj.js
-    ! dstr/ary-ptrn-rest-not-final-ary.js
-    ! dstr/ary-ptrn-rest-not-final-id.js
-    ! dstr/ary-ptrn-rest-not-final-obj.js
-    ! dstr/ary-ptrn-rest-obj-id.js
-    ! dstr/ary-ptrn-rest-obj-prop-id.js
-    ! dstr/obj-init-null.js
-    ! dstr/obj-init-undefined.js
-    ! dstr/obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/obj-ptrn-id-init-fn-name-class.js
-    ! dstr/obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/obj-ptrn-id-init-skipped.js
-    ! dstr/obj-ptrn-id-init-throws.js
-    ! dstr/obj-ptrn-id-init-unresolvable.js
-    ! dstr/obj-ptrn-list-err.js
-    ! dstr/obj-ptrn-prop-ary-init.js
-    ! dstr/obj-ptrn-prop-ary-value-null.js
-    ! dstr/obj-ptrn-prop-ary.js
-    ! dstr/obj-ptrn-prop-eval-err.js
-    ! dstr/obj-ptrn-prop-id-get-value-err.js
-    ! dstr/obj-ptrn-prop-id-init-skipped.js
-    ! dstr/obj-ptrn-prop-id-init-throws.js
-    ! dstr/obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/obj-ptrn-prop-id-init.js
-    ! dstr/obj-ptrn-prop-obj-init.js
-    ! dstr/obj-ptrn-prop-obj-value-null.js
-    ! dstr/obj-ptrn-prop-obj-value-undef.js
-    ! dstr/obj-ptrn-prop-obj.js
-    ! arguments-with-arguments-fn.js
-    ! arguments-with-arguments-lex.js
-    ! array-destructuring-param-strict-body.js
-    ! dflt-params-trailing-comma.js
-    ! name-arguments-strict-body.js
-    ! name-eval-strict-body.js
-    ! name.js
-    ! object-destructuring-param-strict-body.js
-    ! param-duplicated-strict-body-1.js
-    ! param-duplicated-strict-body-2.js
-    ! param-duplicated-strict-body-3.js
-    ! param-eval-strict-body.js
-    ! params-trailing-comma-multiple.js
-    ! params-trailing-comma-single.js
-    ! scope-body-lex-distinct.js
-    ! scope-name-var-open-non-strict.js
-    ! scope-name-var-open-strict.js
-    ! scope-param-elem-var-close.js
-    ! scope-param-elem-var-open.js
-    ! scope-param-rest-elem-var-close.js
-    ! scope-param-rest-elem-var-open.js
-    ! scope-paramsbody-var-close.js
-    ! scope-paramsbody-var-open.js
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-init-ary.js
+    dstr/ary-ptrn-rest-init-id.js
+    dstr/ary-ptrn-rest-init-obj.js
+    dstr/ary-ptrn-rest-not-final-ary.js
+    dstr/ary-ptrn-rest-not-final-id.js
+    dstr/ary-ptrn-rest-not-final-obj.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-prop-obj.js
+    arguments-with-arguments-fn.js
+    arguments-with-arguments-lex.js
+    array-destructuring-param-strict-body.js
+    dflt-params-trailing-comma.js
+    name-arguments-strict-body.js
+    name-eval-strict-body.js
+    name.js
+    object-destructuring-param-strict-body.js
+    param-duplicated-strict-body-1.js
+    param-duplicated-strict-body-2.js
+    param-duplicated-strict-body-3.js
+    param-eval-strict-body.js
+    params-trailing-comma-multiple.js
+    params-trailing-comma-single.js
+    scope-body-lex-distinct.js
+    scope-name-var-open-non-strict.js
+    scope-name-var-open-strict.js
+    scope-param-elem-var-close.js
+    scope-param-elem-var-open.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
+    scope-paramsbody-var-close.js
+    scope-paramsbody-var-open.js
 
 language/expressions/generators
-    ! dstr/ary-init-iter-close.js
-    ! dstr/ary-init-iter-get-err.js
-    ! dstr/ary-name-iter-val.js
-    ! dstr/ary-ptrn-elem-ary-elem-init.js
-    ! dstr/ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/ary-ptrn-elem-ary-elision-init.js
-    ! dstr/ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/ary-ptrn-elem-ary-empty-init.js
-    ! dstr/ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/ary-ptrn-elem-ary-rest-init.js
-    ! dstr/ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/ary-ptrn-elem-ary-val-null.js
-    ! dstr/ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/ary-ptrn-elem-id-init-hole.js
-    ! dstr/ary-ptrn-elem-id-init-skipped.js
-    ! dstr/ary-ptrn-elem-id-init-throws.js
-    ! dstr/ary-ptrn-elem-id-init-undef.js
-    ! dstr/ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/ary-ptrn-elem-id-iter-done.js
-    ! dstr/ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/ary-ptrn-elem-id-iter-val.js
-    ! dstr/ary-ptrn-elem-obj-id-init.js
-    ! dstr/ary-ptrn-elem-obj-id.js
-    ! dstr/ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/ary-ptrn-elem-obj-prop-id.js
-    ! dstr/ary-ptrn-elem-obj-val-null.js
-    ! dstr/ary-ptrn-elem-obj-val-undef.js
-    ! dstr/ary-ptrn-elision-step-err.js
-    ! dstr/ary-ptrn-elision.js
-    ! dstr/ary-ptrn-rest-ary-elem.js
-    ! dstr/ary-ptrn-rest-ary-elision.js
-    ! dstr/ary-ptrn-rest-ary-empty.js
-    ! dstr/ary-ptrn-rest-ary-rest.js
-    ! dstr/ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/ary-ptrn-rest-id-elision.js
-    ! dstr/ary-ptrn-rest-id-exhausted.js
-    ! dstr/ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/ary-ptrn-rest-id.js
-    ! dstr/ary-ptrn-rest-obj-id.js
-    ! dstr/ary-ptrn-rest-obj-prop-id.js
-    ! dstr/obj-init-null.js
-    ! dstr/obj-init-undefined.js
-    ! dstr/obj-ptrn-id-get-value-err.js
-    ! dstr/obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/obj-ptrn-id-init-fn-name-class.js
-    ! dstr/obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/obj-ptrn-id-init-skipped.js
-    ! dstr/obj-ptrn-id-init-throws.js
-    ! dstr/obj-ptrn-id-init-unresolvable.js
-    ! dstr/obj-ptrn-id-trailing-comma.js
-    ! dstr/obj-ptrn-list-err.js
-    ! dstr/obj-ptrn-prop-ary-init.js
-    ! dstr/obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/obj-ptrn-prop-ary-value-null.js
-    ! dstr/obj-ptrn-prop-ary.js
-    ! dstr/obj-ptrn-prop-eval-err.js
-    ! dstr/obj-ptrn-prop-id-get-value-err.js
-    ! dstr/obj-ptrn-prop-id-init-skipped.js
-    ! dstr/obj-ptrn-prop-id-init-throws.js
-    ! dstr/obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/obj-ptrn-prop-id-init.js
-    ! dstr/obj-ptrn-prop-obj-init.js
-    ! dstr/obj-ptrn-prop-obj-value-null.js
-    ! dstr/obj-ptrn-prop-obj-value-undef.js
-    ! dstr/obj-ptrn-prop-obj.js
-    ! arguments-with-arguments-fn.js
-    ! arguments-with-arguments-lex.js
-    ! array-destructuring-param-strict-body.js
-    ! default-proto.js
-    ! dflt-params-trailing-comma.js
-    ! generator-created-after-decl-inst.js
-    ! has-instance.js
-    ! implicit-name.js
-    ! invoke-as-constructor.js
-    ! length-property-descriptor.js
-    ! name.js
-    ! named-yield-as-binding-identifier-escaped.js
-    ! named-yield-as-identifier-reference-escaped.js
-    ! named-yield-as-label-identifier-escaped.js
-    ! named-yield-identifier-non-strict.js
-    ! named-yield-identifier-spread-non-strict.js
-    ! named-yield-spread-arr-multiple.js
-    ! named-yield-spread-arr-single.js
-    ! named-yield-spread-obj.js
-    ! object-destructuring-param-strict-body.js
-    ! params-trailing-comma-multiple.js
-    ! params-trailing-comma-single.js
-    ! prototype-own-properties.js
-    ! prototype-relation-to-function.js
-    ! prototype-value.js
-    ! scope-body-lex-distinct.js
-    ! scope-name-var-close.js
-    ! scope-name-var-open-non-strict.js
-    ! scope-name-var-open-strict.js
-    ! scope-param-elem-var-close.js
-    ! scope-param-elem-var-open.js
-    ! scope-param-rest-elem-var-close.js
-    ! scope-param-rest-elem-var-open.js
-    ! scope-paramsbody-var-close.js
-    ! scope-paramsbody-var-open.js
-    ! yield-as-binding-identifier-escaped.js
-    ! yield-as-function-expression-binding-identifier.js
-    ! yield-as-identifier-in-nested-function.js
-    ! yield-as-identifier-reference-escaped.js
-    ! yield-as-label-identifier-escaped.js
-    ! yield-identifier-non-strict.js
-    ! yield-identifier-spread-non-strict.js
-    ! yield-spread-arr-multiple.js
-    ! yield-spread-arr-single.js
-    ! yield-spread-obj.js
-    ! yield-star-after-newline.js
-    ! yield-star-before-newline.js
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-name-iter-val.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-ary-val-null.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-done.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-id-iter-val.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-val-null.js
+    dstr/ary-ptrn-elem-obj-val-undef.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-get-value-err.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-id-trailing-comma.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-trailing-comma.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-prop-obj.js
+    arguments-with-arguments-fn.js
+    arguments-with-arguments-lex.js
+    array-destructuring-param-strict-body.js
+    default-proto.js
+    dflt-params-trailing-comma.js
+    generator-created-after-decl-inst.js
+    has-instance.js
+    implicit-name.js
+    invoke-as-constructor.js
+    length-property-descriptor.js
+    name.js
+    named-yield-as-binding-identifier-escaped.js
+    named-yield-as-identifier-reference-escaped.js
+    named-yield-as-label-identifier-escaped.js
+    named-yield-identifier-non-strict.js
+    named-yield-identifier-spread-non-strict.js
+    named-yield-spread-arr-multiple.js
+    named-yield-spread-arr-single.js
+    named-yield-spread-obj.js
+    object-destructuring-param-strict-body.js
+    params-trailing-comma-multiple.js
+    params-trailing-comma-single.js
+    prototype-own-properties.js
+    prototype-relation-to-function.js
+    prototype-value.js
+    scope-body-lex-distinct.js
+    scope-name-var-close.js
+    scope-name-var-open-non-strict.js
+    scope-name-var-open-strict.js
+    scope-param-elem-var-close.js
+    scope-param-elem-var-open.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
+    scope-paramsbody-var-close.js
+    scope-paramsbody-var-open.js
+    yield-as-binding-identifier-escaped.js
+    yield-as-function-expression-binding-identifier.js
+    yield-as-identifier-in-nested-function.js
+    yield-as-identifier-reference-escaped.js
+    yield-as-label-identifier-escaped.js
+    yield-identifier-non-strict.js
+    yield-identifier-spread-non-strict.js
+    yield-spread-arr-multiple.js
+    yield-spread-arr-single.js
+    yield-spread-obj.js
+    yield-star-after-newline.js
+    yield-star-before-newline.js
 
 language/expressions/greater-than
-    ! bigint-and-incomparable-string.js
-    ! bigint-and-string.js
+    bigint-and-incomparable-string.js
+    bigint-and-string.js
 
 language/expressions/greater-than-or-equal
-    ! bigint-and-incomparable-string.js
+    bigint-and-incomparable-string.js
 
 language/expressions/grouping
 
 language/expressions/in
 
 language/expressions/instanceof
-    ! S11.8.6_A6_T1.js
-    ! S11.8.6_A6_T2.js
-    ! S11.8.6_A6_T4.js
-    ! symbol-hasinstance-get-err.js
-    ! symbol-hasinstance-invocation.js
-    ! symbol-hasinstance-not-callable.js
-    ! symbol-hasinstance-to-boolean.js
+    S11.8.6_A6_T1.js
+    S11.8.6_A6_T2.js
+    S11.8.6_A6_T4.js
+    symbol-hasinstance-get-err.js
+    symbol-hasinstance-invocation.js
+    symbol-hasinstance-not-callable.js
+    symbol-hasinstance-to-boolean.js
 
 language/expressions/left-shift
-    ! bigint-non-primitive.js
-    ! order-of-evaluation.js
+    bigint-non-primitive.js
+    order-of-evaluation.js
 
 language/expressions/less-than
-    ! bigint-and-incomparable-string.js
+    bigint-and-incomparable-string.js
 
 language/expressions/less-than-or-equal
-    ! bigint-and-incomparable-string.js
-    ! bigint-and-string.js
+    bigint-and-incomparable-string.js
+    bigint-and-string.js
 
 language/expressions/logical-and
 
@@ -3217,1714 +3182,1713 @@ language/expressions/logical-not
 language/expressions/logical-or
 
 language/expressions/modulus
-    ! order-of-evaluation.js
+    order-of-evaluation.js
 
 language/expressions/multiplication
-    ! order-of-evaluation.js
+    order-of-evaluation.js
 
 language/expressions/object
-    ! dstr/gen-meth-ary-init-iter-close.js
-    ! dstr/gen-meth-ary-init-iter-get-err.js
-    ! dstr/gen-meth-ary-init-iter-no-close.js
-    ! dstr/gen-meth-ary-name-iter-val.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/gen-meth-ary-ptrn-elem-ary-val-null.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-hole.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-throws.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-undef.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-iter-complete.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-iter-done.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/gen-meth-ary-ptrn-elem-id-iter-val.js
-    ! dstr/gen-meth-ary-ptrn-elem-obj-id-init.js
-    ! dstr/gen-meth-ary-ptrn-elem-obj-id.js
-    ! dstr/gen-meth-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/gen-meth-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/gen-meth-ary-ptrn-elem-obj-val-null.js
-    ! dstr/gen-meth-ary-ptrn-elem-obj-val-undef.js
-    ! dstr/gen-meth-ary-ptrn-elision-exhausted.js
-    ! dstr/gen-meth-ary-ptrn-elision-step-err.js
-    ! dstr/gen-meth-ary-ptrn-elision.js
-    ! dstr/gen-meth-ary-ptrn-empty.js
-    ! dstr/gen-meth-ary-ptrn-rest-ary-elem.js
-    ! dstr/gen-meth-ary-ptrn-rest-ary-elision.js
-    ! dstr/gen-meth-ary-ptrn-rest-ary-empty.js
-    ! dstr/gen-meth-ary-ptrn-rest-ary-rest.js
-    ! dstr/gen-meth-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/gen-meth-ary-ptrn-rest-id-elision.js
-    ! dstr/gen-meth-ary-ptrn-rest-id-exhausted.js
-    ! dstr/gen-meth-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/gen-meth-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/gen-meth-ary-ptrn-rest-id.js
-    ! dstr/gen-meth-ary-ptrn-rest-obj-id.js
-    ! dstr/gen-meth-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/gen-meth-obj-init-null.js
-    ! dstr/gen-meth-obj-init-undefined.js
-    ! dstr/gen-meth-obj-ptrn-empty.js
-    ! dstr/gen-meth-obj-ptrn-id-get-value-err.js
-    ! dstr/gen-meth-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/gen-meth-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/gen-meth-obj-ptrn-id-init-skipped.js
-    ! dstr/gen-meth-obj-ptrn-id-init-throws.js
-    ! dstr/gen-meth-obj-ptrn-id-init-unresolvable.js
-    ! dstr/gen-meth-obj-ptrn-id-trailing-comma.js
-    ! dstr/gen-meth-obj-ptrn-list-err.js
-    ! dstr/gen-meth-obj-ptrn-prop-ary-init.js
-    ! dstr/gen-meth-obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/gen-meth-obj-ptrn-prop-ary-value-null.js
-    ! dstr/gen-meth-obj-ptrn-prop-ary.js
-    ! dstr/gen-meth-obj-ptrn-prop-eval-err.js
-    ! dstr/gen-meth-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/gen-meth-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/gen-meth-obj-ptrn-prop-id-init-throws.js
-    ! dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/gen-meth-obj-ptrn-prop-id-init.js
-    ! dstr/gen-meth-obj-ptrn-prop-id-trailing-comma.js
-    ! dstr/gen-meth-obj-ptrn-prop-id.js
-    ! dstr/gen-meth-obj-ptrn-prop-obj-init.js
-    ! dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
-    ! dstr/gen-meth-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/gen-meth-obj-ptrn-prop-obj.js
-    ! dstr/meth-ary-init-iter-close.js
-    ! dstr/meth-ary-init-iter-get-err.js
-    ! dstr/meth-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/meth-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/meth-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/meth-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/meth-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/meth-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/meth-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/meth-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/meth-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/meth-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/meth-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/meth-ary-ptrn-elem-id-init-hole.js
-    ! dstr/meth-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/meth-ary-ptrn-elem-id-init-throws.js
-    ! dstr/meth-ary-ptrn-elem-id-init-undef.js
-    ! dstr/meth-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/meth-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/meth-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/meth-ary-ptrn-elem-obj-id-init.js
-    ! dstr/meth-ary-ptrn-elem-obj-id.js
-    ! dstr/meth-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/meth-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/meth-ary-ptrn-elision-step-err.js
-    ! dstr/meth-ary-ptrn-elision.js
-    ! dstr/meth-ary-ptrn-rest-ary-elem.js
-    ! dstr/meth-ary-ptrn-rest-ary-elision.js
-    ! dstr/meth-ary-ptrn-rest-ary-empty.js
-    ! dstr/meth-ary-ptrn-rest-ary-rest.js
-    ! dstr/meth-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/meth-ary-ptrn-rest-id-elision.js
-    ! dstr/meth-ary-ptrn-rest-id-exhausted.js
-    ! dstr/meth-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/meth-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/meth-ary-ptrn-rest-id.js
-    ! dstr/meth-ary-ptrn-rest-obj-id.js
-    ! dstr/meth-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/meth-obj-init-null.js
-    ! dstr/meth-obj-init-undefined.js
-    ! dstr/meth-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/meth-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/meth-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/meth-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/meth-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/meth-obj-ptrn-id-init-skipped.js
-    ! dstr/meth-obj-ptrn-id-init-throws.js
-    ! dstr/meth-obj-ptrn-id-init-unresolvable.js
-    ! dstr/meth-obj-ptrn-list-err.js
-    ! dstr/meth-obj-ptrn-prop-ary-init.js
-    ! dstr/meth-obj-ptrn-prop-ary-value-null.js
-    ! dstr/meth-obj-ptrn-prop-ary.js
-    ! dstr/meth-obj-ptrn-prop-eval-err.js
-    ! dstr/meth-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/meth-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/meth-obj-ptrn-prop-id-init-throws.js
-    ! dstr/meth-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/meth-obj-ptrn-prop-id-init.js
-    ! dstr/meth-obj-ptrn-prop-obj-init.js
-    ! dstr/meth-obj-ptrn-prop-obj-value-null.js
-    ! dstr/meth-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/meth-obj-ptrn-prop-obj.js
-    ! method-definition/early-errors-object-method-duplicate-parameters.js
-    ! method-definition/escaped-get.js
-    ! method-definition/escaped-set.js
-    ! method-definition/fn-name-fn.js
-    ! method-definition/fn-name-gen.js
-    ! method-definition/gen-meth-dflt-params-trailing-comma.js
-    ! method-definition/gen-meth-params-trailing-comma-multiple.js
-    ! method-definition/gen-meth-params-trailing-comma-single.js
-    ! method-definition/gen-yield-identifier-non-strict.js
-    ! method-definition/gen-yield-identifier-spread-non-strict.js
-    ! method-definition/gen-yield-spread-arr-multiple.js
-    ! method-definition/gen-yield-spread-arr-single.js
-    ! method-definition/gen-yield-spread-obj.js
-    ! method-definition/generator-invoke-ctor.js
-    ! method-definition/generator-invoke-fn-no-strict.js
-    ! method-definition/generator-invoke-fn-strict.js
-    ! method-definition/generator-length.js
-    ! method-definition/generator-name-prop-string.js
-    ! method-definition/generator-name-prop-symbol.js
-    ! method-definition/generator-no-yield.js
-    ! method-definition/generator-params.js
-    ! method-definition/generator-prop-name-eval-error.js
-    ! method-definition/generator-prop-name-yield-expr.js
-    ! method-definition/generator-prop-name-yield-id.js
-    ! method-definition/generator-property-desc.js
-    ! method-definition/generator-prototype-prop.js
-    ! method-definition/generator-prototype.js
-    ! method-definition/generator-return.js
-    ! method-definition/generator-super-prop-body.js
-    ! method-definition/meth-array-destructuring-param-strict-body.js
-    ! method-definition/meth-dflt-params-trailing-comma.js
-    ! method-definition/meth-object-destructuring-param-strict-body.js
-    ! method-definition/meth-params-trailing-comma-multiple.js
-    ! method-definition/meth-params-trailing-comma-single.js
-    ! method-definition/name-invoke-ctor.js
-    ! method-definition/name-invoke-fn-strict.js
-    ! method-definition/name-length.js
-    ! method-definition/name-name-prop-string.js
-    ! method-definition/name-name-prop-symbol.js
-    ! method-definition/name-param-id-yield.js
-    ! method-definition/name-param-init-yield.js
-    ! method-definition/name-param-redecl.js
-    ! method-definition/name-prop-name-eval-error.js
-    ! method-definition/name-prop-name-yield-expr.js
-    ! method-definition/name-prop-name-yield-id.js
-    ! method-definition/name-prototype-prop.js
-    ! method-definition/object-method-returns-promise.js
-    ! method-definition/yield-as-expression-with-rhs.js
-    ! method-definition/yield-as-expression-without-rhs.js
-    ! method-definition/yield-as-function-expression-binding-identifier.js
-    ! method-definition/yield-as-generator-method-binding-identifier.js
-    ! method-definition/yield-as-identifier-in-nested-function.js
-    ! method-definition/yield-as-literal-property-name.js
-    ! method-definition/yield-as-property-name.js
-    ! method-definition/yield-as-statement.js
-    ! method-definition/yield-as-yield-operand.js
-    ! method-definition/yield-newline.js
-    ! method-definition/yield-return.js
-    ! method-definition/yield-star-before-newline.js
-    ! 11.1.5-2gs.js
-    ! 11.1.5_4-4-a-3.js
-    ! 11.1.5_4-4-b-1.js
-    ! __proto__-permitted-dup.js
-    ! accessor-name-computed-err-evaluation.js
-    ! accessor-name-computed-err-to-prop-key.js
-    ! accessor-name-computed-err-unresolvable.js
-    ! accessor-name-computed-in.js
-    ! accessor-name-computed-yield-expr.js
-    ! accessor-name-computed-yield-id.js
-    ! accessor-name-computed.js
-    ! accessor-name-literal-numeric-binary.js
-    ! accessor-name-literal-numeric-exponent.js
-    ! accessor-name-literal-numeric-hex.js
-    ! accessor-name-literal-numeric-leading-decimal.js
-    ! accessor-name-literal-numeric-non-canonical.js
-    ! accessor-name-literal-numeric-octal.js
-    ! accessor-name-literal-numeric-zero.js
-    ! accessor-name-literal-string-char-escape.js
-    ! accessor-name-literal-string-default-escaped-ext.js
-    ! accessor-name-literal-string-default-escaped.js
-    ! accessor-name-literal-string-default.js
-    ! accessor-name-literal-string-double-quote.js
-    ! accessor-name-literal-string-empty.js
-    ! accessor-name-literal-string-hex-escape.js
-    ! accessor-name-literal-string-line-continuation.js
-    ! accessor-name-literal-string-single-quote.js
-    ! accessor-name-literal-string-unicode-escape.js
-    ! computed-__proto__.js
-    ! computed-property-evaluation-order.js
-    ! concise-generator.js
-    ! covered-ident-name-prop-name-literal-break-escaped.js
-    ! covered-ident-name-prop-name-literal-case-escaped.js
-    ! covered-ident-name-prop-name-literal-catch-escaped.js
-    ! covered-ident-name-prop-name-literal-class-escaped.js
-    ! covered-ident-name-prop-name-literal-const-escaped.js
-    ! covered-ident-name-prop-name-literal-continue-escaped.js
-    ! covered-ident-name-prop-name-literal-debugger-escaped.js
-    ! covered-ident-name-prop-name-literal-default-escaped-ext.js
-    ! covered-ident-name-prop-name-literal-default-escaped.js
-    ! covered-ident-name-prop-name-literal-delete-escaped.js
-    ! covered-ident-name-prop-name-literal-do-escaped.js
-    ! covered-ident-name-prop-name-literal-else-escaped.js
-    ! covered-ident-name-prop-name-literal-enum-escaped.js
-    ! covered-ident-name-prop-name-literal-export-escaped.js
-    ! covered-ident-name-prop-name-literal-extends-escaped-ext.js
-    ! covered-ident-name-prop-name-literal-extends-escaped.js
-    ! covered-ident-name-prop-name-literal-finally-escaped.js
-    ! covered-ident-name-prop-name-literal-for-escaped.js
-    ! covered-ident-name-prop-name-literal-function-escaped.js
-    ! covered-ident-name-prop-name-literal-if-escaped.js
-    ! covered-ident-name-prop-name-literal-implements-escaped.js
-    ! covered-ident-name-prop-name-literal-import-escaped.js
-    ! covered-ident-name-prop-name-literal-in-escaped.js
-    ! covered-ident-name-prop-name-literal-instanceof-escaped.js
-    ! covered-ident-name-prop-name-literal-interface-escaped.js
-    ! covered-ident-name-prop-name-literal-let-escaped.js
-    ! covered-ident-name-prop-name-literal-new-escaped.js
-    ! covered-ident-name-prop-name-literal-package-escaped.js
-    ! covered-ident-name-prop-name-literal-private-escaped.js
-    ! covered-ident-name-prop-name-literal-protected-escaped.js
-    ! covered-ident-name-prop-name-literal-public-escaped.js
-    ! covered-ident-name-prop-name-literal-return-escaped.js
-    ! covered-ident-name-prop-name-literal-static-escaped.js
-    ! covered-ident-name-prop-name-literal-super-escaped.js
-    ! covered-ident-name-prop-name-literal-switch-escaped.js
-    ! covered-ident-name-prop-name-literal-this-escaped.js
-    ! covered-ident-name-prop-name-literal-throw-escaped.js
-    ! covered-ident-name-prop-name-literal-try-escaped.js
-    ! covered-ident-name-prop-name-literal-typeof-escaped.js
-    ! covered-ident-name-prop-name-literal-var-escaped.js
-    ! covered-ident-name-prop-name-literal-void-escaped.js
-    ! covered-ident-name-prop-name-literal-while-escaped.js
-    ! covered-ident-name-prop-name-literal-with-escaped.js
-    ! fn-name-accessor-get.js
-    ! fn-name-accessor-set.js
-    ! fn-name-arrow.js
-    ! fn-name-cover.js
-    ! fn-name-fn.js
-    ! fn-name-gen.js
-    ! getter-body-strict-inside.js
-    ! getter-body-strict-outside.js
-    ! getter-super-prop.js
-    ! ident-name-method-def-break-escaped.js
-    ! ident-name-method-def-case-escaped.js
-    ! ident-name-method-def-catch-escaped.js
-    ! ident-name-method-def-class-escaped.js
-    ! ident-name-method-def-const-escaped.js
-    ! ident-name-method-def-continue-escaped.js
-    ! ident-name-method-def-debugger-escaped.js
-    ! ident-name-method-def-default-escaped-ext.js
-    ! ident-name-method-def-default-escaped.js
-    ! ident-name-method-def-delete-escaped.js
-    ! ident-name-method-def-do-escaped.js
-    ! ident-name-method-def-else-escaped.js
-    ! ident-name-method-def-enum-escaped.js
-    ! ident-name-method-def-export-escaped.js
-    ! ident-name-method-def-extends-escaped-ext.js
-    ! ident-name-method-def-extends-escaped.js
-    ! ident-name-method-def-finally-escaped.js
-    ! ident-name-method-def-for-escaped.js
-    ! ident-name-method-def-function-escaped.js
-    ! ident-name-method-def-if-escaped.js
-    ! ident-name-method-def-implements-escaped.js
-    ! ident-name-method-def-import-escaped.js
-    ! ident-name-method-def-in-escaped.js
-    ! ident-name-method-def-instanceof-escaped.js
-    ! ident-name-method-def-interface-escaped.js
-    ! ident-name-method-def-let-escaped.js
-    ! ident-name-method-def-new-escaped.js
-    ! ident-name-method-def-package-escaped.js
-    ! ident-name-method-def-private-escaped.js
-    ! ident-name-method-def-protected-escaped.js
-    ! ident-name-method-def-public-escaped.js
-    ! ident-name-method-def-return-escaped.js
-    ! ident-name-method-def-static-escaped.js
-    ! ident-name-method-def-super-escaped.js
-    ! ident-name-method-def-switch-escaped.js
-    ! ident-name-method-def-this-escaped.js
-    ! ident-name-method-def-throw-escaped.js
-    ! ident-name-method-def-try-escaped.js
-    ! ident-name-method-def-typeof-escaped.js
-    ! ident-name-method-def-var-escaped.js
-    ! ident-name-method-def-void-escaped.js
-    ! ident-name-method-def-while-escaped.js
-    ! ident-name-method-def-with-escaped.js
-    ! ident-name-prop-name-literal-break-escaped.js
-    ! ident-name-prop-name-literal-case-escaped.js
-    ! ident-name-prop-name-literal-catch-escaped.js
-    ! ident-name-prop-name-literal-class-escaped.js
-    ! ident-name-prop-name-literal-const-escaped.js
-    ! ident-name-prop-name-literal-continue-escaped.js
-    ! ident-name-prop-name-literal-debugger-escaped.js
-    ! ident-name-prop-name-literal-default-escaped-ext.js
-    ! ident-name-prop-name-literal-default-escaped.js
-    ! ident-name-prop-name-literal-delete-escaped.js
-    ! ident-name-prop-name-literal-do-escaped.js
-    ! ident-name-prop-name-literal-else-escaped.js
-    ! ident-name-prop-name-literal-enum-escaped.js
-    ! ident-name-prop-name-literal-export-escaped.js
-    ! ident-name-prop-name-literal-extends-escaped-ext.js
-    ! ident-name-prop-name-literal-extends-escaped.js
-    ! ident-name-prop-name-literal-finally-escaped.js
-    ! ident-name-prop-name-literal-for-escaped.js
-    ! ident-name-prop-name-literal-function-escaped.js
-    ! ident-name-prop-name-literal-if-escaped.js
-    ! ident-name-prop-name-literal-implements-escaped.js
-    ! ident-name-prop-name-literal-import-escaped.js
-    ! ident-name-prop-name-literal-in-escaped.js
-    ! ident-name-prop-name-literal-instanceof-escaped.js
-    ! ident-name-prop-name-literal-interface-escaped.js
-    ! ident-name-prop-name-literal-let-escaped.js
-    ! ident-name-prop-name-literal-new-escaped.js
-    ! ident-name-prop-name-literal-package-escaped.js
-    ! ident-name-prop-name-literal-private-escaped.js
-    ! ident-name-prop-name-literal-protected-escaped.js
-    ! ident-name-prop-name-literal-public-escaped.js
-    ! ident-name-prop-name-literal-return-escaped.js
-    ! ident-name-prop-name-literal-static-escaped.js
-    ! ident-name-prop-name-literal-super-escaped.js
-    ! ident-name-prop-name-literal-switch-escaped.js
-    ! ident-name-prop-name-literal-this-escaped.js
-    ! ident-name-prop-name-literal-throw-escaped.js
-    ! ident-name-prop-name-literal-try-escaped.js
-    ! ident-name-prop-name-literal-typeof-escaped.js
-    ! ident-name-prop-name-literal-var-escaped.js
-    ! ident-name-prop-name-literal-void-escaped.js
-    ! ident-name-prop-name-literal-while-escaped.js
-    ! ident-name-prop-name-literal-with-escaped.js
-    ! let-non-strict-access.js
-    ! let-non-strict-syntax.js
-    ! method.js
-    ! prop-def-id-eval-error.js
-    ! prop-dup-data-data.js
-    ! prop-dup-data-set.js
-    ! prop-dup-get-data.js
-    ! prop-dup-get-get.js
-    ! prop-dup-get-set-get.js
-    ! prop-dup-set-data.js
-    ! prop-dup-set-get-set.js
-    ! prop-dup-set-set.js
-    ! scope-gen-meth-body-lex-distinct.js
-    ! scope-gen-meth-param-elem-var-close.js
-    ! scope-gen-meth-param-elem-var-open.js
-    ! scope-gen-meth-param-rest-elem-var-close.js
-    ! scope-gen-meth-param-rest-elem-var-open.js
-    ! scope-gen-meth-paramsbody-var-close.js
-    ! scope-gen-meth-paramsbody-var-open.js
-    ! scope-getter-body-lex-distinc.js
-    ! scope-meth-body-lex-distinct.js
-    ! scope-meth-param-elem-var-close.js
-    ! scope-meth-param-elem-var-open.js
-    ! scope-meth-param-rest-elem-var-close.js
-    ! scope-meth-param-rest-elem-var-open.js
-    ! scope-meth-paramsbody-var-close.js
-    ! scope-meth-paramsbody-var-open.js
-    ! scope-setter-body-lex-distinc.js
-    ! scope-setter-paramsbody-var-close.js
-    ! scope-setter-paramsbody-var-open.js
-    ! setter-body-strict-inside.js
-    ! setter-body-strict-outside.js
-    ! setter-param-arguments-strict-inside.js
-    ! setter-param-eval-strict-inside.js
-    ! setter-super-prop.js
-    ! yield-non-strict-access.js
-    ! yield-non-strict-syntax.js
+    dstr/gen-meth-ary-init-iter-close.js
+    dstr/gen-meth-ary-init-iter-get-err.js
+    dstr/gen-meth-ary-init-iter-no-close.js
+    dstr/gen-meth-ary-name-iter-val.js
+    dstr/gen-meth-ary-ptrn-elem-ary-elem-init.js
+    dstr/gen-meth-ary-ptrn-elem-ary-elem-iter.js
+    dstr/gen-meth-ary-ptrn-elem-ary-elision-init.js
+    dstr/gen-meth-ary-ptrn-elem-ary-elision-iter.js
+    dstr/gen-meth-ary-ptrn-elem-ary-empty-init.js
+    dstr/gen-meth-ary-ptrn-elem-ary-empty-iter.js
+    dstr/gen-meth-ary-ptrn-elem-ary-rest-init.js
+    dstr/gen-meth-ary-ptrn-elem-ary-rest-iter.js
+    dstr/gen-meth-ary-ptrn-elem-ary-val-null.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-exhausted.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-hole.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-skipped.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-throws.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-undef.js
+    dstr/gen-meth-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-complete.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-done.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-step-err.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-val-err.js
+    dstr/gen-meth-ary-ptrn-elem-id-iter-val.js
+    dstr/gen-meth-ary-ptrn-elem-obj-id-init.js
+    dstr/gen-meth-ary-ptrn-elem-obj-id.js
+    dstr/gen-meth-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/gen-meth-ary-ptrn-elem-obj-prop-id.js
+    dstr/gen-meth-ary-ptrn-elem-obj-val-null.js
+    dstr/gen-meth-ary-ptrn-elem-obj-val-undef.js
+    dstr/gen-meth-ary-ptrn-elision-exhausted.js
+    dstr/gen-meth-ary-ptrn-elision-step-err.js
+    dstr/gen-meth-ary-ptrn-elision.js
+    dstr/gen-meth-ary-ptrn-empty.js
+    dstr/gen-meth-ary-ptrn-rest-ary-elem.js
+    dstr/gen-meth-ary-ptrn-rest-ary-elision.js
+    dstr/gen-meth-ary-ptrn-rest-ary-empty.js
+    dstr/gen-meth-ary-ptrn-rest-ary-rest.js
+    dstr/gen-meth-ary-ptrn-rest-id-elision-next-err.js
+    dstr/gen-meth-ary-ptrn-rest-id-elision.js
+    dstr/gen-meth-ary-ptrn-rest-id-exhausted.js
+    dstr/gen-meth-ary-ptrn-rest-id-iter-step-err.js
+    dstr/gen-meth-ary-ptrn-rest-id-iter-val-err.js
+    dstr/gen-meth-ary-ptrn-rest-id.js
+    dstr/gen-meth-ary-ptrn-rest-obj-id.js
+    dstr/gen-meth-ary-ptrn-rest-obj-prop-id.js
+    dstr/gen-meth-obj-init-null.js
+    dstr/gen-meth-obj-init-undefined.js
+    dstr/gen-meth-obj-ptrn-empty.js
+    dstr/gen-meth-obj-ptrn-id-get-value-err.js
+    dstr/gen-meth-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+    dstr/gen-meth-obj-ptrn-id-init-fn-name-cover.js
+    dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+    dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+    dstr/gen-meth-obj-ptrn-id-init-skipped.js
+    dstr/gen-meth-obj-ptrn-id-init-throws.js
+    dstr/gen-meth-obj-ptrn-id-init-unresolvable.js
+    dstr/gen-meth-obj-ptrn-id-trailing-comma.js
+    dstr/gen-meth-obj-ptrn-list-err.js
+    dstr/gen-meth-obj-ptrn-prop-ary-init.js
+    dstr/gen-meth-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/gen-meth-obj-ptrn-prop-ary-value-null.js
+    dstr/gen-meth-obj-ptrn-prop-ary.js
+    dstr/gen-meth-obj-ptrn-prop-eval-err.js
+    dstr/gen-meth-obj-ptrn-prop-id-get-value-err.js
+    dstr/gen-meth-obj-ptrn-prop-id-init-skipped.js
+    dstr/gen-meth-obj-ptrn-prop-id-init-throws.js
+    dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/gen-meth-obj-ptrn-prop-id-init.js
+    dstr/gen-meth-obj-ptrn-prop-id-trailing-comma.js
+    dstr/gen-meth-obj-ptrn-prop-id.js
+    dstr/gen-meth-obj-ptrn-prop-obj-init.js
+    dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
+    dstr/gen-meth-obj-ptrn-prop-obj-value-undef.js
+    dstr/gen-meth-obj-ptrn-prop-obj.js
+    dstr/meth-ary-init-iter-close.js
+    dstr/meth-ary-init-iter-get-err.js
+    dstr/meth-ary-ptrn-elem-ary-elem-init.js
+    dstr/meth-ary-ptrn-elem-ary-elem-iter.js
+    dstr/meth-ary-ptrn-elem-ary-elision-init.js
+    dstr/meth-ary-ptrn-elem-ary-elision-iter.js
+    dstr/meth-ary-ptrn-elem-ary-empty-init.js
+    dstr/meth-ary-ptrn-elem-ary-empty-iter.js
+    dstr/meth-ary-ptrn-elem-ary-rest-init.js
+    dstr/meth-ary-ptrn-elem-ary-rest-iter.js
+    dstr/meth-ary-ptrn-elem-id-init-exhausted.js
+    dstr/meth-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/meth-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/meth-ary-ptrn-elem-id-init-hole.js
+    dstr/meth-ary-ptrn-elem-id-init-skipped.js
+    dstr/meth-ary-ptrn-elem-id-init-throws.js
+    dstr/meth-ary-ptrn-elem-id-init-undef.js
+    dstr/meth-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/meth-ary-ptrn-elem-id-iter-step-err.js
+    dstr/meth-ary-ptrn-elem-id-iter-val-err.js
+    dstr/meth-ary-ptrn-elem-obj-id-init.js
+    dstr/meth-ary-ptrn-elem-obj-id.js
+    dstr/meth-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/meth-ary-ptrn-elem-obj-prop-id.js
+    dstr/meth-ary-ptrn-elision-step-err.js
+    dstr/meth-ary-ptrn-elision.js
+    dstr/meth-ary-ptrn-rest-ary-elem.js
+    dstr/meth-ary-ptrn-rest-ary-elision.js
+    dstr/meth-ary-ptrn-rest-ary-empty.js
+    dstr/meth-ary-ptrn-rest-ary-rest.js
+    dstr/meth-ary-ptrn-rest-id-elision-next-err.js
+    dstr/meth-ary-ptrn-rest-id-elision.js
+    dstr/meth-ary-ptrn-rest-id-exhausted.js
+    dstr/meth-ary-ptrn-rest-id-iter-step-err.js
+    dstr/meth-ary-ptrn-rest-id-iter-val-err.js
+    dstr/meth-ary-ptrn-rest-id.js
+    dstr/meth-ary-ptrn-rest-obj-id.js
+    dstr/meth-ary-ptrn-rest-obj-prop-id.js
+    dstr/meth-obj-init-null.js
+    dstr/meth-obj-init-undefined.js
+    dstr/meth-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/meth-obj-ptrn-id-init-fn-name-class.js
+    dstr/meth-obj-ptrn-id-init-fn-name-cover.js
+    dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+    dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+    dstr/meth-obj-ptrn-id-init-skipped.js
+    dstr/meth-obj-ptrn-id-init-throws.js
+    dstr/meth-obj-ptrn-id-init-unresolvable.js
+    dstr/meth-obj-ptrn-list-err.js
+    dstr/meth-obj-ptrn-prop-ary-init.js
+    dstr/meth-obj-ptrn-prop-ary-value-null.js
+    dstr/meth-obj-ptrn-prop-ary.js
+    dstr/meth-obj-ptrn-prop-eval-err.js
+    dstr/meth-obj-ptrn-prop-id-get-value-err.js
+    dstr/meth-obj-ptrn-prop-id-init-skipped.js
+    dstr/meth-obj-ptrn-prop-id-init-throws.js
+    dstr/meth-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/meth-obj-ptrn-prop-id-init.js
+    dstr/meth-obj-ptrn-prop-obj-init.js
+    dstr/meth-obj-ptrn-prop-obj-value-null.js
+    dstr/meth-obj-ptrn-prop-obj-value-undef.js
+    dstr/meth-obj-ptrn-prop-obj.js
+    method-definition/early-errors-object-method-duplicate-parameters.js
+    method-definition/escaped-get.js
+    method-definition/escaped-set.js
+    method-definition/fn-name-fn.js
+    method-definition/fn-name-gen.js
+    method-definition/gen-meth-dflt-params-trailing-comma.js
+    method-definition/gen-meth-params-trailing-comma-multiple.js
+    method-definition/gen-meth-params-trailing-comma-single.js
+    method-definition/gen-yield-identifier-non-strict.js
+    method-definition/gen-yield-identifier-spread-non-strict.js
+    method-definition/gen-yield-spread-arr-multiple.js
+    method-definition/gen-yield-spread-arr-single.js
+    method-definition/gen-yield-spread-obj.js
+    method-definition/generator-invoke-ctor.js
+    method-definition/generator-invoke-fn-no-strict.js
+    method-definition/generator-invoke-fn-strict.js
+    method-definition/generator-length.js
+    method-definition/generator-name-prop-string.js
+    method-definition/generator-name-prop-symbol.js
+    method-definition/generator-no-yield.js
+    method-definition/generator-params.js
+    method-definition/generator-prop-name-eval-error.js
+    method-definition/generator-prop-name-yield-expr.js
+    method-definition/generator-prop-name-yield-id.js
+    method-definition/generator-property-desc.js
+    method-definition/generator-prototype-prop.js
+    method-definition/generator-prototype.js
+    method-definition/generator-return.js
+    method-definition/generator-super-prop-body.js
+    method-definition/meth-array-destructuring-param-strict-body.js
+    method-definition/meth-dflt-params-trailing-comma.js
+    method-definition/meth-object-destructuring-param-strict-body.js
+    method-definition/meth-params-trailing-comma-multiple.js
+    method-definition/meth-params-trailing-comma-single.js
+    method-definition/name-invoke-ctor.js
+    method-definition/name-invoke-fn-strict.js
+    method-definition/name-length.js
+    method-definition/name-name-prop-string.js
+    method-definition/name-name-prop-symbol.js
+    method-definition/name-param-id-yield.js
+    method-definition/name-param-init-yield.js
+    method-definition/name-param-redecl.js
+    method-definition/name-prop-name-eval-error.js
+    method-definition/name-prop-name-yield-expr.js
+    method-definition/name-prop-name-yield-id.js
+    method-definition/name-prototype-prop.js
+    method-definition/object-method-returns-promise.js
+    method-definition/yield-as-expression-with-rhs.js
+    method-definition/yield-as-expression-without-rhs.js
+    method-definition/yield-as-function-expression-binding-identifier.js
+    method-definition/yield-as-generator-method-binding-identifier.js
+    method-definition/yield-as-identifier-in-nested-function.js
+    method-definition/yield-as-literal-property-name.js
+    method-definition/yield-as-property-name.js
+    method-definition/yield-as-statement.js
+    method-definition/yield-as-yield-operand.js
+    method-definition/yield-newline.js
+    method-definition/yield-return.js
+    method-definition/yield-star-before-newline.js
+    11.1.5-2gs.js
+    11.1.5_4-4-a-3.js
+    11.1.5_4-4-b-1.js
+    __proto__-permitted-dup.js
+    accessor-name-computed-err-evaluation.js
+    accessor-name-computed-err-to-prop-key.js
+    accessor-name-computed-err-unresolvable.js
+    accessor-name-computed-in.js
+    accessor-name-computed-yield-expr.js
+    accessor-name-computed-yield-id.js
+    accessor-name-computed.js
+    accessor-name-literal-numeric-binary.js
+    accessor-name-literal-numeric-exponent.js
+    accessor-name-literal-numeric-hex.js
+    accessor-name-literal-numeric-leading-decimal.js
+    accessor-name-literal-numeric-non-canonical.js
+    accessor-name-literal-numeric-octal.js
+    accessor-name-literal-numeric-zero.js
+    accessor-name-literal-string-char-escape.js
+    accessor-name-literal-string-default-escaped-ext.js
+    accessor-name-literal-string-default-escaped.js
+    accessor-name-literal-string-default.js
+    accessor-name-literal-string-double-quote.js
+    accessor-name-literal-string-empty.js
+    accessor-name-literal-string-hex-escape.js
+    accessor-name-literal-string-line-continuation.js
+    accessor-name-literal-string-single-quote.js
+    accessor-name-literal-string-unicode-escape.js
+    computed-__proto__.js
+    computed-property-evaluation-order.js
+    concise-generator.js
+    covered-ident-name-prop-name-literal-break-escaped.js
+    covered-ident-name-prop-name-literal-case-escaped.js
+    covered-ident-name-prop-name-literal-catch-escaped.js
+    covered-ident-name-prop-name-literal-class-escaped.js
+    covered-ident-name-prop-name-literal-const-escaped.js
+    covered-ident-name-prop-name-literal-continue-escaped.js
+    covered-ident-name-prop-name-literal-debugger-escaped.js
+    covered-ident-name-prop-name-literal-default-escaped-ext.js
+    covered-ident-name-prop-name-literal-default-escaped.js
+    covered-ident-name-prop-name-literal-delete-escaped.js
+    covered-ident-name-prop-name-literal-do-escaped.js
+    covered-ident-name-prop-name-literal-else-escaped.js
+    covered-ident-name-prop-name-literal-enum-escaped.js
+    covered-ident-name-prop-name-literal-export-escaped.js
+    covered-ident-name-prop-name-literal-extends-escaped-ext.js
+    covered-ident-name-prop-name-literal-extends-escaped.js
+    covered-ident-name-prop-name-literal-finally-escaped.js
+    covered-ident-name-prop-name-literal-for-escaped.js
+    covered-ident-name-prop-name-literal-function-escaped.js
+    covered-ident-name-prop-name-literal-if-escaped.js
+    covered-ident-name-prop-name-literal-implements-escaped.js
+    covered-ident-name-prop-name-literal-import-escaped.js
+    covered-ident-name-prop-name-literal-in-escaped.js
+    covered-ident-name-prop-name-literal-instanceof-escaped.js
+    covered-ident-name-prop-name-literal-interface-escaped.js
+    covered-ident-name-prop-name-literal-let-escaped.js
+    covered-ident-name-prop-name-literal-new-escaped.js
+    covered-ident-name-prop-name-literal-package-escaped.js
+    covered-ident-name-prop-name-literal-private-escaped.js
+    covered-ident-name-prop-name-literal-protected-escaped.js
+    covered-ident-name-prop-name-literal-public-escaped.js
+    covered-ident-name-prop-name-literal-return-escaped.js
+    covered-ident-name-prop-name-literal-static-escaped.js
+    covered-ident-name-prop-name-literal-super-escaped.js
+    covered-ident-name-prop-name-literal-switch-escaped.js
+    covered-ident-name-prop-name-literal-this-escaped.js
+    covered-ident-name-prop-name-literal-throw-escaped.js
+    covered-ident-name-prop-name-literal-try-escaped.js
+    covered-ident-name-prop-name-literal-typeof-escaped.js
+    covered-ident-name-prop-name-literal-var-escaped.js
+    covered-ident-name-prop-name-literal-void-escaped.js
+    covered-ident-name-prop-name-literal-while-escaped.js
+    covered-ident-name-prop-name-literal-with-escaped.js
+    fn-name-accessor-get.js
+    fn-name-accessor-set.js
+    fn-name-arrow.js
+    fn-name-cover.js
+    fn-name-fn.js
+    fn-name-gen.js
+    getter-body-strict-inside.js
+    getter-body-strict-outside.js
+    getter-super-prop.js
+    ident-name-method-def-break-escaped.js
+    ident-name-method-def-case-escaped.js
+    ident-name-method-def-catch-escaped.js
+    ident-name-method-def-class-escaped.js
+    ident-name-method-def-const-escaped.js
+    ident-name-method-def-continue-escaped.js
+    ident-name-method-def-debugger-escaped.js
+    ident-name-method-def-default-escaped-ext.js
+    ident-name-method-def-default-escaped.js
+    ident-name-method-def-delete-escaped.js
+    ident-name-method-def-do-escaped.js
+    ident-name-method-def-else-escaped.js
+    ident-name-method-def-enum-escaped.js
+    ident-name-method-def-export-escaped.js
+    ident-name-method-def-extends-escaped-ext.js
+    ident-name-method-def-extends-escaped.js
+    ident-name-method-def-finally-escaped.js
+    ident-name-method-def-for-escaped.js
+    ident-name-method-def-function-escaped.js
+    ident-name-method-def-if-escaped.js
+    ident-name-method-def-implements-escaped.js
+    ident-name-method-def-import-escaped.js
+    ident-name-method-def-in-escaped.js
+    ident-name-method-def-instanceof-escaped.js
+    ident-name-method-def-interface-escaped.js
+    ident-name-method-def-let-escaped.js
+    ident-name-method-def-new-escaped.js
+    ident-name-method-def-package-escaped.js
+    ident-name-method-def-private-escaped.js
+    ident-name-method-def-protected-escaped.js
+    ident-name-method-def-public-escaped.js
+    ident-name-method-def-return-escaped.js
+    ident-name-method-def-static-escaped.js
+    ident-name-method-def-super-escaped.js
+    ident-name-method-def-switch-escaped.js
+    ident-name-method-def-this-escaped.js
+    ident-name-method-def-throw-escaped.js
+    ident-name-method-def-try-escaped.js
+    ident-name-method-def-typeof-escaped.js
+    ident-name-method-def-var-escaped.js
+    ident-name-method-def-void-escaped.js
+    ident-name-method-def-while-escaped.js
+    ident-name-method-def-with-escaped.js
+    ident-name-prop-name-literal-break-escaped.js
+    ident-name-prop-name-literal-case-escaped.js
+    ident-name-prop-name-literal-catch-escaped.js
+    ident-name-prop-name-literal-class-escaped.js
+    ident-name-prop-name-literal-const-escaped.js
+    ident-name-prop-name-literal-continue-escaped.js
+    ident-name-prop-name-literal-debugger-escaped.js
+    ident-name-prop-name-literal-default-escaped-ext.js
+    ident-name-prop-name-literal-default-escaped.js
+    ident-name-prop-name-literal-delete-escaped.js
+    ident-name-prop-name-literal-do-escaped.js
+    ident-name-prop-name-literal-else-escaped.js
+    ident-name-prop-name-literal-enum-escaped.js
+    ident-name-prop-name-literal-export-escaped.js
+    ident-name-prop-name-literal-extends-escaped-ext.js
+    ident-name-prop-name-literal-extends-escaped.js
+    ident-name-prop-name-literal-finally-escaped.js
+    ident-name-prop-name-literal-for-escaped.js
+    ident-name-prop-name-literal-function-escaped.js
+    ident-name-prop-name-literal-if-escaped.js
+    ident-name-prop-name-literal-implements-escaped.js
+    ident-name-prop-name-literal-import-escaped.js
+    ident-name-prop-name-literal-in-escaped.js
+    ident-name-prop-name-literal-instanceof-escaped.js
+    ident-name-prop-name-literal-interface-escaped.js
+    ident-name-prop-name-literal-let-escaped.js
+    ident-name-prop-name-literal-new-escaped.js
+    ident-name-prop-name-literal-package-escaped.js
+    ident-name-prop-name-literal-private-escaped.js
+    ident-name-prop-name-literal-protected-escaped.js
+    ident-name-prop-name-literal-public-escaped.js
+    ident-name-prop-name-literal-return-escaped.js
+    ident-name-prop-name-literal-static-escaped.js
+    ident-name-prop-name-literal-super-escaped.js
+    ident-name-prop-name-literal-switch-escaped.js
+    ident-name-prop-name-literal-this-escaped.js
+    ident-name-prop-name-literal-throw-escaped.js
+    ident-name-prop-name-literal-try-escaped.js
+    ident-name-prop-name-literal-typeof-escaped.js
+    ident-name-prop-name-literal-var-escaped.js
+    ident-name-prop-name-literal-void-escaped.js
+    ident-name-prop-name-literal-while-escaped.js
+    ident-name-prop-name-literal-with-escaped.js
+    let-non-strict-access.js
+    let-non-strict-syntax.js
+    method.js
+    prop-def-id-eval-error.js
+    prop-dup-data-data.js
+    prop-dup-data-set.js
+    prop-dup-get-data.js
+    prop-dup-get-get.js
+    prop-dup-get-set-get.js
+    prop-dup-set-data.js
+    prop-dup-set-get-set.js
+    prop-dup-set-set.js
+    scope-gen-meth-body-lex-distinct.js
+    scope-gen-meth-param-elem-var-close.js
+    scope-gen-meth-param-elem-var-open.js
+    scope-gen-meth-param-rest-elem-var-close.js
+    scope-gen-meth-param-rest-elem-var-open.js
+    scope-gen-meth-paramsbody-var-close.js
+    scope-gen-meth-paramsbody-var-open.js
+    scope-getter-body-lex-distinc.js
+    scope-meth-body-lex-distinct.js
+    scope-meth-param-elem-var-close.js
+    scope-meth-param-elem-var-open.js
+    scope-meth-param-rest-elem-var-close.js
+    scope-meth-param-rest-elem-var-open.js
+    scope-meth-paramsbody-var-close.js
+    scope-meth-paramsbody-var-open.js
+    scope-setter-body-lex-distinc.js
+    scope-setter-paramsbody-var-close.js
+    scope-setter-paramsbody-var-open.js
+    setter-body-strict-inside.js
+    setter-body-strict-outside.js
+    setter-param-arguments-strict-inside.js
+    setter-param-eval-strict-inside.js
+    setter-super-prop.js
+    yield-non-strict-access.js
+    yield-non-strict-syntax.js
 
 language/expressions/postfix-decrement
-    ! arguments.js
-    ! eval.js
-    ! S11.3.2_A6_T1.js
-    ! S11.3.2_A6_T2.js
-    ! S11.3.2_A6_T3.js
-    ! target-cover-yieldexpr.js
+    arguments.js
+    eval.js
+    S11.3.2_A6_T1.js
+    S11.3.2_A6_T2.js
+    S11.3.2_A6_T3.js
+    target-cover-yieldexpr.js
 
 language/expressions/postfix-increment
-    ! 11.3.1-2-1gs.js
-    ! arguments.js
-    ! eval.js
-    ! S11.3.1_A6_T1.js
-    ! S11.3.1_A6_T2.js
-    ! S11.3.1_A6_T3.js
-    ! target-cover-yieldexpr.js
+    11.3.1-2-1gs.js
+    arguments.js
+    eval.js
+    S11.3.1_A6_T1.js
+    S11.3.1_A6_T2.js
+    S11.3.1_A6_T3.js
+    target-cover-yieldexpr.js
 
 language/expressions/prefix-decrement
-    ! 11.4.5-2-2gs.js
-    ! arguments.js
-    ! eval.js
-    ! S11.4.5_A6_T1.js
-    ! S11.4.5_A6_T2.js
-    ! S11.4.5_A6_T3.js
-    ! target-cover-yieldexpr.js
+    11.4.5-2-2gs.js
+    arguments.js
+    eval.js
+    S11.4.5_A6_T1.js
+    S11.4.5_A6_T2.js
+    S11.4.5_A6_T3.js
+    target-cover-yieldexpr.js
 
 language/expressions/prefix-increment
-    ! arguments.js
-    ! eval.js
-    ! S11.4.4_A6_T1.js
-    ! S11.4.4_A6_T2.js
-    ! S11.4.4_A6_T3.js
-    ! target-cover-yieldexpr.js
+    arguments.js
+    eval.js
+    S11.4.4_A6_T1.js
+    S11.4.4_A6_T2.js
+    S11.4.4_A6_T3.js
+    target-cover-yieldexpr.js
 
 language/expressions/property-accessors
 
 language/expressions/relational
 
 language/expressions/right-shift
-    ! bigint-non-primitive.js
-    ! order-of-evaluation.js
+    bigint-non-primitive.js
+    order-of-evaluation.js
 
 language/expressions/strict-does-not-equals
 
 language/expressions/strict-equals
 
 language/expressions/subtraction
-    ! order-of-evaluation.js
+    order-of-evaluation.js
 
-#language/expressions/super
+~language/expressions/super
 
 language/expressions/tagged-template
-    ! call-expression-context-strict.js
+    call-expression-context-strict.js
 
 language/expressions/template-literal
 
 language/expressions/this
-    ! S11.1.1_A1.js
+    S11.1.1_A1.js
 
 language/expressions/typeof
-    ! built-in-ordinary-objects-no-call.js
+    built-in-ordinary-objects-no-call.js
 
 language/expressions/unary-minus
-    ! bigint-non-primitive.js
+    bigint-non-primitive.js
 
 language/expressions/unary-plus
 
 language/expressions/unsigned-right-shift
-    ! bigint-non-primitive.js
-    ! order-of-evaluation.js
+    bigint-non-primitive.js
+    order-of-evaluation.js
 
 language/expressions/void
 
 language/expressions/yield
-    ! rhs-omitted.js
-    ! rhs-primitive.js
-    ! star-rhs-iter-nrml-next-invoke.js
+    rhs-omitted.js
+    rhs-primitive.js
+    star-rhs-iter-nrml-next-invoke.js
 
 language/function-code
-    ! 10.4.3-1-1-s.js
-    ! 10.4.3-1-10-s.js
-    ! 10.4.3-1-100-s.js
-    ! 10.4.3-1-100gs.js
-    ! 10.4.3-1-102-s.js
-    ! 10.4.3-1-102gs.js
-    ! 10.4.3-1-104.js
-    ! 10.4.3-1-106.js
-    ! 10.4.3-1-10gs.js
-    ! 10.4.3-1-11-s.js
-    ! 10.4.3-1-11gs.js
-    ! 10.4.3-1-12-s.js
-    ! 10.4.3-1-12gs.js
-    ! 10.4.3-1-14-s.js
-    ! 10.4.3-1-14gs.js
-    ! 10.4.3-1-16-s.js
-    ! 10.4.3-1-16gs.js
-    ! 10.4.3-1-17-s.js
-    ! 10.4.3-1-2-s.js
-    ! 10.4.3-1-27-s.js
-    ! 10.4.3-1-27gs.js
-    ! 10.4.3-1-28-s.js
-    ! 10.4.3-1-28gs.js
-    ! 10.4.3-1-29-s.js
-    ! 10.4.3-1-29gs.js
-    ! 10.4.3-1-3-s.js
-    ! 10.4.3-1-30-s.js
-    ! 10.4.3-1-30gs.js
-    ! 10.4.3-1-31-s.js
-    ! 10.4.3-1-31gs.js
-    ! 10.4.3-1-32-s.js
-    ! 10.4.3-1-32gs.js
-    ! 10.4.3-1-33-s.js
-    ! 10.4.3-1-33gs.js
-    ! 10.4.3-1-34-s.js
-    ! 10.4.3-1-34gs.js
-    ! 10.4.3-1-35-s.js
-    ! 10.4.3-1-35gs.js
-    ! 10.4.3-1-36-s.js
-    ! 10.4.3-1-36gs.js
-    ! 10.4.3-1-37-s.js
-    ! 10.4.3-1-37gs.js
-    ! 10.4.3-1-38-s.js
-    ! 10.4.3-1-38gs.js
-    ! 10.4.3-1-39-s.js
-    ! 10.4.3-1-39gs.js
-    ! 10.4.3-1-4-s.js
-    ! 10.4.3-1-40-s.js
-    ! 10.4.3-1-40gs.js
-    ! 10.4.3-1-41-s.js
-    ! 10.4.3-1-41gs.js
-    ! 10.4.3-1-42-s.js
-    ! 10.4.3-1-42gs.js
-    ! 10.4.3-1-43-s.js
-    ! 10.4.3-1-43gs.js
-    ! 10.4.3-1-44-s.js
-    ! 10.4.3-1-44gs.js
-    ! 10.4.3-1-45-s.js
-    ! 10.4.3-1-45gs.js
-    ! 10.4.3-1-46-s.js
-    ! 10.4.3-1-46gs.js
-    ! 10.4.3-1-47-s.js
-    ! 10.4.3-1-47gs.js
-    ! 10.4.3-1-48-s.js
-    ! 10.4.3-1-48gs.js
-    ! 10.4.3-1-49-s.js
-    ! 10.4.3-1-49gs.js
-    ! 10.4.3-1-50-s.js
-    ! 10.4.3-1-50gs.js
-    ! 10.4.3-1-51-s.js
-    ! 10.4.3-1-51gs.js
-    ! 10.4.3-1-52-s.js
-    ! 10.4.3-1-52gs.js
-    ! 10.4.3-1-53-s.js
-    ! 10.4.3-1-53gs.js
-    ! 10.4.3-1-62-s.js
-    ! 10.4.3-1-62gs.js
-    ! 10.4.3-1-63-s.js
-    ! 10.4.3-1-63gs.js
-    ! 10.4.3-1-64-s.js
-    ! 10.4.3-1-64gs.js
-    ! 10.4.3-1-65-s.js
-    ! 10.4.3-1-65gs.js
-    ! 10.4.3-1-66-s.js
-    ! 10.4.3-1-66gs.js
-    ! 10.4.3-1-67-s.js
-    ! 10.4.3-1-67gs.js
-    ! 10.4.3-1-68-s.js
-    ! 10.4.3-1-68gs.js
-    ! 10.4.3-1-7-s.js
-    ! 10.4.3-1-71-s.js
-    ! 10.4.3-1-71gs.js
-    ! 10.4.3-1-72-s.js
-    ! 10.4.3-1-72gs.js
-    ! 10.4.3-1-73-s.js
-    ! 10.4.3-1-73gs.js
-    ! 10.4.3-1-76-s.js
-    ! 10.4.3-1-76gs.js
-    ! 10.4.3-1-77-s.js
-    ! 10.4.3-1-77gs.js
-    ! 10.4.3-1-78-s.js
-    ! 10.4.3-1-78gs.js
-    ! 10.4.3-1-7gs.js
-    ! 10.4.3-1-8-s.js
-    ! 10.4.3-1-86-s.js
-    ! 10.4.3-1-86gs.js
-    ! 10.4.3-1-87-s.js
-    ! 10.4.3-1-87gs.js
-    ! 10.4.3-1-8gs.js
-    ! 10.4.3-1-9-s.js
-    ! 10.4.3-1-90-s.js
-    ! 10.4.3-1-90gs.js
-    ! 10.4.3-1-91-s.js
-    ! 10.4.3-1-91gs.js
-    ! 10.4.3-1-92-s.js
-    ! 10.4.3-1-92gs.js
-    ! 10.4.3-1-9gs.js
-    ! block-decl-onlystrict.js
-    ! eval-param-env-with-computed-key.js
-    ! eval-param-env-with-prop-initializer.js
-    ! S10.4.3_A1.js
-    ! switch-case-decl-onlystrict.js
-    ! switch-dflt-decl-onlystrict.js
+    10.4.3-1-1-s.js
+    10.4.3-1-10-s.js
+    10.4.3-1-100-s.js
+    10.4.3-1-100gs.js
+    10.4.3-1-102-s.js
+    10.4.3-1-102gs.js
+    10.4.3-1-104.js
+    10.4.3-1-106.js
+    10.4.3-1-10gs.js
+    10.4.3-1-11-s.js
+    10.4.3-1-11gs.js
+    10.4.3-1-12-s.js
+    10.4.3-1-12gs.js
+    10.4.3-1-14-s.js
+    10.4.3-1-14gs.js
+    10.4.3-1-16-s.js
+    10.4.3-1-16gs.js
+    10.4.3-1-17-s.js
+    10.4.3-1-2-s.js
+    10.4.3-1-27-s.js
+    10.4.3-1-27gs.js
+    10.4.3-1-28-s.js
+    10.4.3-1-28gs.js
+    10.4.3-1-29-s.js
+    10.4.3-1-29gs.js
+    10.4.3-1-3-s.js
+    10.4.3-1-30-s.js
+    10.4.3-1-30gs.js
+    10.4.3-1-31-s.js
+    10.4.3-1-31gs.js
+    10.4.3-1-32-s.js
+    10.4.3-1-32gs.js
+    10.4.3-1-33-s.js
+    10.4.3-1-33gs.js
+    10.4.3-1-34-s.js
+    10.4.3-1-34gs.js
+    10.4.3-1-35-s.js
+    10.4.3-1-35gs.js
+    10.4.3-1-36-s.js
+    10.4.3-1-36gs.js
+    10.4.3-1-37-s.js
+    10.4.3-1-37gs.js
+    10.4.3-1-38-s.js
+    10.4.3-1-38gs.js
+    10.4.3-1-39-s.js
+    10.4.3-1-39gs.js
+    10.4.3-1-4-s.js
+    10.4.3-1-40-s.js
+    10.4.3-1-40gs.js
+    10.4.3-1-41-s.js
+    10.4.3-1-41gs.js
+    10.4.3-1-42-s.js
+    10.4.3-1-42gs.js
+    10.4.3-1-43-s.js
+    10.4.3-1-43gs.js
+    10.4.3-1-44-s.js
+    10.4.3-1-44gs.js
+    10.4.3-1-45-s.js
+    10.4.3-1-45gs.js
+    10.4.3-1-46-s.js
+    10.4.3-1-46gs.js
+    10.4.3-1-47-s.js
+    10.4.3-1-47gs.js
+    10.4.3-1-48-s.js
+    10.4.3-1-48gs.js
+    10.4.3-1-49-s.js
+    10.4.3-1-49gs.js
+    10.4.3-1-50-s.js
+    10.4.3-1-50gs.js
+    10.4.3-1-51-s.js
+    10.4.3-1-51gs.js
+    10.4.3-1-52-s.js
+    10.4.3-1-52gs.js
+    10.4.3-1-53-s.js
+    10.4.3-1-53gs.js
+    10.4.3-1-62-s.js
+    10.4.3-1-62gs.js
+    10.4.3-1-63-s.js
+    10.4.3-1-63gs.js
+    10.4.3-1-64-s.js
+    10.4.3-1-64gs.js
+    10.4.3-1-65-s.js
+    10.4.3-1-65gs.js
+    10.4.3-1-66-s.js
+    10.4.3-1-66gs.js
+    10.4.3-1-67-s.js
+    10.4.3-1-67gs.js
+    10.4.3-1-68-s.js
+    10.4.3-1-68gs.js
+    10.4.3-1-7-s.js
+    10.4.3-1-71-s.js
+    10.4.3-1-71gs.js
+    10.4.3-1-72-s.js
+    10.4.3-1-72gs.js
+    10.4.3-1-73-s.js
+    10.4.3-1-73gs.js
+    10.4.3-1-76-s.js
+    10.4.3-1-76gs.js
+    10.4.3-1-77-s.js
+    10.4.3-1-77gs.js
+    10.4.3-1-78-s.js
+    10.4.3-1-78gs.js
+    10.4.3-1-7gs.js
+    10.4.3-1-8-s.js
+    10.4.3-1-86-s.js
+    10.4.3-1-86gs.js
+    10.4.3-1-87-s.js
+    10.4.3-1-87gs.js
+    10.4.3-1-8gs.js
+    10.4.3-1-9-s.js
+    10.4.3-1-90-s.js
+    10.4.3-1-90gs.js
+    10.4.3-1-91-s.js
+    10.4.3-1-91gs.js
+    10.4.3-1-92-s.js
+    10.4.3-1-92gs.js
+    10.4.3-1-9gs.js
+    block-decl-onlystrict.js
+    eval-param-env-with-computed-key.js
+    eval-param-env-with-prop-initializer.js
+    S10.4.3_A1.js
+    switch-case-decl-onlystrict.js
+    switch-dflt-decl-onlystrict.js
 
-#language/future-reserved-words
+~language/future-reserved-words
 
 language/global-code
-    ! block-decl-strict.js
-    ! decl-lex-configurable-global.js
-    ! decl-lex-deletion.js
-    ! decl-lex-restricted-global.js
-    ! decl-lex.js
-    ! export.js
-    ! import.js
-    ! return.js
-    ! script-decl-func-dups.js
-    ! script-decl-func-err-non-configurable.js
-    ! script-decl-func-err-non-extensible.js
-    ! script-decl-func.js
-    ! script-decl-lex-deletion.js
-    ! script-decl-lex-lex.js
-    ! script-decl-lex-restricted-global.js
-    ! script-decl-lex-var.js
-    ! script-decl-lex.js
-    ! script-decl-var-collision.js
-    ! script-decl-var-err.js
-    ! script-decl-var.js
-    ! switch-case-decl-strict.js
-    ! switch-dflt-decl-strict.js
-    ! yield-non-strict.js
-    ! yield-strict.js
+    block-decl-strict.js
+    decl-lex-configurable-global.js
+    decl-lex-deletion.js
+    decl-lex-restricted-global.js
+    decl-lex.js
+    export.js
+    import.js
+    return.js
+    script-decl-func-dups.js
+    script-decl-func-err-non-configurable.js
+    script-decl-func-err-non-extensible.js
+    script-decl-func.js
+    script-decl-lex-deletion.js
+    script-decl-lex-lex.js
+    script-decl-lex-restricted-global.js
+    script-decl-lex-var.js
+    script-decl-lex.js
+    script-decl-var-collision.js
+    script-decl-var-err.js
+    script-decl-var.js
+    switch-case-decl-strict.js
+    switch-dflt-decl-strict.js
+    yield-non-strict.js
+    yield-strict.js
 
 language/identifier-resolution
 
 language/identifiers
-    ! other_id_continue.js
-    ! other_id_start.js
-    ! part-digits-via-escape-hex.js
-    ! val-break-via-escape-hex.js
-    ! val-break-via-escape-hex4.js
-    ! val-break.js
-    ! val-case-via-escape-hex.js
-    ! val-case-via-escape-hex4.js
-    ! val-case.js
-    ! val-catch-via-escape-hex.js
-    ! val-catch-via-escape-hex4.js
-    ! val-catch.js
-    ! val-class-via-escape-hex.js
-    ! val-class-via-escape-hex4.js
-    ! val-class.js
-    ! val-const-via-escape-hex.js
-    ! val-const-via-escape-hex4.js
-    ! val-const.js
-    ! val-continue-via-escape-hex.js
-    ! val-continue-via-escape-hex4.js
-    ! val-continue.js
-    ! val-debugger-via-escape-hex.js
-    ! val-debugger-via-escape-hex4.js
-    ! val-debugger.js
-    ! val-default-via-escape-hex.js
-    ! val-default-via-escape-hex4.js
-    ! val-default.js
-    ! val-delete-via-escape-hex.js
-    ! val-delete-via-escape-hex4.js
-    ! val-delete.js
-    ! val-do-via-escape-hex.js
-    ! val-do-via-escape-hex4.js
-    ! val-do.js
-    ! val-dollar-sign-via-escape-hex.js
-    ! val-else-via-escape-hex.js
-    ! val-else-via-escape-hex4.js
-    ! val-else.js
-    ! val-enum-via-escape-hex.js
-    ! val-enum-via-escape-hex4.js
-    ! val-enum.js
-    ! val-export-via-escape-hex.js
-    ! val-export-via-escape-hex4.js
-    ! val-export.js
-    ! val-extends-via-escape-hex.js
-    ! val-extends-via-escape-hex4.js
-    ! val-extends.js
-    ! val-false-via-escape-hex.js
-    ! val-false-via-escape-hex4.js
-    ! val-false.js
-    ! val-finally-via-escape-hex.js
-    ! val-finally-via-escape-hex4.js
-    ! val-finally.js
-    ! val-for-via-escape-hex.js
-    ! val-for-via-escape-hex4.js
-    ! val-for.js
-    ! val-function-via-escape-hex.js
-    ! val-function-via-escape-hex4.js
-    ! val-function.js
-    ! val-if-via-escape-hex.js
-    ! val-if-via-escape-hex4.js
-    ! val-if.js
-    ! val-import-via-escape-hex.js
-    ! val-import-via-escape-hex4.js
-    ! val-import.js
-    ! val-in-via-escape-hex.js
-    ! val-in-via-escape-hex4.js
-    ! val-in.js
-    ! val-instanceof-via-escape-hex.js
-    ! val-instanceof-via-escape-hex4.js
-    ! val-instanceof.js
-    ! val-new-via-escape-hex.js
-    ! val-new-via-escape-hex4.js
-    ! val-new.js
-    ! val-null-via-escape-hex.js
-    ! val-null-via-escape-hex4.js
-    ! val-null.js
-    ! val-return-via-escape-hex.js
-    ! val-return-via-escape-hex4.js
-    ! val-return.js
-    ! val-super-via-escape-hex.js
-    ! val-super-via-escape-hex4.js
-    ! val-super.js
-    ! val-switch-via-escape-hex.js
-    ! val-switch-via-escape-hex4.js
-    ! val-switch.js
-    ! val-this-via-escape-hex.js
-    ! val-this-via-escape-hex4.js
-    ! val-this.js
-    ! val-throw-via-escape-hex.js
-    ! val-throw-via-escape-hex4.js
-    ! val-throw.js
-    ! val-true-via-escape-hex.js
-    ! val-true-via-escape-hex4.js
-    ! val-true.js
-    ! val-try-via-escape-hex.js
-    ! val-try-via-escape-hex4.js
-    ! val-try.js
-    ! val-typeof-via-escape-hex.js
-    ! val-typeof-via-escape-hex4.js
-    ! val-typeof.js
-    ! val-underscore-via-escape-hex.js
-    ! val-var-via-escape-hex.js
-    ! val-var-via-escape-hex4.js
-    ! val-var.js
-    ! val-void-via-escape-hex.js
-    ! val-void-via-escape-hex4.js
-    ! val-void.js
-    ! val-while-via-escape-hex.js
-    ! val-while-via-escape-hex4.js
-    ! val-while.js
-    ! val-with-via-escape-hex.js
-    ! val-with-via-escape-hex4.js
-    ! val-with.js
-    ! val-yield-strict.js
-    ! vals-eng-alpha-lower-via-escape-hex.js
-    ! vals-eng-alpha-upper-via-escape-hex.js
-    ! vals-rus-alpha-lower-via-escape-hex.js
-    ! vals-rus-alpha-upper-via-escape-hex.js
-    ! vertical-tilde-continue-escaped.js
-    ! vertical-tilde-continue.js
-    ! vertical-tilde-start-escaped.js
-    ! vertical-tilde-start.js
+    other_id_continue.js
+    other_id_start.js
+    part-digits-via-escape-hex.js
+    val-break-via-escape-hex.js
+    val-break-via-escape-hex4.js
+    val-break.js
+    val-case-via-escape-hex.js
+    val-case-via-escape-hex4.js
+    val-case.js
+    val-catch-via-escape-hex.js
+    val-catch-via-escape-hex4.js
+    val-catch.js
+    val-class-via-escape-hex.js
+    val-class-via-escape-hex4.js
+    val-class.js
+    val-const-via-escape-hex.js
+    val-const-via-escape-hex4.js
+    val-const.js
+    val-continue-via-escape-hex.js
+    val-continue-via-escape-hex4.js
+    val-continue.js
+    val-debugger-via-escape-hex.js
+    val-debugger-via-escape-hex4.js
+    val-debugger.js
+    val-default-via-escape-hex.js
+    val-default-via-escape-hex4.js
+    val-default.js
+    val-delete-via-escape-hex.js
+    val-delete-via-escape-hex4.js
+    val-delete.js
+    val-do-via-escape-hex.js
+    val-do-via-escape-hex4.js
+    val-do.js
+    val-dollar-sign-via-escape-hex.js
+    val-else-via-escape-hex.js
+    val-else-via-escape-hex4.js
+    val-else.js
+    val-enum-via-escape-hex.js
+    val-enum-via-escape-hex4.js
+    val-enum.js
+    val-export-via-escape-hex.js
+    val-export-via-escape-hex4.js
+    val-export.js
+    val-extends-via-escape-hex.js
+    val-extends-via-escape-hex4.js
+    val-extends.js
+    val-false-via-escape-hex.js
+    val-false-via-escape-hex4.js
+    val-false.js
+    val-finally-via-escape-hex.js
+    val-finally-via-escape-hex4.js
+    val-finally.js
+    val-for-via-escape-hex.js
+    val-for-via-escape-hex4.js
+    val-for.js
+    val-function-via-escape-hex.js
+    val-function-via-escape-hex4.js
+    val-function.js
+    val-if-via-escape-hex.js
+    val-if-via-escape-hex4.js
+    val-if.js
+    val-import-via-escape-hex.js
+    val-import-via-escape-hex4.js
+    val-import.js
+    val-in-via-escape-hex.js
+    val-in-via-escape-hex4.js
+    val-in.js
+    val-instanceof-via-escape-hex.js
+    val-instanceof-via-escape-hex4.js
+    val-instanceof.js
+    val-new-via-escape-hex.js
+    val-new-via-escape-hex4.js
+    val-new.js
+    val-null-via-escape-hex.js
+    val-null-via-escape-hex4.js
+    val-null.js
+    val-return-via-escape-hex.js
+    val-return-via-escape-hex4.js
+    val-return.js
+    val-super-via-escape-hex.js
+    val-super-via-escape-hex4.js
+    val-super.js
+    val-switch-via-escape-hex.js
+    val-switch-via-escape-hex4.js
+    val-switch.js
+    val-this-via-escape-hex.js
+    val-this-via-escape-hex4.js
+    val-this.js
+    val-throw-via-escape-hex.js
+    val-throw-via-escape-hex4.js
+    val-throw.js
+    val-true-via-escape-hex.js
+    val-true-via-escape-hex4.js
+    val-true.js
+    val-try-via-escape-hex.js
+    val-try-via-escape-hex4.js
+    val-try.js
+    val-typeof-via-escape-hex.js
+    val-typeof-via-escape-hex4.js
+    val-typeof.js
+    val-underscore-via-escape-hex.js
+    val-var-via-escape-hex.js
+    val-var-via-escape-hex4.js
+    val-var.js
+    val-void-via-escape-hex.js
+    val-void-via-escape-hex4.js
+    val-void.js
+    val-while-via-escape-hex.js
+    val-while-via-escape-hex4.js
+    val-while.js
+    val-with-via-escape-hex.js
+    val-with-via-escape-hex4.js
+    val-with.js
+    val-yield-strict.js
+    vals-eng-alpha-lower-via-escape-hex.js
+    vals-eng-alpha-upper-via-escape-hex.js
+    vals-rus-alpha-lower-via-escape-hex.js
+    vals-rus-alpha-upper-via-escape-hex.js
+    vertical-tilde-continue-escaped.js
+    vertical-tilde-continue.js
+    vertical-tilde-start-escaped.js
+    vertical-tilde-start.js
 
-#language/import
+~language/import
 
 language/keywords
 
 language/line-terminators
-    ! S7.3_A6_T1.js
-    ! S7.3_A6_T2.js
-    ! S7.3_A6_T3.js
-    ! S7.3_A6_T4.js
+    S7.3_A6_T1.js
+    S7.3_A6_T2.js
+    S7.3_A6_T3.js
+    S7.3_A6_T4.js
 
 language/literals
-    ! bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    ! bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
-    ! bigint/legacy-octal-like-invalid-00n.js
-    ! bigint/legacy-octal-like-invalid-01n.js
-    ! bigint/legacy-octal-like-invalid-07n.js
-    ! bigint/non-octal-like-invalid-0008n.js
-    ! bigint/non-octal-like-invalid-012348n.js
-    ! bigint/non-octal-like-invalid-08n.js
-    ! bigint/non-octal-like-invalid-09n.js
-    ! numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    ! numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
-    ! numeric/numeric-followed-by-ident.js
-    # Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
-    ! regexp/early-err-pattern.js
-    ! regexp/invalid-braced-quantifier-exact.js
-    ! regexp/invalid-braced-quantifier-lower.js
-    ! regexp/invalid-braced-quantifier-range.js
-    ! regexp/S7.8.5_A1.1_T2.js
-    ! regexp/S7.8.5_A1.4_T2.js
-    ! regexp/S7.8.5_A1.5_T1.js
-    ! regexp/S7.8.5_A1.5_T3.js
-    ! regexp/S7.8.5_A2.1_T2.js
-    ! regexp/S7.8.5_A2.4_T2.js
-    ! regexp/S7.8.5_A2.5_T1.js
-    ! regexp/S7.8.5_A2.5_T3.js
-    ! regexp/u-astral.js
-    ! regexp/u-case-mapping.js
-    ! regexp/u-surrogate-pairs-atom-char-class.js
-    ! regexp/u-surrogate-pairs-atom-dot.js
-    ! regexp/u-surrogate-pairs-atom-escape-char-class.js
-    ! regexp/u-surrogate-pairs-atom-escape-decimal.js
-    ! regexp/u-surrogate-pairs.js
-    ! regexp/u-unicode-esc.js
-    ! regexp/y-assertion-start.js
-    ! string/legacy-non-octal-escape-sequence-strict.js
-    ! string/legacy-octal-escape-sequence-prologue-strict.js
-    ! string/legacy-octal-escape-sequence-strict.js
-    ! string/S7.8.4_A4.3_T1.js
-    ! string/S7.8.4_A4.3_T2.js
-    ! string/S7.8.4_A7.1_T4.js
-    ! string/S7.8.4_A7.2_T1.js
-    ! string/S7.8.4_A7.2_T2.js
-    ! string/S7.8.4_A7.2_T3.js
-    ! string/S7.8.4_A7.2_T4.js
-    ! string/S7.8.4_A7.2_T5.js
-    ! string/S7.8.4_A7.2_T6.js
-    ! string/unicode-escape-nls-err-double.js
-    ! string/unicode-escape-nls-err-single.js
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
+    bigint/legacy-octal-like-invalid-00n.js
+    bigint/legacy-octal-like-invalid-01n.js
+    bigint/legacy-octal-like-invalid-07n.js
+    bigint/non-octal-like-invalid-0008n.js
+    bigint/non-octal-like-invalid-012348n.js
+    bigint/non-octal-like-invalid-08n.js
+    bigint/non-octal-like-invalid-09n.js
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
+    numeric/numeric-followed-by-ident.js
+    regexp/early-err-pattern.js Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
+    regexp/invalid-braced-quantifier-exact.js
+    regexp/invalid-braced-quantifier-lower.js
+    regexp/invalid-braced-quantifier-range.js
+    regexp/S7.8.5_A1.1_T2.js
+    regexp/S7.8.5_A1.4_T2.js
+    regexp/S7.8.5_A1.5_T1.js
+    regexp/S7.8.5_A1.5_T3.js
+    regexp/S7.8.5_A2.1_T2.js
+    regexp/S7.8.5_A2.4_T2.js
+    regexp/S7.8.5_A2.5_T1.js
+    regexp/S7.8.5_A2.5_T3.js
+    regexp/u-astral.js
+    regexp/u-case-mapping.js
+    regexp/u-surrogate-pairs-atom-char-class.js
+    regexp/u-surrogate-pairs-atom-dot.js
+    regexp/u-surrogate-pairs-atom-escape-char-class.js
+    regexp/u-surrogate-pairs-atom-escape-decimal.js
+    regexp/u-surrogate-pairs.js
+    regexp/u-unicode-esc.js
+    regexp/y-assertion-start.js
+    string/legacy-non-octal-escape-sequence-strict.js
+    string/legacy-octal-escape-sequence-prologue-strict.js
+    string/legacy-octal-escape-sequence-strict.js
+    string/S7.8.4_A4.3_T1.js
+    string/S7.8.4_A4.3_T2.js
+    string/S7.8.4_A7.1_T4.js
+    string/S7.8.4_A7.2_T1.js
+    string/S7.8.4_A7.2_T2.js
+    string/S7.8.4_A7.2_T3.js
+    string/S7.8.4_A7.2_T4.js
+    string/S7.8.4_A7.2_T5.js
+    string/S7.8.4_A7.2_T6.js
+    string/unicode-escape-nls-err-double.js
+    string/unicode-escape-nls-err-single.js
 
-#language/module-code
+~language/module-code
 
 language/punctuators
-    ! S7.7_A2_T1.js
-    ! S7.7_A2_T2.js
-    ! S7.7_A2_T3.js
-    ! S7.7_A2_T4.js
-    ! S7.7_A2_T5.js
+    S7.7_A2_T1.js
+    S7.7_A2_T2.js
+    S7.7_A2_T3.js
+    S7.7_A2_T4.js
+    S7.7_A2_T5.js
 
 language/reserved-words
-    ! await-script.js
-    ! ident-reference-false-escaped.js
-    ! ident-reference-null-escaped.js
-    ! ident-reference-true-escaped.js
-    ! label-ident-false-escaped.js
-    ! label-ident-null-escaped.js
-    ! label-ident-true-escaped.js
+    await-script.js
+    ident-reference-false-escaped.js
+    ident-reference-null-escaped.js
+    ident-reference-true-escaped.js
+    label-ident-false-escaped.js
+    label-ident-null-escaped.js
+    label-ident-true-escaped.js
 
 language/rest-parameters
-    ! array-pattern.js
-    ! arrow-function.js
-    ! expected-argument-count.js
-    ! no-alias-arguments.js
-    ! object-pattern.js
-    ! rest-index.js
-    ! rest-parameters-apply.js
-    ! rest-parameters-call.js
-    ! rest-parameters-produce-an-array.js
-    ! with-new-target.js
+    array-pattern.js
+    arrow-function.js
+    expected-argument-count.js
+    no-alias-arguments.js
+    object-pattern.js
+    rest-index.js
+    rest-parameters-apply.js
+    rest-parameters-call.js
+    rest-parameters-produce-an-array.js
+    with-new-target.js
 
 language/source-text
 
 language/statements/for
-    ! dstr/const-ary-init-iter-close.js
-    ! dstr/const-ary-init-iter-get-err.js
-    ! dstr/const-ary-init-iter-no-close.js
-    ! dstr/const-ary-name-iter-val.js
-    ! dstr/const-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/const-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/const-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/const-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/const-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-val-null.js
-    ! dstr/const-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/const-ary-ptrn-elem-id-init-hole.js
-    ! dstr/const-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/const-ary-ptrn-elem-id-init-throws.js
-    ! dstr/const-ary-ptrn-elem-id-init-undef.js
-    ! dstr/const-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/const-ary-ptrn-elem-id-iter-complete.js
-    ! dstr/const-ary-ptrn-elem-id-iter-done.js
-    ! dstr/const-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/const-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/const-ary-ptrn-elem-id-iter-val.js
-    ! dstr/const-ary-ptrn-elem-obj-id-init.js
-    ! dstr/const-ary-ptrn-elem-obj-id.js
-    ! dstr/const-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/const-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/const-ary-ptrn-elem-obj-val-null.js
-    ! dstr/const-ary-ptrn-elem-obj-val-undef.js
-    ! dstr/const-ary-ptrn-elision-exhausted.js
-    ! dstr/const-ary-ptrn-elision-iter-close.js
-    ! dstr/const-ary-ptrn-elision-step-err.js
-    ! dstr/const-ary-ptrn-elision.js
-    ! dstr/const-ary-ptrn-empty.js
-    ! dstr/const-ary-ptrn-rest-ary-elem.js
-    ! dstr/const-ary-ptrn-rest-ary-elision.js
-    ! dstr/const-ary-ptrn-rest-ary-empty.js
-    ! dstr/const-ary-ptrn-rest-ary-rest.js
-    ! dstr/const-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/const-ary-ptrn-rest-id-elision.js
-    ! dstr/const-ary-ptrn-rest-id-exhausted.js
-    ! dstr/const-ary-ptrn-rest-id-iter-close.js
-    ! dstr/const-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/const-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/const-ary-ptrn-rest-id.js
-    ! dstr/const-ary-ptrn-rest-obj-id.js
-    ! dstr/const-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/const-obj-init-null.js
-    ! dstr/const-obj-init-undefined.js
-    ! dstr/const-obj-ptrn-empty.js
-    ! dstr/const-obj-ptrn-id-get-value-err.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/const-obj-ptrn-id-init-skipped.js
-    ! dstr/const-obj-ptrn-id-init-throws.js
-    ! dstr/const-obj-ptrn-id-init-unresolvable.js
-    ! dstr/const-obj-ptrn-id-trailing-comma.js
-    ! dstr/const-obj-ptrn-list-err.js
-    ! dstr/const-obj-ptrn-prop-ary-init.js
-    ! dstr/const-obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/const-obj-ptrn-prop-ary-value-null.js
-    ! dstr/const-obj-ptrn-prop-ary.js
-    ! dstr/const-obj-ptrn-prop-eval-err.js
-    ! dstr/const-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/const-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/const-obj-ptrn-prop-id-init-throws.js
-    ! dstr/const-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/const-obj-ptrn-prop-id-init.js
-    ! dstr/const-obj-ptrn-prop-id-trailing-comma.js
-    ! dstr/const-obj-ptrn-prop-id.js
-    ! dstr/const-obj-ptrn-prop-obj-init.js
-    ! dstr/const-obj-ptrn-prop-obj-value-null.js
-    ! dstr/const-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/const-obj-ptrn-prop-obj.js
-    ! dstr/let-ary-init-iter-close.js
-    ! dstr/let-ary-init-iter-get-err.js
-    ! dstr/let-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/let-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/let-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/let-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/let-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/let-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/let-ary-ptrn-elem-id-init-hole.js
-    ! dstr/let-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/let-ary-ptrn-elem-id-init-throws.js
-    ! dstr/let-ary-ptrn-elem-id-init-undef.js
-    ! dstr/let-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/let-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/let-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/let-ary-ptrn-elem-obj-id-init.js
-    ! dstr/let-ary-ptrn-elem-obj-id.js
-    ! dstr/let-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/let-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/let-ary-ptrn-elision-iter-close.js
-    ! dstr/let-ary-ptrn-elision-step-err.js
-    ! dstr/let-ary-ptrn-elision.js
-    ! dstr/let-ary-ptrn-rest-ary-elem.js
-    ! dstr/let-ary-ptrn-rest-ary-elision.js
-    ! dstr/let-ary-ptrn-rest-ary-empty.js
-    ! dstr/let-ary-ptrn-rest-ary-rest.js
-    ! dstr/let-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/let-ary-ptrn-rest-id-elision.js
-    ! dstr/let-ary-ptrn-rest-id-exhausted.js
-    ! dstr/let-ary-ptrn-rest-id-iter-close.js
-    ! dstr/let-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/let-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/let-ary-ptrn-rest-id.js
-    ! dstr/let-ary-ptrn-rest-obj-id.js
-    ! dstr/let-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/let-obj-init-null.js
-    ! dstr/let-obj-init-undefined.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/let-obj-ptrn-id-init-skipped.js
-    ! dstr/let-obj-ptrn-id-init-throws.js
-    ! dstr/let-obj-ptrn-id-init-unresolvable.js
-    ! dstr/let-obj-ptrn-list-err.js
-    ! dstr/let-obj-ptrn-prop-ary-init.js
-    ! dstr/let-obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/let-obj-ptrn-prop-ary-value-null.js
-    ! dstr/let-obj-ptrn-prop-ary.js
-    ! dstr/let-obj-ptrn-prop-eval-err.js
-    ! dstr/let-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/let-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/let-obj-ptrn-prop-id-init-throws.js
-    ! dstr/let-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/let-obj-ptrn-prop-id-init.js
-    ! dstr/let-obj-ptrn-prop-obj-init.js
-    ! dstr/let-obj-ptrn-prop-obj-value-null.js
-    ! dstr/let-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/let-obj-ptrn-prop-obj.js
-    ! dstr/var-ary-init-iter-close.js
-    ! dstr/var-ary-init-iter-get-err.js
-    ! dstr/var-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/var-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/var-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/var-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/var-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/var-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/var-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/var-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/var-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/var-ary-ptrn-elem-id-init-hole.js
-    ! dstr/var-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/var-ary-ptrn-elem-id-init-throws.js
-    ! dstr/var-ary-ptrn-elem-id-init-undef.js
-    ! dstr/var-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/var-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/var-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/var-ary-ptrn-elem-obj-id-init.js
-    ! dstr/var-ary-ptrn-elem-obj-id.js
-    ! dstr/var-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/var-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/var-ary-ptrn-elision-iter-close.js
-    ! dstr/var-ary-ptrn-elision-step-err.js
-    ! dstr/var-ary-ptrn-elision.js
-    ! dstr/var-ary-ptrn-rest-ary-elem.js
-    ! dstr/var-ary-ptrn-rest-ary-elision.js
-    ! dstr/var-ary-ptrn-rest-ary-empty.js
-    ! dstr/var-ary-ptrn-rest-ary-rest.js
-    ! dstr/var-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/var-ary-ptrn-rest-id-elision.js
-    ! dstr/var-ary-ptrn-rest-id-exhausted.js
-    ! dstr/var-ary-ptrn-rest-id-iter-close.js
-    ! dstr/var-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/var-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/var-ary-ptrn-rest-id.js
-    ! dstr/var-ary-ptrn-rest-obj-id.js
-    ! dstr/var-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/var-obj-init-null.js
-    ! dstr/var-obj-init-undefined.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/var-obj-ptrn-id-init-skipped.js
-    ! dstr/var-obj-ptrn-id-init-throws.js
-    ! dstr/var-obj-ptrn-id-init-unresolvable.js
-    ! dstr/var-obj-ptrn-list-err.js
-    ! dstr/var-obj-ptrn-prop-ary-init.js
-    ! dstr/var-obj-ptrn-prop-ary-value-null.js
-    ! dstr/var-obj-ptrn-prop-ary.js
-    ! dstr/var-obj-ptrn-prop-eval-err.js
-    ! dstr/var-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/var-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/var-obj-ptrn-prop-id-init-throws.js
-    ! dstr/var-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/var-obj-ptrn-prop-id-init.js
-    ! dstr/var-obj-ptrn-prop-obj-init.js
-    ! dstr/var-obj-ptrn-prop-obj-value-null.js
-    ! dstr/var-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/var-obj-ptrn-prop-obj.js
-    ! cptn-decl-expr-iter.js
-    ! cptn-decl-expr-no-iter.js
-    ! cptn-expr-expr-iter.js
-    ! cptn-expr-expr-no-iter.js
-    ! decl-const.js
-    ! decl-fun.js
-    ! decl-gen.js
-    ! head-const-fresh-binding-per-iteration.js
-    ! head-init-expr-check-empty-inc-empty-completion.js
-    ! head-init-var-check-empty-inc-empty-completion.js
-    ! head-let-bound-names-in-stmt.js
-    ! head-lhs-let.js
-    ! labelled-fn-stmt-expr.js
-    ! labelled-fn-stmt-let.js
-    ! labelled-fn-stmt-var.js
-    ! let-array-with-newline.js
-    ! let-block-with-newline.js
-    ! let-identifier-with-newline.js
-    ! scope-body-lex-boundary.js
-    ! scope-body-lex-open.js
-    ! scope-head-lex-open.js
+    dstr/const-ary-init-iter-close.js
+    dstr/const-ary-init-iter-get-err.js
+    dstr/const-ary-init-iter-no-close.js
+    dstr/const-ary-name-iter-val.js
+    dstr/const-ary-ptrn-elem-ary-elem-init.js
+    dstr/const-ary-ptrn-elem-ary-elem-iter.js
+    dstr/const-ary-ptrn-elem-ary-elision-init.js
+    dstr/const-ary-ptrn-elem-ary-elision-iter.js
+    dstr/const-ary-ptrn-elem-ary-empty-init.js
+    dstr/const-ary-ptrn-elem-ary-empty-iter.js
+    dstr/const-ary-ptrn-elem-ary-rest-init.js
+    dstr/const-ary-ptrn-elem-ary-rest-iter.js
+    dstr/const-ary-ptrn-elem-ary-val-null.js
+    dstr/const-ary-ptrn-elem-id-init-exhausted.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/const-ary-ptrn-elem-id-init-hole.js
+    dstr/const-ary-ptrn-elem-id-init-skipped.js
+    dstr/const-ary-ptrn-elem-id-init-throws.js
+    dstr/const-ary-ptrn-elem-id-init-undef.js
+    dstr/const-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/const-ary-ptrn-elem-id-iter-complete.js
+    dstr/const-ary-ptrn-elem-id-iter-done.js
+    dstr/const-ary-ptrn-elem-id-iter-step-err.js
+    dstr/const-ary-ptrn-elem-id-iter-val-err.js
+    dstr/const-ary-ptrn-elem-id-iter-val.js
+    dstr/const-ary-ptrn-elem-obj-id-init.js
+    dstr/const-ary-ptrn-elem-obj-id.js
+    dstr/const-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/const-ary-ptrn-elem-obj-prop-id.js
+    dstr/const-ary-ptrn-elem-obj-val-null.js
+    dstr/const-ary-ptrn-elem-obj-val-undef.js
+    dstr/const-ary-ptrn-elision-exhausted.js
+    dstr/const-ary-ptrn-elision-iter-close.js
+    dstr/const-ary-ptrn-elision-step-err.js
+    dstr/const-ary-ptrn-elision.js
+    dstr/const-ary-ptrn-empty.js
+    dstr/const-ary-ptrn-rest-ary-elem.js
+    dstr/const-ary-ptrn-rest-ary-elision.js
+    dstr/const-ary-ptrn-rest-ary-empty.js
+    dstr/const-ary-ptrn-rest-ary-rest.js
+    dstr/const-ary-ptrn-rest-id-elision-next-err.js
+    dstr/const-ary-ptrn-rest-id-elision.js
+    dstr/const-ary-ptrn-rest-id-exhausted.js
+    dstr/const-ary-ptrn-rest-id-iter-close.js
+    dstr/const-ary-ptrn-rest-id-iter-step-err.js
+    dstr/const-ary-ptrn-rest-id-iter-val-err.js
+    dstr/const-ary-ptrn-rest-id.js
+    dstr/const-ary-ptrn-rest-obj-id.js
+    dstr/const-ary-ptrn-rest-obj-prop-id.js
+    dstr/const-obj-init-null.js
+    dstr/const-obj-init-undefined.js
+    dstr/const-obj-ptrn-empty.js
+    dstr/const-obj-ptrn-id-get-value-err.js
+    dstr/const-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/const-obj-ptrn-id-init-fn-name-class.js
+    dstr/const-obj-ptrn-id-init-fn-name-cover.js
+    dstr/const-obj-ptrn-id-init-fn-name-fn.js
+    dstr/const-obj-ptrn-id-init-fn-name-gen.js
+    dstr/const-obj-ptrn-id-init-skipped.js
+    dstr/const-obj-ptrn-id-init-throws.js
+    dstr/const-obj-ptrn-id-init-unresolvable.js
+    dstr/const-obj-ptrn-id-trailing-comma.js
+    dstr/const-obj-ptrn-list-err.js
+    dstr/const-obj-ptrn-prop-ary-init.js
+    dstr/const-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/const-obj-ptrn-prop-ary-value-null.js
+    dstr/const-obj-ptrn-prop-ary.js
+    dstr/const-obj-ptrn-prop-eval-err.js
+    dstr/const-obj-ptrn-prop-id-get-value-err.js
+    dstr/const-obj-ptrn-prop-id-init-skipped.js
+    dstr/const-obj-ptrn-prop-id-init-throws.js
+    dstr/const-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/const-obj-ptrn-prop-id-init.js
+    dstr/const-obj-ptrn-prop-id-trailing-comma.js
+    dstr/const-obj-ptrn-prop-id.js
+    dstr/const-obj-ptrn-prop-obj-init.js
+    dstr/const-obj-ptrn-prop-obj-value-null.js
+    dstr/const-obj-ptrn-prop-obj-value-undef.js
+    dstr/const-obj-ptrn-prop-obj.js
+    dstr/let-ary-init-iter-close.js
+    dstr/let-ary-init-iter-get-err.js
+    dstr/let-ary-ptrn-elem-ary-elem-init.js
+    dstr/let-ary-ptrn-elem-ary-elem-iter.js
+    dstr/let-ary-ptrn-elem-ary-elision-init.js
+    dstr/let-ary-ptrn-elem-ary-elision-iter.js
+    dstr/let-ary-ptrn-elem-ary-empty-init.js
+    dstr/let-ary-ptrn-elem-ary-empty-iter.js
+    dstr/let-ary-ptrn-elem-ary-rest-init.js
+    dstr/let-ary-ptrn-elem-ary-rest-iter.js
+    dstr/let-ary-ptrn-elem-id-init-exhausted.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/let-ary-ptrn-elem-id-init-hole.js
+    dstr/let-ary-ptrn-elem-id-init-skipped.js
+    dstr/let-ary-ptrn-elem-id-init-throws.js
+    dstr/let-ary-ptrn-elem-id-init-undef.js
+    dstr/let-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/let-ary-ptrn-elem-id-iter-step-err.js
+    dstr/let-ary-ptrn-elem-id-iter-val-err.js
+    dstr/let-ary-ptrn-elem-obj-id-init.js
+    dstr/let-ary-ptrn-elem-obj-id.js
+    dstr/let-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/let-ary-ptrn-elem-obj-prop-id.js
+    dstr/let-ary-ptrn-elision-iter-close.js
+    dstr/let-ary-ptrn-elision-step-err.js
+    dstr/let-ary-ptrn-elision.js
+    dstr/let-ary-ptrn-rest-ary-elem.js
+    dstr/let-ary-ptrn-rest-ary-elision.js
+    dstr/let-ary-ptrn-rest-ary-empty.js
+    dstr/let-ary-ptrn-rest-ary-rest.js
+    dstr/let-ary-ptrn-rest-id-elision-next-err.js
+    dstr/let-ary-ptrn-rest-id-elision.js
+    dstr/let-ary-ptrn-rest-id-exhausted.js
+    dstr/let-ary-ptrn-rest-id-iter-close.js
+    dstr/let-ary-ptrn-rest-id-iter-step-err.js
+    dstr/let-ary-ptrn-rest-id-iter-val-err.js
+    dstr/let-ary-ptrn-rest-id.js
+    dstr/let-ary-ptrn-rest-obj-id.js
+    dstr/let-ary-ptrn-rest-obj-prop-id.js
+    dstr/let-obj-init-null.js
+    dstr/let-obj-init-undefined.js
+    dstr/let-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/let-obj-ptrn-id-init-fn-name-class.js
+    dstr/let-obj-ptrn-id-init-fn-name-cover.js
+    dstr/let-obj-ptrn-id-init-fn-name-fn.js
+    dstr/let-obj-ptrn-id-init-fn-name-gen.js
+    dstr/let-obj-ptrn-id-init-skipped.js
+    dstr/let-obj-ptrn-id-init-throws.js
+    dstr/let-obj-ptrn-id-init-unresolvable.js
+    dstr/let-obj-ptrn-list-err.js
+    dstr/let-obj-ptrn-prop-ary-init.js
+    dstr/let-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/let-obj-ptrn-prop-ary-value-null.js
+    dstr/let-obj-ptrn-prop-ary.js
+    dstr/let-obj-ptrn-prop-eval-err.js
+    dstr/let-obj-ptrn-prop-id-get-value-err.js
+    dstr/let-obj-ptrn-prop-id-init-skipped.js
+    dstr/let-obj-ptrn-prop-id-init-throws.js
+    dstr/let-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/let-obj-ptrn-prop-id-init.js
+    dstr/let-obj-ptrn-prop-obj-init.js
+    dstr/let-obj-ptrn-prop-obj-value-null.js
+    dstr/let-obj-ptrn-prop-obj-value-undef.js
+    dstr/let-obj-ptrn-prop-obj.js
+    dstr/var-ary-init-iter-close.js
+    dstr/var-ary-init-iter-get-err.js
+    dstr/var-ary-ptrn-elem-ary-elem-init.js
+    dstr/var-ary-ptrn-elem-ary-elem-iter.js
+    dstr/var-ary-ptrn-elem-ary-elision-init.js
+    dstr/var-ary-ptrn-elem-ary-elision-iter.js
+    dstr/var-ary-ptrn-elem-ary-empty-init.js
+    dstr/var-ary-ptrn-elem-ary-empty-iter.js
+    dstr/var-ary-ptrn-elem-ary-rest-init.js
+    dstr/var-ary-ptrn-elem-ary-rest-iter.js
+    dstr/var-ary-ptrn-elem-id-init-exhausted.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/var-ary-ptrn-elem-id-init-hole.js
+    dstr/var-ary-ptrn-elem-id-init-skipped.js
+    dstr/var-ary-ptrn-elem-id-init-throws.js
+    dstr/var-ary-ptrn-elem-id-init-undef.js
+    dstr/var-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/var-ary-ptrn-elem-id-iter-step-err.js
+    dstr/var-ary-ptrn-elem-id-iter-val-err.js
+    dstr/var-ary-ptrn-elem-obj-id-init.js
+    dstr/var-ary-ptrn-elem-obj-id.js
+    dstr/var-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/var-ary-ptrn-elem-obj-prop-id.js
+    dstr/var-ary-ptrn-elision-iter-close.js
+    dstr/var-ary-ptrn-elision-step-err.js
+    dstr/var-ary-ptrn-elision.js
+    dstr/var-ary-ptrn-rest-ary-elem.js
+    dstr/var-ary-ptrn-rest-ary-elision.js
+    dstr/var-ary-ptrn-rest-ary-empty.js
+    dstr/var-ary-ptrn-rest-ary-rest.js
+    dstr/var-ary-ptrn-rest-id-elision-next-err.js
+    dstr/var-ary-ptrn-rest-id-elision.js
+    dstr/var-ary-ptrn-rest-id-exhausted.js
+    dstr/var-ary-ptrn-rest-id-iter-close.js
+    dstr/var-ary-ptrn-rest-id-iter-step-err.js
+    dstr/var-ary-ptrn-rest-id-iter-val-err.js
+    dstr/var-ary-ptrn-rest-id.js
+    dstr/var-ary-ptrn-rest-obj-id.js
+    dstr/var-ary-ptrn-rest-obj-prop-id.js
+    dstr/var-obj-init-null.js
+    dstr/var-obj-init-undefined.js
+    dstr/var-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/var-obj-ptrn-id-init-fn-name-class.js
+    dstr/var-obj-ptrn-id-init-fn-name-cover.js
+    dstr/var-obj-ptrn-id-init-fn-name-fn.js
+    dstr/var-obj-ptrn-id-init-fn-name-gen.js
+    dstr/var-obj-ptrn-id-init-skipped.js
+    dstr/var-obj-ptrn-id-init-throws.js
+    dstr/var-obj-ptrn-id-init-unresolvable.js
+    dstr/var-obj-ptrn-list-err.js
+    dstr/var-obj-ptrn-prop-ary-init.js
+    dstr/var-obj-ptrn-prop-ary-value-null.js
+    dstr/var-obj-ptrn-prop-ary.js
+    dstr/var-obj-ptrn-prop-eval-err.js
+    dstr/var-obj-ptrn-prop-id-get-value-err.js
+    dstr/var-obj-ptrn-prop-id-init-skipped.js
+    dstr/var-obj-ptrn-prop-id-init-throws.js
+    dstr/var-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/var-obj-ptrn-prop-id-init.js
+    dstr/var-obj-ptrn-prop-obj-init.js
+    dstr/var-obj-ptrn-prop-obj-value-null.js
+    dstr/var-obj-ptrn-prop-obj-value-undef.js
+    dstr/var-obj-ptrn-prop-obj.js
+    cptn-decl-expr-iter.js
+    cptn-decl-expr-no-iter.js
+    cptn-expr-expr-iter.js
+    cptn-expr-expr-no-iter.js
+    decl-const.js
+    decl-fun.js
+    decl-gen.js
+    head-const-fresh-binding-per-iteration.js
+    head-init-expr-check-empty-inc-empty-completion.js
+    head-init-var-check-empty-inc-empty-completion.js
+    head-let-bound-names-in-stmt.js
+    head-lhs-let.js
+    labelled-fn-stmt-expr.js
+    labelled-fn-stmt-let.js
+    labelled-fn-stmt-var.js
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
+    scope-body-lex-boundary.js
+    scope-body-lex-open.js
+    scope-head-lex-open.js
 
 language/statements/for-in
-    ! 12.6.4-2.js
-    ! cptn-decl-abrupt-empty.js
-    ! cptn-decl-itr.js
-    ! cptn-decl-skip-itr.js
-    ! cptn-decl-zero-itr.js
-    ! cptn-expr-abrupt-empty.js
-    ! cptn-expr-itr.js
-    ! cptn-expr-skip-itr.js
-    ! cptn-expr-zero-itr.js
-    ! decl-const.js
-    ! decl-fun.js
-    ! decl-gen.js
-    ! head-const-bound-names-fordecl-tdz.js
-    ! head-const-fresh-binding-per-iteration.js
-    ! head-let-bound-names-dup.js
-    ! head-let-bound-names-fordecl-tdz.js
-    ! head-let-bound-names-in-stmt.js
-    ! head-let-destructuring.js
-    ! head-let-fresh-binding-per-iteration.js
-    ! head-lhs-let.js
-    ! head-var-bound-names-dup.js
-    ! head-var-bound-names-let.js
-    ! identifier-let-allowed-as-lefthandside-expression-not-strict.js
-    ! labelled-fn-stmt-let.js
-    ! labelled-fn-stmt-lhs.js
-    ! labelled-fn-stmt-var.js
-    ! let-array-with-newline.js
-    ! let-block-with-newline.js
-    ! let-identifier-with-newline.js
-    ! scope-body-lex-boundary.js
-    ! scope-body-lex-close.js
-    ! scope-body-lex-open.js
-    ! scope-body-var-none.js
-    ! scope-head-lex-close.js
-    ! scope-head-lex-open.js
-    ! scope-head-var-none.js
+    12.6.4-2.js
+    cptn-decl-abrupt-empty.js
+    cptn-decl-itr.js
+    cptn-decl-skip-itr.js
+    cptn-decl-zero-itr.js
+    cptn-expr-abrupt-empty.js
+    cptn-expr-itr.js
+    cptn-expr-skip-itr.js
+    cptn-expr-zero-itr.js
+    decl-const.js
+    decl-fun.js
+    decl-gen.js
+    head-const-bound-names-fordecl-tdz.js
+    head-const-fresh-binding-per-iteration.js
+    head-let-bound-names-dup.js
+    head-let-bound-names-fordecl-tdz.js
+    head-let-bound-names-in-stmt.js
+    head-let-destructuring.js
+    head-let-fresh-binding-per-iteration.js
+    head-lhs-let.js
+    head-var-bound-names-dup.js
+    head-var-bound-names-let.js
+    identifier-let-allowed-as-lefthandside-expression-not-strict.js
+    labelled-fn-stmt-let.js
+    labelled-fn-stmt-lhs.js
+    labelled-fn-stmt-var.js
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
+    scope-body-lex-boundary.js
+    scope-body-lex-close.js
+    scope-body-lex-open.js
+    scope-body-var-none.js
+    scope-head-lex-close.js
+    scope-head-lex-open.js
+    scope-head-var-none.js
 
 language/statements/for-of
-    ! dstr/array-elem-init-assignment.js
-    ! dstr/array-elem-init-evaluation.js
-    ! dstr/array-elem-init-fn-name-arrow.js
-    ! dstr/array-elem-init-fn-name-cover.js
-    ! dstr/array-elem-init-fn-name-gen.js
-    ! dstr/array-elem-init-in.js
-    ! dstr/array-elem-init-let.js
-    ! dstr/array-elem-init-order.js
-    ! dstr/array-elem-init-simple-no-strict.js
-    ! dstr/array-elem-init-yield-expr.js
-    ! dstr/array-elem-init-yield-ident-invalid.js
-    ! dstr/array-elem-init-yield-ident-valid.js
-    ! dstr/array-elem-iter-get-err.js
-    ! dstr/array-elem-iter-nrml-close-err.js
-    ! dstr/array-elem-iter-nrml-close-null.js
-    ! dstr/array-elem-iter-nrml-close-skip.js
-    ! dstr/array-elem-iter-nrml-close.js
-    ! dstr/array-elem-iter-rtrn-close-err.js
-    ! dstr/array-elem-iter-rtrn-close-null.js
-    ! dstr/array-elem-iter-rtrn-close.js
-    ! dstr/array-elem-iter-thrw-close-err.js
-    ! dstr/array-elem-iter-thrw-close-skip.js
-    ! dstr/array-elem-iter-thrw-close.js
-    ! dstr/array-elem-nested-array-yield-ident-valid.js
-    ! dstr/array-elem-nested-obj-invalid.js
-    ! dstr/array-elem-nested-obj-yield-expr.js
-    ! dstr/array-elem-nested-obj-yield-ident-invalid.js
-    ! dstr/array-elem-nested-obj-yield-ident-valid.js
-    ! dstr/array-elem-put-const.js
-    ! dstr/array-elem-put-let.js
-    ! dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    ! dstr/array-elem-put-obj-literal-prop-ref-init.js
-    ! dstr/array-elem-put-obj-literal-prop-ref.js
-    ! dstr/array-elem-target-simple-strict.js
-    ! dstr/array-elem-target-yield-valid.js
-    ! dstr/array-elem-trlg-iter-elision-iter-abpt.js
-    ! dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
-    ! dstr/array-elem-trlg-iter-elision-iter-nrml-close-null.js
-    ! dstr/array-elem-trlg-iter-elision-iter-nrml-close-skip.js
-    ! dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
-    ! dstr/array-elem-trlg-iter-get-err.js
-    ! dstr/array-elem-trlg-iter-list-nrml-close-err.js
-    ! dstr/array-elem-trlg-iter-list-nrml-close-null.js
-    ! dstr/array-elem-trlg-iter-list-nrml-close-skip.js
-    ! dstr/array-elem-trlg-iter-list-nrml-close.js
-    ! dstr/array-elem-trlg-iter-list-rtrn-close-err.js
-    ! dstr/array-elem-trlg-iter-list-rtrn-close-null.js
-    ! dstr/array-elem-trlg-iter-list-rtrn-close.js
-    ! dstr/array-elem-trlg-iter-list-thrw-close-err.js
-    ! dstr/array-elem-trlg-iter-list-thrw-close-skip.js
-    ! dstr/array-elem-trlg-iter-list-thrw-close.js
-    ! dstr/array-elem-trlg-iter-rest-nrml-close-skip.js
-    ! dstr/array-elem-trlg-iter-rest-rtrn-close-err.js
-    ! dstr/array-elem-trlg-iter-rest-rtrn-close-null.js
-    ! dstr/array-elem-trlg-iter-rest-rtrn-close.js
-    ! dstr/array-elem-trlg-iter-rest-thrw-close-err.js
-    ! dstr/array-elem-trlg-iter-rest-thrw-close-skip.js
-    ! dstr/array-elem-trlg-iter-rest-thrw-close.js
-    ! dstr/array-elision-iter-abpt.js
-    ! dstr/array-elision-iter-get-err.js
-    ! dstr/array-elision-iter-nrml-close-err.js
-    ! dstr/array-elision-iter-nrml-close-null.js
-    ! dstr/array-elision-iter-nrml-close-skip.js
-    ! dstr/array-elision-iter-nrml-close.js
-    ! dstr/array-elision-val-bool.js
-    ! dstr/array-elision-val-null.js
-    ! dstr/array-elision-val-num.js
-    ! dstr/array-elision-val-symbol.js
-    ! dstr/array-elision-val-undef.js
-    ! dstr/array-empty-iter-close-err.js
-    ! dstr/array-empty-iter-close-null.js
-    ! dstr/array-empty-iter-close.js
-    ! dstr/array-empty-iter-get-err.js
-    ! dstr/array-empty-val-bool.js
-    ! dstr/array-empty-val-null.js
-    ! dstr/array-empty-val-num.js
-    ! dstr/array-empty-val-symbol.js
-    ! dstr/array-empty-val-undef.js
-    ! dstr/array-iteration.js
-    ! dstr/array-rest-after-element.js
-    ! dstr/array-rest-after-elision.js
-    ! dstr/array-rest-elision-iter-abpt.js
-    ! dstr/array-rest-elision.js
-    ! dstr/array-rest-iter-get-err.js
-    ! dstr/array-rest-iter-nrml-close-skip.js
-    ! dstr/array-rest-iter-rtrn-close-err.js
-    ! dstr/array-rest-iter-rtrn-close-null.js
-    ! dstr/array-rest-iter-rtrn-close.js
-    ! dstr/array-rest-iter-thrw-close-err.js
-    ! dstr/array-rest-iter-thrw-close-skip.js
-    ! dstr/array-rest-iter-thrw-close.js
-    ! dstr/array-rest-iteration.js
-    ! dstr/array-rest-lref-err.js
-    ! dstr/array-rest-lref.js
-    ! dstr/array-rest-nested-array-iter-thrw-close-skip.js
-    ! dstr/array-rest-nested-array-null.js
-    ! dstr/array-rest-nested-array-undefined-hole.js
-    ! dstr/array-rest-nested-array-undefined-own.js
-    ! dstr/array-rest-nested-array-undefined.js
-    ! dstr/array-rest-nested-array-yield-expr.js
-    ! dstr/array-rest-nested-array-yield-ident-valid.js
-    ! dstr/array-rest-nested-array.js
-    ! dstr/array-rest-nested-obj-null.js
-    ! dstr/array-rest-nested-obj-undefined-hole.js
-    ! dstr/array-rest-nested-obj-undefined-own.js
-    ! dstr/array-rest-nested-obj-undefined.js
-    ! dstr/array-rest-nested-obj-yield-expr.js
-    ! dstr/array-rest-nested-obj-yield-ident-valid.js
-    ! dstr/array-rest-nested-obj.js
-    ! dstr/array-rest-put-const.js
-    ! dstr/array-rest-put-let.js
-    ! dstr/array-rest-put-prop-ref-no-get.js
-    ! dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    ! dstr/array-rest-put-prop-ref-user-err.js
-    ! dstr/array-rest-put-prop-ref.js
-    ! dstr/array-rest-put-unresolvable-no-strict.js
-    ! dstr/array-rest-put-unresolvable-strict.js
-    ! dstr/array-rest-yield-expr.js
-    ! dstr/array-rest-yield-ident-valid.js
-    ! dstr/const-ary-init-iter-close.js
-    ! dstr/const-ary-init-iter-get-err.js
-    ! dstr/const-ary-init-iter-no-close.js
-    ! dstr/const-ary-name-iter-val.js
-    ! dstr/const-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/const-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/const-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/const-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/const-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/const-ary-ptrn-elem-ary-val-null.js
-    ! dstr/const-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/const-ary-ptrn-elem-id-init-hole.js
-    ! dstr/const-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/const-ary-ptrn-elem-id-init-throws.js
-    ! dstr/const-ary-ptrn-elem-id-init-undef.js
-    ! dstr/const-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/const-ary-ptrn-elem-id-iter-complete.js
-    ! dstr/const-ary-ptrn-elem-id-iter-done.js
-    ! dstr/const-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/const-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/const-ary-ptrn-elem-id-iter-val.js
-    ! dstr/const-ary-ptrn-elem-obj-id-init.js
-    ! dstr/const-ary-ptrn-elem-obj-id.js
-    ! dstr/const-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/const-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/const-ary-ptrn-elem-obj-val-null.js
-    ! dstr/const-ary-ptrn-elem-obj-val-undef.js
-    ! dstr/const-ary-ptrn-elision-exhausted.js
-    ! dstr/const-ary-ptrn-elision-iter-close.js
-    ! dstr/const-ary-ptrn-elision-step-err.js
-    ! dstr/const-ary-ptrn-elision.js
-    ! dstr/const-ary-ptrn-empty.js
-    ! dstr/const-ary-ptrn-rest-ary-elem.js
-    ! dstr/const-ary-ptrn-rest-ary-elision.js
-    ! dstr/const-ary-ptrn-rest-ary-empty.js
-    ! dstr/const-ary-ptrn-rest-ary-rest.js
-    ! dstr/const-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/const-ary-ptrn-rest-id-elision.js
-    ! dstr/const-ary-ptrn-rest-id-exhausted.js
-    ! dstr/const-ary-ptrn-rest-id-iter-close.js
-    ! dstr/const-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/const-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/const-ary-ptrn-rest-id.js
-    ! dstr/const-ary-ptrn-rest-obj-id.js
-    ! dstr/const-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/const-obj-init-null.js
-    ! dstr/const-obj-init-undefined.js
-    ! dstr/const-obj-ptrn-empty.js
-    ! dstr/const-obj-ptrn-id-get-value-err.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/const-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/const-obj-ptrn-id-init-skipped.js
-    ! dstr/const-obj-ptrn-id-init-throws.js
-    ! dstr/const-obj-ptrn-id-init-unresolvable.js
-    ! dstr/const-obj-ptrn-id-trailing-comma.js
-    ! dstr/const-obj-ptrn-list-err.js
-    ! dstr/const-obj-ptrn-prop-ary-init.js
-    ! dstr/const-obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/const-obj-ptrn-prop-ary-value-null.js
-    ! dstr/const-obj-ptrn-prop-ary.js
-    ! dstr/const-obj-ptrn-prop-eval-err.js
-    ! dstr/const-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/const-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/const-obj-ptrn-prop-id-init-throws.js
-    ! dstr/const-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/const-obj-ptrn-prop-id-init.js
-    ! dstr/const-obj-ptrn-prop-id-trailing-comma.js
-    ! dstr/const-obj-ptrn-prop-id.js
-    ! dstr/const-obj-ptrn-prop-obj-init.js
-    ! dstr/const-obj-ptrn-prop-obj-value-null.js
-    ! dstr/const-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/const-obj-ptrn-prop-obj.js
-    ! dstr/let-ary-init-iter-close.js
-    ! dstr/let-ary-init-iter-get-err.js
-    ! dstr/let-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/let-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/let-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/let-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/let-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/let-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/let-ary-ptrn-elem-id-init-hole.js
-    ! dstr/let-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/let-ary-ptrn-elem-id-init-throws.js
-    ! dstr/let-ary-ptrn-elem-id-init-undef.js
-    ! dstr/let-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/let-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/let-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/let-ary-ptrn-elem-obj-id-init.js
-    ! dstr/let-ary-ptrn-elem-obj-id.js
-    ! dstr/let-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/let-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/let-ary-ptrn-elision-iter-close.js
-    ! dstr/let-ary-ptrn-elision-step-err.js
-    ! dstr/let-ary-ptrn-elision.js
-    ! dstr/let-ary-ptrn-rest-ary-elem.js
-    ! dstr/let-ary-ptrn-rest-ary-elision.js
-    ! dstr/let-ary-ptrn-rest-ary-empty.js
-    ! dstr/let-ary-ptrn-rest-ary-rest.js
-    ! dstr/let-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/let-ary-ptrn-rest-id-elision.js
-    ! dstr/let-ary-ptrn-rest-id-exhausted.js
-    ! dstr/let-ary-ptrn-rest-id-iter-close.js
-    ! dstr/let-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/let-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/let-ary-ptrn-rest-id.js
-    ! dstr/let-ary-ptrn-rest-obj-id.js
-    ! dstr/let-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/let-obj-init-null.js
-    ! dstr/let-obj-init-undefined.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/let-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/let-obj-ptrn-id-init-skipped.js
-    ! dstr/let-obj-ptrn-id-init-throws.js
-    ! dstr/let-obj-ptrn-id-init-unresolvable.js
-    ! dstr/let-obj-ptrn-list-err.js
-    ! dstr/let-obj-ptrn-prop-ary-init.js
-    ! dstr/let-obj-ptrn-prop-ary-value-null.js
-    ! dstr/let-obj-ptrn-prop-ary.js
-    ! dstr/let-obj-ptrn-prop-eval-err.js
-    ! dstr/let-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/let-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/let-obj-ptrn-prop-id-init-throws.js
-    ! dstr/let-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/let-obj-ptrn-prop-id-init.js
-    ! dstr/let-obj-ptrn-prop-obj-init.js
-    ! dstr/let-obj-ptrn-prop-obj-value-null.js
-    ! dstr/let-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/let-obj-ptrn-prop-obj.js
-    ! dstr/obj-empty-null.js
-    ! dstr/obj-empty-undef.js
-    ! dstr/obj-id-identifier-yield-ident-valid.js
-    ! dstr/obj-id-init-assignment-missing.js
-    ! dstr/obj-id-init-assignment-null.js
-    ! dstr/obj-id-init-assignment-truthy.js
-    ! dstr/obj-id-init-assignment-undef.js
-    ! dstr/obj-id-init-evaluation.js
-    ! dstr/obj-id-init-fn-name-arrow.js
-    ! dstr/obj-id-init-fn-name-cover.js
-    ! dstr/obj-id-init-fn-name-fn.js
-    ! dstr/obj-id-init-fn-name-gen.js
-    ! dstr/obj-id-init-in.js
-    ! dstr/obj-id-init-let.js
-    ! dstr/obj-id-init-order.js
-    ! dstr/obj-id-init-simple-no-strict.js
-    ! dstr/obj-id-init-yield-expr.js
-    ! dstr/obj-id-init-yield-ident-valid.js
-    ! dstr/obj-id-put-const.js
-    ! dstr/obj-id-put-let.js
-    ! dstr/obj-id-simple-strict.js
-    ! dstr/obj-prop-elem-init-assignment-missing.js
-    ! dstr/obj-prop-elem-init-assignment-null.js
-    ! dstr/obj-prop-elem-init-assignment-truthy.js
-    ! dstr/obj-prop-elem-init-assignment-undef.js
-    ! dstr/obj-prop-elem-init-evaluation.js
-    ! dstr/obj-prop-elem-init-fn-name-arrow.js
-    ! dstr/obj-prop-elem-init-fn-name-cover.js
-    ! dstr/obj-prop-elem-init-fn-name-fn.js
-    ! dstr/obj-prop-elem-init-fn-name-gen.js
-    ! dstr/obj-prop-elem-init-in.js
-    ! dstr/obj-prop-elem-init-let.js
-    ! dstr/obj-prop-elem-init-yield-expr.js
-    ! dstr/obj-prop-elem-init-yield-ident-valid.js
-    ! dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    ! dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
-    ! dstr/obj-prop-elem-target-obj-literal-prop-ref.js
-    ! dstr/obj-prop-elem-target-yield-ident-valid.js
-    ! dstr/obj-prop-name-evaluation-error.js
-    ! dstr/obj-prop-name-evaluation.js
-    ! dstr/obj-prop-nested-array-yield-expr.js
-    ! dstr/obj-prop-nested-array-yield-ident-valid.js
-    ! dstr/obj-prop-nested-obj-yield-expr.js
-    ! dstr/obj-prop-nested-obj-yield-ident-valid.js
-    ! dstr/obj-prop-put-const.js
-    ! dstr/obj-prop-put-let.js
-    ! dstr/var-ary-init-iter-close.js
-    ! dstr/var-ary-init-iter-get-err.js
-    ! dstr/var-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/var-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/var-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/var-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/var-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/var-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/var-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/var-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/var-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/var-ary-ptrn-elem-id-init-hole.js
-    ! dstr/var-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/var-ary-ptrn-elem-id-init-throws.js
-    ! dstr/var-ary-ptrn-elem-id-init-undef.js
-    ! dstr/var-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/var-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/var-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/var-ary-ptrn-elem-obj-id-init.js
-    ! dstr/var-ary-ptrn-elem-obj-id.js
-    ! dstr/var-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/var-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/var-ary-ptrn-elision-iter-close.js
-    ! dstr/var-ary-ptrn-elision-step-err.js
-    ! dstr/var-ary-ptrn-elision.js
-    ! dstr/var-ary-ptrn-rest-ary-elem.js
-    ! dstr/var-ary-ptrn-rest-ary-elision.js
-    ! dstr/var-ary-ptrn-rest-ary-empty.js
-    ! dstr/var-ary-ptrn-rest-ary-rest.js
-    ! dstr/var-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/var-ary-ptrn-rest-id-elision.js
-    ! dstr/var-ary-ptrn-rest-id-exhausted.js
-    ! dstr/var-ary-ptrn-rest-id-iter-close.js
-    ! dstr/var-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/var-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/var-ary-ptrn-rest-id.js
-    ! dstr/var-ary-ptrn-rest-obj-id.js
-    ! dstr/var-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/var-obj-init-null.js
-    ! dstr/var-obj-init-undefined.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/var-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/var-obj-ptrn-id-init-skipped.js
-    ! dstr/var-obj-ptrn-id-init-throws.js
-    ! dstr/var-obj-ptrn-id-init-unresolvable.js
-    ! dstr/var-obj-ptrn-list-err.js
-    ! dstr/var-obj-ptrn-prop-ary-init.js
-    ! dstr/var-obj-ptrn-prop-ary-value-null.js
-    ! dstr/var-obj-ptrn-prop-ary.js
-    ! dstr/var-obj-ptrn-prop-eval-err.js
-    ! dstr/var-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/var-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/var-obj-ptrn-prop-id-init-throws.js
-    ! dstr/var-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/var-obj-ptrn-prop-id-init.js
-    ! dstr/var-obj-ptrn-prop-obj-init.js
-    ! dstr/var-obj-ptrn-prop-obj-value-null.js
-    ! dstr/var-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/var-obj-ptrn-prop-obj.js
-    ! body-dstr-assign-error.js
-    ! body-put-error.js
-    ! cptn-decl-abrupt-empty.js
-    ! cptn-decl-itr.js
-    ! cptn-decl-no-itr.js
-    ! cptn-expr-abrupt-empty.js
-    ! cptn-expr-itr.js
-    ! cptn-expr-no-itr.js
-    ! decl-const.js
-    ! decl-fun.js
-    ! decl-gen.js
-    ! escaped-of.js
-    ! generator-close-via-break.js
-    ! generator-close-via-continue.js
-    ! generator-close-via-return.js
-    ! generator-close-via-throw.js
-    ! head-const-bound-names-fordecl-tdz.js
-    ! head-const-fresh-binding-per-iteration.js
-    ! head-decl-no-expr.js
-    ! head-expr-no-expr.js
-    ! head-let-bound-names-dup.js
-    ! head-let-bound-names-fordecl-tdz.js
-    ! head-let-bound-names-in-stmt.js
-    ! head-let-fresh-binding-per-iteration.js
-    ! head-let-init.js
-    ! head-var-bound-names-let.js
-    ! head-var-init.js
-    ! head-var-no-expr.js
-    ! iterator-close-get-method-error.js
-    ! iterator-close-non-object.js
-    ! iterator-close-via-break.js
-    ! iterator-close-via-continue.js
-    ! iterator-close-via-return.js
-    ! iterator-close-via-throw.js
-    ! iterator-next-reference.js
-    ! iterator-next-result-type.js
-    ! labelled-fn-stmt-let.js
-    ! labelled-fn-stmt-lhs.js
-    ! labelled-fn-stmt-var.js
-    ! let-array-with-newline.js
-    ! let-block-with-newline.js
-    ! let-identifier-with-newline.js
-    ! scope-body-lex-boundary.js
-    ! scope-body-lex-close.js
-    ! scope-body-lex-open.js
-    ! scope-body-var-none.js
-    ! scope-head-lex-close.js
-    ! scope-head-lex-open.js
-    ! scope-head-var-none.js
+    dstr/array-elem-init-assignment.js
+    dstr/array-elem-init-evaluation.js
+    dstr/array-elem-init-fn-name-arrow.js
+    dstr/array-elem-init-fn-name-cover.js
+    dstr/array-elem-init-fn-name-gen.js
+    dstr/array-elem-init-in.js
+    dstr/array-elem-init-let.js
+    dstr/array-elem-init-order.js
+    dstr/array-elem-init-simple-no-strict.js
+    dstr/array-elem-init-yield-expr.js
+    dstr/array-elem-init-yield-ident-invalid.js
+    dstr/array-elem-init-yield-ident-valid.js
+    dstr/array-elem-iter-get-err.js
+    dstr/array-elem-iter-nrml-close-err.js
+    dstr/array-elem-iter-nrml-close-null.js
+    dstr/array-elem-iter-nrml-close-skip.js
+    dstr/array-elem-iter-nrml-close.js
+    dstr/array-elem-iter-rtrn-close-err.js
+    dstr/array-elem-iter-rtrn-close-null.js
+    dstr/array-elem-iter-rtrn-close.js
+    dstr/array-elem-iter-thrw-close-err.js
+    dstr/array-elem-iter-thrw-close-skip.js
+    dstr/array-elem-iter-thrw-close.js
+    dstr/array-elem-nested-array-yield-ident-valid.js
+    dstr/array-elem-nested-obj-invalid.js
+    dstr/array-elem-nested-obj-yield-expr.js
+    dstr/array-elem-nested-obj-yield-ident-invalid.js
+    dstr/array-elem-nested-obj-yield-ident-valid.js
+    dstr/array-elem-put-const.js
+    dstr/array-elem-put-let.js
+    dstr/array-elem-put-obj-literal-prop-ref-init-active.js
+    dstr/array-elem-put-obj-literal-prop-ref-init.js
+    dstr/array-elem-put-obj-literal-prop-ref.js
+    dstr/array-elem-target-simple-strict.js
+    dstr/array-elem-target-yield-valid.js
+    dstr/array-elem-trlg-iter-elision-iter-abpt.js
+    dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
+    dstr/array-elem-trlg-iter-elision-iter-nrml-close-null.js
+    dstr/array-elem-trlg-iter-elision-iter-nrml-close-skip.js
+    dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
+    dstr/array-elem-trlg-iter-get-err.js
+    dstr/array-elem-trlg-iter-list-nrml-close-err.js
+    dstr/array-elem-trlg-iter-list-nrml-close-null.js
+    dstr/array-elem-trlg-iter-list-nrml-close-skip.js
+    dstr/array-elem-trlg-iter-list-nrml-close.js
+    dstr/array-elem-trlg-iter-list-rtrn-close-err.js
+    dstr/array-elem-trlg-iter-list-rtrn-close-null.js
+    dstr/array-elem-trlg-iter-list-rtrn-close.js
+    dstr/array-elem-trlg-iter-list-thrw-close-err.js
+    dstr/array-elem-trlg-iter-list-thrw-close-skip.js
+    dstr/array-elem-trlg-iter-list-thrw-close.js
+    dstr/array-elem-trlg-iter-rest-nrml-close-skip.js
+    dstr/array-elem-trlg-iter-rest-rtrn-close-err.js
+    dstr/array-elem-trlg-iter-rest-rtrn-close-null.js
+    dstr/array-elem-trlg-iter-rest-rtrn-close.js
+    dstr/array-elem-trlg-iter-rest-thrw-close-err.js
+    dstr/array-elem-trlg-iter-rest-thrw-close-skip.js
+    dstr/array-elem-trlg-iter-rest-thrw-close.js
+    dstr/array-elision-iter-abpt.js
+    dstr/array-elision-iter-get-err.js
+    dstr/array-elision-iter-nrml-close-err.js
+    dstr/array-elision-iter-nrml-close-null.js
+    dstr/array-elision-iter-nrml-close-skip.js
+    dstr/array-elision-iter-nrml-close.js
+    dstr/array-elision-val-bool.js
+    dstr/array-elision-val-null.js
+    dstr/array-elision-val-num.js
+    dstr/array-elision-val-symbol.js
+    dstr/array-elision-val-undef.js
+    dstr/array-empty-iter-close-err.js
+    dstr/array-empty-iter-close-null.js
+    dstr/array-empty-iter-close.js
+    dstr/array-empty-iter-get-err.js
+    dstr/array-empty-val-bool.js
+    dstr/array-empty-val-null.js
+    dstr/array-empty-val-num.js
+    dstr/array-empty-val-symbol.js
+    dstr/array-empty-val-undef.js
+    dstr/array-iteration.js
+    dstr/array-rest-after-element.js
+    dstr/array-rest-after-elision.js
+    dstr/array-rest-elision-iter-abpt.js
+    dstr/array-rest-elision.js
+    dstr/array-rest-iter-get-err.js
+    dstr/array-rest-iter-nrml-close-skip.js
+    dstr/array-rest-iter-rtrn-close-err.js
+    dstr/array-rest-iter-rtrn-close-null.js
+    dstr/array-rest-iter-rtrn-close.js
+    dstr/array-rest-iter-thrw-close-err.js
+    dstr/array-rest-iter-thrw-close-skip.js
+    dstr/array-rest-iter-thrw-close.js
+    dstr/array-rest-iteration.js
+    dstr/array-rest-lref-err.js
+    dstr/array-rest-lref.js
+    dstr/array-rest-nested-array-iter-thrw-close-skip.js
+    dstr/array-rest-nested-array-null.js
+    dstr/array-rest-nested-array-undefined-hole.js
+    dstr/array-rest-nested-array-undefined-own.js
+    dstr/array-rest-nested-array-undefined.js
+    dstr/array-rest-nested-array-yield-expr.js
+    dstr/array-rest-nested-array-yield-ident-valid.js
+    dstr/array-rest-nested-array.js
+    dstr/array-rest-nested-obj-null.js
+    dstr/array-rest-nested-obj-undefined-hole.js
+    dstr/array-rest-nested-obj-undefined-own.js
+    dstr/array-rest-nested-obj-undefined.js
+    dstr/array-rest-nested-obj-yield-expr.js
+    dstr/array-rest-nested-obj-yield-ident-valid.js
+    dstr/array-rest-nested-obj.js
+    dstr/array-rest-put-const.js
+    dstr/array-rest-put-let.js
+    dstr/array-rest-put-prop-ref-no-get.js
+    dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
+    dstr/array-rest-put-prop-ref-user-err.js
+    dstr/array-rest-put-prop-ref.js
+    dstr/array-rest-put-unresolvable-no-strict.js
+    dstr/array-rest-put-unresolvable-strict.js
+    dstr/array-rest-yield-expr.js
+    dstr/array-rest-yield-ident-valid.js
+    dstr/const-ary-init-iter-close.js
+    dstr/const-ary-init-iter-get-err.js
+    dstr/const-ary-init-iter-no-close.js
+    dstr/const-ary-name-iter-val.js
+    dstr/const-ary-ptrn-elem-ary-elem-init.js
+    dstr/const-ary-ptrn-elem-ary-elem-iter.js
+    dstr/const-ary-ptrn-elem-ary-elision-init.js
+    dstr/const-ary-ptrn-elem-ary-elision-iter.js
+    dstr/const-ary-ptrn-elem-ary-empty-init.js
+    dstr/const-ary-ptrn-elem-ary-empty-iter.js
+    dstr/const-ary-ptrn-elem-ary-rest-init.js
+    dstr/const-ary-ptrn-elem-ary-rest-iter.js
+    dstr/const-ary-ptrn-elem-ary-val-null.js
+    dstr/const-ary-ptrn-elem-id-init-exhausted.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/const-ary-ptrn-elem-id-init-hole.js
+    dstr/const-ary-ptrn-elem-id-init-skipped.js
+    dstr/const-ary-ptrn-elem-id-init-throws.js
+    dstr/const-ary-ptrn-elem-id-init-undef.js
+    dstr/const-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/const-ary-ptrn-elem-id-iter-complete.js
+    dstr/const-ary-ptrn-elem-id-iter-done.js
+    dstr/const-ary-ptrn-elem-id-iter-step-err.js
+    dstr/const-ary-ptrn-elem-id-iter-val-err.js
+    dstr/const-ary-ptrn-elem-id-iter-val.js
+    dstr/const-ary-ptrn-elem-obj-id-init.js
+    dstr/const-ary-ptrn-elem-obj-id.js
+    dstr/const-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/const-ary-ptrn-elem-obj-prop-id.js
+    dstr/const-ary-ptrn-elem-obj-val-null.js
+    dstr/const-ary-ptrn-elem-obj-val-undef.js
+    dstr/const-ary-ptrn-elision-exhausted.js
+    dstr/const-ary-ptrn-elision-iter-close.js
+    dstr/const-ary-ptrn-elision-step-err.js
+    dstr/const-ary-ptrn-elision.js
+    dstr/const-ary-ptrn-empty.js
+    dstr/const-ary-ptrn-rest-ary-elem.js
+    dstr/const-ary-ptrn-rest-ary-elision.js
+    dstr/const-ary-ptrn-rest-ary-empty.js
+    dstr/const-ary-ptrn-rest-ary-rest.js
+    dstr/const-ary-ptrn-rest-id-elision-next-err.js
+    dstr/const-ary-ptrn-rest-id-elision.js
+    dstr/const-ary-ptrn-rest-id-exhausted.js
+    dstr/const-ary-ptrn-rest-id-iter-close.js
+    dstr/const-ary-ptrn-rest-id-iter-step-err.js
+    dstr/const-ary-ptrn-rest-id-iter-val-err.js
+    dstr/const-ary-ptrn-rest-id.js
+    dstr/const-ary-ptrn-rest-obj-id.js
+    dstr/const-ary-ptrn-rest-obj-prop-id.js
+    dstr/const-obj-init-null.js
+    dstr/const-obj-init-undefined.js
+    dstr/const-obj-ptrn-empty.js
+    dstr/const-obj-ptrn-id-get-value-err.js
+    dstr/const-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/const-obj-ptrn-id-init-fn-name-class.js
+    dstr/const-obj-ptrn-id-init-fn-name-cover.js
+    dstr/const-obj-ptrn-id-init-fn-name-fn.js
+    dstr/const-obj-ptrn-id-init-fn-name-gen.js
+    dstr/const-obj-ptrn-id-init-skipped.js
+    dstr/const-obj-ptrn-id-init-throws.js
+    dstr/const-obj-ptrn-id-init-unresolvable.js
+    dstr/const-obj-ptrn-id-trailing-comma.js
+    dstr/const-obj-ptrn-list-err.js
+    dstr/const-obj-ptrn-prop-ary-init.js
+    dstr/const-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/const-obj-ptrn-prop-ary-value-null.js
+    dstr/const-obj-ptrn-prop-ary.js
+    dstr/const-obj-ptrn-prop-eval-err.js
+    dstr/const-obj-ptrn-prop-id-get-value-err.js
+    dstr/const-obj-ptrn-prop-id-init-skipped.js
+    dstr/const-obj-ptrn-prop-id-init-throws.js
+    dstr/const-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/const-obj-ptrn-prop-id-init.js
+    dstr/const-obj-ptrn-prop-id-trailing-comma.js
+    dstr/const-obj-ptrn-prop-id.js
+    dstr/const-obj-ptrn-prop-obj-init.js
+    dstr/const-obj-ptrn-prop-obj-value-null.js
+    dstr/const-obj-ptrn-prop-obj-value-undef.js
+    dstr/const-obj-ptrn-prop-obj.js
+    dstr/let-ary-init-iter-close.js
+    dstr/let-ary-init-iter-get-err.js
+    dstr/let-ary-ptrn-elem-ary-elem-init.js
+    dstr/let-ary-ptrn-elem-ary-elem-iter.js
+    dstr/let-ary-ptrn-elem-ary-elision-init.js
+    dstr/let-ary-ptrn-elem-ary-elision-iter.js
+    dstr/let-ary-ptrn-elem-ary-empty-init.js
+    dstr/let-ary-ptrn-elem-ary-empty-iter.js
+    dstr/let-ary-ptrn-elem-ary-rest-init.js
+    dstr/let-ary-ptrn-elem-ary-rest-iter.js
+    dstr/let-ary-ptrn-elem-id-init-exhausted.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/let-ary-ptrn-elem-id-init-hole.js
+    dstr/let-ary-ptrn-elem-id-init-skipped.js
+    dstr/let-ary-ptrn-elem-id-init-throws.js
+    dstr/let-ary-ptrn-elem-id-init-undef.js
+    dstr/let-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/let-ary-ptrn-elem-id-iter-step-err.js
+    dstr/let-ary-ptrn-elem-id-iter-val-err.js
+    dstr/let-ary-ptrn-elem-obj-id-init.js
+    dstr/let-ary-ptrn-elem-obj-id.js
+    dstr/let-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/let-ary-ptrn-elem-obj-prop-id.js
+    dstr/let-ary-ptrn-elision-iter-close.js
+    dstr/let-ary-ptrn-elision-step-err.js
+    dstr/let-ary-ptrn-elision.js
+    dstr/let-ary-ptrn-rest-ary-elem.js
+    dstr/let-ary-ptrn-rest-ary-elision.js
+    dstr/let-ary-ptrn-rest-ary-empty.js
+    dstr/let-ary-ptrn-rest-ary-rest.js
+    dstr/let-ary-ptrn-rest-id-elision-next-err.js
+    dstr/let-ary-ptrn-rest-id-elision.js
+    dstr/let-ary-ptrn-rest-id-exhausted.js
+    dstr/let-ary-ptrn-rest-id-iter-close.js
+    dstr/let-ary-ptrn-rest-id-iter-step-err.js
+    dstr/let-ary-ptrn-rest-id-iter-val-err.js
+    dstr/let-ary-ptrn-rest-id.js
+    dstr/let-ary-ptrn-rest-obj-id.js
+    dstr/let-ary-ptrn-rest-obj-prop-id.js
+    dstr/let-obj-init-null.js
+    dstr/let-obj-init-undefined.js
+    dstr/let-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/let-obj-ptrn-id-init-fn-name-class.js
+    dstr/let-obj-ptrn-id-init-fn-name-cover.js
+    dstr/let-obj-ptrn-id-init-fn-name-fn.js
+    dstr/let-obj-ptrn-id-init-fn-name-gen.js
+    dstr/let-obj-ptrn-id-init-skipped.js
+    dstr/let-obj-ptrn-id-init-throws.js
+    dstr/let-obj-ptrn-id-init-unresolvable.js
+    dstr/let-obj-ptrn-list-err.js
+    dstr/let-obj-ptrn-prop-ary-init.js
+    dstr/let-obj-ptrn-prop-ary-value-null.js
+    dstr/let-obj-ptrn-prop-ary.js
+    dstr/let-obj-ptrn-prop-eval-err.js
+    dstr/let-obj-ptrn-prop-id-get-value-err.js
+    dstr/let-obj-ptrn-prop-id-init-skipped.js
+    dstr/let-obj-ptrn-prop-id-init-throws.js
+    dstr/let-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/let-obj-ptrn-prop-id-init.js
+    dstr/let-obj-ptrn-prop-obj-init.js
+    dstr/let-obj-ptrn-prop-obj-value-null.js
+    dstr/let-obj-ptrn-prop-obj-value-undef.js
+    dstr/let-obj-ptrn-prop-obj.js
+    dstr/obj-empty-null.js
+    dstr/obj-empty-undef.js
+    dstr/obj-id-identifier-yield-ident-valid.js
+    dstr/obj-id-init-assignment-missing.js
+    dstr/obj-id-init-assignment-null.js
+    dstr/obj-id-init-assignment-truthy.js
+    dstr/obj-id-init-assignment-undef.js
+    dstr/obj-id-init-evaluation.js
+    dstr/obj-id-init-fn-name-arrow.js
+    dstr/obj-id-init-fn-name-cover.js
+    dstr/obj-id-init-fn-name-fn.js
+    dstr/obj-id-init-fn-name-gen.js
+    dstr/obj-id-init-in.js
+    dstr/obj-id-init-let.js
+    dstr/obj-id-init-order.js
+    dstr/obj-id-init-simple-no-strict.js
+    dstr/obj-id-init-yield-expr.js
+    dstr/obj-id-init-yield-ident-valid.js
+    dstr/obj-id-put-const.js
+    dstr/obj-id-put-let.js
+    dstr/obj-id-simple-strict.js
+    dstr/obj-prop-elem-init-assignment-missing.js
+    dstr/obj-prop-elem-init-assignment-null.js
+    dstr/obj-prop-elem-init-assignment-truthy.js
+    dstr/obj-prop-elem-init-assignment-undef.js
+    dstr/obj-prop-elem-init-evaluation.js
+    dstr/obj-prop-elem-init-fn-name-arrow.js
+    dstr/obj-prop-elem-init-fn-name-cover.js
+    dstr/obj-prop-elem-init-fn-name-fn.js
+    dstr/obj-prop-elem-init-fn-name-gen.js
+    dstr/obj-prop-elem-init-in.js
+    dstr/obj-prop-elem-init-let.js
+    dstr/obj-prop-elem-init-yield-expr.js
+    dstr/obj-prop-elem-init-yield-ident-valid.js
+    dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
+    dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
+    dstr/obj-prop-elem-target-obj-literal-prop-ref.js
+    dstr/obj-prop-elem-target-yield-ident-valid.js
+    dstr/obj-prop-name-evaluation-error.js
+    dstr/obj-prop-name-evaluation.js
+    dstr/obj-prop-nested-array-yield-expr.js
+    dstr/obj-prop-nested-array-yield-ident-valid.js
+    dstr/obj-prop-nested-obj-yield-expr.js
+    dstr/obj-prop-nested-obj-yield-ident-valid.js
+    dstr/obj-prop-put-const.js
+    dstr/obj-prop-put-let.js
+    dstr/var-ary-init-iter-close.js
+    dstr/var-ary-init-iter-get-err.js
+    dstr/var-ary-ptrn-elem-ary-elem-init.js
+    dstr/var-ary-ptrn-elem-ary-elem-iter.js
+    dstr/var-ary-ptrn-elem-ary-elision-init.js
+    dstr/var-ary-ptrn-elem-ary-elision-iter.js
+    dstr/var-ary-ptrn-elem-ary-empty-init.js
+    dstr/var-ary-ptrn-elem-ary-empty-iter.js
+    dstr/var-ary-ptrn-elem-ary-rest-init.js
+    dstr/var-ary-ptrn-elem-ary-rest-iter.js
+    dstr/var-ary-ptrn-elem-id-init-exhausted.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/var-ary-ptrn-elem-id-init-hole.js
+    dstr/var-ary-ptrn-elem-id-init-skipped.js
+    dstr/var-ary-ptrn-elem-id-init-throws.js
+    dstr/var-ary-ptrn-elem-id-init-undef.js
+    dstr/var-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/var-ary-ptrn-elem-id-iter-step-err.js
+    dstr/var-ary-ptrn-elem-id-iter-val-err.js
+    dstr/var-ary-ptrn-elem-obj-id-init.js
+    dstr/var-ary-ptrn-elem-obj-id.js
+    dstr/var-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/var-ary-ptrn-elem-obj-prop-id.js
+    dstr/var-ary-ptrn-elision-iter-close.js
+    dstr/var-ary-ptrn-elision-step-err.js
+    dstr/var-ary-ptrn-elision.js
+    dstr/var-ary-ptrn-rest-ary-elem.js
+    dstr/var-ary-ptrn-rest-ary-elision.js
+    dstr/var-ary-ptrn-rest-ary-empty.js
+    dstr/var-ary-ptrn-rest-ary-rest.js
+    dstr/var-ary-ptrn-rest-id-elision-next-err.js
+    dstr/var-ary-ptrn-rest-id-elision.js
+    dstr/var-ary-ptrn-rest-id-exhausted.js
+    dstr/var-ary-ptrn-rest-id-iter-close.js
+    dstr/var-ary-ptrn-rest-id-iter-step-err.js
+    dstr/var-ary-ptrn-rest-id-iter-val-err.js
+    dstr/var-ary-ptrn-rest-id.js
+    dstr/var-ary-ptrn-rest-obj-id.js
+    dstr/var-ary-ptrn-rest-obj-prop-id.js
+    dstr/var-obj-init-null.js
+    dstr/var-obj-init-undefined.js
+    dstr/var-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/var-obj-ptrn-id-init-fn-name-class.js
+    dstr/var-obj-ptrn-id-init-fn-name-cover.js
+    dstr/var-obj-ptrn-id-init-fn-name-fn.js
+    dstr/var-obj-ptrn-id-init-fn-name-gen.js
+    dstr/var-obj-ptrn-id-init-skipped.js
+    dstr/var-obj-ptrn-id-init-throws.js
+    dstr/var-obj-ptrn-id-init-unresolvable.js
+    dstr/var-obj-ptrn-list-err.js
+    dstr/var-obj-ptrn-prop-ary-init.js
+    dstr/var-obj-ptrn-prop-ary-value-null.js
+    dstr/var-obj-ptrn-prop-ary.js
+    dstr/var-obj-ptrn-prop-eval-err.js
+    dstr/var-obj-ptrn-prop-id-get-value-err.js
+    dstr/var-obj-ptrn-prop-id-init-skipped.js
+    dstr/var-obj-ptrn-prop-id-init-throws.js
+    dstr/var-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/var-obj-ptrn-prop-id-init.js
+    dstr/var-obj-ptrn-prop-obj-init.js
+    dstr/var-obj-ptrn-prop-obj-value-null.js
+    dstr/var-obj-ptrn-prop-obj-value-undef.js
+    dstr/var-obj-ptrn-prop-obj.js
+    body-dstr-assign-error.js
+    body-put-error.js
+    cptn-decl-abrupt-empty.js
+    cptn-decl-itr.js
+    cptn-decl-no-itr.js
+    cptn-expr-abrupt-empty.js
+    cptn-expr-itr.js
+    cptn-expr-no-itr.js
+    decl-const.js
+    decl-fun.js
+    decl-gen.js
+    escaped-of.js
+    generator-close-via-break.js
+    generator-close-via-continue.js
+    generator-close-via-return.js
+    generator-close-via-throw.js
+    head-const-bound-names-fordecl-tdz.js
+    head-const-fresh-binding-per-iteration.js
+    head-decl-no-expr.js
+    head-expr-no-expr.js
+    head-let-bound-names-dup.js
+    head-let-bound-names-fordecl-tdz.js
+    head-let-bound-names-in-stmt.js
+    head-let-fresh-binding-per-iteration.js
+    head-let-init.js
+    head-var-bound-names-let.js
+    head-var-init.js
+    head-var-no-expr.js
+    iterator-close-get-method-error.js
+    iterator-close-non-object.js
+    iterator-close-via-break.js
+    iterator-close-via-continue.js
+    iterator-close-via-return.js
+    iterator-close-via-throw.js
+    iterator-next-reference.js
+    iterator-next-result-type.js
+    labelled-fn-stmt-let.js
+    labelled-fn-stmt-lhs.js
+    labelled-fn-stmt-var.js
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
+    scope-body-lex-boundary.js
+    scope-body-lex-close.js
+    scope-body-lex-open.js
+    scope-body-var-none.js
+    scope-head-lex-close.js
+    scope-head-lex-open.js
+    scope-head-var-none.js
 
 language/statements/generators
-    ! dstr/ary-init-iter-close.js
-    ! dstr/ary-init-iter-get-err.js
-    ! dstr/ary-name-iter-val.js
-    ! dstr/ary-ptrn-elem-ary-elem-init.js
-    ! dstr/ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/ary-ptrn-elem-ary-elision-init.js
-    ! dstr/ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/ary-ptrn-elem-ary-empty-init.js
-    ! dstr/ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/ary-ptrn-elem-ary-rest-init.js
-    ! dstr/ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/ary-ptrn-elem-ary-val-null.js
-    ! dstr/ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/ary-ptrn-elem-id-init-hole.js
-    ! dstr/ary-ptrn-elem-id-init-skipped.js
-    ! dstr/ary-ptrn-elem-id-init-throws.js
-    ! dstr/ary-ptrn-elem-id-init-undef.js
-    ! dstr/ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/ary-ptrn-elem-id-iter-done.js
-    ! dstr/ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/ary-ptrn-elem-id-iter-val.js
-    ! dstr/ary-ptrn-elem-obj-id-init.js
-    ! dstr/ary-ptrn-elem-obj-id.js
-    ! dstr/ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/ary-ptrn-elem-obj-prop-id.js
-    ! dstr/ary-ptrn-elem-obj-val-null.js
-    ! dstr/ary-ptrn-elem-obj-val-undef.js
-    ! dstr/ary-ptrn-elision-step-err.js
-    ! dstr/ary-ptrn-elision.js
-    ! dstr/ary-ptrn-rest-ary-elem.js
-    ! dstr/ary-ptrn-rest-ary-elision.js
-    ! dstr/ary-ptrn-rest-ary-empty.js
-    ! dstr/ary-ptrn-rest-ary-rest.js
-    ! dstr/ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/ary-ptrn-rest-id-elision.js
-    ! dstr/ary-ptrn-rest-id-exhausted.js
-    ! dstr/ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/ary-ptrn-rest-id.js
-    ! dstr/ary-ptrn-rest-obj-id.js
-    ! dstr/ary-ptrn-rest-obj-prop-id.js
-    ! dstr/obj-init-null.js
-    ! dstr/obj-init-undefined.js
-    ! dstr/obj-ptrn-id-get-value-err.js
-    ! dstr/obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/obj-ptrn-id-init-fn-name-class.js
-    ! dstr/obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/obj-ptrn-id-init-skipped.js
-    ! dstr/obj-ptrn-id-init-throws.js
-    ! dstr/obj-ptrn-id-init-unresolvable.js
-    ! dstr/obj-ptrn-id-trailing-comma.js
-    ! dstr/obj-ptrn-list-err.js
-    ! dstr/obj-ptrn-prop-ary-init.js
-    ! dstr/obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/obj-ptrn-prop-ary-value-null.js
-    ! dstr/obj-ptrn-prop-ary.js
-    ! dstr/obj-ptrn-prop-eval-err.js
-    ! dstr/obj-ptrn-prop-id-get-value-err.js
-    ! dstr/obj-ptrn-prop-id-init-skipped.js
-    ! dstr/obj-ptrn-prop-id-init-throws.js
-    ! dstr/obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/obj-ptrn-prop-id-init.js
-    ! dstr/obj-ptrn-prop-obj-init.js
-    ! dstr/obj-ptrn-prop-obj-value-null.js
-    ! dstr/obj-ptrn-prop-obj-value-undef.js
-    ! dstr/obj-ptrn-prop-obj.js
-    ! arguments-with-arguments-fn.js
-    ! arguments-with-arguments-lex.js
-    ! array-destructuring-param-strict-body.js
-    ! cptn-decl.js
-    ! default-proto.js
-    ! dflt-params-trailing-comma.js
-    ! generator-created-after-decl-inst.js
-    ! has-instance.js
-    ! invoke-as-constructor.js
-    ! length-property-descriptor.js
-    ! name.js
-    ! object-destructuring-param-strict-body.js
-    ! params-trailing-comma-multiple.js
-    ! params-trailing-comma-single.js
-    ! prototype-own-properties.js
-    ! prototype-relation-to-function.js
-    ! prototype-value.js
-    ! restricted-properties.js
-    ! scope-body-lex-distinct.js
-    ! scope-param-elem-var-close.js
-    ! scope-param-elem-var-open.js
-    ! scope-param-rest-elem-var-close.js
-    ! scope-param-rest-elem-var-open.js
-    ! scope-paramsbody-var-close.js
-    ! scope-paramsbody-var-open.js
-    ! yield-as-binding-identifier-escaped.js
-    ! yield-as-function-expression-binding-identifier.js
-    ! yield-as-generator-declaration-binding-identifier.js
-    ! yield-as-identifier-in-nested-function.js
-    ! yield-as-identifier-reference-escaped.js
-    ! yield-as-label-identifier-escaped.js
-    ! yield-identifier-non-strict.js
-    ! yield-identifier-spread-non-strict.js
-    ! yield-spread-arr-multiple.js
-    ! yield-spread-arr-single.js
-    ! yield-spread-obj.js
-    ! yield-star-after-newline.js
-    ! yield-star-before-newline.js
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-name-iter-val.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-ary-val-null.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-done.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-id-iter-val.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-val-null.js
+    dstr/ary-ptrn-elem-obj-val-undef.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-get-value-err.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-id-trailing-comma.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-trailing-comma.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-prop-obj.js
+    arguments-with-arguments-fn.js
+    arguments-with-arguments-lex.js
+    array-destructuring-param-strict-body.js
+    cptn-decl.js
+    default-proto.js
+    dflt-params-trailing-comma.js
+    generator-created-after-decl-inst.js
+    has-instance.js
+    invoke-as-constructor.js
+    length-property-descriptor.js
+    name.js
+    object-destructuring-param-strict-body.js
+    params-trailing-comma-multiple.js
+    params-trailing-comma-single.js
+    prototype-own-properties.js
+    prototype-relation-to-function.js
+    prototype-value.js
+    restricted-properties.js
+    scope-body-lex-distinct.js
+    scope-param-elem-var-close.js
+    scope-param-elem-var-open.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
+    scope-paramsbody-var-close.js
+    scope-paramsbody-var-open.js
+    yield-as-binding-identifier-escaped.js
+    yield-as-function-expression-binding-identifier.js
+    yield-as-generator-declaration-binding-identifier.js
+    yield-as-identifier-in-nested-function.js
+    yield-as-identifier-reference-escaped.js
+    yield-as-label-identifier-escaped.js
+    yield-identifier-non-strict.js
+    yield-identifier-spread-non-strict.js
+    yield-spread-arr-multiple.js
+    yield-spread-arr-single.js
+    yield-spread-obj.js
+    yield-star-after-newline.js
+    yield-star-before-newline.js
 
 language/types
-    ! boolean/S8.3_A2.1.js
-    ! boolean/S8.3_A2.2.js
-    ! number/S8.5_A10_T1.js
-    ! number/S8.5_A10_T2.js
-    ! number/S8.5_A4_T1.js
-    ! number/S8.5_A4_T2.js
-    ! reference/S8.7.2_A1_T1.js
-    ! reference/S8.7.2_A1_T2.js
-    ! undefined/S8.1_A3_T1.js
-    ! undefined/S8.1_A3_T2.js
+    boolean/S8.3_A2.1.js
+    boolean/S8.3_A2.2.js
+    number/S8.5_A10_T1.js
+    number/S8.5_A10_T2.js
+    number/S8.5_A4_T1.js
+    number/S8.5_A4_T2.js
+    reference/S8.7.2_A1_T1.js
+    reference/S8.7.2_A1_T2.js
+    undefined/S8.1_A3_T1.js
+    undefined/S8.1_A3_T2.js
 
 language/white-space
-    ! S7.2_A5_T1.js
-    ! S7.2_A5_T2.js
-    ! S7.2_A5_T3.js
-    ! S7.2_A5_T4.js
-    ! S7.2_A5_T5.js
+    S7.2_A5_T1.js
+    S7.2_A5_T2.js
+    S7.2_A5_T3.js
+    S7.2_A5_T4.js
+    S7.2_A5_T5.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -14,34 +14,63 @@
 #   that contain it in their paths. It affects only files added
 #   by directory inclusion defined on a closest line above it
 
-######### BUILT-INS #########
-
 built-ins/Array
-# incorrect length handling
-    ! prototype/push/S15.4.4.7_A2_T2.js
-    ! prototype/push/throws-if-integer-limit-exceeded.js
-    ! prototype/splice/S15.4.4.12_A6.1_T2.js
-# bugs?
-    ! splice/S15.4.4.12_A6.1_T3.js
-# strictness issues
-    ! every/15.4.4.16-5-1-s.js
-    ! filter/15.4.4.20-5-1-s.js
-    ! forEach/15.4.4.18-5-1-s.js
-    ! map/15.4.4.19-5-1-s.js
-    ! reduce/15.4.4.21-9-c-ii-4-s.js
-    ! reduceRight/15.4.4.22-9-c-ii-4-s.js
-    ! some/15.4.4.17-5-1-s.js
-    ! sort/S15.4.4.11_A8.js
+    # Spec pretty clearly says this should be undefined
+    ! from/calling-from-valid-1-noStrict.js
+    # Checking to see if length changed, but spec says it should not
+    ! from/elements-deleted-after.js
+    # Error propagation needs work in general
+    ! from/iter-map-fn-this-non-strict.js
+    # Error propagation needs work in general
+    ! from/iter-set-elem-prop-err.js
+    # Error propagation needs work in general
+    ! from/source-object-constructor.js
+    # Uses "get" syntax that's not implemented
+    ! from/source-object-iterator-1.js
+    # Uses "get" syntax that's not implemented
+    ! from/source-object-iterator-2.js
+    # Object.preventExtensions doesn't seem to throw
+    ! of/return-abrupt-from-data-property.js
+    # new
+    ! prototype/concat/Array.prototype.concat_large-typed-array.js
+    ! prototype/concat/Array.prototype.concat_non-array.js
+    ! prototype/concat/Array.prototype.concat_small-typed-array.js
+    ! prototype/concat/create-ctor-non-object.js
+    ! prototype/concat/create-ctor-poisoned.js
+    ! prototype/concat/create-species-abrupt.js
+    ! prototype/concat/create-species-non-ctor.js
+    ! prototype/concat/create-species-poisoned.js
+    ! prototype/concat/create-species.js
+    # Not throwing properly on unwritable
+    ! prototype/copyWithin/return-abrupt-from-delete-target.js
+    ! prototype/every/15.4.4.16-5-1-s.js
+    ! prototype/filter/15.4.4.20-5-1-s.js
+    ! prototype/filter/create-ctor-non-object.js
+    ! prototype/filter/create-ctor-poisoned.js
+    ! prototype/filter/create-species-abrupt.js
+    ! prototype/filter/create-species-non-ctor.js
+    ! prototype/filter/create-species-poisoned.js
+    ! prototype/filter/create-species.js
     ! prototype/findIndex/predicate-call-this-strict.js
     ! prototype/find/predicate-call-this-strict.js
-    ! prototype/splice/set_length_no_args.js
-    ! prototype/toLocaleString/primitive_this_value.js
-    ! prototype/toLocaleString/primitive_this_value_getter.js
-# not implemented
-    ! Symbol.species/length.js
-    ! Symbol.species/return-value.js
-    ! Symbol.species/symbol-species-name.js
-    ! Symbol.species/symbol-species.js
+    ! prototype/flatMap/array-like-objects-nested.js
+    ! prototype/flatMap/array-like-objects-poisoned-length.js
+    ! prototype/flatMap/array-like-objects-typedarrays.js
+    ! prototype/flatMap/array-like-objects.js
+    ! prototype/flatMap/bound-function-argument.js
+    ! prototype/flatMap/depth-always-one.js
+    ! prototype/flatMap/length.js
+    ! prototype/flatMap/name.js
+    ! prototype/flatMap/non-callable-argument-throws.js
+    ! prototype/flatMap/prop-desc.js
+    ! prototype/flatMap/proxy-access-count.js
+    ! prototype/flatMap/this-value-ctor-non-object.js
+    ! prototype/flatMap/this-value-ctor-object-species-bad-throws.js
+    ! prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
+    ! prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
+    ! prototype/flatMap/this-value-ctor-object-species.js
+    ! prototype/flatMap/this-value-null-undefined-throws.js
+    ! prototype/flatMap/thisArg-argument.js
     ! prototype/flat/array-like-objects.js
     ! prototype/flat/bound-function-call.js
     ! prototype/flat/empty-array-elements.js
@@ -56,64 +85,58 @@ built-ins/Array
     ! prototype/flat/prop-desc.js
     ! prototype/flat/proxy-access-count.js
     ! prototype/flat/symbol-object-create-null-depth-throws.js
-    ! prototype/flatMap/array-like-objects.js
-    ! prototype/flatMap/array-like-objects-nested.js
-    ! prototype/flatMap/array-like-objects-poisoned-length.js
-    ! prototype/flatMap/array-like-objects-typedarrays.js
-    ! prototype/flatMap/bound-function-argument.js
-    ! prototype/flatMap/depth-always-one.js
-    ! prototype/flatMap/length.js
-    ! prototype/flatMap/name.js
-    ! prototype/flatMap/non-callable-argument-throws.js
-    ! prototype/flatMap/prop-desc.js
-    ! prototype/flatMap/proxy-access-count.js
-    ! prototype/flatMap/thisArg-argument.js
-    ! prototype/flatMap/this-value-ctor-non-object.js
-    ! prototype/flatMap/this-value-ctor-object-species.js
-    ! prototype/flatMap/this-value-ctor-object-species-bad-throws.js
-    ! prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
-    ! prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    ! prototype/flatMap/this-value-null-undefined-throws.js
-    # Spec pretty clearly says this should be undefined
-    ! from/calling-from-valid-1-noStrict.js
-    # Checking to see if length changed, but spec says it should not
-    ! from/elements-deleted-after.js
-    # Error propagation needs work in general
-    ! from/iter-map-fn-this-non-strict.js
-    ! from/iter-set-elem-prop-err.js
-    ! from/source-object-constructor.js
-    # Uses "get" syntax that's not implemented
-    ! from/source-object-iterator-1.js
-    ! from/source-object-iterator-2.js
-    # Object.preventExtensions doesn't seem to throw
-    ! of/return-abrupt-from-data-property.js
-    ! prototype/Symbol.unscopables/prop-desc.js
-    ! prototype/Symbol.unscopables/value.js
-    # Not throwing properly on unwritable
-    ! prototype/copyWithin/return-abrupt-from-delete-target.js
-
-    # Expects a particular string value
-    ! prototype/Symbol.iterator.js
-# new
-     ! prototype/concat/Array.prototype.concat_large-typed-array.js
-# No class support yet
-     ! prototype/concat/Array.prototype.concat_non-array.js
-     ! prototype/concat/Array.prototype.concat_small-typed-array.js
+    ! prototype/forEach/15.4.4.18-5-1-s.js
+    ! prototype/map/15.4.4.19-5-1-s.js
+    ! prototype/map/create-ctor-non-object.js
+    ! prototype/map/create-ctor-poisoned.js
+    ! prototype/map/create-species-abrupt.js
+    ! prototype/map/create-species-non-ctor.js
+    ! prototype/map/create-species-poisoned.js
+    ! prototype/map/create-species.js
+    # incorrect length handling
+    ! prototype/push/S15.4.4.7_A2_T2.js
+    # incorrect length handling
+    ! prototype/push/throws-if-integer-limit-exceeded.js
+    ! prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js
+    ! prototype/reduce/15.4.4.21-9-c-ii-4-s.js
     ! prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+    ! prototype/slice/create-ctor-non-object.js
+    ! prototype/slice/create-ctor-poisoned.js
+    ! prototype/slice/create-species-abrupt.js
     ! prototype/slice/create-species-neg-zero.js
+    ! prototype/slice/create-species-non-ctor.js
+    ! prototype/slice/create-species-poisoned.js
+    ! prototype/slice/create-species.js
     ! prototype/slice/length-exceeding-integer-limit-proxied-array.js
+    ! prototype/some/15.4.4.17-5-1-s.js
+    ! prototype/sort/S15.4.4.11_A8.js
     ! prototype/sort/stability-2048-elements.js
     ! prototype/sort/stability-513-elements.js
     ! prototype/splice/clamps-length-to-integer-limit.js
+    ! prototype/splice/create-ctor-non-object.js
+    ! prototype/splice/create-ctor-poisoned.js
+    ! prototype/splice/create-species-abrupt.js
     ! prototype/splice/create-species-length-exceeding-integer-limit.js
     ! prototype/splice/create-species-neg-zero.js
-# several similar tests for filter, map, etc.
-    ! create-ctor-non-object.js
-    ! create-ctor-poisoned.js
-    ! create-species-abrupt.js
-    ! create-species-non-ctor.js
-    ! create-species-poisoned.js
-    ! create-species.js
+    ! prototype/splice/create-species-non-ctor.js
+    ! prototype/splice/create-species-poisoned.js
+    ! prototype/splice/create-species.js
+    # incorrect length handling
+    ! prototype/splice/S15.4.4.12_A6.1_T2.js
+    ! prototype/splice/S15.4.4.12_A6.1_T3.js
+    ! prototype/splice/set_length_no_args.js
+    # Object.preventExtensions doesn't seem to throw
+    ! prototype/Symbol.unscopables/prop-desc.js
+    # Object.preventExtensions doesn't seem to throw
+    ! prototype/Symbol.unscopables/value.js
+    ! prototype/toLocaleString/primitive_this_value.js
+    ! prototype/toLocaleString/primitive_this_value_getter.js
+    # Expects a particular string value
+    ! prototype/Symbol.iterator.js
+    ! Symbol.species/length.js
+    ! Symbol.species/return-value.js
+    ! Symbol.species/symbol-species-name.js
+    ! Symbol.species/symbol-species.js
 
 built-ins/ArrayBuffer
     ! prototype/byteLength/detached-buffer.js
@@ -121,7 +144,6 @@ built-ins/ArrayBuffer
     ! prototype/byteLength/length.js
     ! prototype/byteLength/name.js
     ! prototype/byteLength/prop-desc.js
-    ! prototype/byteLength/this-is-sharedarraybuffer.js
     ! prototype/slice/species-constructor-is-not-object.js
     ! prototype/slice/species-constructor-is-undefined.js
     ! prototype/slice/species-is-not-constructor.js
@@ -133,7 +155,6 @@ built-ins/ArrayBuffer
     ! prototype/slice/species-returns-same-arraybuffer.js
     ! prototype/slice/species-returns-smaller-arraybuffer.js
     ! prototype/slice/species.js
-    ! prototype/slice/this-is-sharedarraybuffer.js
     ! prototype/Symbol.toStringTag.js
     ! Symbol.species/length.js
     ! Symbol.species/return-value.js
@@ -144,13 +165,12 @@ built-ins/ArrayBuffer
 built-ins/ArrayIteratorPrototype
     ! next/detach-typedarray-in-progress.js
 
-# built-ins/AsyncFunction
+#built-ins/AsyncFunction
 
-# built-ins/Atomics
+#built-ins/Atomics
 
 built-ins/BigInt
-    # Check IsInteger in ES2020, not IsSafeInteger
-    # https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
+    # Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     ! prototype/toString/prototype-call.js
     # Computed property is not support
     ! prototype/toString/thisbigintvalue-not-valid-throws.js
@@ -158,31 +178,21 @@ built-ins/BigInt
 built-ins/Boolean
 
 built-ins/DataView
-    ! detached-buffer.js
-    ! instance-extensibility-sab.js
-    ! newtarget-undefined-throws.js
-    ! prototype/Symbol.toStringTag.js
     ! prototype/buffer/detached-buffer.js
     ! prototype/buffer/invoked-as-accessor.js
     ! prototype/buffer/length.js
     ! prototype/buffer/name.js
     ! prototype/buffer/prop-desc.js
-    ! prototype/buffer/return-buffer-sab.js
-    ! prototype/buffer/this-has-no-dataview-internal-sab.js
     ! prototype/byteLength/detached-buffer.js
     ! prototype/byteLength/invoked-as-accessor.js
     ! prototype/byteLength/length.js
     ! prototype/byteLength/name.js
     ! prototype/byteLength/prop-desc.js
-    ! prototype/byteLength/return-bytelength-sab.js
-    ! prototype/byteLength/this-has-no-dataview-internal-sab.js
     ! prototype/byteOffset/detached-buffer.js
     ! prototype/byteOffset/invoked-as-accessor.js
     ! prototype/byteOffset/length.js
     ! prototype/byteOffset/name.js
     ! prototype/byteOffset/prop-desc.js
-    ! prototype/byteOffset/return-byteoffset-sab.js
-    ! prototype/byteOffset/this-has-no-dataview-internal-sab.js
     ! prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getBigInt64/detached-buffer-before-outofrange-byteoffset.js
     ! prototype/getBigInt64/detached-buffer.js
@@ -195,9 +205,6 @@ built-ins/DataView
     ! prototype/getBigInt64/return-values-custom-offset.js
     ! prototype/getBigInt64/return-values.js
     ! prototype/getBigInt64/to-boolean-littleendian.js
-    ! prototype/getBigInt64/toindex-byteoffset-errors.js
-    ! prototype/getBigInt64/toindex-byteoffset-toprimitive.js
-    ! prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
     ! prototype/getBigInt64/toindex-byteoffset.js
     ! prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
@@ -211,19 +218,19 @@ built-ins/DataView
     ! prototype/getBigUint64/return-values-custom-offset.js
     ! prototype/getBigUint64/return-values.js
     ! prototype/getBigUint64/to-boolean-littleendian.js
-    ! prototype/getBigUint64/toindex-byteoffset-errors.js
-    ! prototype/getBigUint64/toindex-byteoffset-toprimitive.js
-    ! prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
     ! prototype/getBigUint64/toindex-byteoffset.js
     ! prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/getFloat32/detached-buffer.js
     ! prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/getFloat64/detached-buffer.js
     ! prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/getInt16/detached-buffer.js
     ! prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
-    ! prototype/getInt32/index-is-out-of-range-sab.js
+    ! prototype/getInt32/detached-buffer.js
     ! prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
     ! prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
     ! prototype/getInt8/detached-buffer.js
@@ -259,27 +266,36 @@ built-ins/DataView
     ! prototype/setFloat64/detached-buffer-after-number-value.js
     ! prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setFloat64/detached-buffer.js
     ! prototype/setInt16/detached-buffer-after-number-value.js
     ! prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setInt16/detached-buffer.js
     ! prototype/setInt32/detached-buffer-after-number-value.js
     ! prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setInt32/detached-buffer.js
     ! prototype/setInt8/detached-buffer-after-number-value.js
     ! prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setInt8/detached-buffer.js
     ! prototype/setUint16/detached-buffer-after-number-value.js
     ! prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setUint16/detached-buffer.js
     ! prototype/setUint32/detached-buffer-after-number-value.js
     ! prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setUint32/detached-buffer.js
     ! prototype/setUint8/detached-buffer-after-number-value.js
     ! prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
     ! prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
+    ! prototype/setUint8/detached-buffer.js
+    ! prototype/Symbol.toStringTag.js
+    ! detached-buffer.js
+    ! newtarget-undefined-throws.js
 
 built-ins/Date
-    ! coercion-order.js
     ! prototype/setFullYear/15.9.5.40_1.js
     ! prototype/Symbol.toPrimitive/hint-default-first-invalid.js
     ! prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
@@ -299,6 +315,8 @@ built-ins/Date
     ! prototype/toJSON/to-primitive-symbol.js
     ! prototype/toJSON/to-primitive-value-of.js
     ! prototype/toString/non-date-receiver.js
+    ! UTC/coercion-order.js
+    ! coercion-order.js
     ! value-get-symbol-to-prim-err.js
     ! value-symbol-to-prim-err.js
     ! value-symbol-to-prim-invocation.js
@@ -312,16 +330,16 @@ built-ins/Date
     ! value-to-primitive-result-string.js
 
 # this is really; slow disable for now
-# built-ins/decodeURI
-#    ! name.js
-#    ! S15.1.3.1_A2.4_T1.js
-#    ! S15.1.3.1_A5.2.js
+#built-ins/decodeURI
+#    name.js
+#    S15.1.3.1_A2.4_T1.js
+#    S15.1.3.1_A5.2.js
 
 # this is really; slow disable for now
-# built-ins/decodeURIComponent
-#    ! name.js
-#    ! S15.1.3.2_A2.4_T1.js
-#    ! S15.1.3.2_A5.2.js
+#built-ins/decodeURIComponent
+#    name.js
+#    S15.1.3.2_A2.4_T1.js
+#    S15.1.3.2_A5.2.js
 
 built-ins/encodeURI
     ! name.js
@@ -333,21 +351,12 @@ built-ins/encodeURIComponent
 
 built-ins/Error
     ! prototype/S15.11.4_A2.js
-    ! proto-from-ctor-realm.js
 
 built-ins/eval
     ! length-non-configurable.js
     ! name.js
 
 built-ins/Function
-    ! internals/Call/class-ctor-realm.js
-    ! internals/Call/class-ctor.js
-    ! internals/Construct/base-ctor-revoked-proxy-realm.js
-    ! internals/Construct/base-ctor-revoked-proxy.js
-    ! internals/Construct/derived-return-val-realm.js
-    ! internals/Construct/derived-return-val.js
-    ! internals/Construct/derived-this-uninitialized-realm.js
-    ! internals/Construct/derived-this-uninitialized.js
     ! length/S15.3.5.1_A1_T3.js
     ! length/S15.3.5.1_A2_T1.js
     ! length/S15.3.5.1_A2_T2.js
@@ -375,17 +384,11 @@ built-ins/Function
     ! prototype/bind/15.3.4.5-15-2.js
     ! prototype/bind/15.3.4.5-15-5.js
     ! prototype/bind/BoundFunction_restricted-properties.js
-    ! prototype/bind/get-fn-realm.js
-    ! prototype/bind/instance-construct-newtarget-boundtarget-bound.js
-    ! prototype/bind/instance-construct-newtarget-boundtarget.js
-    ! prototype/bind/instance-construct-newtarget-self-new.js
-    ! prototype/bind/instance-construct-newtarget-self-reflect.js
     ! prototype/bind/instance-name-chained.js
     ! prototype/bind/instance-name-error.js
     ! prototype/bind/instance-name-non-string.js
     ! prototype/bind/instance-name.js
     ! prototype/bind/length-exceeds-int32.js
-    ! prototype/bind/proto-from-ctor-realm.js
     ! prototype/call/15.3.4.4-1-s.js
     ! prototype/call/15.3.4.4-2-s.js
     ! prototype/call/15.3.4.4-3-s.js
@@ -410,28 +413,10 @@ built-ins/Function
     ! prototype/Symbol.hasInstance/this-val-bound-target.js
     ! prototype/Symbol.hasInstance/this-val-not-callable.js
     ! prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
-    ! prototype/Symbol.hasInstance/value-get-prototype-of-err.js
     ! prototype/Symbol.hasInstance/value-negative.js
     ! prototype/Symbol.hasInstance/value-non-obj.js
     ! prototype/Symbol.hasInstance/value-positive.js
     ! prototype/toString/arrow-function.js
-    ! prototype/toString/async-arrow-function.js
-    ! prototype/toString/async-function-declaration.js
-    ! prototype/toString/async-function-expression.js
-    ! prototype/toString/async-generator-declaration.js
-    ! prototype/toString/async-generator-expression.js
-    ! prototype/toString/async-generator-method-class-expression-static.js
-    ! prototype/toString/async-generator-method-class-expression.js
-    ! prototype/toString/async-generator-method-class-statement-static.js
-    ! prototype/toString/async-generator-method-class-statement.js
-    ! prototype/toString/async-generator-method-object.js
-    ! prototype/toString/async-method-class-expression-static.js
-    ! prototype/toString/async-method-class-expression.js
-    ! prototype/toString/async-method-class-statement-static.js
-    ! prototype/toString/async-method-class-statement.js
-    ! prototype/toString/async-method-object.js
-    ! prototype/toString/AsyncFunction.js
-    ! prototype/toString/AsyncGenerator.js
     ! prototype/toString/class-declaration-complex-heritage.js
     ! prototype/toString/class-declaration-explicit-ctor.js
     ! prototype/toString/class-declaration-implicit-ctor.js
@@ -515,33 +500,10 @@ built-ins/Function
     ! 15.3.5.4_2-5gs.js
     ! 15.3.5.4_2-7gs.js
     ! 15.3.5.4_2-9gs.js
-    ! call-bind-this-realm-undef.js
-    ! call-bind-this-realm-value.js
     ! instance-name.js
-    ! proto-from-ctor-realm.js
     ! StrictFunction_restricted-properties.js
 
-built-ins/GeneratorFunction
-    ! prototype/constructor.js
-    ! prototype/extensibility.js
-    ! prototype/prop-desc.js
-    ! prototype/prototype.js
-    ! prototype/Symbol.toStringTag.js
-    ! extensibility.js
-    ! has-instance.js
-    ! instance-construct-throws.js
-    ! instance-length.js
-    ! instance-name.js
-    ! instance-prototype.js
-    ! instance-restricted-properties.js
-    ! instance-yield-expr-in-param.js
-    ! invoked-as-constructor-no-arguments.js
-    ! invoked-as-function-multiple-arguments.js
-    ! invoked-as-function-no-arguments.js
-    ! invoked-as-function-single-argument.js
-    ! /length.js
-    ! /name.js
-    ! proto-from-ctor-realm.js
+#built-ins/GeneratorFunction
 
 built-ins/GeneratorPrototype
     ! next/from-state-executing.js
@@ -587,8 +549,8 @@ built-ins/global
 built-ins/Infinity
 
 built-ins/isFinite
-    ! /length.js
-    ! /name.js
+    ! length.js
+    ! name.js
     ! toprimitive-call-abrupt.js
     ! toprimitive-get-abrupt.js
     ! toprimitive-not-callable-throws.js
@@ -597,8 +559,8 @@ built-ins/isFinite
     ! toprimitive-valid-result.js
 
 built-ins/isNaN
-    ! /length.js
-    ! /name.js
+    ! length.js
+    ! name.js
     ! toprimitive-call-abrupt.js
     ! toprimitive-get-abrupt.js
     ! toprimitive-not-callable-throws.js
@@ -606,14 +568,9 @@ built-ins/isNaN
     ! toprimitive-result-is-symbol-throws.js
     ! toprimitive-valid-result.js
 
-built-ins/IteratorPrototype
-    ! Symbol.iterator/length.js
-    ! Symbol.iterator/name.js
-    ! Symbol.iterator/prop-desc.js
-    ! Symbol.iterator/return-val.js
+#built-ins/IteratorPrototype
 
 built-ins/JSON
-    ! Symbol.toStringTag.js
     ! parse/S15.12.2_A1.js
     ! parse/text-negative-zero.js
     ! stringify/replacer-array-number.js
@@ -624,13 +581,14 @@ built-ins/JSON
     ! stringify/value-string-escape-unicode.js
     ! stringify/value-symbol.js
     ! stringify/value-tojson-arguments.js
+    ! Symbol.toStringTag.js
 
 built-ins/Map
-    ! iterator-is-undefined-throws.js
     ! Symbol.species/length.js
     ! Symbol.species/return-value.js
     ! Symbol.species/symbol-species-name.js
     ! Symbol.species/symbol-species.js
+    ! iterator-is-undefined-throws.js
 
 built-ins/MapIteratorPrototype
 
@@ -708,6 +666,18 @@ built-ins/Object
     ! fromEntries/iterator-not-closed-for-uncallable-next.js
     ! fromEntries/to-property-key.js
     ! fromEntries/uses-keys-not-iterator.js
+    ! getOwnPropertyDescriptors/function-length.js
+    ! getOwnPropertyDescriptors/function-name.js
+    ! getOwnPropertyDescriptors/function-property-descriptor.js
+    ! getOwnPropertyDescriptors/inherited-properties-omitted.js
+    ! getOwnPropertyDescriptors/normal-object.js
+    ! getOwnPropertyDescriptors/primitive-booleans.js
+    ! getOwnPropertyDescriptors/primitive-numbers.js
+    ! getOwnPropertyDescriptors/primitive-strings.js
+    ! getOwnPropertyDescriptors/primitive-symbols.js
+    ! getOwnPropertyDescriptors/symbols-included.js
+    ! getOwnPropertyDescriptors/tamper-with-global-object.js
+    ! getOwnPropertyDescriptors/tamper-with-object-keys.js
     ! getOwnPropertyDescriptor/15.2.3.3-4-187.js
     ! getOwnPropertyDescriptor/15.2.3.3-4-212.js
     ! getOwnPropertyDescriptor/15.2.3.3-4-213.js
@@ -715,20 +685,12 @@ built-ins/Object
     ! getOwnPropertyDescriptor/15.2.3.3-4-215.js
     ! getOwnPropertyDescriptor/15.2.3.3-4-249.js
     ! getOwnPropertyDescriptor/15.2.3.3-4-250.js
-    ! getOwnPropertyDescriptors/function-length.js
-    ! getOwnPropertyDescriptors/function-name.js
-    ! getOwnPropertyDescriptors/function-property-descriptor.js
-    ! getOwnPropertyDescriptors/inherited-properties-omitted.js
-    ! getOwnPropertyDescriptors/normal-object.js
-    ! getOwnPropertyDescriptors/observable-operations.js
-    ! getOwnPropertyDescriptors/primitive-booleans.js
-    ! getOwnPropertyDescriptors/primitive-numbers.js
-    ! getOwnPropertyDescriptors/primitive-strings.js
-    ! getOwnPropertyDescriptors/primitive-symbols.js
-    ! getOwnPropertyDescriptors/proxy-undefined-descriptor.js
-    ! getOwnPropertyDescriptors/symbols-included.js
-    ! getOwnPropertyDescriptors/tamper-with-global-object.js
-    ! getOwnPropertyDescriptors/tamper-with-object-keys.js
+    ! getPrototypeOf/15.2.3.2-2-12.js
+    ! getPrototypeOf/15.2.3.2-2-13.js
+    ! getPrototypeOf/15.2.3.2-2-14.js
+    ! getPrototypeOf/15.2.3.2-2-15.js
+    ! getPrototypeOf/15.2.3.2-2-16.js
+    ! getPrototypeOf/15.2.3.2-2-17.js
     ! internals/DefineOwnProperty/consistent-value-function-arguments.js
     ! internals/DefineOwnProperty/consistent-value-function-caller.js
     ! internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
@@ -740,10 +702,10 @@ built-ins/Object
     ! prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     ! prototype/propertyIsEnumerable/symbol_property_toString.js
     ! prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    ! prototype/toLocaleString/S15.2.4.3_A12.js
-    ! prototype/toLocaleString/S15.2.4.3_A13.js
     ! prototype/toLocaleString/primitive_this_value.js
     ! prototype/toLocaleString/primitive_this_value_getter.js
+    ! prototype/toLocaleString/S15.2.4.3_A12.js
+    ! prototype/toLocaleString/S15.2.4.3_A13.js
     ! prototype/toString/get-symbol-tag-err.js
     ! prototype/toString/symbol-tag-non-str-bigint.js
     ! prototype/toString/symbol-tag-non-str-builtin.js
@@ -753,7 +715,6 @@ built-ins/Object
     ! prototype/toString/symbol-tag-str.js
     ! prototype/valueOf/S15.2.4.4_A14.js
     ! prototype/valueOf/S15.2.4.4_A15.js
-    ! setPrototypeOf/set-error.js
 
 built-ins/parseFloat
     ! name.js
@@ -763,48 +724,37 @@ built-ins/parseInt
     ! name.js
     ! S15.1.2.2_A9.2.js
 
-# built-ins/Promise
+#built-ins/Promise
 
-# built-ins/Proxy
+#built-ins/Proxy
 
-# built-ins/Reflect
+#built-ins/Reflect
 
 built-ins/RegExp
-    ! 15.10.4.1-1.js
-    ! call_with_non_regexp_same_constructor.js
-    ! call_with_regexp_match_falsy.js
-    ! call_with_regexp_not_same_constructor.js
-    ! CharacterClassEscapes/character-class-digit-class-escape.js
     ! CharacterClassEscapes/character-class-digit-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
     ! CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-non-digit-class-escape.js
+    ! CharacterClassEscapes/character-class-digit-class-escape-plus-quantifier.js
+    ! CharacterClassEscapes/character-class-digit-class-escape.js
     ! CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
     ! CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-non-whitespace-class-escape.js
+    ! CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier.js
+    ! CharacterClassEscapes/character-class-non-digit-class-escape.js
     ! CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
     ! CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-non-word-class-escape.js
+    ! CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier.js
+    ! CharacterClassEscapes/character-class-non-whitespace-class-escape.js
     ! CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
     ! CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-whitespace-class-escape.js
+    ! CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js
+    ! CharacterClassEscapes/character-class-non-word-class-escape.js
     ! CharacterClassEscapes/character-class-whitespace-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
     ! CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier-flags-u.js
-    ! CharacterClassEscapes/character-class-word-class-escape.js
+    ! CharacterClassEscapes/character-class-whitespace-class-escape-plus-quantifier.js
+    ! CharacterClassEscapes/character-class-whitespace-class-escape.js
     ! CharacterClassEscapes/character-class-word-class-escape-flags-u.js
-    ! CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
     ! CharacterClassEscapes/character-class-word-class-escape-plus-quantifier-flags-u.js
-    ! from-regexp-like-flag-override.js
-    ! from-regexp-like-get-ctor-err.js
-    ! from-regexp-like-get-flags-err.js
-    ! from-regexp-like-get-source-err.js
-    ! from-regexp-like-short-circuit.js
-    ! from-regexp-like.js
-    ! match-indices/indices-array.js
+    ! CharacterClassEscapes/character-class-word-class-escape-plus-quantifier.js
+    ! CharacterClassEscapes/character-class-word-class-escape.js
     ! match-indices/indices-array-element.js
     ! match-indices/indices-array-matched.js
     ! match-indices/indices-array-non-unicode-match.js
@@ -812,12 +762,8 @@ built-ins/RegExp
     ! match-indices/indices-array-unicode-match.js
     ! match-indices/indices-array-unicode-property-names.js
     ! match-indices/indices-array-unmatched.js
-    ! match-indices/indices-groups-object.js
-    ! match-indices/indices-groups-object-undefined.js
-    ! match-indices/indices-groups-object-unmatched.js
-    ! match-indices/indices-groups-properties.js
+    ! match-indices/indices-array.js
     ! match-indices/indices-property.js
-    ! property-escapes/character-class.js
     ! prototype/exec/failure-lastindex-access.js
     ! prototype/exec/S15.10.6.2_A5_T3.js
     ! prototype/exec/success-lastindex-access.js
@@ -829,21 +775,16 @@ built-ins/RegExp
     ! prototype/exec/y-fail-return.js
     ! prototype/exec/y-init-lastindex.js
     ! prototype/exec/y-set-lastindex.js
-    ! prototype/flags/coercion-dotall.js
     ! prototype/flags/coercion-global.js
     ! prototype/flags/coercion-ignoreCase.js
     ! prototype/flags/coercion-multiline.js
     ! prototype/flags/coercion-sticky.js
     ! prototype/flags/coercion-unicode.js
-    ! prototype/flags/get-order.js
     ! prototype/flags/length.js
     ! prototype/flags/name.js
     ! prototype/flags/prop-desc.js
-    ! prototype/flags/rethrow.js
-    ! prototype/flags/return-order.js
     ! prototype/flags/this-val-non-obj.js
     ! prototype/flags/this-val-regexp-prototype.js
-    ! prototype/flags/this-val-regexp.js
     ! prototype/global/15.10.7.2-2.js
     ! prototype/global/length.js
     ! prototype/global/name.js
@@ -878,8 +819,8 @@ built-ins/RegExp
     ! prototype/Symbol.match/builtin-failure-y-set-lastindex-err.js
     ! prototype/Symbol.match/builtin-failure-y-set-lastindex.js
     ! prototype/Symbol.match/builtin-infer-unicode.js
-    ! prototype/Symbol.match/builtin-success-g-set-lastindex.js
     ! prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
+    ! prototype/Symbol.match/builtin-success-g-set-lastindex.js
     ! prototype/Symbol.match/builtin-success-u-return-val-groups.js
     ! prototype/Symbol.match/builtin-success-y-set-lastindex-err.js
     ! prototype/Symbol.match/builtin-success-y-set-lastindex.js
@@ -893,9 +834,9 @@ built-ins/RegExp
     ! prototype/Symbol.match/g-get-exec-err.js
     ! prototype/Symbol.match/g-get-result-err.js
     ! prototype/Symbol.match/g-init-lastindex.js
-    ! prototype/Symbol.match/g-match-empty-set-lastindex-err.js
     ! prototype/Symbol.match/g-match-empty-advance-lastindex.js
     ! prototype/Symbol.match/g-match-empty-coerce-lastindex-err.js
+    ! prototype/Symbol.match/g-match-empty-set-lastindex-err.js
     ! prototype/Symbol.match/g-success-return-val.js
     ! prototype/Symbol.match/get-exec-err.js
     ! prototype/Symbol.match/get-global-err.js
@@ -993,7 +934,6 @@ built-ins/RegExp
     ! prototype/Symbol.split/species-ctor-species-undef.js
     ! prototype/Symbol.split/species-ctor-y.js
     ! prototype/Symbol.split/species-ctor.js
-    ! prototype/Symbol.split/splitter-proto-from-ctor-realm.js
     ! prototype/Symbol.split/str-adv-thru-empty-match.js
     ! prototype/Symbol.split/str-coerce-lastindex-err.js
     ! prototype/Symbol.split/str-coerce-lastindex.js
@@ -1033,6 +973,16 @@ built-ins/RegExp
     ! Symbol.species/return-value.js
     ! Symbol.species/symbol-species-name.js
     ! Symbol.species/symbol-species.js
+    ! 15.10.4.1-1.js
+    ! call_with_non_regexp_same_constructor.js
+    ! call_with_regexp_match_falsy.js
+    ! call_with_regexp_not_same_constructor.js
+    ! from-regexp-like-flag-override.js
+    ! from-regexp-like-get-ctor-err.js
+    ! from-regexp-like-get-flags-err.js
+    ! from-regexp-like-get-source-err.js
+    ! from-regexp-like-short-circuit.js
+    ! from-regexp-like.js
     ! S15.10.1_A1_T13.js
     ! S15.10.1_A1_T14.js
     ! S15.10.1_A1_T15.js
@@ -1052,7 +1002,7 @@ built-ins/Set
 
 built-ins/SetIteratorPrototype
 
-# built-ins/SharedArrayBuffer
+#built-ins/SharedArrayBuffer
 
 built-ins/String
     ! prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
@@ -1060,13 +1010,9 @@ built-ins/String
     ! prototype/match/cstm-matcher-get-err.js
     ! prototype/match/cstm-matcher-invocation.js
     ! prototype/match/invoke-builtin-match.js
-    ! prototype/matchAll/length.js
-    ! prototype/matchAll/name.js
-    ! prototype/matchAll/prop-desc.js
-    ! prototype/matchAll/this-val-non-obj-coercible.js
-    ! prototype/replace/S15.5.4.11_A12.js
     ! prototype/replace/cstm-replace-get-err.js
     ! prototype/replace/cstm-replace-invocation.js
+    ! prototype/replace/S15.5.4.11_A12.js
     ! prototype/search/cstm-search-get-err.js
     ! prototype/search/cstm-search-invocation.js
     ! prototype/search/invoke-builtin-search-searcher-undef.js
@@ -1109,22 +1055,20 @@ built-ins/StringIteratorPrototype
 built-ins/Symbol
     ! asyncIterator/prop-desc.js
     ! keyFor/arg-non-symbol.js
-    ! matchAll/cross-realm.js
-    ! matchAll/prop-desc.js
-    ! species/builtin-getter-name.js
-    ! species/subclassing.js
-    ! prototype/description/descriptor.js
     ! prototype/description/description-symboldescriptivestring.js
+    ! prototype/description/descriptor.js
     ! prototype/description/get.js
     ! prototype/description/this-val-non-symbol.js
     ! prototype/description/this-val-symbol.js
     ! prototype/description/wrapper.js
     ! prototype/Symbol.toPrimitive/name.js
     ! prototype/Symbol.toPrimitive/prop-desc.js
-    ! this-val-non-obj.js
+    ! prototype/Symbol.toPrimitive/this-val-non-obj.js
+    ! prototype/valueOf/this-val-non-obj.js
+    ! species/builtin-getter-name.js
+    ! species/subclassing.js
 
 built-ins/ThrowTypeError
-    ! distinct-cross-realm.js
     ! extensible.js
     ! forbidden-arguments.js
     ! frozen.js
@@ -1146,13 +1090,6 @@ built-ins/TypedArray
     ! of/length.js
     ! of/name.js
     ! of/prop-desc.js
-    ! prototype/Symbol.toStringTag/BigInt/detached-buffer.js
-    ! prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
-    ! prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
-    ! prototype/Symbol.toStringTag/BigInt/prop-desc.js
-    ! prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
-    ! prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
-    ! prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
     ! prototype/buffer/BigInt/detached-buffer.js
     ! prototype/buffer/BigInt/return-buffer.js
     ! prototype/buffer/detached-buffer.js
@@ -1232,6 +1169,7 @@ built-ins/TypedArray
     ! prototype/copyWithin/this-is-not-typedarray-instance.js
     ! prototype/copyWithin/undefined-end.js
     ! prototype/entries/BigInt/detached-buffer.js
+    ! prototype/entries/BigInt/iter-prototype.js
     ! prototype/entries/BigInt/return-itor.js
     ! prototype/entries/detached-buffer.js
     ! prototype/entries/invoked-as-func.js
@@ -1264,7 +1202,6 @@ built-ins/TypedArray
     ! prototype/every/callbackfn-not-called-on-empty.js
     ! prototype/every/callbackfn-return-does-not-change-instance.js
     ! prototype/every/callbackfn-returns-abrupt.js
-    ! prototype/every/callbackfn-set-value-during-interaction.js
     ! prototype/every/callbackfn-this.js
     ! prototype/every/detached-buffer.js
     ! prototype/every/get-length-uses-internal-arraylength.js
@@ -1359,7 +1296,6 @@ built-ins/TypedArray
     ! prototype/filter/callbackfn-not-called-on-empty.js
     ! prototype/filter/callbackfn-return-does-not-change-instance.js
     ! prototype/filter/callbackfn-returns-abrupt.js
-    ! prototype/filter/callbackfn-set-value-during-iteration.js
     ! prototype/filter/callbackfn-this.js
     ! prototype/filter/detached-buffer.js
     ! prototype/filter/invoked-as-func.js
@@ -1396,24 +1332,6 @@ built-ins/TypedArray
     ! prototype/find/BigInt/return-abrupt-from-predicate-call.js
     ! prototype/find/BigInt/return-found-value-predicate-result-is-true.js
     ! prototype/find/BigInt/return-undefined-if-predicate-returns-false-value.js
-    ! prototype/find/detached-buffer.js
-    ! prototype/find/get-length-ignores-length-prop.js
-    ! prototype/find/invoked-as-func.js
-    ! prototype/find/invoked-as-method.js
-    ! prototype/find/length.js
-    ! prototype/find/name.js
-    ! prototype/find/predicate-call-changes-value.js
-    ! prototype/find/predicate-call-parameters.js
-    ! prototype/find/predicate-call-this-non-strict.js
-    ! prototype/find/predicate-call-this-strict.js
-    ! prototype/find/predicate-may-detach-buffer.js
-    ! prototype/find/predicate-not-called-on-empty-array.js
-    ! prototype/find/prop-desc.js
-    ! prototype/find/return-abrupt-from-predicate-call.js
-    ! prototype/find/return-found-value-predicate-result-is-true.js
-    ! prototype/find/return-undefined-if-predicate-returns-false-value.js
-    ! prototype/find/this-is-not-object.js
-    ! prototype/find/this-is-not-typedarray-instance.js
     ! prototype/findIndex/BigInt/detached-buffer.js
     ! prototype/findIndex/BigInt/get-length-ignores-length-prop.js
     ! prototype/findIndex/BigInt/predicate-call-changes-value.js
@@ -1444,6 +1362,24 @@ built-ins/TypedArray
     ! prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
     ! prototype/findIndex/this-is-not-object.js
     ! prototype/findIndex/this-is-not-typedarray-instance.js
+    ! prototype/find/detached-buffer.js
+    ! prototype/find/get-length-ignores-length-prop.js
+    ! prototype/find/invoked-as-func.js
+    ! prototype/find/invoked-as-method.js
+    ! prototype/find/length.js
+    ! prototype/find/name.js
+    ! prototype/find/predicate-call-changes-value.js
+    ! prototype/find/predicate-call-parameters.js
+    ! prototype/find/predicate-call-this-non-strict.js
+    ! prototype/find/predicate-call-this-strict.js
+    ! prototype/find/predicate-may-detach-buffer.js
+    ! prototype/find/predicate-not-called-on-empty-array.js
+    ! prototype/find/prop-desc.js
+    ! prototype/find/return-abrupt-from-predicate-call.js
+    ! prototype/find/return-found-value-predicate-result-is-true.js
+    ! prototype/find/return-undefined-if-predicate-returns-false-value.js
+    ! prototype/find/this-is-not-object.js
+    ! prototype/find/this-is-not-typedarray-instance.js
     ! prototype/forEach/BigInt/arraylength-internal.js
     ! prototype/forEach/BigInt/callbackfn-arguments-with-thisarg.js
     ! prototype/forEach/BigInt/callbackfn-arguments-without-thisarg.js
@@ -1465,7 +1401,6 @@ built-ins/TypedArray
     ! prototype/forEach/callbackfn-not-called-on-empty.js
     ! prototype/forEach/callbackfn-return-does-not-change-instance.js
     ! prototype/forEach/callbackfn-returns-abrupt.js
-    ! prototype/forEach/callbackfn-set-value-during-interaction.js
     ! prototype/forEach/callbackfn-this.js
     ! prototype/forEach/detached-buffer.js
     ! prototype/forEach/invoked-as-func.js
@@ -1558,6 +1493,7 @@ built-ins/TypedArray
     ! prototype/join/this-is-not-object.js
     ! prototype/join/this-is-not-typedarray-instance.js
     ! prototype/keys/BigInt/detached-buffer.js
+    ! prototype/keys/BigInt/iter-prototype.js
     ! prototype/keys/BigInt/return-itor.js
     ! prototype/keys/detached-buffer.js
     ! prototype/keys/invoked-as-func.js
@@ -1620,20 +1556,20 @@ built-ins/TypedArray
     ! prototype/map/BigInt/detached-buffer.js
     ! prototype/map/BigInt/return-new-typedarray-from-empty-length.js
     ! prototype/map/BigInt/return-new-typedarray-from-positive-length.js
-    ! prototype/map/BigInt/speciesctor-get-ctor.js
     ! prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
     ! prototype/map/BigInt/speciesctor-get-ctor-inherited.js
     ! prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
-    ! prototype/map/BigInt/speciesctor-get-species.js
+    ! prototype/map/BigInt/speciesctor-get-ctor.js
     ! prototype/map/BigInt/speciesctor-get-species-abrupt.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
     ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
     ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
     ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
     ! prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    ! prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
     ! prototype/map/BigInt/speciesctor-get-species-returns-throws.js
     ! prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
+    ! prototype/map/BigInt/speciesctor-get-species.js
     ! prototype/map/BigInt/values-are-not-cached.js
     ! prototype/map/arraylength-internal.js
     ! prototype/map/callbackfn-arguments-with-thisarg.js
@@ -1645,7 +1581,6 @@ built-ins/TypedArray
     ! prototype/map/callbackfn-return-does-not-change-instance.js
     ! prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
     ! prototype/map/callbackfn-returns-abrupt.js
-    ! prototype/map/callbackfn-set-value-during-interaction.js
     ! prototype/map/callbackfn-this.js
     ! prototype/map/detached-buffer.js
     ! prototype/map/invoked-as-func.js
@@ -1657,16 +1592,16 @@ built-ins/TypedArray
     ! prototype/map/return-new-typedarray-conversion-operation.js
     ! prototype/map/return-new-typedarray-from-empty-length.js
     ! prototype/map/return-new-typedarray-from-positive-length.js
-    ! prototype/map/speciesctor-get-ctor.js
     ! prototype/map/speciesctor-get-ctor-abrupt.js
     ! prototype/map/speciesctor-get-ctor-inherited.js
-    ! prototype/map/speciesctor-get-species.js
+    ! prototype/map/speciesctor-get-ctor.js
     ! prototype/map/speciesctor-get-species-abrupt.js
-    ! prototype/map/speciesctor-get-species-custom-ctor.js
     ! prototype/map/speciesctor-get-species-custom-ctor-invocation.js
     ! prototype/map/speciesctor-get-species-custom-ctor-length.js
     ! prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    ! prototype/map/speciesctor-get-species-custom-ctor.js
     ! prototype/map/speciesctor-get-species-use-default-ctor.js
+    ! prototype/map/speciesctor-get-species.js
     ! prototype/map/this-is-not-object.js
     ! prototype/map/this-is-not-typedarray-instance.js
     ! prototype/map/values-are-not-cached.js
@@ -1687,29 +1622,6 @@ built-ins/TypedArray
     ! prototype/reduce/BigInt/result-of-any-type.js
     ! prototype/reduce/BigInt/return-first-value-without-callbackfn.js
     ! prototype/reduce/BigInt/values-are-not-cached.js
-    ! prototype/reduce/callbackfn-arguments-custom-accumulator.js
-    ! prototype/reduce/callbackfn-arguments-default-accumulator.js
-    ! prototype/reduce/callbackfn-detachbuffer.js
-    ! prototype/reduce/callbackfn-no-iteration-over-non-integer-properties.js
-    ! prototype/reduce/callbackfn-not-called-on-empty.js
-    ! prototype/reduce/callbackfn-return-does-not-change-instance.js
-    ! prototype/reduce/callbackfn-returns-abrupt.js
-    ! prototype/reduce/callbackfn-set-value-during-iteration.js
-    ! prototype/reduce/callbackfn-this.js
-    ! prototype/reduce/detached-buffer.js
-    ! prototype/reduce/empty-instance-return-initialvalue.js
-    ! prototype/reduce/get-length-uses-internal-arraylength.js
-    ! prototype/reduce/invoked-as-func.js
-    ! prototype/reduce/invoked-as-method.js
-    ! prototype/reduce/length.js
-    ! prototype/reduce/name.js
-    ! prototype/reduce/prop-desc.js
-    ! prototype/reduce/result-is-last-callbackfn-return.js
-    ! prototype/reduce/result-of-any-type.js
-    ! prototype/reduce/return-first-value-without-callbackfn.js
-    ! prototype/reduce/this-is-not-object.js
-    ! prototype/reduce/this-is-not-typedarray-instance.js
-    ! prototype/reduce/values-are-not-cached.js
     ! prototype/reduceRight/BigInt/callbackfn-arguments-custom-accumulator.js
     ! prototype/reduceRight/BigInt/callbackfn-arguments-default-accumulator.js
     ! prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
@@ -1734,7 +1646,6 @@ built-ins/TypedArray
     ! prototype/reduceRight/callbackfn-not-called-on-empty.js
     ! prototype/reduceRight/callbackfn-return-does-not-change-instance.js
     ! prototype/reduceRight/callbackfn-returns-abrupt.js
-    ! prototype/reduceRight/callbackfn-set-value-during-iteration.js
     ! prototype/reduceRight/callbackfn-this.js
     ! prototype/reduceRight/detached-buffer.js
     ! prototype/reduceRight/empty-instance-return-initialvalue.js
@@ -1750,6 +1661,28 @@ built-ins/TypedArray
     ! prototype/reduceRight/this-is-not-object.js
     ! prototype/reduceRight/this-is-not-typedarray-instance.js
     ! prototype/reduceRight/values-are-not-cached.js
+    ! prototype/reduce/callbackfn-arguments-custom-accumulator.js
+    ! prototype/reduce/callbackfn-arguments-default-accumulator.js
+    ! prototype/reduce/callbackfn-detachbuffer.js
+    ! prototype/reduce/callbackfn-no-iteration-over-non-integer-properties.js
+    ! prototype/reduce/callbackfn-not-called-on-empty.js
+    ! prototype/reduce/callbackfn-return-does-not-change-instance.js
+    ! prototype/reduce/callbackfn-returns-abrupt.js
+    ! prototype/reduce/callbackfn-this.js
+    ! prototype/reduce/detached-buffer.js
+    ! prototype/reduce/empty-instance-return-initialvalue.js
+    ! prototype/reduce/get-length-uses-internal-arraylength.js
+    ! prototype/reduce/invoked-as-func.js
+    ! prototype/reduce/invoked-as-method.js
+    ! prototype/reduce/length.js
+    ! prototype/reduce/name.js
+    ! prototype/reduce/prop-desc.js
+    ! prototype/reduce/result-is-last-callbackfn-return.js
+    ! prototype/reduce/result-of-any-type.js
+    ! prototype/reduce/return-first-value-without-callbackfn.js
+    ! prototype/reduce/this-is-not-object.js
+    ! prototype/reduce/this-is-not-typedarray-instance.js
+    ! prototype/reduce/values-are-not-cached.js
     ! prototype/reverse/BigInt/detached-buffer.js
     ! prototype/reverse/BigInt/get-length-uses-internal-arraylength.js
     ! prototype/reverse/BigInt/preserves-non-numeric-properties.js
@@ -1836,11 +1769,7 @@ built-ins/TypedArray
     ! prototype/set/this-is-not-object.js
     ! prototype/set/this-is-not-typedarray-instance.js
     ! prototype/set/typedarray-arg-negative-integer-offset-throws.js
-    ! prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js
-    ! prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js
-    ! prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js
     ! prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
-    ! prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js
     ! prototype/set/typedarray-arg-src-arraylength-internal.js
     ! prototype/set/typedarray-arg-src-byteoffset-internal.js
     ! prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
@@ -1848,26 +1777,6 @@ built-ins/TypedArray
     ! prototype/set/typedarray-arg-target-arraylength-internal.js
     ! prototype/set/typedarray-arg-target-byteoffset-internal.js
     ! prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    ! prototype/sort/sort-tonumber.js
-    ! /length.js
-    ! /name.js
-    ! Symbol.species/length.js
-    ! Symbol.species/name.js
-    ! Symbol.species/prop-desc.js
-    ! Symbol.species/result.js
-    ! invoked.js
-    ! prototype.js
-    ! prototype/Symbol.iterator.js
-    ! prototype/Symbol.toStringTag/detached-buffer.js
-    ! prototype/Symbol.toStringTag/invoked-as-accessor.js
-    ! prototype/Symbol.toStringTag/invoked-as-func.js
-    ! prototype/Symbol.toStringTag/length.js
-    ! prototype/Symbol.toStringTag/name.js
-    ! prototype/Symbol.toStringTag/prop-desc.js
-    ! prototype/Symbol.toStringTag/return-typedarrayname.js
-    ! prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
-    ! prototype/Symbol.toStringTag/this-is-not-object.js
-    ! prototype/constructor.js
     ! prototype/slice/BigInt/arraylength-internal.js
     ! prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
     ! prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
@@ -1957,7 +1866,6 @@ built-ins/TypedArray
     ! prototype/some/callbackfn-not-called-on-empty.js
     ! prototype/some/callbackfn-return-does-not-change-instance.js
     ! prototype/some/callbackfn-returns-abrupt.js
-    ! prototype/some/callbackfn-set-value-during-interaction.js
     ! prototype/some/callbackfn-this.js
     ! prototype/some/detached-buffer.js
     ! prototype/some/get-length-uses-internal-arraylength.js
@@ -1991,9 +1899,11 @@ built-ins/TypedArray
     ! prototype/sort/name.js
     ! prototype/sort/prop-desc.js
     ! prototype/sort/return-same-instance.js
+    ! prototype/sort/sort-tonumber.js
     ! prototype/sort/sortcompare-with-no-tostring.js
     ! prototype/sort/sorted-values-nan.js
     ! prototype/sort/sorted-values.js
+    ! prototype/sort/stability.js
     ! prototype/sort/this-is-not-object.js
     ! prototype/sort/this-is-not-typedarray-instance.js
     ! prototype/subarray/BigInt/detached-buffer.js
@@ -2043,6 +1953,24 @@ built-ins/TypedArray
     ! prototype/subarray/speciesctor-get-species.js
     ! prototype/subarray/this-is-not-object.js
     ! prototype/subarray/this-is-not-typedarray-instance.js
+    ! prototype/Symbol.toStringTag/BigInt/detached-buffer.js
+    ! prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
+    ! prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
+    ! prototype/Symbol.toStringTag/BigInt/length.js
+    ! prototype/Symbol.toStringTag/BigInt/name.js
+    ! prototype/Symbol.toStringTag/BigInt/prop-desc.js
+    ! prototype/Symbol.toStringTag/BigInt/return-typedarrayname.js
+    ! prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
+    ! prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
+    ! prototype/Symbol.toStringTag/detached-buffer.js
+    ! prototype/Symbol.toStringTag/invoked-as-accessor.js
+    ! prototype/Symbol.toStringTag/invoked-as-func.js
+    ! prototype/Symbol.toStringTag/length.js
+    ! prototype/Symbol.toStringTag/name.js
+    ! prototype/Symbol.toStringTag/prop-desc.js
+    ! prototype/Symbol.toStringTag/return-typedarrayname.js
+    ! prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
+    ! prototype/Symbol.toStringTag/this-is-not-object.js
     ! prototype/toLocaleString/BigInt/calls-tolocalestring-from-each-value.js
     ! prototype/toLocaleString/BigInt/calls-tostring-from-each-value.js
     ! prototype/toLocaleString/BigInt/calls-valueof-from-each-value.js
@@ -2074,10 +2002,10 @@ built-ins/TypedArray
     ! prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
     ! prototype/toLocaleString/this-is-not-object.js
     ! prototype/toLocaleString/this-is-not-typedarray-instance.js
-    ! prototype/toString.js
     ! prototype/toString/BigInt/detached-buffer.js
     ! prototype/toString/detached-buffer.js
     ! prototype/values/BigInt/detached-buffer.js
+    ! prototype/values/BigInt/iter-prototype.js
     ! prototype/values/BigInt/return-itor.js
     ! prototype/values/detached-buffer.js
     ! prototype/values/invoked-as-func.js
@@ -2089,9 +2017,23 @@ built-ins/TypedArray
     ! prototype/values/return-itor.js
     ! prototype/values/this-is-not-object.js
     ! prototype/values/this-is-not-typedarray-instance.js
-    ! stability.js
+    ! prototype/constructor.js
+    ! prototype/Symbol.iterator.js
+    ! prototype/toString.js
+    ! Symbol.species/length.js
+    ! Symbol.species/name.js
+    ! Symbol.species/prop-desc.js
+    ! Symbol.species/result.js
+    ! invoked.js
+    ! length.js
+    ! name.js
+    ! prototype.js
 
 built-ins/TypedArrayConstructors
+    ! BigInt64Array/prototype/BYTES_PER_ELEMENT.js
+    ! BigInt64Array/prototype/constructor.js
+    ! BigInt64Array/prototype/not-typedarray-object.js
+    ! BigInt64Array/prototype/proto.js
     ! BigInt64Array/BYTES_PER_ELEMENT.js
     ! BigInt64Array/constructor.js
     ! BigInt64Array/length.js
@@ -2099,10 +2041,10 @@ built-ins/TypedArrayConstructors
     ! BigInt64Array/prop-desc.js
     ! BigInt64Array/proto.js
     ! BigInt64Array/prototype.js
-    ! BigInt64Array/prototype/BYTES_PER_ELEMENT.js
-    ! BigInt64Array/prototype/constructor.js
-    ! BigInt64Array/prototype/not-typedarray-object.js
-    ! BigInt64Array/prototype/proto.js
+    ! BigUint64Array/prototype/BYTES_PER_ELEMENT.js
+    ! BigUint64Array/prototype/constructor.js
+    ! BigUint64Array/prototype/not-typedarray-object.js
+    ! BigUint64Array/prototype/proto.js
     ! BigUint64Array/BYTES_PER_ELEMENT.js
     ! BigUint64Array/constructor.js
     ! BigUint64Array/length.js
@@ -2110,28 +2052,6 @@ built-ins/TypedArrayConstructors
     ! BigUint64Array/prop-desc.js
     ! BigUint64Array/proto.js
     ! BigUint64Array/prototype.js
-    ! BigUint64Array/prototype/BYTES_PER_ELEMENT.js
-    ! BigUint64Array/prototype/constructor.js
-    ! BigUint64Array/prototype/not-typedarray-object.js
-    ! BigUint64Array/prototype/proto.js
-    ! Float32Array/prototype/not-typedarray-object.js
-    ! Float32Array/prototype/proto.js
-    ! Float64Array/prototype/not-typedarray-object.js
-    ! Float64Array/prototype/proto.js
-    ! Int16Array/prototype/not-typedarray-object.js
-    ! Int16Array/prototype/proto.js
-    ! Int32Array/prototype/not-typedarray-object.js
-    ! Int32Array/prototype/proto.js
-    ! Int8Array/prototype/not-typedarray-object.js
-    ! Int8Array/prototype/proto.js
-    ! Uint16Array/prototype/not-typedarray-object.js
-    ! Uint16Array/prototype/proto.js
-    ! Uint32Array/prototype/not-typedarray-object.js
-    ! Uint32Array/prototype/proto.js
-    ! Uint8Array/prototype/not-typedarray-object.js
-    ! Uint8Array/prototype/proto.js
-    ! Uint8ClampedArray/prototype/not-typedarray-object.js
-    ! Uint8ClampedArray/prototype/proto.js
     ! ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size.js
     ! ctors-bigint/buffer-arg/byteoffset-is-negative-throws.js
     ! ctors-bigint/buffer-arg/byteoffset-is-negative-zero.js
@@ -2220,54 +2140,19 @@ built-ins/TypedArrayConstructors
     ! ctors-bigint/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
     ! ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
     ! ctors-bigint/typedarray-arg/undefined-newtarget-throws.js
-    ! ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js
-    ! ctors/buffer-arg/byteoffset-is-negative-throws-sab.js
     ! ctors/buffer-arg/byteoffset-is-negative-throws.js
-    ! ctors/buffer-arg/byteoffset-is-negative-zero-sab.js
-    ! ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js
-    ! ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js
     ! ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
-    ! ctors/buffer-arg/byteoffset-to-number-throws-sab.js
-    ! ctors/buffer-arg/custom-proto-access-throws-sab.js
-    ! ctors/buffer-arg/custom-proto-access-throws.js
-    ! ctors/buffer-arg/defined-length-and-offset-sab.js
-    ! ctors/buffer-arg/defined-length-sab.js
-    ! ctors/buffer-arg/defined-negative-length-sab.js
     ! ctors/buffer-arg/defined-negative-length.js
-    ! ctors/buffer-arg/defined-offset-sab.js
     ! ctors/buffer-arg/detachedbuffer.js
-    ! ctors/buffer-arg/excessive-length-throws-sab.js
-    ! ctors/buffer-arg/excessive-offset-throws-sab.js
-    ! ctors/buffer-arg/invoked-with-undefined-newtarget-sab.js
-    ! ctors/buffer-arg/is-referenced-sab.js
-    ! ctors/buffer-arg/length-access-throws-sab.js
-    ! ctors/buffer-arg/length-is-symbol-throws-sab.js
     ! ctors/buffer-arg/length-to-number-detachbuffer.js
-    ! ctors/buffer-arg/new-instance-extensibility-sab.js
-    ! ctors/buffer-arg/proto-from-ctor-realm-sab.js
-    ! ctors/buffer-arg/proto-from-ctor-realm.js
-    ! ctors/buffer-arg/returns-new-instance-sab.js
-    ! ctors/buffer-arg/toindex-bytelength-sab.js
-    ! ctors/buffer-arg/toindex-byteoffset-sab.js
-    ! ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js
-    ! ctors/buffer-arg/use-custom-proto-if-object-sab.js
-    ! ctors/buffer-arg/use-custom-proto-if-object.js
-    ! ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js
     ! ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/length-arg/custom-proto-access-throws.js
     ! ctors/length-arg/is-infinity-throws-rangeerror.js
     ! ctors/length-arg/is-negative-integer-throws-rangeerror.js
     ! ctors/length-arg/is-symbol-throws.js
-    ! ctors/length-arg/proto-from-ctor-realm.js
     ! ctors/length-arg/toindex-length.js
-    ! ctors/length-arg/use-custom-proto-if-object.js
     ! ctors/length-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/no-args/custom-proto-access-throws.js
-    ! ctors/no-args/proto-from-ctor-realm.js
-    ! ctors/no-args/use-custom-proto-if-object.js
     ! ctors/no-args/use-default-proto-if-custom-proto-is-not-object.js
     ! ctors/object-arg/as-generator-iterable-returns.js
-    ! ctors/object-arg/custom-proto-access-throws.js
     ! ctors/object-arg/iterating-throws.js
     ! ctors/object-arg/iterator-not-callable-throws.js
     ! ctors/object-arg/iterator-throws.js
@@ -2275,36 +2160,33 @@ built-ins/TypedArrayConstructors
     ! ctors/object-arg/length-is-symbol-throws.js
     ! ctors/object-arg/length-throws.js
     ! ctors/object-arg/new-instance-extensibility.js
-    ! ctors/object-arg/proto-from-ctor-realm.js
     ! ctors/object-arg/returns.js
     ! ctors/object-arg/throws-from-property.js
     ! ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
     ! ctors/object-arg/throws-setting-obj-to-primitive.js
     ! ctors/object-arg/throws-setting-property.js
     ! ctors/object-arg/throws-setting-symbol-property.js
-    ! ctors/object-arg/use-custom-proto-if-object.js
     ! ctors/object-arg/use-default-proto-if-custom-proto-is-not-object.js
-    ! ctors/typedarray-arg/custom-proto-access-throws.js
     ! ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
     ! ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ! ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
     ! ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
-    ! ctors/typedarray-arg/proto-from-ctor-realm.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
     ! ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
     ! ctors/typedarray-arg/src-typedarray-big-throws.js
-    ! ctors/typedarray-arg/use-custom-proto-if-object.js
     ! ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ! Float32Array/prototype/not-typedarray-object.js
+    ! Float32Array/prototype/proto.js
+    ! Float64Array/prototype/not-typedarray-object.js
+    ! Float64Array/prototype/proto.js
     ! from/BigInt/arylk-get-length-error.js
     ! from/BigInt/arylk-to-length-error.js
     ! from/BigInt/custom-ctor-does-not-instantiate-ta-throws.js
@@ -2356,29 +2238,16 @@ built-ins/TypedArrayConstructors
     ! from/new-instance-without-mapfn.js
     ! from/property-abrupt-completion.js
     ! from/set-value-abrupt-completion.js
+    ! Int16Array/prototype/not-typedarray-object.js
+    ! Int16Array/prototype/proto.js
+    ! Int32Array/prototype/not-typedarray-object.js
+    ! Int32Array/prototype/proto.js
+    ! Int8Array/prototype/not-typedarray-object.js
+    ! Int8Array/prototype/proto.js
     ! internals/DefineOwnProperty/BigInt/desc-value-throws.js
     ! internals/DefineOwnProperty/conversion-operation-consistent-nan.js
     ! internals/DefineOwnProperty/conversion-operation.js
     ! internals/DefineOwnProperty/desc-value-throws.js
-    ! internals/DefineOwnProperty/detached-buffer-realm.js
-    ! internals/DefineOwnProperty/detached-buffer.js
-    ! internals/DefineOwnProperty/key-is-greater-than-last-index.js
-    ! internals/DefineOwnProperty/key-is-lower-than-zero.js
-    ! internals/DefineOwnProperty/key-is-minus-zero.js
-    ! internals/DefineOwnProperty/key-is-not-canonical-index.js
-    ! internals/DefineOwnProperty/key-is-not-integer.js
-    ! internals/DefineOwnProperty/key-is-not-numeric-index.js
-    ! internals/DefineOwnProperty/key-is-numericindex-accessor-desc.js
-    ! internals/DefineOwnProperty/key-is-numericindex-desc-configurable.js
-    ! internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable.js
-    ! internals/DefineOwnProperty/key-is-numericindex-desc-not-writable.js
-    ! internals/DefineOwnProperty/key-is-numericindex.js
-    ! internals/DefineOwnProperty/key-is-symbol.js
-    ! internals/DefineOwnProperty/non-extensible-new-key.js
-    ! internals/DefineOwnProperty/non-extensible-redefine-key.js
-    ! internals/DefineOwnProperty/set-value.js
-    ! internals/DefineOwnProperty/this-is-not-extensible.js
-    ! internals/DefineOwnProperty/tonumber-value-detached-buffer.js
     ! internals/Get/BigInt/detached-buffer-key-is-not-numeric-index.js
     ! internals/Get/BigInt/detached-buffer-key-is-symbol.js
     ! internals/Get/BigInt/detached-buffer.js
@@ -2391,19 +2260,6 @@ built-ins/TypedArrayConstructors
     ! internals/Get/BigInt/key-is-not-numeric-index.js
     ! internals/Get/BigInt/key-is-out-of-bounds.js
     ! internals/Get/BigInt/key-is-symbol.js
-    ! internals/Get/detached-buffer-key-is-not-numeric-index.js
-    ! internals/Get/detached-buffer-key-is-symbol.js
-    ! internals/Get/detached-buffer-realm.js
-    ! internals/Get/detached-buffer.js
-    ! internals/Get/indexed-value-sab.js
-    ! internals/Get/indexed-value.js
-    ! internals/Get/infinity-detached-buffer.js
-    ! internals/Get/key-is-not-canonical-index.js
-    ! internals/Get/key-is-not-integer.js
-    ! internals/Get/key-is-not-minus-zero.js
-    ! internals/Get/key-is-not-numeric-index.js
-    ! internals/Get/key-is-out-of-bounds.js
-    ! internals/Get/key-is-symbol.js
     ! internals/GetOwnProperty/BigInt/detached-buffer-key-is-not-number.js
     ! internals/GetOwnProperty/BigInt/detached-buffer-key-is-symbol.js
     ! internals/GetOwnProperty/BigInt/detached-buffer.js
@@ -2417,30 +2273,22 @@ built-ins/TypedArrayConstructors
     ! internals/GetOwnProperty/BigInt/key-is-symbol.js
     ! internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     ! internals/GetOwnProperty/detached-buffer-key-is-symbol.js
-    ! internals/GetOwnProperty/detached-buffer-realm.js
     ! internals/GetOwnProperty/detached-buffer.js
     ! internals/GetOwnProperty/enumerate-detached-buffer.js
     ! internals/GetOwnProperty/index-prop-desc.js
+    ! internals/Get/detached-buffer-key-is-not-numeric-index.js
+    ! internals/Get/detached-buffer-key-is-symbol.js
+    ! internals/Get/detached-buffer.js
+    ! internals/Get/indexed-value.js
+    ! internals/Get/infinity-detached-buffer.js
+    ! internals/Get/key-is-not-canonical-index.js
+    ! internals/Get/key-is-not-integer.js
+    ! internals/Get/key-is-not-minus-zero.js
+    ! internals/Get/key-is-not-numeric-index.js
+    ! internals/Get/key-is-out-of-bounds.js
+    ! internals/Get/key-is-symbol.js
     ! internals/HasProperty/BigInt/infinity-with-detached-buffer.js
-    ! internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
-    ! internals/HasProperty/detached-buffer-key-is-not-number.js
-    ! internals/HasProperty/detached-buffer-key-is-symbol.js
-    ! internals/HasProperty/detached-buffer-realm.js
-    ! internals/HasProperty/detached-buffer.js
-    ! internals/HasProperty/indexed-value.js
     ! internals/HasProperty/infinity-with-detached-buffer.js
-    ! internals/HasProperty/inherited-property.js
-    ! internals/HasProperty/key-is-greater-than-last-index.js
-    ! internals/HasProperty/key-is-lower-than-zero.js
-    ! internals/HasProperty/key-is-minus-zero.js
-    ! internals/HasProperty/key-is-not-canonical-index.js
-    ! internals/HasProperty/key-is-not-integer.js
-    ! internals/HasProperty/key-is-not-numeric-index.js
-    ! internals/HasProperty/key-is-symbol.js
-    ! internals/OwnPropertyKeys/integer-indexes-and-string-and-symbol-keys-.js
-    ! internals/OwnPropertyKeys/integer-indexes-and-string-keys.js
-    ! internals/OwnPropertyKeys/integer-indexes.js
-    ! internals/OwnPropertyKeys/not-enumerable-keys.js
     ! internals/Set/BigInt/bigint-tobigint64.js
     ! internals/Set/BigInt/bigint-tobiguint64.js
     ! internals/Set/BigInt/boolean-tobigint.js
@@ -2453,18 +2301,7 @@ built-ins/TypedArrayConstructors
     ! internals/Set/BigInt/symbol-tobigint.js
     ! internals/Set/BigInt/tonumber-value-throws.js
     ! internals/Set/BigInt/undefined-tobigint.js
-    ! internals/Set/detached-buffer-key-is-not-numeric-index.js
-    ! internals/Set/detached-buffer-key-is-symbol.js
-    ! internals/Set/detached-buffer-realm.js
     ! internals/Set/detached-buffer.js
-    ! internals/Set/indexed-value.js
-    ! internals/Set/key-is-minus-zero.js
-    ! internals/Set/key-is-not-canonical-index.js
-    ! internals/Set/key-is-not-integer.js
-    ! internals/Set/key-is-not-numeric-index.js
-    ! internals/Set/key-is-out-of-bounds.js
-    ! internals/Set/key-is-symbol.js
-    ! internals/Set/tonumber-value-detached-buffer.js
     ! internals/Set/tonumber-value-throws.js
     ! of/BigInt/argument-is-symbol-throws.js
     ! of/BigInt/argument-number-value-throws.js
@@ -2486,9 +2323,6 @@ built-ins/TypedArrayConstructors
     ! of/new-instance-from-zero.js
     ! of/new-instance-using-custom-ctor.js
     ! of/new-instance.js
-    ! prototype/Symbol.iterator.js
-    ! prototype/Symbol.toStringTag/bigint-inherited.js
-    ! prototype/bigint-Symbol.iterator.js
     ! prototype/buffer/bigint-inherited.js
     ! prototype/buffer/inherited.js
     ! prototype/byteLength/bigint-inherited.js
@@ -2500,8 +2334,8 @@ built-ins/TypedArrayConstructors
     ! prototype/every/bigint-inherited.js
     ! prototype/fill/bigint-inherited.js
     ! prototype/filter/bigint-inherited.js
-    ! prototype/find/bigint-inherited.js
     ! prototype/findIndex/bigint-inherited.js
+    ! prototype/find/bigint-inherited.js
     ! prototype/forEach/bigint-inherited.js
     ! prototype/indexOf/bigint-inherited.js
     ! prototype/join/bigint-inherited.js
@@ -2510,8 +2344,8 @@ built-ins/TypedArrayConstructors
     ! prototype/length/bigint-inherited.js
     ! prototype/length/inherited.js
     ! prototype/map/bigint-inherited.js
-    ! prototype/reduce/bigint-inherited.js
     ! prototype/reduceRight/bigint-inherited.js
+    ! prototype/reduce/bigint-inherited.js
     ! prototype/reverse/bigint-inherited.js
     ! prototype/set/bigint-inherited.js
     ! prototype/set/inherited.js
@@ -2520,10 +2354,21 @@ built-ins/TypedArrayConstructors
     ! prototype/sort/bigint-inherited.js
     ! prototype/subarray/bigint-inherited.js
     ! prototype/subarray/inherited.js
+    ! prototype/Symbol.toStringTag/bigint-inherited.js
     ! prototype/toLocaleString/bigint-inherited.js
     ! prototype/toString/bigint-inherited.js
     ! prototype/toString/inherited.js
     ! prototype/values/bigint-inherited.js
+    ! prototype/bigint-Symbol.iterator.js
+    ! prototype/Symbol.iterator.js
+    ! Uint16Array/prototype/not-typedarray-object.js
+    ! Uint16Array/prototype/proto.js
+    ! Uint32Array/prototype/not-typedarray-object.js
+    ! Uint32Array/prototype/proto.js
+    ! Uint8Array/prototype/not-typedarray-object.js
+    ! Uint8Array/prototype/proto.js
+    ! Uint8ClampedArray/prototype/not-typedarray-object.js
+    ! Uint8ClampedArray/prototype/proto.js
 
 built-ins/undefined
 
@@ -2531,119 +2376,7 @@ built-ins/WeakMap
 
 built-ins/WeakSet
 
-######### LANGUAGE #########
-
 language/arguments-object
-    ! arguments-caller.js
-    ! cls-decl-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-decl-gen-meth-args-trailing-comma-undefined.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-null.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-decl-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-decl-meth-args-trailing-comma-multiple.js
-    ! cls-decl-meth-args-trailing-comma-null.js
-    ! cls-decl-meth-args-trailing-comma-single-args.js
-    ! cls-decl-meth-args-trailing-comma-spread-operator.js
-    ! cls-decl-meth-args-trailing-comma-undefined.js
-    ! cls-decl-meth-static-args-trailing-comma-multiple.js
-    ! cls-decl-meth-static-args-trailing-comma-null.js
-    ! cls-decl-meth-static-args-trailing-comma-single-args.js
-    ! cls-decl-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-decl-meth-static-args-trailing-comma-undefined.js
-    ! cls-decl-private-gen-meth-args-trailing-comma-multiple.js
-    ! cls-decl-private-gen-meth-args-trailing-comma-null.js
-    ! cls-decl-private-gen-meth-args-trailing-comma-single-args.js
-    ! cls-decl-private-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-decl-private-gen-meth-args-trailing-comma-undefined.js
-    ! cls-decl-private-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-decl-private-gen-meth-static-args-trailing-comma-null.js
-    ! cls-decl-private-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-decl-private-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-decl-private-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-decl-private-meth-args-trailing-comma-multiple.js
-    ! cls-decl-private-meth-args-trailing-comma-null.js
-    ! cls-decl-private-meth-args-trailing-comma-single-args.js
-    ! cls-decl-private-meth-args-trailing-comma-spread-operator.js
-    ! cls-decl-private-meth-args-trailing-comma-undefined.js
-    ! cls-decl-private-meth-static-args-trailing-comma-multiple.js
-    ! cls-decl-private-meth-static-args-trailing-comma-null.js
-    ! cls-decl-private-meth-static-args-trailing-comma-single-args.js
-    ! cls-decl-private-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-decl-private-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-async-gen-func-args-trailing-comma-multiple.js
-    ! cls-expr-async-gen-func-args-trailing-comma-null.js
-    ! cls-expr-async-gen-func-args-trailing-comma-single-args.js
-    ! cls-expr-async-gen-func-args-trailing-comma-spread-operator.js
-    ! cls-expr-async-gen-func-args-trailing-comma-undefined.js
-    ! cls-expr-async-gen-meth-args-trailing-comma-multiple.js
-    ! cls-expr-async-gen-meth-args-trailing-comma-null.js
-    ! cls-expr-async-gen-meth-args-trailing-comma-single-args.js
-    ! cls-expr-async-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-async-gen-meth-args-trailing-comma-undefined.js
-    ! cls-expr-async-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-async-gen-meth-static-args-trailing-comma-null.js
-    ! cls-expr-async-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-async-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-async-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-async-private-gen-meth-args-trailing-comma-multiple.js
-    ! cls-expr-async-private-gen-meth-args-trailing-comma-null.js
-    ! cls-expr-async-private-gen-meth-args-trailing-comma-single-args.js
-    ! cls-expr-async-private-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-async-private-gen-meth-args-trailing-comma-undefined.js
-    ! cls-expr-async-private-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-async-private-gen-meth-static-args-trailing-comma-null.js
-    ! cls-expr-async-private-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-async-private-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-async-private-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-gen-meth-args-trailing-comma-multiple.js
-    ! cls-expr-gen-meth-args-trailing-comma-null.js
-    ! cls-expr-gen-meth-args-trailing-comma-single-args.js
-    ! cls-expr-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-gen-meth-args-trailing-comma-undefined.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-null.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-meth-args-trailing-comma-multiple.js
-    ! cls-expr-meth-args-trailing-comma-null.js
-    ! cls-expr-meth-args-trailing-comma-single-args.js
-    ! cls-expr-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-meth-args-trailing-comma-undefined.js
-    ! cls-expr-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-meth-static-args-trailing-comma-null.js
-    ! cls-expr-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-private-gen-meth-args-trailing-comma-multiple.js
-    ! cls-expr-private-gen-meth-args-trailing-comma-null.js
-    ! cls-expr-private-gen-meth-args-trailing-comma-single-args.js
-    ! cls-expr-private-gen-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-private-gen-meth-args-trailing-comma-undefined.js
-    ! cls-expr-private-gen-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-private-gen-meth-static-args-trailing-comma-null.js
-    ! cls-expr-private-gen-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-private-gen-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-private-gen-meth-static-args-trailing-comma-undefined.js
-    ! cls-expr-private-meth-args-trailing-comma-multiple.js
-    ! cls-expr-private-meth-args-trailing-comma-null.js
-    ! cls-expr-private-meth-args-trailing-comma-single-args.js
-    ! cls-expr-private-meth-args-trailing-comma-spread-operator.js
-    ! cls-expr-private-meth-args-trailing-comma-undefined.js
-    ! cls-expr-private-meth-static-args-trailing-comma-multiple.js
-    ! cls-expr-private-meth-static-args-trailing-comma-null.js
-    ! cls-expr-private-meth-static-args-trailing-comma-single-args.js
-    ! cls-expr-private-meth-static-args-trailing-comma-spread-operator.js
-    ! cls-expr-private-meth-static-args-trailing-comma-undefined.js
-    ! func-decl-args-trailing-comma-spread-operator.js
-    ! func-expr-args-trailing-comma-spread-operator.js
-    ! gen-func-decl-args-trailing-comma-spread-operator.js
-    ! gen-func-expr-args-trailing-comma-spread-operator.js
-    ! gen-meth-args-trailing-comma-spread-operator.js
-    ! gen-meth-args-trailing-comma-undefined.js
-    ! meth-args-trailing-comma-spread-operator.js
     ! mapped/mapped-arguments-nonconfigurable-3.js
     ! mapped/mapped-arguments-nonconfigurable-delete-1.js
     ! mapped/mapped-arguments-nonconfigurable-delete-2.js
@@ -2684,42 +2417,57 @@ language/arguments-object
     ! unmapped/via-params-dflt.js
     ! unmapped/via-params-dstr.js
     ! unmapped/via-params-rest.js
+    ! arguments-caller.js
     ! cls-decl-gen-meth-args-trailing-comma-multiple.js
     ! cls-decl-gen-meth-args-trailing-comma-null.js
     ! cls-decl-gen-meth-args-trailing-comma-single-args.js
+    ! cls-decl-gen-meth-args-trailing-comma-spread-operator.js
     ! cls-decl-gen-meth-args-trailing-comma-undefined.js
     ! cls-decl-gen-meth-static-args-trailing-comma-multiple.js
     ! cls-decl-gen-meth-static-args-trailing-comma-null.js
     ! cls-decl-gen-meth-static-args-trailing-comma-single-args.js
+    ! cls-decl-gen-meth-static-args-trailing-comma-spread-operator.js
     ! cls-decl-gen-meth-static-args-trailing-comma-undefined.js
     ! cls-decl-meth-args-trailing-comma-multiple.js
     ! cls-decl-meth-args-trailing-comma-null.js
     ! cls-decl-meth-args-trailing-comma-single-args.js
+    ! cls-decl-meth-args-trailing-comma-spread-operator.js
     ! cls-decl-meth-args-trailing-comma-undefined.js
     ! cls-decl-meth-static-args-trailing-comma-multiple.js
     ! cls-decl-meth-static-args-trailing-comma-null.js
     ! cls-decl-meth-static-args-trailing-comma-single-args.js
+    ! cls-decl-meth-static-args-trailing-comma-spread-operator.js
     ! cls-decl-meth-static-args-trailing-comma-undefined.js
     ! cls-expr-gen-meth-args-trailing-comma-multiple.js
     ! cls-expr-gen-meth-args-trailing-comma-null.js
     ! cls-expr-gen-meth-args-trailing-comma-single-args.js
+    ! cls-expr-gen-meth-args-trailing-comma-spread-operator.js
     ! cls-expr-gen-meth-args-trailing-comma-undefined.js
     ! cls-expr-gen-meth-static-args-trailing-comma-multiple.js
     ! cls-expr-gen-meth-static-args-trailing-comma-null.js
     ! cls-expr-gen-meth-static-args-trailing-comma-single-args.js
+    ! cls-expr-gen-meth-static-args-trailing-comma-spread-operator.js
     ! cls-expr-gen-meth-static-args-trailing-comma-undefined.js
     ! cls-expr-meth-args-trailing-comma-multiple.js
     ! cls-expr-meth-args-trailing-comma-null.js
     ! cls-expr-meth-args-trailing-comma-single-args.js
+    ! cls-expr-meth-args-trailing-comma-spread-operator.js
     ! cls-expr-meth-args-trailing-comma-undefined.js
     ! cls-expr-meth-static-args-trailing-comma-multiple.js
     ! cls-expr-meth-static-args-trailing-comma-null.js
     ! cls-expr-meth-static-args-trailing-comma-single-args.js
+    ! cls-expr-meth-static-args-trailing-comma-spread-operator.js
     ! cls-expr-meth-static-args-trailing-comma-undefined.js
+    ! func-decl-args-trailing-comma-spread-operator.js
+    ! func-expr-args-trailing-comma-spread-operator.js
+    ! gen-func-decl-args-trailing-comma-spread-operator.js
+    ! gen-func-expr-args-trailing-comma-spread-operator.js
     ! gen-meth-args-trailing-comma-multiple.js
     ! gen-meth-args-trailing-comma-null.js
     ! gen-meth-args-trailing-comma-single-args.js
+    ! gen-meth-args-trailing-comma-spread-operator.js
     ! gen-meth-args-trailing-comma-undefined.js
+    ! meth-args-trailing-comma-spread-operator.js
 
 language/asi
     ! S7.9_A5.7_T1.js
@@ -2735,39 +2483,29 @@ language/block-scope
     ! syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
     ! syntax/function-declarations/in-statement-position-if-expression-statement.js
     ! syntax/function-declarations/in-statement-position-while-expression-statement.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js
-    ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js
     ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-class.js
     ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
     ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
     ! syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
     ! syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js
-    ! syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js
     ! syntax/redeclaration/function-name-redeclaration-attempt-with-class.js
     ! syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     ! syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
     ! syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     ! syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     ! syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js
-    ! syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js
     ! syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js
     ! syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     ! syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     ! syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     ! syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     ! syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js
-    ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js
     ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-class.js
     ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
     ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     ! syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js
-    ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js
     ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-class.js
     ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
     ! syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
@@ -2776,8 +2514,6 @@ language/block-scope
     ! syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     ! syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     ! syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-async-function.js
-    ! syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js
     ! syntax/redeclaration/var-redeclaration-attempt-after-class.js
     ! syntax/redeclaration/var-redeclaration-attempt-after-const.js
     ! syntax/redeclaration/var-redeclaration-attempt-after-function.js
@@ -2791,56 +2527,9 @@ language/comments
     ! multi-line-asi-paragraph-separator.js
     ! multi-line-html-close-extra.js
 
-language/computed-property-names
-    ! basics/number.js
-    ! basics/string.js
-    ! basics/symbol.js
-    ! class/accessor/getter-duplicates.js
-    ! class/accessor/getter.js
-    ! class/accessor/setter-duplicates.js
-    ! class/accessor/setter.js
-    ! class/method/constructor-can-be-generator.js
-    ! class/method/constructor-can-be-getter.js
-    ! class/method/constructor-can-be-setter.js
-    ! class/method/constructor-duplicate-1.js
-    ! class/method/constructor-duplicate-2.js
-    ! class/method/constructor-duplicate-3.js
-    ! class/method/constructor.js
-    ! class/method/generator.js
-    ! class/method/number.js
-    ! class/method/string.js
-    ! class/method/symbol.js
-    ! class/static/generator-constructor.js
-    ! class/static/generator-prototype.js
-    ! class/static/getter-constructor.js
-    ! class/static/getter-prototype.js
-    ! class/static/method-constructor.js
-    ! class/static/method-number.js
-    ! class/static/method-prototype.js
-    ! class/static/method-string.js
-    ! class/static/method-symbol.js
-    ! class/static/setter-constructor.js
-    ! class/static/setter-prototype.js
-    ! object/accessor/getter-duplicates.js
-    ! object/accessor/getter-super.js
-    ! object/accessor/getter.js
-    ! object/accessor/setter-duplicates.js
-    ! object/accessor/setter-super.js
-    ! object/accessor/setter.js
-    ! object/method/generator.js
-    ! object/method/number.js
-    ! object/method/string.js
-    ! object/method/super.js
-    ! object/method/symbol.js
-    ! object/property/number-duplicates.js
-    ! to-name-side-effects/class.js
-    ! to-name-side-effects/numbers-class.js
-    ! to-name-side-effects/numbers-object.js
-    ! to-name-side-effects/object.js
+#language/computed-property-names
 
 language/destructuring
-    ! binding/initialization-requires-object-coercible-null.js
-    ! binding/initialization-requires-object-coercible-undefined.js
     ! binding/syntax/array-elements-with-initializer.js
     ! binding/syntax/array-elements-with-object-patterns.js
     ! binding/syntax/array-rest-elements.js
@@ -2848,17 +2537,11 @@ language/destructuring
     ! binding/syntax/property-list-single-name-bindings.js
     ! binding/syntax/property-list-with-property-list.js
     ! binding/syntax/recursive-array-and-object-patterns.js
+    ! binding/initialization-requires-object-coercible-null.js
+    ! binding/initialization-requires-object-coercible-undefined.js
 
 language/directive-prologue
     ! 14.1-1-s.js
-    ! 14.1-2-s.js
-    ! 14.1-3-s.js
-    ! 14.1-4-s.js
-    ! 14.1-5-s.js
-    ! 14.1-6-s.js
-    ! 14.1-7-s.js
-    ! 14.1-8-s.js
-    ! 14.1-9-s.js
     ! 14.1-10-s.js
     ! 14.1-11-s.js
     ! 14.1-12-s.js
@@ -2867,6 +2550,14 @@ language/directive-prologue
     ! 14.1-15-s.js
     ! 14.1-16-s.js
     ! 14.1-17-s.js
+    ! 14.1-2-s.js
+    ! 14.1-3-s.js
+    ! 14.1-4-s.js
+    ! 14.1-5-s.js
+    ! 14.1-6-s.js
+    ! 14.1-7-s.js
+    ! 14.1-8-s.js
+    ! 14.1-9-s.js
     ! func-decl-inside-func-decl-parse.js
 
 language/eval-code
@@ -2877,7 +2568,6 @@ language/eval-code
     ! direct/lex-env-distinct-let.js
     ! direct/lex-env-no-init-const.js
     ! direct/lex-env-no-init-let.js
-    ! direct/new.target-fn.js
     ! direct/non-definable-global-var.js
     ! direct/switch-case-decl-eval-source-is-strict-nostrict.js
     ! direct/switch-case-decl-eval-source-is-strict-onlystrict.js
@@ -2887,25 +2577,32 @@ language/eval-code
     ! direct/switch-dflt-decl-onlystrict.js
     ! direct/this-value-func-strict-caller.js
     ! direct/var-env-func-init-global-update-configurable.js
-    ! direct/var-env-func-strict-caller.js
     ! direct/var-env-func-strict-caller-2.js
+    ! direct/var-env-func-strict-caller.js
     ! direct/var-env-func-strict-source.js
     ! direct/var-env-global-lex-non-strict.js
-    ! /direct/var-env-lower-lex-non-strict.js
+    ! direct/var-env-lower-lex-non-strict.js
     ! direct/var-env-var-strict-caller-2.js
     ! direct/var-env-var-strict-caller-3.js
     ! direct/var-env-var-strict-caller.js
     ! direct/var-env-var-strict-source.js
     ! indirect/always-non-strict.js
     ! indirect/block-decl-strict.js
+    ! indirect/lex-env-distinct-const.js
+    ! indirect/lex-env-distinct-let.js
+    ! indirect/lex-env-no-init-const.js
+    ! indirect/lex-env-no-init-let.js
     ! indirect/non-definable-function-with-function.js
     ! indirect/non-definable-function-with-variable.js
+    ! indirect/non-definable-global-var.js
     ! indirect/switch-case-decl-strict.js
     ! indirect/switch-dflt-decl-strict.js
+    ! indirect/var-env-func-init-global-update-configurable.js
     ! indirect/var-env-func-strict.js
+    ! indirect/var-env-global-lex-non-strict.js
     ! indirect/var-env-var-strict.js
 
-language/export
+#language/export
 
 language/expressions/addition
     ! coerce-symbol-to-prim-err.js
@@ -2916,17 +2613,6 @@ language/expressions/addition
     ! order-of-evaluation.js
 
 language/expressions/arrow-function
-    ! array-destructuring-param-strict-body.js
-    ! ArrowFunction_restricted-properties.js
-    ! dflt-params-abrupt.js
-    ! dflt-params-arg-val-not-undefined.js
-    ! dflt-params-arg-val-undefined.js
-    ! dflt-params-duplicates.js
-    ! dflt-params-ref-later.js
-    ! dflt-params-ref-prior.js
-    ! dflt-params-ref-self.js
-    ! dflt-params-rest.js
-    ! dflt-params-trailing-comma.js
     ! dstr/ary-init-iter-close.js
     ! dstr/ary-init-iter-get-err.js
     ! dstr/ary-ptrn-elem-ary-elem-init.js
@@ -2974,96 +2660,6 @@ language/expressions/arrow-function
     ! dstr/ary-ptrn-rest-not-final-obj.js
     ! dstr/ary-ptrn-rest-obj-id.js
     ! dstr/ary-ptrn-rest-obj-prop-id.js
-    ! dstr/dflt-ary-init-iter-close.js
-    ! dstr/dflt-ary-init-iter-get-err.js
-    ! dstr/dflt-ary-init-iter-no-close.js
-    ! dstr/dflt-ary-name-iter-val.js
-    ! dstr/dflt-ary-ptrn-elem-ary-elem-init.js
-    ! dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
-    ! dstr/dflt-ary-ptrn-elem-ary-elision-init.js
-    ! dstr/dflt-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/dflt-ary-ptrn-elem-ary-empty-init.js
-    ! dstr/dflt-ary-ptrn-elem-ary-empty-iter.js
-    ! dstr/dflt-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/dflt-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/dflt-ary-ptrn-elem-ary-val-null.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-exhausted.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-hole.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-skipped.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-throws.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-undef.js
-    ! dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js
-    ! dstr/dflt-ary-ptrn-elem-id-iter-complete.js
-    ! dstr/dflt-ary-ptrn-elem-id-iter-done.js
-    ! dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
-    ! dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/dflt-ary-ptrn-elem-id-iter-val.js
-    ! dstr/dflt-ary-ptrn-elem-obj-id-init.js
-    ! dstr/dflt-ary-ptrn-elem-obj-id.js
-    ! dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/dflt-ary-ptrn-elem-obj-prop-id.js
-    ! dstr/dflt-ary-ptrn-elem-obj-val-null.js
-    ! dstr/dflt-ary-ptrn-elem-obj-val-undef.js
-    ! dstr/dflt-ary-ptrn-elision-exhausted.js
-    ! dstr/dflt-ary-ptrn-elision-step-err.js
-    ! dstr/dflt-ary-ptrn-elision.js
-    ! dstr/dflt-ary-ptrn-empty.js
-    ! dstr/dflt-ary-ptrn-rest-ary-elem.js
-    ! dstr/dflt-ary-ptrn-rest-ary-elision.js
-    ! dstr/dflt-ary-ptrn-rest-ary-empty.js
-    ! dstr/dflt-ary-ptrn-rest-ary-rest.js
-    ! dstr/dflt-ary-ptrn-rest-id-elision-next-err.js
-    ! dstr/dflt-ary-ptrn-rest-id-elision.js
-    ! dstr/dflt-ary-ptrn-rest-id-exhausted.js
-    ! dstr/dflt-ary-ptrn-rest-id-iter-step-err.js
-    ! dstr/dflt-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/dflt-ary-ptrn-rest-id.js
-    ! dstr/dflt-ary-ptrn-rest-init-ary.js
-    ! dstr/dflt-ary-ptrn-rest-init-id.js
-    ! dstr/dflt-ary-ptrn-rest-init-obj.js
-    ! dstr/dflt-ary-ptrn-rest-not-final-ary.js
-    ! dstr/dflt-ary-ptrn-rest-not-final-id.js
-    ! dstr/dflt-ary-ptrn-rest-not-final-obj.js
-    ! dstr/dflt-ary-ptrn-rest-obj-id.js
-    ! dstr/dflt-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/dflt-obj-init-null.js
-    ! dstr/dflt-obj-init-undefined.js
-    ! dstr/dflt-obj-ptrn-empty.js
-    ! dstr/dflt-obj-ptrn-id-get-value-err.js
-    ! dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
-    ! dstr/dflt-obj-ptrn-id-init-fn-name-class.js
-    ! dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
-    ! dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
-    ! dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
-    ! dstr/dflt-obj-ptrn-id-init-skipped.js
-    ! dstr/dflt-obj-ptrn-id-init-throws.js
-    ! dstr/dflt-obj-ptrn-id-init-unresolvable.js
-    ! dstr/dflt-obj-ptrn-id-trailing-comma.js
-    ! dstr/dflt-obj-ptrn-list-err.js
-    ! dstr/dflt-obj-ptrn-prop-ary-init.js
-    ! dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
-    ! dstr/dflt-obj-ptrn-prop-ary-value-null.js
-    ! dstr/dflt-obj-ptrn-prop-ary.js
-    ! dstr/dflt-obj-ptrn-prop-eval-err.js
-    ! dstr/dflt-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/dflt-obj-ptrn-prop-id-init-skipped.js
-    ! dstr/dflt-obj-ptrn-prop-id-init-throws.js
-    ! dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/dflt-obj-ptrn-prop-id-init.js
-    ! dstr/dflt-obj-ptrn-prop-id-trailing-comma.js
-    ! dstr/dflt-obj-ptrn-prop-id.js
-    ! dstr/dflt-obj-ptrn-prop-obj-init.js
-    ! dstr/dflt-obj-ptrn-prop-obj-value-null.js
-    ! dstr/dflt-obj-ptrn-prop-obj-value-undef.js
-    ! dstr/dflt-obj-ptrn-prop-obj.js
-    ! dstr/dflt-obj-ptrn-rest-getter.js
-    ! dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js
-    ! dstr/dflt-obj-ptrn-rest-val-obj.js
     ! dstr/obj-init-null.js
     ! dstr/obj-init-undefined.js
     ! dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -3088,9 +2684,6 @@ language/expressions/arrow-function
     ! dstr/obj-ptrn-prop-obj-value-null.js
     ! dstr/obj-ptrn-prop-obj-value-undef.js
     ! dstr/obj-ptrn-prop-obj.js
-    ! dstr/obj-ptrn-rest-getter.js
-    ! dstr/obj-ptrn-rest-skip-non-enumerable.js
-    ! dstr/obj-ptrn-rest-val-obj.js
     ! dstr/syntax-error-ident-ref-break-escaped.js
     ! dstr/syntax-error-ident-ref-case-escaped.js
     ! dstr/syntax-error-ident-ref-catch-escaped.js
@@ -3098,17 +2691,17 @@ language/expressions/arrow-function
     ! dstr/syntax-error-ident-ref-const-escaped.js
     ! dstr/syntax-error-ident-ref-continue-escaped.js
     ! dstr/syntax-error-ident-ref-debugger-escaped.js
-    ! dstr/syntax-error-ident-ref-default.js
-    ! dstr/syntax-error-ident-ref-default-escaped.js
     ! dstr/syntax-error-ident-ref-default-escaped-ext.js
+    ! dstr/syntax-error-ident-ref-default-escaped.js
+    ! dstr/syntax-error-ident-ref-default.js
     ! dstr/syntax-error-ident-ref-delete-escaped.js
     ! dstr/syntax-error-ident-ref-do-escaped.js
     ! dstr/syntax-error-ident-ref-else-escaped.js
     ! dstr/syntax-error-ident-ref-enum-escaped.js
     ! dstr/syntax-error-ident-ref-export-escaped.js
-    ! dstr/syntax-error-ident-ref-extends.js
-    ! dstr/syntax-error-ident-ref-extends-escaped.js
     ! dstr/syntax-error-ident-ref-extends-escaped-ext.js
+    ! dstr/syntax-error-ident-ref-extends-escaped.js
+    ! dstr/syntax-error-ident-ref-extends.js
     ! dstr/syntax-error-ident-ref-finally-escaped.js
     ! dstr/syntax-error-ident-ref-for-escaped.js
     ! dstr/syntax-error-ident-ref-function-escaped.js
@@ -3136,36 +2729,6 @@ language/expressions/arrow-function
     ! dstr/syntax-error-ident-ref-void-escaped.js
     ! dstr/syntax-error-ident-ref-while-escaped.js
     ! dstr/syntax-error-ident-ref-with-escaped.js
-    ! length-dflt.js
-    ! lexical-new.target-closure-returned.js
-    ! lexical-new.target.js
-    ! lexical-super-call-from-within-constructor.js
-    ! lexical-super-property-from-within-constructor.js
-    ! lexical-super-property.js
-    ! lexical-supercall-from-immediately-invoked-arrow.js
-    ! /name.js
-    ! object-destructuring-param-strict-body.js
-    ! param-dflt-yield-expr.js
-    ! param-dflt-yield-id-non-strict.js
-    ! param-dflt-yield-id-strict.js
-    ! params-duplicate.js
-    ! params-trailing-comma-multiple.js
-    ! params-trailing-comma-single.js
-    ! rest-params-trailing-comma-early-error.js
-    ! scope-body-lex-distinct.js
-    ! scope-param-elem-var-close.js
-    ! scope-param-elem-var-open.js
-    ! scope-param-rest-elem-var-close.js
-    ! scope-param-rest-elem-var-open.js
-    ! scope-paramsbody-var-close.js
-    ! scope-paramsbody-var-open.js
-    ! syntax/arrowparameters-bindingidentifier-yield.js
-    ! syntax/arrowparameters-cover-formalparameters-yield.js
-    ! syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
-    ! syntax/arrowparameters-cover-initialize-1.js
-    ! syntax/arrowparameters-cover-initialize-2.js
-    ! syntax/arrowparameters-cover-rest-concisebody-functionbody.js
-    ! syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
     ! syntax/early-errors/arrowparameters-bindingidentifier-identifier-futurereservedword.js
     ! syntax/early-errors/arrowparameters-bindingidentifier-identifier-strict-futurereservedword.js
     ! syntax/early-errors/arrowparameters-bindingidentifier-identifier.js
@@ -3191,6 +2754,33 @@ language/expressions/arrow-function
     ! syntax/early-errors/asi-restriction-invalid-parenless-parameters.js
     ! syntax/early-errors/asi-restriction-invalid.js
     ! syntax/early-errors/use-strict-with-non-simple-param.js
+    ! syntax/arrowparameters-bindingidentifier-yield.js
+    ! syntax/arrowparameters-cover-formalparameters-yield.js
+    ! syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
+    ! syntax/arrowparameters-cover-initialize-1.js
+    ! syntax/arrowparameters-cover-initialize-2.js
+    ! syntax/arrowparameters-cover-rest-concisebody-functionbody.js
+    ! syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
+    ! array-destructuring-param-strict-body.js
+    ! ArrowFunction_restricted-properties.js
+    ! dflt-params-trailing-comma.js
+    ! lexical-super-call-from-within-constructor.js
+    ! lexical-super-property-from-within-constructor.js
+    ! lexical-super-property.js
+    ! lexical-supercall-from-immediately-invoked-arrow.js
+    ! name.js
+    ! object-destructuring-param-strict-body.js
+    ! params-duplicate.js
+    ! params-trailing-comma-multiple.js
+    ! params-trailing-comma-single.js
+    ! rest-params-trailing-comma-early-error.js
+    ! scope-body-lex-distinct.js
+    ! scope-param-elem-var-close.js
+    ! scope-param-elem-var-open.js
+    ! scope-param-rest-elem-var-close.js
+    ! scope-param-rest-elem-var-open.js
+    ! scope-paramsbody-var-close.js
+    ! scope-paramsbody-var-open.js
 
 language/expressions/bitwise-and
     ! bigint-non-primitive.js
@@ -3215,11 +2805,10 @@ language/expressions/call
     ! 11.2.3-3_6.js
     ! 11.2.3-3_7.js
     ! 11.2.3-3_8.js
-    ! eval-realm-indirect.js
-    ! eval-spread.js
-    ! eval-spread-empty.js
     ! eval-spread-empty-leading.js
     ! eval-spread-empty-trailing.js
+    ! eval-spread-empty.js
+    ! eval-spread.js
     ! spread-err-mult-err-expr-throws.js
     ! spread-err-mult-err-iter-get-value.js
     ! spread-err-mult-err-itr-get-call.js
@@ -3246,8 +2835,8 @@ language/expressions/call
     ! spread-obj-getter-descriptor.js
     ! spread-obj-getter-init.js
     ! spread-obj-manipulate-outter-obj-in-getter.js
-    ! spread-obj-mult-spread.js
     ! spread-obj-mult-spread-getter.js
+    ! spread-obj-mult-spread.js
     ! spread-obj-null.js
     ! spread-obj-override-immutable.js
     ! spread-obj-overrides-prev-properties.js
@@ -3261,19 +2850,9 @@ language/expressions/call
     ! spread-sngl-iter.js
     ! spread-sngl-literal.js
     ! spread-sngl-obj-ident.js
-    ! tco-call-args.js
-    ! tco-cross-realm-class-construct.js
-    ! tco-cross-realm-class-derived-construct.js
-    ! tco-cross-realm-fun-call.js
-    ! tco-cross-realm-fun-construct.js
-    ! tco-member-args.js
-    ! tco-non-eval-function.js
-    ! tco-non-eval-function-dynamic.js
-    ! tco-non-eval-global.js
-    ! tco-non-eval-with.js
     ! trailing-comma.js
 
-# language/expressions/class
+#language/expressions/class
 
 language/expressions/comma
 
@@ -3301,27 +2880,27 @@ language/expressions/compound-assignment
     ! div-arguments-strict.js
     ! div-eval-strict.js
     ! div-non-simple.js
+    ! left-shift-non-simple.js
     ! lshift-arguments-strict.js
     ! lshift-eval-strict.js
-    ! left-shift-non-simple.js
     ! mod-arguments-strict.js
-    ! mod-eval-strict.js
     ! mod-div-non-simple.js
+    ! mod-eval-strict.js
     ! mult-arguments-strict.js
     ! mult-eval-strict.js
     ! mult-non-simple.js
     ! or-arguments-strict.js
     ! or-eval-strict.js
     ! right-shift-non-simple.js
-    ! S11.13.2_A7.1_T1.js
-    ! S11.13.2_A7.1_T2.js
-    ! S11.13.2_A7.1_T4.js
     ! S11.13.2_A7.10_T1.js
     ! S11.13.2_A7.10_T2.js
     ! S11.13.2_A7.10_T4.js
     ! S11.13.2_A7.11_T1.js
     ! S11.13.2_A7.11_T2.js
     ! S11.13.2_A7.11_T4.js
+    ! S11.13.2_A7.1_T1.js
+    ! S11.13.2_A7.1_T2.js
+    ! S11.13.2_A7.1_T4.js
     ! S11.13.2_A7.2_T1.js
     ! S11.13.2_A7.2_T2.js
     ! S11.13.2_A7.2_T4.js
@@ -3348,9 +2927,9 @@ language/expressions/compound-assignment
     ! S11.13.2_A7.9_T4.js
     ! srshift-arguments-strict.js
     ! srshift-eval-strict.js
-    ! subtract-non-simple.js
     ! sub-arguments-strict.js
     ! sub-eval-strict.js
+    ! subtract-non-simple.js
     ! urshift-arguments-strict.js
     ! urshift-eval-strict.js
     ! xor-arguments-strict.js
@@ -3382,10 +2961,6 @@ language/expressions/exponentiation
     ! order-of-evaluation.js
 
 language/expressions/function
-    ! array-destructuring-param-strict-body.js
-    ! arguments-with-arguments-fn.js
-    ! arguments-with-arguments-lex.js
-    ! dflt-params-trailing-comma.js
     ! dstr/ary-init-iter-close.js
     ! dstr/ary-init-iter-get-err.js
     ! dstr/ary-ptrn-elem-ary-elem-init.js
@@ -3409,22 +2984,22 @@ language/expressions/function
     ! dstr/ary-ptrn-elem-id-init-unresolvable.js
     ! dstr/ary-ptrn-elem-id-iter-step-err.js
     ! dstr/ary-ptrn-elem-id-iter-val-err.js
-    ! dstr/ary-ptrn-elem-obj-id.js
     ! dstr/ary-ptrn-elem-obj-id-init.js
-    ! dstr/ary-ptrn-elem-obj-prop-id.js
+    ! dstr/ary-ptrn-elem-obj-id.js
     ! dstr/ary-ptrn-elem-obj-prop-id-init.js
-    ! dstr/ary-ptrn-elision.js
+    ! dstr/ary-ptrn-elem-obj-prop-id.js
     ! dstr/ary-ptrn-elision-step-err.js
+    ! dstr/ary-ptrn-elision.js
     ! dstr/ary-ptrn-rest-ary-elem.js
     ! dstr/ary-ptrn-rest-ary-elision.js
     ! dstr/ary-ptrn-rest-ary-empty.js
     ! dstr/ary-ptrn-rest-ary-rest.js
-    ! dstr/ary-ptrn-rest-id.js
-    ! dstr/ary-ptrn-rest-id-elision.js
     ! dstr/ary-ptrn-rest-id-elision-next-err.js
+    ! dstr/ary-ptrn-rest-id-elision.js
     ! dstr/ary-ptrn-rest-id-exhausted.js
     ! dstr/ary-ptrn-rest-id-iter-step-err.js
     ! dstr/ary-ptrn-rest-id-iter-val-err.js
+    ! dstr/ary-ptrn-rest-id.js
     ! dstr/ary-ptrn-rest-init-ary.js
     ! dstr/ary-ptrn-rest-init-id.js
     ! dstr/ary-ptrn-rest-init-obj.js
@@ -3444,32 +3019,33 @@ language/expressions/function
     ! dstr/obj-ptrn-id-init-throws.js
     ! dstr/obj-ptrn-id-init-unresolvable.js
     ! dstr/obj-ptrn-list-err.js
-    ! dstr/obj-ptrn-prop-ary.js
     ! dstr/obj-ptrn-prop-ary-init.js
     ! dstr/obj-ptrn-prop-ary-value-null.js
+    ! dstr/obj-ptrn-prop-ary.js
     ! dstr/obj-ptrn-prop-eval-err.js
     ! dstr/obj-ptrn-prop-id-get-value-err.js
-    ! dstr/obj-ptrn-prop-id-init.js
     ! dstr/obj-ptrn-prop-id-init-skipped.js
     ! dstr/obj-ptrn-prop-id-init-throws.js
     ! dstr/obj-ptrn-prop-id-init-unresolvable.js
-    ! dstr/obj-ptrn-prop-obj.js
+    ! dstr/obj-ptrn-prop-id-init.js
     ! dstr/obj-ptrn-prop-obj-init.js
     ! dstr/obj-ptrn-prop-obj-value-null.js
     ! dstr/obj-ptrn-prop-obj-value-undef.js
-    ! dstr/obj-ptrn-rest-getter.js
-    ! dstr/obj-ptrn-rest-skip-non-enumerable.js
-    ! dstr/obj-ptrn-rest-val-obj.js
+    ! dstr/obj-ptrn-prop-obj.js
+    ! arguments-with-arguments-fn.js
+    ! arguments-with-arguments-lex.js
+    ! array-destructuring-param-strict-body.js
+    ! dflt-params-trailing-comma.js
     ! name-arguments-strict-body.js
     ! name-eval-strict-body.js
     ! name.js
     ! object-destructuring-param-strict-body.js
-    ! params-trailing-comma-multiple.js
-    ! params-trailing-comma-single.js
     ! param-duplicated-strict-body-1.js
     ! param-duplicated-strict-body-2.js
     ! param-duplicated-strict-body-3.js
     ! param-eval-strict-body.js
+    ! params-trailing-comma-multiple.js
+    ! params-trailing-comma-single.js
     ! scope-body-lex-distinct.js
     ! scope-name-var-open-non-strict.js
     ! scope-name-var-open-strict.js
@@ -3481,11 +3057,6 @@ language/expressions/function
     ! scope-paramsbody-var-open.js
 
 language/expressions/generators
-    ! array-destructuring-param-strict-body.js
-    ! arguments-with-arguments-fn.js
-    ! arguments-with-arguments-lex.js
-    ! default-proto.js
-    ! dflt-params-trailing-comma.js
     ! dstr/ary-init-iter-close.js
     ! dstr/ary-init-iter-get-err.js
     ! dstr/ary-name-iter-val.js
@@ -3560,12 +3131,17 @@ language/expressions/generators
     ! dstr/obj-ptrn-prop-obj-value-null.js
     ! dstr/obj-ptrn-prop-obj-value-undef.js
     ! dstr/obj-ptrn-prop-obj.js
+    ! arguments-with-arguments-fn.js
+    ! arguments-with-arguments-lex.js
+    ! array-destructuring-param-strict-body.js
+    ! default-proto.js
+    ! dflt-params-trailing-comma.js
     ! generator-created-after-decl-inst.js
     ! has-instance.js
-    ! invoke-as-constructor.js
     ! implicit-name.js
+    ! invoke-as-constructor.js
     ! length-property-descriptor.js
-    ! /name.js
+    ! name.js
     ! named-yield-as-binding-identifier-escaped.js
     ! named-yield-as-identifier-reference-escaped.js
     ! named-yield-as-label-identifier-escaped.js
@@ -3574,9 +3150,9 @@ language/expressions/generators
     ! named-yield-spread-arr-multiple.js
     ! named-yield-spread-arr-single.js
     ! named-yield-spread-obj.js
+    ! object-destructuring-param-strict-body.js
     ! params-trailing-comma-multiple.js
     ! params-trailing-comma-single.js
-    ! object-destructuring-param-strict-body.js
     ! prototype-own-properties.js
     ! prototype-relation-to-function.js
     ! prototype-value.js
@@ -3593,10 +3169,10 @@ language/expressions/generators
     ! yield-as-binding-identifier-escaped.js
     ! yield-as-function-expression-binding-identifier.js
     ! yield-as-identifier-in-nested-function.js
-    ! yield-identifier-spread-non-strict.js
     ! yield-as-identifier-reference-escaped.js
     ! yield-as-label-identifier-escaped.js
     ! yield-identifier-non-strict.js
+    ! yield-identifier-spread-non-strict.js
     ! yield-spread-arr-multiple.js
     ! yield-spread-arr-single.js
     ! yield-spread-obj.js
@@ -3647,80 +3223,6 @@ language/expressions/multiplication
     ! order-of-evaluation.js
 
 language/expressions/object
-    ! 11.1.5-2gs.js
-    ! 11.1.5_4-4-a-3.js
-    ! 11.1.5_4-4-b-1.js
-    ! __proto__-permitted-dup.js
-    ! accessor-name-computed-err-evaluation.js
-    ! accessor-name-computed-err-to-prop-key.js
-    ! accessor-name-computed-err-unresolvable.js
-    ! accessor-name-computed-in.js
-    ! accessor-name-computed-yield-expr.js
-    ! accessor-name-computed-yield-id.js
-    ! accessor-name-computed.js
-    ! accessor-name-literal-numeric-binary.js
-    ! accessor-name-literal-numeric-exponent.js
-    ! accessor-name-literal-numeric-hex.js
-    ! accessor-name-literal-numeric-leading-decimal.js
-    ! accessor-name-literal-numeric-non-canonical.js
-    ! accessor-name-literal-numeric-octal.js
-    ! accessor-name-literal-numeric-zero.js
-    ! accessor-name-literal-string-char-escape.js
-    ! accessor-name-literal-string-default.js
-    ! accessor-name-literal-string-default-escaped.js
-    ! accessor-name-literal-string-default-escaped-ext.js
-    ! accessor-name-literal-string-double-quote.js
-    ! accessor-name-literal-string-empty.js
-    ! accessor-name-literal-string-hex-escape.js
-    ! accessor-name-literal-string-line-continuation.js
-    ! accessor-name-literal-string-single-quote.js
-    ! accessor-name-literal-string-unicode-escape.js
-    ! computed-__proto__.js
-    ! computed-property-evaluation-order.js
-    ! concise-generator.js
-    ! covered-ident-name-prop-name-literal-break-escaped.js
-    ! covered-ident-name-prop-name-literal-case-escaped.js
-    ! covered-ident-name-prop-name-literal-catch-escaped.js
-    ! covered-ident-name-prop-name-literal-class-escaped.js
-    ! covered-ident-name-prop-name-literal-const-escaped.js
-    ! covered-ident-name-prop-name-literal-continue-escaped.js
-    ! covered-ident-name-prop-name-literal-debugger-escaped.js
-    ! covered-ident-name-prop-name-literal-default-escaped.js
-    ! covered-ident-name-prop-name-literal-default-escaped-ext.js
-    ! covered-ident-name-prop-name-literal-delete-escaped.js
-    ! covered-ident-name-prop-name-literal-do-escaped.js
-    ! covered-ident-name-prop-name-literal-else-escaped.js
-    ! covered-ident-name-prop-name-literal-enum-escaped.js
-    ! covered-ident-name-prop-name-literal-export-escaped.js
-    ! covered-ident-name-prop-name-literal-extends-escaped.js
-    ! covered-ident-name-prop-name-literal-extends-escaped-ext.js
-    ! covered-ident-name-prop-name-literal-finally-escaped.js
-    ! covered-ident-name-prop-name-literal-for-escaped.js
-    ! covered-ident-name-prop-name-literal-function-escaped.js
-    ! covered-ident-name-prop-name-literal-if-escaped.js
-    ! covered-ident-name-prop-name-literal-implements-escaped.js
-    ! covered-ident-name-prop-name-literal-import-escaped.js
-    ! covered-ident-name-prop-name-literal-in-escaped.js
-    ! covered-ident-name-prop-name-literal-instanceof-escaped.js
-    ! covered-ident-name-prop-name-literal-interface-escaped.js
-    ! covered-ident-name-prop-name-literal-let-escaped.js
-    ! covered-ident-name-prop-name-literal-new-escaped.js
-    ! covered-ident-name-prop-name-literal-package-escaped.js
-    ! covered-ident-name-prop-name-literal-private-escaped.js
-    ! covered-ident-name-prop-name-literal-protected-escaped.js
-    ! covered-ident-name-prop-name-literal-public-escaped.js
-    ! covered-ident-name-prop-name-literal-return-escaped.js
-    ! covered-ident-name-prop-name-literal-static-escaped.js
-    ! covered-ident-name-prop-name-literal-super-escaped.js
-    ! covered-ident-name-prop-name-literal-switch-escaped.js
-    ! covered-ident-name-prop-name-literal-this-escaped.js
-    ! covered-ident-name-prop-name-literal-throw-escaped.js
-    ! covered-ident-name-prop-name-literal-try-escaped.js
-    ! covered-ident-name-prop-name-literal-typeof-escaped.js
-    ! covered-ident-name-prop-name-literal-var-escaped.js
-    ! covered-ident-name-prop-name-literal-void-escaped.js
-    ! covered-ident-name-prop-name-literal-while-escaped.js
-    ! covered-ident-name-prop-name-literal-with-escaped.js
     ! dstr/gen-meth-ary-init-iter-close.js
     ! dstr/gen-meth-ary-init-iter-get-err.js
     ! dstr/gen-meth-ary-init-iter-no-close.js
@@ -3867,103 +3369,6 @@ language/expressions/object
     ! dstr/meth-obj-ptrn-prop-obj-value-null.js
     ! dstr/meth-obj-ptrn-prop-obj-value-undef.js
     ! dstr/meth-obj-ptrn-prop-obj.js
-    ! fn-name-accessor-get.js
-    ! fn-name-accessor-set.js
-    ! fn-name-arrow.js
-    ! fn-name-cover.js
-    ! fn-name-fn.js
-    ! fn-name-gen.js
-    ! getter-body-strict-inside.js
-    ! getter-body-strict-outside.js
-    ! getter-super-prop.js
-    ! ident-name-method-def-break-escaped.js
-    ! ident-name-method-def-case-escaped.js
-    ! ident-name-method-def-catch-escaped.js
-    ! ident-name-method-def-class-escaped.js
-    ! ident-name-method-def-const-escaped.js
-    ! ident-name-method-def-continue-escaped.js
-    ! ident-name-method-def-debugger-escaped.js
-    ! ident-name-method-def-default-escaped.js
-    ! ident-name-method-def-default-escaped-ext.js
-    ! ident-name-method-def-delete-escaped.js
-    ! ident-name-method-def-do-escaped.js
-    ! ident-name-method-def-else-escaped.js
-    ! ident-name-method-def-enum-escaped.js
-    ! ident-name-method-def-export-escaped.js
-    ! ident-name-method-def-extends-escaped.js
-    ! ident-name-method-def-extends-escaped-ext.js
-    ! ident-name-method-def-finally-escaped.js
-    ! ident-name-method-def-for-escaped.js
-    ! ident-name-method-def-function-escaped.js
-    ! ident-name-method-def-if-escaped.js
-    ! ident-name-method-def-implements-escaped.js
-    ! ident-name-method-def-import-escaped.js
-    ! ident-name-method-def-in-escaped.js
-    ! ident-name-method-def-instanceof-escaped.js
-    ! ident-name-method-def-interface-escaped.js
-    ! ident-name-method-def-let-escaped.js
-    ! ident-name-method-def-new-escaped.js
-    ! ident-name-method-def-package-escaped.js
-    ! ident-name-method-def-private-escaped.js
-    ! ident-name-method-def-protected-escaped.js
-    ! ident-name-method-def-public-escaped.js
-    ! ident-name-method-def-return-escaped.js
-    ! ident-name-method-def-static-escaped.js
-    ! ident-name-method-def-super-escaped.js
-    ! ident-name-method-def-switch-escaped.js
-    ! ident-name-method-def-this-escaped.js
-    ! ident-name-method-def-throw-escaped.js
-    ! ident-name-method-def-try-escaped.js
-    ! ident-name-method-def-typeof-escaped.js
-    ! ident-name-method-def-var-escaped.js
-    ! ident-name-method-def-void-escaped.js
-    ! ident-name-method-def-while-escaped.js
-    ! ident-name-method-def-with-escaped.js
-    ! ident-name-prop-name-literal-break-escaped.js
-    ! ident-name-prop-name-literal-case-escaped.js
-    ! ident-name-prop-name-literal-catch-escaped.js
-    ! ident-name-prop-name-literal-class-escaped.js
-    ! ident-name-prop-name-literal-const-escaped.js
-    ! ident-name-prop-name-literal-continue-escaped.js
-    ! ident-name-prop-name-literal-debugger-escaped.js
-    ! ident-name-prop-name-literal-default-escaped.js
-    ! ident-name-prop-name-literal-default-escaped-ext.js
-    ! ident-name-prop-name-literal-delete-escaped.js
-    ! ident-name-prop-name-literal-do-escaped.js
-    ! ident-name-prop-name-literal-else-escaped.js
-    ! ident-name-prop-name-literal-enum-escaped.js
-    ! ident-name-prop-name-literal-export-escaped.js
-    ! ident-name-prop-name-literal-extends-escaped.js
-    ! ident-name-prop-name-literal-extends-escaped-ext.js
-    ! ident-name-prop-name-literal-finally-escaped.js
-    ! ident-name-prop-name-literal-for-escaped.js
-    ! ident-name-prop-name-literal-function-escaped.js
-    ! ident-name-prop-name-literal-if-escaped.js
-    ! ident-name-prop-name-literal-implements-escaped.js
-    ! ident-name-prop-name-literal-import-escaped.js
-    ! ident-name-prop-name-literal-in-escaped.js
-    ! ident-name-prop-name-literal-instanceof-escaped.js
-    ! ident-name-prop-name-literal-interface-escaped.js
-    ! ident-name-prop-name-literal-let-escaped.js
-    ! ident-name-prop-name-literal-new-escaped.js
-    ! ident-name-prop-name-literal-package-escaped.js
-    ! ident-name-prop-name-literal-private-escaped.js
-    ! ident-name-prop-name-literal-protected-escaped.js
-    ! ident-name-prop-name-literal-public-escaped.js
-    ! ident-name-prop-name-literal-return-escaped.js
-    ! ident-name-prop-name-literal-static-escaped.js
-    ! ident-name-prop-name-literal-super-escaped.js
-    ! ident-name-prop-name-literal-switch-escaped.js
-    ! ident-name-prop-name-literal-this-escaped.js
-    ! ident-name-prop-name-literal-throw-escaped.js
-    ! ident-name-prop-name-literal-try-escaped.js
-    ! ident-name-prop-name-literal-typeof-escaped.js
-    ! ident-name-prop-name-literal-var-escaped.js
-    ! ident-name-prop-name-literal-void-escaped.js
-    ! ident-name-prop-name-literal-while-escaped.js
-    ! ident-name-prop-name-literal-with-escaped.js
-    ! let-non-strict-access.js
-    ! let-non-strict-syntax.js
     ! method-definition/early-errors-object-method-duplicate-parameters.js
     ! method-definition/escaped-get.js
     ! method-definition/escaped-set.js
@@ -4023,8 +3428,178 @@ language/expressions/object
     ! method-definition/yield-newline.js
     ! method-definition/yield-return.js
     ! method-definition/yield-star-before-newline.js
+    ! 11.1.5-2gs.js
+    ! 11.1.5_4-4-a-3.js
+    ! 11.1.5_4-4-b-1.js
+    ! __proto__-permitted-dup.js
+    ! accessor-name-computed-err-evaluation.js
+    ! accessor-name-computed-err-to-prop-key.js
+    ! accessor-name-computed-err-unresolvable.js
+    ! accessor-name-computed-in.js
+    ! accessor-name-computed-yield-expr.js
+    ! accessor-name-computed-yield-id.js
+    ! accessor-name-computed.js
+    ! accessor-name-literal-numeric-binary.js
+    ! accessor-name-literal-numeric-exponent.js
+    ! accessor-name-literal-numeric-hex.js
+    ! accessor-name-literal-numeric-leading-decimal.js
+    ! accessor-name-literal-numeric-non-canonical.js
+    ! accessor-name-literal-numeric-octal.js
+    ! accessor-name-literal-numeric-zero.js
+    ! accessor-name-literal-string-char-escape.js
+    ! accessor-name-literal-string-default-escaped-ext.js
+    ! accessor-name-literal-string-default-escaped.js
+    ! accessor-name-literal-string-default.js
+    ! accessor-name-literal-string-double-quote.js
+    ! accessor-name-literal-string-empty.js
+    ! accessor-name-literal-string-hex-escape.js
+    ! accessor-name-literal-string-line-continuation.js
+    ! accessor-name-literal-string-single-quote.js
+    ! accessor-name-literal-string-unicode-escape.js
+    ! computed-__proto__.js
+    ! computed-property-evaluation-order.js
+    ! concise-generator.js
+    ! covered-ident-name-prop-name-literal-break-escaped.js
+    ! covered-ident-name-prop-name-literal-case-escaped.js
+    ! covered-ident-name-prop-name-literal-catch-escaped.js
+    ! covered-ident-name-prop-name-literal-class-escaped.js
+    ! covered-ident-name-prop-name-literal-const-escaped.js
+    ! covered-ident-name-prop-name-literal-continue-escaped.js
+    ! covered-ident-name-prop-name-literal-debugger-escaped.js
+    ! covered-ident-name-prop-name-literal-default-escaped-ext.js
+    ! covered-ident-name-prop-name-literal-default-escaped.js
+    ! covered-ident-name-prop-name-literal-delete-escaped.js
+    ! covered-ident-name-prop-name-literal-do-escaped.js
+    ! covered-ident-name-prop-name-literal-else-escaped.js
+    ! covered-ident-name-prop-name-literal-enum-escaped.js
+    ! covered-ident-name-prop-name-literal-export-escaped.js
+    ! covered-ident-name-prop-name-literal-extends-escaped-ext.js
+    ! covered-ident-name-prop-name-literal-extends-escaped.js
+    ! covered-ident-name-prop-name-literal-finally-escaped.js
+    ! covered-ident-name-prop-name-literal-for-escaped.js
+    ! covered-ident-name-prop-name-literal-function-escaped.js
+    ! covered-ident-name-prop-name-literal-if-escaped.js
+    ! covered-ident-name-prop-name-literal-implements-escaped.js
+    ! covered-ident-name-prop-name-literal-import-escaped.js
+    ! covered-ident-name-prop-name-literal-in-escaped.js
+    ! covered-ident-name-prop-name-literal-instanceof-escaped.js
+    ! covered-ident-name-prop-name-literal-interface-escaped.js
+    ! covered-ident-name-prop-name-literal-let-escaped.js
+    ! covered-ident-name-prop-name-literal-new-escaped.js
+    ! covered-ident-name-prop-name-literal-package-escaped.js
+    ! covered-ident-name-prop-name-literal-private-escaped.js
+    ! covered-ident-name-prop-name-literal-protected-escaped.js
+    ! covered-ident-name-prop-name-literal-public-escaped.js
+    ! covered-ident-name-prop-name-literal-return-escaped.js
+    ! covered-ident-name-prop-name-literal-static-escaped.js
+    ! covered-ident-name-prop-name-literal-super-escaped.js
+    ! covered-ident-name-prop-name-literal-switch-escaped.js
+    ! covered-ident-name-prop-name-literal-this-escaped.js
+    ! covered-ident-name-prop-name-literal-throw-escaped.js
+    ! covered-ident-name-prop-name-literal-try-escaped.js
+    ! covered-ident-name-prop-name-literal-typeof-escaped.js
+    ! covered-ident-name-prop-name-literal-var-escaped.js
+    ! covered-ident-name-prop-name-literal-void-escaped.js
+    ! covered-ident-name-prop-name-literal-while-escaped.js
+    ! covered-ident-name-prop-name-literal-with-escaped.js
+    ! fn-name-accessor-get.js
+    ! fn-name-accessor-set.js
+    ! fn-name-arrow.js
+    ! fn-name-cover.js
+    ! fn-name-fn.js
+    ! fn-name-gen.js
+    ! getter-body-strict-inside.js
+    ! getter-body-strict-outside.js
+    ! getter-super-prop.js
+    ! ident-name-method-def-break-escaped.js
+    ! ident-name-method-def-case-escaped.js
+    ! ident-name-method-def-catch-escaped.js
+    ! ident-name-method-def-class-escaped.js
+    ! ident-name-method-def-const-escaped.js
+    ! ident-name-method-def-continue-escaped.js
+    ! ident-name-method-def-debugger-escaped.js
+    ! ident-name-method-def-default-escaped-ext.js
+    ! ident-name-method-def-default-escaped.js
+    ! ident-name-method-def-delete-escaped.js
+    ! ident-name-method-def-do-escaped.js
+    ! ident-name-method-def-else-escaped.js
+    ! ident-name-method-def-enum-escaped.js
+    ! ident-name-method-def-export-escaped.js
+    ! ident-name-method-def-extends-escaped-ext.js
+    ! ident-name-method-def-extends-escaped.js
+    ! ident-name-method-def-finally-escaped.js
+    ! ident-name-method-def-for-escaped.js
+    ! ident-name-method-def-function-escaped.js
+    ! ident-name-method-def-if-escaped.js
+    ! ident-name-method-def-implements-escaped.js
+    ! ident-name-method-def-import-escaped.js
+    ! ident-name-method-def-in-escaped.js
+    ! ident-name-method-def-instanceof-escaped.js
+    ! ident-name-method-def-interface-escaped.js
+    ! ident-name-method-def-let-escaped.js
+    ! ident-name-method-def-new-escaped.js
+    ! ident-name-method-def-package-escaped.js
+    ! ident-name-method-def-private-escaped.js
+    ! ident-name-method-def-protected-escaped.js
+    ! ident-name-method-def-public-escaped.js
+    ! ident-name-method-def-return-escaped.js
+    ! ident-name-method-def-static-escaped.js
+    ! ident-name-method-def-super-escaped.js
+    ! ident-name-method-def-switch-escaped.js
+    ! ident-name-method-def-this-escaped.js
+    ! ident-name-method-def-throw-escaped.js
+    ! ident-name-method-def-try-escaped.js
+    ! ident-name-method-def-typeof-escaped.js
+    ! ident-name-method-def-var-escaped.js
+    ! ident-name-method-def-void-escaped.js
+    ! ident-name-method-def-while-escaped.js
+    ! ident-name-method-def-with-escaped.js
+    ! ident-name-prop-name-literal-break-escaped.js
+    ! ident-name-prop-name-literal-case-escaped.js
+    ! ident-name-prop-name-literal-catch-escaped.js
+    ! ident-name-prop-name-literal-class-escaped.js
+    ! ident-name-prop-name-literal-const-escaped.js
+    ! ident-name-prop-name-literal-continue-escaped.js
+    ! ident-name-prop-name-literal-debugger-escaped.js
+    ! ident-name-prop-name-literal-default-escaped-ext.js
+    ! ident-name-prop-name-literal-default-escaped.js
+    ! ident-name-prop-name-literal-delete-escaped.js
+    ! ident-name-prop-name-literal-do-escaped.js
+    ! ident-name-prop-name-literal-else-escaped.js
+    ! ident-name-prop-name-literal-enum-escaped.js
+    ! ident-name-prop-name-literal-export-escaped.js
+    ! ident-name-prop-name-literal-extends-escaped-ext.js
+    ! ident-name-prop-name-literal-extends-escaped.js
+    ! ident-name-prop-name-literal-finally-escaped.js
+    ! ident-name-prop-name-literal-for-escaped.js
+    ! ident-name-prop-name-literal-function-escaped.js
+    ! ident-name-prop-name-literal-if-escaped.js
+    ! ident-name-prop-name-literal-implements-escaped.js
+    ! ident-name-prop-name-literal-import-escaped.js
+    ! ident-name-prop-name-literal-in-escaped.js
+    ! ident-name-prop-name-literal-instanceof-escaped.js
+    ! ident-name-prop-name-literal-interface-escaped.js
+    ! ident-name-prop-name-literal-let-escaped.js
+    ! ident-name-prop-name-literal-new-escaped.js
+    ! ident-name-prop-name-literal-package-escaped.js
+    ! ident-name-prop-name-literal-private-escaped.js
+    ! ident-name-prop-name-literal-protected-escaped.js
+    ! ident-name-prop-name-literal-public-escaped.js
+    ! ident-name-prop-name-literal-return-escaped.js
+    ! ident-name-prop-name-literal-static-escaped.js
+    ! ident-name-prop-name-literal-super-escaped.js
+    ! ident-name-prop-name-literal-switch-escaped.js
+    ! ident-name-prop-name-literal-this-escaped.js
+    ! ident-name-prop-name-literal-throw-escaped.js
+    ! ident-name-prop-name-literal-try-escaped.js
+    ! ident-name-prop-name-literal-typeof-escaped.js
+    ! ident-name-prop-name-literal-var-escaped.js
+    ! ident-name-prop-name-literal-void-escaped.js
+    ! ident-name-prop-name-literal-while-escaped.js
+    ! ident-name-prop-name-literal-with-escaped.js
+    ! let-non-strict-access.js
+    ! let-non-strict-syntax.js
     ! method.js
-    ! prop-def-id-eval-error.js
     ! prop-def-id-eval-error.js
     ! prop-dup-data-data.js
     ! prop-dup-data-set.js
@@ -4061,46 +3636,38 @@ language/expressions/object
     ! yield-non-strict-syntax.js
 
 language/expressions/postfix-decrement
+    ! arguments.js
+    ! eval.js
     ! S11.3.2_A6_T1.js
     ! S11.3.2_A6_T2.js
     ! S11.3.2_A6_T3.js
-    ! arguments.js
-    ! eval.js
-    ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
-    ! target-newtarget.js
 
 language/expressions/postfix-increment
     ! 11.3.1-2-1gs.js
+    ! arguments.js
+    ! eval.js
     ! S11.3.1_A6_T1.js
     ! S11.3.1_A6_T2.js
     ! S11.3.1_A6_T3.js
-    ! arguments.js
-    ! eval.js
-    ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
-    ! target-newtarget.js
 
 language/expressions/prefix-decrement
     ! 11.4.5-2-2gs.js
+    ! arguments.js
+    ! eval.js
     ! S11.4.5_A6_T1.js
     ! S11.4.5_A6_T2.js
     ! S11.4.5_A6_T3.js
-    ! arguments.js
-    ! eval.js
-    ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
-    ! target-newtarget.js
 
 language/expressions/prefix-increment
+    ! arguments.js
+    ! eval.js
     ! S11.4.4_A6_T1.js
     ! S11.4.4_A6_T2.js
     ! S11.4.4_A6_T3.js
-    ! arguments.js
-    ! eval.js
-    ! target-cover-newtarget.js
     ! target-cover-yieldexpr.js
-    ! target-newtarget.js
 
 language/expressions/property-accessors
 
@@ -4117,94 +3684,9 @@ language/expressions/strict-equals
 language/expressions/subtraction
     ! order-of-evaluation.js
 
-language/expressions/super
-    ! call-arg-evaluation-err.js
-    ! call-bind-this-value.js
-    ! call-bind-this-value-twice.js
-    ! call-construct-error.js
-    ! call-construct-invocation.js
-    ! call-expr-value.js
-    ! call-proto-not-ctor.js
-    ! call-spread-err-mult-err-expr-throws.js
-    ! call-spread-err-mult-err-iter-get-value.js
-    ! call-spread-err-mult-err-itr-get-call.js
-    ! call-spread-err-mult-err-itr-get-get.js
-    ! call-spread-err-mult-err-itr-step.js
-    ! call-spread-err-mult-err-itr-value.js
-    ! call-spread-err-mult-err-obj-unresolvable.js
-    ! call-spread-err-mult-err-unresolvable.js
-    ! call-spread-err-sngl-err-expr-throws.js
-    ! call-spread-err-sngl-err-itr-get-call.js
-    ! call-spread-err-sngl-err-itr-get-get.js
-    ! call-spread-err-sngl-err-itr-get-value.js
-    ! call-spread-err-sngl-err-itr-step.js
-    ! call-spread-err-sngl-err-itr-value.js
-    ! call-spread-err-sngl-err-obj-unresolvable.js
-    ! call-spread-err-sngl-err-unresolvable.js
-    ! call-spread-mult-empty.js
-    ! call-spread-mult-expr.js
-    ! call-spread-mult-iter.js
-    ! call-spread-mult-literal.js
-    ! call-spread-mult-obj-ident.js
-    ! call-spread-mult-obj-null.js
-    ! call-spread-mult-obj-undefined.js
-    ! call-spread-obj-getter-descriptor.js
-    ! call-spread-obj-getter-init.js
-    ! call-spread-obj-manipulate-outter-obj-in-getter.js
-    ! call-spread-obj-mult-spread.js
-    ! call-spread-obj-mult-spread-getter.js
-    ! call-spread-obj-null.js
-    ! call-spread-obj-override-immutable.js
-    ! call-spread-obj-overrides-prev-properties.js
-    ! call-spread-obj-skip-non-enumerable.js
-    ! call-spread-obj-spread-order.js
-    ! call-spread-obj-symbol-property.js
-    ! call-spread-obj-undefined.js
-    ! call-spread-obj-with-overrides.js
-    ! call-spread-sngl-empty.js
-    ! call-spread-sngl-expr.js
-    ! call-spread-sngl-iter.js
-    ! call-spread-sngl-literal.js
-    ! call-spread-sngl-obj-ident.js
-    ! prop-dot-cls-null-proto.js
-    ! prop-dot-cls-ref-strict.js
-    ! prop-dot-cls-ref-this.js
-    ! prop-dot-cls-this-uninit.js
-    ! prop-dot-cls-val.js
-    ! prop-dot-cls-val-from-arrow.js
-    ! prop-dot-cls-val-from-eval.js
-    ! prop-dot-obj-null-proto.js
-    ! prop-dot-obj-ref-non-strict.js
-    ! prop-dot-obj-ref-strict.js
-    ! prop-dot-obj-ref-this.js
-    ! prop-dot-obj-val.js
-    ! prop-dot-obj-val-from-arrow.js
-    ! prop-dot-obj-val-from-eval.js
-    ! prop-expr-cls-err.js
-    ! prop-expr-cls-key-err.js
-    ! prop-expr-cls-null-proto.js
-    ! prop-expr-cls-ref-strict.js
-    ! prop-expr-cls-ref-this.js
-    ! prop-expr-cls-this-uninit.js
-    ! prop-expr-cls-unresolvable.js
-    ! prop-expr-cls-val.js
-    ! prop-expr-cls-val-from-arrow.js
-    ! prop-expr-cls-val-from-eval.js
-    ! prop-expr-obj-err.js
-    ! prop-expr-obj-key-err.js
-    ! prop-expr-obj-null-proto.js
-    ! prop-expr-obj-ref-non-strict.js
-    ! prop-expr-obj-ref-strict.js
-    ! prop-expr-obj-ref-this.js
-    ! prop-expr-obj-unresolvable.js
-    ! prop-expr-obj-val.js
-    ! prop-expr-obj-val-from-arrow.js
-    ! prop-expr-obj-val-from-eval.js
-    ! prop-poisoned-underscore-proto.js
-    ! realm.js
+#language/expressions/super
 
 language/expressions/tagged-template
-    # Fails because Rhino doesn't support the strict mode semantics for the 'this' value
     ! call-expression-context-strict.js
 
 language/expressions/template-literal
@@ -4222,7 +3704,6 @@ language/expressions/unary-plus
 
 language/expressions/unsigned-right-shift
     ! bigint-non-primitive.js
-    ! bigint-toprimitive.js
     ! order-of-evaluation.js
 
 language/expressions/void
@@ -4351,18 +3832,14 @@ language/function-code
     ! 10.4.3-1-92gs.js
     ! 10.4.3-1-9gs.js
     ! block-decl-onlystrict.js
-    ! each-param-has-own-non-shared-eval-scope.js
-    ! each-param-has-own-scope.js
     ! eval-param-env-with-computed-key.js
     ! eval-param-env-with-prop-initializer.js
     ! S10.4.3_A1.js
     ! switch-case-decl-onlystrict.js
     ! switch-dflt-decl-onlystrict.js
 
-language/future-reserved-words
-    ! -strict-escaped.js
+#language/future-reserved-words
 
-# expressions
 language/global-code
     ! block-decl-strict.js
     ! decl-lex-configurable-global.js
@@ -4371,8 +3848,6 @@ language/global-code
     ! decl-lex.js
     ! export.js
     ! import.js
-    ! new.target-arrow.js
-    ! new.target.js
     ! return.js
     ! script-decl-func-dups.js
     ! script-decl-func-err-non-configurable.js
@@ -4386,10 +3861,6 @@ language/global-code
     ! script-decl-var-collision.js
     ! script-decl-var-err.js
     ! script-decl-var.js
-    ! super-call-arrow.js
-    ! super-call.js
-    ! super-prop-arrow.js
-    ! super-prop.js
     ! switch-case-decl-strict.js
     ! switch-dflt-decl-strict.js
     ! yield-non-strict.js
@@ -4521,11 +3992,7 @@ language/identifiers
     ! vertical-tilde-start-escaped.js
     ! vertical-tilde-start.js
 
-language/import
-    ! dup-bound-names.js
-    ! escaped-as-import-specifier.js
-    ! escaped-as-namespace-import.js
-    ! escaped-from.js
+#language/import
 
 language/keywords
 
@@ -4536,6 +4003,8 @@ language/line-terminators
     ! S7.3_A6_T4.js
 
 language/literals
+    ! bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
+    ! bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     ! bigint/legacy-octal-like-invalid-00n.js
     ! bigint/legacy-octal-like-invalid-01n.js
     ! bigint/legacy-octal-like-invalid-07n.js
@@ -4543,11 +4012,14 @@ language/literals
     ! bigint/non-octal-like-invalid-012348n.js
     ! bigint/non-octal-like-invalid-08n.js
     ! bigint/non-octal-like-invalid-09n.js
-    ! bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    ! bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
-    ! numeric/numeric-followed-by-ident.js
     ! numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     ! numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
+    ! numeric/numeric-followed-by-ident.js
+    # Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
+    ! regexp/early-err-pattern.js
+    ! regexp/invalid-braced-quantifier-exact.js
+    ! regexp/invalid-braced-quantifier-lower.js
+    ! regexp/invalid-braced-quantifier-range.js
     ! regexp/S7.8.5_A1.1_T2.js
     ! regexp/S7.8.5_A1.4_T2.js
     ! regexp/S7.8.5_A1.5_T1.js
@@ -4556,9 +4028,6 @@ language/literals
     ! regexp/S7.8.5_A2.4_T2.js
     ! regexp/S7.8.5_A2.5_T1.js
     ! regexp/S7.8.5_A2.5_T3.js
-    ! regexp/invalid-braced-quantifier-exact.js
-    ! regexp/invalid-braced-quantifier-lower.js
-    ! regexp/invalid-braced-quantifier-range.js
     ! regexp/u-astral.js
     ! regexp/u-case-mapping.js
     ! regexp/u-surrogate-pairs-atom-char-class.js
@@ -4568,6 +4037,9 @@ language/literals
     ! regexp/u-surrogate-pairs.js
     ! regexp/u-unicode-esc.js
     ! regexp/y-assertion-start.js
+    ! string/legacy-non-octal-escape-sequence-strict.js
+    ! string/legacy-octal-escape-sequence-prologue-strict.js
+    ! string/legacy-octal-escape-sequence-strict.js
     ! string/S7.8.4_A4.3_T1.js
     ! string/S7.8.4_A4.3_T2.js
     ! string/S7.8.4_A7.1_T4.js
@@ -4577,14 +4049,8 @@ language/literals
     ! string/S7.8.4_A7.2_T4.js
     ! string/S7.8.4_A7.2_T5.js
     ! string/S7.8.4_A7.2_T6.js
-    ! string/legacy-non-octal-escape-sequence-strict.js
-    ! string/legacy-octal-escape-sequence-prologue-strict.js
-    ! string/legacy-octal-escape-sequence-strict.js
     ! string/unicode-escape-nls-err-double.js
     ! string/unicode-escape-nls-err-single.js
-# Weird case of SyntaxError thrown at the script execution ('runtime')
-# not on compilation ('early'), but only for opt levels >= 0
-    ! regexp/early-err-pattern.js
 
 #language/module-code
 
@@ -4618,15 +4084,7 @@ language/rest-parameters
 
 language/source-text
 
-# language/statements
 language/statements/for
-    ! cptn-decl-expr-iter.js
-    ! cptn-decl-expr-no-iter.js
-    ! cptn-expr-expr-iter.js
-    ! cptn-expr-expr-no-iter.js
-    ! decl-const.js
-    ! decl-fun.js
-    ! decl-gen.js
     ! dstr/const-ary-init-iter-close.js
     ! dstr/const-ary-init-iter-get-err.js
     ! dstr/const-ary-init-iter-no-close.js
@@ -4845,6 +4303,13 @@ language/statements/for
     ! dstr/var-obj-ptrn-prop-obj-value-null.js
     ! dstr/var-obj-ptrn-prop-obj-value-undef.js
     ! dstr/var-obj-ptrn-prop-obj.js
+    ! cptn-decl-expr-iter.js
+    ! cptn-decl-expr-no-iter.js
+    ! cptn-expr-expr-iter.js
+    ! cptn-expr-expr-no-iter.js
+    ! decl-const.js
+    ! decl-fun.js
+    ! decl-gen.js
     ! head-const-fresh-binding-per-iteration.js
     ! head-init-expr-check-empty-inc-empty-completion.js
     ! head-init-var-check-empty-inc-empty-completion.js
@@ -4899,84 +4364,10 @@ language/statements/for-in
     ! scope-head-var-none.js
 
 language/statements/for-of
-    ! body-dstr-assign-error.js
-    ! body-put-error.js
-    ! cptn-decl-abrupt-empty.js
-    ! cptn-decl-itr.js
-    ! cptn-decl-no-itr.js
-    ! cptn-expr-abrupt-empty.js
-    ! cptn-expr-itr.js
-    ! cptn-expr-no-itr.js
-    ! decl-gen.js
-    ! dstr/array-rest-after-element.js
-    ! dstr/array-rest-after-elision.js
-    ! dstr/array-rest-elision-iter-abpt.js
-    ! dstr/array-rest-elision.js
-    ! dstr/array-rest-iter-get-err.js
-    ! dstr/array-rest-iter-nrml-close-skip.js
-    ! dstr/array-rest-lref-err.js
-    ! dstr/array-rest-iter-thrw-close-err.js
-    ! dstr/array-rest-iter-thrw-close-skip.js
-    ! dstr/array-rest-iter-thrw-close.js
-    ! dstr/array-rest-lref.js
-    ! dstr/array-rest-nested-array-iter-thrw-close-skip.js
-    ! dstr/array-rest-nested-array-null.js
-    ! dstr/array-rest-nested-array-undefined-hole.js
-    ! dstr/array-rest-nested-array-undefined-own.js
-    ! dstr/array-rest-nested-array-undefined.js
-    ! dstr/array-rest-nested-array-yield-ident-valid.js
-    ! dstr/array-rest-nested-array.js
-    ! dstr/array-rest-nested-obj-null.js
-    ! dstr/array-rest-nested-obj-undefined-hole.js
-    ! dstr/array-rest-nested-obj-undefined-own.js
-    ! dstr/array-rest-nested-obj-yield-ident-valid.js
-    ! dstr/array-rest-nested-obj.js
-    ! dstr/array-rest-put-const.js
-    ! dstr/array-rest-put-let.js
-    ! dstr/array-rest-put-prop-ref-no-get.js
-    ! dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    ! dstr/array-rest-put-prop-ref-user-err.js
-    ! dstr/array-rest-put-prop-ref.js
-    ! dstr/array-rest-put-unresolvable-no-strict.js
-    ! dstr/array-rest-put-unresolvable-strict.js
-    ! dstr/array-rest-yield-ident-valid.js
-    ! dstr/array-rest-nested-obj-undefined.js
-    ! dstr/const-ary-ptrn-rest-ary-elem.js
-    ! dstr/const-ary-ptrn-rest-ary-rest.js
-    ! dstr/const-ary-ptrn-rest-id-elision.js
-    ! dstr/const-ary-ptrn-rest-id-exhausted.js
-    ! dstr/const-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/const-ary-ptrn-rest-id.js
-    ! dstr/const-ary-ptrn-rest-obj-id.js
-    ! dstr/const-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/let-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/let-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/let-ary-ptrn-rest-ary-elem.js
-    ! dstr/let-ary-ptrn-rest-ary-rest.js
-    ! dstr/let-ary-ptrn-rest-id-elision.js
-    ! dstr/let-ary-ptrn-rest-id-exhausted.js
-    ! dstr/let-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/let-ary-ptrn-rest-id.js
-    ! dstr/let-ary-ptrn-rest-obj-id.js
-    ! dstr/let-ary-ptrn-rest-obj-prop-id.js
-    ! dstr/var-ary-ptrn-elem-ary-rest-init.js
-    ! dstr/var-ary-ptrn-elem-ary-rest-iter.js
-    ! dstr/var-ary-ptrn-rest-ary-elem.js
-    ! dstr/var-ary-ptrn-rest-ary-rest.js
-    ! dstr/var-ary-ptrn-rest-id-elision.js
-    ! dstr/var-ary-ptrn-rest-id-exhausted.js
-    ! dstr/var-ary-ptrn-rest-id-iter-val-err.js
-    ! dstr/var-ary-ptrn-rest-id.js
-    ! dstr/var-ary-ptrn-rest-obj-id.js
-    ! dstr/var-ary-ptrn-rest-obj-prop-id.js
-    ! decl-const.js
-    ! decl-fun.js
     ! dstr/array-elem-init-assignment.js
     ! dstr/array-elem-init-evaluation.js
     ! dstr/array-elem-init-fn-name-arrow.js
-    ! dstr/array-elem-init-fn-name-class.js
     ! dstr/array-elem-init-fn-name-cover.js
-    ! dstr/array-elem-init-fn-name-fn.js
     ! dstr/array-elem-init-fn-name-gen.js
     ! dstr/array-elem-init-in.js
     ! dstr/array-elem-init-let.js
@@ -5003,9 +4394,9 @@ language/statements/for-of
     ! dstr/array-elem-nested-obj-yield-ident-valid.js
     ! dstr/array-elem-put-const.js
     ! dstr/array-elem-put-let.js
-    ! dstr/array-elem-put-obj-literal-prop-ref.js
-    ! dstr/array-elem-put-obj-literal-prop-ref-init.js
     ! dstr/array-elem-put-obj-literal-prop-ref-init-active.js
+    ! dstr/array-elem-put-obj-literal-prop-ref-init.js
+    ! dstr/array-elem-put-obj-literal-prop-ref.js
     ! dstr/array-elem-target-simple-strict.js
     ! dstr/array-elem-target-yield-valid.js
     ! dstr/array-elem-trlg-iter-elision-iter-abpt.js
@@ -5052,13 +4443,46 @@ language/statements/for-of
     ! dstr/array-empty-val-symbol.js
     ! dstr/array-empty-val-undef.js
     ! dstr/array-iteration.js
+    ! dstr/array-rest-after-element.js
+    ! dstr/array-rest-after-elision.js
+    ! dstr/array-rest-elision-iter-abpt.js
+    ! dstr/array-rest-elision.js
+    ! dstr/array-rest-iter-get-err.js
+    ! dstr/array-rest-iter-nrml-close-skip.js
     ! dstr/array-rest-iter-rtrn-close-err.js
     ! dstr/array-rest-iter-rtrn-close-null.js
     ! dstr/array-rest-iter-rtrn-close.js
+    ! dstr/array-rest-iter-thrw-close-err.js
+    ! dstr/array-rest-iter-thrw-close-skip.js
+    ! dstr/array-rest-iter-thrw-close.js
     ! dstr/array-rest-iteration.js
+    ! dstr/array-rest-lref-err.js
+    ! dstr/array-rest-lref.js
+    ! dstr/array-rest-nested-array-iter-thrw-close-skip.js
+    ! dstr/array-rest-nested-array-null.js
+    ! dstr/array-rest-nested-array-undefined-hole.js
+    ! dstr/array-rest-nested-array-undefined-own.js
+    ! dstr/array-rest-nested-array-undefined.js
     ! dstr/array-rest-nested-array-yield-expr.js
+    ! dstr/array-rest-nested-array-yield-ident-valid.js
+    ! dstr/array-rest-nested-array.js
+    ! dstr/array-rest-nested-obj-null.js
+    ! dstr/array-rest-nested-obj-undefined-hole.js
+    ! dstr/array-rest-nested-obj-undefined-own.js
+    ! dstr/array-rest-nested-obj-undefined.js
     ! dstr/array-rest-nested-obj-yield-expr.js
+    ! dstr/array-rest-nested-obj-yield-ident-valid.js
+    ! dstr/array-rest-nested-obj.js
+    ! dstr/array-rest-put-const.js
+    ! dstr/array-rest-put-let.js
+    ! dstr/array-rest-put-prop-ref-no-get.js
+    ! dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
+    ! dstr/array-rest-put-prop-ref-user-err.js
+    ! dstr/array-rest-put-prop-ref.js
+    ! dstr/array-rest-put-unresolvable-no-strict.js
+    ! dstr/array-rest-put-unresolvable-strict.js
     ! dstr/array-rest-yield-expr.js
+    ! dstr/array-rest-yield-ident-valid.js
     ! dstr/const-ary-init-iter-close.js
     ! dstr/const-ary-init-iter-get-err.js
     ! dstr/const-ary-init-iter-no-close.js
@@ -5099,11 +4523,19 @@ language/statements/for-of
     ! dstr/const-ary-ptrn-elision-step-err.js
     ! dstr/const-ary-ptrn-elision.js
     ! dstr/const-ary-ptrn-empty.js
+    ! dstr/const-ary-ptrn-rest-ary-elem.js
     ! dstr/const-ary-ptrn-rest-ary-elision.js
     ! dstr/const-ary-ptrn-rest-ary-empty.js
+    ! dstr/const-ary-ptrn-rest-ary-rest.js
     ! dstr/const-ary-ptrn-rest-id-elision-next-err.js
+    ! dstr/const-ary-ptrn-rest-id-elision.js
+    ! dstr/const-ary-ptrn-rest-id-exhausted.js
     ! dstr/const-ary-ptrn-rest-id-iter-close.js
     ! dstr/const-ary-ptrn-rest-id-iter-step-err.js
+    ! dstr/const-ary-ptrn-rest-id-iter-val-err.js
+    ! dstr/const-ary-ptrn-rest-id.js
+    ! dstr/const-ary-ptrn-rest-obj-id.js
+    ! dstr/const-ary-ptrn-rest-obj-prop-id.js
     ! dstr/const-obj-init-null.js
     ! dstr/const-obj-init-undefined.js
     ! dstr/const-obj-ptrn-empty.js
@@ -5140,8 +4572,10 @@ language/statements/for-of
     ! dstr/let-ary-ptrn-elem-ary-elem-iter.js
     ! dstr/let-ary-ptrn-elem-ary-elision-init.js
     ! dstr/let-ary-ptrn-elem-ary-elision-iter.js
-    ! dstr/let-ary-ptrn-elem-ary-empty-iter.js
     ! dstr/let-ary-ptrn-elem-ary-empty-init.js
+    ! dstr/let-ary-ptrn-elem-ary-empty-iter.js
+    ! dstr/let-ary-ptrn-elem-ary-rest-init.js
+    ! dstr/let-ary-ptrn-elem-ary-rest-iter.js
     ! dstr/let-ary-ptrn-elem-id-init-exhausted.js
     ! dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
     ! dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
@@ -5162,11 +4596,19 @@ language/statements/for-of
     ! dstr/let-ary-ptrn-elision-iter-close.js
     ! dstr/let-ary-ptrn-elision-step-err.js
     ! dstr/let-ary-ptrn-elision.js
+    ! dstr/let-ary-ptrn-rest-ary-elem.js
     ! dstr/let-ary-ptrn-rest-ary-elision.js
     ! dstr/let-ary-ptrn-rest-ary-empty.js
+    ! dstr/let-ary-ptrn-rest-ary-rest.js
     ! dstr/let-ary-ptrn-rest-id-elision-next-err.js
+    ! dstr/let-ary-ptrn-rest-id-elision.js
+    ! dstr/let-ary-ptrn-rest-id-exhausted.js
     ! dstr/let-ary-ptrn-rest-id-iter-close.js
     ! dstr/let-ary-ptrn-rest-id-iter-step-err.js
+    ! dstr/let-ary-ptrn-rest-id-iter-val-err.js
+    ! dstr/let-ary-ptrn-rest-id.js
+    ! dstr/let-ary-ptrn-rest-obj-id.js
+    ! dstr/let-ary-ptrn-rest-obj-prop-id.js
     ! dstr/let-obj-init-null.js
     ! dstr/let-obj-init-undefined.js
     ! dstr/let-obj-ptrn-id-init-fn-name-arrow.js
@@ -5179,18 +4621,18 @@ language/statements/for-of
     ! dstr/let-obj-ptrn-id-init-unresolvable.js
     ! dstr/let-obj-ptrn-list-err.js
     ! dstr/let-obj-ptrn-prop-ary-init.js
-    ! dstr/let-obj-ptrn-prop-ary.js
     ! dstr/let-obj-ptrn-prop-ary-value-null.js
+    ! dstr/let-obj-ptrn-prop-ary.js
     ! dstr/let-obj-ptrn-prop-eval-err.js
     ! dstr/let-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/let-obj-ptrn-prop-id-init.js
     ! dstr/let-obj-ptrn-prop-id-init-skipped.js
     ! dstr/let-obj-ptrn-prop-id-init-throws.js
     ! dstr/let-obj-ptrn-prop-id-init-unresolvable.js
+    ! dstr/let-obj-ptrn-prop-id-init.js
     ! dstr/let-obj-ptrn-prop-obj-init.js
-    ! dstr/let-obj-ptrn-prop-obj.js
     ! dstr/let-obj-ptrn-prop-obj-value-null.js
     ! dstr/let-obj-ptrn-prop-obj-value-undef.js
+    ! dstr/let-obj-ptrn-prop-obj.js
     ! dstr/obj-empty-null.js
     ! dstr/obj-empty-undef.js
     ! dstr/obj-id-identifier-yield-ident-valid.js
@@ -5225,10 +4667,10 @@ language/statements/for-of
     ! dstr/obj-prop-elem-init-let.js
     ! dstr/obj-prop-elem-init-yield-expr.js
     ! dstr/obj-prop-elem-init-yield-ident-valid.js
-    ! dstr/obj-prop-elem-target-yield-ident-valid.js
-    ! dstr/obj-prop-elem-target-obj-literal-prop-ref.js
-    ! dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     ! dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
+    ! dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
+    ! dstr/obj-prop-elem-target-obj-literal-prop-ref.js
+    ! dstr/obj-prop-elem-target-yield-ident-valid.js
     ! dstr/obj-prop-name-evaluation-error.js
     ! dstr/obj-prop-name-evaluation.js
     ! dstr/obj-prop-nested-array-yield-expr.js
@@ -5245,6 +4687,8 @@ language/statements/for-of
     ! dstr/var-ary-ptrn-elem-ary-elision-iter.js
     ! dstr/var-ary-ptrn-elem-ary-empty-init.js
     ! dstr/var-ary-ptrn-elem-ary-empty-iter.js
+    ! dstr/var-ary-ptrn-elem-ary-rest-init.js
+    ! dstr/var-ary-ptrn-elem-ary-rest-iter.js
     ! dstr/var-ary-ptrn-elem-id-init-exhausted.js
     ! dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
     ! dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
@@ -5265,11 +4709,19 @@ language/statements/for-of
     ! dstr/var-ary-ptrn-elision-iter-close.js
     ! dstr/var-ary-ptrn-elision-step-err.js
     ! dstr/var-ary-ptrn-elision.js
+    ! dstr/var-ary-ptrn-rest-ary-elem.js
     ! dstr/var-ary-ptrn-rest-ary-elision.js
     ! dstr/var-ary-ptrn-rest-ary-empty.js
+    ! dstr/var-ary-ptrn-rest-ary-rest.js
     ! dstr/var-ary-ptrn-rest-id-elision-next-err.js
+    ! dstr/var-ary-ptrn-rest-id-elision.js
+    ! dstr/var-ary-ptrn-rest-id-exhausted.js
     ! dstr/var-ary-ptrn-rest-id-iter-close.js
     ! dstr/var-ary-ptrn-rest-id-iter-step-err.js
+    ! dstr/var-ary-ptrn-rest-id-iter-val-err.js
+    ! dstr/var-ary-ptrn-rest-id.js
+    ! dstr/var-ary-ptrn-rest-obj-id.js
+    ! dstr/var-ary-ptrn-rest-obj-prop-id.js
     ! dstr/var-obj-init-null.js
     ! dstr/var-obj-init-undefined.js
     ! dstr/var-obj-ptrn-id-init-fn-name-arrow.js
@@ -5282,18 +4734,29 @@ language/statements/for-of
     ! dstr/var-obj-ptrn-id-init-unresolvable.js
     ! dstr/var-obj-ptrn-list-err.js
     ! dstr/var-obj-ptrn-prop-ary-init.js
-    ! dstr/var-obj-ptrn-prop-ary.js
     ! dstr/var-obj-ptrn-prop-ary-value-null.js
+    ! dstr/var-obj-ptrn-prop-ary.js
     ! dstr/var-obj-ptrn-prop-eval-err.js
     ! dstr/var-obj-ptrn-prop-id-get-value-err.js
-    ! dstr/var-obj-ptrn-prop-id-init.js
     ! dstr/var-obj-ptrn-prop-id-init-skipped.js
     ! dstr/var-obj-ptrn-prop-id-init-throws.js
     ! dstr/var-obj-ptrn-prop-id-init-unresolvable.js
+    ! dstr/var-obj-ptrn-prop-id-init.js
     ! dstr/var-obj-ptrn-prop-obj-init.js
-    ! dstr/var-obj-ptrn-prop-obj.js
     ! dstr/var-obj-ptrn-prop-obj-value-null.js
     ! dstr/var-obj-ptrn-prop-obj-value-undef.js
+    ! dstr/var-obj-ptrn-prop-obj.js
+    ! body-dstr-assign-error.js
+    ! body-put-error.js
+    ! cptn-decl-abrupt-empty.js
+    ! cptn-decl-itr.js
+    ! cptn-decl-no-itr.js
+    ! cptn-expr-abrupt-empty.js
+    ! cptn-expr-itr.js
+    ! cptn-expr-no-itr.js
+    ! decl-const.js
+    ! decl-fun.js
+    ! decl-gen.js
     ! escaped-of.js
     ! generator-close-via-break.js
     ! generator-close-via-continue.js
@@ -5309,8 +4772,8 @@ language/statements/for-of
     ! head-let-fresh-binding-per-iteration.js
     ! head-let-init.js
     ! head-var-bound-names-let.js
-    ! head-var-no-expr.js
     ! head-var-init.js
+    ! head-var-no-expr.js
     ! iterator-close-get-method-error.js
     ! iterator-close-non-object.js
     ! iterator-close-via-break.js
@@ -5334,12 +4797,6 @@ language/statements/for-of
     ! scope-head-var-none.js
 
 language/statements/generators
-    ! array-destructuring-param-strict-body.js
-    ! arguments-with-arguments-fn.js
-    ! arguments-with-arguments-lex.js
-    ! cptn-decl.js
-    ! default-proto.js
-    ! dflt-params-trailing-comma.js
     ! dstr/ary-init-iter-close.js
     ! dstr/ary-init-iter-get-err.js
     ! dstr/ary-name-iter-val.js
@@ -5364,9 +4821,9 @@ language/statements/generators
     ! dstr/ary-ptrn-elem-id-init-undef.js
     ! dstr/ary-ptrn-elem-id-init-unresolvable.js
     ! dstr/ary-ptrn-elem-id-iter-done.js
-    ! dstr/ary-ptrn-elem-id-iter-val.js
     ! dstr/ary-ptrn-elem-id-iter-step-err.js
     ! dstr/ary-ptrn-elem-id-iter-val-err.js
+    ! dstr/ary-ptrn-elem-id-iter-val.js
     ! dstr/ary-ptrn-elem-obj-id-init.js
     ! dstr/ary-ptrn-elem-obj-id.js
     ! dstr/ary-ptrn-elem-obj-prop-id-init.js
@@ -5401,8 +4858,8 @@ language/statements/generators
     ! dstr/obj-ptrn-id-trailing-comma.js
     ! dstr/obj-ptrn-list-err.js
     ! dstr/obj-ptrn-prop-ary-init.js
-    ! dstr/obj-ptrn-prop-ary-value-null.js
     ! dstr/obj-ptrn-prop-ary-trailing-comma.js
+    ! dstr/obj-ptrn-prop-ary-value-null.js
     ! dstr/obj-ptrn-prop-ary.js
     ! dstr/obj-ptrn-prop-eval-err.js
     ! dstr/obj-ptrn-prop-id-get-value-err.js
@@ -5414,11 +4871,17 @@ language/statements/generators
     ! dstr/obj-ptrn-prop-obj-value-null.js
     ! dstr/obj-ptrn-prop-obj-value-undef.js
     ! dstr/obj-ptrn-prop-obj.js
+    ! arguments-with-arguments-fn.js
+    ! arguments-with-arguments-lex.js
+    ! array-destructuring-param-strict-body.js
+    ! cptn-decl.js
+    ! default-proto.js
+    ! dflt-params-trailing-comma.js
     ! generator-created-after-decl-inst.js
     ! has-instance.js
     ! invoke-as-constructor.js
     ! length-property-descriptor.js
-    ! /name.js
+    ! name.js
     ! object-destructuring-param-strict-body.js
     ! params-trailing-comma-multiple.js
     ! params-trailing-comma-single.js
@@ -5439,8 +4902,8 @@ language/statements/generators
     ! yield-as-identifier-in-nested-function.js
     ! yield-as-identifier-reference-escaped.js
     ! yield-as-label-identifier-escaped.js
-    ! yield-identifier-spread-non-strict.js
     ! yield-identifier-non-strict.js
+    ! yield-identifier-spread-non-strict.js
     ! yield-spread-arr-multiple.js
     ! yield-spread-arr-single.js
     ! yield-spread-obj.js
@@ -5460,8 +4923,6 @@ language/types
     ! undefined/S8.1_A3_T2.js
 
 language/white-space
-    ! mongolian-vowel-separator-eval.js
-    ! mongolian-vowel-separator.js
     ! S7.2_A5_T1.js
     ! S7.2_A5_T2.js
     ! S7.2_A5_T3.js


### PR DESCRIPTION
As we now have Template Literal support, I wanted to update the version of the test2626 TestSuite we run against to the latest commit in master.

As I didn't want to manually update test262.properties accordingly, I set out to write some code to generate test262.properties from the results of running the TestSuite at the standard optLevels (-1, 0 and 9).

In order to make things easier, I changed the format a bit:
- removed the `!` in front of every .js file: if the file is listed in test262.properties, it's already an exclusion, so the `!` is unneeded
  This step makes the directory/file path a key in the Java Properties file format, instead of a commented line. As a result, it's now possible to add comments after the path and if your editor supports the Java Properties file format, you get nice colors 
- changed from `#` to `~` for excluding a directory
- support for comments after the folder/.js file name

I've also changed the behavior a bit:
- removed the logic that allowed excluding a similarly named file in multiple subfolders, by excluding the parent path
  While excluding this logic made it easier to (re)generate the properties file, I think it was also very confusing behavior to begin with
- on .js files that only fail in some strict-mode/optLevel combinations, details which variations fail is added as the first comment:
  - `strict`: fails only in strict mode on all optLevels
  - `non-strict`: fails only in non-strict mode on all optLevels
  - `non-interpreted`: always passes in interpreted mode, but fails on all other optLevels
  - `{unsupported: [...]}`: skipped due to depending on unsupported features
  - `{strict: [1,9], non-strict: [9]}`: any other scenario not matching the ones above
- if all tests fail for a subfolder (i.e. built-in/Array/prototype/xxxx), the .js files can be omitted and replaced by an `*` in front of the subfolder
- all tests that fail due to depending on unsupported features are included (by default), in order to:
  - have a full picture
  - easier to comprehend the delta between the old and new .properties file when regenerating it after updating the version of the test262 Test Suite
- on (rolled-up) folder entries stats are included as the first part in the comment # of failed tests vs. the total # of tests
  
Check out the updated ./testsrc/README.md for more details, but the basic gist of regenerating the test262.properties file is `./gradlew test --tests org.mozilla.javascript.tests.Test262SuiteTest --rerun-tasks -DupdateTest262properties`

The only downside of regenerating the test262.properties file is that any lines that are just comments are lost. To me, that is a reasonable tradeoff though

If the changes in this PR seem overwhelming (especially comparing test262.properties against master): I did things in steps (1 through 6), see the individual commits

@rbri I hope you don't mind but I took your work in https://github.com/mozilla/rhino/pull/910 as the basis of my work. I think this PR makes yours obsolete, as it adds all the relevant info directly as comments on the individual test cases in the test262.properties file.

When attempting to update to the latest commit in the main branch of test262 I discovered that since September last year, the test262 harness utilizes rest parameters, so unfortunately wasn't able to update all the way to the latest commit on their main branch.

Some open questions:
- when (re)generating the test262.properties file, there are a couple of flags that affect the output (see readme). The default is to do rollup, include stats and include failing tests due to unsupported features. To me this makes the most sense, but the default (thus what we should also commit) could be changed
- the stats show the % failed test. Could change that to show the % passed. Dunno which number makes us happier :-)

Next steps (can be a future PR(s)):
- add rest parameter support to Rhino, so we can attempt to update the version of test262 we test against to the latest commit on their main branch
- move excluded features list out of Test262TestSuite and into test262.properties
- move excluded flags list out of Test262TestSuite and into test262.properties
- when (re)generating the .properties file, include all test262/test/*/* folders in the newly generated .properties file (so new folders added in the test262 repo will automatically be included)

Hope you guys see this as a good step forwards.

closes https://github.com/mozilla/rhino/issues/817
