### PR TITLE
Implement Map.put() for NativeObject

### DIFF
--- a/src/org/mozilla/javascript/NativeObject.java
+++ b/src/org/mozilla/javascript/NativeObject.java
@@ -778,7 +778,13 @@ public class NativeObject extends IdScriptableObject implements Map {
 
     @Override
     public Object put(Object key, Object value) {
-        throw new UnsupportedOperationException();
+        Object previousValue = get(key);
+        if (key instanceof String) {
+            super.put((String) key, this, value);
+        } else if (key instanceof Number) {
+            super.put(((Number) key).intValue(), this, value);
+        }
+        return previousValue == NOT_FOUND ? null : previousValue;
     }
 
     @Override


### PR DESCRIPTION
Untested code – could something as simple as this work? It sucks to see `implements Map` while not being able to rely on super basic `Map` methods.