### PR TITLE
Add support to track unhandled promise rejections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,6 +411,7 @@ jacocoTestReport.dependsOn test
 jacocoTestReport {
     reports {
         csv.enabled true
+        html.enabled true
     }
 }
 

--- a/src/org/mozilla/javascript/Context.java
+++ b/src/org/mozilla/javascript/Context.java
@@ -2339,6 +2339,26 @@ public class Context implements Closeable {
         } while (head != null);
     }
 
+    /**
+     * Control whether to track unhandled promise rejections. If "track" is set to true, then the
+     * tracker returned by "getUnhandledPromiseTracker" must be periodically used to process the
+     * queue of unhandled promise rejections, or a memory leak may result.
+     *
+     * @param track if true, then track unhandled promise rejections
+     */
+    public void setTrackUnhandledPromiseRejections(boolean track) {
+        unhandledPromises.enable(track);
+    }
+
+    /**
+     * Return the object used to track unhandled promise rejections.
+     *
+     * @return the tracker object
+     */
+    public UnhandledRejectionTracker getUnhandledPromiseTracker() {
+        return unhandledPromises;
+    }
+
     /* ******** end of API ********* */
 
     /** Internal method that reports an error for missing calls to enter(). */
@@ -2632,6 +2652,7 @@ public class Context implements Closeable {
     private ClassLoader applicationClassLoader;
     private UnaryOperator<Object> javaToJSONConverter;
     private final ArrayDeque<Runnable> microtasks = new ArrayDeque<>();
+    private final UnhandledRejectionTracker unhandledPromises = new UnhandledRejectionTracker();
 
     /** This is the list of names of objects forcing the creation of function activation records. */
     Set<String> activationNames;

--- a/src/org/mozilla/javascript/UnhandledRejectionTracker.java
+++ b/src/org/mozilla/javascript/UnhandledRejectionTracker.java
@@ -1,0 +1,77 @@
+package org.mozilla.javascript;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * This class is responsible for handling tracking of unhandled Promise rejections. These come up
+ * when a Promise is either rejected or an exception is thrown and there is no "catch" handler set
+ * up. There is one of these tracker objects for each Context class.
+ *
+ * <p>Different frameworks will choose different ways to handle unhandled rejections. As a result,
+ * Rhino does nothing by default.
+ *
+ * <p>However, if "trackUnhandledPromiseRejections" is called on the Context object, then Rhino will
+ * track them in this object. It is the responsibility of the product embedding Rhino to
+ * periodically check for unhandled rejections in this class and either remove them or terminate the
+ * script and allow the context and its tracker to be garbage- collected.
+ *
+ * <p>Note that if "trackUnhandledPromiseRejections" is set, and rejections are not handled, then
+ * Promise objects will accumulate in this object and cause a memory leak.
+ */
+public class UnhandledRejectionTracker {
+    private boolean enabled = false;
+    private static final IdentityHashMap<NativePromise, NativePromise> unhandled =
+            new IdentityHashMap<>(0);
+
+    /**
+     * Iterate through all the rejected promises that have not yet been handled. As each promise is
+     * handled by this method, it is removed from this tracker and will not appear again. This is
+     * useful for delivering unhandled promise notifications to users one time via a callback.
+     */
+    public void process(Consumer<Object> handler) {
+        Iterator<NativePromise> it = unhandled.values().iterator();
+        while (it.hasNext()) {
+            try {
+                handler.accept(it.next().getResult());
+            } finally {
+                // Always remove even if handler throws
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Return a collection of all of the results of any unhandled rejected promises. This does not
+     * remove unhandled promises from the collection, but reports the current state. It is useful
+     * for command-line tools.
+     *
+     * @return a read-only collection of promise results. To clear them, call "process".
+     */
+    public List<Object> enumerate() {
+        ArrayList<Object> ret = new ArrayList<>();
+        for (NativePromise result : unhandled.values()) {
+            ret.add(result.getResult());
+        }
+        return ret;
+    }
+
+    void enable(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    void promiseRejected(NativePromise p) {
+        if (enabled) {
+            unhandled.put(p, p);
+        }
+    }
+
+    void promiseHandled(NativePromise p) {
+        if (enabled) {
+            unhandled.remove(p);
+        }
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/es6/UnhandledPromiseTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/UnhandledPromiseTest.java
@@ -1,0 +1,121 @@
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.tools.shell.Global;
+
+public class UnhandledPromiseTest {
+    private Context cx;
+    private Scriptable scope;
+
+    @Before
+    public void init() {
+        cx = Context.enter();
+        cx.setGeneratingDebug(true);
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        cx.setTrackUnhandledPromiseRejections(true);
+        scope = new Global(cx);
+    }
+
+    @After
+    public void terminate() {
+        cx.close();
+    }
+
+    @Test
+    public void testSimpleRejection() {
+        exec("new Promise((resolve, reject) => { reject(); });");
+        assertEquals(1, cx.getUnhandledPromiseTracker().enumerate().size());
+        assertTrue(Undefined.isUndefined(cx.getUnhandledPromiseTracker().enumerate().get(0)));
+        AtomicBoolean handled = new AtomicBoolean();
+        cx.getUnhandledPromiseTracker()
+                .process(
+                        (Object o) -> {
+                            assertFalse(handled.get());
+                            assertTrue(Undefined.isUndefined(o));
+                            handled.set(true);
+                        });
+        assertTrue(handled.get());
+    }
+
+    @Test
+    public void testSimpleRejectionHandled() {
+        scope.put("caught", scope, Boolean.FALSE);
+        exec(
+                "let p = new Promise((resolve, reject) => { reject(); });\n"
+                        + "p.catch((e) => { caught = true; });\n");
+        assertTrue(cx.getUnhandledPromiseTracker().enumerate().isEmpty());
+        AtomicBoolean handled = new AtomicBoolean();
+        // We should actually never see anything in the tracker here
+        cx.getUnhandledPromiseTracker()
+                .process(
+                        (Object o) -> {
+                            assertFalse(handled.get());
+                            handled.set(true);
+                        });
+        assertFalse(handled.get());
+        assertTrue(Context.toBoolean(scope.get("caught", scope)));
+    }
+
+    @Test
+    public void testRejectionObject() {
+        exec("new Promise((resolve, reject) => { reject('rejected'); });");
+        assertEquals(1, cx.getUnhandledPromiseTracker().enumerate().size());
+        assertEquals("rejected", cx.getUnhandledPromiseTracker().enumerate().get(0));
+        AtomicBoolean handled = new AtomicBoolean();
+        cx.getUnhandledPromiseTracker()
+                .process(
+                        (Object o) -> {
+                            assertEquals("rejected", o);
+                            handled.set(true);
+                            assertEquals("rejected", o);
+                        });
+        assertTrue(handled.get());
+    }
+
+    @Test
+    public void testSimpleThrowHandled() {
+        scope.put("caught", scope, Boolean.FALSE);
+        exec(
+                "let p = new Promise((resolve, reject) => { throw 'threw'; });\n"
+                        + "p.catch((e) => { assertEquals('threw', e); caught = true; });\n");
+        assertTrue(cx.getUnhandledPromiseTracker().enumerate().isEmpty());
+        AtomicBoolean handled = new AtomicBoolean();
+        // We should actually never see anything in the tracker here
+        cx.getUnhandledPromiseTracker()
+                .process(
+                        (Object o) -> {
+                            assertFalse(handled.get());
+                            handled.set(true);
+                        });
+        assertFalse(handled.get());
+        assertTrue(Context.toBoolean(scope.get("caught", scope)));
+    }
+
+    @Test
+    public void testThrowInThen() {
+        exec(
+                "new Promise((resolve, reject) => { resolve() }).then(() => { throw 'threw in then' });");
+        assertEquals(1, cx.getUnhandledPromiseTracker().enumerate().size());
+        AtomicBoolean handled = new AtomicBoolean();
+        cx.getUnhandledPromiseTracker()
+                .process(
+                        (Object o) -> {
+                            assertFalse(handled.get());
+                            handled.set(true);
+                            assertEquals("threw in then", o);
+                        });
+        assertTrue(handled.get());
+    }
+
+    private void exec(String script) {
+        cx.evaluateString(scope, "load('./testsrc/assert.js'); " + script, "test.js", 0, null);
+    }
+}


### PR DESCRIPTION
This does nothing by default, but adds an object on the Context class that tracks unhandled rejected promises and lets the user process them. The shell now prints out warnings about unhandled rejections as it runs and at the end of any executed script.

For example, in the interactive shell:

js> let p = new Promise((resolve, reject) => {reject('rejected')});
Unhandled rejected promise: rejected
js> let q = new Promise((resolve, reject) => {throw new Error('threw')});
Unhandled rejected promise: Error: threw
	at <stdin>:3 (anonymous)
	at <stdin>:3

  and 1 other unhandled rejected promises
js> q.catch((e)=>{print('Caught ' + e)});
Caught Error: threw
Unhandled rejected promise: rejected
[object Promise]
js> p.catch((e)=>{print('Caught ' + e)});
Caught rejected
[object Promise]