### PR TITLE
fix #977 Support ES2019 JSON superset

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -117,7 +117,6 @@ public class Test262SuiteTest {
                             "String.prototype.matchAll",
                             "Symbol.matchAll",
                             "tail-call-optimization",
-                            "json-superset",
                             "hashbang",
                             "u180e"));
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -5170,7 +5170,7 @@ language/line-terminators 4/41 (9.76%)
     S7.3_A6_T3.js
     S7.3_A6_T4.js
 
-language/literals 117/434 (26.96%)
+language/literals 113/434 (26.04%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     bigint/legacy-octal-like-invalid-00n.js
@@ -5214,12 +5214,8 @@ language/literals 117/434 (26.96%)
     string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
     string/legacy-octal-escape-sequence-strict.js strict
-    string/line-separator.js {unsupported: [json-superset]}
-    string/line-separator-eval.js {unsupported: [json-superset]}
     string/mongolian-vowel-separator.js {unsupported: [u180e]}
     string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
-    string/paragraph-separator.js {unsupported: [json-superset]}
-    string/paragraph-separator-eval.js {unsupported: [json-superset]}
     string/S7.8.4_A4.3_T1.js strict
     string/S7.8.4_A4.3_T2.js strict
     string/S7.8.4_A7.1_T4.js


### PR DESCRIPTION
Closes #977

Is it necessary to check `compilerEnv.getLanguageVersion()`?
These do not seem to be checked.
- https://github.com/mozilla/rhino/pull/904
- https://github.com/mozilla/rhino/pull/952