### PR TITLE
Add proper import package instructions in the OSGi manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,8 @@ task runtimeJar(type: Jar) {
             "Bundle-ManifestVersion": "2",
             "Bundle-SymbolicName": "org.mozilla.rhino-runtime",
             "Bundle-Version": project.version.replaceAll("-.*", ""),
-            "Export-Package": "org.mozilla.javascript,org.mozilla.javascript.ast,org.mozilla.javascript.annotations"
+            "Export-Package": "org.mozilla.javascript,org.mozilla.javascript.ast,org.mozilla.javascript.annotations",
+            "Import-Package": "javax.lang.model,javax.script"
         )
     }
 }
@@ -230,7 +231,8 @@ jar {
             "Bundle-ManifestVersion": "2",
             "Bundle-SymbolicName": "org.mozilla.rhino",
             "Bundle-Version": project.version.replaceAll("-.*", ""),
-            "Export-Package": "org.mozilla.javascript,org.mozilla.javascript.ast,org.mozilla.javascript.annotations"
+            "Export-Package": "org.mozilla.javascript,org.mozilla.javascript.ast,org.mozilla.javascript.annotations",
+            "Import-Package": "javax.lang.model,javax.script"
         )
     }
 }


### PR DESCRIPTION
As Rhino now uses classes from javax-packages, add proper imports for them. Namely: javax.lang.model.SourceVersion and the various javax.script classes used for implementing the Java scripting support. This fixes the use of current Rhino version as an OSGi bundle.