### PR TITLE
Bring back output on passing tests while excluded via test262.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,9 @@ test {
         systemProperty 'TEST_OPTLEVEL', System.getProperty('optLevel')
     }
     systemProperty 'test262properties', System.getProperty('test262properties')
-    systemProperty 'updateTest262properties', System.getProperty('updateTest262properties')
+    if (System.getProperty('updateTest262properties') != null) {
+        systemProperty 'updateTest262properties', System.getProperty('updateTest262properties')
+    }
     maxHeapSize = "1g"
     testLogging.showStandardStreams = true
     // Many tests do not clean up contexts properly. This makes the tests much

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -186,206 +187,231 @@ public class Test262SuiteTest {
     public static void tearDownClass() {
         TestUtils.setGlobalContextFactory(null);
 
-        if (!updateTest262Properties) return;
+        for (Entry<Test262Case, TestResultTracker> entry : RESULT_TRACKERS.entrySet()) {
+            if (entry.getKey().file.isFile()) {
+                TestResultTracker tt = entry.getValue();
 
-        // Regenerate .properties file
-        try {
-            Path previousReportingDir = null;
-            Path currentReportingDir;
-            List<String> failures = new ArrayList<String>();
-            int testCount = 0;
-            Path previousTestFileParentPath =
-                    testDir.toPath(); // tracks the current directory for which files are processed
-            int rollUpCount = 0;
-            int rolledUpFailureCount = 0;
-
-            // Converting to an array, so a regular loop over an array can be used,
-            // as there's the need to peek the next entry
-            Test262Case[] testCases = new Test262Case[RESULT_TRACKERS.size()];
-            RESULT_TRACKERS.keySet().toArray(testCases);
-
-            BufferedWriter writer = new BufferedWriter(new FileWriter(testProperties));
-            writer.write(
-                    "# This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file\n");
-
-            for (int j = 0; j < testCases.length; j++) {
-                File testFile = testCases[j].file;
-                TestResultTracker tt = RESULT_TRACKERS.get(testCases[j]);
-
-                boolean ontoNextReportingDir = false;
-                String testResult = null;
-
-                Path testFilePath = testFile.toPath();
-                // hardcoded for just language/expression and language/statements
-                // to be split out on a deeper level
-                int reportDepth =
-                        testFilePath.getNameCount() > 3
-                                        && testFilePath.getName(2).toString().equals("language")
-                                        && (testFilePath.getName(3).toString().equals("expressions")
-                                                || testFilePath
-                                                        .getName(3)
-                                                        .toString()
-                                                        .equals("statements"))
-                                ? 5
-                                : Math.min(4, testFilePath.getNameCount());
-                currentReportingDir = testFilePath.subpath(0, reportDepth);
-
-                if (previousReportingDir == null) {
-                    previousReportingDir = currentReportingDir;
-                } else if (!currentReportingDir.startsWith(previousReportingDir)
-                        || testFile.isDirectory()) {
-                    ontoNextReportingDir = true;
+                if (tt.expectedFailure && tt.expectationsMet()) {
+                    System.out.println(
+                            String.format(
+                                    "Test is marked as failing but it does not: %s",
+                                    entry.getKey().file));
                 }
+            }
+        }
 
-                // Determine if switching to another directory and if so whether all files in the
-                // previous directory failed
-                // If so, dont list all failing files, but list only the folder path
-                if (rollUpEnabled
-                        && (!testFilePath.startsWith(previousTestFileParentPath)
-                                || !testFilePath.getParent().equals(previousTestFileParentPath))) {
-                    if (!previousReportingDir.equals(previousTestFileParentPath)
-                            && rollUpCount > 1) {
-                        failures.add(
-                                "    "
-                                        + currentReportingDir
-                                                .relativize(previousTestFileParentPath)
+        if (updateTest262Properties) {
+            // Regenerate .properties file
+            try {
+                Path previousReportingDir = null;
+                Path currentReportingDir;
+                List<String> failures = new ArrayList<String>();
+                int testCount = 0;
+                Path previousTestFileParentPath =
+                        testDir.toPath(); // tracks the current directory for which files are
+                // processed
+                int rollUpCount = 0;
+                int rolledUpFailureCount = 0;
+
+                // Converting to an array, so a regular loop over an array can be used,
+                // as there's the need to peek the next entry
+                Test262Case[] testCases = new Test262Case[RESULT_TRACKERS.size()];
+                RESULT_TRACKERS.keySet().toArray(testCases);
+
+                BufferedWriter writer = new BufferedWriter(new FileWriter(testProperties));
+                writer.write(
+                        "# This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file\n");
+
+                for (int j = 0; j < testCases.length; j++) {
+                    File testFile = testCases[j].file;
+                    TestResultTracker tt = RESULT_TRACKERS.get(testCases[j]);
+
+                    boolean ontoNextReportingDir = false;
+                    String testResult = null;
+
+                    Path testFilePath = testFile.toPath();
+                    // hardcoded for just language/expression and language/statements
+                    // to be split out on a deeper level
+                    int reportDepth =
+                            testFilePath.getNameCount() > 3
+                                            && testFilePath.getName(2).toString().equals("language")
+                                            && (testFilePath
+                                                            .getName(3)
+                                                            .toString()
+                                                            .equals("expressions")
+                                                    || testFilePath
+                                                            .getName(3)
+                                                            .toString()
+                                                            .equals("statements"))
+                                    ? 5
+                                    : Math.min(4, testFilePath.getNameCount());
+                    currentReportingDir = testFilePath.subpath(0, reportDepth);
+
+                    if (previousReportingDir == null) {
+                        previousReportingDir = currentReportingDir;
+                    } else if (!currentReportingDir.startsWith(previousReportingDir)
+                            || testFile.isDirectory()) {
+                        ontoNextReportingDir = true;
+                    }
+
+                    // Determine if switching to another directory and if so whether all files in
+                    // the
+                    // previous directory failed
+                    // If so, dont list all failing files, but list only the folder path
+                    if (rollUpEnabled
+                            && (!testFilePath.startsWith(previousTestFileParentPath)
+                                    || !testFilePath
+                                            .getParent()
+                                            .equals(previousTestFileParentPath))) {
+                        if (!previousReportingDir.equals(previousTestFileParentPath)
+                                && rollUpCount > 1) {
+                            failures.add(
+                                    "    "
+                                            + currentReportingDir
+                                                    .relativize(previousTestFileParentPath)
+                                                    .toString()
+                                                    .replace("\\", "/")
+                                            + (statsEnabled
+                                                    ? " "
+                                                            + rollUpCount
+                                                            + "/"
+                                                            + rollUpCount
+                                                            + " (100.0%)"
+                                                    : ""));
+                            rolledUpFailureCount += rollUpCount - 1;
+
+                            for (; rollUpCount > 0; rollUpCount--) {
+                                failures.remove(failures.size() - 2);
+                            }
+                        }
+
+                        previousTestFileParentPath = testFilePath.getParent();
+                        rollUpCount = 0;
+                    }
+
+                    if (!testFile.isDirectory()) {
+                        testResult = tt.getResult(OPT_LEVELS, testCases[j]);
+
+                        if (testResult == null) {
+                            // At least one passing test in currentParent directory, so prevent
+                            // rollUp
+                            rollUpCount = -1;
+                        } else {
+                            if (rollUpCount != -1) rollUpCount++;
+
+                            testResult =
+                                    "    "
+                                            + currentReportingDir
+                                                    .relativize(testFilePath)
+                                                    .toString()
+                                                    .replace("\\", "/")
+                                            + (statsEnabled && testResult != ""
+                                                    ? " " + testResult
+                                                    : "");
+                            if (tt.comment != null && !tt.comment.isEmpty()) {
+                                testResult += " " + tt.comment;
+                            }
+                        }
+
+                        // Making sure the last folder gets properly logged
+                        if (j == testCases.length - 1) {
+                            if (testResult != null) {
+                                failures.add(testResult);
+                            }
+                            testCount++;
+                            ontoNextReportingDir = true;
+                        }
+                    }
+
+                    if (ontoNextReportingDir) {
+                        int failureCount = rolledUpFailureCount + failures.size();
+                        Double failurePercentage =
+                                testCount == 0
+                                        ? 0
+                                        : ((double) failureCount * 100 / (double) testCount);
+
+                        writer.write('\n');
+                        writer.write(
+                                previousReportingDir
+                                                .subpath(2, previousReportingDir.getNameCount())
                                                 .toString()
                                                 .replace("\\", "/")
                                         + (statsEnabled
                                                 ? " "
-                                                        + rollUpCount
+                                                        + failureCount
                                                         + "/"
-                                                        + rollUpCount
-                                                        + " (100.0%)"
+                                                        + testCount
+                                                        + " ("
+                                                        + new BigDecimal(
+                                                                        failurePercentage
+                                                                                .toString())
+                                                                .setScale(2, RoundingMode.HALF_UP)
+                                                                .doubleValue()
+                                                        + "%)"
                                                 : ""));
-                        rolledUpFailureCount += rollUpCount - 1;
-
-                        for (; rollUpCount > 0; rollUpCount--) {
-                            failures.remove(failures.size() - 2);
-                        }
-                    }
-
-                    previousTestFileParentPath = testFilePath.getParent();
-                    rollUpCount = 0;
-                }
-
-                if (!testFile.isDirectory()) {
-                    testResult = tt.getResult(OPT_LEVELS, testCases[j]);
-
-                    if (testResult == null) {
-                        // At least one passing test in currentParent directory, so prevent rollUp
-                        rollUpCount = -1;
-                    } else {
-                        if (rollUpCount != -1) rollUpCount++;
-
-                        testResult =
-                                "    "
-                                        + currentReportingDir
-                                                .relativize(testFilePath)
-                                                .toString()
-                                                .replace("\\", "/")
-                                        + (statsEnabled && testResult != ""
-                                                ? " " + testResult
-                                                : "");
-                        if (tt.comment != null && !tt.comment.isEmpty()) {
-                            testResult += " " + tt.comment;
-                        }
-                    }
-
-                    // Making sure the last folder gets properly logged
-                    if (j == testCases.length - 1) {
-                        if (testResult != null) {
-                            failures.add(testResult);
-                        }
-                        testCount++;
-                        ontoNextReportingDir = true;
-                    }
-                }
-
-                if (ontoNextReportingDir) {
-                    int failureCount = rolledUpFailureCount + failures.size();
-                    Double failurePercentage =
-                            testCount == 0 ? 0 : ((double) failureCount * 100 / (double) testCount);
-
-                    writer.write('\n');
-                    writer.write(
-                            previousReportingDir
-                                            .subpath(2, previousReportingDir.getNameCount())
-                                            .toString()
-                                            .replace("\\", "/")
-                                    + (statsEnabled
-                                            ? " "
-                                                    + failureCount
-                                                    + "/"
-                                                    + testCount
-                                                    + " ("
-                                                    + new BigDecimal(failurePercentage.toString())
-                                                            .setScale(2, RoundingMode.HALF_UP)
-                                                            .doubleValue()
-                                                    + "%)"
-                                            : ""));
-                    writer.write('\n');
-
-                    if (failurePercentage != 0 && failurePercentage != 100) {
-                        writer.write(
-                                failures.stream()
-                                        .map(Object::toString)
-                                        .collect(Collectors.joining("\n")));
                         writer.write('\n');
+
+                        if (failurePercentage != 0 && failurePercentage != 100) {
+                            writer.write(
+                                    failures.stream()
+                                            .map(Object::toString)
+                                            .collect(Collectors.joining("\n")));
+                            writer.write('\n');
+                        }
+
+                        previousReportingDir = currentReportingDir;
+                        failures.clear();
+                        testCount = rolledUpFailureCount = 0;
                     }
 
-                    previousReportingDir = currentReportingDir;
-                    failures.clear();
-                    testCount = rolledUpFailureCount = 0;
-                }
-
-                if (testFile.isDirectory()) {
-                    String message =
-                            "~"
-                                    + currentReportingDir
-                                            .subpath(2, currentReportingDir.getNameCount())
-                                            .toString()
-                                            .replace("\\", "/");
-
-                    if (tt.comment != null && !tt.comment.isEmpty()) {
-                        message += " " + tt.comment;
-                    }
-                    writer.write('\n');
-                    writer.write(message);
-                    writer.write('\n');
-
-                    // Consume testcases belonging to a skipped directory
-                    while (testCases.length > j + 1
-                            && testCases[j + 1].file.isFile()
-                            && testCases[j + 1].file.getParentFile().equals(testFile)) {
-                        TestResultTracker tt2 = RESULT_TRACKERS.get(testCases[j + 1]);
-
-                        testResult =
-                                "    "
+                    if (testFile.isDirectory()) {
+                        String message =
+                                "~"
                                         + currentReportingDir
-                                                .relativize(testCases[j + 1].file.toPath())
+                                                .subpath(2, currentReportingDir.getNameCount())
                                                 .toString()
                                                 .replace("\\", "/");
-                        if (tt2.comment != null && !tt2.comment.isEmpty()) {
-                            testResult += " " + tt2.comment;
+
+                        if (tt.comment != null && !tt.comment.isEmpty()) {
+                            message += " " + tt.comment;
                         }
-                        writer.write(testResult);
                         writer.write('\n');
-                        j++;
+                        writer.write(message);
+                        writer.write('\n');
+
+                        // Consume testcases belonging to a skipped directory
+                        while (testCases.length > j + 1
+                                && testCases[j + 1].file.isFile()
+                                && testCases[j + 1].file.getParentFile().equals(testFile)) {
+                            TestResultTracker tt2 = RESULT_TRACKERS.get(testCases[j + 1]);
+
+                            testResult =
+                                    "    "
+                                            + currentReportingDir
+                                                    .relativize(testCases[j + 1].file.toPath())
+                                                    .toString()
+                                                    .replace("\\", "/");
+                            if (tt2.comment != null && !tt2.comment.isEmpty()) {
+                                testResult += " " + tt2.comment;
+                            }
+                            writer.write(testResult);
+                            writer.write('\n');
+                            j++;
+                        }
+
+                        previousReportingDir = null;
+                        continue;
                     }
 
-                    previousReportingDir = null;
-                    continue;
+                    if (testResult != null) {
+                        failures.add(testResult);
+                    }
+                    testCount++;
                 }
-
-                if (testResult != null) {
-                    failures.add(testResult);
-                }
-                testCount++;
+                writer.close();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-            writer.close();
-        } catch (IOException e) {
-            e.printStackTrace();
         }
     }
 
@@ -678,7 +704,7 @@ public class Test262SuiteTest {
                     topLevelFolderContents.stream()
                             .forEach(
                                     file -> {
-                                        if (file.toPath().startsWith(subFolder.toPath())) {
+                                        if (file.toPath().getParent().equals(subFolder.toPath())) {
                                             filesExpectedToFail.put(file, null);
                                         }
                                     });
@@ -732,7 +758,6 @@ public class Test262SuiteTest {
             for (String feature : testCase.features) {
                 if (UNSUPPORTED_FEATURES.contains(feature)) {
                     if (includeUnsupported) {
-                        // FIXME this only adds the first unsupported feature, instead of all
                         TestResultTracker tracker =
                                 RESULT_TRACKERS.computeIfAbsent(
                                         testCase, k -> new TestResultTracker(comment));
@@ -926,6 +951,10 @@ public class Test262SuiteTest {
             this.expectedFailure = expectedFailure;
         }
 
+        public boolean expectationsMet() {
+            return strictOptLevel.size() + nonStrictOptLevel.size() == 0;
+        }
+
         public void passes(int optLevel, boolean useStrict) {
             if (useStrict) {
                 strictOptLevel.remove(optLevel);
@@ -978,10 +1007,12 @@ public class Test262SuiteTest {
             }
 
             // success in interpreted optLevel, but failure in all other optLevels
-            if (strictOptLevel.size() == optLevels.length - 1
-                    && !strictOptLevel.contains(-1)
-                    && nonStrictOptLevel.size() == optLevels.length - 1
-                    && !nonStrictOptLevel.contains(-1)) {
+            if ((noStrict
+                            || (strictOptLevel.size() == optLevels.length - 1
+                                    && !strictOptLevel.contains(-1)))
+                    && (onlyStrict
+                            || (nonStrictOptLevel.size() == optLevels.length - 1
+                                    && !nonStrictOptLevel.contains(-1)))) {
                 return "non-interpreted";
             }
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -516,10 +516,10 @@ built-ins/Function 199/505 (39.41%)
     prototype/apply/S15.3.4.3_A3_T3.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T4.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T5.js non-interpreted
-    prototype/apply/S15.3.4.3_A3_T6.js {non-strict: [0, 9]}
+    prototype/apply/S15.3.4.3_A3_T6.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T7.js non-interpreted
-    prototype/apply/S15.3.4.3_A3_T8.js {non-strict: [0, 9]}
-    prototype/apply/S15.3.4.3_A5_T4.js {non-strict: [0, 9]}
+    prototype/apply/S15.3.4.3_A3_T8.js non-interpreted
+    prototype/apply/S15.3.4.3_A5_T4.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T1.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T2.js non-interpreted
     prototype/apply/S15.3.4.3_A7_T5.js non-interpreted
@@ -552,10 +552,10 @@ built-ins/Function 199/505 (39.41%)
     prototype/call/S15.3.4.4_A3_T3.js non-interpreted
     prototype/call/S15.3.4.4_A3_T4.js non-interpreted
     prototype/call/S15.3.4.4_A3_T5.js non-interpreted
-    prototype/call/S15.3.4.4_A3_T6.js {non-strict: [0, 9]}
+    prototype/call/S15.3.4.4_A3_T6.js non-interpreted
     prototype/call/S15.3.4.4_A3_T7.js non-interpreted
-    prototype/call/S15.3.4.4_A3_T8.js {non-strict: [0, 9]}
-    prototype/call/S15.3.4.4_A5_T4.js {non-strict: [0, 9]}
+    prototype/call/S15.3.4.4_A3_T8.js non-interpreted
+    prototype/call/S15.3.4.4_A5_T4.js non-interpreted
     prototype/call/S15.3.4.4_A6_T1.js non-interpreted
     prototype/call/S15.3.4.4_A6_T2.js non-interpreted
     prototype/call/S15.3.4.4_A6_T5.js non-interpreted
@@ -993,7 +993,7 @@ built-ins/parseInt 3/60 (5.0%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 926/1464 (63.25%)
+built-ins/RegExp 925/1464 (63.18%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     lookBehind 17/17 (100.0%)
@@ -1144,7 +1144,6 @@ built-ins/RegExp 926/1464 (63.25%)
     prototype/Symbol.replace/y-init-lastindex.js
     prototype/Symbol.replace/y-set-lastindex.js
     prototype/Symbol.search/cstm-exec-return-index.js
-    prototype/Symbol.search/failure-return-val.js
     prototype/Symbol.search/get-lastindex-err.js
     prototype/Symbol.search/lastindex-no-restore.js
     prototype/Symbol.search/match-err.js
@@ -2469,14 +2468,14 @@ language/directive-prologue 18/62 (29.03%)
     14.1-13-s.js {non-strict: [-1]}
     14.1-14-s.js {non-strict: [-1]}
     14.1-15-s.js {non-strict: [-1]}
-    14.1-16-s.js {non-strict: [0, 9]}
-    14.1-17-s.js {non-strict: [0, 9]}
+    14.1-16-s.js non-interpreted
+    14.1-17-s.js non-interpreted
     14.1-2-s.js {non-strict: [-1]}
-    14.1-3-s.js {non-strict: [0, 9]}
-    14.1-4-s.js {non-strict: [0, 9]}
-    14.1-5-s.js {non-strict: [0, 9]}
-    14.1-6-s.js {non-strict: [0, 9]}
-    14.1-7-s.js {non-strict: [0, 9]}
+    14.1-3-s.js non-interpreted
+    14.1-4-s.js non-interpreted
+    14.1-5-s.js non-interpreted
+    14.1-6-s.js non-interpreted
+    14.1-7-s.js non-interpreted
     14.1-8-s.js {non-strict: [-1]}
     14.1-9-s.js {non-strict: [-1]}
     func-decl-inside-func-decl-parse.js non-strict
@@ -4937,18 +4936,18 @@ language/function-code 123/217 (56.68%)
     10.4.3-1-78gs.js
     10.4.3-1-7gs.js strict
     10.4.3-1-8-s.js non-strict
-    10.4.3-1-86-s.js {non-strict: [0, 9]}
-    10.4.3-1-86gs.js {non-strict: [0, 9]}
-    10.4.3-1-87-s.js {non-strict: [0, 9]}
-    10.4.3-1-87gs.js {non-strict: [0, 9]}
+    10.4.3-1-86-s.js non-interpreted
+    10.4.3-1-86gs.js non-interpreted
+    10.4.3-1-87-s.js non-interpreted
+    10.4.3-1-87gs.js non-interpreted
     10.4.3-1-8gs.js non-strict
     10.4.3-1-9-s.js strict
-    10.4.3-1-90-s.js {non-strict: [0, 9]}
-    10.4.3-1-90gs.js {non-strict: [0, 9]}
-    10.4.3-1-91-s.js {non-strict: [0, 9]}
-    10.4.3-1-91gs.js {non-strict: [0, 9]}
-    10.4.3-1-92-s.js {non-strict: [0, 9]}
-    10.4.3-1-92gs.js {non-strict: [0, 9]}
+    10.4.3-1-90-s.js non-interpreted
+    10.4.3-1-90gs.js non-interpreted
+    10.4.3-1-91-s.js non-interpreted
+    10.4.3-1-91gs.js non-interpreted
+    10.4.3-1-92-s.js non-interpreted
+    10.4.3-1-92gs.js non-interpreted
     10.4.3-1-9gs.js strict
     block-decl-onlystrict.js strict
     eval-param-env-with-computed-key.js non-strict


### PR DESCRIPTION
Realized when I started using the new test2626 mechanism that the output of tests actually passing during a testrun while excluded in test262.properties as they are expected to fail had gone missing

While fixing that I noticed that all files from subfolders of a rolled-up folder were assumed to fail by the test runner, instead of just its own files, so fixed that as well

And did an optimize to report 'non-interpreted' instead of {(non-)strict: [0, 9]} if test is flagged with noStrict or onlyStrict