### PR TITLE
Fix broken build from too many merges

### DIFF
--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -622,7 +622,7 @@ public abstract class ScriptableObject
      *     setter for the property, depending on the value of isSetter (may be undefined if unset).
      */
     @Deprecated
-    public Function getGetterOrSetter(String name, int index, boolean isSetter) {
+    public Object getGetterOrSetter(String name, int index, boolean isSetter) {
         return getGetterOrSetter(name, index, this, isSetter);
     }
 


### PR DESCRIPTION
Fix return type of getGetterOrSetter.

(Note to future maintainers -- manually testing each change, in order, before merging is preferable to using the convenient "Rebase and Merge" feature in GitHub too quickly!