### PR TITLE
Remove spotless "ratchet"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -442,7 +442,6 @@ spotbugs {
 }
 
 spotless {
-    ratchetFrom 'code-formatting-required'
     java {
         googleJavaFormat().aosp()
     }


### PR DESCRIPTION
Now that everything has been reformatted, we can take out the spotless
logic that compares changes to a known tag. This makes it easier for
people to clone the repo because they don't have to fetch the
optional tag.