### PR TITLE
Add setTimeout and clearTimeout to Rhino shell

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -17,30 +17,17 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-import org.mozilla.javascript.drivers.JsTestsBase;
-import org.mozilla.javascript.drivers.ShellTest;
-import org.mozilla.javascript.drivers.TestUtils;
-import org.mozilla.javascript.tools.shell.ShellContextFactory;
-
 /**
- * This JUnit suite runs the Mozilla test suite (in mozilla.org CVS
- * at /mozilla/js/tests).
+ * This JUnit suite runs the Mozilla test suite (in mozilla.org CVS at /mozilla/js/tests).
  *
- * Not all tests in the suite are run. Since the mozilla.org tests are
- * designed and maintained for the SpiderMonkey engine, tests in the
- * suite may not pass due to feature set differences and known bugs.
- * To make sure that this unit test is stable in the midst of changes
- * to the mozilla.org suite, we maintain a list of passing tests in
- * files opt-1.tests, opt0.tests, and opt9.tests. This class also
- * implements the ability to run skipped tests, see if any pass, and
- * print out a script to modify the *.tests files.
- * (This approach doesn't handle breaking changes to existing passing
+ * <p>Not all tests in the suite are run. Since the mozilla.org tests are designed and maintained
+ * for the SpiderMonkey engine, tests in the suite may not pass due to feature set differences and
+ * known bugs. To make sure that this unit test is stable in the midst of changes to the mozilla.org
+ * suite, we maintain a list of passing tests in files opt-1.tests, opt0.tests, and opt9.tests. This
+ * class also implements the ability to run skipped tests, see if any pass, and print out a script
+ * to modify the *.tests files. (This approach doesn't handle breaking changes to existing passing
  * tests, but in practice that has been very rare.)
+ *
  * @author Norris Boyd
  * @author Attila Szegedi
  */
@@ -55,9 +42,9 @@ public class MozillaSuiteTest {
         // Reduce the number of tests that we run by a factor of three...
         String overriddenLevel = System.getProperty("TEST_OPTLEVEL");
         if (overriddenLevel != null) {
-            OPT_LEVELS = new int[]{Integer.parseInt(overriddenLevel)};
+            OPT_LEVELS = new int[] {Integer.parseInt(overriddenLevel)};
         } else {
-            OPT_LEVELS = new int[]{-1, 0, 9};
+            OPT_LEVELS = new int[] {-1, 0, 9};
         }
     }
 
