### PR TITLE
Should ScriptableObject.sealObject also prevent modifications of parent and prototype

### DIFF
--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -146,14 +146,10 @@ public class ScriptRuntime {
         scope.associateValue(LIBRARY_SCOPE_KEY, scope);
         (new ClassCache()).associate(scope);
 
-        BaseFunction.init(scope, sealed);
         NativeObject.init(scope, sealed);
+        BaseFunction.init(scope, sealed);
 
         Scriptable objectProto = ScriptableObject.getObjectPrototype(scope);
-
-        // Function.prototype.__proto__ should be Object.prototype
-        Scriptable functionProto = ScriptableObject.getClassPrototype(scope, "Function");
-        functionProto.setPrototype(objectProto);
 
         // Set the prototype of the object passed in if need be
         if (scope.getPrototype() == null) scope.setPrototype(objectProto);

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -680,6 +680,7 @@ public abstract class ScriptableObject
     /** Sets the prototype of the object. */
     @Override
     public void setPrototype(Scriptable m) {
+        checkNotSealed("__proto__", 0);
         prototypeObject = m;
     }
 
@@ -692,6 +693,7 @@ public abstract class ScriptableObject
     /** Sets the parent (enclosing) scope of the object. */
     @Override
     public void setParentScope(Scriptable m) {
+        checkNotSealed("__parent__", 0);
         parentScopeObject = m;
     }
 


### PR DESCRIPTION
_Please consider this PR first as question, if I (mis)understand documentation or if it is really a bug_

My use case is, that I have a shared scope and I want to prevent that scope from any modifications.

So I thougt, it would be a good idea to call `scope.sealObject()`

I noticed, that no normal property is writeable - but I can change the `__parent__` and `__proto__` of such sealed objects.
(This is also what I try to fix in this PR)

I planned also to implement `sealObject` in NativeJavaObject, so that you can seal them too, to prevent from further modification. For example block `put` operations and especially `__parent__` and `__proto__` property (I'm aware that I can use UnmodifiableMap and so on, but this does not prevent modification of the special props)

Then I found in the documentation of [ScriptableObject](https://github.com/mozilla/rhino/blob/master/src/org/mozilla/javascript/ScriptableObject.java#L1942):
> It is possible to change the value of an existing property

This seems not to be true, at least what I have found in my tests. I dig further into documentation and found https://github.com/mozilla/rhino/issues/676 and https://262.ecma-international.org/11.0/#sec-object.seal which confirms that existing properties should be modifiable.

So there IS a difference between java `ScriptableObject.sealObject` and js `Object.seal` (the later one does not call the first one and objects sealed with `Object.seal` throw only an EcmaError in strict mode, while objects sealed with `ScriptableObject.sealObject` throw an EvaluatorException)

Maybe someone can explain, what's the intention of `sealObject`