### PR TITLE
Fix ClassCastException when using StringBuilder/Buffer #496

### DIFF
--- a/src/org/mozilla/javascript/ConsString.java
+++ b/src/org/mozilla/javascript/ConsString.java
@@ -32,6 +32,12 @@ public class ConsString implements CharSequence, Serializable {
     private boolean isFlat;
 
     public ConsString(CharSequence str1, CharSequence str2) {
+        if (!(str1 instanceof String) && !(str1 instanceof ConsString)) {
+            str1 = str1.toString();
+        }
+        if (!(str2 instanceof String) && !(str2 instanceof ConsString)) {
+            str2 = str2.toString();
+        }
         left = str1;
         right = str2;
         length = left.length() + right.length();
@@ -69,7 +75,7 @@ public class ConsString implements CharSequence, Serializable {
                     }
                 }
 
-                final String str = next.toString();
+                final String str = (String) next;
                 charPos -= str.length();
                 str.getChars(0, str.length(), chars, charPos);
                 next = stack.isEmpty() ? null : stack.removeFirst();

--- a/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
@@ -5,7 +5,6 @@
 package org.mozilla.javascript.tests;
 
 import junit.framework.TestCase;
-
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;

--- a/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 
-/** Tests the ConsString class to ensure it properly supports String, StringBuffer and StringBuilder. */
+/**
+ * Tests the ConsString class to ensure it properly supports String, StringBuffer and StringBuilder.
+ */
 public class Issue1206Test {
     @Test
     public void testConsStringUsingString() {

--- a/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.javascript.tests;
 
+import junit.framework.TestCase;
+
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
@@ -11,13 +13,14 @@ import org.mozilla.javascript.Scriptable;
 /**
  * Tests the ConsString class to ensure it properly supports String, StringBuffer and StringBuilder.
  */
-public class Issue1206Test {
+public class Issue1206Test extends TestCase {
     @Test
     public void testConsStringUsingString() {
         Context cx = Context.enter();
         Scriptable scope = cx.initStandardObjects(null);
         scope.put("var1", scope, "hello");
-        cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+        Object result = cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+        assertEquals("hello world", result);
     }
 
     @Test
@@ -25,7 +28,8 @@ public class Issue1206Test {
         Context cx = Context.enter();
         Scriptable scope = cx.initStandardObjects(null);
         scope.put("var1", scope, new StringBuffer("hello"));
-        cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+        Object result = cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+        assertEquals("hello world", result);
     }
 
     @Test
@@ -33,6 +37,7 @@ public class Issue1206Test {
         Context cx = Context.enter();
         Scriptable scope = cx.initStandardObjects(null);
         scope.put("var1", scope, new StringBuilder("hello"));
-        cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+        Object result = cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+        assertEquals("hello world", result);
     }
 }

--- a/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1206Test.java
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+/** Tests the ConsString class to ensure it properly supports String, StringBuffer and StringBuilder. */
+public class Issue1206Test {
+    @Test
+    public void testConsStringUsingString() {
+        Context cx = Context.enter();
+        Scriptable scope = cx.initStandardObjects(null);
+        scope.put("var1", scope, "hello");
+        cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+    }
+
+    @Test
+    public void testConsStringUsingStringBuffer() {
+        Context cx = Context.enter();
+        Scriptable scope = cx.initStandardObjects(null);
+        scope.put("var1", scope, new StringBuffer("hello"));
+        cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+    }
+
+    @Test
+    public void testConsStringUsingStringBuilder() {
+        Context cx = Context.enter();
+        Scriptable scope = cx.initStandardObjects(null);
+        scope.put("var1", scope, new StringBuilder("hello"));
+        cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
+    }
+}


### PR DESCRIPTION
Fixes a ClassCastException in the flatten() method, if a StringBuilder or StringBuffer was used to initialize a JavaScript variable.