### PR TITLE
Fix invalid single quotes in French messages

### DIFF
--- a/src/org/mozilla/javascript/resources/Messages_fr.properties
+++ b/src/org/mozilla/javascript/resources/Messages_fr.properties
@@ -97,7 +97,7 @@ msg.eval.nonstring =\
     c''est la valeur en question qui est renvoy\u00E9e. \u00E9tait-ce votre intention?
 
 msg.eval.nonstring.strict =\
-    La fonction eval() ne peut \u00eatre appel\u00e9e avec une valeur autre qu'une cha\u00EEne primitive \
+    La fonction eval() ne peut \u00eatre appel\u00e9e avec une valeur autre qu''une cha\u00EEne primitive \
     en mode strict
 
 msg.bad.destruct.op =\
@@ -152,8 +152,8 @@ msg.no.empty.interface.conversion =\
     Impossible de convertir la fonction en interface {0} sans aucune m\u00e9thode
 
 msg.no.function.interface.conversion =\
-    Impossible de convertir la fonction {0} en interface puisqu'elle contient des m\u00e9thodes avec \
-    des noms diff\u00e9rentes
+    Impossible de convertir la fonction {0} en interface puisqu''elle contient des m\u00e9thodes avec \
+    des noms diff\u00e9rents
 
 msg.undefined.function.interface =\
     La propri\u00E9t\u00E9 "{0}" n''est pas d\u00E9finie dans l''adaptateur d''interface
@@ -200,7 +200,7 @@ msg.trail.backslash =\
     \\ \u00e0 la fin d''une expression rationnelle
 
 msg.re.unmatched.right.paren =\
-    Parenth\u00e8se fermante orpheline dans l'expression rationnelle
+    Parenth\u00e8se fermante orpheline dans l''expression rationnelle
 
 msg.no.regexp =\
     Les expressions rationnelles ne sont pas disponibles
@@ -245,7 +245,7 @@ msg.let.decl.not.in.block =\
     Erreur de syntaxe: la d\u00e9claration ''let'' n''est pas directement dans un block
 
 msg.bad.object.init =\
-    Erreur de syntaxe: initialiseur d'objet incorrect
+    Erreur de syntaxe: initialiseur d''objet incorrect
 
 # NodeTransformer
 msg.dup.label =\
@@ -352,7 +352,7 @@ msg.no.paren.after.with =\
     il manque '')'' apr\u00E8s un objet with-statement
 
 msg.no.with.strict =\
-    L'instruction with n''est pas autoris\u00e9e en mode strict
+    L''instruction with n''est pas autoris\u00e9e en mode strict
 
 msg.no.paren.after.let =\
     il manque ''('' apr\u00e8s let
@@ -361,7 +361,7 @@ msg.no.paren.let =\
     il manque '')'' apr\u00e8s la liste de variables
 
 msg.no.curly.let =\
-    il manque ''}'' apr\u00e8s l'instruction let
+    il manque ''}'' apr\u00e8s l''instruction let
 
 msg.bad.return =\
     la valeur renvoy\u00E9e est incorrecte
@@ -427,7 +427,7 @@ msg.anon.no.return.value =\
     la fonction anonyme ne renvoie pas toujours de valeur
 
 msg.return.inconsistent =\
-    l'instruction return est incoh\u00e9rente avec les usages pr\u00e9c\u00e9dents
+    l''instruction return est incoh\u00e9rente avec les usages pr\u00e9c\u00e9dents
 
 msg.generator.returns =\
     Erreur de type: la fonction g\u00e9n\u00e9ratrice {0} renvoie une valeur
@@ -548,22 +548,22 @@ msg.undef.prop.delete =\
     Impossible de supprimer la propri\u00e9t\u00e9 "{1}" de {0}
 
 msg.undef.method.call =\
-    Impossible d'appeler la m\u00e9thode "{1}" de {0}
+    Impossible d''appeler la m\u00e9thode "{1}" de {0}
 
 msg.undef.with =\
-    Impossible d'appliquer "with" \u00e0 {0}
+    Impossible d''appliquer "with" \u00e0 {0}
 
 msg.isnt.function =\
     {0} n''est pas une fonction, c''est un {1}
 
 msg.isnt.function.in =\
-    Impossible d'appeler la propri\u00e9t\u00e9 {0} de l'objet {1}. Ce n''est pas une fonction, c''est un "{2}".
+    Impossible d''appeler la propri\u00e9t\u00e9 {0} de l''objet {1}. Ce n''est pas une fonction, c''est un "{2}".
 
 msg.function.not.found =\
     Impossible de trouver la fonction {0}.
 
 msg.function.not.found.in =\
-    Impossible de trouver la fonction {0} dans l'objet {1}.
+    Impossible de trouver la fonction {0} dans l''objet {1}.
 
 msg.isnt.xml.object =\
     {0} n''est pas un objet xml.
@@ -576,7 +576,7 @@ msg.no.ref.to.set =\
 
 msg.no.ref.from.function =\
     La fonction {0} ne peut pas \u00eatre utilis\u00e9e comme la partie gauche de l''assignation \
-    ou comme l'op\u00e9rande de l''op\u00e9rateur ++ ou --.
+    ou comme l''op\u00e9rande de l''op\u00e9rateur ++ ou --.
 
 msg.bad.default.value =\
     La m\u00E9thode getDefaultValue() de l''objet a renvoy\u00E9 un objet
@@ -781,7 +781,7 @@ msg.not.java.class.arg = \
 
 #JavaAdapter
 msg.only.one.super = \
-    Un JavaAdapter ne peut \u00e9tendre qu'une seule classe. Les classes {0} et {1} ont \u00e9t\u00e9 donn\u00e9es.
+    Un JavaAdapter ne peut \u00e9tendre qu''une seule classe. Les classes {0} et {1} ont \u00e9t\u00e9 donn\u00e9es.
 
 
 # Arrays


### PR DESCRIPTION
When running in a French locale, some error messages are not very helpful as rogue single quotes prevent important pattern replacements elsewhere in the message.  An example:

> org.mozilla.javascript.EcmaError: TypeError: Impossible dappeler la méthode "{1}" de {0}

The single quote in _d'appeler_ causes the patterns to remain unchanged, even though the arguments were correctly provided.

Also fixed a tiny grammatical error on line 156.