### PR TITLE
ref. #1112 Fix Array.from when called with a sparse array

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -812,13 +812,11 @@ public class NativeArray extends IdScriptableObject implements List {
         final long length = getLengthProperty(cx, items);
         final Scriptable result = callConstructorOrCreateArray(cx, scope, thisObj, length, true);
         for (long k = 0; k < length; k++) {
-            Object temp = getRawElem(items, k);
-            if (temp != Scriptable.NOT_FOUND) {
-                if (mapping) {
-                    temp = mapFn.call(cx, scope, thisArg, new Object[] {temp, Long.valueOf(k)});
-                }
-                defineElem(cx, result, k, temp);
+            Object temp = getElem(cx, items, k);
+            if (mapping) {
+                temp = mapFn.call(cx, scope, thisArg, new Object[] {temp, Long.valueOf(k)});
             }
+            defineElem(cx, result, k, temp);
         }
 
         setLengthProperty(cx, result, length);

--- a/testsrc/jstests/es6/array.js
+++ b/testsrc/jstests/es6/array.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+load("testsrc/assert.js");
+
+// # Array.from
+// ## sparse array
+var a = Array.from({0: 123, length: 3});
+
+assertEquals(a[0], 123);
+assertTrue(1 in a);
+assertEquals(a.map(_ => 'a'), ['a', 'a', 'a']);
+
+var a = Array.from(Array(2));
+
+assertTrue(0 in a);
+assertEquals(a.map(_ => 'a'), ['a', 'a']);
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeArrayTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeArrayTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es6;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es6/array.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class NativeArrayTest extends ScriptTestsBase {}


### PR DESCRIPTION
Closes #1112

https://262.ecma-international.org/12.0/#sec-array.from
> 12. Repeat, while k < len,
>   b. Let kValue be ? Get(arrayLike, Pk).
>   d. Else, let mappedValue be kValue.
>   e. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).