### PR TITLE
FIX: Instanceof for java objects/classes

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -11,30 +11,24 @@ import java.lang.reflect.Modifier;
 import java.util.Map;
 
 /**
- * This class reflects Java classes into the JavaScript environment, mainly
- * for constructors and static members.  We lazily reflect properties,
- * and currently do not guarantee that a single j.l.Class is only
- * reflected once into the JS environment, although we should.
- * The only known case where multiple reflections
- * are possible occurs when a j.l.Class is wrapped as part of a
- * method return or property access, rather than by walking the
- * Packages/java tree.
+ * This class reflects Java classes into the JavaScript environment, mainly for constructors and
+ * static members. We lazily reflect properties, and currently do not guarantee that a single
+ * j.l.Class is only reflected once into the JS environment, although we should. The only known case
+ * where multiple reflections are possible occurs when a j.l.Class is wrapped as part of a method
+ * return or property access, rather than by walking the Packages/java tree.
  *
  * @author Mike Shaver
  * @see NativeJavaArray
  * @see NativeJavaObject
  * @see NativeJavaPackage
  */
-
-public class NativeJavaClass extends NativeJavaObject implements Function
-{
+public class NativeJavaClass extends NativeJavaObject implements Function {
     private static final long serialVersionUID = -6460763940409461664L;
 
     // Special property for getting the underlying Java class object.
     static final String javaClassPropertyName = "__javaObject__";
 
-    public NativeJavaClass() {
-    }
+    public NativeJavaClass() {}
 
     public NativeJavaClass(Scriptable scope, Class<?> cl) {
         this(scope, cl, false);
@@ -46,7 +40,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
 
     @Override
     protected void initMembers() {
-        Class<?> cl = (Class<?>)javaObject;
+        Class<?> cl = (Class<?>) javaObject;
         members = JavaMembers.lookupClass(parent, cl, cl, isAdapter);
         staticFieldAndMethods = members.getFieldAndMethodsObjects(this, cl, true);
     }
@@ -67,13 +61,11 @@ public class NativeJavaClass extends NativeJavaObject implements Function
         // for our prototype to create an object of the correct type.
         // We don't really care what the object is, since we're returning
         // one constructed out of whole cloth, so we return null.
-        if (name.equals("prototype"))
-            return null;
+        if (name.equals("prototype")) return null;
 
-         if (staticFieldAndMethods != null) {
+        if (staticFieldAndMethods != null) {
             Object result = staticFieldAndMethods.get(name);
-            if (result != null)
-                return result;
+            if (result != null) return result;
         }
 
         if (members.has(name, true)) {
@@ -85,16 +77,14 @@ public class NativeJavaClass extends NativeJavaObject implements Function
         WrapFactory wrapFactory = cx.getWrapFactory();
 
         if (javaClassPropertyName.equals(name)) {
-            return wrapFactory.wrap(cx, scope, javaObject,
-                                    ScriptRuntime.ClassClass);
+            return wrapFactory.wrap(cx, scope, javaObject, ScriptRuntime.ClassClass);
         }
 
         // experimental:  look for nested classes by appending $name to
         // current class' name.
         Class<?> nestedClass = findNestedClass(getClassObject(), name);
         if (nestedClass != null) {
-            Scriptable nestedValue = wrapFactory.wrapJavaClass(cx, scope,
-                    nestedClass);
+            Scriptable nestedValue = wrapFactory.wrapJavaClass(cx, scope, nestedClass);
             nestedValue.setParentScope(this);
             return nestedValue;
         }
@@ -118,19 +108,14 @@ public class NativeJavaClass extends NativeJavaObject implements Function
 
     @Override
     public Object getDefaultValue(Class<?> hint) {
-        if (hint == null || hint == ScriptRuntime.StringClass)
-            return this.toString();
-        if (hint == ScriptRuntime.BooleanClass)
-            return Boolean.TRUE;
-        if (hint == ScriptRuntime.NumberClass)
-            return ScriptRuntime.NaNobj;
+        if (hint == null || hint == ScriptRuntime.StringClass) return this.toString();
+        if (hint == ScriptRuntime.BooleanClass) return Boolean.TRUE;
+        if (hint == ScriptRuntime.NumberClass) return ScriptRuntime.NaNobj;
         return this;
     }
 
     @Override
-    public Object call(Context cx, Scriptable scope, Scriptable thisObj,
-                       Object[] args)
-    {
+    public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         // If it looks like a "cast" of an object to this class type,
         // walk the prototype chain to see if there's a wrapper of a
         // object that's an instanceof this class.
@@ -140,8 +125,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function
             do {
                 if (p instanceof Wrapper) {
                     Object o = ((Wrapper) p).unwrap();
-                    if (c.isInstance(o))
-                        return p;
+                    if (c.isInstance(o)) return p;
                 }
                 p = p.getPrototype();
             } while (p != null);
@@ -150,19 +134,16 @@ public class NativeJavaClass extends NativeJavaObject implements Function
     }
 
     @Override
-    public Scriptable construct(Context cx, Scriptable scope, Object[] args)
-    {
+    public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
         Class<?> classObject = getClassObject();
         int modifiers = classObject.getModifiers();
-        if (! (Modifier.isInterface(modifiers) ||
-               Modifier.isAbstract(modifiers)))
-        {
+        if (!(Modifier.isInterface(modifiers) || Modifier.isAbstract(modifiers))) {
             NativeJavaMethod ctors = members.ctors;
             int index = ctors.findCachedFunction(cx, args);
             if (index < 0) {
                 String sig = NativeJavaMethod.scriptSignature(args);
                 throw Context.reportRuntimeErrorById(
-                    "msg.no.java.ctor", classObject.getName(), sig);
+                        "msg.no.java.ctor", classObject.getName(), sig);
             }
 
             // Found the constructor, so try invoking it.
@@ -176,10 +157,10 @@ public class NativeJavaClass extends NativeJavaObject implements Function
         try {
             // When running on Android create an InterfaceAdapter since our
             // bytecode generation won't work on Dalvik VM.
-            if ("Dalvik".equals(System.getProperty("java.vm.name"))
-                    && classObject.isInterface()) {
-                Object obj = createInterfaceAdapter(classObject,
-                        ScriptableObject.ensureScriptableObject(args[0]));
+            if ("Dalvik".equals(System.getProperty("java.vm.name")) && classObject.isInterface()) {
+                Object obj =
+                        createInterfaceAdapter(
+                                classObject, ScriptableObject.ensureScriptableObject(args[0]));
                 return cx.getWrapFactory().wrapAsJavaObject(cx, scope, obj, null);
             }
             // use JavaAdapter to construct a new class on the fly that
@@ -188,22 +169,19 @@ public class NativeJavaClass extends NativeJavaObject implements Function
             if (v != NOT_FOUND) {
                 Function f = (Function) v;
                 // Args are (interface, js object)
-                Object[] adapterArgs = { this, args[0] };
+                Object[] adapterArgs = {this, args[0]};
                 return f.construct(cx, topLevel, adapterArgs);
             }
         } catch (Exception ex) {
             // fall through to error
             String m = ex.getMessage();
-            if (m != null)
-                msg = m;
+            if (m != null) msg = m;
         }
-        throw Context.reportRuntimeErrorById(
-            "msg.cant.instantiate", msg, classObject.getName());
+        throw Context.reportRuntimeErrorById("msg.cant.instantiate", msg, classObject.getName());
     }
 
-    static Scriptable constructSpecific(Context cx, Scriptable scope,
-                                        Object[] args, MemberBox ctor)
-    {
+    static Scriptable constructSpecific(
+            Context cx, Scriptable scope, Object[] args, MemberBox ctor) {
         Object instance = constructInternal(args, ctor);
         // we need to force this to be wrapped, because construct _has_
         // to return a scriptable
@@ -211,14 +189,13 @@ public class NativeJavaClass extends NativeJavaObject implements Function
         return cx.getWrapFactory().wrapNewObject(cx, topLevel, instance);
     }
 
-    static Object constructInternal(Object[] args, MemberBox ctor)
-    {
+    static Object constructInternal(Object[] args, MemberBox ctor) {
         Class<?>[] argTypes = ctor.argTypes;
 
         if (ctor.vararg) {
             // marshall the explicit parameter
             Object[] newArgs = new Object[argTypes.length];
-            for (int i = 0; i < argTypes.length-1; i++) {
+            for (int i = 0; i < argTypes.length - 1; i++) {
                 newArgs[i] = Context.jsToJava(args[i], argTypes[i]);
             }
 
@@ -226,29 +203,24 @@ public class NativeJavaClass extends NativeJavaObject implements Function
 
             // Handle special situation where a single variable parameter
             // is given and it is a Java or ECMA array.
-            if (args.length == argTypes.length &&
-                (args[args.length-1] == null ||
-                 args[args.length-1] instanceof NativeArray ||
-                 args[args.length-1] instanceof NativeJavaArray))
-            {
+            if (args.length == argTypes.length
+                    && (args[args.length - 1] == null
+                            || args[args.length - 1] instanceof NativeArray
+                            || args[args.length - 1] instanceof NativeJavaArray)) {
                 // convert the ECMA array into a native array
-                varArgs = Context.jsToJava(args[args.length-1],
-                                           argTypes[argTypes.length - 1]);
+                varArgs = Context.jsToJava(args[args.length - 1], argTypes[argTypes.length - 1]);
             } else {
                 // marshall the variable parameter
-                Class<?> componentType = argTypes[argTypes.length - 1].
-                                        getComponentType();
-                varArgs = Array.newInstance(componentType,
-                                            args.length - argTypes.length + 1);
-                for (int i=0; i < Array.getLength(varArgs); i++) {
-                    Object value = Context.jsToJava(args[argTypes.length-1 + i],
-                                                    componentType);
+                Class<?> componentType = argTypes[argTypes.length - 1].getComponentType();
+                varArgs = Array.newInstance(componentType, args.length - argTypes.length + 1);
+                for (int i = 0; i < Array.getLength(varArgs); i++) {
+                    Object value = Context.jsToJava(args[argTypes.length - 1 + i], componentType);
                     Array.set(varArgs, i, value);
                 }
             }
 
             // add varargs
-            newArgs[argTypes.length-1] = varArgs;
+            newArgs[argTypes.length - 1] = varArgs;
             // replace the original args with the new one
             args = newArgs;
         } else {
@@ -274,23 +246,21 @@ public class NativeJavaClass extends NativeJavaObject implements Function
     }
 
     /**
-     * Determines if prototype is a wrapped Java object and performs
-     * a Java "instanceof".
-     * Exception: if value is an instance of NativeJavaClass, it isn't
-     * considered an instance of the Java class; this forestalls any
-     * name conflicts between java.lang.Class's methods and the
-     * static methods exposed by a JavaNativeClass.
+     * Determines if prototype is a wrapped Java object and performs a Java "instanceof". Exception:
+     * if value is an instance of NativeJavaClass, it isn't considered an instance of the Java
+     * class; this forestalls any name conflicts between java.lang.Class's methods and the static
+     * methods exposed by a JavaNativeClass.
      */
     @Override
     public boolean hasInstance(Scriptable value) {
 
-        // 'Class<String> instanceof Class' must be true 
+        // 'Class<String> instanceof Class' must be true
         if (value instanceof NativeJavaClass) {
             return getClassObject() == Class.class;
         }
 
         if (value instanceof Wrapper) {
-            Object instance = ((Wrapper)value).unwrap();
+            Object instance = ((Wrapper) value).unwrap();
             return getClassObject().isInstance(instance);
         }
 
@@ -311,5 +281,5 @@ public class NativeJavaClass extends NativeJavaObject implements Function
         return Kit.classOrNull(loader, nestedClassName);
     }
 
-    private Map<String,FieldAndMethods> staticFieldAndMethods;
+    private Map<String, FieldAndMethods> staticFieldAndMethods;
 }

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -284,10 +284,13 @@ public class NativeJavaClass extends NativeJavaObject implements Function
     @Override
     public boolean hasInstance(Scriptable value) {
 
-        if (value instanceof Wrapper &&
-            !(value instanceof NativeJavaClass)) {
-            Object instance = ((Wrapper)value).unwrap();
+        // 'Class<String> instanceof Class' must be true 
+        if (value instanceof NativeJavaClass) {
+            return getClassObject() == Class.class;
+        }
 
+        if (value instanceof Wrapper) {
+            Object instance = ((Wrapper)value).unwrap();
             return getClassObject().isInstance(instance);
         }
 

--- a/src/org/mozilla/javascript/WrapFactory.java
+++ b/src/org/mozilla/javascript/WrapFactory.java
@@ -112,7 +112,9 @@ public class WrapFactory {
      */
     public Scriptable wrapAsJavaObject(
             Context cx, Scriptable scope, Object javaObject, Class<?> staticType) {
-        if (List.class.isAssignableFrom(javaObject.getClass())) {
+        if (javaObject instanceof Class) {
+            return new NativeJavaClass(scope, (Class<?>) javaObject);
+        } else if (List.class.isAssignableFrom(javaObject.getClass())) {
             return new NativeJavaList(scope, javaObject);
         } else if (Map.class.isAssignableFrom(javaObject.getClass())) {
             return new NativeJavaMap(scope, javaObject);

--- a/testsrc/org/mozilla/javascript/tests/JavaAcessibilityTest.java
+++ b/testsrc/org/mozilla/javascript/tests/JavaAcessibilityTest.java
@@ -148,6 +148,24 @@ public class JavaAcessibilityTest extends TestCase {
         assertEquals("success", result);
     }
 
+    public void testInstanceOf() {
+
+        Object result = runScript("(new java.util.HashMap()) instanceof java.util.HashMap;");
+        assertEquals(true, result);
+        result = runScript("(new java.util.HashMap()) instanceof java.util.Map;");
+        assertEquals(true, result);
+        result = runScript("(new java.util.HashMap()) instanceof java.util.List;");
+        assertEquals(false, result);
+    }
+
+    public void testExceptionInstanceOf() {
+
+        Object result =
+                runScript(
+                        "try { (new java.util.ArrayList()).set(2,2) } catch(e) {e.javaException instanceof java.lang.IndexOutOfBoundsException;}");
+        assertEquals(true, result);
+    }
+
     private Object runScript(final String scriptSourceText) {
         return contextFactory.call(
                 context -> {

--- a/testsrc/org/mozilla/javascript/tests/JavaAcessibilityTest.java
+++ b/testsrc/org/mozilla/javascript/tests/JavaAcessibilityTest.java
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/**
- *
- */
 package org.mozilla.javascript.tests;
 
+import junit.framework.TestCase;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.NativeJavaObject;
@@ -15,135 +13,146 @@ import org.mozilla.javascript.drivers.TestUtils;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.ShellContextFactory;
 
-import junit.framework.TestCase;
-
-/**
- * @author donnamalayeri
- */
+/** @author donnamalayeri */
 public class JavaAcessibilityTest extends TestCase {
 
-  protected final Global global = new Global();
-  String importClass = "importClass(Packages.org.mozilla.javascript.tests.PrivateAccessClass)\n";
+    protected final Global global = new Global();
+    String importClass = "importClass(Packages.org.mozilla.javascript.tests.PrivateAccessClass)\n";
 
-  public JavaAcessibilityTest() {
-    global.init(contextFactory);
-  }
-
-  @Override
-  protected void setUp() {
-    TestUtils.setGlobalContextFactory(contextFactory);
-  }
-
-  @Override
-  protected void tearDown() {
-    TestUtils.setGlobalContextFactory(null);
-  }
-
-  private ContextFactory contextFactory = new ShellContextFactory() {
-    @Override
-    protected boolean hasFeature(Context cx, int featureIndex) {
-      if (featureIndex == Context.FEATURE_ENHANCED_JAVA_ACCESS)
-            return true;
-      return super.hasFeature(cx, featureIndex);
+    public JavaAcessibilityTest() {
+        global.init(contextFactory);
     }
-  };
 
-  public void testAccessingFields() {
-    Object result = runScript(importClass + "PrivateAccessClass.staticPackagePrivateInt");
-    assertEquals(new Integer(0), result);
+    @Override
+    protected void setUp() {
+        TestUtils.setGlobalContextFactory(contextFactory);
+    }
 
-    result = runScript(importClass + "PrivateAccessClass.staticPrivateInt");
-    assertEquals(new Integer(1), result);
+    @Override
+    protected void tearDown() {
+        TestUtils.setGlobalContextFactory(null);
+    }
 
-    result = runScript(importClass + "PrivateAccessClass.staticProtectedInt");
-    assertEquals(new Integer(2), result);
+    private ContextFactory contextFactory =
+            new ShellContextFactory() {
+                @Override
+                protected boolean hasFeature(Context cx, int featureIndex) {
+                    if (featureIndex == Context.FEATURE_ENHANCED_JAVA_ACCESS) return true;
+                    return super.hasFeature(cx, featureIndex);
+                }
+            };
 
-    result = runScript(importClass + "new PrivateAccessClass().packagePrivateString");
-    assertEquals("package private", ((NativeJavaObject) result).unwrap());
+    public void testAccessingFields() {
+        Object result = runScript(importClass + "PrivateAccessClass.staticPackagePrivateInt");
+        assertEquals(new Integer(0), result);
 
-    result = runScript(importClass + "new PrivateAccessClass().privateString");
-    assertEquals("private", ((NativeJavaObject) result).unwrap());
+        result = runScript(importClass + "PrivateAccessClass.staticPrivateInt");
+        assertEquals(new Integer(1), result);
 
-    result = runScript(importClass + "new PrivateAccessClass().protectedString");
-    assertEquals("protected", ((NativeJavaObject) result).unwrap());
+        result = runScript(importClass + "PrivateAccessClass.staticProtectedInt");
+        assertEquals(new Integer(2), result);
 
-    result = runScript(importClass + "new PrivateAccessClass.PrivateNestedClass().packagePrivateInt");
-    assertEquals(new Integer(0), result);
+        result = runScript(importClass + "new PrivateAccessClass().packagePrivateString");
+        assertEquals("package private", ((NativeJavaObject) result).unwrap());
 
-    result = runScript(importClass + "new PrivateAccessClass.PrivateNestedClass().privateInt");
-    assertEquals(new Integer(1), result);
+        result = runScript(importClass + "new PrivateAccessClass().privateString");
+        assertEquals("private", ((NativeJavaObject) result).unwrap());
 
-    result = runScript(importClass + "new PrivateAccessClass.PrivateNestedClass().protectedInt");
-    assertEquals(new Integer(2), result);
-  }
+        result = runScript(importClass + "new PrivateAccessClass().protectedString");
+        assertEquals("protected", ((NativeJavaObject) result).unwrap());
 
-  public void testAccessingMethods() {
-    Object result = runScript(importClass + "PrivateAccessClass.staticPackagePrivateMethod()");
-    assertEquals(new Integer(0), result);
+        result =
+                runScript(
+                        importClass
+                                + "new PrivateAccessClass.PrivateNestedClass().packagePrivateInt");
+        assertEquals(new Integer(0), result);
 
-    result = runScript(importClass + "PrivateAccessClass.staticPrivateMethod()");
-    assertEquals(new Integer(1), result);
+        result = runScript(importClass + "new PrivateAccessClass.PrivateNestedClass().privateInt");
+        assertEquals(new Integer(1), result);
 
-    result = runScript(importClass + "PrivateAccessClass.staticProtectedMethod()");
-    assertEquals(new Integer(2), result);
+        result =
+                runScript(importClass + "new PrivateAccessClass.PrivateNestedClass().protectedInt");
+        assertEquals(new Integer(2), result);
+    }
 
-    result = runScript(importClass + "new PrivateAccessClass().packagePrivateMethod()");
-    assertEquals(new Integer(3), result);
+    public void testAccessingMethods() {
+        Object result = runScript(importClass + "PrivateAccessClass.staticPackagePrivateMethod()");
+        assertEquals(new Integer(0), result);
 
-    result = runScript(importClass + "new PrivateAccessClass().privateMethod()");
-    assertEquals(new Integer(4), result);
+        result = runScript(importClass + "PrivateAccessClass.staticPrivateMethod()");
+        assertEquals(new Integer(1), result);
 
-    result = runScript(importClass + "new PrivateAccessClass().protectedMethod()");
-    assertEquals(new Integer(5), result);
-  }
+        result = runScript(importClass + "PrivateAccessClass.staticProtectedMethod()");
+        assertEquals(new Integer(2), result);
 
-  public void testAccessingConstructors() {
-    runScript(importClass + "new PrivateAccessClass(\"foo\")");
-    runScript(importClass + "new PrivateAccessClass(5)");
-    runScript(importClass + "new PrivateAccessClass(5, \"foo\")");
-  }
+        result = runScript(importClass + "new PrivateAccessClass().packagePrivateMethod()");
+        assertEquals(new Integer(3), result);
 
-  public void testAccessingJavaBeanProperty() {
-      Object result = runScript(importClass +
-          "var x = new PrivateAccessClass(); x.javaBeanProperty + ' ' + x.getterCalled;");
-      assertEquals("6 true", result);
+        result = runScript(importClass + "new PrivateAccessClass().privateMethod()");
+        assertEquals(new Integer(4), result);
 
-      result = runScript(importClass +
-      "var x = new PrivateAccessClass(); x.javaBeanProperty = 4; x.javaBeanProperty + ' ' + x.setterCalled;");
-      assertEquals("4 true", result);
-      
-      // assume javaObjectProperty is 'false'
-      result = runScript(importClass +
-              "var x = new PrivateAccessClass(); x.javaObjectProperty = x.javaObjectProperty || true; x.javaObjectProperty + ' ' + x.setterCalled;");
-      assertEquals("true true", result);
+        result = runScript(importClass + "new PrivateAccessClass().protectedMethod()");
+        assertEquals(new Integer(5), result);
+    }
 
-      // performs a bitxor, so integer/number is returned;
-      result = runScript(importClass +
-              "var x = new PrivateAccessClass(); x.javaObjectProperty ^= true; x.javaObjectProperty + ' ' + x.setterCalled;");
-      assertEquals("1 true", result);
+    public void testAccessingConstructors() {
+        runScript(importClass + "new PrivateAccessClass(\"foo\")");
+        runScript(importClass + "new PrivateAccessClass(5)");
+        runScript(importClass + "new PrivateAccessClass(5, \"foo\")");
+    }
 
-      // assume javaObjectProperty is '0'
-      result = runScript(importClass +
-              "var x = new PrivateAccessClass(); x.javaObjectProperty = x.javaObjectProperty + 7; x.javaObjectProperty + ' ' + x.setterCalled;");
-      assertEquals("7 true", result);
+    public void testAccessingJavaBeanProperty() {
+        Object result =
+                runScript(
+                        importClass
+                                + "var x = new PrivateAccessClass(); x.javaBeanProperty + ' ' + x.getterCalled;");
+        assertEquals("6 true", result);
 
-      // perform simple addition, shoud return "10" and not "3" + "7" = "37"
-      result = runScript(importClass +
-              "var x = new PrivateAccessClass(); x.javaObjectProperty = 3; x.javaObjectProperty = x.javaObjectProperty + 7; x.javaObjectProperty + ' ' + x.setterCalled;");
-      assertEquals("10 true", result);
-  }
+        result =
+                runScript(
+                        importClass
+                                + "var x = new PrivateAccessClass(); x.javaBeanProperty = 4; x.javaBeanProperty + ' ' + x.setterCalled;");
+        assertEquals("4 true", result);
 
-  public void testOverloadFunctionRegression() {
-      Object result = runScript(
-        "(new java.util.GregorianCalendar()).set(3,4);'success';");
-      assertEquals("success", result);
-  }
+        // assume javaObjectProperty is 'false'
+        result =
+                runScript(
+                        importClass
+                                + "var x = new PrivateAccessClass(); x.javaObjectProperty = x.javaObjectProperty || true; x.javaObjectProperty + ' ' + x.setterCalled;");
+        assertEquals("true true", result);
 
+        // performs a bitxor, so integer/number is returned;
+        result =
+                runScript(
+                        importClass
+                                + "var x = new PrivateAccessClass(); x.javaObjectProperty ^= true; x.javaObjectProperty + ' ' + x.setterCalled;");
+        assertEquals("1 true", result);
 
-  private Object runScript(final String scriptSourceText) {
-    return contextFactory.call(context -> {
-        Script script = context.compileString(scriptSourceText, "", 1, null);
-        return script.exec(context, global);
-    });
-  }
+        // assume javaObjectProperty is '0'
+        result =
+                runScript(
+                        importClass
+                                + "var x = new PrivateAccessClass(); x.javaObjectProperty = x.javaObjectProperty + 7; x.javaObjectProperty + ' ' + x.setterCalled;");
+        assertEquals("7 true", result);
+
+        // perform simple addition, shoud return "10" and not "3" + "7" = "37"
+        result =
+                runScript(
+                        importClass
+                                + "var x = new PrivateAccessClass(); x.javaObjectProperty = 3; x.javaObjectProperty = x.javaObjectProperty + 7; x.javaObjectProperty + ' ' + x.setterCalled;");
+        assertEquals("10 true", result);
+    }
+
+    public void testOverloadFunctionRegression() {
+        Object result = runScript("(new java.util.GregorianCalendar()).set(3,4);'success';");
+        assertEquals("success", result);
+    }
+
+    private Object runScript(final String scriptSourceText) {
+        return contextFactory.call(
+                context -> {
+                    Script script = context.compileString(scriptSourceText, "", 1, null);
+                    return script.exec(context, global);
+                });
+    }
 }

--- a/testsrc/tests/lc3/instanceof/instanceof-001.js
+++ b/testsrc/tests/lc3/instanceof/instanceof-001.js
@@ -53,6 +53,11 @@ new TestCase(
   java.lang.Class.forName("java.lang.String") instanceof java.lang.Class );
 
 new TestCase(
+  "java.lang.Class.forName(\"java.lang.String\") == java.lang.String",
+  true,
+  java.lang.Class.forName("java.lang.String") == java.lang.String );
+
+new TestCase(
   "new java.lang.Double(5.0) instanceof java.lang.Double",
   true,
   new java.lang.Double(5.0) instanceof java.lang.Double );

--- a/testsrc/tests/lc3/instanceof/instanceof-001.js
+++ b/testsrc/tests/lc3/instanceof/instanceof-001.js
@@ -33,9 +33,19 @@ new TestCase(
   new java.lang.String("hi") instanceof java.lang.Object );
 
 new TestCase(
+  "java.lang.Class instanceof java.lang.Class",
+  true,
+  java.lang.Class instanceof java.lang.Class );
+
+new TestCase(
   "java.lang.String instanceof java.lang.Class",
-  false,
+  true,
   java.lang.String instanceof java.lang.Class );
+
+new TestCase(
+  "java.lang.Class instanceof java.lang.String",
+  false,
+  java.lang.Class instanceof java.lang.String );
 
 new TestCase(
   "java.lang.Class.forName(\"java.lang.String\") instanceof java.lang.Class",
@@ -53,8 +63,8 @@ new TestCase(
   new java.lang.Double(5.0) instanceof java.lang.Number );
 
 new TestCase(
-  "new java.lang.String(\"hi\").getBytes() instanceof java.lang.Double",
+  "new java.lang.String(\"hi\").getBytes() instanceof byte[]",
   true,
-  new java.lang.Double(5.0) instanceof java.lang.Double );
+  new java.lang.String("hi").getBytes() instanceof java.lang.Class.forName("[B") );
 
 test();


### PR DESCRIPTION
This fixes an error, when `instanceOf` is used with java objects.

- `java.lang.String instanceof java.lang.Class` this was wron IMHO, as java.lang.String is wrapped as NativeJavaClass. So every NativeJavaClass is instance of `Class`
- Now, the return value of a function is wrapped into a NativeJavaClass if it was instanceof class (old behaviour a function/property returning a class was wrapped into a NativeJavaObject, which looks wrong to me), so `Class.forName("java.lang.String") == java.lang.String`