### PR TITLE
fix #780 fix Object.assign when undefined value and inextensible

### DIFF
--- a/src/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/src/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -160,7 +160,7 @@ class AbstractEcmaObjectOperations {
      *     constructor on "s" or if the "species" symbol is not set.
      * @see <a href="https://tc39.es/ecma262/#sec-speciesconstructor"></a>
      */
-    public static Constructable speciesConstructor(
+    static Constructable speciesConstructor(
             Context cx, Scriptable s, Constructable defaultConstructor) {
         /*
         The abstract operation SpeciesConstructor takes arguments O (an Object) and
@@ -194,5 +194,37 @@ class AbstractEcmaObjectOperations {
             throw ScriptRuntime.typeErrorById("msg.not.ctor", ScriptRuntime.typeof(species));
         }
         return (Constructable) species;
+    }
+
+    /**
+     * Set ( O, P, V, Throw)
+     *
+     * <p>https://262.ecma-international.org/12.0/#sec-set-o-p-v-throw
+     */
+    static void put(Context cx, Scriptable o, String p, Object v, boolean isThrow) {
+        Scriptable base = ScriptableObject.getBase(o, p);
+        if (base == null) base = o;
+
+        if (base instanceof ScriptableObject) {
+            ((ScriptableObject) base).putImpl(p, 0, o, v, isThrow);
+        } else {
+            base.put(p, o, v);
+        }
+    }
+
+    /**
+     * Set ( O, P, V, Throw)
+     *
+     * <p>https://262.ecma-international.org/12.0/#sec-set-o-p-v-throw
+     */
+    static void put(Context cx, Scriptable o, int p, Object v, boolean isThrow) {
+        Scriptable base = ScriptableObject.getBase(o, p);
+        if (base == null) base = o;
+
+        if (base instanceof ScriptableObject) {
+            ((ScriptableObject) base).putImpl(null, p, o, v, isThrow);
+        } else {
+            base.put(p, o, v);
+        }
     }
 }

--- a/src/org/mozilla/javascript/AccessorSlot.java
+++ b/src/org/mozilla/javascript/AccessorSlot.java
@@ -47,7 +47,7 @@ public class AccessorSlot extends Slot {
     }
 
     @Override
-    public boolean setValue(Object value, Scriptable owner, Scriptable start) {
+    public boolean setValue(Object value, Scriptable owner, Scriptable start, boolean isThrow) {
         if (setter == null) {
             if (getter != null) {
                 throwNoSetterException(start, value);
@@ -56,7 +56,7 @@ public class AccessorSlot extends Slot {
         } else {
             return setter.setValue(value, owner, start);
         }
-        return super.setValue(value, owner, start);
+        return super.setValue(value, owner, start, isThrow);
     }
 
     @Override

--- a/src/org/mozilla/javascript/LambdaSlot.java
+++ b/src/org/mozilla/javascript/LambdaSlot.java
@@ -44,7 +44,7 @@ public class LambdaSlot extends Slot {
     }
 
     @Override
-    public boolean setValue(Object value, Scriptable owner, Scriptable start) {
+    public boolean setValue(Object value, Scriptable owner, Scriptable start, boolean isThrow) {
         if (setter != null) {
             if (owner == start) {
                 setter.accept(value);
@@ -52,7 +52,7 @@ public class LambdaSlot extends Slot {
             }
             return false;
         }
-        return super.setValue(value, owner, start);
+        return super.setValue(value, owner, start, isThrow);
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -629,27 +629,21 @@ public class NativeObject extends IdScriptableObject implements Map {
                         Scriptable sourceObj = ScriptRuntime.toObject(cx, scope, args[i]);
                         Object[] ids = sourceObj.getIds();
                         for (Object key : ids) {
-                            if (targetObj instanceof ScriptableObject) {
-                                ScriptableObject desc =
-                                        ((ScriptableObject) targetObj)
-                                                .getOwnPropertyDescriptor(cx, key);
-                                if (desc != null
-                                        && isDataDescriptor(desc)
-                                        && isFalse(desc.get("writable"))) {
-                                    throw ScriptRuntime.typeErrorById(
-                                            "msg.change.value.with.writable.false", key);
+                            if (key instanceof Integer) {
+                                int intId = (Integer) key;
+                                if (sourceObj.has(intId, sourceObj)
+                                        && isEnumerable(intId, sourceObj)) {
+                                    Object val = sourceObj.get(intId, sourceObj);
+                                    AbstractEcmaObjectOperations.put(
+                                            cx, targetObj, intId, val, true);
                                 }
-                            }
-                            if (key instanceof String) {
-                                Object val = sourceObj.get((String) key, sourceObj);
-                                if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {
-                                    targetObj.put((String) key, targetObj, val);
-                                }
-                            } else if (key instanceof Number) {
-                                int ii = ScriptRuntime.toInt32(key);
-                                Object val = sourceObj.get(ii, sourceObj);
-                                if ((val != Scriptable.NOT_FOUND) && !Undefined.isUndefined(val)) {
-                                    targetObj.put(ii, targetObj, val);
+                            } else {
+                                String stringId = ScriptRuntime.toString(key);
+                                if (sourceObj.has(stringId, sourceObj)
+                                        && isEnumerable(stringId, sourceObj)) {
+                                    Object val = sourceObj.get(stringId, sourceObj);
+                                    AbstractEcmaObjectOperations.put(
+                                            cx, targetObj, stringId, val, true);
                                 }
                             }
                         }

--- a/src/org/mozilla/javascript/Slot.java
+++ b/src/org/mozilla/javascript/Slot.java
@@ -56,9 +56,13 @@ public class Slot implements Serializable {
         }
     }
 
-    public boolean setValue(Object value, Scriptable owner, Scriptable start) {
+    public final boolean setValue(Object value, Scriptable owner, Scriptable start) {
+        return setValue(value, owner, start, Context.isCurrentContextStrict());
+    }
+
+    public boolean setValue(Object value, Scriptable owner, Scriptable start, boolean isThrow) {
         if ((attributes & ScriptableObject.READONLY) != 0) {
-            if (Context.isCurrentContextStrict()) {
+            if (isThrow) {
                 throw ScriptRuntime.typeErrorById("msg.modify.readonly", name);
             }
             return true;

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeObjectTest.java
@@ -9,277 +9,170 @@ package org.mozilla.javascript.tests.es6;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.tests.Utils;
 
 /** Test for NativeObject. */
 public class NativeObjectTest {
-
-    private Context cx;
-    private ScriptableObject scope;
-
-    @Before
-    public void setUp() {
-        cx = Context.enter();
-        cx.setLanguageVersion(Context.VERSION_ES6);
-        scope = cx.initStandardObjects();
-    }
-
-    @After
-    public void tearDown() {
-        Context.exit();
-    }
-
     @Test
     public void testAssignPropertyGetter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "var obj = Object.defineProperty({}, 'propA', {\n"
-                                + "                 enumerable: true,\n"
-                                + "                 get: function () {\n"
-                                + "                        Object.defineProperty(this, 'propB', {\n"
-                                + "                                 value: 3,\n"
-                                + "                                 enumerable: false\n"
-                                + "                        });\n"
-                                + "                      }\n"
-                                + "          });\n"
-                                + "Object.assign(obj, {propB: 2});\n"
-                                + "Object.assign({propB: 1}, obj);\n"
-                                + "'obj.propB = ' + obj.propB + ', enumerable = ' + Object.getOwnPropertyDescriptor(obj, 'propB').enumerable",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("obj.propB = 3, enumerable = false", result);
+        evaluateAndAssert(
+                "var obj = Object.defineProperty({}, 'propA', {\n"
+                        + "                 enumerable: true,\n"
+                        + "                 get: function () {\n"
+                        + "                        Object.defineProperty(this, 'propB', {\n"
+                        + "                                 value: 3,\n"
+                        + "                                 enumerable: false\n"
+                        + "                        });\n"
+                        + "                      }\n"
+                        + "          });\n"
+                        + "Object.assign(obj, {propB: 2});\n"
+                        + "Object.assign({propB: 1}, obj);\n"
+                        + "'obj.propB = ' + obj.propB + ', enumerable = ' + Object.getOwnPropertyDescriptor(obj, 'propB').enumerable",
+                "obj.propB = 3, enumerable = false");
     }
 
     @Test
     public void testAssignOneParameter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "var obj = {};" + "res = Object.assign(obj);" + "res === obj;",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals(true, result);
+        evaluateAndAssert("var obj = {};" + "res = Object.assign(obj);" + "res === obj;", true);
     }
 
     @Test
     public void testAssignMissingParameters() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.assign();" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Cannot convert undefined to an object.", result);
+        evaluateAndAssert(
+                "try { " + "  Object.assign();" + "} catch (e) { e.message }",
+                "Cannot convert undefined to an object.");
     }
 
     @Test
     public void testAssignNumericPropertyGetter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "var obj = Object.defineProperty({}, 1, {\n"
-                                + "                 enumerable: true,\n"
-                                + "                 get: function () {\n"
-                                + "                        Object.defineProperty(this, 2, {\n"
-                                + "                                 value: 3,\n"
-                                + "                                 enumerable: false\n"
-                                + "                        });\n"
-                                + "                      }\n"
-                                + "          });\n"
-                                + "Object.assign(obj, {2: 2});\n"
-                                + "Object.assign({2: 1}, obj);\n"
-                                + "'obj[2] = ' + obj[2] + ', enumerable = ' + Object.getOwnPropertyDescriptor(obj, 2).enumerable",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("obj[2] = 3, enumerable = false", result);
+        evaluateAndAssert(
+                "var obj = Object.defineProperty({}, 1, {\n"
+                        + "                 enumerable: true,\n"
+                        + "                 get: function () {\n"
+                        + "                        Object.defineProperty(this, 2, {\n"
+                        + "                                 value: 3,\n"
+                        + "                                 enumerable: false\n"
+                        + "                        });\n"
+                        + "                      }\n"
+                        + "          });\n"
+                        + "Object.assign(obj, {2: 2});\n"
+                        + "Object.assign({2: 1}, obj);\n"
+                        + "'obj[2] = ' + obj[2] + ', enumerable = ' + Object.getOwnPropertyDescriptor(obj, 2).enumerable",
+                "obj[2] = 3, enumerable = false");
     }
 
     @Test
     public void testSetPrototypeOfNull() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { "
-                                + "  Object.setPrototypeOf(null, new Object());"
-                                + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Object.prototype.setPrototypeOf method called on null or undefined", result);
+        evaluateAndAssert(
+                "try { "
+                        + "  Object.setPrototypeOf(null, new Object());"
+                        + "} catch (e) { e.message }",
+                "Object.prototype.setPrototypeOf method called on null or undefined");
     }
 
     @Test
     public void testSetPrototypeOfUndefined() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { "
-                                + "  Object.setPrototypeOf(undefined, new Object());"
-                                + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Object.prototype.setPrototypeOf method called on null or undefined", result);
+        evaluateAndAssert(
+                "try { "
+                        + "  Object.setPrototypeOf(undefined, new Object());"
+                        + "} catch (e) { e.message }",
+                "Object.prototype.setPrototypeOf method called on null or undefined");
     }
 
     @Test
     public void testSetPrototypeOfMissingParameters() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.setPrototypeOf();" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
+        evaluateAndAssert(
+                "try { " + "  Object.setPrototypeOf();" + "} catch (e) { e.message }",
+                "Object.setPrototypeOf: At least 2 arguments required, but only 0 passed");
 
-        assertEquals(
-                "Object.setPrototypeOf: At least 2 arguments required, but only 0 passed", result);
-
-        result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.setPrototypeOf({});" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals(
-                "Object.setPrototypeOf: At least 2 arguments required, but only 1 passed", result);
+        evaluateAndAssert(
+                "try { " + "  Object.setPrototypeOf({});" + "} catch (e) { e.message }",
+                "Object.setPrototypeOf: At least 2 arguments required, but only 1 passed");
     }
 
     @Test
     public void testKeysMissingParameter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.keys();" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Cannot convert undefined to an object.", result);
+        evaluateAndAssert(
+                "try { " + "  Object.keys();" + "} catch (e) { e.message }",
+                "Cannot convert undefined to an object.");
     }
 
     @Test
     public void testKeysOnObjectParameter() {
-        evaluateAndAssert(
-                "Object.keys({'foo':'bar', 2: 'y', 1: 'x'})", Arrays.asList("1", "2", "foo"));
+        evaluateAndAssert("Object.keys({'foo':'bar', 2: 'y', 1: 'x'}).join()", "1,2,foo");
     }
 
     @Test
     public void testKeysOnArray() {
-        evaluateAndAssert("Object.keys(['x','y','z'])", Arrays.asList("0", "1", "2"));
+        evaluateAndAssert("Object.keys(['x','y','z']).join()", "0,1,2");
     }
 
     @Test
     public void testKeysOnArrayWithProp() {
         evaluateAndAssert(
-                "var arr = ['x','y','z'];\n" + "arr['foo'] = 'bar'; Object.keys(arr)",
-                Arrays.asList("0", "1", "2", "foo"));
+                "var arr = ['x','y','z'];\n" + "arr['foo'] = 'bar';\n" + "Object.keys(arr).join()",
+                "0,1,2,foo");
     }
 
     @Test
     public void testValuesMissingParameter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.values();" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Cannot convert undefined to an object.", result);
+        evaluateAndAssert(
+                "try { " + "  Object.values();" + "} catch (e) { e.message }",
+                "Cannot convert undefined to an object.");
     }
 
     @Test
     public void testValuesOnObjectParameter() {
-        evaluateAndAssert(
-                "Object.values({'foo':'bar', 2: 'y', 1: 'x'})", Arrays.asList("x", "y", "bar"));
+        evaluateAndAssert("Object.values({'foo':'bar', 2: 'y', 1: 'x'}).join()", "x,y,bar");
     }
 
     @Test
     public void testValuesOnArray() {
-        evaluateAndAssert("Object.values(['x','y','z'])", Arrays.asList("x", "y", "z"));
+        evaluateAndAssert("Object.values(['x','y','z']).join()", "x,y,z");
     }
 
     @Test
     public void testValuesOnArrayWithProp() {
         evaluateAndAssert(
-                "var arr = [3,4,5];\n" + "arr['foo'] = 'bar'; Object.values(arr)",
-                Arrays.asList(3, 4, 5, "bar"));
+                "var arr = [3,4,5];\n" + "arr['foo'] = 'bar';\n" + "Object.values(arr).join();",
+                "3,4,5,bar");
     }
 
     @Test
     public void testEntriesMissingParameter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.entries();" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Cannot convert undefined to an object.", result);
+        evaluateAndAssert(
+                "try { " + "  Object.entries();" + "} catch (e) { e.message }",
+                "Cannot convert undefined to an object.");
     }
 
     @Test
     public void testEntriesOnObjectParameter() {
         evaluateAndAssert(
-                "Object.entries({'foo':'bar', 2: 'y', 1: 'x'})",
-                Arrays.asList(
-                        Arrays.asList("1", "x"),
-                        Arrays.asList("2", "y"),
-                        Arrays.asList("foo", "bar")));
+                "Object.entries({'foo':'bar', 2: 'y', 1: 'x'}).join()", "1,x,2,y,foo,bar");
     }
 
     @Test
     public void testEntriesOnArray() {
-        evaluateAndAssert(
-                "Object.entries(['x','y','z'])",
-                Arrays.asList(
-                        Arrays.asList("0", "x"), Arrays.asList("1", "y"), Arrays.asList("2", "z")));
+        evaluateAndAssert("Object.entries(['x','y','z']).join()", "0,x,1,y,2,z");
     }
 
     @Test
     public void testEntriesOnArrayWithProp() {
         evaluateAndAssert(
-                "var arr = [3,4,5];\n" + "arr['foo'] = 'bar'; Object.entries(arr)",
-                Arrays.asList(
-                        Arrays.asList("0", 3),
-                        Arrays.asList("1", 4),
-                        Arrays.asList("2", 5),
-                        Arrays.asList("foo", "bar")));
+                "var arr = [3,4,5];\n" + "arr['foo'] = 'bar';\n" + "Object.entries(arr).join()",
+                "0,3,1,4,2,5,foo,bar");
     }
 
     @Test
     public void testFromEntriesMissingParameter() {
-        Object result =
-                cx.evaluateString(
-                        scope,
-                        "try { " + "  Object.fromEntries();" + "} catch (e) { e.message }",
-                        "test",
-                        1,
-                        null);
-
-        assertEquals("Cannot convert undefined to an object.", result);
+        evaluateAndAssert(
+                "try { " + "  Object.fromEntries();" + "} catch (e) { e.message }",
+                "Cannot convert undefined to an object.");
     }
 
     @Test
