### PR TITLE
Clean up handling of SCRIPTABLE_UNDEFINED

### DIFF
--- a/src/org/mozilla/javascript/NativeNumber.java
+++ b/src/org/mozilla/javascript/NativeNumber.java
@@ -143,7 +143,7 @@ final class NativeNumber extends IdScriptableObject {
                 {
                     // toLocaleString is just an alias for toString for now
                     int base =
-                            (args.length == 0 || args[0] == Undefined.instance)
+                            (args.length == 0 || Undefined.isUndefined(args[0]))
                                     ? 10
                                     : ScriptRuntime.toInt32(args[0]);
                     return ScriptRuntime.numberToString(value, base);
@@ -184,7 +184,7 @@ final class NativeNumber extends IdScriptableObject {
             case Id_toPrecision:
                 {
                     // Undefined precision, fall back to ToString()
-                    if (args.length == 0 || args[0] == Undefined.instance) {
+                    if (args.length == 0 || Undefined.isUndefined(args[0])) {
                         return ScriptRuntime.numberToString(value, 10);
                     }
                     // Handle special values before range check
@@ -208,7 +208,7 @@ final class NativeNumber extends IdScriptableObject {
     private static Object execConstructorCall(int id, Object[] args) {
         switch (id) {
             case ConstructorId_isFinite:
-                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                if ((args.length == 0) || Undefined.isUndefined(args[0])) {
                     return Boolean.FALSE;
                 }
                 if (args[0] instanceof Number) {
@@ -218,7 +218,7 @@ final class NativeNumber extends IdScriptableObject {
                 return Boolean.FALSE;
 
             case ConstructorId_isNaN:
-                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                if ((args.length == 0) || Undefined.isUndefined(args[0])) {
                     return Boolean.FALSE;
                 }
                 if (args[0] instanceof Number) {
@@ -227,7 +227,7 @@ final class NativeNumber extends IdScriptableObject {
                 return Boolean.FALSE;
 
             case ConstructorId_isInteger:
-                if ((args.length == 0) || (Undefined.instance == args[0])) {
+                if ((args.length == 0) || Undefined.isUndefined(args[0])) {
                     return Boolean.FALSE;
                 }
                 if (args[0] instanceof Number) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2430,9 +2430,7 @@ public class ScriptRuntime {
      */
     public static boolean loadFromIterable(
             Context cx, Scriptable scope, Object arg1, BiConsumer<Object, Object> setter) {
-        if ((arg1 == null) || Undefined.isUndefined(arg1)) {
-            return false;
-        }
+        if ((arg1 == null) || Undefined.isUndefined(arg1)) return false;
 
         // Call the "[Symbol.iterator]" property as a function.
         final Object ito = ScriptRuntime.callIterator(arg1, cx, scope);

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -383,7 +383,7 @@ public class ScriptRuntime {
     public static boolean toBoolean(Object val) {
         for (; ; ) {
             if (val instanceof Boolean) return ((Boolean) val).booleanValue();
-            if (val == null || val == Undefined.instance) return false;
+            if (val == null || Undefined.isUndefined(val)) return false;
             if (val instanceof CharSequence) return ((CharSequence) val).length() != 0;
             if (val instanceof BigInteger) {
                 return !((BigInteger) val).equals(BigInteger.ZERO);
@@ -424,7 +424,7 @@ public class ScriptRuntime {
             }
             if (val instanceof Number) return ((Number) val).doubleValue();
             if (val == null) return +0.0;
-            if (val == Undefined.instance) return NaN;
+            if (Undefined.isUndefined(val)) return NaN;
             if (val instanceof String) return toNumber((String) val);
             if (val instanceof CharSequence) return toNumber(val.toString());
             if (val instanceof Boolean) return ((Boolean) val).booleanValue() ? 1 : +0.0;
@@ -730,7 +730,7 @@ public class ScriptRuntime {
                     }
                 }
             }
-            if (val == null || val == Undefined.instance) {
+            if (val == null || Undefined.isUndefined(val)) {
                 throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
             }
             if (val instanceof String) {
@@ -982,7 +982,7 @@ public class ScriptRuntime {
             if (val == null) {
                 return "null";
             }
-            if (val == Undefined.instance || val == Undefined.SCRIPTABLE_UNDEFINED) {
+            if (Undefined.isUndefined(val)) {
                 return "undefined";
             }
             if (val instanceof String) {
@@ -1064,7 +1064,7 @@ public class ScriptRuntime {
         if (value == null) {
             return "null";
         }
-        if (value == Undefined.instance) {
+        if (Undefined.isUndefined(value)) {
             return "undefined";
         }
         if (value instanceof CharSequence) {
@@ -1182,7 +1182,7 @@ public class ScriptRuntime {
     public static Scriptable toObjectOrNull(Context cx, Object obj) {
         if (obj instanceof Scriptable) {
             return (Scriptable) obj;
-        } else if (obj != null && obj != Undefined.instance) {
+        } else if (obj != null && !Undefined.isUndefined(obj)) {
             return toObject(cx, getTopCallScope(cx), obj);
         }
         return null;
@@ -1192,7 +1192,7 @@ public class ScriptRuntime {
     public static Scriptable toObjectOrNull(Context cx, Object obj, Scriptable scope) {
         if (obj instanceof Scriptable) {
             return (Scriptable) obj;
-        } else if (obj != null && obj != Undefined.instance) {
+        } else if (obj != null && !Undefined.isUndefined(obj)) {
             return toObject(cx, scope, obj);
         }
         return null;
@@ -2430,13 +2430,13 @@ public class ScriptRuntime {
      */
     public static boolean loadFromIterable(
             Context cx, Scriptable scope, Object arg1, BiConsumer<Object, Object> setter) {
-        if ((arg1 == null) || Undefined.instance.equals(arg1)) {
+        if ((arg1 == null) || Undefined.isUndefined(arg1)) {
             return false;
         }
 
         // Call the "[Symbol.iterator]" property as a function.
         final Object ito = ScriptRuntime.callIterator(arg1, cx, scope);
-        if (Undefined.instance.equals(ito)) {
+        if (Undefined.isUndefined(ito)) {
             // Per spec, ignore if the iterator is undefined
             return false;
         }
@@ -2773,7 +2773,7 @@ public class ScriptRuntime {
     }
 
     static Object[] getApplyArguments(Context cx, Object arg1) {
-        if (arg1 == null || arg1 == Undefined.instance) {
+        if (arg1 == null || Undefined.isUndefined(arg1)) {
             return ScriptRuntime.emptyArgs;
         } else if (arg1 instanceof Scriptable && isArrayLike((Scriptable) arg1)) {
             return cx.getElements((Scriptable) arg1);
@@ -2873,7 +2873,7 @@ public class ScriptRuntime {
         if (value == null) {
             return false;
         }
-        if (Undefined.instance.equals(value)) {
+        if (Undefined.isUndefined(value)) {
             return false;
         }
         if (value instanceof ScriptableObject) {
@@ -3329,8 +3329,8 @@ public class ScriptRuntime {
      * <p>See ECMA 11.9
      */
     public static boolean eq(Object x, Object y) {
-        if (x == null || x == Undefined.instance) {
-            if (y == null || y == Undefined.instance) {
+        if (x == null || Undefined.isUndefined(x)) {
+            if (y == null || Undefined.isUndefined(y)) {
                 return true;
             }
             if (y instanceof ScriptableObject) {
@@ -3462,7 +3462,7 @@ public class ScriptRuntime {
 
     public static boolean isPrimitive(Object obj) {
         return obj == null
-                || obj == Undefined.instance
+                || Undefined.isUndefined(obj)
                 || (obj instanceof Number)
                 || (obj instanceof String)
                 || (obj instanceof Boolean);
@@ -3470,7 +3470,7 @@ public class ScriptRuntime {
 
     static boolean eqNumber(double x, Object y) {
         for (; ; ) {
-            if (y == null || y == Undefined.instance) {
+            if (y == null || Undefined.isUndefined(y)) {
                 return false;
             } else if (y instanceof BigInteger) {
                 return eqBigInt((BigInteger) y, x);
@@ -3500,7 +3500,7 @@ public class ScriptRuntime {
 
     static boolean eqBigInt(BigInteger x, Object y) {
         for (; ; ) {
-            if (y == null || y == Undefined.instance) {
+            if (y == null || Undefined.isUndefined(y)) {
                 return false;
             } else if (y instanceof BigInteger) {
                 return x.equals(y);
@@ -3551,7 +3551,7 @@ public class ScriptRuntime {
 
     private static boolean eqString(CharSequence x, Object y) {
         for (; ; ) {
-            if (y == null || y == Undefined.instance) {
+            if (y == null || Undefined.isUndefined(y)) {
                 return false;
             } else if (y instanceof CharSequence) {
                 CharSequence c = (CharSequence) y;

--- a/src/org/mozilla/javascript/Undefined.java
+++ b/src/org/mozilla/javascript/Undefined.java
@@ -27,6 +27,8 @@ public class Undefined implements Serializable {
      */
     public static final Object instance = new Undefined();
 
+    private static final int instanceHash = System.identityHashCode(instance);
+
     private Undefined() {}
 
     public Object readResolve() {
@@ -41,7 +43,7 @@ public class Undefined implements Serializable {
     @Override
     public int hashCode() {
         // All instances of Undefined are equivalent!
-        return System.identityHashCode(instance);
+        return instanceHash;
     }
 
     /**
@@ -132,7 +134,7 @@ public class Undefined implements Serializable {
 
                 @Override
                 public int hashCode() {
-                    return System.identityHashCode(instance);
+                    return instanceHash;
                 }
             };
 

--- a/src/org/mozilla/javascript/Undefined.java
+++ b/src/org/mozilla/javascript/Undefined.java
@@ -7,25 +7,29 @@
 package org.mozilla.javascript;
 
 import java.io.Serializable;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 
 /**
  * This class implements the Undefined value in JavaScript.
+ *
+ * <p>We represent "undefined" internally using two static objects -- "Undefined.instance" and
+ * SCRIPTABLE_UNDEFINED. Java code that needs to make something undefined should generally use the
+ * first, and use the second if a Scriptable object is absolutely required.
+ *
+ * <p>Java code that needs to test whether something is undefined <b>must</b> use the "isUndefined"
+ * method because of the multiple internal representations.
  */
-public class Undefined implements Serializable
-{
+public class Undefined implements Serializable {
     private static final long serialVersionUID = 9195680630202616767L;
 
+    /**
+     * This is the standard value for "undefined" in Rhino. Java code that needs to represent
+     * "undefined" should use this object (rather than a new instance of this class).
+     */
     public static final Object instance = new Undefined();
 
-    private Undefined()
-    {
-    }
+    private Undefined() {}
 
-    public Object readResolve()
-    {
+    public Object readResolve() {
         return instance;
     }
 
@@ -37,26 +41,106 @@ public class Undefined implements Serializable
     @Override
     public int hashCode() {
         // All instances of Undefined are equivalent!
-        return 0;
+        return System.identityHashCode(instance);
     }
 
-    public static final Scriptable SCRIPTABLE_UNDEFINED;
-
-    static {
-        SCRIPTABLE_UNDEFINED = (Scriptable) Proxy.newProxyInstance(Undefined.class.getClassLoader(), new Class[]{Scriptable.class}, new InvocationHandler() {
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) {
-                if (method.getName().equals("toString")) return "undefined";
-                if (method.getName().equals("equals")) {
-                    return Boolean.valueOf(args.length > 0 && isUndefined(args[0]));
+    /**
+     * An alternate representation of undefined, to be used only when we need to pass it to a method
+     * that takes as Scriptable as a parameter. This is used when we need to pass undefined as the
+     * "this" parmeter of a Callable instance, because we cannot change that interface without
+     * breaking backward compatibility.
+     */
+    public static final Scriptable SCRIPTABLE_UNDEFINED =
+            new Scriptable() {
+                @Override
+                public String getClassName() {
+                    return "undefined";
                 }
-                throw new UnsupportedOperationException("undefined doesn't support " + method.getName());
-            }
-        });
-    }
 
-    public static boolean isUndefined(Object obj)
-    {
+                @Override
+                public Object get(String name, Scriptable start) {
+                    return NOT_FOUND;
+                }
+
+                @Override
+                public Object get(int index, Scriptable start) {
+                    return NOT_FOUND;
+                }
+
+                @Override
+                public boolean has(String name, Scriptable start) {
+                    return false;
+                }
+
+                @Override
+                public boolean has(int index, Scriptable start) {
+                    return false;
+                }
+
+                @Override
+                public void put(String name, Scriptable start, Object value) {}
+
+                @Override
+                public void put(int index, Scriptable start, Object value) {}
+
+                @Override
+                public void delete(String name) {}
+
+                @Override
+                public void delete(int index) {}
+
+                @Override
+                public Scriptable getPrototype() {
+                    return null;
+                }
+
+                @Override
+                public void setPrototype(Scriptable prototype) {}
+
+                @Override
+                public Scriptable getParentScope() {
+                    return null;
+                }
+
+                @Override
+                public void setParentScope(Scriptable parent) {}
+
+                @Override
+                public Object[] getIds() {
+                    return ScriptRuntime.emptyArgs;
+                }
+
+                @Override
+                public Object getDefaultValue(Class<?> hint) {
+                    return null;
+                }
+
+                @Override
+                public boolean hasInstance(Scriptable instance) {
+                    return false;
+                }
+
+                @Override
+                public String toString() {
+                    return "undefined";
+                }
+
+                @Override
+                public boolean equals(Object obj) {
+                    return isUndefined(obj) || super.equals(obj);
+                }
+
+                @Override
+                public int hashCode() {
+                    return System.identityHashCode(instance);
+                }
+            };
+
+    /**
+     * Safely test whether "obj" is undefined. Java code must use this function rather than testing
+     * the value directly since we have two representations of undefined in Rhino.
+     */
+    public static boolean isUndefined(Object obj) {
         return Undefined.instance == obj || Undefined.SCRIPTABLE_UNDEFINED == obj;
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/UndefinedTest.java
+++ b/testsrc/org/mozilla/javascript/tests/UndefinedTest.java
@@ -1,0 +1,68 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.tools.shell.Global;
+
+public class UndefinedTest {
+    private Context cx;
+    private Scriptable global;
+
+    @Before
+    public void init() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        global = new Global(cx);
+    }
+
+    @After
+    public void close() {
+        cx.close();
+    }
+
+    @Test
+    public void testUndefinedInstances() {
+        // Ensure that our two internal representations of "undefined" are equivalent
+        assertEquals(Undefined.instance, Undefined.SCRIPTABLE_UNDEFINED);
+        assertEquals(Undefined.instance.hashCode(), Undefined.SCRIPTABLE_UNDEFINED.hashCode());
+        assertTrue(Undefined.isUndefined(Undefined.instance));
+        assertTrue(Undefined.isUndefined(Undefined.SCRIPTABLE_UNDEFINED));
+        assertFalse(Undefined.isUndefined(cx.newObject(global)));
+    }
+
+    @Test
+    public void testUndefinedThis() {
+        // Run a function that checks the value of "this"
+        final String testFuncSource =
+                "load('testsrc/assert.js');\n"
+                        + "function testFunc() {\n"
+                        + "assertSame(this, undefined);\n"
+                        + "}\n"
+                        + "testFunc;";
+        Callable testFunc =
+                (Callable) cx.evaluateString(global, testFuncSource, "test.js", 1, null);
+        // Ensure that using SCRIPTABLE_UNDEFINED means that "this" is really undefined
+        testFunc.call(cx, global, Undefined.SCRIPTABLE_UNDEFINED, ScriptRuntime.emptyArgs);
+    }
+
+    @Test
+    public void testInstanceOf() {
+        // These are specific instanceof checks used in the "kangax/compat-table" code
+        // that once failed because of a SCRIPTABLE_UNDEFINED implementation.
+        final String testSource =
+                "load('testsrc/assert.js');\n"
+                        + "let x = ({ __proto__ : [] } instanceof Array);\n"
+                        + "assertTrue(x);\n"
+                        + "let y = ({ __proto__ : null } instanceof Object);\n"
+                        + "assertFalse(y);";
+        cx.evaluateString(global, testSource, "test.js", 1, null);
+    }
+}

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -497,7 +497,7 @@ built-ins/eval 3/9 (33.33%)
     name.js
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
-built-ins/Function 199/505 (39.41%)
+built-ins/Function 197/505 (39.01%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -545,7 +545,6 @@ built-ins/Function 199/505 (39.41%)
     prototype/call/15.3.4.4-1-s.js strict
     prototype/call/15.3.4.4-2-s.js strict
     prototype/call/15.3.4.4-3-s.js strict
-    prototype/call/S15.3.4.4_A13.js
     prototype/call/S15.3.4.4_A14.js
     prototype/call/S15.3.4.4_A3_T1.js non-interpreted
     prototype/call/S15.3.4.4_A3_T2.js non-interpreted
@@ -632,7 +631,6 @@ built-ins/Function 199/505 (39.41%)
     prototype/toString/proxy-generator-function.js {unsupported: [Proxy]}
     prototype/toString/proxy-method-definition.js {unsupported: [Proxy]}
     prototype/toString/proxy-non-callable-throws.js {unsupported: [Proxy]}
-    prototype/toString/S15.3.4.2_A12.js
     prototype/toString/S15.3.4.2_A13.js
     prototype/toString/setter-class-expression.js
     prototype/toString/setter-class-expression-static.js
@@ -818,7 +816,7 @@ built-ins/Number 9/283 (3.18%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 155/3150 (4.92%)
+built-ins/Object 154/3150 (4.89%)
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
     assign/source-own-prop-error.js {unsupported: [Proxy]}
     assign/source-own-prop-keys-error.js {unsupported: [Proxy]}
@@ -946,7 +944,6 @@ built-ins/Object 155/3150 (4.92%)
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
-    prototype/toLocaleString/S15.2.4.3_A12.js
     prototype/toLocaleString/S15.2.4.3_A13.js
     prototype/toString/get-symbol-tag-err.js
     prototype/toString/proxy-array.js {unsupported: [Proxy]}


### PR DESCRIPTION
We introduced SCRIPTABLE_UNDEFINED a while back as an alternate representation
of "undefined" for passing as "this" to functions, as Rhino originally
couldn't do that.

However, the original implementation was as a Proxy object that threw
UnsupportedOperationException in some cases and which ended up causing
failures on the kangax/compat-table tests.

This makes SCRIPTABLE_UNDEFINED a real Scriptable and cleans up a few
other things as well.