### PR TITLE
Provide console API in shell.

### DIFF
--- a/man/rhino.1
+++ b/man/rhino.1
@@ -80,6 +80,34 @@ creates a synchronized function (in the sense of a Java synchronized method) fro
 Quit shell. The shell will also quit in interactive mode if an end-of-file character is typed at the prompt.
 .IP version(\fI[number]\fP)
 Get or set JavaScript version number. If no argument is supplied, the current version number is returned. If an argument is supplied, it is expected to be one of 100, 110, 120, 130, or 140 to indicate JavaScript version 1.0, 1.1, 1.2, 1.3, or 1.4 respectively.
+.IP console
+The console object provides a simple debugging console similar to the console object provided by web browsers.
+.RS
+.IP console.log(\fIformat[arg,\&.\&.\&.]\fP)
+For general output of logging information. String substitution and additional arguments are supported. Prints formatted text according to the format and args supplied with "INFO" prefix. This function is identical to console.info(\fIformat\fP[arg,\&.\&.\&.]).
+.IP console.trace(\fIformat[arg,\&.\&.\&.]\fP)
+This function is identical to console.log(\fIformat\fP[arg,\&.\&.\&.]) except it prints "TRACE" prefix instead of "INFO".
+.IP console.debug(\fIformat[arg,\&.\&.\&.]\fP)
+This function is identical to console.log(\fIformat\fP[arg,\&.\&.\&.]) except it prints "DEBUG" prefix instead of "INFO".
+.IP console.info(\fIformat[arg,\&.\&.\&.]\fP)
+This function is identical to console.log(\fIformat\fP[arg,\&.\&.\&.]).
+.IP console.warn(\fIformat[arg,\&.\&.\&.]\fP)
+This function is identical to console.log(\fIformat\fP[arg,\&.\&.\&.]) except it prints "WARN" prefix instead of "INFO".
+.IP console.error(\fIformat[arg,\&.\&.\&.]\fP)
+This function is identical to console.log(\fIformat\fP[arg,\&.\&.\&.]) except it prints "ERROR" prefix instead of "INFO".
+.IP console.assert(\fIexpression[arg,\&.\&.\&.]\fP)
+Prints error if expression is false. If args are supplied, they will be printed also.
+.IP console.count(\fI[label]\fP)
+Increases the counter of label by one which starts from zero and prints the label and value after increment. If label is not supplied, "default" is the label.
+.IP console.countReset(\fI[label]\fP)
+Resets the counter of label to zero. If label is not supplied, "default" is the label.
+.IP console.time(\fI[label]\fP)
+Starts a timer of label. Use console.timeEnd(\fI[label]\fP) to stop the timer and print the elapsed time. Use console.timeLog(\fI[label]\fP) to print the elapsed time without stopping the timer.
+.IP console.timeLog(\fI[label]\fP)
+See console.time(\fI[label]\fP).
+.IP console.timeEnd(\fI[label]\fP)
+See console.time(\fI[label]\fP).
+.RE
 
 .SH SEE ALSO
 The online documentation under

--- a/src/org/mozilla/javascript/NativeConsole.java
+++ b/src/org/mozilla/javascript/NativeConsole.java
@@ -281,7 +281,7 @@ public class NativeConsole extends IdScriptableObject {
             return ScriptRuntime.toString(number);
         }
 