@@ -81,8 +68,9 @@ public class MozillaSuiteTest {
             } else {
                 int jsIndex = path.lastIndexOf("/js");
                 if (jsIndex == -1) {
-                    throw new IllegalStateException("You aren't running the tests "+
-                        "from within the standard mozilla/js directory structure");
+                    throw new IllegalStateException(
+                            "You aren't running the tests "
+                                    + "from within the standard mozilla/js directory structure");
                 }
                 path = path.substring(0, jsIndex + 3).replace('/', File.separatorChar);
                 path = path.replace("%20", " ");
@@ -101,11 +89,11 @@ public class MozillaSuiteTest {
 
     public static File[] getTestFiles(int optimizationLevel) throws IOException {
         File testDir = getTestDir();
-        String[] tests = TestUtils.loadTestsFromResource(
-            "/" + getTestFilename(optimizationLevel), null);
+        String[] tests =
+                TestUtils.loadTestsFromResource("/" + getTestFilename(optimizationLevel), null);
         Arrays.sort(tests);
         File[] files = new File[tests.length];
-        for (int i=0; i < files.length; i++) {
+        for (int i = 0; i < files.length; i++) {
             files[i] = new File(testDir, tests[i]);
         }
         return files;
@@ -122,17 +110,17 @@ public class MozillaSuiteTest {
     public static Collection<Object[]> mozillaSuiteValues() throws IOException {
         List<Object[]> result = new ArrayList<Object[]>();
         int[] optLevels = OPT_LEVELS;
-        for (int i=0; i < optLevels.length; i++) {
+        for (int i = 0; i < optLevels.length; i++) {
             File[] tests = getTestFiles(optLevels[i]);
             for (File f : tests) {
-                result.add(new Object[] { f, optLevels[i] });
+                result.add(new Object[] {f, optLevels[i]});
             }
         }
         return result;
     }
 
     // move "@Parameters" to this method to test a single Mozilla test
-//    @Parameters(name = "{index}, js={0}, opt={1}")
+    //    @Parameters(name = "{index}, js={0}, opt={1}")
     public static Collection<Object[]> singleDoctest() throws IOException {
         final String SINGLE_TEST_FILE = "...";
         final int[] SINGLE_TEST_OPTIMIZATION_LEVEL = OPT_LEVELS;
@@ -140,7 +128,7 @@ public class MozillaSuiteTest {
         List<Object[]> result = new ArrayList<Object[]>();
         for (int optLevel : SINGLE_TEST_OPTIMIZATION_LEVEL) {
             File f = new File(getTestDir(), SINGLE_TEST_FILE);
-            result.add(new Object[] { f, optLevel });
+            result.add(new Object[] {f, optLevel});
         }
         return result;
     }
@@ -149,8 +137,7 @@ public class MozillaSuiteTest {
         @Override
         public int getTimeoutMilliseconds() {
             if (System.getProperty("mozilla.js.tests.timeout") != null) {
-                return Integer.parseInt(System.getProperty(
-                    "mozilla.js.tests.timeout"));
+                return Integer.parseInt(System.getProperty("mozilla.js.tests.timeout"));
             }
             return 10000;
         }
@@ -169,8 +156,7 @@ public class MozillaSuiteTest {
         public final void failed(String s) {
             // Include test source in message, this is the only way
             // to locate the test in a Parameterized JUnit test
-            String msg = "In \"" + file + "\":" +
-                         System.getProperty("line.separator") + s;
+            String msg = "In \"" + file + "\":" + System.getProperty("line.separator") + s;
             System.out.println(msg);
             Assert.fail(msg);
         }
@@ -199,45 +185,45 @@ public class MozillaSuiteTest {
 
     @Test
     public void runMozillaTest() throws Exception {
-        //System.out.println("Test \"" + jsFile + "\" running under optimization level " + optimizationLevel);
-        final ShellContextFactory shellContextFactory =
-            new ShellContextFactory();
+        // System.out.println("Test \"" + jsFile + "\" running under optimization level " +
+        // optimizationLevel);
+        final ShellContextFactory shellContextFactory = new ShellContextFactory();
         shellContextFactory.setOptimizationLevel(optimizationLevel);
         ShellTestParameters params = new ShellTestParameters();
         JunitStatus status = new JunitStatus();
         ShellTest.runNoFork(shellContextFactory, jsFile, params, status);
     }
 
-
     /**
-     * The main class will run all the test files that are *not* covered in
-     * the *.tests files, and print out a list of all the tests that pass.
+     * The main class will run all the test files that are *not* covered in the *.tests files, and
+     * print out a list of all the tests that pass.
      */
     public static void main(String[] args) throws IOException {
         PrintStream out = new PrintStream("fix-tests-files.sh");
         try {
-            for (int i=0; i < OPT_LEVELS.length; i++) {
+            for (int i = 0; i < OPT_LEVELS.length; i++) {
                 int optLevel = OPT_LEVELS[i];
                 File testDir = getTestDir();
                 File[] allTests =
-                    TestUtils.recursiveListFiles(testDir,
-                        new FileFilter() {
-                            public boolean accept(File pathname)
-                            {
-                                return ShellTest.DIRECTORY_FILTER.accept(pathname) ||
-                                       ShellTest.TEST_FILTER.accept(pathname);
-                            }
-                    });
+                        TestUtils.recursiveListFiles(
+                                testDir,
+                                new FileFilter() {
+                                    public boolean accept(File pathname) {
+                                        return ShellTest.DIRECTORY_FILTER.accept(pathname)
+                                                || ShellTest.TEST_FILTER.accept(pathname);
+                                    }
+                                });
                 HashSet<File> diff = new HashSet<File>(Arrays.asList(allTests));
                 File testFiles[] = getTestFiles(optLevel);
                 diff.removeAll(Arrays.asList(testFiles));
                 ArrayList<String> skippedPassed = new ArrayList<String>();
                 int absolutePathLength = testDir.getAbsolutePath().length() + 1;
-                for (File testFile: diff) {
+                for (File testFile : diff) {
                     try {
                         (new MozillaSuiteTest(testFile, optLevel)).runMozillaTest();
                         // strip off testDir
-                        String canonicalized = testFile.getAbsolutePath().substring(absolutePathLength);
+                        String canonicalized =
+                                testFile.getAbsolutePath().substring(absolutePathLength);
                         canonicalized = canonicalized.replace('\\', '/');
                         skippedPassed.add(canonicalized);
                     } catch (Throwable t) {
@@ -251,7 +237,7 @@ public class MozillaSuiteTest {
                     out.println("cat >> " + getTestFilename(optLevel) + " <<EOF");
                     String[] sorted = skippedPassed.toArray(new String[0]);
                     Arrays.sort(sorted);
-                    for (int j=0; j < sorted.length; j++) {
+                    for (int j = 0; j < sorted.length; j++) {
                         out.println(sorted[j]);
                     }
                     out.println("EOF");

--- a/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -16,6 +16,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mozilla.javascript.drivers.JsTestsBase;
+import org.mozilla.javascript.drivers.ShellTest;
+import org.mozilla.javascript.drivers.TestUtils;
+import org.mozilla.javascript.tools.shell.ShellContextFactory;
 
 /**
  * This JUnit suite runs the Mozilla test suite (in mozilla.org CVS at /mozilla/js/tests).
@@ -36,17 +45,7 @@ public class MozillaSuiteTest {
     private final File jsFile;
     private final int optimizationLevel;
 
-    private static final int[] OPT_LEVELS;
-
-    static {
-        // Reduce the number of tests that we run by a factor of three...
-        String overriddenLevel = System.getProperty("TEST_OPTLEVEL");
-        if (overriddenLevel != null) {
-            OPT_LEVELS = new int[] {Integer.parseInt(overriddenLevel)};
-        } else {
-            OPT_LEVELS = new int[] {-1, 0, 9};
-        }
-    }
+    private static final int[] OPT_LEVELS = Utils.getTestOptLevels();
 
     public MozillaSuiteTest(File jsFile, int optimizationLevel) {
         this.jsFile = jsFile;

--- a/testsrc/org/mozilla/javascript/tests/ShellTimerTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ShellTimerTest.java
@@ -1,0 +1,134 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.tools.shell.Global;
+import org.mozilla.javascript.tools.shell.Timers;
+
+/** Test the setTimeout and clearTimeout functions added to the shell. */
+@RunWith(Parameterized.class)
+public class ShellTimerTest {
+    final int optLevel;
+    private Context cx;
+    private Scriptable global;
+    private final Timers timers = new Timers();
+
+    public ShellTimerTest(int optLevel) {
+        this.optLevel = optLevel;
+    }
+
+    @Before
+    public void init() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        global = new Global(cx);
+        timers.install(global);
+        global.put("TestsComplete", global, false);
+    }
+
+    @After
+    public void cleanup() {
+        cx.close();
+    }
+
+    @Parameters(name = "{index}, opt={0}")
+    public static Collection<Object[]> optLevels() {
+        return Arrays.asList(new Object[] {-1}, new Object[] {1}, new Object[] {9});
+    }
+
+    /** Just make sure that a timeout fires. */
+    @Test
+    public void setImmediateTimeout() throws InterruptedException {
+        runTest("setTimeout(() => { TestsComplete = true; });");
+    }
+
+    /** Ensure that parameters work. */
+    @Test
+    public void checkTimeoutParameters() throws InterruptedException {
+        runTest(
+                "load('testsrc/assert.js');\n"
+                        + "setTimeout((a, b) => { \n"
+                        + "assertTrue(this != null);\n"
+                        + "assertTrue(this != undefined);\n"
+                        + "assertEquals('one', a);\n"
+                        + "assertEquals(2, b);\n"
+                        + "TestsComplete = true; }, 0, 'one', 2);");
+    }
+
+    /** Ensure that invalid stuff doesn't happen. */
+    @Test
+    public void checkTypeChecks() throws InterruptedException {
+        runTest(
+                "load('testsrc/assert.js');\n"
+                        +
+                        // Timeout must be a function and we don't support the "eval" style of
+                        // setTimeout
+                        "assertThrows(() => {setTimeout('x = 1;');}, TypeError);\n"
+                        +
+                        // Need to pass a function as the first argument
+                        "assertThrows(() => {setTimeout();}, TypeError);\n"
+                        +
+                        // Need to pass a timer ID as the second argument
+                        "assertThrows(() => {clearTimeout()}, TypeError);\n"
+                        +
+                        // OK because you can clear a timeout with an invalid ID.
+                        "clearTimeout(999);\n"
+                        +
+                        // OK because of the semantics of "ToInteger"
+                        "setTimeout(() => {TestsComplete = true}, 'later');\n"
+                        + "clearTimeout('hello');");
+    }
+
+    /** Make sure that timeouts are executed in absolute numerical order. */
+    @Test
+    public void setTimeoutOrder() throws InterruptedException {
+        runTest(
+                "load('testsrc/assert.js');\n"
+                        + "var count = 0;\n"
+                        + "setTimeout(() => { assertEquals(0, count++); });\n"
+                        + "setTimeout(() => { assertEquals(1, count++); }, 1);\n"
+                        + "setTimeout(() => { assertEquals(2, count); TestsComplete = true; }, 2);");
+    }
+
+    /** Make sure that timers can be cancelled. */
+    @Test
+    public void testTimerCancellation() throws InterruptedException {
+        runTest(
+                "load('testsrc/assert.js');\n"
+                        + "let count = 0;\n"
+                        + "let timer1 = setTimeout(() => { count++; });\n"
+                        + "assertEquals('number', typeof timer1);\n"
+                        + "setTimeout(() => { assertEquals(0, count++); }, 1);\n"
+                        + "setTimeout(() => { assertEquals(1, count); TestsComplete = true; }, 2);\n"
+                        + "clearTimeout(timer1);");
+    }
+
+    /** Make sure that timers can be nested inside other timers and so on. */
+    @Test
+    public void testNestedTimers() throws InterruptedException {
+        runTest(
+                "load('testsrc/assert.js');\n"
+                        + "let count = 0;\n"
+                        + "setTimeout(() => { assertEquals(0, count++);\n"
+                        + "  setTimeout(() => { assertEquals(2, count++); TestsComplete = true; }, 5);\n"
+                        + "  setTimeout(() => { assertEquals(1, count++); }, 2);\n"
+                        + "});");
+    }
+
+    private void runTest(String script) throws InterruptedException {
+        cx.evaluateString(global, script, "test.js", 1, null);
+        timers.runAllTimers(cx, global);
+        assertTrue(ScriptRuntime.toBoolean(global.get("TestsComplete", global)));
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/ShellTimerTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ShellTimerTest.java
@@ -2,7 +2,7 @@ package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import org.junit.After;
 import org.junit.Before;
@@ -44,7 +44,12 @@ public class ShellTimerTest {
 
     @Parameters(name = "{index}, opt={0}")
     public static Collection<Object[]> optLevels() {
-        return Arrays.asList(new Object[] {-1}, new Object[] {1}, new Object[] {9});
+        int[] optLevels = Utils.getTestOptLevels();
+        ArrayList<Object[]> params = new ArrayList<>();
+        for (int ol : optLevels) {
+            params.add(new Object[] {ol});
+        }
+        return params;
     }
 
     /** Just make sure that a timeout fires. */

--- a/testsrc/org/mozilla/javascript/tests/Utils.java
+++ b/testsrc/org/mozilla/javascript/tests/Utils.java
@@ -9,66 +9,58 @@ import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
 
-
 /**
  * Misc utilities to make test code easier.
+ *
  * @author Marc Guillemot
  */
-public class Utils
-{
-    /**
-     * Runs the action successively with all available optimization levels
-     */
-    public static void runWithAllOptimizationLevels(final ContextAction action)
-    {
+public class Utils {
+    /** Runs the action successively with all available optimization levels */
+    public static void runWithAllOptimizationLevels(final ContextAction action) {
         runWithOptimizationLevel(action, -1);
         runWithOptimizationLevel(action, 0);
         runWithOptimizationLevel(action, 1);
     }
 
-    /**
-     * Runs the action successively with all available optimization levels
-     */
-    public static void runWithAllOptimizationLevels(final ContextFactory contextFactory, final ContextAction action)
-    {
+    /** Runs the action successively with all available optimization levels */
+    public static void runWithAllOptimizationLevels(
+            final ContextFactory contextFactory, final ContextAction action) {
         runWithOptimizationLevel(contextFactory, action, -1);
         runWithOptimizationLevel(contextFactory, action, 0);
         runWithOptimizationLevel(contextFactory, action, 1);
     }
 
-    /**
-     * Runs the provided action at the given optimization level
-     */
-    public static void runWithOptimizationLevel(final ContextAction action, final int optimizationLevel)
-    {
+    /** Runs the provided action at the given optimization level */
+    public static void runWithOptimizationLevel(
+            final ContextAction action, final int optimizationLevel) {
         runWithOptimizationLevel(new ContextFactory(), action, optimizationLevel);
     }
 
-    /**
-     * Runs the provided action at the given optimization level
-     */
-    public static void runWithOptimizationLevel(final ContextFactory contextFactory, final ContextAction action, final int optimizationLevel)
-    {
+    /** Runs the provided action at the given optimization level */
+    public static void runWithOptimizationLevel(
+            final ContextFactory contextFactory,
+            final ContextAction action,
+            final int optimizationLevel) {
         final Context cx = contextFactory.enterContext();
-        try
-        {
+        try {
             cx.setOptimizationLevel(optimizationLevel);
             action.run(cx);
-        }
-        finally
-        {
+        } finally {
             Context.exit();
         }
     }
 
     /**
      * Execute the provided script in a fresh context as "myScript.js".
+     *
      * @param script the script code
      */
     static void executeScript(final String script, final int optimizationLevel) {
-        Utils.runWithOptimizationLevel(cx -> {
-            final Scriptable scope = cx.initStandardObjects();
-            return cx.evaluateString(scope, script, "myScript.js", 1, null);
-        }, optimizationLevel);
+        Utils.runWithOptimizationLevel(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    return cx.evaluateString(scope, script, "myScript.js", 1, null);
+                },
+                optimizationLevel);
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/Utils.java
+++ b/testsrc/org/mozilla/javascript/tests/Utils.java
@@ -15,6 +15,9 @@ import org.mozilla.javascript.Scriptable;
  * @author Marc Guillemot
  */
 public class Utils {
+    /** The default set of levels to run tests at. */
+    public static final int[] DEFAULT_OPT_LEVELS = new int[] {-1, 0, 9};
+
     /** Runs the action successively with all available optimization levels */
     public static void runWithAllOptimizationLevels(final ContextAction action) {
         runWithOptimizationLevel(action, -1);
@@ -62,5 +65,17 @@ public class Utils {
                     return cx.evaluateString(scope, script, "myScript.js", 1, null);
                 },
                 optimizationLevel);
+    }
+
+    /**
+     * If the TEST_OPTLEVEL system property is set, then return an array containing only that one
+     * integer. Otherwise, return an array of the typical opt levels that we expect for testing.
+     */
+    public static int[] getTestOptLevels() {
+        String overriddenLevel = System.getProperty("TEST_OPTLEVEL");
+        if (overriddenLevel != null && !overriddenLevel.isEmpty()) {
+            return new int[] {Integer.parseInt(overriddenLevel)};
+        }
+        return DEFAULT_OPT_LEVELS;
     }
 }

--- a/toolsrc/org/mozilla/javascript/tools/shell/Main.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Main.java
@@ -79,6 +79,7 @@ public class Main {
         private int type;
         String[] args;
         String scriptText;
+        private final Timers timers = new Timers();
 
         IProxy(int type) {
             this.type = type;
@@ -87,6 +88,7 @@ public class Main {
         @Override
         public Object run(Context cx) {
             cx.setTrackUnhandledPromiseRejections(true);
+            timers.install(global);
             if (useRequire) {
                 require = global.installRequire(cx, modulePath, sandboxed);
             }
@@ -97,6 +99,11 @@ public class Main {
                 evalInlineScript(cx, scriptText);
             } else {
                 throw Kit.codeBug();
+            }
+            try {
+                timers.runAllTimers(cx, global);
+            } catch (InterruptedException ie) {
+                // Shell has no facility to handle interrupts so stop now
             }
             return null;
         }

--- a/toolsrc/org/mozilla/javascript/tools/shell/Timers.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Timers.java
@@ -1,0 +1,160 @@
+package org.mozilla.javascript.tools.shell;
+
+import java.util.HashMap;
+import java.util.PriorityQueue;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.LambdaFunction;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
+
+/**
+ * This class supports the "setTimeout" and "clearTimeout" methods of semi-standard JavaScript. It
+ * does it within a single thread by keeping track of a queue of timeout objects, and then it blocks
+ * the thread. It's used solely within the Shell right now.
+ */
+public class Timers {
+    private int lastId = 0;
+    private final HashMap<Integer, Timeout> timers = new HashMap<>();
+    private final PriorityQueue<Timeout> timerQueue = new PriorityQueue<>();
+
+    /**
+     * Initialize the "setTimeout" and "clearTimeout" functions on the specified scope.
+     *
+     * @param scope the scope where the functions should be defined
+     */
+    public void install(Scriptable scope) {
+        LambdaFunction setTimeout =
+                new LambdaFunction(
+                        scope,
+                        "setTimeout",
+                        1,
+                        (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) ->
+                                setTimeout(args));
+        ScriptableObject.defineProperty(scope, "setTimeout", setTimeout, ScriptableObject.DONTENUM);
+        LambdaFunction clearTimeout =
+                new LambdaFunction(
+                        scope,
+                        "clearTimeout",
+                        1,
+                        (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) ->
+                                clearTimeout(args));
+        ScriptableObject.defineProperty(
+                scope, "clearTimeout", clearTimeout, ScriptableObject.DONTENUM);
+    }
+
+    /**
+     * Execute all pending timers and microtasks, blocking the thread if we need to wait for any
+     * timers to time out.
+     *
+     * @param cx The Context to use to execute microtasks and timer functions
+     * @param scope the global scope
+     * @throws InterruptedException if the thread is interrupted while sleeping
+     */
+    public void runAllTimers(Context cx, Scriptable scope) throws InterruptedException {
+        boolean executed;
+        do {
+            cx.processMicrotasks();
+            executed = executeNext(cx, scope);
+        } while (executed);
+        cx.processMicrotasks();
+    }
+
+    /**
+     * Put up to one task on the context's "microtask queue." If the next task is not ready to run
+     * for some time, then block the calling thread until the time is up.
+     *
+     * @param cx the context
+     * @param scope the current scope
+     * @return true if something was placed on the queue, and false if the queue is empty
+     * @throws InterruptedException if the thread was interrupted
+     */
+    private boolean executeNext(Context cx, Scriptable scope) throws InterruptedException {
+        Timeout t = timerQueue.peek();
+        if (t == null) {
+            return false;
+        }
+        long remaining = t.expiration - System.currentTimeMillis();
+        if (remaining > 0) {
+            Thread.sleep(remaining);
+        }
+        timerQueue.remove();
+        timers.remove(t.id);
+        cx.enqueueMicrotask(() -> t.func.call(cx, scope, scope, t.funcArgs));
+        return true;
+    }
+
+    private Object setTimeout(Object[] args) {
+        if (args.length == 0) {
+            throw ScriptRuntime.typeError("Expected function parameter");
+        }
+        if (!(args[0] instanceof Function)) {
+            throw ScriptRuntime.typeError("Expected first argument to be a function");
+        }
+
+        int id = ++lastId;
+        Timeout t = new Timeout();
+        t.id = id;
+        t.func = (Function) args[0];
+        int delay = 0;
+        if (args.length > 1) {
+            delay = ScriptRuntime.toInt32(args[1]);
+        }
+        t.expiration = System.currentTimeMillis() + delay;
+        if (args.length > 2) {
+            t.funcArgs = new Object[args.length - 2];
+            System.arraycopy(args, 2, t.funcArgs, 0, t.funcArgs.length);
+        }
+
+        timers.put(id, t);
+        timerQueue.add(t);
+        return id;
+    }
+
+    private Object clearTimeout(Object[] args) {
+        if (args.length == 0) {
+            throw ScriptRuntime.typeError("Expected function parameter");
+        }
+        int id = ScriptRuntime.toInt32(args[0]);
+        Timeout t = timers.remove(id);
+        if (t != null) {
+            timerQueue.remove(t);
+        }
+        return Undefined.instance;
+    }
+
+    /**
+     * An object to go on the priority queue.
+     *
+     * <p>Note: this class has a natural ordering that is inconsistent with equals.
+     */
+    private static final class Timeout implements Comparable<Timeout> {
+        int id;
+        Function func;
+        Object[] funcArgs = ScriptRuntime.emptyArgs;
+        long expiration;
+
+        @Override
+        public int compareTo(Timeout o) {
+            return Long.compare(expiration, o.expiration);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            try {
+                return expiration == ((Timeout) obj).expiration;
+            } catch (ClassCastException cce) {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            // This private class should never go in a HashMap.
+            assert false;
+            return (int) expiration;
+        }
+    }
+}


### PR DESCRIPTION
The "kangax" compat table tests need setTimeout and clearTimeout to be implemented in order for the Promise tests to run.

This requires a mini event loop, and I wasn't comfortable building that into Rhino, so these functions are only implemented in the Shell right now. That means that Rhino tests launched from the shell can use these functions, and that those scripts will not exit until all of the timer tasks are finished.