### PR TITLE
Fix some NPEs in tests

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -1149,7 +1149,7 @@ class CodeGenerator extends Icode {
             }
         } else if (type == Token.OBJECTLIT) {
             propertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
-            count = propertyIds.length;
+            count = propertyIds == null ? 0 : propertyIds.length;
         } else {
             throw badTree(node);
         }

--- a/src/org/mozilla/javascript/NativeSymbol.java
+++ b/src/org/mozilla/javascript/NativeSymbol.java
@@ -197,18 +197,18 @@ public class NativeSymbol extends IdScriptableObject implements Symbol {
                 return construct(cx, scope, args);
 
             case Id_toString:
-                return getSelf(thisObj).toString();
+                return getSelf(cx, scope, thisObj).toString();
             case Id_valueOf:
             case SymbolId_toPrimitive:
-                return getSelf(thisObj).js_valueOf();
+                return getSelf(cx, scope, thisObj).js_valueOf();
             default:
                 return super.execIdCall(f, cx, scope, thisObj, args);
         }
     }
 
-    private static NativeSymbol getSelf(Object thisObj) {
+    private static NativeSymbol getSelf(Context cx, Scriptable scope, Object thisObj) {
         try {
-            return (NativeSymbol) thisObj;
+            return (NativeSymbol) ScriptRuntime.toObject(cx, scope, thisObj);
         } catch (ClassCastException cce) {
             throw ScriptRuntime.typeErrorById("msg.invalid.type", thisObj.getClass().getName());
         }

--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -223,7 +223,11 @@ public class Parser {
     }
 
     void addError(String messageId, String messageArg) {
-        addError(messageId, messageArg, ts.tokenBeg, ts.tokenEnd - ts.tokenBeg);
+        if (ts == null) {
+            addError(messageId, messageArg, 0, 0);
+        } else {
+            addError(messageId, messageArg, ts.tokenBeg, ts.tokenEnd - ts.tokenBeg);
+        }
     }
 
     void addError(String messageId, int c) {

--- a/src/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/src/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -2110,7 +2110,7 @@ class BodyCodegen {
 
     private void visitObjectLiteral(Node node, Node child, boolean topLevel) {
         Object[] properties = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
-        int count = properties.length;
+        int count = properties == null ? 0 : properties.length;
 
         // If code budget is tight swap out literals into separate method
         if (!topLevel

--- a/src/org/mozilla/javascript/optimizer/OptTransformer.java
+++ b/src/org/mozilla/javascript/optimizer/OptTransformer.java
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 package org.mozilla.javascript.optimizer;
 
 import java.util.Map;
-
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.NodeTransformer;
@@ -20,11 +18,9 @@ import org.mozilla.javascript.ast.ScriptNode;
  * @see NodeTransformer
  * @author Norris Boyd
  */
-
 class OptTransformer extends NodeTransformer {
 
-    OptTransformer(Map<String,OptFunctionNode> possibleDirectCalls, ObjArray directCallTargets)
-    {
+    OptTransformer(Map<String, OptFunctionNode> possibleDirectCalls, ObjArray directCallTargets) {
         this.possibleDirectCalls = possibleDirectCalls;
         this.directCallTargets = directCallTargets;
     }
@@ -41,17 +37,18 @@ class OptTransformer extends NodeTransformer {
         super.visitCall(node, tree);
     }
 
-    private void detectDirectCall(Node node, ScriptNode tree)
-    {
+    private void detectDirectCall(Node node, ScriptNode tree) {
         if (tree.getType() == Token.FUNCTION) {
             Node left = node.getFirstChild();
 
             // count the arguments
             int argCount = 0;
-            Node arg = left.getNext();
-            while (arg != null) {
-                arg = arg.getNext();
-                argCount++;
+            if (left != null) {
+                Node arg = left.getNext();
+                while (arg != null) {
+                    arg = arg.getNext();
+                    argCount++;
+                }
             }
 
             if (argCount == 0) {
@@ -83,9 +80,8 @@ class OptTransformer extends NodeTransformer {
                     OptFunctionNode ofn;
                     ofn = possibleDirectCalls.get(targetName);
                     if (ofn != null
-                        && argCount == ofn.fnode.getParamCount()
-                        && !ofn.fnode.requiresActivation())
-                    {
+                            && argCount == ofn.fnode.getParamCount()
+                            && !ofn.fnode.requiresActivation()) {
                         // Refuse to directCall any function with more
                         // than 32 parameters - prevent code explosion
                         // for wacky test cases
@@ -103,6 +99,6 @@ class OptTransformer extends NodeTransformer {
         }
     }
 
-    private Map<String,OptFunctionNode> possibleDirectCalls;
+    private Map<String, OptFunctionNode> possibleDirectCalls;
     private ObjArray directCallTargets;
 }

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1309,7 +1309,7 @@ built-ins/String 121/1114 (10.86%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 32/85 (37.65%)
+built-ins/Symbol 30/85 (35.29%)
     asyncIterator 2/2 (100.0%)
     for/cross-realm.js {unsupported: [cross-realm]}
     hasInstance/cross-realm.js {unsupported: [cross-realm]}
@@ -1327,8 +1327,6 @@ built-ins/Symbol 32/85 (37.65%)
     prototype/description/wrapper.js
     prototype/Symbol.toPrimitive/name.js
     prototype/Symbol.toPrimitive/prop-desc.js
-    prototype/Symbol.toPrimitive/this-val-non-obj.js
-    prototype/valueOf/this-val-non-obj.js
     replace/cross-realm.js {unsupported: [cross-realm]}
     search/cross-realm.js {unsupported: [cross-realm]}
     species 4/4 (100.0%)
@@ -5404,7 +5402,7 @@ language/statements/for 263/384 (68.49%)
     tco-lhs-body.js {unsupported: [tail-call-optimization]}
     tco-var-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/for-in 44/114 (38.6%)
+language/statements/for-in 43/114 (37.72%)
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
@@ -5422,7 +5420,6 @@ language/statements/for-in 44/114 (38.6%)
     decl-gen.js
     head-const-bound-names-fordecl-tdz.js
     head-const-fresh-binding-per-iteration.js
-    head-let-bound-names-dup.js
     head-let-bound-names-fordecl-tdz.js
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
@@ -5450,7 +5447,7 @@ language/statements/for-in 44/114 (38.6%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 472/725 (65.1%)
+language/statements/for-of 471/725 (64.97%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -5891,7 +5888,6 @@ language/statements/for-of 472/725 (65.1%)
     head-const-fresh-binding-per-iteration.js
     head-decl-no-expr.js
     head-expr-no-expr.js
-    head-let-bound-names-dup.js
     head-let-bound-names-fordecl-tdz.js
     head-let-bound-names-in-stmt.js
     head-let-fresh-binding-per-iteration.js


### PR DESCRIPTION
Mostly these are fixed in easy ways. The Symbol class is also changed
to more properly test the type of "this" and throw a more appropriate
error.

Fixes the following (although it does not necessarily make all the Test262 tests pass):

Closes https://github.com/mozilla/rhino/issues/986
Closes https://github.com/mozilla/rhino/issues/985
Closes https://github.com/mozilla/rhino/issues/984
Closes https://github.com/mozilla/rhino/issues/983

I realize that this is an easy fix but since I was working on a similar PR I wanted to make sure that this was not related.