### PR TITLE
switch to a vmbridge for jdk_11 and above

### DIFF
--- a/src/org/mozilla/javascript/VMBridge.java
+++ b/src/org/mozilla/javascript/VMBridge.java
@@ -10,23 +10,24 @@ package org.mozilla.javascript;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
 
-public abstract class VMBridge
-{
+public abstract class VMBridge {
 
     static final VMBridge instance = makeInstance();
 
-    private static VMBridge makeInstance()
-    {
+    private static VMBridge makeInstance() {
         String[] classNames = {
             "org.mozilla.javascript.VMBridge_custom",
+            "org.mozilla.javascript.jdk11.VMBridge_jdk11",
             "org.mozilla.javascript.jdk18.VMBridge_jdk18",
         };
         for (int i = 0; i != classNames.length; ++i) {
             String className = classNames[i];
             Class<?> cl = Kit.classOrNull(className);
             if (cl != null) {
-                VMBridge bridge = (VMBridge)Kit.newInstanceOrNull(cl);
+                VMBridge bridge = (VMBridge) Kit.newInstanceOrNull(cl);
                 if (bridge != null) {
                     return bridge;
                 }
@@ -37,49 +38,45 @@ public abstract class VMBridge
 
     /**
      * Return a helper object to optimize {@link Context} access.
-     * <p>
-     * The runtime will pass the resulting helper object to the subsequent
-     * calls to {@link #getContext(Object contextHelper)} and
-     * {@link #setContext(Object contextHelper, Context cx)} methods.
-     * In this way the implementation can use the helper to cache
-     * information about current thread to make {@link Context} access faster.
+     *
+     * <p>The runtime will pass the resulting helper object to the subsequent calls to {@link
+     * #getContext(Object contextHelper)} and {@link #setContext(Object contextHelper, Context cx)}
+     * methods. In this way the implementation can use the helper to cache information about current
+     * thread to make {@link Context} access faster.
      */
     protected abstract Object getThreadContextHelper();
 
     /**
-     * Get {@link Context} instance associated with the current thread
-     * or null if none.
+     * Get {@link Context} instance associated with the current thread or null if none.
      *
-     * @param contextHelper The result of {@link #getThreadContextHelper()}
-     *                      called from the current thread.
+     * @param contextHelper The result of {@link #getThreadContextHelper()} called from the current
+     *     thread.
      */
     protected abstract Context getContext(Object contextHelper);
 
     /**
-     * Associate {@link Context} instance with the current thread or remove
-     * the current association if <code>cx</code> is null.
+     * Associate {@link Context} instance with the current thread or remove the current association
+     * if <code>cx</code> is null.
      *
-     * @param contextHelper The result of {@link #getThreadContextHelper()}
-     *                      called from the current thread.
+     * @param contextHelper The result of {@link #getThreadContextHelper()} called from the current
+     *     thread.
      */
     protected abstract void setContext(Object contextHelper, Context cx);
 
     /**
-     * In many JVMSs, public methods in private
-     * classes are not accessible by default (Sun Bug #4071593).
-     * VMBridge instance should try to workaround that via, for example,
-     * calling method.setAccessible(true) when it is available.
-     * The implementation is responsible to catch all possible exceptions
-     * like SecurityException if the workaround is not available.
+     * In many JVMSs, public methods in private classes are not accessible by default (Sun Bug
+     * #4071593). VMBridge instance should try to workaround that via, for example, calling
+     * method.setAccessible(true) when it is available. The implementation is responsible to catch
+     * all possible exceptions like SecurityException if the workaround is not available.
      *
-     * @return true if it was possible to make method accessible
-     *         or false otherwise.
+     * @return true if it was possible to make method accessible or false otherwise.
      */
     protected abstract boolean tryToMakeAccessible(AccessibleObject accessible);
 
     /**
-     * Create helper object to create later proxies implementing the specified
-     * interfaces later. Under JDK 1.3 the implementation can look like:
+     * Create helper object to create later proxies implementing the specified interfaces later.
+     * Under JDK 1.3 the implementation can look like:
+     *
      * <pre>
      * return java.lang.reflect.Proxy.getProxyClass(..., interfaces).
      *     getConstructor(new Class[] {
@@ -88,22 +85,50 @@ public abstract class VMBridge
      *
      * @param interfaces Array with one or more interface class objects.
      */
-    protected abstract Object getInterfaceProxyHelper(ContextFactory cf,
-                                             Class<?>[] interfaces);
+    protected abstract Object getInterfaceProxyHelper(ContextFactory cf, Class<?>[] interfaces);
 
     /**
-     * Create proxy object for {@link InterfaceAdapter}. The proxy should call
-     * {@link InterfaceAdapter#invoke(ContextFactory, Object, Scriptable,
-     *                                Object, Method, Object[])}
-     * as implementation of interface methods associated with
-     * <code>proxyHelper</code>. {@link Method}
+     * Create proxy object for {@link InterfaceAdapter}. The proxy should call {@link
+     * InterfaceAdapter#invoke(ContextFactory, Object, Scriptable, Object, Method, Object[])} as
+     * implementation of interface methods associated with <code>proxyHelper</code>. {@link Method}
      *
-     * @param proxyHelper The result of the previous call to
-     *        {@link #getInterfaceProxyHelper(ContextFactory, Class[])}.
+     * @param proxyHelper The result of the previous call to {@link
+     *     #getInterfaceProxyHelper(ContextFactory, Class[])}.
      */
-    protected abstract Object newInterfaceProxy(Object proxyHelper,
-                                       ContextFactory cf,
-                                       InterfaceAdapter adapter,
-                                       Object target,
-                                       Scriptable topScope);
+    protected abstract Object newInterfaceProxy(
+            Object proxyHelper,
+            ContextFactory cf,
+            InterfaceAdapter adapter,
+            Object target,
+            Scriptable topScope);
+
+    public abstract void discoverPublicMethods(Class<?> clazz, Map<MethodSignature, Method> map);
+
+    public static final class MethodSignature {
+        private final String name;
+        private final Class<?>[] args;
+
+        private MethodSignature(String name, Class<?>[] args) {
+            this.name = name;
+            this.args = args;
+        }
+
+        public MethodSignature(Method method) {
+            this(method.getName(), method.getParameterTypes());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof MethodSignature) {
+                MethodSignature ms = (MethodSignature) o;
+                return ms.name.equals(name) && Arrays.equals(args, ms.args);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode() ^ args.length;
+        }
+    }
 }

--- a/src/org/mozilla/javascript/jdk11/VMBridge_jdk11.java
+++ b/src/org/mozilla/javascript/jdk11/VMBridge_jdk11.java
@@ -4,22 +4,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.javascript;
+package org.mozilla.javascript.jdk11;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
+import org.mozilla.javascript.jdk18.VMBridge_jdk18;
 
-/** Version of {@link JavaMembers} for modular JDKs. */
-class JavaMembers_jdk11 extends JavaMembers {
-
-    JavaMembers_jdk11(Scriptable scope, Class<?> cl, boolean includeProtected) {
-        super(scope, cl, includeProtected);
-    }
-
+public class VMBridge_jdk11 extends VMBridge_jdk18 {
     @Override
-    void discoverPublicMethods(Class<?> clazz, Map<MethodSignature, Method> map) {
+    public void discoverPublicMethods(Class<?> clazz, Map<MethodSignature, Method> map) {
         if (isExportedClass(clazz)) {
             super.discoverPublicMethods(clazz, map);
         } else {

--- a/src/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
+++ b/src/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
@@ -12,20 +12,18 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-
+import java.util.Map;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.InterfaceAdapter;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.VMBridge;
 
-public class VMBridge_jdk18 extends VMBridge
-{
+public class VMBridge_jdk18 extends VMBridge {
     private static final ThreadLocal<Object[]> contextLocal = new ThreadLocal<Object[]>();
 
     @Override
-    protected Object getThreadContextHelper()
-    {
+    protected Object getThreadContextHelper() {
         // To make subsequent batch calls to getContext/setContext faster
         // associate permanently one element array with contextLocal
         // so getContext/setContext would need just to read/write the first
@@ -44,43 +42,39 @@ public class VMBridge_jdk18 extends VMBridge
     }
 
     @Override
-    protected Context getContext(Object contextHelper)
-    {
-        Object[] storage = (Object[])contextHelper;
-        return (Context)storage[0];
+    protected Context getContext(Object contextHelper) {
+        Object[] storage = (Object[]) contextHelper;
+        return (Context) storage[0];
     }
 
     @Override
-    protected void setContext(Object contextHelper, Context cx)
-    {
-        Object[] storage = (Object[])contextHelper;
+    protected void setContext(Object contextHelper, Context cx) {
+        Object[] storage = (Object[]) contextHelper;
         storage[0] = cx;
     }
 
     @Override
-    protected boolean tryToMakeAccessible(AccessibleObject accessible)
-    {
+    protected boolean tryToMakeAccessible(AccessibleObject accessible) {
         if (accessible.isAccessible()) {
             return true;
         }
         try {
             accessible.setAccessible(true);
-        } catch (Exception ex) { }
+        } catch (Exception ex) {
+        }
 
         return accessible.isAccessible();
     }
 
     @Override
-    protected Object getInterfaceProxyHelper(ContextFactory cf,
-                                             Class<?>[] interfaces)
-    {
+    protected Object getInterfaceProxyHelper(ContextFactory cf, Class<?>[] interfaces) {
         // XXX: How to handle interfaces array withclasses from different
         // class loaders? Using cf.getApplicationClassLoader() ?
         ClassLoader loader = interfaces[0].getClassLoader();
         Class<?> cl = Proxy.getProxyClass(loader, interfaces);
         Constructor<?> c;
         try {
-            c = cl.getConstructor(new Class[] { InvocationHandler.class });
+            c = cl.getConstructor(new Class[] {InvocationHandler.class});
         } catch (NoSuchMethodException ex) {
             // Should not happen
             throw new IllegalStateException(ex);
@@ -89,43 +83,41 @@ public class VMBridge_jdk18 extends VMBridge
     }
 
     @Override
-    protected Object newInterfaceProxy(Object proxyHelper,
-                                       final ContextFactory cf,
-                                       final InterfaceAdapter adapter,
-                                       final Object target,
-                                       final Scriptable topScope)
-    {
-        Constructor<?> c = (Constructor<?>)proxyHelper;
+    protected Object newInterfaceProxy(
+            Object proxyHelper,
+            final ContextFactory cf,
+            final InterfaceAdapter adapter,
+            final Object target,
+            final Scriptable topScope) {
+        Constructor<?> c = (Constructor<?>) proxyHelper;
 
-        InvocationHandler handler = new InvocationHandler() {
-                @Override
-                public Object invoke(Object proxy,
-                                     Method method,
-                                     Object[] args)
-                {
-                    // In addition to methods declared in the interface, proxies
-                    // also route some java.lang.Object methods through the
-                    // invocation handler.
-                    if (method.getDeclaringClass() == Object.class) {
-                        String methodName = method.getName();
-                        if (methodName.equals("equals")) {
-                            Object other = args[0];
-                            // Note: we could compare a proxy and its wrapped function
-                            // as equal here but that would break symmetry of equal().
-                            // The reason == suffices here is that proxies are cached
-                            // in ScriptableObject (see NativeJavaObject.coerceType())
-                            return Boolean.valueOf(proxy == other);
+        InvocationHandler handler =
+                new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) {
+                        // In addition to methods declared in the interface, proxies
+                        // also route some java.lang.Object methods through the
+                        // invocation handler.
+                        if (method.getDeclaringClass() == Object.class) {
+                            String methodName = method.getName();
+                            if (methodName.equals("equals")) {
+                                Object other = args[0];
+                                // Note: we could compare a proxy and its wrapped function
+                                // as equal here but that would break symmetry of equal().
+                                // The reason == suffices here is that proxies are cached
+                                // in ScriptableObject (see NativeJavaObject.coerceType())
+                                return Boolean.valueOf(proxy == other);
+                            }
+                            if (methodName.equals("hashCode")) {
+                                return Integer.valueOf(target.hashCode());
+                            }
+                            if (methodName.equals("toString")) {
+                                return "Proxy[" + target.toString() + "]";
+                            }
                         }
-                        if (methodName.equals("hashCode")) {
-                            return Integer.valueOf(target.hashCode());
-                        }
-                        if (methodName.equals("toString")) {
-                            return "Proxy[" + target.toString() + "]";
-                        }
+                        return adapter.invoke(cf, target, topScope, proxy, method, args);
                     }
-                    return adapter.invoke(cf, target, topScope, proxy, method, args);
-                }
-            };
+                };
         Object proxy;
         try {
             proxy = c.newInstance(handler);
@@ -139,5 +131,19 @@ public class VMBridge_jdk18 extends VMBridge
             throw new IllegalStateException(ex);
         }
         return proxy;
+    }
+
+    @Override
+    public void discoverPublicMethods(Class<?> clazz, Map<MethodSignature, Method> map) {
+        Method[] methods = clazz.getMethods();
+        for (Method method : methods) {
+            registerMethod(map, method);
+        }
+    }
+
+    protected static void registerMethod(Map<MethodSignature, Method> map, Method method) {
+        MethodSignature sig = new MethodSignature(method);
+        // Array may contain methods with same signature but different return value!
+        map.putIfAbsent(sig, method);
     }
 }


### PR DESCRIPTION
There is this concept of the VMBride to handle JDK specifics - let us use this for the jdk11 specific stuff to follow a unique path.