### PR TITLE
Consstring optimization

### DIFF
--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -327,14 +327,14 @@ public class FunctionObject extends BaseFunction {
         boolean checkMethodResult = false;
         int argsLength = args.length;
 
-        for (int i = 0; i < argsLength; i++) {
-            // flatten cons-strings before passing them as arguments
-            if (args[i] instanceof ConsString) {
-                args[i] = args[i].toString();
-            }
-        }
-
         if (parmsLength < 0) {
+            for (int i = 0; i < argsLength; i++) {
+                // flatten cons-strings before passing them as arguments
+                if (args[i] instanceof ConsString) {
+                    args[i] = args[i].toString();
+                }
+            }
+
             if (parmsLength == VARARGS_METHOD) {
                 Object[] invokeArgs = {cx, thisObj, args, this};
                 result = member.invoke(null, invokeArgs);

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -180,6 +180,7 @@ public class FunctionObject extends BaseFunction {
             case JAVA_SCRIPTABLE_TYPE:
                 return ScriptRuntime.toObjectOrNull(cx, arg, scope);
             case JAVA_OBJECT_TYPE:
+                if (arg instanceof ConsString) return arg.toString();
                 return arg;
             default:
                 throw new IllegalArgumentException();

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -2911,7 +2911,7 @@ public class ScriptRuntime {
         if (val1 instanceof CharSequence && val2 instanceof CharSequence) {
             // If we let this happen later, then the "getDefaultValue" logic
             // undoes many optimizations
-            return new ConsString(toCharSequence(val1), toCharSequence(val2));
+            return new ConsString((CharSequence) val1, (CharSequence) val2);
         }
         if (val1 instanceof XMLObject) {
             Object test = ((XMLObject) val1).addValues(cx, true, val2);
@@ -4692,8 +4692,6 @@ public class ScriptRuntime {
 
     public static Scriptable getTemplateLiteralCallSite(
             Context cx, Scriptable scope, Object[] strings, int index) {
-        final int INTEGRITY_FREEZE = ScriptableObject.PERMANENT | ScriptableObject.READONLY;
-
         Object callsite = strings[index];
 
         if (callsite instanceof Scriptable) return (Scriptable) callsite;

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -569,13 +569,13 @@ public abstract class ScriptableObject
         // Emulate old behavior where nothing happened if it wasn't actually a Function
         if (isSetter) {
             if (getterOrSetter instanceof Function) {
-                aSlot.setter = new AccessorSlot.FunctionSetter((Function) getterOrSetter);
+                aSlot.setter = new AccessorSlot.FunctionSetter(getterOrSetter);
             } else {
                 aSlot.setter = null;
             }
         } else {
             if (getterOrSetter instanceof Function) {
-                aSlot.getter = new AccessorSlot.FunctionGetter((Function) getterOrSetter);
+                aSlot.getter = new AccessorSlot.FunctionGetter(getterOrSetter);
             } else {
                 aSlot.getter = null;
             }

--- a/testsrc/org/mozilla/javascript/tests/ConsStringTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ConsStringTest.java
@@ -1,8 +1,11 @@
 package org.mozilla.javascript.tests;
 
-import org.mozilla.javascript.ConsString;
-
+import java.lang.reflect.Method;
 import junit.framework.TestCase;
+import org.mozilla.javascript.ConsString;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.annotations.JSFunction;
 
 public class ConsStringTest extends TestCase {
 
@@ -22,7 +25,7 @@ public class ConsStringTest extends TestCase {
 
     public void testAppendManyStrings() {
         ConsString current = new ConsString("a", "a");
-        for(int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 1000000; i++) {
             current = new ConsString(current, "a");
         }
         assertNotNull(current.toString());
@@ -35,12 +38,73 @@ public class ConsStringTest extends TestCase {
     private void recurseAndAppend(int depth) {
         if (depth == 0) {
             ConsString current = new ConsString("a", "a");
-            for(int i = 0; i < 1000000; i++) {
+            for (int i = 0; i < 1000000; i++) {
                 current = new ConsString(current, "a");
             }
             assertNotNull(current.toString());
         } else {
-            recurseAndAppend(depth-1);
+            recurseAndAppend(depth - 1);
+        }
+    }
+
+    public void testDoNotLeakConsStringIntoSetter() throws Exception {
+        Context cx = Context.enter();
+        try {
+            final ScriptableObject topScope = cx.initStandardObjects();
+            final MyHostObject myHostObject = new MyHostObject();
+
+            // define custom getter method
+            final Method getter = MyHostObject.class.getMethod("getFoo");
+            final Method setter = MyHostObject.class.getMethod("setFoo", Object.class);
+            myHostObject.defineProperty("foo", null, getter, setter, ScriptableObject.EMPTY);
+            topScope.put("MyHostObject", topScope, myHostObject);
+
+            final String script =
+                    "var a = 'Rhino';\n" + "MyHostObject.foo = '#' + a;\n" + "MyHostObject.foo;";
+
+            final String result = (String) cx.evaluateString(topScope, script, "myScript", 1, null);
+
+            assertEquals("java.lang.String", result);
+        } finally {
+            Context.exit();
+        }
+    }
+
+    public void testDoNotLeakConsStringIntoFunction() throws Exception {
+        Context cx = Context.enter();
+        try {
+            final ScriptableObject topScope = cx.initStandardObjects();
+            ScriptableObject.defineClass(topScope, MyHostObject.class);
+
+            final String script = "var a = 'Rhino'; new MyHostObject().test('#' + a);";
+            final String result = (String) cx.evaluateString(topScope, script, "myScript", 1, null);
+
+            assertEquals("java.lang.String", result);
+        } finally {
+            Context.exit();
+        }
+    }
+
+    public static class MyHostObject extends ScriptableObject {
+
+        private String foo;
+
+        @Override
+        public String getClassName() {
+            return "MyHostObject";
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(Object foo) {
+            this.foo = foo.getClass().getName();
+        }
+
+        @JSFunction
+        public String test(Object obj) {
+            return obj.getClass().getName();
         }
     }
 }


### PR DESCRIPTION
Two minor optimizations
* there is no need to call a method because a simple cast is sufficient here
* the second one is more complex, in the else case we already have a parameter conversion loop that also flattens the ConsStrings. Because of this we do not need to run the loop for this branch

Have done the usual test with my HtmlUnit test suite a found no notable performance change. But reducing i think we have to do this to reduce the load a bit.