### PR TITLE
Make getCharacterEncoding in UrlModuleSourceProvider protected

### DIFF
--- a/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
+++ b/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
@@ -156,7 +156,7 @@ public class UrlModuleSourceProvider extends ModuleSourceProviderBase {
         }
     }
 
-    private static Reader getReader(URLConnection urlConnection) throws IOException {
+    private Reader getReader(URLConnection urlConnection) throws IOException {
         return new InputStreamReader(
                 urlConnection.getInputStream(), getCharacterEncoding(urlConnection));
     }

--- a/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
+++ b/src/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
@@ -161,7 +161,7 @@ public class UrlModuleSourceProvider extends ModuleSourceProviderBase {
                 urlConnection.getInputStream(), getCharacterEncoding(urlConnection));
     }
 
-    private static String getCharacterEncoding(URLConnection urlConnection) {
+    protected String getCharacterEncoding(URLConnection urlConnection) {
         final ParsedContentType pct = new ParsedContentType(urlConnection.getContentType());
         final String encoding = pct.getEncoding();
         if (encoding != null) {

--- a/testsrc/org/mozilla/javascript/tests/commonjs/module/provider/UrlModuleSourceProviderTest.java
+++ b/testsrc/org/mozilla/javascript/tests/commonjs/module/provider/UrlModuleSourceProviderTest.java
@@ -4,8 +4,11 @@
 
 package org.mozilla.javascript.tests.commonjs.module.provider;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -65,6 +68,15 @@ public class UrlModuleSourceProviderTest {
         // then
         Assert.assertNotNull(result);
         Assert.assertNotEquals("Modified", ModuleSourceProvider.NOT_MODIFIED, result);
+    }
+
+    @Test
+    public void getCharacterEncodingCanBeModifiedInSubclass() throws NoSuchMethodException {
+        Method method =
+                UrlModuleSourceProvider.class.getDeclaredMethod(
+                        "getCharacterEncoding", new Class[] {URLConnection.class});
+        int mods = method.getModifiers();
+        Assert.assertTrue(Modifier.isPublic(mods) || Modifier.isProtected(mods));
     }
 
     private static URI getModuleURI(final Path filePath) throws URISyntaxException {


### PR DESCRIPTION
Allows subclasses to override the encoding used in case a local
javascript file is interpreted as being latin-1, when it should be
whatever the file is encoded with. Before openJDK 17.0.3 this was
automatically interpreted as utf-8.

Allows #1232 to be worked around by code calling Rhino.