-        return String.valueOf((int) number);
+        return String.valueOf((long) number);
     }
 
     private static String formatObj(Context cx, Scriptable scope, Object[] args, int argIndex) {

--- a/src/org/mozilla/javascript/NativeConsole.java
+++ b/src/org/mozilla/javascript/NativeConsole.java
@@ -337,83 +337,53 @@ public class NativeConsole extends IdScriptableObject {
         return nano / 1000000D;
     }
 
-    // #string_id_map#
-
     @Override
     protected int findPrototypeId(String s) {
         int id;
-        // #generated# Last update: 2021-11-10 14:43:23 CST
-        L0:
-        {
-            id = 0;
-            String X = null;
-            int c;
-            L:
-            switch (s.length()) {
-                case 3:
-                    X = "log";
-                    id = Id_log;
-                    break L;
-                case 4:
-                    c = s.charAt(0);
-                    if (c == 'i') {
-                        X = "info";
-                        id = Id_info;
-                    } else if (c == 't') {
-                        X = "time";
-                        id = Id_time;
-                    } else if (c == 'w') {
-                        X = "warn";
-                        id = Id_warn;
-                    }
-                    break L;
-                case 5:
-                    switch (s.charAt(0)) {
-                        case 'c':
-                            X = "count";
-                            id = Id_count;
-                            break L;
-                        case 'd':
-                            X = "debug";
-                            id = Id_debug;
-                            break L;
-                        case 'e':
-                            X = "error";
-                            id = Id_error;
-                            break L;
-                        case 't':
-                            X = "trace";
-                            id = Id_trace;
-                            break L;
-                    }
-                    break L;
-                case 6:
-                    X = "assert";
-                    id = Id_assert;
-                    break L;
-                case 7:
-                    c = s.charAt(4);
-                    if (c == 'E') {
-                        X = "timeEnd";
-                        id = Id_timeEnd;
-                    } else if (c == 'L') {
-                        X = "timeLog";
-                        id = Id_timeLog;
-                    }
-                    break L;
-                case 8:
-                    X = "toSource";
-                    id = Id_toSource;
-                    break L;
-                case 10:
-                    X = "countReset";
-                    id = Id_countReset;
-                    break L;
-            }
-            if (X != null && X != s && !X.equals(s)) id = 0;
-            break L0;
+        switch (s) {
+            case "log":
+                id = Id_log;
+                break;
+            case "info":
+                id = Id_info;
+                break;
+            case "time":
+                id = Id_time;
+                break;
+            case "warn":
+                id = Id_warn;
+                break;
+            case "count":
+                id = Id_count;
+                break;
+            case "debug":
+                id = Id_debug;
+                break;
+            case "error":
+                id = Id_error;
+                break;
+            case "trace":
+                id = Id_trace;
+                break;
+            case "assert":
+                id = Id_assert;
+                break;
+            case "timeEnd":
+                id = Id_timeEnd;
+                break;
+            case "timeLog":
+                id = Id_timeLog;
+                break;
+            case "toSource":
+                id = Id_toSource;
+                break;
+            case "countReset":
+                id = Id_countReset;
+                break;
+            default:
+                id = 0;
+                break;
         }
-        // #/generated#
         return id;
     }
 
@@ -432,6 +402,4 @@ public class NativeConsole extends IdScriptableObject {
             Id_timeLog = 13,
             LAST_METHOD_ID = 13,
             MAX_ID = 13;
-
-    // #/string_id_map#
 }

--- a/src/org/mozilla/javascript/NativeConsole.java
+++ b/src/org/mozilla/javascript/NativeConsole.java
@@ -37,7 +37,12 @@ public class NativeConsole extends IdScriptableObject {
     }
 
     public interface ConsolePrinter extends Serializable {
-        void print(Context cx, Scriptable scope, Level level, Object[] args);
+        void print(
+                Context cx,
+                Scriptable scope,
+                Level level,
+                ScriptStackElement[] stack,
+                Object[] args);
     }
 
     public static void init(Scriptable scope, boolean sealed, ConsolePrinter printer) {
@@ -140,24 +145,28 @@ public class NativeConsole extends IdScriptableObject {
                 return "Console";
 
             case Id_trace:
-                printer.print(cx, scope, Level.TRACE, args);
-                break;
+                {
+                    ScriptStackElement[] stack =
+                            new EvaluatorException("[object Object]").getScriptStack();
+                    printer.print(cx, scope, Level.TRACE, stack, args);
+                    break;
+                }
 
             case Id_debug:
-                printer.print(cx, scope, Level.DEBUG, args);
+                printer.print(cx, scope, Level.DEBUG, null, args);
                 break;
 
             case Id_log:
             case Id_info:
-                printer.print(cx, scope, Level.INFO, args);
+                printer.print(cx, scope, Level.INFO, null, args);
                 break;
 
             case Id_warn:
-                printer.print(cx, scope, Level.WARN, args);
+                printer.print(cx, scope, Level.WARN, null, args);
                 break;
 
             case Id_error:
-                printer.print(cx, scope, Level.ERROR, args);
+                printer.print(cx, scope, Level.ERROR, null, args);
                 break;
 
             case Id_assert:
@@ -192,7 +201,7 @@ public class NativeConsole extends IdScriptableObject {
     }
 
     private void print(Context cx, Scriptable scope, Level level, String msg) {
-        printer.print(cx, scope, level, new String[] {msg});
+        printer.print(cx, scope, level, null, new String[] {msg});
     }
 
     public static String format(Context cx, Scriptable scope, Object[] args) {

--- a/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.math.BigInteger;
+import org.junit.Test;
+import org.mozilla.javascript.*;
+
+/** Test NativeConsole */
+public class NativeConsoleTest {
+
+    @Test
+    public void testFormatPercentSign() {
+        assertFormat(new Object[] {"%%"}, "%");
+        assertFormat(new Object[] {"a%%"}, "a%");
+        assertFormat(new Object[] {"%%b"}, "%b");
+        assertFormat(new Object[] {"a%%b"}, "a%b");
+        assertFormat(new Object[] {"a%%%%b"}, "a%%b");
+        assertFormat(new Object[] {"a%%c%%b"}, "a%c%b");
+    }
+
+    @Test
+    public void testFormatString() {
+        assertFormat(new Object[] {"%s", "abc"}, "abc");
+        assertFormat(new Object[] {"%s", 100}, "100");
+        assertFormat(new Object[] {"%s", 100.1D}, "100.1");
+        assertFormat(new Object[] {"%s", Integer.MAX_VALUE}, String.valueOf(Integer.MAX_VALUE));
+        assertFormat(new Object[] {"%s", Integer.MIN_VALUE}, String.valueOf(Integer.MIN_VALUE));
+        assertFormat(new Object[] {"%s", Long.MAX_VALUE}, "9223372036854776000");
+        assertFormat(new Object[] {"%s", Long.MIN_VALUE}, "-9223372036854776000");
+
+        assertFormat(new Object[] {"%s", Double.NaN}, "NaN");
+        assertFormat(new Object[] {"%s", Double.POSITIVE_INFINITY}, "Infinity");
+        assertFormat(new Object[] {"%s", Double.NEGATIVE_INFINITY}, "-Infinity");
+        assertFormat(new Object[] {"%s", Undefined.instance}, "undefined");
+        assertFormat(new Object[] {"%s", SymbolKey.ITERATOR}, "Symbol(Symbol.iterator)");
+
+        assertFormat(new Object[] {"%s", BigInteger.valueOf(100)}, "100n");
+        assertFormat(
+                new Object[] {"%s", new BigInteger("1234567890123456789012345678901234567890")},
+                "1234567890123456789012345678901234567890n");
+
+        assertFormat(new Object[] {"a%s", "abc"}, "aabc");
+        assertFormat(new Object[] {"%sb", "abc"}, "abcb");
+        assertFormat(new Object[] {"a%sb", "abc"}, "aabcb");
+        assertFormat(new Object[] {"a%s%sb", "abc", "def"}, "aabcdefb");
+        assertFormat(new Object[] {"a%sc%sb", "abc", "def"}, "aabccdefb");
+        assertFormat(new Object[] {"a%s%sb", "abc"}, "aabc%sb");
+        assertFormat(new Object[] {"a%sb"}, "a%sb");
+    }
+
+    @Test
+    public void testFormatInt() {
+        assertFormat(new Object[] {"%d", 100}, "100");
+        assertFormat(new Object[] {"%d", -100}, "-100");
+        assertFormat(new Object[] {"%d", Integer.MAX_VALUE}, String.valueOf(Integer.MAX_VALUE));
+        assertFormat(new Object[] {"%d", Integer.MIN_VALUE}, String.valueOf(Integer.MIN_VALUE));
+        assertFormat(new Object[] {"%d", Long.MAX_VALUE}, String.valueOf(Long.MAX_VALUE));
+        assertFormat(new Object[] {"%d", Long.MIN_VALUE}, String.valueOf(Long.MIN_VALUE));
+        assertFormat(new Object[] {"%d", 100.1D}, "100");
+        assertFormat(new Object[] {"%d", -100.7D}, "-100");
+
+        assertFormat(new Object[] {"%d", Double.NaN}, "NaN");
+        assertFormat(new Object[] {"%d", Double.POSITIVE_INFINITY}, "Infinity");
+        assertFormat(new Object[] {"%d", Double.NEGATIVE_INFINITY}, "-Infinity");
+        assertFormat(new Object[] {"%d", Undefined.instance}, "NaN");
+        assertFormat(new Object[] {"%d", SymbolKey.ITERATOR}, "NaN");
+
+        assertFormat(new Object[] {"%d", 9007199254740991.0D}, "9007199254740991");
+        assertFormat(new Object[] {"%d", -9007199254740991.0D}, "-9007199254740991");
+        assertFormat(new Object[] {"%d", 9007199254740991L}, "9007199254740991");
+        assertFormat(new Object[] {"%d", -9007199254740991L}, "-9007199254740991");
+
+        assertFormat(new Object[] {"%d", BigInteger.valueOf(100)}, "100n");
+        assertFormat(new Object[] {"%d", BigInteger.valueOf(-100)}, "-100n");
+        assertFormat(
+                new Object[] {"%d", new BigInteger("1234567890123456789012345678901234567890")},
+                "1234567890123456789012345678901234567890n");
+
+        assertFormat(new Object[] {"a%d", 100}, "a100");
+        assertFormat(new Object[] {"%db", 100}, "100b");
+        assertFormat(new Object[] {"a%db", 100}, "a100b");
+        assertFormat(new Object[] {"a%d%db", 100, 200}, "a100200b");
+        assertFormat(new Object[] {"a%dc%db", 100, 200}, "a100c200b");
+        assertFormat(new Object[] {"a%d%db", 100}, "a100%db");
+        assertFormat(new Object[] {"a%db"}, "a%db");
+    }
+
+    @Test
+    public void testFormatFloat() {
+        assertFormat(new Object[] {"%f", 100}, "100");
+        assertFormat(new Object[] {"%f", -100}, "-100");
+        assertFormat(new Object[] {"%f", Integer.MAX_VALUE}, String.valueOf(Integer.MAX_VALUE));
+        assertFormat(new Object[] {"%f", Integer.MIN_VALUE}, String.valueOf(Integer.MIN_VALUE));
+        assertFormat(new Object[] {"%f", Long.MAX_VALUE}, "9223372036854776000");
+        assertFormat(new Object[] {"%f", Long.MIN_VALUE}, "-9223372036854776000");
+        assertFormat(new Object[] {"%f", 100.1D}, "100.1");
+        assertFormat(new Object[] {"%f", -100.7D}, "-100.7");
+        assertFormat(
+                new Object[] {"%f", (double) Integer.MAX_VALUE + 0.1D},
+                String.valueOf(Integer.MAX_VALUE) + ".1");
+        assertFormat(
+                new Object[] {"%f", (double) Integer.MIN_VALUE - 0.1D},
+                String.valueOf(Integer.MIN_VALUE) + ".1");
+
+        assertFormat(new Object[] {"%f", Double.NaN}, "NaN");
+        assertFormat(new Object[] {"%f", Double.POSITIVE_INFINITY}, "Infinity");
+        assertFormat(new Object[] {"%f", Double.NEGATIVE_INFINITY}, "-Infinity");
+        assertFormat(new Object[] {"%f", Undefined.instance}, "NaN");
+        assertFormat(new Object[] {"%f", SymbolKey.ITERATOR}, "NaN");
+
+        assertFormat(new Object[] {"%f", 9007199254740991.0D}, "9007199254740991");
+        assertFormat(new Object[] {"%f", -9007199254740991.0D}, "-9007199254740991");
+        assertFormat(new Object[] {"%f", 9007199254740991L}, "9007199254740991");
+        assertFormat(new Object[] {"%f", -9007199254740991L}, "-9007199254740991");
+
+        assertFormat(new Object[] {"%f", BigInteger.valueOf(100)}, "NaN");
+        assertFormat(new Object[] {"%f", BigInteger.valueOf(-100)}, "NaN");
+
+        assertFormat(new Object[] {"a%f", 100}, "a100");
+        assertFormat(new Object[] {"%fb", 100}, "100b");
+        assertFormat(new Object[] {"a%fb", 100}, "a100b");
+        assertFormat(new Object[] {"a%f%fb", 100, 200}, "a100200b");
+        assertFormat(new Object[] {"a%fc%fb", 100, 200}, "a100c200b");
+        assertFormat(new Object[] {"a%f%fb", 100}, "a100%fb");
+        assertFormat(new Object[] {"a%fb"}, "a%fb");
+    }
+
+    @Test
+    public void testFormatObject() {
+        try (Context cx = Context.enter()) {
+            Scriptable scope = cx.initStandardObjects();
+
+            Scriptable emptyObject = cx.newObject(scope);
+            assertFormat(new Object[] {"%o", emptyObject}, "{}");
+
+            Scriptable emptyArray = cx.newArray(scope, 0);
+            assertFormat(new Object[] {"%o", emptyArray}, "[]");
+
+            Scriptable object1 = cx.newObject(scope);
+            object1.put("int1", object1, 100);
+            object1.put("float1", object1, 100.1);
+            object1.put("string1", object1, "abc");
+            assertFormat(
+                    new Object[] {"%o", object1},
+                    "{" + "\"int1\":100," + "\"float1\":100.1," + "\"string1\":\"abc\"" + "}");
+
+            Scriptable array1 = cx.newArray(scope, 0);
+            array1.put(0, array1, 100);
+            array1.put(1, array1, 100.1);
+            array1.put(2, array1, "abc");
+            assertFormat(new Object[] {"%o", array1}, "[" + "100," + "100.1," + "\"abc\"" + "]");
+
+            Scriptable object2 = cx.newObject(scope);
+            object2.put("bigint1", object2, BigInteger.valueOf(100));
+            assertFormat(new Object[] {"%o", object2}, "[object Object]");
+        }
+    }
+
+    private void assertFormat(Object[] args, String expected) {
+        try (Context cx = Context.enter()) {
+            Scriptable scope = cx.initStandardObjects();
+            assertEquals(expected, NativeConsole.format(cx, scope, args));
+        }
+    }
+
+    private void assertException(Object[] args, Class<? extends Exception> ex) {
+        try (Context cx = Context.enter()) {
+            Scriptable scope = cx.initStandardObjects();
+            NativeConsole.format(cx, scope, args);
+            fail();
+        } catch (Exception e) {
+            if (!ex.isInstance(e)) {
+                fail();
+            }
+        }
+    }
+}

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -105,6 +105,7 @@ public class Global extends ImporterTopLevel {
         // Define some global functions particular to the shell. Note
         // that these functions are not part of ECMA.
         initStandardObjects(cx, sealedStdLib);
+        NativeConsole.init(this, sealedStdLib);
         String[] names = {
             "defineClass",
             "deserialize",

--- a/toolsrc/org/mozilla/javascript/tools/shell/Global.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/Global.java
@@ -38,6 +38,7 @@ import org.mozilla.javascript.ErrorReporter;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.NativeArray;
+import org.mozilla.javascript.NativeConsole;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptRuntime;
@@ -105,7 +106,7 @@ public class Global extends ImporterTopLevel {
         // Define some global functions particular to the shell. Note
         // that these functions are not part of ECMA.
         initStandardObjects(cx, sealedStdLib);
-        NativeConsole.init(this, sealedStdLib);
+        NativeConsole.init(this, sealedStdLib, new ShellConsolePrinter());
         String[] names = {
             "defineClass",
             "deserialize",

--- a/toolsrc/org/mozilla/javascript/tools/shell/NativeConsole.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/NativeConsole.java
@@ -1,0 +1,455 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tools.shell;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.IdFunctionObject;
+import org.mozilla.javascript.IdScriptableObject;
+import org.mozilla.javascript.NativeJSON;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
+
+public class NativeConsole extends IdScriptableObject {
+    private static final long serialVersionUID = 5694613212458273057L;
+
+    private static final Object CONSOLE_TAG = "Console";
+
+    private static final String DEFAULT_LABEL = "default";
+
+    private static final Pattern FMT_REG = Pattern.compile("%[sfdio%]");
+
+    private final Map<String, Long> timers = new ConcurrentHashMap<>();
+
+    private final Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+    private enum Level {
+        TRACE,
+        DEBUG,
+        INFO,
+        WARN,
+        ERROR
+    }
+
+    static void init(Scriptable scope, boolean sealed) {
+        NativeConsole obj = new NativeConsole();
+        obj.activatePrototypeMap(MAX_ID);
+        obj.setPrototype(getObjectPrototype(scope));
+        obj.setParentScope(scope);
+        if (sealed) {
+            obj.sealObject();
+        }
+        ScriptableObject.defineProperty(scope, "console", obj, ScriptableObject.DONTENUM);
+    }
+
+    private NativeConsole() {}
+
+    @Override
+    public String getClassName() {
+        return "Console";
+    }
+
+    @Override
+    protected void initPrototypeId(int id) {
+        if (id > LAST_METHOD_ID) {
+            throw new IllegalStateException(String.valueOf(id));
+        }
+
+        String name;
+        int arity;
+        switch (id) {
+            case Id_toSource:
+                arity = 0;
+                name = "toSrouce";
+                break;
+            case Id_trace:
+                arity = 1;
+                name = "trace";
+                break;
+            case Id_debug:
+                arity = 1;
+                name = "debug";
+                break;
+            case Id_log:
+                arity = 1;
+                name = "log";
+                break;
+            case Id_info:
+                arity = 1;
+                name = "info";
+                break;
+            case Id_warn:
+                arity = 1;
+                name = "warn";
+                break;
+            case Id_error:
+                arity = 1;
+                name = "error";
+                break;
+            case Id_assert:
+                arity = 2;
+                name = "assert";
+                break;
+            case Id_count:
+                arity = 1;
+                name = "count";
+                break;
+            case Id_countReset:
+                arity = 1;
+                name = "countReset";
+                break;
+            case Id_time:
+                arity = 1;
+                name = "time";
+                break;
+            case Id_timeEnd:
+                arity = 1;
+                name = "timeEnd";
+                break;
+            case Id_timeLog:
+                arity = 2;
+                name = "timeLog";
+                break;
+            default:
+                throw new IllegalStateException(String.valueOf(id));
+        }
+        initPrototypeMethod(CONSOLE_TAG, id, name, arity);
+    }
+
+    @Override
+    public Object execIdCall(
+            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!f.hasTag(CONSOLE_TAG)) {
+            return super.execIdCall(f, cx, scope, thisObj, args);
+        }
+
+        int methodId = f.methodId();
+        switch (methodId) {
+            case Id_toSource:
+                return "Console";
+
+            case Id_trace:
+                print(cx, scope, Level.TRACE, args);
+                break;
+
+            case Id_debug:
+                print(cx, scope, Level.DEBUG, args);
+                break;
+
+            case Id_log:
+            case Id_info:
+                print(cx, scope, Level.INFO, args);
+                break;
+
+            case Id_warn:
+                print(cx, scope, Level.WARN, args);
+                break;
+
+            case Id_error:
+                print(cx, scope, Level.ERROR, args);
+                break;
+
+            case Id_assert:
+                jsAssert(args);
+                break;
+
+            case Id_count:
+                count(args);
+                break;
+
+            case Id_countReset:
+                countReset(args);
+                break;
+
+            case Id_time:
+                time(args);
+                break;
+
+            case Id_timeEnd:
+                timeEnd(args);
+                break;
+
+            case Id_timeLog:
+                timeLog(args);
+                break;
+
+            default:
+                throw new IllegalStateException(String.valueOf(methodId));
+        }
+
+        return Undefined.instance;
+    }
+
+    private void print(Context cx, Scriptable scope, Level level, Object[] args) {
+        if (args.length == 0) {
+            return;
+        }
+
+        String msg = ScriptRuntime.toString(args[0]);
+        if (args.length > 1) {
+            Object[] fmtArgs = Arrays.copyOfRange(args, 1, args.length);
+            msg = format(cx, scope, msg, fmtArgs);
+        }
+        print(level, msg);
+    }
+
+    private void print(Level level, String msg) {
+        try {
+            ShellConsole shellConsole = Main.getGlobal().getConsole(Charset.defaultCharset());
+            shellConsole.println(level + " " + msg);
+        } catch (IOException e) {
+            throw Context.reportRuntimeError(e.getMessage());
+        }
+    }
+
+    private String format(Context cx, Scriptable scope, String msg, Object[] args) {
+        if (msg == null || msg.length() == 0) {
+            return "";
+        }
+
+        int argIndex = 0;
+        Matcher matcher = FMT_REG.matcher(msg);
+        StringBuffer buffer = new StringBuffer(msg.length() * 2);
+        while (matcher.find()) {
+            String placeHolder = matcher.group();
+            String replaceArg;
+            switch (placeHolder) {
+                case "%%":
+                    replaceArg = "%";
+                    break;
+
+                case "%s":
+                    replaceArg = ScriptRuntime.toString(args, argIndex);
+                    break;
+
+                case "%d":
+                case "%i":
+                    double number = ScriptRuntime.toNumber(args, argIndex);
+                    if (Double.isInfinite(number) || Double.isNaN(number)) {
+                        replaceArg = "0";
+                    } else {
+                        replaceArg = String.valueOf(((Double) number).intValue());
+                    }
+                    break;
+
+                case "%f":
+                    replaceArg = String.valueOf(ScriptRuntime.toNumber(args, argIndex));
+                    break;
+
+                case "%o":
+                    replaceArg = formatObj(cx, scope, args, argIndex);
+                    break;
+
+                default:
+                    replaceArg = "";
+                    break;
+            }
+
+            argIndex++;
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replaceArg));
+        }
+        matcher.appendTail(buffer);
+
+        return buffer.toString();
+    }
+
+    private String formatObj(Context cx, Scriptable scope, Object[] args, int argIndex) {
+        if (argIndex >= args.length) {
+            return "";
+        }
+
+        Object arg = args[argIndex];
+        if (arg == null) {
+            return "null";
+        }
+        if (arg == Undefined.instance || arg == Undefined.SCRIPTABLE_UNDEFINED) {
+            return "undefined";
+        }
+
+        return ScriptRuntime.toString(NativeJSON.stringify(cx, scope, arg, null, null));
+    }
+
+    private void jsAssert(Object[] args) {
+        if (args != null && args.length > 0 && ScriptRuntime.toBoolean(args[0])) {
+            return;
+        }
+
+        StringBuilder msg = new StringBuilder("Assertion failed:");
+        if (args != null && args.length > 1) {
+            for (int i = 1; i < args.length; ++i) {
+                msg.append(" ").append(ScriptRuntime.toString(args[i]));
+            }
+        } else {
+            msg.append(" console.assert");
+        }
+
+        print(Level.ERROR, msg.toString());
+    }
+
+    private void count(Object[] args) {
+        String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
+        int count = counters.computeIfAbsent(label, l -> new AtomicInteger(0)).incrementAndGet();
+        print(Level.INFO, label + ": " + count);
+    }
+
+    private void countReset(Object[] args) {
+        String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
+        AtomicInteger counter = counters.remove(label);
+        if (counter == null) {
+            print(Level.WARN, "Count for '" + label + "' does not exist.");
+        }
+    }
+
+    private void time(Object[] args) {
+        String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
+        Long start = timers.get(label);
+        if (start != null) {
+            print(Level.WARN, "Timer '" + label + "' already exists.");
+            return;
+        }
+        timers.put(label, System.nanoTime());
+    }
+
+    private void timeEnd(Object[] args) {
+        String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
+        Long start = timers.remove(label);
+        if (start == null) {
+            print(Level.WARN, "Timer '" + label + "' does not exist.");
+            return;
+        }
+        print(Level.INFO, label + ": " + nano2Milli(System.nanoTime() - start) + "ms");
+    }
+
+    private void timeLog(Object[] args) {
+        String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
+        Long start = timers.get(label);
+        if (start == null) {
+            print(Level.WARN, "Timer '" + label + "' does not exist.");
+            return;
+        }
+        StringBuilder msg =
+                new StringBuilder(label + ": " + nano2Milli(System.nanoTime() - start) + "ms");
+
+        if (args.length > 1) {
+            for (int i = 1; i < args.length; i++) {
+                msg.append(" ").append(ScriptRuntime.toString(args[i]));
+            }
+        }
+        print(Level.INFO, msg.toString());
+    }
+
+    private double nano2Milli(Long nano) {
+        return nano / 1000000D;
+    }
+
+    // #string_id_map#
+
+    @Override
+    protected int findPrototypeId(String s) {
+        int id;
+        // #generated# Last update: 2021-11-10 14:43:23 CST
+        L0:
+        {
+            id = 0;
+            String X = null;
+            int c;
+            L:
+            switch (s.length()) {
+                case 3:
+                    X = "log";
+                    id = Id_log;
+                    break L;
+                case 4:
+                    c = s.charAt(0);
+                    if (c == 'i') {
+                        X = "info";
+                        id = Id_info;
+                    } else if (c == 't') {
+                        X = "time";
+                        id = Id_time;
+                    } else if (c == 'w') {
+                        X = "warn";
+                        id = Id_warn;
+                    }
+                    break L;
+                case 5:
+                    switch (s.charAt(0)) {
+                        case 'c':
+                            X = "count";
+                            id = Id_count;
+                            break L;
+                        case 'd':
+                            X = "debug";
+                            id = Id_debug;
+                            break L;
+                        case 'e':
+                            X = "error";
+                            id = Id_error;
+                            break L;
+                        case 't':
+                            X = "trace";
+                            id = Id_trace;
+                            break L;
+                    }
+                    break L;
+                case 6:
+                    X = "assert";
+                    id = Id_assert;
+                    break L;
+                case 7:
+                    c = s.charAt(4);
+                    if (c == 'E') {
+                        X = "timeEnd";
+                        id = Id_timeEnd;
+                    } else if (c == 'L') {
+                        X = "timeLog";
+                        id = Id_timeLog;
+                    }
+                    break L;
+                case 8:
+                    X = "toSource";
+                    id = Id_toSource;
+                    break L;
+                case 10:
+                    X = "countReset";
+                    id = Id_countReset;
+                    break L;
+            }
+            if (X != null && X != s && !X.equals(s)) id = 0;
+            break L0;
+        }
+        // #/generated#
+        return id;
+    }
+
+    private static final int Id_toSource = 1,
+            Id_trace = 2,
+            Id_debug = 3,
+            Id_log = 4,
+            Id_info = 5,
+            Id_warn = 6,
+            Id_error = 7,
+            Id_assert = 8,
+            Id_count = 9,
+            Id_countReset = 10,
+            Id_time = 11,
+            Id_timeEnd = 12,
+            Id_timeLog = 13,
+            LAST_METHOD_ID = 13,
+            MAX_ID = 13;
+
+    // #/string_id_map#
+}

--- a/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
@@ -8,15 +8,21 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeConsole;
+import org.mozilla.javascript.Scriptable;
 
 /** Provide a printer use in console API */
 class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
     private static final long serialVersionUID = 5869832740127501857L;
 
     @Override
-    public void print(NativeConsole.Level level, String msg) {
+    public void print(Context cx, Scriptable scope, NativeConsole.Level level, Object[] args) {
+        if (args.length == 0) {
+            return;
+        }
+
+        String msg = NativeConsole.format(cx, scope, args);
+        ShellConsole console = Main.getGlobal().getConsole(Charset.defaultCharset());
         try {
-            ShellConsole console = Main.getGlobal().getConsole(Charset.defaultCharset());
             console.println(level + " " + msg);
         } catch (IOException e) {
             throw Context.reportRuntimeError(e.getMessage());

--- a/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
@@ -20,8 +20,8 @@ class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
             Context cx,
             Scriptable scope,
             NativeConsole.Level level,
-            ScriptStackElement[] stack,
-            Object[] args) {
+            Object[] args,
+            ScriptStackElement[] stack) {
         if (args.length == 0) {
             return;
         }

--- a/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tools.shell;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeConsole;
+
+/** Provide a printer use in console API */
+class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
+    private static final long serialVersionUID = 5869832740127501857L;
+
+    @Override
+    public void print(NativeConsole.Level level, String msg) {
+        try {
+            ShellConsole console = Main.getGlobal().getConsole(Charset.defaultCharset());
+            console.println(level + " " + msg);
+        } catch (IOException e) {
+            throw Context.reportRuntimeError(e.getMessage());
+        }
+    }
+}

--- a/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
+++ b/toolsrc/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeConsole;
+import org.mozilla.javascript.ScriptStackElement;
 import org.mozilla.javascript.Scriptable;
 
 /** Provide a printer use in console API */
@@ -15,7 +16,12 @@ class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
     private static final long serialVersionUID = 5869832740127501857L;
 
     @Override
-    public void print(Context cx, Scriptable scope, NativeConsole.Level level, Object[] args) {
+    public void print(
+            Context cx,
+            Scriptable scope,
+            NativeConsole.Level level,
+            ScriptStackElement[] stack,
+            Object[] args) {
         if (args.length == 0) {
             return;
         }
@@ -24,6 +30,12 @@ class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
         ShellConsole console = Main.getGlobal().getConsole(Charset.defaultCharset());
         try {
             console.println(level + " " + msg);
+
+            if (stack != null) {
+                for (ScriptStackElement element : stack) {
+                    console.println(element.toString());
+                }
+            }
         } catch (IOException e) {
             throw Context.reportRuntimeError(e.getMessage());
         }


### PR DESCRIPTION
As #1012 says, I've been trying to implement the `console` API in shell.

PR #1104 is prerequisite as p-bakker said. After #1104 is merged. I'll rebase this PR.

Basic usage:
```
js> console.info('obj: %o', {a: 123, b: "abc"})
INFO obj: {"a":123,"b":"abc"}
js> console.error("Error message.");
ERROR Error message.
js> console.count('counter1')
INFO counter1: 1
js> console.count('counter1')
INFO counter1: 2
js> console.count('counter1')
INFO counter1: 3
js> console.countReset('counter1')
js> console.count('counter1')
INFO counter1: 1
js> console.time()
js> console.timeLog()
INFO default: 3804.4751ms
js> console.timeLog()
INFO default: 7525.4994ms
js> console.timeEnd()
INFO default: 15393.5158ms
js> console.timeEnd()
WARN Timer 'default' does not exist.
```

Closes #1012 