### PR TITLE
Implement promises

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,4 @@ version=1.7.14-SNAPSHOT
 buildDir=buildGradle
 mavenSnapshotRepo=https://oss.sonatype.org/content/repositories/snapshots
 mavenReleaseRepo=https://oss.sonatype.org/service/local/staging/deploy/maven2/
-org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,5 @@ version=1.7.14-SNAPSHOT
 buildDir=buildGradle
 mavenSnapshotRepo=https://oss.sonatype.org/content/repositories/snapshots
 mavenReleaseRepo=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+org.gradle.caching=true
 org.gradle.parallel=true

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -463,6 +463,20 @@ public class BaseFunction extends IdScriptableObject implements Function {
         return "";
     }
 
+    /**
+     * Sets the attributes of the "name", "length", and "arity" properties, which differ for many
+     * native objects.
+     */
+    public void setStandardPropertyAttributes(int attributes) {
+        namePropertyAttributes = attributes;
+        lengthPropertyAttributes = attributes;
+        arityPropertyAttributes = attributes;
+    }
+
+    public void setPrototypePropertyAttributes(int attributes) {
+        prototypePropertyAttributes = attributes;
+    }
+
     protected boolean hasPrototypeProperty() {
         return prototypeProperty != null || this instanceof NativeFunction;
     }

--- a/src/org/mozilla/javascript/InterpretedFunction.java
+++ b/src/org/mozilla/javascript/InterpretedFunction.java
@@ -96,12 +96,17 @@ final class InterpretedFunction extends NativeFunction implements Script {
             // Can only be applied to scripts
             throw new IllegalStateException();
         }
+        Object ret;
         if (!ScriptRuntime.hasTopCall(cx)) {
             // It will go through "call" path. but they are equivalent
-            return ScriptRuntime.doTopCall(
-                    this, cx, scope, scope, ScriptRuntime.emptyArgs, idata.isStrict);
+            ret =
+                    ScriptRuntime.doTopCall(
+                            this, cx, scope, scope, ScriptRuntime.emptyArgs, idata.isStrict);
+        } else {
+            ret = Interpreter.interpret(this, cx, scope, scope, ScriptRuntime.emptyArgs);
         }
