### PR TITLE
Try setting superblock locals from an initialised exception handler

### DIFF
--- a/src/org/mozilla/classfile/ClassFileWriter.java
+++ b/src/org/mozilla/classfile/ClassFileWriter.java
@@ -1605,7 +1605,11 @@ public class ClassFileWriter {
                     int handlerPC = getLabelPC(ete.itsHandlerLabel);
                     SuperBlock handlerSB = getSuperBlockFromOffset(handlerPC);
                     locals = handlerSB.getLocals();
-                    break;
+                    if (handlerSB.isInitialized()) {
+                        break;
+                    } else {
+                        continue;
+                    }
                 }
                 if (eteStart > sbStart && eteStart < sb.getEnd()) {
                     int handlerPC = getLabelPC(ete.itsHandlerLabel);
@@ -1623,7 +1627,7 @@ public class ClassFileWriter {
             for (int i = 0; i < itsExceptionTableTop; i++) {
                 ExceptionTableEntry ete = itsExceptionTable[i];
                 int eteStart = getLabelPC(ete.itsStartLabel);
-                if (eteStart == sb.getStart()) {
+                if (eteStart == sb.getStart() || getLabelPC(ete.itsHandlerLabel) == sb.getStart()) {
                     for (int j = i + 1; j < itsExceptionTableTop; j++) {
                         itsExceptionTable[j - 1] = itsExceptionTable[j];
                     }

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -6580,6 +6580,123 @@ language/statements/generators 225/259 (86.87%)
     yield-star-after-newline.js
     yield-star-before-newline.js
 
+language/statements/try 115/195 (58.97%)
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
+    dstr/ary-init-iter-no-close.js
+    dstr/ary-name-iter-val.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-ary-val-null.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-complete.js
+    dstr/ary-ptrn-elem-id-iter-done.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elem-obj-val-null.js
+    dstr/ary-ptrn-elem-obj-val-undef.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-exhausted.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-empty.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-empty.js
+    dstr/obj-ptrn-id-get-value-err.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-id-trailing-comma.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-trailing-comma.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-id-trailing-comma.js
+    dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    12.14-13.js non-strict
+    12.14-14.js non-strict
+    12.14-15.js non-strict
+    12.14-16.js non-strict
+    cptn-catch.js
+    cptn-catch-empty-break.js
+    cptn-catch-empty-continue.js
+    cptn-catch-finally-empty-break.js
+    cptn-catch-finally-empty-continue.js
+    cptn-finally-empty-break.js
+    cptn-finally-empty-continue.js
+    cptn-finally-from-catch.js
+    cptn-finally-skip-catch.js
+    cptn-finally-wo-catch.js
+    cptn-try.js
+    early-catch-function.js
+    early-catch-lex.js
+    optional-catch-binding.js
+    optional-catch-binding-finally.js
+    optional-catch-binding-lexical.js
+    optional-catch-binding-throws.js
+    scope-catch-block-lex-close.js
+    scope-catch-block-lex-open.js
+    scope-catch-param-lex-open.js
+    scope-catch-param-var-none.js non-strict
+    tco-catch.js {unsupported: [tail-call-optimization]}
+    tco-catch-finally.js {unsupported: [tail-call-optimization]}
+    tco-finally.js {unsupported: [tail-call-optimization]}
+
 language/types 9/113 (7.96%)
     number/S8.5_A10_T1.js
     number/S8.5_A10_T2.js non-strict


### PR DESCRIPTION
The patch to `ClassFileWriter` contains two hunks: the first one is the real fix, the second unmaps dead exception handlers (that generally happen with nested `finally` clauses) which otherwise may trigger JRE verifier errors. That second hunk could be removed if the performance hit is considered undesirable.

Closes #915.