### PR TITLE
Exclude `testsrc` and `examples` from spotbugs on Windows systems

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -6,7 +6,13 @@
     <Source name="~.*\/testsrc\/.*"/>
   </Match>
   <Match>
+    <Source name="~.*\\testsrc\\.*"/>
+  </Match>
+  <Match>
     <Source name="~.*\/examples\/.*"/>
+  </Match>
+  <Match>
+    <Source name="~.*\\examples\\.*"/>
   </Match>
   <Match>
     <Class name="~org\.mozilla\.javascript\.benchmarks\.jmh_generated.*"/>


### PR DESCRIPTION
Excludes `testsrc` and `examples` directories from spotbugs on Windows systems. I also include a few version upgrades (following the practice of upgrading plugin/dependency versions before a release).

Closes #1086.

EDIT: I removed the version upgrades.