### PR TITLE
fixed SourceVersion

### DIFF
--- a/src/org/mozilla/javascript/JVMVersionUtils.java
+++ b/src/org/mozilla/javascript/JVMVersionUtils.java
@@ -1,0 +1,30 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+public enum JVMVersionUtils {
+    JAVA_1_8_UNDER,
+    JAVA_1_8,
+    JAVA_1_8_ABOVE;
+
+    public static JVMVersionUtils getJavaVersion() {
+        if (ScriptRuntime.IS_ANDROID) return JAVA_1_8;
+
+        String specVersion = System.getProperty("java.specification.version");
+
+        if (specVersion.startsWith("1.")) {
+            int version = Integer.parseInt(specVersion.substring(2));
+            if (version < 8) {
+                return JAVA_1_8_UNDER;
+            } else {
+                return JAVA_1_8;
+            }
+        } else {
+            return JAVA_1_8_ABOVE;
+        }
+    }
+}

--- a/src/org/mozilla/javascript/JavaMembers.java
+++ b/src/org/mozilla/javascript/JavaMembers.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.lang.model.SourceVersion;
 
 /**
  * @author Mike Shaver
@@ -34,7 +33,7 @@ import javax.lang.model.SourceVersion;
 class JavaMembers {
 
     private static final boolean STRICT_REFLECTIVE_ACCESS =
-            SourceVersion.latestSupported().ordinal() > 8;
+            JVMVersionUtils.getJavaVersion().ordinal() >= 1;
 
     private static final Permission allPermission = new AllPermission();
 

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -157,7 +157,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         try {
             // When running on Android create an InterfaceAdapter since our
             // bytecode generation won't work on Dalvik VM.
-            if ("Dalvik".equals(System.getProperty("java.vm.name")) && classObject.isInterface()) {
+            if (ScriptRuntime.IS_ANDROID && classObject.isInterface()) {
                 Object obj =
                         createInterfaceAdapter(
                                 classObject, ScriptableObject.ensureScriptableObject(args[0]));

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -315,9 +315,11 @@ public class ScriptRuntime {
         return s;
     }
 
+    public static final boolean IS_ANDROID = "Dalvik".equals(System.getProperty("java.vm.name"));
+
     static String[] getTopPackageNames() {
         // Include "android" top package if running on Android
-        return "Dalvik".equals(System.getProperty("java.vm.name"))
+        return IS_ANDROID
                 ? new String[] {"java", "javax", "org", "com", "edu", "net", "android"}
                 : new String[] {"java", "javax", "org", "com", "edu", "net"};
     }


### PR DESCRIPTION
Check Android by creating a variable called `IS_ANDROID` in the `ScriptRuntime` class

++ Fixed `SourceVersion` bug.