### PR TITLE
Gradle: allow spotless in Java 17 CI & small nits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,17 +411,22 @@ spotless {
     }
 }
 
-if (JavaVersion.current() > JavaVersion.VERSION_15 && (!project.hasProperty('org.gradle.jvmargs')
-            || !project.property('org.gradle.jvmargs').contains('com.sun.tools.javac.api'))) {
-    logger.warn('spotless plugin disabled due to bug, ' + \
-        'see README for a workaround when building with Java 16+.')
-    tasks.withType(com.diffplug.gradle.spotless.SpotlessTask) {
-        enabled = false
+if (JavaVersion.current() > JavaVersion.VERSION_15
+        && (!System.properties.containsKey('org.gradle.jvmargs')
+        || !System.properties.get('org.gradle.jvmargs').contains('com.sun.tools.javac.api'))
+        && (!project.hasProperty('org.gradle.jvmargs')
+        || !project.property('org.gradle.jvmargs').contains('com.sun.tools.javac.api'))) {
+    tasks.named('check') {
+        doFirst {
+            logger.warn('WARNING: spotless plugin removed from check due to bug, ' + \
+                'see README for a workaround when building with Java 16+.')
+        }
     }
+    spotless.enforceCheck false
 }
 
-jacocoTestReport.dependsOn test
 jacocoTestReport {
+    dependsOn test
     reports {
         csv.required = true
         html.required = true
@@ -464,4 +469,5 @@ distributions {
     }
 }
 
+distTar.dependsOn javadoc, jar
 distZip.dependsOn javadoc, jar, sourceJar, runtimeSourceJar


### PR DESCRIPTION
The JVM arguments were not being found during my check for the spotless fix, when CI was run with Java 17, leading to spotless being unnecessarily disabled.

This Gradle fix should have been part of my previous PR, but somehow only saw the spotless warning after the merge.

The spotless warning is now only printed when the `check` task is executed, and the plugin is only excluded from that task. Otherwise, the warning was appearing when running unrelated tasks.

Also, a couple of small Gradle improvements are included (one removes a warning).