### PR TITLE
Action to publish packages on Github (#980)

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,0 +1,36 @@
+name: Github Packages deployment
+
+on:
+  # Publishes packages on release (the Rhino version should not be
+  # changed to '-SNAPSHOT' before creating the release in Github).
+  release:
+    types: [published]
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        server-id: github
+        settings-path: ${{ github.workspace }}
+
+    - name: Publish to GitHub Packages
+      run: >-
+        ./gradlew publish
+        -PmavenReleaseRepo="https://maven.pkg.github.com/mozilla/rhino"
+        -PmavenSnapshotRepo="https://maven.pkg.github.com/mozilla/rhino"
+        -PmavenUser=${{ github.actor }}
+        -PmavenPassword=${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -420,6 +420,8 @@ publishing {
 }
 
 signing {
+    required = project.hasProperty('mavenReleaseRepo')
+        && !project.property('mavenReleaseRepo').contains('github')
     useGpgCmd()
     sign publishing.publications.rhino
     sign publishing.publications.rhinoengine


### PR DESCRIPTION
Publishes packages on release (important: the version should not be changed to '-SNAPSHOT' before creating the release in Github). Can also be run manually to publish snapshot packages (publishing a snapshot on each `master` push, as suggested in #980, seems too frequent).

The Github packages are not being signed, although that could be changed in the future if deemed appropriate (requires a private key being stored as a "secret" in Github).

Note: to automatically build on release, I'm using the `published` release type instead of `created` which is what is [being suggested by the documentation](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows). The `created` type did not work for me (in another repository).

Once it is merged, I'd suggest testing it by manually publishing a snapshot package.