-        return Interpreter.interpret(this, cx, scope, scope, ScriptRuntime.emptyArgs);
+        cx.processMicrotasks();
+        return ret;
     }
 
     public boolean isScript() {

--- a/src/org/mozilla/javascript/InterpretedFunction.java
+++ b/src/org/mozilla/javascript/InterpretedFunction.java
@@ -8,17 +8,14 @@ package org.mozilla.javascript;
 
 import org.mozilla.javascript.debug.DebuggableScript;
 
-final class InterpretedFunction extends NativeFunction implements Script
-{
+final class InterpretedFunction extends NativeFunction implements Script {
     private static final long serialVersionUID = 541475680333911468L;
 
     InterpreterData idata;
     SecurityController securityController;
     Object securityDomain;
 
-    private InterpretedFunction(InterpreterData idata,
-                                Object staticSecurityDomain)
-    {
+    private InterpretedFunction(InterpreterData idata, Object staticSecurityDomain) {
         this.idata = idata;
 
         // Always get Context from the current thread to
@@ -40,69 +37,53 @@ final class InterpretedFunction extends NativeFunction implements Script
         this.securityDomain = dynamicDomain;
     }
 
-    private InterpretedFunction(InterpretedFunction parent, int index)
-    {
+    private InterpretedFunction(InterpretedFunction parent, int index) {
         this.idata = parent.idata.itsNestedFunctions[index];
         this.securityController = parent.securityController;
         this.securityDomain = parent.securityDomain;
     }
 
-    /**
-     * Create script from compiled bytecode.
-     */
-    static InterpretedFunction createScript(InterpreterData idata,
-                                            Object staticSecurityDomain)
-    {
+    /** Create script from compiled bytecode. */
+    static InterpretedFunction createScript(InterpreterData idata, Object staticSecurityDomain) {
         InterpretedFunction f;
         f = new InterpretedFunction(idata, staticSecurityDomain);
         return f;
     }
 
-    /**
-     * Create function compiled from Function(...) constructor.
-     */
-    static InterpretedFunction createFunction(Context cx,Scriptable scope,
-                                              InterpreterData idata,
-                                              Object staticSecurityDomain)
-    {
+    /** Create function compiled from Function(...) constructor. */
+    static InterpretedFunction createFunction(
+            Context cx, Scriptable scope, InterpreterData idata, Object staticSecurityDomain) {
         InterpretedFunction f;
         f = new InterpretedFunction(idata, staticSecurityDomain);
         f.initScriptFunction(cx, scope, f.idata.isES6Generator);
         return f;
     }
 
-    /**
-     * Create function embedded in script or another function.
-     */
-    static InterpretedFunction createFunction(Context cx, Scriptable scope,
-                                              InterpretedFunction parent,
-                                              int index)
-    {
+    /** Create function embedded in script or another function. */
+    static InterpretedFunction createFunction(
+            Context cx, Scriptable scope, InterpretedFunction parent, int index) {
         InterpretedFunction f = new InterpretedFunction(parent, index);
         f.initScriptFunction(cx, scope, f.idata.isES6Generator);
         return f;
     }
 
-
     @Override
-    public String getFunctionName()
-    {
+    public String getFunctionName() {
         return (idata.itsName == null) ? "" : idata.itsName;
     }
 
     /**
      * Calls the function.
+     *
      * @param cx the current context
      * @param scope the scope used for the call
      * @param thisObj the value of "this"
-     * @param args function arguments. Must not be null. You can use
-     * {@link ScriptRuntime#emptyArgs} to pass empty arguments.
+     * @param args function arguments. Must not be null. You can use {@link ScriptRuntime#emptyArgs}
+     *     to pass empty arguments.
      * @return the result of the function call.
      */
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
-                       Object[] args)
-    {
+    public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         if (!ScriptRuntime.hasTopCall(cx)) {
             return ScriptRuntime.doTopCall(this, cx, scope, thisObj, args, idata.isStrict);
         }
@@ -110,8 +91,7 @@ final class InterpretedFunction extends NativeFunction implements Script
     }
 
     @Override
-    public Object exec(Context cx, Scriptable scope)
-    {
+    public Object exec(Context cx, Scriptable scope) {
         if (!isScript()) {
             // Can only be applied to scripts
             throw new IllegalStateException();
@@ -119,10 +99,9 @@ final class InterpretedFunction extends NativeFunction implements Script
         if (!ScriptRuntime.hasTopCall(cx)) {
             // It will go through "call" path. but they are equivalent
             return ScriptRuntime.doTopCall(
-                this, cx, scope, scope, ScriptRuntime.emptyArgs, idata.isStrict);
+                    this, cx, scope, scope, ScriptRuntime.emptyArgs, idata.isStrict);
         }
-        return Interpreter.interpret(
-            this, cx, scope, scope, ScriptRuntime.emptyArgs);
+        return Interpreter.interpret(this, cx, scope, scope, ScriptRuntime.emptyArgs);
     }
 
     public boolean isScript() {
@@ -130,51 +109,43 @@ final class InterpretedFunction extends NativeFunction implements Script
     }
 
     @Override
-    public String getEncodedSource()
-    {
+    public String getEncodedSource() {
         return Interpreter.getEncodedSource(idata);
     }
 
     @Override
-    public DebuggableScript getDebuggableView()
-    {
+    public DebuggableScript getDebuggableView() {
         return idata;
     }
 
     @Override
-    public Object resumeGenerator(Context cx, Scriptable scope, int operation,
-                                  Object state, Object value)
-    {
+    public Object resumeGenerator(
+            Context cx, Scriptable scope, int operation, Object state, Object value) {
         return Interpreter.resumeGenerator(cx, scope, operation, state, value);
     }
 
     @Override
-    protected int getLanguageVersion()
-    {
+    protected int getLanguageVersion() {
         return idata.languageVersion;
     }
 
     @Override
-    protected int getParamCount()
-    {
+    protected int getParamCount() {
         return idata.argCount;
     }
 
     @Override
-    protected int getParamAndVarCount()
-    {
+    protected int getParamAndVarCount() {
         return idata.argNames.length;
     }
 
     @Override
-    protected String getParamOrVarName(int index)
-    {
+    protected String getParamOrVarName(int index) {
         return idata.argNames[index];
     }
 
     @Override
-    protected boolean getParamOrVarConst(int index)
-    {
+    protected boolean getParamOrVarConst(int index) {
         return idata.argIsConst[index];
     }
 
@@ -189,4 +160,3 @@ final class InterpretedFunction extends NativeFunction implements Script
         return true;
     }
 }
-

--- a/src/org/mozilla/javascript/IteratorLikeIterable.java
+++ b/src/org/mozilla/javascript/IteratorLikeIterable.java
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
- 
+
 package org.mozilla.javascript;
 
 import java.io.Closeable;
@@ -9,21 +9,17 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * This is a class that makes it easier to iterate over "iterator-like" objects as defined
- * in the ECMAScript spec. The caller is responsible for retrieving an object that implements
- * the "iterator" pattern. This class will follow that pattern and throw appropriate
- * JavaScript exceptions.
+ * This is a class that makes it easier to iterate over "iterator-like" objects as defined in the
+ * ECMAScript spec. The caller is responsible for retrieving an object that implements the
+ * "iterator" pattern. This class will follow that pattern and throw appropriate JavaScript
+ * exceptions.
  *
- * The pattern that the target class should follow is:
- * * It must have a function property called "next"
- * * The function must return an object with a boolean value called "done".
- * * If "done" is true, then the returned object should also contain a "value" property.
- * * If it has a function property called "return" then it will be called
- *   when the caller is done iterating.
+ * <p>The pattern that the target class should follow is: * It must have a function property called
+ * "next" * The function must return an object with a boolean value called "done". * If "done" is
+ * true, then the returned object should also contain a "value" property. * If it has a function
+ * property called "return" then it will be called when the caller is done iterating.
  */
-public class IteratorLikeIterable
-    implements Iterable<Object>, Closeable
-{
+public class IteratorLikeIterable implements Iterable<Object>, Closeable {
     private final Context cx;
     private final Scriptable scope;
     private final Callable next;
@@ -37,13 +33,14 @@ public class IteratorLikeIterable
         // This will throw if "next" is not a function or undefined
         next = ScriptRuntime.getPropFunctionAndThis(target, ES6Iterator.NEXT_METHOD, cx, scope);
         iterator = ScriptRuntime.lastStoredScriptable(cx);
-        Object retObj = ScriptRuntime.getObjectPropNoWarn(target, ES6Iterator.RETURN_PROPERTY, cx, scope);
+        Object retObj =
+                ScriptRuntime.getObjectPropNoWarn(target, ES6Iterator.RETURN_PROPERTY, cx, scope);
         // We only care about "return" if it is not null or undefined
         if ((retObj != null) && !Undefined.isUndefined(retObj)) {
             if (!(retObj instanceof Callable)) {
                 throw ScriptRuntime.notFunctionError(target, retObj, ES6Iterator.RETURN_PROPERTY);
             }
-            returnFunc = (Callable)retObj;
+            returnFunc = (Callable) retObj;
         } else {
             returnFunc = null;
         }
@@ -64,19 +61,21 @@ public class IteratorLikeIterable
         return new Itr();
     }
 
-    public final class Itr
-        implements Iterator<Object>
-    {
+    public final class Itr implements Iterator<Object> {
         private Object nextVal;
         private boolean isDone;
 
         @Override
         public boolean hasNext() {
+            if (isDone) {
+                return false;
+            }
             Object val = next.call(cx, scope, iterator, ScriptRuntime.emptyArgs);
-            // This will throw if "val" is not an object. 
+            // This will throw if "val" is not an object.
             // "getObjectPropNoWarn" won't, so do this as follows.
-            Object doneval = ScriptableObject.getProperty(
-                ScriptableObject.ensureScriptable(val), ES6Iterator.DONE_PROPERTY);
+            Object doneval =
+                    ScriptableObject.getProperty(
+                            ScriptableObject.ensureScriptable(val), ES6Iterator.DONE_PROPERTY);
             if (doneval == Scriptable.NOT_FOUND) {
                 doneval = Undefined.instance;
             }
@@ -95,6 +94,16 @@ public class IteratorLikeIterable
                 throw new NoSuchElementException();
             }
             return nextVal;
+        }
+
+        /** Find out if "hasNext" returned done without invoking the function again. */
+        public boolean isDone() {
+            return isDone;
+        }
+
+        /** Manually set "done." Used for exception handling in promises. */
+        public void setDone(boolean done) {
+            this.isDone = done;
         }
     }
 }

--- a/src/org/mozilla/javascript/LambdaConstructor.java
+++ b/src/org/mozilla/javascript/LambdaConstructor.java
@@ -90,15 +90,32 @@ public class LambdaConstructor extends LambdaFunction {
         proto.defineProperty(name, f, 0);
     }
 
+    /**
+     * Define a function property on the prototype of the constructor using a LambdaFunction under
+     * the covers.
+     */
+    public void definePrototypeMethod(
+            Scriptable scope,
+            String name,
+            int length,
+            Callable target,
+            int attributes,
+            int propertyAttributes) {
+        LambdaFunction f = new LambdaFunction(scope, name, length, target);
+        f.setStandardPropertyAttributes(propertyAttributes);
+        ScriptableObject proto = getPrototypeScriptable();
+        proto.defineProperty(name, f, attributes);
+    }
+
     /** Define a property that may be of any type on the prototype of this constructor. */
     public void definePrototypeProperty(String name, Object value, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
-        proto.defineProperty(name, value, 0);
+        proto.defineProperty(name, value, attributes);
     }
 
     public void definePrototypeProperty(Symbol key, Object value, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
-        proto.defineProperty(key, value, 0);
+        proto.defineProperty(key, value, attributes);
     }
 
     /**
@@ -106,9 +123,26 @@ public class LambdaConstructor extends LambdaFunction {
      * by a LambdaFunction.
      */
     public void defineConstructorMethod(
-            Scriptable scope, String name, int length, Callable target) {
+            Scriptable scope, String name, int length, Callable target, int attributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
-        defineProperty(name, f, DONTENUM);
+        defineProperty(name, f, attributes);
+    }
+
+    /**
+     * Define a function property directly on the constructor that is implemented under the covers
+     * by a LambdaFunction, and override the properties of its "name", "length", and "arity"
+     * properties.
+     */
+    public void defineConstructorMethod(
+            Scriptable scope,
+            String name,
+            int length,
+            Callable target,
+            int attributes,
+            int propertyAttributes) {
+        LambdaFunction f = new LambdaFunction(scope, name, length, target);
+        f.setStandardPropertyAttributes(propertyAttributes);
+        defineProperty(name, f, attributes);
     }
 
     /**

--- a/src/org/mozilla/javascript/LambdaConstructor.java
+++ b/src/org/mozilla/javascript/LambdaConstructor.java
@@ -121,11 +121,38 @@ public class LambdaConstructor extends LambdaFunction {
     /**
      * Define a function property directly on the constructor that is implemented under the covers
      * by a LambdaFunction.
+     *
+     * @param name the key to use to look up the new function property, and also the value to return
+     *     for the "name" property of the Function object
+     * @param length the value to return for the "length" property of the Function object
+     * @param target the target to call when the method is invoked
+     * @param attributes the attributes to set on the new property
      */
     public void defineConstructorMethod(
             Scriptable scope, String name, int length, Callable target, int attributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
         defineProperty(name, f, attributes);
+    }
+
+    /**
+     * Define a function property directly on the constructor that is implemented under the covers
+     * by a LambdaFunction.
+     *
+     * @param key the Symbol to use to look up the property
+     * @param name the value to return for the "name" property of the Function object
+     * @param length the value to return for the "length" property of the Function object
+     * @param target the target to call when the method is invoked
+     * @param attributes the attributes to set on the new property
+     */
+    public void defineConstructorMethod(
+            Scriptable scope,
+            Symbol key,
+            String name,
+            int length,
+            Callable target,
+            int attributes) {
+        LambdaFunction f = new LambdaFunction(scope, name, length, target);
+        defineProperty(key, f, attributes);
     }
 
     /**

--- a/src/org/mozilla/javascript/NativePromise.java
+++ b/src/org/mozilla/javascript/NativePromise.java
@@ -92,16 +92,11 @@ public class NativePromise extends ScriptableObject {
     }
 
     private static Scriptable constructor(Context cx, Scriptable scope, Object[] args) {
-        if (args.length < 1) {
-            throw ScriptRuntime.typeErrorById("msg.function.expected");
-        }
-        if (!(args[0] instanceof Callable)) {
+        if (args.length < 1 || !(args[0] instanceof Callable)) {
             throw ScriptRuntime.typeErrorById("msg.function.expected");
         }
         Callable executor = (Callable) args[0];
-
         NativePromise promise = new NativePromise();
-
         ResolvingFunctions resolving = new ResolvingFunctions(scope, promise);
 
         try {
@@ -283,7 +278,8 @@ public class NativePromise extends ScriptableObject {
     // Promise.prototype.then
     private Object then(
             Context cx, Scriptable scope, LambdaConstructor defaultConstructor, Object[] args) {
-        Constructable constructable = ScriptRuntime.getSpeciesConstructor(this, defaultConstructor);
+        Constructable constructable =
+                AbstractEcmaObjectOperations.speciesConstructor(cx, this, defaultConstructor);
         Capability capability = new Capability(cx, scope, constructable);
 
         Callable onFulfilled = null;
@@ -337,7 +333,7 @@ public class NativePromise extends ScriptableObject {
         Object thenFinally = onFinally;
         Object catchFinally = onFinally;
         Constructable constructor =
-                ScriptRuntime.getSpeciesConstructor(thisObj, defaultConstructor);
+                AbstractEcmaObjectOperations.speciesConstructor(cx, thisObj, defaultConstructor);
         if (onFinally instanceof Callable) {
             Callable callableOnFinally = (Callable) thenFinally;
             thenFinally = makeThenFinally(scope, constructor, callableOnFinally);

--- a/src/org/mozilla/javascript/NativePromise.java
+++ b/src/org/mozilla/javascript/NativePromise.java
@@ -1,0 +1,767 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.util.ArrayList;
+import org.mozilla.javascript.TopLevel.NativeErrors;
+
+public class NativePromise extends ScriptableObject {
+
+    enum State {
+        PENDING,
+        FULFILLED,
+        REJECTED
+    }
+
+    enum ReactionType {
+        FULFILL,
+        REJECT
+    }
+
+    private State state = State.PENDING;
+    private Object result = null;
+
+    private ArrayList<Reaction> fulfillReactions = new ArrayList<>();
+    private ArrayList<Reaction> rejectReactions = new ArrayList<>();
+
+    public static void init(Context cx, Scriptable scope, boolean sealed) {
+        LambdaConstructor constructor =
+                new LambdaConstructor(
+                        scope,
+                        "Promise",
+                        1,
+                        LambdaConstructor.CONSTRUCTOR_NEW,
+                        NativePromise::constructor);
+        constructor.setStandardPropertyAttributes(DONTENUM | READONLY);
+        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
+
+        constructor.defineConstructorMethod(
+                scope, "resolve", 1, NativePromise::resolve, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "reject", 1, NativePromise::reject, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "all", 1, NativePromise::all, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "race", 1, NativePromise::race, DONTENUM, DONTENUM | READONLY);
+
+        constructor.definePrototypeMethod(
+                scope,
+                "then",
+                2,
+                (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
+                    NativePromise self =
+                            LambdaConstructor.convertThisObject(thisObj, NativePromise.class);
+                    return self.then(lcx, lscope, args);
+                },
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope, "catch", 1, NativePromise::doCatch, DONTENUM, DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope, "finally", 1, NativePromise::doFinally, DONTENUM, DONTENUM | READONLY);
+
+        constructor.definePrototypeProperty(
+                SymbolKey.TO_STRING_TAG, "Promise", DONTENUM | READONLY);
+
+        ScriptableObject.defineProperty(scope, "Promise", constructor, DONTENUM);
+        if (sealed) {
+            constructor.sealObject();
+        }
+    }
+
+    private static Scriptable constructor(Context cx, Scriptable scope, Object[] args) {
+        if (args.length < 1) {
+            throw ScriptRuntime.typeErrorById("msg.function.expected");
+        }
+        if (!(args[0] instanceof Callable)) {
+            throw ScriptRuntime.typeErrorById("msg.function.expected");
+        }
+        Callable executor = (Callable) args[0];
+
+        NativePromise promise = new NativePromise();
+
+        ResolvingFunctions resolving = new ResolvingFunctions(scope, promise);
+
+        try {
+            executor.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {resolving.resolve, resolving.reject});
+        } catch (RhinoException re) {
+            resolving.reject.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {getErrorObject(cx, scope, re)});
+        }
+
+        return promise;
+    }
+
+    @Override
+    public String getClassName() {
+        return "Promise";
+    }
+
+    // Promise.resolve
+    private static Object resolve(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!ScriptRuntime.isObject(thisObj)) {
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
+        }
+        Object arg = (args.length > 0 ? args[0] : Undefined.instance);
+        return resolveInternal(cx, scope, thisObj, arg);
+    }
+
+    // PromiseResolve abstract operation
+    private static Object resolveInternal(
+            Context cx, Scriptable scope, Scriptable constructor, Object arg) {
+        if (arg instanceof NativePromise) {
+            Object argConstructor = ScriptRuntime.getObjectProp(arg, "constructor", cx, scope);
+            if (argConstructor == constructor) {
+                return arg;
+            }
+        }
+        Capability cap = new Capability(cx, scope, constructor);
+        cap.resolve.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
+        return cap.promise;
+    }
+
+    // Promise.reject
+    private static Object reject(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!ScriptRuntime.isObject(thisObj)) {
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
+        }
+        Object arg = (args.length > 0 ? args[0] : Undefined.instance);
+        Capability cap = new Capability(cx, scope, thisObj);
+        cap.reject.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
+        return cap.promise;
+    }
+
+    // Promise.all
+    private static Object all(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        Capability cap = new Capability(cx, scope, thisObj);
+        Object arg = (args.length > 0 ? args[0] : Undefined.instance);
+
+        IteratorLikeIterable iterable;
+        try {
+            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, scope);
+            iterable = new IteratorLikeIterable(cx, scope, maybeIterable);
+        } catch (RhinoException re) {
+            cap.reject.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {getErrorObject(cx, scope, re)});
+            return cap.promise;
+        }
+
+        IteratorLikeIterable.Itr iterator = iterable.iterator();
+        try {
+            PromiseAllResolver resolver = new PromiseAllResolver(iterator, thisObj, cap);
+            try {
+                return resolver.resolve(cx, scope);
+            } finally {
+                if (!iterator.isDone()) {
+                    iterable.close();
+                }
+            }
+        } catch (RhinoException re) {
+            cap.reject.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {getErrorObject(cx, scope, re)});
+            return cap.promise;
+        }
+    }
+
+    // Promise.race
+    private static Object race(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        Capability cap = new Capability(cx, scope, thisObj);
+        Object arg = (args.length > 0 ? args[0] : Undefined.instance);
+
+        IteratorLikeIterable iterable;
+        try {
+            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, scope);
+            iterable = new IteratorLikeIterable(cx, scope, maybeIterable);
+        } catch (RhinoException re) {
+            cap.reject.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {getErrorObject(cx, scope, re)});
+            return cap.promise;
+        }
+
+        IteratorLikeIterable.Itr iterator = iterable.iterator();
+        try {
+            try {
+                return performRace(cx, scope, iterator, thisObj, cap);
+            } finally {
+                if (!iterator.isDone()) {
+                    iterable.close();
+                }
+            }
+        } catch (RhinoException re) {
+            cap.reject.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {getErrorObject(cx, scope, re)});
+            return cap.promise;
+        }
+    }
+
+    private static Object performRace(
+            Context cx,
+            Scriptable scope,
+            IteratorLikeIterable.Itr iterator,
+            Scriptable thisObj,
+            Capability cap) {
+        Callable resolve = ScriptRuntime.getPropFunctionAndThis(thisObj, "resolve", cx, scope);
+        Scriptable localThis = ScriptRuntime.lastStoredScriptable(cx);
+
+        // Manually iterate for exception handling purposes
+        while (true) {
+            boolean hasNext;
+            Object nextVal = Undefined.instance;
+            boolean nextOk = false;
+            try {
+                hasNext = iterator.hasNext();
+                if (hasNext) {
+                    nextVal = iterator.next();
+                }
+                nextOk = true;
+            } finally {
+                if (!nextOk) {
+                    iterator.setDone(true);
+                }
+            }
+
+            if (!hasNext) {
+                return cap.promise;
+            }
+
+            // Call "resolve" to get the next promise in the chain
+            Object nextPromise = resolve.call(cx, scope, localThis, new Object[] {nextVal});
+
+            // And then call "then" on it.
+            // Logic in the resolution function ensures we don't deliver duplicate results
+            Callable thenFunc =
+                    ScriptRuntime.getPropFunctionAndThis(nextPromise, "then", cx, scope);
+            thenFunc.call(
+                    cx,
+                    scope,
+                    ScriptRuntime.lastStoredScriptable(cx),
+                    new Object[] {cap.resolve, cap.reject});
+        }
+    }
+
+    // Promise.prototype.then
+    private Object then(Context cx, Scriptable scope, Object[] args) {
+        Object ourNativeConstructor = ScriptableObject.getProperty(this, "constructor");
+        Capability capability = new Capability(cx, scope, ourNativeConstructor);
+
+        Callable onFulfilled = null;
+        if (args.length >= 1 && args[0] instanceof Callable) {
+            onFulfilled = (Callable) args[0];
+        }
+        Callable onRejected = null;
+        if (args.length >= 2 && args[1] instanceof Callable) {
+            onRejected = (Callable) args[1];
+        }
+
+        Reaction fulfillReaction = new Reaction(capability, ReactionType.FULFILL, onFulfilled);
+        Reaction rejectReaction = new Reaction(capability, ReactionType.REJECT, onRejected);
+
+        if (state == State.PENDING) {
+            fulfillReactions.add(fulfillReaction);
+            rejectReactions.add(rejectReaction);
+        } else if (state == State.FULFILLED) {
+            cx.enqueueMicrotask(() -> fulfillReaction.invoke(cx, scope, result));
+        } else {
+            assert (state == State.REJECTED);
+            cx.enqueueMicrotask(() -> rejectReaction.invoke(cx, scope, result));
+        }
+        return capability.promise;
+    }
+
+    // Promise.prototype.catch
+    private static Object doCatch(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        Object arg = (args.length > 0 ? args[0] : Undefined.instance);
+        Scriptable coercedThis = ScriptRuntime.toObject(cx, scope, thisObj);
+        // No guarantee that the caller didn't change the prototype of "then"!
+        Callable thenFunc = ScriptRuntime.getPropFunctionAndThis(coercedThis, "then", cx, scope);
+        return thenFunc.call(
+                cx,
+                scope,
+                ScriptRuntime.lastStoredScriptable(cx),
+                new Object[] {Undefined.instance, arg});
+    }
+
+    // Promise.prototype.finally
+    private static Object doFinally(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!ScriptRuntime.isObject(thisObj)) {
+            throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
+        }
+        Object onFinally = args.length > 0 ? args[0] : Undefined.SCRIPTABLE_UNDEFINED;
+        Object thenFinally = onFinally;
+        Object catchFinally = onFinally;
+        Scriptable constructor =
+                ensureScriptable(ScriptableObject.getProperty(thisObj, "constructor"));
+        if (onFinally instanceof Callable) {
+            Callable callableOnFinally = (Callable) thenFinally;
+            thenFinally = makeThenFinally(scope, constructor, callableOnFinally);
+            catchFinally = makeCatchFinally(scope, constructor, callableOnFinally);
+        }
+        Callable thenFunc = ScriptRuntime.getPropFunctionAndThis(thisObj, "then", cx, scope);
+        Scriptable to = ScriptRuntime.lastStoredScriptable(cx);
+        return thenFunc.call(cx, scope, to, new Object[] {thenFinally, catchFinally});
+    }
+
+    // Abstract "Then Finally Function"
+    private static Callable makeThenFinally(
+            Scriptable scope, Scriptable constructor, Callable onFinally) {
+        return new LambdaFunction(
+                scope,
+                1,
+                (Context cx, Scriptable ls, Scriptable thisObj, Object[] args) -> {
+                    Object value = args.length > 0 ? args[0] : Undefined.instance;
+                    LambdaFunction valueThunk =
+                            new LambdaFunction(
+                                    scope,
+                                    0,
+                                    (Context vc, Scriptable vs, Scriptable vt, Object[] va) ->
+                                            value);
+                    Object result =
+                            onFinally.call(
+                                    cx,
+                                    ls,
+                                    Undefined.SCRIPTABLE_UNDEFINED,
+                                    ScriptRuntime.emptyArgs);
+                    Object promise = resolveInternal(cx, scope, constructor, result);
+                    Callable thenFunc =
+                            ScriptRuntime.getPropFunctionAndThis(promise, "then", cx, scope);
+                    return thenFunc.call(
+                            cx,
+                            scope,
+                            ScriptRuntime.lastStoredScriptable(cx),
+                            new Object[] {valueThunk});
+                });
+    }
+
+    // Abstract "Catch Finally Thrower"
+    private static Callable makeCatchFinally(
+            Scriptable scope, Scriptable constructor, Callable onFinally) {
+        return new LambdaFunction(
+                scope,
+                1,
+                (Context cx, Scriptable ls, Scriptable thisObj, Object[] args) -> {
+                    Object reason = args.length > 0 ? args[0] : Undefined.instance;
+                    LambdaFunction reasonThrower =
+                            new LambdaFunction(
+                                    scope,
+                                    0,
+                                    (Context vc, Scriptable vs, Scriptable vt, Object[] va) -> {
+                                        throw new JavaScriptException(reason, null, 0);
+                                    });
+                    Object result =
+                            onFinally.call(
+                                    cx,
+                                    ls,
+                                    Undefined.SCRIPTABLE_UNDEFINED,
+                                    ScriptRuntime.emptyArgs);
+                    Object promise = resolveInternal(cx, scope, constructor, result);
+                    Callable thenFunc =
+                            ScriptRuntime.getPropFunctionAndThis(promise, "then", cx, scope);
+                    return thenFunc.call(
+                            cx,
+                            scope,
+                            ScriptRuntime.lastStoredScriptable(cx),
+                            new Object[] {reasonThrower});
+                });
+    }
+
+    // Abstract operation to fulfill a promise
+    private Object fulfillPromise(Context cx, Scriptable scope, Object value) {
+        assert (state == State.PENDING);
+        result = value;
+        ArrayList<Reaction> reactions = fulfillReactions;
+        fulfillReactions = new ArrayList<>();
+        if (!rejectReactions.isEmpty()) {
+            rejectReactions = new ArrayList<>();
+        }
+        state = State.FULFILLED;
+        for (Reaction r : reactions) {
+            cx.enqueueMicrotask(() -> r.invoke(cx, scope, value));
+        }
+        return Undefined.instance;
+    }
+
+    // Abstract operation to reject a promise.
+    private Object rejectPromise(Context cx, Scriptable scope, Object reason) {
+        assert (state == State.PENDING);
+        result = reason;
+        ArrayList<Reaction> reactions = rejectReactions;
+        rejectReactions = new ArrayList<>();
+        if (!fulfillReactions.isEmpty()) {
+            fulfillReactions = new ArrayList<>();
+        }
+        state = State.REJECTED;
+        for (Reaction r : reactions) {
+            cx.enqueueMicrotask(() -> r.invoke(cx, scope, reason));
+        }
+        return Undefined.instance;
+    }
+
+    // Promise Resolve Thenable Job.
+    // This gets called by the "resolving func" as a microtask.
+    private void callThenable(Context cx, Scriptable scope, Object resolution, Callable thenFunc) {
+        ResolvingFunctions resolving = new ResolvingFunctions(scope, this);
+        Scriptable thisObj =
+                (resolution instanceof Scriptable
+                        ? (Scriptable) resolution
+                        : Undefined.SCRIPTABLE_UNDEFINED);
+        try {
+            thenFunc.call(cx, scope, thisObj, new Object[] {resolving.resolve, resolving.reject});
+        } catch (RhinoException re) {
+            resolving.reject.call(
+                    cx,
+                    scope,
+                    Undefined.SCRIPTABLE_UNDEFINED,
+                    new Object[] {getErrorObject(cx, scope, re)});
+        }
+    }
+
+    private static Object getErrorObject(Context cx, Scriptable scope, RhinoException re) {
+        if (re instanceof JavaScriptException) {
+            return ((JavaScriptException) re).getValue();
+        }
+
+        TopLevel.NativeErrors constructor = NativeErrors.Error;
+        if (re instanceof EcmaError) {
+            EcmaError ee = (EcmaError) re;
+            switch (ee.getName()) {
+                case "EvalError":
+                    constructor = NativeErrors.EvalError;
+                    break;
+                case "RangeError":
+                    constructor = NativeErrors.RangeError;
+                    break;
+                case "ReferenceError":
+                    constructor = NativeErrors.ReferenceError;
+                    break;
+                case "SyntaxError":
+                    constructor = NativeErrors.SyntaxError;
+                    break;
+                case "TypeError":
+                    constructor = NativeErrors.TypeError;
+                    break;
+                case "URIError":
+                    constructor = NativeErrors.URIError;
+                    break;
+                case "InternalError":
+                    constructor = NativeErrors.InternalError;
+                    break;
+                case "JavaException":
+                    constructor = NativeErrors.JavaException;
+                    break;
+                default:
+                    break;
+            }
+        }
+        return ScriptRuntime.newNativeError(cx, scope, constructor, new Object[] {re.getMessage()});
+    }
+
+    // Output of "CreateResolvingFunctions." Carries with it an "alreadyResolved" state,
+    // so we make it a separate object. This actually fires resolution functions on
+    // the passed callbacks.
+    private static class ResolvingFunctions {
+
+        private boolean alreadyResolved = false;
+        LambdaFunction resolve;
+        LambdaFunction reject;
+
+        ResolvingFunctions(Scriptable topScope, NativePromise promise) {
+            resolve =
+                    new LambdaFunction(
+                            topScope,
+                            1,
+                            (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) ->
+                                    resolve(
+                                            cx,
+                                            scope,
+                                            promise,
+                                            (args.length > 0 ? args[0] : Undefined.instance)));
+            resolve.setStandardPropertyAttributes(DONTENUM | READONLY);
+            reject =
+                    new LambdaFunction(
+                            topScope,
+                            1,
+                            (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) ->
+                                    reject(
+                                            cx,
+                                            scope,
+                                            promise,
+                                            (args.length > 0 ? args[0] : Undefined.instance)));
+            reject.setStandardPropertyAttributes(DONTENUM | READONLY);
+        }
+
+        private Object reject(Context cx, Scriptable scope, NativePromise promise, Object reason) {
+            if (alreadyResolved) {
+                return Undefined.instance;
+            }
+            alreadyResolved = true;
+            return promise.rejectPromise(cx, scope, reason);
+        }
+
+        private Object resolve(
+                Context cx, Scriptable scope, NativePromise promise, Object resolution) {
+            if (alreadyResolved) {
+                return Undefined.instance;
+            }
+            alreadyResolved = true;
+
+            if (resolution == promise) {
+                Object err =
+                        ScriptRuntime.newNativeError(
+                                cx,
+                                scope,
+                                NativeErrors.TypeError,
+                                new Object[] {"No promise self-resolution"});
+                return promise.rejectPromise(cx, scope, err);
+            }
+
+            if (!ScriptRuntime.isObject(resolution)) {
+                return promise.fulfillPromise(cx, scope, resolution);
+            }
+
+            Scriptable sresolution = ScriptableObject.ensureScriptable(resolution);
+            Object thenObj = ScriptableObject.getProperty(sresolution, "then");
+            if (!(thenObj instanceof Callable)) {
+                return promise.fulfillPromise(cx, scope, resolution);
+            }
+
+            cx.enqueueMicrotask(
+                    () -> promise.callThenable(cx, scope, resolution, (Callable) thenObj));
+            return Undefined.instance;
+        }
+    }
+
+    // "Promise Reaction" record. This is an input to the microtask.
+    private static class Reaction {
+        Capability capability;
+        ReactionType reaction = ReactionType.REJECT;
+        Callable handler;
+
+        Reaction(Capability cap, ReactionType type, Callable handler) {
+            this.capability = cap;
+            this.reaction = type;
+            this.handler = handler;
+        }
+
+        // Implementation of NewPromiseReactionJob
+        void invoke(Context cx, Scriptable scope, Object arg) {
+            try {
+                Object result = null;
+                if (handler == null) {
+                    switch (reaction) {
+                        case FULFILL:
+                            result = arg;
+                            break;
+                        case REJECT:
+                            capability.reject.call(
+                                    cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
+                            return;
+                    }
+                } else {
+                    result =
+                            handler.call(
+                                    cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
+                }
+                capability.resolve.call(
+                        cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {result});
+
+            } catch (RhinoException re) {
+                capability.reject.call(
+                        cx,
+                        scope,
+                        Undefined.SCRIPTABLE_UNDEFINED,
+                        new Object[] {getErrorObject(cx, scope, re)});
+            }
+        }
+    }
+
+    // "Promise Capability Record"
+    // This abstracts a promise from the specific native implementation by keeping track
+    // of the "resolve" and "reject" functions.
+    private static class Capability {
+        Object promise;
+        private Object rawResolve = Undefined.instance;
+        Callable resolve;
+        private Object rawReject = Undefined.instance;
+        Callable reject;
+
+        // Given an object that represents a constructor function, execute it as if it
+        // meets the "Promise" constructor pattern, which takes a function that will
+        // be called with "resolve" and "reject" functions.
+        Capability(Context topCx, Scriptable topScope, Object pc) {
+            if (!(pc instanceof Constructable)) {
+                throw ScriptRuntime.typeErrorById("msg.constructor.expected");
+            }
+            Constructable promiseConstructor = (Constructable) pc;
+            LambdaFunction executorFunc =
+                    new LambdaFunction(
+                            topScope,
+                            2,
+                            (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) ->
+                                    executor(args));
+            executorFunc.setStandardPropertyAttributes(DONTENUM | READONLY);
+
+            promise = promiseConstructor.construct(topCx, topScope, new Object[] {executorFunc});
+
+            if (!(rawResolve instanceof Callable)) {
+                throw ScriptRuntime.typeErrorById("msg.function.expected");
+            }
+            resolve = (Callable) rawResolve;
+
+            if (!(rawReject instanceof Callable)) {
+                throw ScriptRuntime.typeErrorById("msg.function.expected");
+            }
+            reject = (Callable) rawReject;
+        }
+
+        private Object executor(Object[] args) {
+            if (!Undefined.isUndefined(rawResolve) || !Undefined.isUndefined(rawReject)) {
+                throw ScriptRuntime.typeErrorById("msg.promise.capability.state");
+            }
+            if (args.length > 0) {
+                rawResolve = args[0];
+            }
+            if (args.length > 1) {
+                rawReject = args[1];
+            }
+            return Undefined.instance;
+        }
+    }
+
+    // This object keeps track of the state necessary to execute Promise.all
+    private static class PromiseAllResolver {
+        // Limit the number of promises in Promise.all the same as it is in V8.
+        private static final int MAX_PROMISES = 1 << 21;
+
+        final ArrayList<Object> values = new ArrayList<>();
+        int remainingElements = 1;
+
+        IteratorLikeIterable.Itr iterator;
+        Scriptable thisObj;
+        Capability capability;
+
+        PromiseAllResolver(IteratorLikeIterable.Itr iter, Scriptable thisObj, Capability cap) {
+            this.iterator = iter;
+            this.thisObj = thisObj;
+            this.capability = cap;
+        }
+
+        Object resolve(Context topCx, Scriptable topScope) {
+            int index = 0;
+            // Do this first because we should catch any exception before
+            // invoking the iterator.
+            Callable resolve =
+                    ScriptRuntime.getPropFunctionAndThis(thisObj, "resolve", topCx, topScope);
+            Scriptable storedThis = ScriptRuntime.lastStoredScriptable(topCx);
+
+            // Iterate manually because we need to catch exceptions in a special way.
+            while (true) {
+                if (index == MAX_PROMISES) {
+                    throw ScriptRuntime.rangeErrorById("msg.promise.all.toobig");
+                }
+                boolean hasNext;
+                Object nextVal = Undefined.instance;
+                boolean nextOk = false;
+                try {
+                    hasNext = iterator.hasNext();
+                    if (hasNext) {
+                        nextVal = iterator.next();
+                    }
+                    nextOk = true;
+                } finally {
+                    if (!nextOk) {
+                        iterator.setDone(true);
+                    }
+                }
+
+                if (!hasNext) {
+                    if (--remainingElements == 0) {
+                        finalResolution(topCx, topScope);
+                    }
+                    return capability.promise;
+                }
+
+                values.add(Undefined.instance);
+
+                // Call "resolve" to get the next promise in the chain
+                Object nextPromise =
+                        resolve.call(topCx, topScope, storedThis, new Object[] {nextVal});
+
+                // Create a resolution func that will stash its result in the right place
+                PromiseElementResolver eltResolver = new PromiseElementResolver(index);
+                LambdaFunction resolveFunc =
+                        new LambdaFunction(
+                                topScope,
+                                1,
+                                (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) ->
+                                        eltResolver.resolve(
+                                                cx,
+                                                scope,
+                                                (args.length > 0 ? args[0] : Undefined.instance),
+                                                this));
+                resolveFunc.setStandardPropertyAttributes(DONTENUM | READONLY);
+                remainingElements++;
+
+                // Call "then" on the promise with the resolution func
+                Callable thenFunc =
+                        ScriptRuntime.getPropFunctionAndThis(nextPromise, "then", topCx, topScope);
+                thenFunc.call(
+                        topCx,
+                        topScope,
+                        ScriptRuntime.lastStoredScriptable(topCx),
+                        new Object[] {resolveFunc, capability.reject});
+                index++;
+            }
+        }
+
+        void finalResolution(Context cx, Scriptable scope) {
+            Scriptable newArray = cx.newArray(scope, values.toArray());
+            capability.resolve.call(
+                    cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {newArray});
+        }
+    }
+
+    // This object keeps track of the state necessary to resolve one element in Promise.all
+    private static class PromiseElementResolver {
+
+        private boolean alreadyCalled = false;
+        private final int index;
+
+        PromiseElementResolver(int ix) {
+            this.index = ix;
+        }
+
+        Object resolve(Context cx, Scriptable scope, Object result, PromiseAllResolver resolver) {
+            if (alreadyCalled) {
+                return Undefined.instance;
+            }
+            alreadyCalled = true;
+            resolver.values.set(index, result);
+            if (--resolver.remainingElements == 0) {
+                resolver.finalResolution(cx, scope);
+            }
+            return Undefined.instance;
+        }
+    }
+}

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4863,29 +4863,6 @@ public class ScriptRuntime {
         return new JavaScriptException(error, filename, linep[0]);
     }
 
-    /**
-     * Implement the ECMAScript abstract operation "SpeciesConstructor" defined in section 7.2.33 of
-     * ECMA262.
-     */
-    public static Constructable getSpeciesConstructor(
-            Scriptable s, Constructable defaultConstructor) {
-        Object constructor = ScriptableObject.getProperty(s, "constructor");
-        if (constructor == Scriptable.NOT_FOUND || Undefined.isUndefined(constructor)) {
-            return defaultConstructor;
-        }
-        if (!isObject(constructor)) {
-            throw typeErrorById("msg.arg.not.object", typeof(constructor));
-        }
-        Object species = ScriptableObject.getProperty((Scriptable) constructor, SymbolKey.SPECIES);
-        if (species == Scriptable.NOT_FOUND || species == null || Undefined.isUndefined(species)) {
-            return defaultConstructor;
-        }
-        if (!(species instanceof Constructable)) {
-            throw typeErrorById("msg.not.ctor", typeof(species));
-        }
-        return (Constructable) species;
-    }
-
     public static final Object[] emptyArgs = new Object[0];
     public static final String[] emptyStrings = new String[0];
 }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -278,6 +278,7 @@ public class ScriptRuntime {
             NativeCollectionIterator.init(scope, NativeSet.ITERATOR_TAG, sealed);
             NativeCollectionIterator.init(scope, NativeMap.ITERATOR_TAG, sealed);
             NativeMap.init(cx, scope, sealed);
+            NativePromise.init(cx, scope, sealed);
             NativeSet.init(cx, scope, sealed);
             NativeWeakMap.init(scope, sealed);
             NativeWeakSet.init(scope, sealed);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4863,6 +4863,29 @@ public class ScriptRuntime {
         return new JavaScriptException(error, filename, linep[0]);
     }
 
+    /**
+     * Implement the ECMAScript abstract operation "SpeciesConstructor" defined in section 7.2.33 of
+     * ECMA262.
+     */
+    public static Constructable getSpeciesConstructor(
+            Scriptable s, Constructable defaultConstructor) {
+        Object constructor = ScriptableObject.getProperty(s, "constructor");
+        if (constructor == Scriptable.NOT_FOUND || Undefined.isUndefined(constructor)) {
+            return defaultConstructor;
+        }
+        if (!isObject(constructor)) {
+            throw typeErrorById("msg.arg.not.object", typeof(constructor));
+        }
+        Object species = ScriptableObject.getProperty((Scriptable) constructor, SymbolKey.SPECIES);
+        if (species == Scriptable.NOT_FOUND || species == null || Undefined.isUndefined(species)) {
+            return defaultConstructor;
+        }
+        if (!(species instanceof Constructable)) {
+            throw typeErrorById("msg.not.ctor", typeof(species));
+        }
+        return (Constructable) species;
+    }
+
     public static final Object[] emptyArgs = new Object[0];
     public static final String[] emptyStrings = new String[0];
 }

--- a/src/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/org/mozilla/javascript/optimizer/Codegen.java
@@ -600,6 +600,13 @@ public class Codegen implements Evaluator {
                         + "[Ljava/lang/Object;"
                         + ")Ljava/lang/Object;");
 
+        cfw.addALoad(CONTEXT_ARG);
+        cfw.addInvoke(
+                ByteCode.INVOKEVIRTUAL,
+                "org.mozilla.javascript.Context",
+                "processMicrotasks",
+                "()V");
+
         cfw.add(ByteCode.ARETURN);
         // 3 = this + context + scope
         cfw.stopMethod((short) 3);

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -940,3 +940,19 @@ msg.constructor.no.function \=
   The constructor for {0} may not be invoked as a function
 
 msg.this.not.instance \= \"this\" is not an instance of the class
+
+# Promises
+msg.function.expected =\
+  Expecting the first argument to be a function
+
+msg.constructor.expected =\
+  Expecting the first argument to be a constructor
+
+msg.promise.self.resolution =\
+  Promise is being self-resolved
+
+msg.promise.capability.state \=
+Invalid promise capability state
+
+msg.promise.all.toobig \=
+  Too many inputs to Promise.all

--- a/testsrc/jstests/es6/promise-all-overflow-2.js
+++ b/testsrc/jstests/es6/promise-all-overflow-2.js
@@ -1,0 +1,20 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+load('testsrc/test-async.js');
+
+// Test that pre-allocation of the result array works even if it needs to be
+// allocated in large object space.
+const a = new Array(64 * 1024);
+a.fill(Promise.resolve(1));
+testAsync(assert => {
+  assert.plan(1);
+  Promise.all(a).then(b => {
+    assert.equals(a.length, b.length);
+  }, assertUnreachable);
+});
+
+"success";

--- a/testsrc/jstests/es6/promises.js
+++ b/testsrc/jstests/es6/promises.js
@@ -1,0 +1,1003 @@
+// Copyright 2013 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Flags: --allow-natives-syntax
+
+load('testsrc/assert.js');
+
+// Make sure we don't rely on functions patchable by monkeys.
+var call = Function.prototype.call.call.bind(Function.prototype.call)
+var getOwnPropertyNames = Object.getOwnPropertyNames;
+var defineProperty = Object.defineProperty;
+var numberPrototype = Number.prototype;
+var symbolIterator = Symbol.iterator;
+
+function assertUnreachable() {
+  AbortJS("Failure: unreachable");
+}
+
+(function() {
+  // Test before clearing global (fails otherwise)
+  assertEquals("[object Promise]",
+      Object.prototype.toString.call(new Promise(function() {})));
+})();
+
+function defer(constructor) {
+  var resolve, reject;
+  var promise = new constructor((res, rej) => { resolve = res; reject = rej });
+  return {
+    promise: promise,
+    resolve: resolve,
+    reject: reject
+  };
+}
+
+var asyncAssertsExpected = 0;
+
+function assertAsyncRan() { ++asyncAssertsExpected }
+
+function assertAsync(b, s) {
+  if (b) {
+    //print(s, "succeeded")
+  } else {
+    AbortJS(s + " FAILED!")  // Simply throwing here will have no effect.
+  }
+  --asyncAssertsExpected
+}
+
+function assertLater(f, name) {
+  assertFalse(f()); // should not be true synchronously
+  ++asyncAssertsExpected;
+  var iterations = 0;
+  function runAssertion() {
+    if (f()) {
+      //print(name, "succeeded");
+      --asyncAssertsExpected;
+    } else if (iterations++ < 10) {
+      EnqueueMicrotask(runAssertion);
+    } else {
+      AbortJS(name + " FAILED!");
+    }
+  }
+  EnqueueMicrotask(runAssertion);
+}
+
+function assertAsyncDone(iteration) {
+  var iteration = iteration || 0;
+  EnqueueMicrotask(function() {
+    if (asyncAssertsExpected === 0)
+      assertAsync(true, "all")
+    else if (iteration > 10)  // Shouldn't take more.
+      assertAsync(false, "all... " + asyncAssertsExpected)
+    else
+      assertAsyncDone(iteration + 1)
+  });
+}
+
+(function() {
+  assertThrows(function() { Promise(function() {}) }, TypeError)
+})();
+
+(function() {
+  assertTrue(new Promise(function() {}) instanceof Promise)
+})();
+
+(function() {
+  assertThrows(function() { new Promise(5) }, TypeError)
+})();
+
+(function() {
+  assertDoesNotThrow(function() { new Promise(function() { throw 5 }) })
+})();
+
+(function() {
+  (new Promise(function() { throw 5 })).then(
+    assertUnreachable,
+    function(r) { assertAsync(r === 5, "new-throw") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  Promise.resolve(5);
+  Promise.resolve(5).then(undefined, assertUnreachable).then(
+    function(x) { assertAsync(x === 5, "resolved/then-nohandler") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  Promise.resolve(5).then(undefined, assertUnreachable).then(
+    function(x) { assertAsync(x === 5, "resolved/then-nohandler-undefined") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+  Promise.resolve(6).then(null, assertUnreachable).then(
+    function(x) { assertAsync(x === 6, "resolved/then-nohandler-null") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "resolved/then") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.reject(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "rejected/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(function(x) { return x }, assertUnreachable).then(
+    function(x) { assertAsync(x === 5, "resolved/then/then") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(function(x){ return Promise.resolve(x+1) }, assertUnreachable).then(
+    function(x) { assertAsync(x === 6, "resolved/then/then2") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(function(x) { throw 6 }, assertUnreachable).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 6, "resolved/then-throw/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(function(x) { throw 6 }, assertUnreachable).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 6, "resolved/then-throw/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(function(x) { throw 6 }, assertUnreachable).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 6, "resolved/then-throw/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(function(x) { throw 6 }, assertUnreachable).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 6, "resolved/then-throw/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "resolved/thenable/then") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "resolved/thenable/then") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.reject(5)
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "rejected/thenable/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.reject(5)
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "rejected/thenable/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve") },
+    assertUnreachable
+  )
+  deferred.resolve(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve") },
+    assertUnreachable
+  )
+  deferred.resolve(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = Promise.resolve(p1)
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = p1.then(1, 2)
+  p2.then(
+    function(x) { assertAsync(x === 5, "then/resolve-non-function") },
+    assertUnreachable
+  )
+  deferred.resolve(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = p1.then(1, 2)
+  p2.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject-non-function") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve/thenable") },
+    assertUnreachable
+  )
+  deferred.resolve(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve/thenable") },
+    assertUnreachable
+  )
+  deferred.resolve(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject/thenable") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var p3 = Promise.resolve(p2)
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject/thenable") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var deferred = defer(Promise)
+  var p3 = deferred.promise
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve2") },
+    assertUnreachable
+  )
+  deferred.resolve(p2)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var deferred = defer(Promise)
+  var p3 = deferred.promise
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve2") },
+    assertUnreachable
+  )
+  deferred.resolve(p2)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var deferred = defer(Promise)
+  var p3 = deferred.promise
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject2") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = Promise.resolve(p1)
+  var deferred = defer(Promise)
+  var p3 = deferred.promise
+  p3.then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 5, "then/reject2") }
+  )
+  deferred.reject(5)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var deferred = defer(Promise)
+  var p3 = deferred.promise
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve/thenable2") },
+    assertUnreachable
+  )
+  deferred.resolve(p2)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(5)
+  var p2 = {then: function(onResolve, onReject) { onResolve(p1) }}
+  var deferred = defer(Promise)
+  var p3 = deferred.promise
+  p3.then(
+    function(x) { assertAsync(x === 5, "then/resolve/thenable2") },
+    assertUnreachable
+  )
+  deferred.resolve(p2)
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(0)
+  var p2 = p1.then(function(x) { return p2 }, assertUnreachable)
+  p2.then(
+    assertUnreachable,
+    function(r) { assertAsync(r instanceof TypeError, "cyclic/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(0)
+  var p2 = p1.then(function(x) { return p2 }, assertUnreachable)
+  p2.then(
+    assertUnreachable,
+    function(r) { assertAsync(r instanceof TypeError, "cyclic/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p = deferred.promise
+  deferred.resolve(p)
+  p.then(
+    assertUnreachable,
+    function(r) {
+    assertAsync(r instanceof TypeError, "cyclic/deferred/then") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p = deferred.promise
+  deferred.resolve(p)
+  p.then(
+    assertUnreachable,
+    function(r) { assertAsync(r instanceof TypeError, "cyclic/deferred/then 2") }
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  Promise.all([]).then(
+    function(x) { assertAsync(x.length === 0, "all/resolve/empty") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  function testPromiseAllNonIterable(value) {
+    Promise.all(value).then(
+        assertUnreachable,
+        function(r) {
+          assertAsync(r instanceof TypeError, 'all/non iterable');
+        });
+    assertAsyncRan();
+  }
+  testPromiseAllNonIterable(null);
+  testPromiseAllNonIterable(undefined);
+  testPromiseAllNonIterable({});
+  testPromiseAllNonIterable(42);
+})();
+
+(function() {
+  // Rhino slightly different syntax works
+  let o = {};
+  o[Symbol.iterator] = function() { return null; };
+  Promise.all(o).then(
+    assertUnreachable,
+    function(r) {
+      assertAsync(r instanceof TypeError, 'all/non iterable');
+    });
+  assertAsyncRan();
+})();
+
+(function() {
+  var deferred = defer(Promise);
+  var p = deferred.promise;
+  function* f() {
+    yield 1;
+    yield p;
+    yield 3;
+  }
+  Promise.all(f()).then(
+      function(x) {
+        assertAsync(x.length === 3, "all/resolve/iterable");
+        assertAsync(x[0] === 1, "all/resolve/iterable/0");
+        assertAsync(x[1] === 2, "all/resolve/iterable/1");
+        assertAsync(x[2] === 3, "all/resolve/iterable/2");
+      },
+      assertUnreachable);
+  deferred.resolve(2);
+  assertAsyncRan();
+  assertAsyncRan();
+  assertAsyncRan();
+  assertAsyncRan();
+})();
+
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  Promise.all([p1, p2, p3]).then(
+    function(x) {
+      assertAsync(x.length === 3, "all/resolve")
+      assertAsync(x[0] === 1, "all/resolve/0")
+      assertAsync(x[1] === 2, "all/resolve/1")
+      assertAsync(x[2] === 3, "all/resolve/2")
+    },
+    assertUnreachable
+  )
+  deferred1.resolve(1)
+  deferred3.resolve(3)
+  deferred2.resolve(2)
+  assertAsyncRan()
+  assertAsyncRan()
+  assertAsyncRan()
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = Promise.resolve(2)
+  var p3 = defer(Promise).promise
+  Promise.all([p1, p2, p3]).then(
+    assertUnreachable,
+    assertUnreachable
+  )
+  deferred.resolve(1)
+})();
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  Promise.all([p1, p2, p3]).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 2, "all/reject") }
+  )
+  deferred1.resolve(1)
+  deferred3.resolve(3)
+  deferred2.reject(2)
+  assertAsyncRan()
+})();
+
+/* TODO Rhino need to keep working on strict mode
+(function() {
+  'use strict';
+  var getCalls = 0;
+  var funcCalls = 0;
+  var nextCalls = 0;
+  defineProperty(numberPrototype, symbolIterator, {
+    get: function() {
+      assertEquals('number', typeof this);
+      getCalls++;
+      return function() {
+        assertEquals('number', typeof this);
+        funcCalls++;
+        var n = this;
+        var i = 0
+        return {
+          next() {
+            nextCalls++;
+            return {value: i++, done: i > n};
+          }
+        };
+      };
+    },
+    configurable: true
+  });
+
+  Promise.all(3).then(
+      function(x) {
+        assertAsync(x.length === 3, "all/iterable/number/length");
+        assertAsync(x[0] === 0, "all/iterable/number/0");
+        assertAsync(x[1] === 1, "all/iterable/number/1");
+        assertAsync(x[2] === 2, "all/iterable/number/2");
+      },
+      assertUnreachable);
+  delete numberPrototype[symbolIterator];
+
+  assertEquals(getCalls, 1);
+  assertEquals(funcCalls, 1);
+  assertEquals(nextCalls, 3 + 1);  // + 1 for {done: true}
+  assertAsyncRan();
+  assertAsyncRan();
+  assertAsyncRan();
+  assertAsyncRan();
+})();
+*/
+
+(function() {
+  Promise.race([]).then(
+    assertUnreachable,
+    assertUnreachable
+  )
+})();
+
+(function() {
+  var p1 = Promise.resolve(1)
+  var p2 = Promise.resolve(2)
+  var p3 = Promise.resolve(3)
+  Promise.race([p1, p2, p3]).then(
+    function(x) { assertAsync(x === 1, "resolved/one") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var p1 = Promise.resolve(1)
+  var p2 = Promise.resolve(2)
+  var p3 = Promise.resolve(3)
+  Promise.race([0, p1, p2, p3]).then(
+    function(x) { assertAsync(x === 0, "resolved-const/one") },
+    assertUnreachable
+  )
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  Promise.race([p1, p2, p3]).then(
+    function(x) { assertAsync(x === 3, "one/resolve") },
+    assertUnreachable
+  )
+  deferred3.resolve(3)
+  deferred1.resolve(1)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred = defer(Promise)
+  var p1 = deferred.promise
+  var p2 = Promise.resolve(2)
+  var p3 = defer(Promise).promise
+  Promise.race([p1, p2, p3]).then(
+    function(x) { assertAsync(x === 2, "resolved/one") },
+    assertUnreachable
+  )
+  deferred.resolve(1)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  Promise.race([p1, p2, p3]).then(
+    function(x) { assertAsync(x === 3, "one/resolve/reject") },
+    assertUnreachable
+  )
+  deferred3.resolve(3)
+  deferred1.reject(1)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  Promise.race([p1, p2, p3]).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 3, "one/reject/resolve") }
+  )
+  deferred3.reject(3)
+  deferred1.resolve(1)
+  assertAsyncRan()
+})();
+
+
+(function() {
+  function testPromiseRaceNonIterable(value) {
+    Promise.race(value).then(
+        assertUnreachable,
+        function(r) {
+          assertAsync(r instanceof TypeError, 'race/non iterable');
+        });
+    assertAsyncRan();
+  }
+  testPromiseRaceNonIterable(null);
+  testPromiseRaceNonIterable(undefined);
+  testPromiseRaceNonIterable({});
+  testPromiseRaceNonIterable(42);
+})();
+
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  function* f() {
+    yield p1;
+    yield p2;
+    yield p3;
+  }
+  Promise.race(f()).then(
+    function(x) { assertAsync(x === 3, "race/iterable/resolve/reject") },
+    assertUnreachable
+  )
+  deferred3.resolve(3)
+  deferred1.reject(1)
+  assertAsyncRan()
+})();
+
+(function() {
+  var deferred1 = defer(Promise)
+  var p1 = deferred1.promise
+  var deferred2 = defer(Promise)
+  var p2 = deferred2.promise
+  var deferred3 = defer(Promise)
+  var p3 = deferred3.promise
+  function* f() {
+    yield p1;
+    yield p2;
+    yield p3;
+  }
+  Promise.race(f()).then(
+    assertUnreachable,
+    function(x) { assertAsync(x === 3, "race/iterable/reject/resolve") }
+  )
+  deferred3.reject(3)
+  deferred1.resolve(1)
+  assertAsyncRan()
+})();
+
+/* TODO Rhino need to keep working on strict mode
+(function() {
+  'use strict';
+  var getCalls = 0;
+  var funcCalls = 0;
+  var nextCalls = 0;
+  defineProperty(numberPrototype, symbolIterator, {
+    get: function() {
+      assertEquals('number', typeof this);
+      getCalls++;
+      return function() {
+        assertEquals('number', typeof this);
+        funcCalls++;
+        var n = this;
+        var i = 0
+        return {
+          next() {
+            nextCalls++;
+            return {value: i++, done: i > n};
+          }
+        };
+      };
+    },
+    configurable: true
+  });
+
+  Promise.race(3).then(
+      function(x) {
+        assertAsync(x === 0, "race/iterable/number");
+      },
+      assertUnreachable);
+  delete numberPrototype[symbolIterator];
+
+  assertEquals(getCalls, 1);
+  assertEquals(funcCalls, 1);
+  assertEquals(nextCalls, 3 + 1);  // + 1 for {done: true}
+  assertAsyncRan();
+})();
+*/
+
+/* TODO Rhino need to keep working on subclassing.
+(function() {
+  var log
+  function MyPromise(resolver) {
+    log += "n"
+    var promise = new Promise(function(resolve, reject) {
+      resolver(
+        function(x) { log += "x" + x; resolve(x) },
+        function(r) { log += "r" + r; reject(r) }
+      )
+    })
+    promise.__proto__ = MyPromise.prototype
+    return promise
+  }
+
+  MyPromise.__proto__ = Promise
+  MyPromise.defer = function() {
+    log += "d"
+    return call(this.__proto__.defer, this)
+  }
+
+  MyPromise.prototype.__proto__ = Promise.prototype
+  MyPromise.prototype.then = function(resolve, reject) {
+    log += "c"
+    return call(this.__proto__.__proto__.then, this, resolve, reject)
+  }
+
+  log = ""
+  var p1 = new MyPromise(function(resolve, reject) { resolve(1) })
+  var p2 = new MyPromise(function(resolve, reject) { reject(2) })
+  var d3 = defer(MyPromise)
+  assertTrue(d3.promise instanceof Promise, "subclass/instance")
+  assertTrue(d3.promise instanceof MyPromise, "subclass/instance-my3")
+  assertTrue(log === "nx1nr2n", "subclass/create")
+
+  log = ""
+  var p4 = MyPromise.resolve(4)
+  var p5 = MyPromise.reject(5)
+  assertTrue(p4 instanceof MyPromise, "subclass/instance4")
+  assertTrue(p4 instanceof MyPromise, "subclass/instance-my4")
+  assertTrue(p5 instanceof MyPromise, "subclass/instance5")
+  assertTrue(p5 instanceof MyPromise, "subclass/instance-my5")
+  d3.resolve(3)
+  assertTrue(log === "nx4nr5x3", "subclass/resolve")
+
+  log = ""
+  var d6 = defer(MyPromise)
+  d6.promise.then(function(x) {
+    return new Promise(function(resolve) { resolve(x) })
+  }).then(function() {})
+  d6.resolve(6)
+  assertTrue(log === "ncncnx6", "subclass/then")
+
+  log = ""
+  Promise.all([11, Promise.resolve(12), 13, MyPromise.resolve(14), 15, 16])
+
+  assertTrue(log === "nx14", "subclass/all/arg")
+
+  log = ""
+  MyPromise.all([21, Promise.resolve(22), 23, MyPromise.resolve(24), 25, 26])
+  assertTrue(log === "nx24nnx21cnnx[object Promise]cnnx23cncnnx25cnnx26cn",
+             "subclass/all/self")
+})();
+*/
+
+/* TODO Rhino no classes yet
+(function() {
+  'use strict';
+
+  class Pact extends Promise { }
+  class Vow  extends Pact    { }
+  class Oath extends Vow     { }
+
+  Oath.constructor = Vow;
+
+  assertTrue(Pact.resolve(Pact.resolve()).constructor === Pact,
+             "subclass/resolve/own");
+
+  assertTrue(Pact.resolve(Promise.resolve()).constructor === Pact,
+             "subclass/resolve/ancestor");
+
+  assertTrue(Pact.resolve(Vow.resolve()).constructor === Pact,
+             "subclass/resolve/descendant"); var vow = Vow.resolve();
+
+  vow.constructor = Oath;
+  assertTrue(Oath.resolve(vow) === vow,
+             "subclass/resolve/descendant with transplanted own constructor");
+}());
+*/
+
+(function() {
+  var thenCalled = false;
+
+  var resolve;
+  var promise = new Promise(function(res) { resolve = res; });
+  resolve({ then() { thenCalled = true; throw new Error(); } });
+  assertLater(function() { return thenCalled; }, "resolve-with-thenable");
+})();
+
+(function() {
+  var calledWith;
+
+  var resolve;
+  var p1 = (new Promise(function(res) { resolve = res; }));
+  var p2 = p1.then(function(v) {
+    return {
+      then(resolve, reject) { resolve({ then() { calledWith = v }}); }
+    };
+  });
+
+  resolve({ then(resolve) { resolve(2); } });
+  assertLater(function() { return calledWith === 2; },
+              "resolve-with-thenable2");
+})();
+
+(function() {
+  var p = Promise.resolve();
+  var callCount = 0;
+  defineProperty(p, "constructor", {
+    get: function() { ++callCount; return Promise; }
+  });
+  p.then();
+  assertEquals(1, callCount);
+})();
+
+assertAsyncDone()
+
+'success';

--- a/testsrc/jstests/harmony/promise-prototype-finally.js
+++ b/testsrc/jstests/harmony/promise-prototype-finally.js
@@ -1,0 +1,624 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+load('testsrc/test-async.js');
+
+testAsync(assert => {
+  assert.plan(1);
+
+  Promise.resolve(3).finally().then(x => {
+    assert.equals(3, x);
+  }, assert.unreachable);
+}, "resolve/finally/then");
+
+testAsync(assert => {
+  assert.plan(1);
+
+  Promise.reject(3).finally().then(assert.unreachable, x => {
+    assert.equals(3, x);
+  });
+}, "reject/finally/then");
+
+testAsync(assert => {
+  assert.plan(1);
+
+  Promise.resolve(3).finally(2).then(x => {
+    assert.equals(3, x);
+  }, assert.unreachable);
+}, "resolve/finally-return-notcallable/then");
+
+testAsync(assert => {
+  assert.plan(1);
+
+  Promise.reject(3).finally(2).then(assert.unreachable, e => {
+    assert.equals(3, e);
+  });
+}, "reject/finally-return-notcallable/then");
+
+testAsync(assert => {
+  assert.plan(1);
+
+  Promise.reject(3).finally().catch(reason => {
+    assert.equals(3, reason);
+  });
+}, "reject/finally/catch");
+
+testAsync(assert => {
+  assert.plan(1);
+
+  Promise.reject(3).finally().then(assert.unreachable).catch(reason => {
+    assert.equals(3, reason);
+  });
+}, "reject/finally/then/catch");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.resolve(3)
+    .then(x => {
+      assert.equals(3, x);
+      return x;
+    })
+    .finally()
+    .then(x => {
+      assert.equals(3, x);
+    }, assert.unreachable);
+}, "resolve/then/finally/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.reject(3)
+    .catch(x => {
+      assert.equals(3, x);
+      return x;
+    })
+    .finally()
+    .then(x => {
+      assert.equals(3, x);
+    }, assert.unreachable);
+}, "reject/catch/finally/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.resolve(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      throw 1;
+    })
+    .then(assert.unreachable, function onRejected(reason) {
+      assert.equals(1, reason);
+    });
+}, "resolve/finally-throw/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.reject(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      throw 1;
+    })
+    .then(assert.unreachable, function onRejected(reason) {
+      assert.equals(1, reason);
+    });
+}, "reject/finally-throw/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.resolve(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return 4;
+    })
+    .then(x => {
+      assert.equals(x, 3);
+    }, assert.unreachable);
+}, "resolve/finally-return/then");
+
+// reject/finally-return/then
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.reject(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return 4;
+    })
+    .then(assert.unreachable, x => {
+      assert.equals(x, 3);
+    });
+});
+
+// reject/catch-throw/finally-throw/then
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.reject(3)
+    .catch(e => {
+      assert.equals(3, e);
+      throw e;
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      throw 4;
+    })
+    .then(assert.unreachable, function onRejected(e) {
+      assert.equals(4, e);
+    });
+});
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.resolve(3)
+    .then(e => {
+      assert.equals(3, e);
+      throw e;
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      throw 4;
+    })
+    .then(assert.unreachable, function onRejected(e) {
+      assert.equals(4, e);
+    });
+}, "resolve/then-throw/finally-throw/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.resolve(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.reject(4);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(4, e);
+    });
+}, "resolve/finally-return-rejected-promise/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.reject(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.reject(4);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(4, e);
+    });
+}, "reject/finally-return-rejected-promise/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.resolve(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.resolve(4);
+    })
+    .then(x => {
+      assert.equals(3, x);
+    }, assert.unreachable);
+}, "resolve/finally-return-resolved-promise/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.reject(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.resolve(4);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(3, e);
+    });
+}, "reject/finally-return-resolved-promise/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  Promise.reject(3)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.resolve(4);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(3, e);
+    });
+}, "reject/finally-return-resolved-promise/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var thenable = {
+    then: function(onResolve, onReject) {
+      onResolve(5);
+    }
+  };
+
+  Promise.resolve(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return thenable;
+    })
+    .then(x => {
+      assert.equals(5, x);
+    }, assert.unreachable);
+}, "resolve/finally-thenable-resolve/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var thenable = {
+    then: function(onResolve, onReject) {
+      onResolve(1);
+    }
+  };
+
+  Promise.reject(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return thenable;
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(5, e);
+    });
+}, "reject/finally-thenable-resolve/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var thenable = {
+    then: function(onResolve, onReject) {
+      onReject(1);
+    }
+  };
+
+  Promise.reject(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return thenable;
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(1, e);
+    });
+}, "reject/finally-thenable-reject/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var thenable = {
+    then: function(onResolve, onReject) {
+      onReject(1);
+    }
+  };
+
+  Promise.resolve(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return thenable;
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(1, e);
+    });
+}, "resolve/finally-thenable-reject/then");
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.resolve(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(x => {
+      assert.equals(5, x);
+    }, assert.unreachable);
+}, "resolve/finally/finally/then");
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.resolve(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      throw 1;
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(1, e);
+    });
+}, "resolve/finally-throw/finally/then");
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.resolve(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.reject(1);
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(1, e);
+    });
+}, "resolve/finally-return-rejected-promise/finally/then");
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.reject(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(5, e);
+    });
+}, "reject/finally/finally/then");
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.reject(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      throw 1;
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(1, e);
+    });
+}, "reject/finally-throw/finally/then");
+
+testAsync(assert => {
+  assert.plan(3);
+
+  Promise.reject(5)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return Promise.reject(1);
+    })
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(1, e);
+    });
+}, "reject/finally-return-rejected-promise/finally/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var resolve, reject;
+  var deferred = new Promise((x, y) => {
+    resolve = x;
+    reject = y;
+  });
+
+  Promise.resolve(1)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return deferred;
+    })
+    .then(x => {
+      assert.equals(1, x);
+    }, assert.unreachable);
+
+  resolve(5);
+}, "resolve/finally-deferred-resolve/then");
+
+//
+testAsync(assert => {
+  assert.plan(2);
+
+  var resolve, reject;
+  var deferred = new Promise((x, y) => {
+    resolve = x;
+    reject = y;
+  });
+  Promise.resolve(1)
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+      return deferred;
+    })
+    .then(assert.unreachable, e => {
+      assert.equals(5, e);
+    });
+
+  reject(5);
+}, "resolve/finally-deferred-reject/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var resolve, reject;
+  var deferred = new Promise((x, y) => {
+    resolve = x;
+    reject = y;
+  });
+  Promise.all([deferred])
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(([x]) => {
+      assert.equals(1, x);
+    }, assert.unreachable);
+
+  resolve(1);
+}, "all/finally/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  var resolve, reject;
+  var d1 = new Promise((x, y) => {
+    resolve = x;
+    reject = y;
+  });
+  var d2 = new Promise((x, y) => {
+    resolve = x;
+    reject = y;
+  });
+  Promise.race([d1, d2])
+    .finally(function onFinally() {
+      assert.equals(0, arguments.length);
+    })
+    .then(x => {
+      assert.equals(1, x);
+    }, assert.unreachable);
+
+  resolve(1);
+}, "race/finally/then");
+
+/*
+testAsync(assert => {
+  assert.plan(2);
+
+  class MyPromise extends Promise {
+    then(onFulfilled, onRejected) {
+      assert.equals(5, onFulfilled);
+      assert.equals(5, onRejected);
+      return super.then(onFulfilled, onRejected);
+    }
+  }
+
+  MyPromise.resolve(3).finally(5);
+}, "resolve/finally-customthen/then");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  class MyPromise extends Promise {
+    then(onFulfilled, onRejected) {
+      assert.equals(5, onFulfilled);
+      assert.equals(5, onRejected);
+      return super.then(onFulfilled, onRejected);
+    }
+  }
+
+  MyPromise.reject(3).finally(5);
+}, "reject/finally-customthen/then");
+*/
+
+var descriptor = Object.getOwnPropertyDescriptor(Promise.prototype, "finally");
+assertTrue(descriptor.writable);
+assertTrue(descriptor.configurable);
+assertFalse(descriptor.enumerable);
+assertEquals("finally", Promise.prototype.finally.name);
+assertEquals(1, Promise.prototype.finally.length);
+
+/*
+var count = 0;
+class FooPromise extends Promise {
+  constructor(resolve, reject) {
+    count++;
+    return super(resolve, reject);
+  }
+}
+
+testAsync(assert => {
+  assert.plan(1);
+  count = 0;
+
+  new FooPromise(r => r()).finally(() => {}).then(() => {
+    assert.equals(6, count);
+  });
+}, "finally/speciesconstructor");
+
+testAsync(assert => {
+  assert.plan(1);
+  count = 0;
+
+  FooPromise.resolve().finally(() => {}).then(() => {
+    assert.equals(6, count);
+  })
+}, "resolve/finally/speciesconstructor");
+
+testAsync(assert => {
+  assert.plan(1);
+  count = 0;
+
+  FooPromise.reject().finally(() => {}).catch(() => {
+    assert.equals(6, count);
+  })
+}, "reject/finally/speciesconstructor");
+
+testAsync(assert => {
+  assert.plan(2);
+
+  class MyPromise extends Promise {
+    static get [Symbol.species]() { return Promise; }
+  }
+
+  var p = Promise
+      .resolve()
+      .finally(() => MyPromise.resolve());
+
+  assert.equals(true, p instanceof Promise);
+  assert.equals(false, p instanceof MyPromise);
+}, "finally/Symbol.Species");
+*/
+
+testAsync(assert => {
+  assert.plan(3);
+  let resolve;
+  let value = 0;
+
+  let p = new Promise(r => { resolve = r });
+
+  Promise.resolve()
+    .finally(() => {
+      return p;
+    })
+    .then(() => {
+      value = 1;
+    });
+
+  // This makes sure we take the fast path in PromiseResolve that just
+  // returns the promise it receives as value. If we had to create
+  // another wrapper promise, that would cause an additional tick in
+  // the microtask queue.
+  Promise.resolve()
+    // onFinally has run.
+    .then(() => { resolve(); })
+    // thenFinally has run.
+    .then(() => assert.equals(0, value))
+    // promise returned by .finally has been resolved.
+    .then(() => assert.equals(0, value))
+    // onFulfilled callback of .then() has run.
+    .then(() => assert.equals(1, value));
+
+}, "PromiseResolve-ordering");
+
+/*
+(function testIsObject() {
+  var called = false;
+  var p = new Proxy(Promise.resolve(), {});
+  var oldThen = Promise.prototype.then;
+  Promise.prototype.then = () => called = true;
+  Promise.prototype.finally.call(p);
+  assertTrue(called);
+  Promise.prototype.then = oldThen;
+})();
+*/
+
+"success";