@@ -291,8 +184,17 @@ public class NativeObjectTest {
         evaluateAndAssert("Object.fromEntries(Object.entries(['x','y','z']))", map);
     }
 
-    private void evaluateAndAssert(String script, Object expected) {
-        Object result = cx.evaluateString(scope, script, "test", 1, null);
-        assertEquals(expected, result);
+    private void evaluateAndAssert(final String script, final Object expected) {
+        String[] prefixes = {"", "'use strict;'\n"};
+        for (final String prefix : prefixes) {
+            Utils.runWithAllOptimizationLevels(
+                    cx -> {
+                        cx.setLanguageVersion(Context.VERSION_ES6);
+                        ScriptableObject scope = cx.initStandardObjects();
+                        Object result = cx.evaluateString(scope, prefix + script, "test", 1, null);
+                        assertEquals(expected, result);
+                        return null;
+                    });
+        }
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeObjectTest.java
@@ -67,6 +67,86 @@ public class NativeObjectTest {
     }
 
     @Test
+    public void testAssignUndefined() {
+        evaluateAndAssert("Object.keys(Object.assign({a:undefined}, {b:undefined})).join()", "a,b");
+    }
+
+    @Test
+    public void testAssignInextensible() {
+        evaluateAndAssert(
+                "var obj = Object.freeze({});\n"
+                        + "try {\n"
+                        + "  Object.assign(obj, { a: 1 });\n"
+                        + "  'success';\n"
+                        + "} catch(e) {\n"
+                        + "  'error';\n"
+                        + "}",
+                "error");
+        evaluateAndAssert(
+                "var obj = Object.freeze({});\n"
+                        + "try {\n"
+                        + "  Object.assign(obj, {});\n"
+                        + "  'success';\n"
+                        + "} catch(e) {\n"
+                        + "  'error';\n"
+                        + "}",
+                "success");
+    }
+
+    @Test
+    public void testAssignUnwritable() {
+        evaluateAndAssert(
+                "var src = Object.defineProperty({}, 1, {\n"
+                        + "  enumerable: true,\n"
+                        + "  value: 'v'\n"
+                        + "});\n"
+                        + "var dest = Object.defineProperty({}, 1, {\n"
+                        + "  writable: false,\n"
+                        + "  value: 'v'\n"
+                        + "});\n"
+                        + "try {\n"
+                        + "  Object.assign(dest, src);\n"
+                        + "  'success';\n"
+                        + "} catch(e) {\n"
+                        + "  'error';\n"
+                        + "}",
+                "error");
+        evaluateAndAssert(
+                "var src = Object.defineProperty({}, 1, {\n"
+                        + "  enumerable: false,\n"
+                        + "  value: 'v'\n"
+                        + "});\n"
+                        + "var dest = Object.defineProperty({}, 1, {\n"
+                        + "  writable: false,\n"
+                        + "  value: 'v'\n"
+                        + "});\n"
+                        + "try {\n"
+                        + "  Object.assign(dest, src);\n"
+                        + "  'success';\n"
+                        + "} catch(e) {\n"
+                        + "  'error';\n"
+                        + "}",
+                "success");
+        evaluateAndAssert(
+                "var src = Object.defineProperty({}, 1, {\n"
+                        + "  enumerable: true,\n"
+                        + "  value: 'v'\n"
+                        + "});\n"
+                        + "var destProto = Object.defineProperty({}, 1, {\n"
+                        + "  writable: false,\n"
+                        + "  value: 'v'\n"
+                        + "});\n"
+                        + "var dest = Object.create(destProto);\n"
+                        + "try {\n"
+                        + "  Object.assign(dest, src);\n"
+                        + "  'success';\n"
+                        + "} catch(e) {\n"
+                        + "  'error';\n"
+                        + "}",
+                "error");
+    }
+
+    @Test
     public void testSetPrototypeOfNull() {
         evaluateAndAssert(
                 "try { "


### PR DESCRIPTION
ref. #780
```js
Object.keys(Object.assign({a:undefined}, {b:undefined})).join()
// expected:<a[,b]> but was:<a[]>
```
I found another problem with it, so I fixed it while I was at it.
```js
var obj = Object.freeze({});
Object.assign(obj, { a: 1 });
// An error to be thrown, but nothing was thrown.
```