### PR TITLE
improve log output of Callable's

### DIFF
--- a/src/org/mozilla/javascript/NativeConsole.java
+++ b/src/org/mozilla/javascript/NativeConsole.java
@@ -325,7 +325,24 @@ public class NativeConsole extends IdScriptableObject {
         }
 
         try {
-            Object stringify = NativeJSON.stringify(cx, scope, arg, null, null);
+            // NativeJSON.stringify outputs Callable's as null, convert to string
+            // to make the output less confusing
+            final Callable replacer =
+                    new Callable() {
+                        @Override
+                        public Object call(
+                                Context callCx,
+                                Scriptable callScope,
+                                Scriptable callThisObj,
+                                Object[] callArgs) {
+                            final Object value = callArgs[1];
+                            if (value instanceof Callable) {
+                                return ScriptRuntime.toString(value);
+                            }
+                            return value;
+                        }
+                    };
+            Object stringify = NativeJSON.stringify(cx, scope, arg, replacer, null);
             return ScriptRuntime.toString(stringify);
         } catch (EcmaError e) {
             if ("TypeError".equals(e.getName())) {

--- a/src/org/mozilla/javascript/NativeConsole.java
+++ b/src/org/mozilla/javascript/NativeConsole.java
@@ -335,7 +335,17 @@ public class NativeConsole extends IdScriptableObject {
                                 Scriptable callScope,
                                 Scriptable callThisObj,
                                 Object[] callArgs) {
-                            final Object value = callArgs[1];
+                            Object value = callArgs[1];
+                            while (value instanceof Delegator) {
+                                value = ((Delegator) value).getDelegee();
+                            }
+                            if (value instanceof BaseFunction) {
+                                StringBuilder sb = new StringBuilder();
+                                sb.append("function ")
+                                        .append(((BaseFunction) value).getFunctionName())
+                                        .append("() {...}");
+                                return sb.toString();
+                            }
                             if (value instanceof Callable) {
                                 return ScriptRuntime.toString(value);
                             }

--- a/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -363,14 +363,18 @@ public class NativeConsoleTest {
 
     @Test
     public void printCallable() {
-        String js = "function foo() {}\n" + "console.log(foo)";
-        assertPrintMsg(js, "\"\\nfunction foo() {\\n}\\n\"");
+        String js = "function foo() {}\n console.log(foo)";
+        assertPrintMsg(js, "\"function foo() {...}\"");
+
+        // suppress body
+        js = "function fooo() { var i = 0; }\n console.log(fooo)";
+        assertPrintMsg(js, "\"function fooo() {...}\"");
 
         js = "console.log(/abc/i)";
         assertPrintMsg(js, "\"/abc/i\"");
 
         js = "function foo() {}\n" + "console.log([foo, /abc/])";
-        assertPrintMsg(js, "[\"\\nfunction foo() {\\n}\\n\",\"/abc/\"]");
+        assertPrintMsg(js, "[\"function foo() {...}\",\"/abc/\"]");
     }
 
     @Test

--- a/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -362,6 +362,18 @@ public class NativeConsoleTest {
     }
 
     @Test
+    public void printCallable() {
+        String js = "function foo() {}\n" + "console.log(foo)";
+        assertPrintMsg(js, "\"\\nfunction foo() {\\n}\\n\"");
+
+        js = "console.log(/abc/i)";
+        assertPrintMsg(js, "\"/abc/i\"");
+
+        js = "function foo() {}\n" + "console.log([foo, /abc/])";
+        assertPrintMsg(js, "[\"\\nfunction foo() {\\n}\\n\",\"/abc/\"]");
+    }
+
+    @Test
     public void trace() {
         assertPrintMsg(
                 "  function foo() {\n"


### PR DESCRIPTION
NativeJSON.stringify outputs Callable's as null, convert to string to make the log output less confusing