--- a/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/testsrc/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -13,21 +13,25 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
+import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.JavaScriptException;
+import org.mozilla.javascript.LambdaFunction;
+import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
- * This class is used for creating test scripts that are loaded from JS scripts. Each test must
- * be represented by a class that extends this class, and has a "RhinoTest" annotation at the
- * class level that returns the file name of the script to execute.
+ * This class is used for creating test scripts that are loaded from JS scripts. Each test must be
+ * represented by a class that extends this class, and has a "RhinoTest" annotation at the class
+ * level that returns the file name of the script to execute.
  */
-
 @RunWith(BlockJUnit4ClassRunner.class)
 public abstract class ScriptTestsBase {
 
@@ -45,13 +49,19 @@ public abstract class ScriptTestsBase {
         Reader script = null;
         String suiteName = null;
 
-        Context cx = Context.enter();
-        try {
+        try (Context cx = Context.enter()) {
             if (!"".equals(anno.value())) {
-                script = new InputStreamReader(new FileInputStream(anno.value()), "UTF-8");
+                script =
+                        new InputStreamReader(
+                                new FileInputStream(anno.value()), StandardCharsets.UTF_8);
                 suiteName = anno.value();
             } else if (!"".equals(anno.inline())) {
-                script = new StringReader("load('testsrc/assert.js');\n" + anno.inline() + "\n" + "'success';");
+                script =
+                        new StringReader(
+                                "load('testsrc/assert.js');\n"
+                                        + anno.inline()
+                                        + "\n"
+                                        + "'success';");
                 suiteName = "inline.js";
             }
 
@@ -59,6 +69,7 @@ public abstract class ScriptTestsBase {
             cx.setLanguageVersion(jsVersion);
 
             Global global = new Global(cx);
+            loadNatives(global);
 
             Scriptable scope = cx.newObject(global);
             scope.setPrototype(global);
@@ -68,15 +79,70 @@ public abstract class ScriptTestsBase {
         } catch (JavaScriptException ex) {
             fail(String.format("%s%n%s", ex.getMessage(), ex.getScriptStackTrace()));
             return null;
+        } catch (TestFailureException tfe) {
+            fail(tfe.getMessage());
+            return null;
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
-            Context.exit();
             try {
                 if (null != script) script.close();
             } catch (IOException e) {
+                // Ignore
             }
         }
+    }
+
+    /**
+     * Load native functions that are used by the Promise tests:
+     *
+     * <p>AbortJS throws a Java exception that can be caught in the test code, but not by JavaScript
+     * code.
+     *
+     * <p>EnqueueMicrotask enqueues a function to be called at the end of the current test run.
+     *
+     * <p>PerformMicrotaskCheckpoint ensures that all the pending microtasks are executed
+     * immediately.
+     */
+    private void loadNatives(Scriptable scope) {
+        ScriptableObject.putProperty(
+                scope,
+                "AbortJS",
+                new LambdaFunction(
+                        scope,
+                        "AbortJS",
+                        1,
+                        (Context lcx, Scriptable lscope, Scriptable localThis, Object[] args) -> {
+                            assert (args.length > 0);
+                            throw new TestFailureException(ScriptRuntime.toString(args[0]));
+                        }));
+
+        ScriptableObject.putProperty(
+                scope,
+                "EnqueueMicrotask",
+                new LambdaFunction(
+                        scope,
+                        "EnqueueMicrotask",
+                        1,
+                        (Context lcx, Scriptable lscope, Scriptable localThis, Object[] args) -> {
+                            assert (args.length > 0);
+                            assert (args[0] instanceof Callable);
+                            lcx.enqueueMicrotask(
+                                    () -> ((Callable) args[0]).call(lcx, lscope, localThis, args));
+                            return Undefined.instance;
+                        }));
+
+        ScriptableObject.putProperty(
+                scope,
+                "PerformMicrotaskCheckpoint",
+                new LambdaFunction(
+                        scope,
+                        "PerformMicrotaskCheckpoint",
+                        0,
+                        (Context lcx, Scriptable lscope, Scriptable localThis, Object[] args) -> {
+                            lcx.processMicrotasks();
+                            return Undefined.instance;
+                        }));
     }
 
     @Test

--- a/testsrc/org/mozilla/javascript/drivers/TestFailureException.java
+++ b/testsrc/org/mozilla/javascript/drivers/TestFailureException.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript.drivers;
+
+/**
+ * This exception is thrown by Promises and other kinds of tests that need to mess with how
+ * JavaScript does exception handling and still have a way to fail all the way to the top.
+ */
+public class TestFailureException extends RuntimeException {
+
+    public TestFailureException(String msg) {
+        super(msg);
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/LambdaFunctionTest.java
+++ b/testsrc/org/mozilla/javascript/tests/LambdaFunctionTest.java
@@ -223,7 +223,8 @@ public class LambdaFunctionTest {
                     "sayHello",
                     1,
                     (Context cx, Scriptable s, Scriptable thisObj, Object[] args) ->
-                            TestClass.sayHello(args));
+                            TestClass.sayHello(args),
+                    0);
             constructor.definePrototypeMethod(
                     scope,
                     "appendToValue",

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -88,7 +88,6 @@ public class Test262SuiteTest {
                             "Array.prototype.flat",
                             "Atomics",
                             "IsHTMLDDA",
-                            "Promise.prototype.finally",
                             "Proxy",
                             "Reflect",
                             "Reflect.construct",

--- a/testsrc/org/mozilla/javascript/tests/es6/PromiseAllOverflow2.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/PromiseAllOverflow2.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests.es6;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es6/promise-all-overflow-2.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class PromiseAllOverflow2 extends ScriptTestsBase {}

--- a/testsrc/org/mozilla/javascript/tests/es6/PromiseBasicTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/PromiseBasicTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es6;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es6/promises.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class PromiseBasicTest extends ScriptTestsBase {}

--- a/testsrc/org/mozilla/javascript/tests/harmony/PromiseFinallyTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/PromiseFinallyTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/promise-prototype-finally.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class PromiseFinallyTest extends ScriptTestsBase {}

--- a/testsrc/test-async.js
+++ b/testsrc/test-async.js
@@ -1,0 +1,120 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+load('testsrc/assert.js');
+
+// Used for async tests. See definition below for more documentation.
+var testAsync;
+
+(function () {  // Scope for utility functions.
+  /**
+   * This is to be used through the testAsync helper function defined
+   * below.
+   *
+   * This requires the --allow-natives-syntax flag to allow calling
+   * runtime functions.
+   *
+   * There must be at least one assertion in an async test. A test
+   * with no assertions will fail.
+   *
+   * @example
+   * testAsync(assert => {
+   *   assert.plan(1) // There should be one assertion in this test.
+   *   Promise.resolve(1)
+   *    .then(val => assert.equals(1, val),
+   *          assert.unreachable);
+   * })
+   */
+  function AsyncAssertion(test, name) {
+      this.expectedAsserts_ = -1;
+      this.actualAsserts_ = 0;
+      this.test_ = test;
+      this.name_ = name || '';
+    }
+
+    /**
+     * Sets the number of expected asserts in the test. The test fails
+     * if the number of asserts computed after running the test is not
+     * equal to this specified value.
+     * @param {number} expectedAsserts
+     */
+    AsyncAssertion.prototype.plan = function(expectedAsserts) {
+      this.expectedAsserts_ = expectedAsserts;
+    }
+
+    AsyncAssertion.prototype.fail = function(expectedText, found) {
+      let message = formatFailureText(expectedText, found);
+      message += "\nin test:" + this.name_
+      message += "\n" + Function.prototype.toString.apply(this.test_);
+      AbortJS(message);
+    }
+
+    AsyncAssertion.prototype.equals = function(expected, found, name_opt) {
+      this.actualAsserts_++;
+      assertEquals(expected, found);
+      /*if (!assertEquals(expected, found)) {
+        this.fail(prettyPrinted(expected), found, name_opt);
+      }*/
+    }
+
+    AsyncAssertion.prototype.unreachable = function() {
+      let message = "Failure: unreachable in test: " + this.name_;
+      message += "\n" + Function.prototype.toString.apply(this.test_);
+      AbortJS(message);
+    }
+
+    AsyncAssertion.prototype.unexpectedRejection = function(details) {
+      return (error) => {
+        let message =
+            "Failure: unexpected Promise rejection in test: " + this.name_;
+        if (details) message += "\n    @" + details;
+        if (error instanceof Error) {
+          message += "\n" + String(error.stack);
+        } else {
+          message += "\n" + String(error);
+        }
+        message += "\n\n" + Function.prototype.toString.apply(this.test_);
+        AbortJS(message);
+      };
+    }
+
+    AsyncAssertion.prototype.drainMicrotasks = function() {
+      PerformMicrotaskCheckpoint();
+    }
+
+    AsyncAssertion.prototype.done_ = function() {
+      if (this.expectedAsserts_ === -1) {
+        let message = "Please call t.plan(count) to initialize test harness " +
+            "with correct assert count (Note: count > 0)";
+        AbortJS(message);
+      }
+
+      if (this.expectedAsserts_ !== this.actualAsserts_) {
+        let message = "Expected asserts: " + this.expectedAsserts_;
+        message += ", Actual asserts: " + this.actualAsserts_;
+        message += "\nin test: " + this.name_;
+        message += "\n" + Function.prototype.toString.apply(this.test_);
+        AbortJS(message);
+      }
+
+      //print('success: ' + this.name_);
+    }
+
+  /** This is used to test async functions and promises.
+   * @param {testCallback} test - test function
+   * @param {string} [name] - optional name of the test
+   *
+   *
+   * @callback testCallback
+   * @param {AsyncAssertion} assert
+   */
+  testAsync = function(test, name) {
+    let assert = new AsyncAssertion(test, name);
+    test(assert);
+    PerformMicrotaskCheckpoint();
+    assert.done_();
+  }
+})();

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -987,13 +987,454 @@ built-ins/parseInt 3/60 (5.0%)
     S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.2_A9.2.js
 
-~built-ins/Promise
+built-ins/Promise 445/599 (74.29%)
+    allSettled/call-resolve-element.js
+    allSettled/call-resolve-element-after-return.js
+    allSettled/call-resolve-element-items.js
+    allSettled/capability-executor-called-twice.js
+    allSettled/capability-executor-not-callable.js
+    allSettled/capability-resolve-throws-no-close.js
+    allSettled/capability-resolve-throws-reject.js {unsupported: [async]}
+    allSettled/ctx-ctor.js {unsupported: [class]}
+    allSettled/ctx-ctor-throws.js
+    allSettled/does-not-invoke-array-setters.js {unsupported: [async]}
+    allSettled/invoke-resolve.js
+    allSettled/invoke-resolve-error-close.js
+    allSettled/invoke-resolve-error-reject.js {unsupported: [async]}
+    allSettled/invoke-resolve-get-error.js {unsupported: [async]}
+    allSettled/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    allSettled/invoke-resolve-get-once-multiple-calls.js
+    allSettled/invoke-resolve-get-once-no-calls.js
+    allSettled/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    allSettled/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    allSettled/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    allSettled/invoke-resolve-return.js
+    allSettled/invoke-then.js
+    allSettled/invoke-then-error-close.js
+    allSettled/invoke-then-error-reject.js {unsupported: [async]}
+    allSettled/invoke-then-get-error-close.js
+    allSettled/invoke-then-get-error-reject.js {unsupported: [async]}
+    allSettled/is-function.js
+    allSettled/iter-arg-is-false-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-null-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-number-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-poisoned.js {unsupported: [async]}
+    allSettled/iter-arg-is-string-resolve.js {unsupported: [async]}
+    allSettled/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-true-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-false-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-null-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-number-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-string-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-symbol-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-true-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-undefined-reject.js {unsupported: [async]}
+    allSettled/iter-next-err-reject.js {unsupported: [async]}
+    allSettled/iter-next-val-err-no-close.js
+    allSettled/iter-next-val-err-reject.js {unsupported: [async]}
+    allSettled/iter-returns-false-reject.js {unsupported: [async]}
+    allSettled/iter-returns-null-reject.js {unsupported: [async]}
+    allSettled/iter-returns-number-reject.js {unsupported: [async]}
+    allSettled/iter-returns-string-reject.js {unsupported: [async]}
+    allSettled/iter-returns-symbol-reject.js {unsupported: [async]}
+    allSettled/iter-returns-true-reject.js {unsupported: [async]}
+    allSettled/iter-returns-undefined-reject.js {unsupported: [async]}
+    allSettled/iter-step-err-no-close.js
+    allSettled/iter-step-err-reject.js {unsupported: [async]}
+    allSettled/length.js
+    allSettled/name.js
+    allSettled/new-reject-function.js
+    allSettled/new-resolve-function.js
+    allSettled/prop-desc.js
+    allSettled/reject-deferred.js {unsupported: [async]}
+    allSettled/reject-element-function-extensible.js
+    allSettled/reject-element-function-length.js
+    allSettled/reject-element-function-multiple-calls.js
+    allSettled/reject-element-function-name.js
+    allSettled/reject-element-function-nonconstructor.js
+    allSettled/reject-element-function-prototype.js
+    allSettled/reject-ignored-deferred.js {unsupported: [async]}
+    allSettled/reject-ignored-immed.js {unsupported: [async]}
+    allSettled/reject-immed.js {unsupported: [async]}
+    allSettled/resolve-before-loop-exit.js
+    allSettled/resolve-before-loop-exit-from-same.js
+    allSettled/resolve-element-function-extensible.js
+    allSettled/resolve-element-function-length.js
+    allSettled/resolve-element-function-name.js
+    allSettled/resolve-element-function-nonconstructor.js
+    allSettled/resolve-element-function-prototype.js
+    allSettled/resolve-from-same-thenable.js
+    allSettled/resolve-ignores-late-rejection.js {unsupported: [async]}
+    allSettled/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    allSettled/resolve-non-callable.js {unsupported: [async]}
+    allSettled/resolve-non-thenable.js {unsupported: [async]}
+    allSettled/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
+    allSettled/resolve-poisoned-then.js {unsupported: [async]}
+    allSettled/resolve-thenable.js {unsupported: [async]}
+    allSettled/resolved-all-fulfilled.js {unsupported: [async]}
+    allSettled/resolved-all-mixed.js {unsupported: [async]}
+    allSettled/resolved-all-rejected.js {unsupported: [async]}
+    allSettled/resolved-immed.js {unsupported: [async]}
+    allSettled/resolved-sequence.js {unsupported: [async]}
+    allSettled/resolved-sequence-extra-ticks.js {unsupported: [async]}
+    allSettled/resolved-sequence-mixed.js {unsupported: [async]}
+    allSettled/resolved-sequence-with-rejections.js {unsupported: [async]}
+    allSettled/resolved-then-catch-finally.js {unsupported: [async]}
+    allSettled/resolves-empty-array.js {unsupported: [async]}
+    allSettled/resolves-to-array.js {unsupported: [async]}
+    allSettled/returns-promise.js
+    allSettled/species-get-error.js {unsupported: [Symbol.species]}
+    all/capability-resolve-throws-reject.js {unsupported: [async]}
+    all/ctx-ctor.js {unsupported: [class]}
+    all/does-not-invoke-array-setters.js {unsupported: [async]}
+    all/invoke-resolve-error-reject.js {unsupported: [async]}
+    all/invoke-resolve-get-error.js {unsupported: [async]}
+    all/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    all/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    all/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    all/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    all/invoke-then-error-reject.js {unsupported: [async]}
+    all/invoke-then-get-error-reject.js {unsupported: [async]}
+    all/iter-arg-is-false-reject.js {unsupported: [async]}
+    all/iter-arg-is-null-reject.js {unsupported: [async]}
+    all/iter-arg-is-number-reject.js {unsupported: [async]}
+    all/iter-arg-is-string-resolve.js {unsupported: [async]}
+    all/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    all/iter-arg-is-true-reject.js {unsupported: [async]}
+    all/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    all/iter-assigned-false-reject.js {unsupported: [async]}
+    all/iter-assigned-null-reject.js {unsupported: [async]}
+    all/iter-assigned-number-reject.js {unsupported: [async]}
+    all/iter-assigned-string-reject.js {unsupported: [async]}
+    all/iter-assigned-symbol-reject.js {unsupported: [async]}
+    all/iter-assigned-true-reject.js {unsupported: [async]}
+    all/iter-assigned-undefined-reject.js {unsupported: [async]}
+    all/iter-next-val-err-reject.js {unsupported: [async]}
+    all/iter-returns-false-reject.js {unsupported: [async]}
+    all/iter-returns-null-reject.js {unsupported: [async]}
+    all/iter-returns-number-reject.js {unsupported: [async]}
+    all/iter-returns-string-reject.js {unsupported: [async]}
+    all/iter-returns-symbol-reject.js {unsupported: [async]}
+    all/iter-returns-true-reject.js {unsupported: [async]}
+    all/iter-returns-undefined-reject.js {unsupported: [async]}
+    all/iter-step-err-reject.js {unsupported: [async]}
+    all/reject-deferred.js {unsupported: [async]}
+    all/reject-ignored-deferred.js {unsupported: [async]}
+    all/reject-ignored-immed.js {unsupported: [async]}
+    all/reject-immed.js {unsupported: [async]}
+    all/resolve-ignores-late-rejection.js {unsupported: [async]}
+    all/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    all/resolve-non-callable.js {unsupported: [async]}
+    all/resolve-non-thenable.js {unsupported: [async]}
+    all/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
+    all/resolve-poisoned-then.js {unsupported: [async]}
+    all/resolve-thenable.js {unsupported: [async]}
+    all/S25.4.4.1_A2.2_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A2.3_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A2.3_T2.js {unsupported: [async]}
+    all/S25.4.4.1_A2.3_T3.js {unsupported: [async]}
+    all/S25.4.4.1_A3.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A3.1_T2.js {unsupported: [async]}
+    all/S25.4.4.1_A3.1_T3.js {unsupported: [async]}
+    all/S25.4.4.1_A5.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A7.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A7.2_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A8.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A8.2_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A8.2_T2.js {unsupported: [async]}
+    all/species-get-error.js {unsupported: [Symbol.species]}
+    any/call-reject-element-after-return.js
+    any/call-reject-element-items.js
+    any/capability-executor-called-twice.js
+    any/capability-executor-not-callable.js
+    any/capability-reject-throws-no-close.js {unsupported: [async]}
+    any/capability-resolve-throws-no-close.js {unsupported: [async]}
+    any/capability-resolve-throws-reject.js {unsupported: [async]}
+    any/ctx-ctor.js {unsupported: [class]}
+    any/ctx-ctor-throws.js
+    any/ctx-non-ctor.js
+    any/invoke-resolve.js {unsupported: [async]}
+    any/invoke-resolve-error-close.js {unsupported: [computed-property-names, async]}
+    any/invoke-resolve-error-reject.js {unsupported: [async]}
+    any/invoke-resolve-get-error.js {unsupported: [async]}
+    any/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    any/invoke-resolve-get-once-multiple-calls.js {unsupported: [async]}
+    any/invoke-resolve-get-once-no-calls.js {unsupported: [async]}
+    any/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    any/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    any/invoke-resolve-on-values-every-iteration-of-custom.js {unsupported: [class, async]}
+    any/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    any/invoke-resolve-return.js
+    any/invoke-then.js {unsupported: [async]}
+    any/invoke-then-error-close.js {unsupported: [computed-property-names, async]}
+    any/invoke-then-error-reject.js {unsupported: [async]}
+    any/invoke-then-get-error-close.js {unsupported: [computed-property-names, async]}
+    any/invoke-then-get-error-reject.js {unsupported: [async]}
+    any/invoke-then-on-promises-every-iteration.js {unsupported: [async]}
+    any/is-function.js
+    any/iter-arg-is-empty-iterable-reject.js {unsupported: [async]}
+    any/iter-arg-is-empty-string-reject.js {unsupported: [async]}
+    any/iter-arg-is-error-object-reject.js {unsupported: [async]}
+    any/iter-arg-is-false-reject.js {unsupported: [async]}
+    any/iter-arg-is-null-reject.js {unsupported: [async]}
+    any/iter-arg-is-number-reject.js {unsupported: [async]}
+    any/iter-arg-is-poisoned.js {unsupported: [async]}
+    any/iter-arg-is-string-resolve.js {unsupported: [async]}
+    any/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    any/iter-arg-is-true-reject.js {unsupported: [async]}
+    any/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    any/iter-assigned-false-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-null-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-number-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-string-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-symbol-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-true-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-undefined-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-next-val-err-no-close.js {unsupported: [async]}
+    any/iter-next-val-err-reject.js {unsupported: [async]}
+    any/iter-returns-false-reject.js {unsupported: [async]}
+    any/iter-returns-null-reject.js {unsupported: [async]}
+    any/iter-returns-number-reject.js {unsupported: [async]}
+    any/iter-returns-string-reject.js {unsupported: [async]}
+    any/iter-returns-symbol-reject.js {unsupported: [async]}
+    any/iter-returns-true-reject.js {unsupported: [async]}
+    any/iter-returns-undefined-reject.js {unsupported: [async]}
+    any/iter-step-err-no-close.js {unsupported: [computed-property-names, async]}
+    any/iter-step-err-reject.js {unsupported: [computed-property-names, async]}
+    any/length.js
+    any/name.js
+    any/new-reject-function.js
+    any/prop-desc.js
+    any/reject-all-mixed.js {unsupported: [async]}
+    any/reject-deferred.js {unsupported: [async]}
+    any/reject-element-function-extensible.js
+    any/reject-element-function-length.js
+    any/reject-element-function-name.js
+    any/reject-element-function-nonconstructor.js
+    any/reject-element-function-prototype.js
+    any/reject-from-same-thenable.js
+    any/reject-ignored-deferred.js {unsupported: [async]}
+    any/reject-ignored-immed.js {unsupported: [async]}
+    any/reject-immed.js {unsupported: [async]}
+    any/resolve-before-loop-exit.js
+    any/resolve-before-loop-exit-from-same.js
+    any/resolve-from-reject-catch.js {unsupported: [async]}
+    any/resolve-from-resolve-reject-catch.js {unsupported: [async]}
+    any/resolve-from-same-thenable.js
+    any/resolve-ignores-late-rejection.js {unsupported: [async]}
+    any/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    any/resolve-non-callable.js {unsupported: [async]}
+    any/resolve-non-thenable.js {unsupported: [async]}
+    any/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
+    any/resolved-sequence.js {unsupported: [async]}
+    any/resolved-sequence-extra-ticks.js {unsupported: [async]}
+    any/resolved-sequence-mixed.js {unsupported: [async]}
+    any/resolved-sequence-with-rejections.js {unsupported: [async]}
+    any/returns-promise.js
+    any/species-get-error.js {unsupported: [Symbol.species]}
+    prototype/catch/S25.4.5.1_A3.1_T1.js {unsupported: [async]}
+    prototype/catch/S25.4.5.1_A3.1_T2.js {unsupported: [async]}
+    prototype/finally/invokes-then-with-function.js {unsupported: [Reflect.construct]}
+    prototype/finally/rejected-observable-then-calls.js {unsupported: [async]}
+    prototype/finally/rejected-observable-then-calls-argument.js {unsupported: [Reflect.construct, async]}
+    prototype/finally/rejected-observable-then-calls-PromiseResolve.js {unsupported: [async]}
+    prototype/finally/rejection-reason-no-fulfill.js {unsupported: [async]}
+    prototype/finally/rejection-reason-override-with-throw.js {unsupported: [async]}
+    prototype/finally/resolution-value-no-override.js {unsupported: [async]}
+    prototype/finally/resolved-observable-then-calls.js {unsupported: [async]}
+    prototype/finally/resolved-observable-then-calls-argument.js {unsupported: [Reflect.construct, async]}
+    prototype/finally/resolved-observable-then-calls-PromiseResolve.js {unsupported: [async]}
+    prototype/finally/species-constructor.js {unsupported: [async]}
+    prototype/finally/subclass-reject-count.js {unsupported: [async]}
+    prototype/finally/subclass-resolve-count.js {unsupported: [async]}
+    prototype/finally/subclass-species-constructor-reject-count.js
+    prototype/finally/subclass-species-constructor-resolve-count.js
+    prototype/finally/this-value-proxy.js
+    prototype/then/capability-executor-called-twice.js {unsupported: [class]}
+    prototype/then/capability-executor-not-callable.js {unsupported: [class]}
+    prototype/then/ctor-access-count.js {unsupported: [async]}
+    prototype/then/ctor-custom.js {unsupported: [Symbol.species, class]}
+    prototype/then/deferred-is-resolved-value.js {unsupported: [class, async]}
+    prototype/then/prfm-fulfilled.js {unsupported: [async]}
+    prototype/then/prfm-pending-fulfulled.js {unsupported: [async]}
+    prototype/then/prfm-pending-rejected.js {unsupported: [async]}
+    prototype/then/prfm-rejected.js {unsupported: [async]}
+    prototype/then/reject-pending-fulfilled.js {unsupported: [async]}
+    prototype/then/reject-pending-rejected.js {unsupported: [async]}
+    prototype/then/reject-settled-fulfilled.js {unsupported: [async]}
+    prototype/then/reject-settled-rejected.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-self.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-thenable.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-self.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-self.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-self.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-thenable.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-invoke-strict.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-next.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-next-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-return-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-return-normal.js {unsupported: [async]}
+    prototype/then/rxn-handler-identity.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-invoke-nonstrict.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-invoke-strict.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-next.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-next-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-return-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-return-normal.js {unsupported: [async]}
+    prototype/then/rxn-handler-thrower.js {unsupported: [async]}
+    prototype/then/S25.4.4_A1.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.4_A2.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.4_A2.1_T2.js {unsupported: [async]}
+    prototype/then/S25.4.4_A2.1_T3.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.1_T2.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.2_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.2_T2.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A5.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A5.2_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A5.3_T1.js {unsupported: [async]}
+    race/ctx-ctor.js {unsupported: [class]}
+    race/invoke-resolve-error-reject.js {unsupported: [async]}
+    race/invoke-resolve-get-error.js {unsupported: [async]}
+    race/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    race/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    race/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    race/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    race/invoke-then-error-reject.js {unsupported: [async]}
+    race/invoke-then-get-error-reject.js {unsupported: [async]}
+    race/iter-arg-is-false-reject.js {unsupported: [async]}
+    race/iter-arg-is-null-reject.js {unsupported: [async]}
+    race/iter-arg-is-number-reject.js {unsupported: [async]}
+    race/iter-arg-is-string-resolve.js {unsupported: [async]}
+    race/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    race/iter-arg-is-true-reject.js {unsupported: [async]}
+    race/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    race/iter-assigned-false-reject.js {unsupported: [async]}
+    race/iter-assigned-null-reject.js {unsupported: [async]}
+    race/iter-assigned-number-reject.js {unsupported: [async]}
+    race/iter-assigned-string-reject.js {unsupported: [async]}
+    race/iter-assigned-symbol-reject.js {unsupported: [async]}
+    race/iter-assigned-true-reject.js {unsupported: [async]}
+    race/iter-assigned-undefined-reject.js {unsupported: [async]}
+    race/iter-next-val-err-reject.js {unsupported: [async]}
+    race/iter-returns-false-reject.js {unsupported: [async]}
+    race/iter-returns-null-reject.js {unsupported: [async]}
+    race/iter-returns-number-reject.js {unsupported: [async]}
+    race/iter-returns-string-reject.js {unsupported: [async]}
+    race/iter-returns-symbol-reject.js {unsupported: [async]}
+    race/iter-returns-true-reject.js {unsupported: [async]}
+    race/iter-returns-undefined-reject.js {unsupported: [async]}
+    race/iter-step-err-reject.js {unsupported: [async]}
+    race/reject-deferred.js {unsupported: [async]}
+    race/reject-ignored-deferred.js {unsupported: [async]}
+    race/reject-ignored-immed.js {unsupported: [async]}
+    race/reject-immed.js {unsupported: [async]}
+    race/resolve-element-function-name.js
+    race/resolve-ignores-late-rejection.js {unsupported: [async]}
+    race/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    race/resolve-non-callable.js {unsupported: [async]}
+    race/resolve-non-obj.js {unsupported: [async]}
+    race/resolve-non-thenable.js {unsupported: [async]}
+    race/resolve-poisoned-then.js {unsupported: [async]}
+    race/resolve-prms-cstm-then.js {unsupported: [async]}
+    race/resolve-self.js {unsupported: [async]}
+    race/resolve-thenable.js {unsupported: [async]}
+    race/resolved-sequence.js {unsupported: [async]}
+    race/resolved-sequence-extra-ticks.js {unsupported: [async]}
+    race/resolved-sequence-mixed.js {unsupported: [async]}
+    race/resolved-sequence-with-rejections.js {unsupported: [async]}
+    race/resolved-then-catch-finally.js {unsupported: [async]}
+    race/S25.4.4.3_A2.2_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A2.2_T2.js {unsupported: [async]}
+    race/S25.4.4.3_A2.2_T3.js {unsupported: [async]}
+    race/S25.4.4.3_A4.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A4.1_T2.js {unsupported: [async]}
+    race/S25.4.4.3_A5.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A6.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A6.2_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.1_T2.js {unsupported: [async]}
+    race/S25.4.4.3_A7.1_T3.js {unsupported: [async]}
+    race/S25.4.4.3_A7.2_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.3_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.3_T2.js {unsupported: [async]}
+    race/species-get-error.js {unsupported: [Symbol.species]}
+    reject/capability-invocation.js
+    reject/ctx-ctor.js {unsupported: [class]}
+    reject/S25.4.4.4_A2.1_T1.js {unsupported: [async]}
+    resolve/arg-non-thenable.js {unsupported: [async]}
+    resolve/arg-poisoned-then.js {unsupported: [async]}
+    resolve/ctx-ctor.js {unsupported: [class]}
+    resolve/resolve-from-promise-capability.js
+    resolve/resolve-non-obj.js {unsupported: [async]}
+    resolve/resolve-non-thenable.js {unsupported: [async]}
+    resolve/resolve-poisoned-then.js {unsupported: [async]}
+    resolve/resolve-self.js {unsupported: [async]}
+    resolve/resolve-thenable.js {unsupported: [async]}
+    resolve/S25.4.4.5_A2.2_T1.js {unsupported: [async]}
+    resolve/S25.4.4.5_A2.3_T1.js {unsupported: [async]}
+    resolve/S25.4.4.5_A3.1_T1.js {unsupported: [async]}
+    resolve/S25.4.4.5_A4.1_T1.js {unsupported: [async]}
+    resolve/S25.Promise_resolve_foreign_thenable_1.js {unsupported: [async]}
+    resolve/S25.Promise_resolve_foreign_thenable_2.js {unsupported: [async]}
+    Symbol.species 5/5 (100.0%)
+    create-resolving-functions-reject.js {unsupported: [Reflect.construct, async]}
+    create-resolving-functions-resolve.js {unsupported: [Reflect.construct, async]}
+    exception-after-resolve-in-executor.js {unsupported: [async]}
+    exception-after-resolve-in-thenable-job.js {unsupported: [async]}
+    executor-call-context-sloppy.js non-strict
+    executor-function-nonconstructor.js {unsupported: [Reflect.construct]}
+    get-prototype-abrupt.js {unsupported: [Reflect.construct, Reflect]}
+    get-prototype-abrupt-executor-not-callable.js {unsupported: [Reflect.construct, Reflect]}
+    proto-from-ctor-realm.js {unsupported: [Reflect, cross-realm]}
+    reject-ignored-via-abrupt.js {unsupported: [async]}
+    reject-ignored-via-fn-deferred.js {unsupported: [async]}
+    reject-ignored-via-fn-immed.js {unsupported: [async]}
+    reject-via-abrupt.js {unsupported: [async]}
+    reject-via-abrupt-queue.js {unsupported: [async]}
+    reject-via-fn-deferred.js {unsupported: [async]}
+    reject-via-fn-deferred-queue.js {unsupported: [async]}
+    reject-via-fn-immed.js {unsupported: [async]}
+    reject-via-fn-immed-queue.js {unsupported: [async]}
+    resolve-ignored-via-fn-deferred.js {unsupported: [async]}
+    resolve-ignored-via-fn-immed.js {unsupported: [async]}
+    resolve-non-obj-deferred.js {unsupported: [async]}
+    resolve-non-obj-immed.js {unsupported: [async]}
+    resolve-non-thenable-deferred.js {unsupported: [async]}
+    resolve-non-thenable-immed.js {unsupported: [async]}
+    resolve-poisoned-then-deferred.js {unsupported: [async]}
+    resolve-poisoned-then-immed.js {unsupported: [async]}
+    resolve-prms-cstm-then-deferred.js {unsupported: [async]}
+    resolve-prms-cstm-then-immed.js {unsupported: [async]}
+    resolve-self.js {unsupported: [async]}
+    resolve-thenable-deferred.js {unsupported: [async]}
+    resolve-thenable-immed.js {unsupported: [async]}
 
 ~built-ins/Proxy
 
 ~built-ins/Reflect
 
-built-ins/RegExp 926/1464 (63.25%)
+built-ins/RegExp 925/1464 (63.18%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     lookBehind 17/17 (100.0%)
@@ -1144,7 +1585,6 @@ built-ins/RegExp 926/1464 (63.25%)
     prototype/Symbol.replace/y-init-lastindex.js
     prototype/Symbol.replace/y-set-lastindex.js
     prototype/Symbol.search/cstm-exec-return-index.js
-    prototype/Symbol.search/failure-return-val.js
     prototype/Symbol.search/get-lastindex-err.js
     prototype/Symbol.search/lastindex-no-restore.js
     prototype/Symbol.search/match-err.js


### PR DESCRIPTION
This is a working implementation of promises, built using the new LambdaConstructor stuff. It supports:

Promise.all, resolve, reject, and race
Promise.prototype.catch, finally, and then

Promise.allSettled isn't implemented yet -- it seems to be a bit newer and some of this code is a year old or more. That can come soon.

This is a little bit of a naive implementation in that it follows the spec closely. There might be some optimization possible because we are currently not taking advantage of the fact that most of the time, we are calling various methods of NativePromise, but because this is JavaScript we have to look up methods like "then" every time in case they change.

I think that given the amount of Java interoperability people do with Rhino, we also need some way to implement a Promise in Java code, or at least call the various methods to resolve the promise easily from Java. That could be a future PR. I'm hoping that some people who do the deep embedding with Java some more will have ideas of a good way to do it.

Closes #160