### PR TITLE
simplify handling of null values for Map

### DIFF
--- a/src/org/mozilla/javascript/Hashtable.java
+++ b/src/org/mozilla/javascript/Hashtable.java
@@ -138,13 +138,9 @@ public class Hashtable implements Serializable, Iterable<Hashtable.Entry> {
         }
     }
 
-    public Object get(Object key) {
+    public Entry getEntry(Object key) {
         final Entry e = new Entry(key, null);
-        final Entry v = map.get(e);
-        if (v == null) {
-            return null;
-        }
-        return v.value;
+        return map.get(e);
     }
 
     public boolean has(Object key) {

--- a/src/org/mozilla/javascript/NativeMap.java
+++ b/src/org/mozilla/javascript/NativeMap.java
@@ -13,8 +13,6 @@ public class NativeMap extends IdScriptableObject {
     private static final Object MAP_TAG = "Map";
     static final String ITERATOR_TAG = "Map Iterator";
 
-    private static final Object NULL_VALUE = new Object();
-
     private final Hashtable entries = new Hashtable();
 
     private boolean instanceOfMap = false;
@@ -89,15 +87,12 @@ public class NativeMap extends IdScriptableObject {
     }
 
     private Object js_set(Object k, Object v) {
-        // Map.get() does not distinguish between "not found" and a null value. So,
-        // replace true null here with a marker so that we can re-convert in "get".
-        final Object value = (v == null ? NULL_VALUE : v);
         // Special handling of "negative zero" from the spec.
         Object key = k;
         if ((key instanceof Number) && ((Number) key).doubleValue() == ScriptRuntime.negativeZero) {
             key = ScriptRuntime.zeroObj;
         }
-        entries.put(key, value);
+        entries.put(key, v);
         return this;
     }
 
@@ -107,14 +102,11 @@ public class NativeMap extends IdScriptableObject {
     }
 
     private Object js_get(Object arg) {
-        final Object val = entries.get(arg);
-        if (val == null) {
+        final Hashtable.Entry entry = entries.getEntry(arg);
+        if (entry == null) {
             return Undefined.instance;
         }
-        if (val == NULL_VALUE) {
-            return null;
-        }
-        return val;
+        return entry.value;
     }
 
     private Object js_has(Object arg) {
@@ -155,12 +147,7 @@ public class NativeMap extends IdScriptableObject {
             }
 
             final Hashtable.Entry e = i.next();
-            Object val = e.value;
-            if (val == NULL_VALUE) {
-                val = null;
-            }
-
-            f.call(cx, scope, thisObj, new Object[] {val, e.key, this});
+            f.call(cx, scope, thisObj, new Object[] {e.value, e.key, this});
         }
         return Undefined.instance;
     }

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;

--- a/testsrc/jstests/es6/map.js
+++ b/testsrc/jstests/es6/map.js
@@ -34,6 +34,60 @@ function logElement(value, key, m) {
   assertEquals("c) map[key1] = '' map[key2] = 'undefined' map[key3] = 'undefined' map[key4] = 'null' ", res);
 })();
 
+(function TestForOfNoKey() {
+  res = "d) ";
+  var myMap = new Map([['', 'value1'], [, 17], [undefined, 18], [null, 19]]);
+  for (var entry of myMap) {
+    res += "map[" + entry[0] + "] = '" + entry[1] + "' "; 
+  }
+
+  assertEquals("d) map[] = 'value1' map[undefined] = '18' map[null] = '19' ", res);
+})();
+
+(function TestForOfNoValue() {
+  res = "e) ";
+  var myMap = new Map([['key1', ''], ['key2',], ['key3', undefined], ['key4', null]]);
+  for (var entry of myMap) {
+    res += "map[" + entry[0] + "] = '" + entry[1] + "' "; 
+  }
+
+  assertEquals("e) map[key1] = '' map[key2] = 'undefined' map[key3] = 'undefined' map[key4] = 'null' ", res);
+})();
+
+(function TestEntriesNoKey() {
+  res = "f) ";
+  var myMap = new Map([['', 'value1'], [, 17], [undefined, 18], [null, 19]]);
+  
+  var myIter = myMap.entries();
+  var entry = myIter.next();
+  res += "map[0] = '" + entry.value + "' "; 
+  entry = myIter.next();
+  res += "map[1] = '" + entry.value + "' "; 
+  var entry = myIter.next();
+  res += "map[2] = '" + entry.value + "' "; 
+  var entry = myIter.next();
+  res += "map[3] = '" + entry.value + "' "; 
+
+  assertEquals("f) map[0] = ',value1' map[1] = ',18' map[2] = ',19' map[3] = 'undefined' ", res);
+})();
+
+(function TestEntriesNoValue() {
+  res = "g) ";
+  var myMap = new Map([['key1', ''], ['key2',], ['key3', undefined], ['key4', null]]);
+
+  var myIter = myMap.entries();
+  var entry = myIter.next();
+  res += "map[0] = '" + entry.value + "' "; 
+  entry = myIter.next();
+  res += "map[1] = '" + entry.value + "' "; 
+  var entry = myIter.next();
+  res += "map[2] = '" + entry.value + "' "; 
+  var entry = myIter.next();
+  res += "map[3] = '" + entry.value + "' "; 
+
+  assertEquals("g) map[0] = 'key1,' map[1] = 'key2,' map[2] = 'key3,' map[3] = 'key4,' ", res);
+})();
+
 (function TestGetConcatenatedStrings() {
   var myMap = new Map([['key1', 'value1'], ['key2', 17]]);
   for(let i = 1; i <= 1; i++) {

--- a/testsrc/org/mozilla/javascript/tests/es6/CollectionHashtableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/CollectionHashtableTest.java
@@ -42,7 +42,7 @@ public class CollectionHashtableTest
   @Test
   public void testEmpty() {
     assertEquals(0, ht.size());
-    assertNull(null, ht.get("one"));
+    assertNull(null, ht.getEntry("one"));
     assertFalse(ht.has("one"));
     assertNull(ht.delete("one"));
     ht.clear();
@@ -59,15 +59,15 @@ public class CollectionHashtableTest
   public void testCRUD() {
     ht.put("one", 1);
     assertEquals(1, ht.size());
-    assertEquals(1, ht.get("one"));
+    assertEquals(1, ht.getEntry("one").value());
     assertTrue(ht.has("one"));
     ht.put("two", 2);
     assertEquals(2, ht.size());
-    assertEquals(2, ht.get("two"));
+    assertEquals(2, ht.getEntry("two").value());
     assertTrue(ht.has("two"));
     ht.clear();
     assertEquals(0, ht.size());
-    assertNull(ht.get("one"));
+    assertNull(ht.getEntry("one"));
     assertFalse(ht.has("one"));
   }
 
@@ -292,13 +292,13 @@ public class CollectionHashtableTest
     ObjectInputStream oin = new ObjectInputStream(bis);
     Hashtable sht = (Hashtable)oin.readObject();
 
-    assertEquals(1, sht.get("one"));
-    assertEquals(2, sht.get("two"));
-    assertEquals(3, sht.get("three"));
-    assertEquals(Undefined.instance, sht.get("undefined"));
-    assertEquals("undefined", sht.get(Undefined.instance));
-    assertNull(sht.get("null"));
-    assertEquals("null", sht.get(null));
+    assertEquals(1, sht.getEntry("one").value());
+    assertEquals(2, sht.getEntry("two").value());
+    assertEquals(3, sht.getEntry("three").value());
+    assertEquals(Undefined.instance, sht.getEntry("undefined").value());
+    assertEquals("undefined", sht.getEntry(Undefined.instance).value());
+    assertNull(sht.getEntry("null").value());
+    assertEquals("null", sht.getEntry(null).value());
 
     Iterator<Entry> i = ht.iterator();
     Hashtable.Entry e = i.next();


### PR DESCRIPTION
fix: NativeMap's Map.entries() emulation can return NativeMap.NULL_VALUE instead of actual null instance
more test code

see https://github.com/HtmlUnit/htmlunit-core-js/issues/4 for a very detailed bug report