### PR TITLE
ref. #995 Do not convert java.math.BigInteger.

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigInteger;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
@@ -267,6 +268,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
     private static final int JSTYPE_JAVA_OBJECT = 6; // JavaObject
     private static final int JSTYPE_JAVA_ARRAY = 7; // JavaArray
     private static final int JSTYPE_OBJECT = 8; // Scriptable
+    private static final int JSTYPE_BIGINT = 9; // BigInt
 
     static final byte CONVERSION_TRIVIAL = 1;
     static final byte CONVERSION_NONTRIVIAL = 0;
@@ -309,6 +311,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                 break;
 
             case JSTYPE_NUMBER:
+            case JSTYPE_BIGINT:
                 if (to.isPrimitive()) {
                     if (to == Double.TYPE) {
                         return 1;
@@ -319,8 +322,10 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                     if (to == ScriptRuntime.StringClass) {
                         // native numbers are #1-8
                         return 9;
-                    } else if (to == ScriptRuntime.ObjectClass) {
+                    } else if (to == ScriptRuntime.BigIntegerClass) {
                         return 10;
+                    } else if (to == ScriptRuntime.ObjectClass) {
+                        return 11;
                     } else if (ScriptRuntime.NumberClass.isAssignableFrom(to)) {
                         // "double" is #1
                         return 2;
@@ -438,6 +443,8 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
             return JSTYPE_UNDEFINED;
         } else if (value instanceof CharSequence) {
             return JSTYPE_STRING;
+        } else if (value instanceof BigInteger) {
+            return JSTYPE_BIGINT;
         } else if (value instanceof Number) {
             return JSTYPE_NUMBER;
         } else if (value instanceof Boolean) {
@@ -480,7 +487,8 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
             return value;
         }
 
-        switch (getJSTypeCode(value)) {
+        int jsTypeCode = getJSTypeCode(value);
+        switch (jsTypeCode) {
             case JSTYPE_NULL:
                 // raise error if type.isPrimitive()
                 if (type.isPrimitive()) {
@@ -509,6 +517,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                 break;
 
             case JSTYPE_NUMBER:
+            case JSTYPE_BIGINT:
                 if (type == ScriptRuntime.StringClass) {
                     return ScriptRuntime.toString(value);
                 } else if (type == ScriptRuntime.ObjectClass) {
@@ -521,7 +530,8 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                             return coerceToNumber(Long.TYPE, value);
                         }
                     }
-                    return coerceToNumber(Double.TYPE, value);
+                    return coerceToNumber(
+                            jsTypeCode == JSTYPE_BIGINT ? BigInteger.class : Double.TYPE, value);
                 } else if ((type.isPrimitive() && type != Boolean.TYPE)
                         || ScriptRuntime.NumberClass.isAssignableFrom(type)) {
                     return coerceToNumber(type, value);
@@ -674,9 +684,17 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         if (type == ScriptRuntime.ObjectClass
                 || type == ScriptRuntime.DoubleClass
                 || type == Double.TYPE) {
-            return valueClass == ScriptRuntime.DoubleClass
-                    ? value
-                    : Double.valueOf(toDouble(value));
+            if (valueClass == ScriptRuntime.DoubleClass) {
+                return value;
+            }
+            return Double.valueOf(toDouble(value));
+        }
+
+        if (type == ScriptRuntime.BigIntegerClass) {
+            if (valueClass == ScriptRuntime.BigIntegerClass) {
+                return value;
+            }
+            return ScriptRuntime.toBigInt(value);
         }
 
         if (type == ScriptRuntime.FloatClass || type == Float.TYPE) {

--- a/testsrc/org/mozilla/javascript/tests/NativeJavaObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeJavaObjectTest.java
@@ -1,0 +1,58 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.*;
+
+import java.math.BigInteger;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeJavaObject;
+import org.mozilla.javascript.Scriptable;
+
+public class NativeJavaObjectTest extends TestCase {
+
+    @Test
+    public void testCoerceType() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+
+            Scriptable scope = cx.initStandardObjects();
+            {
+                String source = "java.util.Collections.singletonList('123').get(0)";
+                Object result = cx.evaluateString(scope, source, "source", 1, null);
+                assertTrue(result instanceof NativeJavaObject);
+                Object rawObj = ((NativeJavaObject) result).unwrap();
+                assertTrue(rawObj instanceof String);
+                assertEquals("123", rawObj);
+            }
+
+            {
+                String source = "java.util.Collections.singletonList(123).get(0)";
+                Object result = cx.evaluateString(scope, source, "source", 1, null);
+                assertTrue(result instanceof NativeJavaObject);
+                Object rawObj = ((NativeJavaObject) result).unwrap();
+                assertTrue(rawObj instanceof Double);
+                assertEquals(Double.valueOf(123), rawObj);
+            }
+
+            {
+                String source = "java.util.Collections.singletonList(123n).get(0)";
+                Object result = cx.evaluateString(scope, source, "source", 1, null);
+                assertTrue(result instanceof NativeJavaObject);
+                Object rawObj = ((NativeJavaObject) result).unwrap();
+                assertTrue(rawObj instanceof BigInteger);
+                assertEquals(BigInteger.valueOf(123), rawObj);
+            }
+
+        } finally {
+            Context.exit();
+        }
+    }
+}


### PR DESCRIPTION
When passed `BigInt` to Java, it was converted to `java.lang.Double`. I fixed so that `BigInt` keeps `java.math.BigInteger`.

Closes #995