### PR TITLE
Do not init standard properties twice 

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -139,7 +139,10 @@ public class ScriptRuntime {
             Context cx, ScriptableObject scope, boolean sealed) {
         if (scope == null) {
             scope = new NativeObject();
+        } else if (scope instanceof TopLevel) {
+            ((TopLevel) scope).clearCache();
         }
+
         scope.associateValue(LIBRARY_SCOPE_KEY, scope);
         (new ClassCache()).associate(scope);
 

--- a/src/org/mozilla/javascript/TopLevel.java
+++ b/src/org/mozilla/javascript/TopLevel.java
@@ -119,6 +119,12 @@ public class TopLevel extends IdScriptableObject {
         }
     }
 
+    /** Clears the cache, this is necessary, when standard objects are reinitialized. */
+    void clearCache() {
+        ctors = null;
+        errors = null;
+    }
+
     /**
      * Static helper method to get a built-in object constructor with the given <code>type</code>
      * from the given <code>scope</code>. If the scope is not an instance of this class or does have

--- a/testsrc/org/mozilla/javascript/tests/InitStandardObjectsTest.java
+++ b/testsrc/org/mozilla/javascript/tests/InitStandardObjectsTest.java
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import junit.framework.TestCase;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Script;
+import org.mozilla.javascript.tools.shell.Global;
+
+/**
+ * Refer to https://github.com/mozilla/rhino/pull/1025
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class InitStandardObjectsTest extends TestCase {
+
+    private Global global = new Global();
+    private Context context;
+
+    public InitStandardObjectsTest() {
+        global.init(ContextFactory.getGlobal());
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        context = ContextFactory.getGlobal().enterContext();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        context.close();
+    }
+
+    /**
+     * This test calls initStandardObjects a second time. The expection is, that all modified
+     * objects are reset to default. Due a caching issue <code>[] instanceof Object</code> was not
+     * always true.
+     */
+    public void testInitStandardObjects() {
+
+        // Modify some prototypes
+        exec("Array.prototype.toString = function() { return 'foo' }");
+        assertEquals(true, exec("[] instanceof Array"));
+        assertEquals(true, exec("[] instanceof Object"));
+        assertEquals("foo", exec("[1,2,3].toString()"));
+
+        // re-init standard objects (remove prototype modification)
+        context.initStandardObjects(global);
+        assertEquals("1,2,3", exec("[1,2,3].toString()"));
+        assertEquals(true, exec("[] instanceof Array"));
+        assertEquals(true, exec("[] instanceof Object"));
+    }
+
+    private Object exec(String source) {
+        Script script = context.compileString(source, "", 1, null);
+        return script.exec(context, global);
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/JavaIterableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/JavaIterableTest.java
@@ -6,6 +6,14 @@
  */
 package org.mozilla.javascript.tests;
 
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import junit.framework.TestCase;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
@@ -14,15 +22,6 @@ import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.*;
 
 public class JavaIterableTest extends TestCase {
     protected final Global global = new Global();
@@ -35,9 +34,9 @@ public class JavaIterableTest extends TestCase {
     public void testMap() {
         Map map = new LinkedHashMap();
         String script =
-            "var a = [];\n" +
-            "for (var { key, value } of value.entrySet()) a.push(key, value);\n" +
-            "a";
+                "var a = [];\n"
+                        + "for (var { key, value } of value.entrySet()) a.push(key, value);\n"
+                        + "a";
 
         NativeArray resEmpty = (NativeArray) runScript(script, map);
         assertEquals(0, resEmpty.size());
@@ -62,15 +61,15 @@ public class JavaIterableTest extends TestCase {
             NativeArray res = (NativeArray) runScript("Array.from(value.entrySet())", map);
             assertEquals(3, res.size());
 
-            Map.Entry e0 = (Map.Entry)res.get(0);
+            Map.Entry e0 = (Map.Entry) res.get(0);
             assertEquals("a", e0.getKey());
             assertEquals("b", e0.getValue());
 
-            Map.Entry e1 = (Map.Entry)res.get(1);
+            Map.Entry e1 = (Map.Entry) res.get(1);
             assertEquals(123.0, Context.toNumber(e1.getKey()));
             assertEquals(234.0, Context.toNumber(e1.getValue()));
 
-            Map.Entry e2 = (Map.Entry)res.get(2);
+            Map.Entry e2 = (Map.Entry) res.get(2);
             assertEquals(o, e2.getKey());
             assertEquals(o, e2.getValue());
         }
@@ -79,10 +78,7 @@ public class JavaIterableTest extends TestCase {
     @Test
     public void testList() {
         List list = new ArrayList();
-        String script =
-            "var a = [];\n" +
-            "for (var e of value) a.push(e);\n" +
-            "a";
+        String script = "var a = [];\n" + "for (var e of value) a.push(e);\n" + "a";
 
         NativeArray resEmpty = (NativeArray) runScript(script, list);
         assertEquals(0, resEmpty.size());
@@ -112,10 +108,7 @@ public class JavaIterableTest extends TestCase {
     @Test
     public void testSet() {
         Set set = new LinkedHashSet();
-        String script =
-            "var a = [];\n" +
-            "for (var e of value) a.push(e);\n" +
-            "a";
+        String script = "var a = [];\n" + "for (var e of value) a.push(e);\n" + "a";
 
         NativeArray resEmpty = (NativeArray) runScript(script, set);
         assertEquals(0, resEmpty.size());
@@ -146,19 +139,23 @@ public class JavaIterableTest extends TestCase {
     @Test
     public void testNoIterable() {
         Object o = new Object();
-        String script ="for (var e of value) ;";
+        String script = "for (var e of value) ;";
 
-        assertThrows(EcmaError.class, () -> {
-                runScript(script, o);
-            });
+        assertThrows(
+                EcmaError.class,
+                () -> {
+                    runScript(script, o);
+                });
     }
 
     private Object runScript(String scriptSourceText, Object value) {
-        return ContextFactory.getGlobal().call(context -> {
-            context.setLanguageVersion(Context.VERSION_ES6);
-            Scriptable scope = context.newObject(global);
-            scope.put("value", scope, Context.javaToJS(value, scope));
-            return context.evaluateString(scope, scriptSourceText, "", 1, null);
-        });
+        return ContextFactory.getGlobal()
+                .call(
+                        context -> {
+                            context.setLanguageVersion(Context.VERSION_ES6);
+                            Scriptable scope = context.newObject(global);
+                            scope.put("value", scope, Context.javaToJS(value, scope));
+                            return context.evaluateString(scope, scriptSourceText, "", 1, null);
+                        });
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/JavaIterableTest.java
+++ b/testsrc/org/mozilla/javascript/tests/JavaIterableTest.java
@@ -156,7 +156,7 @@ public class JavaIterableTest extends TestCase {
     private Object runScript(String scriptSourceText, Object value) {
         return ContextFactory.getGlobal().call(context -> {
             context.setLanguageVersion(Context.VERSION_ES6);
-            Scriptable scope = context.initStandardObjects(global);
+            Scriptable scope = context.newObject(global);
             scope.put("value", scope, Context.javaToJS(value, scope));
             return context.evaluateString(scope, scriptSourceText, "", 1, null);
         });

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaListTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaListTest.java
@@ -137,7 +137,7 @@ public class NativeJavaListTest extends TestCase {
         return ContextFactory.getGlobal()
                 .call(
                         context -> {
-                            Scriptable scope = context.initStandardObjects(global);
+                            Scriptable scope = context.newObject(global);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return convert.apply(
                                     context.evaluateString(scope, scriptSourceText, "", 1, null));

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -221,7 +221,7 @@ public class NativeJavaMapTest extends TestCase {
         return getContextFactory(enableJavaMapAccess)
                 .call(
                         context -> {
-                            Scriptable scope = context.initStandardObjects(global);
+                            Scriptable scope = context.newObject(global);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return convert.apply(
                                     context.evaluateString(scope, scriptSourceText, "", 1, null));
@@ -232,7 +232,7 @@ public class NativeJavaMapTest extends TestCase {
         return getContextFactory(false)
                 .call(
                         context -> {
-                            Scriptable scope = context.initStandardObjects(global);
+                            Scriptable scope = context.newObject(global);
                             context.setLanguageVersion(Context.VERSION_ES6);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return context.evaluateString(scope, scriptSourceText, "", 1, null);

--- a/testsrc/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
@@ -1,0 +1,209 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.tools.shell.Global;
+
+/**
+ * This testcase performs various <code>instanceof</code> tests or prototype modifications in different modes.
+ *
+ * <ul>
+ *   <li>{@link Mode#GLOBAL}<br>
+ *       All scripts are executed against a {@link Global} object, which holds all standard
+ *       prototypes. Declarations like <code>var x=1</code> or <code>y=2</code> are stored in the
+ *       global context. So different script executions will see both locally and globally changed
+ *       variables.
+ *   <li>{@link Mode#NESTED}<br>
+ *       There is one global context and an other created with <code>
+ *       scope = context.newObject(global)</code>. Prototypes are held in global context. Local
+ *       variables like <code>var x=1</code> are stored in the scoped context, while global
+ *       variables like <code>y=2</code> are stored in the global one. Modification on prototypes
+ *       are done on the one in the global scope. Different script executions will only see globally
+ *       changed variables.
+ *   <li>{@link Mode#SEALED}<br>
+ *       Some applications will share one sealed global context over multiple threads. On each
+ *       script execution an empty scope that has the global scope as prototype is create. This will
+ *       lower the memory footprint, as the global objects have to be created only one. (See
+ *       https://github.com/mozilla/rhino/pull/826 for details) The drawback of this mode is, that
+ *       no prototype modification can be done, because the global scope is sealed.
+ *       So different script executions will not see any modifications
+ *   <li>{@link Mode#SEALED_OWN_OBJECTS} in this case, no empty scope is created but every scope has
+ *       its own standard-objects, which may increase the memory footprint, but some global objects
+ *       can be shared.
+ * </ul>
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+@RunWith(Parameterized.class)
+public class NestedContextPrototypeTest extends TestCase {
+    protected final Global global = new Global();
+    private Mode mode;
+
+    enum Mode {
+        GLOBAL,
+        NESTED,
+        SEALED,
+        SEALED_OWN_OBJECTS;
+    }
+
+    @Parameters(name = "{0}")
+    public static Collection<Mode> data() {
+        return Arrays.asList(Mode.values());
+    }
+
+    public NestedContextPrototypeTest(Mode mode) {
+        this.mode = mode;
+        boolean sealed = mode == Mode.SEALED || mode == Mode.SEALED_OWN_OBJECTS;
+        global.setSealedStdLib(sealed);
+        global.init(ContextFactory.getGlobal());
+
+        ContextFactory.getGlobal()
+                .call(
+                        context -> {
+                            context.evaluateString(
+                                    global,
+                                    "MyClass = function() {};\n" + "myInstance = new MyClass();",
+                                    "",
+                                    1,
+                                    null);
+                            if (sealed) {
+                                global.sealObject();
+                            }
+                            return null;
+                        });
+    }
+
+    private Object runScript(String scriptSourceText) {
+        return ContextFactory.getGlobal()
+                .call(
+                        context -> {
+                            Scriptable scope;
+                            switch (mode) {
+                                case GLOBAL:
+                                    scope = global;
+                                    break;
+                                case NESTED:
+                                    scope = context.newObject(global);
+                                    break;
+                                case SEALED:
+                                    scope = context.newObject(global);
+                                    scope.setPrototype(global);
+                                    scope.setParentScope(null);
+                                    break;
+                                case SEALED_OWN_OBJECTS:
+                                    scope = context.initStandardObjects(null);
+                                    scope.setPrototype(global);
+                                    scope.setParentScope(null);
+                                    break;
+                                default:
+                                    throw new UnsupportedOperationException();
+                            }
+
+                            return context.evaluateString(scope, scriptSourceText, "", 1, null);
+                        });
+    }
+
+    @Test
+    public void testArrayInstanceOfObject() {
+        assertEquals(true, runScript("[] instanceof Object"));
+    }
+
+    @Test
+    public void testArrayInstanceOfArray() {
+        assertEquals(true, runScript("[] instanceof Array"));
+    }
+
+    @Test
+    public void testObjectInstanceOfObject() {
+        assertEquals(true, runScript("({} instanceof Object)"));
+    }
+
+    @Test
+    public void testGlobalInstanceInstance() {
+        assertEquals(true, runScript("myInstance instanceof MyClass"));
+
+        if (mode == Mode.SEALED_OWN_OBJECTS) {
+            // this looks a bit strange, but in this mode, the scope has its own
+            // instance of Object
+            assertEquals(false, runScript("myInstance instanceof this.Object"));
+            assertEquals(true, runScript("myInstance instanceof this.__proto__.Object"));
+            assertEquals(true, runScript("[] instanceof this.Object"));
+            assertEquals(false, runScript("[] instanceof this.__proto__.Object"));
+        } else {
+            assertEquals(true, runScript("myInstance instanceof Object"));
+        }
+    }
+
+    private static String defineFoo =
+            "Object.prototype.foo = function() {\n" + " return 'bar';\n" + "};\n";
+
+    @Test(expected = EvaluatorException.class)
+    public void testPrototypeModification1Sealed() {
+        assumeTrue("check for exception in sealed mode", mode == Mode.SEALED);
+        runScript(defineFoo + "var v=[]; (v.foo())");
+    }
+
+    @Test
+    public void testPrototypeModification1() {
+        assumeFalse("cannot define foo in sealed mode", mode == Mode.SEALED);
+        assertEquals("bar", runScript(defineFoo + "var v=[]; (v.foo())"));
+        if (mode == Mode.GLOBAL || mode == Mode.NESTED)
+            assertEquals("bar", runScript("var v=[]; v.foo()"));
+    }
+
+    @Test
+    public void testPrototypeModification2() {
+        assumeFalse("ignored in sealed mode", mode == Mode.SEALED);
+        assertEquals("bar", runScript(defineFoo + "var v={}; (v.foo())"));
+        if (mode == Mode.GLOBAL || mode == Mode.NESTED)
+            assertEquals("bar", runScript("var v={}; v.foo()"));
+    }
+
+    @Test
+    public void testPrototypeModification3() {
+        assumeFalse("ignored in sealed mode", mode == Mode.SEALED);
+        assertEquals("bar", runScript(defineFoo + "var v=new Object(); v.foo()"));
+        if (mode == Mode.GLOBAL || mode == Mode.NESTED)
+            assertEquals("bar", runScript("var v=new Object(); v.foo()"));
+    }
+
+    @Test
+    public void testModeLocalVar() {
+        runScript("var v='hi'");
+        if (mode == Mode.GLOBAL) {
+            // only in GLOBAL mode, the local value will visible
+            assertEquals("string", runScript("typeof v;"));
+        } else {
+            // all other modes will not see the value in different script executions
+            assertEquals("undefined", runScript("typeof v;"));
+        }
+    }
+
+    @Test
+    public void testModeGlobalVar() {
+        runScript("v='hi'");
+        if (mode == Mode.GLOBAL || mode == Mode.NESTED) {
+            // globally defined values will be visible in GLOBAL and NESTED mode
+            assertEquals("string", runScript("typeof v;"));
+        } else {
+            assertEquals("undefined", runScript("typeof v;"));
+        }
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
@@ -22,7 +22,8 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
- * This testcase performs various <code>instanceof</code> tests or prototype modifications in different modes.
+ * This testcase performs various <code>instanceof</code> tests or prototype modifications in
+ * different modes.
  *
  * <ul>
  *   <li>{@link Mode#GLOBAL}<br>
@@ -42,8 +43,8 @@ import org.mozilla.javascript.tools.shell.Global;
  *       script execution an empty scope that has the global scope as prototype is create. This will
  *       lower the memory footprint, as the global objects have to be created only one. (See
  *       https://github.com/mozilla/rhino/pull/826 for details) The drawback of this mode is, that
- *       no prototype modification can be done, because the global scope is sealed.
- *       So different script executions will not see any modifications
+ *       no prototype modification can be done, because the global scope is sealed. So different
+ *       script executions will not see any modifications
  *   <li>{@link Mode#SEALED_OWN_OBJECTS} in this case, no empty scope is created but every scope has
  *       its own standard-objects, which may increase the memory footprint, but some global objects
  *       can be shared.

--- a/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
+++ b/testsrc/org/mozilla/javascript/tests/WrapFactoryTest.java
@@ -65,7 +65,7 @@ public class WrapFactoryTest {
         Context cx = Context.enter();
         try {
             cx.getWrapFactory().setJavaPrimitiveWrap(javaPrimitiveWrap);
-            Scriptable scope = cx.initStandardObjects(new ImporterTopLevel(cx));
+            Scriptable scope = cx.newObject(new ImporterTopLevel(cx));
 
             // register object
             Map<String, Object> map = new LinkedHashMap<>();


### PR DESCRIPTION
I found a strange behaviour while fixing `instanceof` in #830.

My problem was, while `[] instanceof Array` retured true, `[] instanceof Object` returned false (at least in the NativeJavaListTest)

After some time of debugging, I noticed, that the NativeJavaListTest does the following:

```java
Global global = new Global();
global.init(ContextFactory.getGlobal());
Scriptable scope = context.initStandardObjects(global);
context.evaluateString(scope, "[] instanceof Object",...)
```
The problem is, that `global.init(ContextFactory.getGlobal());` creates all standard objects the first time, while `context.initStandardObjects(global)` will overwrite the standard objects. (Note: initStandardObjects will return the `global` value and no new instance)
So, we have 2 "Object" prototypes:
`scope.get("Object", scope).prototypeProperty` will return an other instance than `ScriptableObject.getObjectPrototype(scope)` 
This has to do something with 
```java
        if (scope instanceof TopLevel) {
            ((TopLevel) scope).cacheBuiltins(scope, sealed);
        }
```
at the end of the `initSafeStandardObjects` method.

In the first call of "initStandardObjects",, the cache is empty, so
- Object-Prototype is created (instance 1)
- Array-prototype is created (requires Object-prototype and gets instance 1 - no cache hit)
- ...
- cacheBuiltins is called.

on the second call of "initStandardObjects", 
- Object-Prototype is created (instance 2)
- Array-prototype is created (requires Object-prototype and gets instance 1 - from cache !)
- ...
- cacheBuiltins is called. (will update cached value to instance 2, but this is too late)


What would you suggest as solution:

**Solution 1:** Not calling "initStandardObjects" twice?
I would add an assert/exception in ScriptRuntime.initSafeStandardObjects:
```java
    public static ScriptableObject initSafeStandardObjects(
            Context cx, ScriptableObject scope, boolean sealed) {
        if (scope == null) {
            scope = new NativeObject();
        } else {
            assert !scope.has("Object",scope) : "already initialized";
        }
```

**Solution 2:** Clearing the cache, when "initStandardObjects" is called a second time:
```java
    public static ScriptableObject initSafeStandardObjects(
            Context cx, ScriptableObject scope, boolean sealed) {
        if (scope == null) {
            scope = new NativeObject();
        } else if (scope instanceof TopLevel) {
            ((TopLevel)scope).clearCache(); // will set TopLevel.ctors and TopLevel.errors to null
        }
```

in my oppinion, it does not make sense, to initialize objects twice, so throwing an exception/printing a warning would make sense, but may break existing code


