### PR TITLE
Fix to exception handling of negative testcases

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -846,13 +846,13 @@ public class Test262SuiteTest {
         private final boolean hasEarlyError;
 
         private final Set<String> flags;
-        private final Set<String> harnessFiles;
+        private final List<String> harnessFiles;
         private final Set<String> features;
 
         Test262Case(
                 File file,
                 String source,
-                Set<String> harnessFiles,
+                List<String> harnessFiles,
                 String expectedError,
                 boolean hasEarlyError,
                 Set<String> flags,
@@ -880,7 +880,7 @@ public class Test262SuiteTest {
             String testSource =
                     (String) SourceReader.readFileOrUrl(testFile.getPath(), true, "UTF-8");
 
-            Set<String> harnessFiles = new HashSet<>();
+            List<String> harnessFiles = new ArrayList<>();
 
             Map<String, Object> metadata;
 
@@ -894,10 +894,6 @@ public class Test262SuiteTest {
                         "WARN: file '%s' doesnt contain /*--- ... ---*/ directive",
                         testFile.getPath());
                 metadata = new HashMap<String, Object>();
-            }
-
-            if (metadata.containsKey("includes")) {
-                harnessFiles.addAll((List<String>) metadata.get("includes"));
             }
 
             String expectedError = null;
@@ -918,14 +914,18 @@ public class Test262SuiteTest {
                 features.addAll((Collection<String>) metadata.get("features"));
             }
 
-            if (!flags.contains(FLAG_RAW)) {
-                // present by default harness files
-                harnessFiles.add("assert.js");
-                harnessFiles.add("sta.js");
-            } else if (!harnessFiles.isEmpty()) {
+            if (flags.contains(FLAG_RAW) && metadata.containsKey("includes")) {
                 System.err.format(
                         "WARN: case '%s' is flagged as 'raw' but also has defined includes%n",
                         testFile.getPath());
+            } else {
+                // present by default harness files
+                harnessFiles.add("assert.js");
+                harnessFiles.add("sta.js");
+
+                if (metadata.containsKey("includes")) {
+                    harnessFiles.addAll((List<String>) metadata.get("includes"));
+                }
             }
 
             return new Test262Case(

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -524,38 +524,49 @@ public class Test262SuiteTest {
                     tracker.passes(optLevel, useStrict);
                 }
             } catch (RhinoException ex) {
-                if (markedAsFailing) {
-                    return;
-                }
-
                 if (!testCase.isNegative()) {
+                    if (markedAsFailing) return;
+
                     fail(String.format("%s%n%s", ex.getMessage(), ex.getScriptStackTrace()));
                 }
 
                 String errorName = extractJSErrorName(ex);
 
                 if (testCase.hasEarlyError && !failedEarly) {
+                    if (markedAsFailing) return;
+
                     fail(
                             String.format(
                                     "Expected an early error: %s, got: %s in the runtime",
                                     testCase.expectedError, errorName));
                 }
 
-                assertEquals(ex.details(), testCase.expectedError, errorName);
+                try {
+                	assertEquals(ex.details(), testCase.expectedError, errorName);
+                } catch (AssertionError aex) {
+                    if (markedAsFailing) return;
+
+                    throw aex;
+                }
 
                 TestResultTracker tracker = RESULT_TRACKERS.get(testCase);
                 if (tracker != null) {
                     tracker.passes(optLevel, useStrict);
                 }
             } catch (Exception ex) {
-                if (markedAsFailing) {
-                    return;
-                }
+                // enable line below to print out stacktraces of unexpected exceptions
+                // disabled for now because too many exceptions are throw
+                // Unexpected non-Rhino-Exception here, so print the exception so it stands out
+                // ex.printStackTrace();
+
+                // Ignore the failed assertion if the test is marked as failing
+                if (markedAsFailing) return;
+
                 throw ex;
             } catch (AssertionError ex) {
-                if (markedAsFailing) {
-                    return;
-                }
+                // Ignore the failed assertion if the test is marked as failing
+                if (markedAsFailing) return;
+
                 throw ex;
             }
         } finally {

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -542,7 +542,7 @@ public class Test262SuiteTest {
                 }
 
                 try {
-                	assertEquals(ex.details(), testCase.expectedError, errorName);
+                    assertEquals(ex.details(), testCase.expectedError, errorName);
                 } catch (AssertionError aex) {
                     if (markedAsFailing) return;
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -2347,10 +2347,9 @@ language/arguments-object 191/260 (73.46%)
     gen-meth-args-trailing-comma-undefined.js
     meth-args-trailing-comma-spread-operator.js
 
-language/asi 1/102 (0.98%)
-    S7.9_A5.7_T1.js
+language/asi 0/102 (0.0%)
 
-language/block-scope 82/145 (56.55%)
+language/block-scope 68/145 (46.9%)
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -2383,39 +2382,28 @@ language/block-scope 82/145 (56.55%)
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-class.js
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-class.js
-    syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-class.js
-    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-class.js
-    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
@@ -2428,13 +2416,10 @@ language/block-scope 82/145 (56.55%)
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/var-redeclaration-attempt-after-class.js
-    syntax/redeclaration/var-redeclaration-attempt-after-const.js
     syntax/redeclaration/var-redeclaration-attempt-after-function.js
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
-    syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
-language/comments 37/52 (71.15%)
+language/comments 36/52 (69.23%)
     hashbang 29/29 (100.0%)
     mongolian-vowel-separator-multi.js {unsupported: [u180e]}
     mongolian-vowel-separator-single.js {unsupported: [u180e]}
@@ -2443,7 +2428,6 @@ language/comments 37/52 (71.15%)
     multi-line-asi-line-feed.js
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
-    multi-line-html-close-extra.js
 
 ~language/computed-property-names
 
@@ -2752,7 +2736,7 @@ language/expressions/addition 9/48 (18.75%)
     get-symbol-to-prim-err.js
     order-of-evaluation.js
 
-language/expressions/arrow-function 283/333 (84.98%)
+language/expressions/arrow-function 254/333 (76.28%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -2795,12 +2779,6 @@ language/expressions/arrow-function 283/333 (84.98%)
     dstr/ary-ptrn-rest-id-exhausted.js
     dstr/ary-ptrn-rest-id-iter-step-err.js
     dstr/ary-ptrn-rest-id-iter-val-err.js
-    dstr/ary-ptrn-rest-init-ary.js
-    dstr/ary-ptrn-rest-init-id.js
-    dstr/ary-ptrn-rest-init-obj.js
-    dstr/ary-ptrn-rest-not-final-ary.js
-    dstr/ary-ptrn-rest-not-final-id.js
-    dstr/ary-ptrn-rest-not-final-obj.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
@@ -2930,17 +2908,13 @@ language/expressions/arrow-function 283/333 (84.98%)
     dstr/syntax-error-ident-ref-const-escaped.js
     dstr/syntax-error-ident-ref-continue-escaped.js
     dstr/syntax-error-ident-ref-debugger-escaped.js
-    dstr/syntax-error-ident-ref-default.js
     dstr/syntax-error-ident-ref-default-escaped.js
-    dstr/syntax-error-ident-ref-default-escaped-ext.js
     dstr/syntax-error-ident-ref-delete-escaped.js
     dstr/syntax-error-ident-ref-do-escaped.js
     dstr/syntax-error-ident-ref-else-escaped.js
     dstr/syntax-error-ident-ref-enum-escaped.js
     dstr/syntax-error-ident-ref-export-escaped.js
-    dstr/syntax-error-ident-ref-extends.js
     dstr/syntax-error-ident-ref-extends-escaped.js
-    dstr/syntax-error-ident-ref-extends-escaped-ext.js
     dstr/syntax-error-ident-ref-finally-escaped.js
     dstr/syntax-error-ident-ref-for-escaped.js
     dstr/syntax-error-ident-ref-function-escaped.js
@@ -2968,7 +2942,13 @@ language/expressions/arrow-function 283/333 (84.98%)
     dstr/syntax-error-ident-ref-void-escaped.js
     dstr/syntax-error-ident-ref-while-escaped.js
     dstr/syntax-error-ident-ref-with-escaped.js
-    syntax/early-errors 25/25 (100.0%)
+    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
     syntax/arrowparameters-bindingidentifier-yield.js non-strict
     syntax/arrowparameters-cover-formalparameters-yield.js non-strict
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
@@ -3000,11 +2980,10 @@ language/expressions/arrow-function 283/333 (84.98%)
     param-dflt-yield-expr.js {unsupported: [default-parameters]}
     param-dflt-yield-id-non-strict.js {unsupported: [default-parameters]}
     param-dflt-yield-id-strict.js {unsupported: [default-parameters]}
-    params-duplicate.js
+    params-duplicate.js non-strict
     params-trailing-comma-multiple.js
     params-trailing-comma-single.js
     rest-param-strict-body.js {unsupported: [rest-parameters]}
-    rest-params-trailing-comma-early-error.js
     scope-body-lex-distinct.js non-strict
     scope-param-elem-var-close.js non-strict
     scope-param-elem-var-open.js non-strict
@@ -3108,7 +3087,7 @@ language/expressions/call 64/96 (66.67%)
 language/expressions/comma 1/6 (16.67%)
     tco-final.js {unsupported: [tail-call-optimization]}
 
-language/expressions/compound-assignment 99/406 (24.38%)
+language/expressions/compound-assignment 89/406 (21.92%)
     11.13.2-34-s.js strict
     11.13.2-35-s.js strict
     11.13.2-36-s.js strict
@@ -3123,12 +3102,8 @@ language/expressions/compound-assignment 99/406 (24.38%)
     11.13.2-6-1gs.js strict
     add-arguments-strict.js strict
     add-eval-strict.js strict
-    add-non-simple.js
     and-arguments-strict.js strict
     and-eval-strict.js strict
-    btws-and-non-simple.js
-    btws-or-non-simple.js
-    btws-xor-non-simple.js
     compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
     compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
     compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
@@ -3153,19 +3128,14 @@ language/expressions/compound-assignment 99/406 (24.38%)
     compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
     div-arguments-strict.js strict
     div-eval-strict.js strict
-    div-non-simple.js
-    left-shift-non-simple.js
     lshift-arguments-strict.js strict
     lshift-eval-strict.js strict
     mod-arguments-strict.js strict
-    mod-div-non-simple.js
     mod-eval-strict.js strict
     mult-arguments-strict.js strict
     mult-eval-strict.js strict
-    mult-non-simple.js
     or-arguments-strict.js strict
     or-eval-strict.js strict
-    right-shift-non-simple.js
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
     S11.13.2_A7.10_T4.js
@@ -3203,7 +3173,6 @@ language/expressions/compound-assignment 99/406 (24.38%)
     srshift-eval-strict.js strict
     sub-arguments-strict.js strict
     sub-eval-strict.js strict
-    subtract-non-simple.js
     urshift-arguments-strict.js strict
     urshift-eval-strict.js strict
     xor-arguments-strict.js strict
@@ -3244,7 +3213,7 @@ language/expressions/exponentiation 4/44 (9.09%)
     bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/function 212/248 (85.48%)
+language/expressions/function 206/248 (83.06%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3287,12 +3256,6 @@ language/expressions/function 212/248 (85.48%)
     dstr/ary-ptrn-rest-id-exhausted.js
     dstr/ary-ptrn-rest-id-iter-step-err.js
     dstr/ary-ptrn-rest-id-iter-val-err.js
-    dstr/ary-ptrn-rest-init-ary.js
-    dstr/ary-ptrn-rest-init-id.js
-    dstr/ary-ptrn-rest-init-obj.js
-    dstr/ary-ptrn-rest-not-final-ary.js
-    dstr/ary-ptrn-rest-not-final-id.js
-    dstr/ary-ptrn-rest-not-final-obj.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
@@ -4401,7 +4364,7 @@ language/expressions/object 971/1081 (89.82%)
     method-definition/async-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
     method-definition/async-super-call-body.js {unsupported: [async]}
     method-definition/async-super-call-param.js {unsupported: [async]}
-    method-definition/early-errors-object-method-duplicate-parameters.js
+    method-definition/early-errors-object-method-duplicate-parameters.js non-strict
     method-definition/escaped-get.js
     method-definition/escaped-get-e.js
     method-definition/escaped-get-g.js
@@ -4719,7 +4682,7 @@ language/expressions/object 971/1081 (89.82%)
     yield-non-strict-access.js non-strict
     yield-non-strict-syntax.js non-strict
 
-language/expressions/postfix-decrement 10/36 (27.78%)
+language/expressions/postfix-decrement 9/36 (25.0%)
     arguments.js strict
     eval.js strict
     operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
@@ -4728,10 +4691,9 @@ language/expressions/postfix-decrement 10/36 (27.78%)
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
     target-cover-newtarget.js {unsupported: [new.target]}
-    target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/postfix-increment 11/37 (29.73%)
+language/expressions/postfix-increment 10/37 (27.03%)
     11.3.1-2-1gs.js strict
     arguments.js strict
     eval.js strict
@@ -4741,10 +4703,9 @@ language/expressions/postfix-increment 11/37 (29.73%)
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
     target-cover-newtarget.js {unsupported: [new.target]}
-    target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-decrement 11/33 (33.33%)
+language/expressions/prefix-decrement 10/33 (30.3%)
     11.4.5-2-2gs.js strict
     arguments.js strict
     eval.js strict
@@ -4754,10 +4715,9 @@ language/expressions/prefix-decrement 11/33 (33.33%)
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
     target-cover-newtarget.js {unsupported: [new.target]}
-    target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-increment 10/32 (31.25%)
+language/expressions/prefix-increment 9/32 (28.13%)
     arguments.js strict
     eval.js strict
     operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
@@ -4766,7 +4726,6 @@ language/expressions/prefix-increment 10/32 (31.25%)
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
     target-cover-newtarget.js {unsupported: [new.target]}
-    target-cover-yieldexpr.js
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/property-accessors 0/21 (0.0%)
@@ -4802,8 +4761,7 @@ language/expressions/template-literal 2/57 (3.51%)
     mongolian-vowel-separator.js {unsupported: [u180e]}
     mongolian-vowel-separator-eval.js {unsupported: [u180e]}
 
-language/expressions/this 1/6 (16.67%)
-    S11.1.1_A1.js
+language/expressions/this 0/6 (0.0%)
 
 language/expressions/typeof 2/16 (12.5%)
     built-in-ordinary-objects-no-call.js
@@ -4956,21 +4914,18 @@ language/function-code 123/217 (56.68%)
 
 ~language/future-reserved-words
 
-language/global-code 34/41 (82.93%)
+language/global-code 30/41 (73.17%)
     block-decl-strict.js strict
     decl-lex.js
     decl-lex-configurable-global.js
     decl-lex-deletion.js non-strict
     decl-lex-restricted-global.js
-    export.js
-    import.js
     invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
     invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
     invalid-private-names-member-expression-bad-reference.js {unsupported: [class-fields-private]}
     invalid-private-names-member-expression-this.js {unsupported: [class-fields-private]}
     new.target.js {unsupported: [new.target]}
     new.target-arrow.js {unsupported: [new.target]}
-    return.js
     script-decl-func.js
     script-decl-func-dups.js
     script-decl-func-err-non-configurable.js
@@ -4990,11 +4945,10 @@ language/global-code 34/41 (82.93%)
     switch-case-decl-strict.js strict
     switch-dflt-decl-strict.js strict
     yield-non-strict.js non-strict
-    yield-strict.js strict
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 164/188 (87.23%)
+language/identifiers 91/188 (48.4%)
     other_id_continue.js
     other_id_start.js
     part-digits-via-escape-hex.js
@@ -5040,117 +4994,44 @@ language/identifiers 164/188 (87.23%)
     start-unicode-9.0.0-escaped.js
     start-zwj-escaped.js
     start-zwnj-escaped.js
-    val-break.js
-    val-break-via-escape-hex.js
     val-break-via-escape-hex4.js
-    val-case.js
-    val-case-via-escape-hex.js
     val-case-via-escape-hex4.js
-    val-catch.js
-    val-catch-via-escape-hex.js
     val-catch-via-escape-hex4.js
-    val-class.js
-    val-class-via-escape-hex.js
     val-class-via-escape-hex4.js
-    val-const.js
-    val-const-via-escape-hex.js
     val-const-via-escape-hex4.js
-    val-continue.js
-    val-continue-via-escape-hex.js
     val-continue-via-escape-hex4.js
-    val-debugger.js
-    val-debugger-via-escape-hex.js
     val-debugger-via-escape-hex4.js
-    val-default.js
-    val-default-via-escape-hex.js
     val-default-via-escape-hex4.js
-    val-delete.js
-    val-delete-via-escape-hex.js
     val-delete-via-escape-hex4.js
-    val-do.js
-    val-do-via-escape-hex.js
     val-do-via-escape-hex4.js
     val-dollar-sign-via-escape-hex.js
-    val-else.js
-    val-else-via-escape-hex.js
     val-else-via-escape-hex4.js
-    val-enum.js
-    val-enum-via-escape-hex.js
     val-enum-via-escape-hex4.js
-    val-export.js
-    val-export-via-escape-hex.js
     val-export-via-escape-hex4.js
-    val-extends.js
-    val-extends-via-escape-hex.js
     val-extends-via-escape-hex4.js
-    val-false.js
-    val-false-via-escape-hex.js
     val-false-via-escape-hex4.js
-    val-finally.js
-    val-finally-via-escape-hex.js
     val-finally-via-escape-hex4.js
-    val-for.js
-    val-for-via-escape-hex.js
     val-for-via-escape-hex4.js
-    val-function.js
-    val-function-via-escape-hex.js
     val-function-via-escape-hex4.js
-    val-if.js
-    val-if-via-escape-hex.js
     val-if-via-escape-hex4.js
-    val-import.js
-    val-import-via-escape-hex.js
     val-import-via-escape-hex4.js
-    val-in.js
-    val-in-via-escape-hex.js
     val-in-via-escape-hex4.js
-    val-instanceof.js
-    val-instanceof-via-escape-hex.js
     val-instanceof-via-escape-hex4.js
-    val-new.js
-    val-new-via-escape-hex.js
     val-new-via-escape-hex4.js
-    val-null.js
-    val-null-via-escape-hex.js
     val-null-via-escape-hex4.js
-    val-return.js
-    val-return-via-escape-hex.js
     val-return-via-escape-hex4.js
-    val-super.js
-    val-super-via-escape-hex.js
     val-super-via-escape-hex4.js
-    val-switch.js
-    val-switch-via-escape-hex.js
     val-switch-via-escape-hex4.js
-    val-this.js
-    val-this-via-escape-hex.js
     val-this-via-escape-hex4.js
-    val-throw.js
-    val-throw-via-escape-hex.js
     val-throw-via-escape-hex4.js
-    val-true.js
-    val-true-via-escape-hex.js
     val-true-via-escape-hex4.js
-    val-try.js
-    val-try-via-escape-hex.js
     val-try-via-escape-hex4.js
-    val-typeof.js
-    val-typeof-via-escape-hex.js
     val-typeof-via-escape-hex4.js
     val-underscore-via-escape-hex.js
-    val-var.js
-    val-var-via-escape-hex.js
     val-var-via-escape-hex4.js
-    val-void.js
-    val-void-via-escape-hex.js
     val-void-via-escape-hex4.js
-    val-while.js
-    val-while-via-escape-hex.js
     val-while-via-escape-hex4.js
-    val-with.js
-    val-with-via-escape-hex.js
     val-with-via-escape-hex4.js
-    val-yield-strict.js strict
     vals-eng-alpha-lower-via-escape-hex.js
     vals-eng-alpha-upper-via-escape-hex.js
     vals-rus-alpha-lower-via-escape-hex.js
@@ -5170,21 +5051,20 @@ language/line-terminators 4/41 (9.76%)
     S7.3_A6_T3.js
     S7.3_A6_T4.js
 
-language/literals 113/434 (26.04%)
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
-    bigint/legacy-octal-like-invalid-00n.js
-    bigint/legacy-octal-like-invalid-01n.js
-    bigint/legacy-octal-like-invalid-07n.js
-    bigint/non-octal-like-invalid-0008n.js
-    bigint/non-octal-like-invalid-012348n.js
-    bigint/non-octal-like-invalid-08n.js
-    bigint/non-octal-like-invalid-09n.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
+language/literals 108/434 (24.88%)
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
+    bigint/legacy-octal-like-invalid-00n.js non-strict
+    bigint/legacy-octal-like-invalid-01n.js non-strict
+    bigint/legacy-octal-like-invalid-07n.js non-strict
+    bigint/non-octal-like-invalid-0008n.js non-strict
+    bigint/non-octal-like-invalid-012348n.js non-strict
+    bigint/non-octal-like-invalid-08n.js non-strict
+    bigint/non-octal-like-invalid-09n.js non-strict
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     numeric/numeric-followed-by-ident.js
     regexp/named-groups 56/56 (100.0%)
-    regexp/early-err-pattern.js Weird case of SyntaxError thrown at the script execution ('runtime'), not on compilation ('early'), but only for opt levels >= 0
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
     regexp/invalid-braced-quantifier-range.js
@@ -5192,12 +5072,8 @@ language/literals 113/434 (26.04%)
     regexp/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     regexp/S7.8.5_A1.1_T2.js
     regexp/S7.8.5_A1.4_T2.js
-    regexp/S7.8.5_A1.5_T1.js
-    regexp/S7.8.5_A1.5_T3.js
     regexp/S7.8.5_A2.1_T2.js
     regexp/S7.8.5_A2.4_T2.js
-    regexp/S7.8.5_A2.5_T1.js
-    regexp/S7.8.5_A2.5_T3.js
     regexp/u-astral.js
     regexp/u-astral-char-class-invert.js
     regexp/u-case-mapping.js
@@ -5574,7 +5450,7 @@ language/statements/for-in 44/114 (38.6%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 475/725 (65.52%)
+language/statements/for-of 472/725 (65.1%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -5587,7 +5463,6 @@ language/statements/for-of 475/725 (65.52%)
     dstr/array-elem-init-order.js
     dstr/array-elem-init-simple-no-strict.js non-strict
     dstr/array-elem-init-yield-expr.js
-    dstr/array-elem-init-yield-ident-invalid.js strict
     dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
@@ -5601,9 +5476,7 @@ language/statements/for-of 475/725 (65.52%)
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
     dstr/array-elem-nested-array-yield-ident-valid.js non-strict
-    dstr/array-elem-nested-obj-invalid.js
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-invalid.js strict
     dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
     dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
@@ -6278,9 +6151,7 @@ language/statements/generators 225/259 (86.87%)
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/types 13/113 (11.5%)
-    boolean/S8.3_A2.1.js
-    boolean/S8.3_A2.2.js
+language/types 9/113 (7.96%)
     number/S8.5_A10_T1.js
     number/S8.5_A10_T2.js non-strict
     number/S8.5_A4_T1.js
@@ -6288,8 +6159,6 @@ language/types 13/113 (11.5%)
     reference/get-value-prop-base-primitive-realm.js {unsupported: [cross-realm]}
     reference/put-value-prop-base-primitive.js {unsupported: [Proxy]}
     reference/put-value-prop-base-primitive-realm.js {unsupported: [Proxy, cross-realm]}
-    reference/S8.7.2_A1_T1.js
-    reference/S8.7.2_A1_T2.js
     undefined/S8.1_A3_T1.js
     undefined/S8.1_A3_T2.js non-strict
 


### PR DESCRIPTION
If negative testcases were marked as failing in test262.properties, they would not get reported when they stopped failing (and also not removed from test262.properties when running with -DupdateTest262properties

Note: on line 560 of Test262SuiteTest the printing of unexpected exceptions is commented out (for now) as there are a ton of them, mostly related to the harness utilizing Es features like default param values or unicode regexes that we don't support yet.

There are however also a bunch related to bugs in the Rhino codebase, resulting in nullPointers

Note that some testcases now reported as passing, as doing so for the wrong reasons: for example `language/block-scope/syntax/redeclaration/fn-scopes-var-name-redeclaration-attempt-with-const` now passes as a SyntaxError is thrown, but that error is thrown because we don't support `class`, not necessarily because we properly wouldn't allow redeclaration. But I think this is fine