### PR TITLE
fix: parent relationship in TaggedTemplateLiteral (#1238)

### DIFF
--- a/src/org/mozilla/javascript/ast/TaggedTemplateLiteral.java
+++ b/src/org/mozilla/javascript/ast/TaggedTemplateLiteral.java
@@ -36,6 +36,7 @@ public class TaggedTemplateLiteral extends AstNode {
 
     public void setTarget(AstNode target) {
         this.target = target;
+        target.setParent(this);
     }
 
     public AstNode getTemplateLiteral() {
@@ -44,6 +45,7 @@ public class TaggedTemplateLiteral extends AstNode {
 
     public void setTemplateLiteral(AstNode templateLiteral) {
         this.templateLiteral = templateLiteral;
+        templateLiteral.setParent(this);
     }
 
     @Override

--- a/testsrc/org/mozilla/javascript/tests/es6/TaggedTemplateLiteralTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/TaggedTemplateLiteralTest.java
@@ -1,21 +1,20 @@
 package org.mozilla.javascript.tests.es6;
 
+import static org.junit.Assert.*;
+
 import org.junit.Test;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.*;
 
-import static org.junit.Assert.*;
-
-/**
- * Tests for ES6+ tagged templates support.
- */
+/** Tests for ES6+ tagged templates support. */
 public class TaggedTemplateLiteralTest {
 
     /**
-     * Target and {@link org.mozilla.javascript.ast.TemplateLiteral} nodes inside the tagged template should have
-     * {@link org.mozilla.javascript.ast.TaggedTemplateLiteral} node as their parent.
+     * Target and {@link org.mozilla.javascript.ast.TemplateLiteral} nodes inside the tagged
+     * template should have {@link org.mozilla.javascript.ast.TaggedTemplateLiteral} node as their
+     * parent.
      *
-     * See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
+     * <p>See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
      */
     @Test
     public void testTaggedTemplateChildrenHaveParent() {
@@ -32,10 +31,10 @@ public class TaggedTemplateLiteralTest {
     }
 
     /**
-     * Target and {@link org.mozilla.javascript.ast.TemplateLiteral} nodes inside the tagged template should resolve
-     * the AST root.
+     * Target and {@link org.mozilla.javascript.ast.TemplateLiteral} nodes inside the tagged
+     * template should resolve the AST root.
      *
-     * See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
+     * <p>See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
      */
     @Test
     public void testTaggedTemplateChildrenHaveAstRoot() {
@@ -55,7 +54,7 @@ public class TaggedTemplateLiteralTest {
     /**
      * AST nodes, which are descendants of a tagged template node should resolve the AST root.
      *
-     * See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
+     * <p>See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
      */
     @Test
     public void testInnerNodeHasAstRoot() {
@@ -70,9 +69,7 @@ public class TaggedTemplateLiteralTest {
         assertEquals(root, nameNode.getAstRoot());
     }
 
-    /**
-     * Finds first {@link TaggedTemplateLiteral} node in the AST.
-     */
+    /** Finds first {@link TaggedTemplateLiteral} node in the AST. */
     private static class TaggedTemplateFinder implements NodeVisitor {
         private TaggedTemplateLiteral node;
 
@@ -90,9 +87,7 @@ public class TaggedTemplateLiteralTest {
         }
     }
 
-    /**
-     * Finds first {@link Name} node for given identifier.
-     */
+    /** Finds first {@link Name} node for given identifier. */
     private static class NameFinder implements NodeVisitor {
         private Name node;
         private String name;

--- a/testsrc/org/mozilla/javascript/tests/es6/TaggedTemplateLiteralTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/TaggedTemplateLiteralTest.java
@@ -1,0 +1,120 @@
+package org.mozilla.javascript.tests.es6;
+
+import org.junit.Test;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.ast.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for ES6+ tagged templates support.
+ */
+public class TaggedTemplateLiteralTest {
+
+    /**
+     * Target and {@link org.mozilla.javascript.ast.TemplateLiteral} nodes inside the tagged template should have
+     * {@link org.mozilla.javascript.ast.TaggedTemplateLiteral} node as their parent.
+     *
+     * See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
+     */
+    @Test
+    public void testTaggedTemplateChildrenHaveParent() {
+        String script = "tag`template`;";
+
+        AstRoot root = new Parser().parse(script, "test", 0);
+        TaggedTemplateFinder finder = new TaggedTemplateFinder();
+        root.visit(finder);
+        TaggedTemplateLiteral taggedTemplate = finder.getNode();
+
+        assertNotNull(taggedTemplate);
+        assertEquals(taggedTemplate, taggedTemplate.getTarget().getParent());
+        assertEquals(taggedTemplate, taggedTemplate.getTemplateLiteral().getParent());
+    }
+
+    /**
+     * Target and {@link org.mozilla.javascript.ast.TemplateLiteral} nodes inside the tagged template should resolve
+     * the AST root.
+     *
+     * See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
+     */
+    @Test
+    public void testTaggedTemplateChildrenHaveAstRoot() {
+        String script = "tag`template`";
+
+        AstRoot root = new Parser().parse(script, "test", 0);
+        TaggedTemplateFinder finder = new TaggedTemplateFinder();
+        root.visit(finder);
+        TaggedTemplateLiteral taggedTemplate = finder.getNode();
+
+        assertNotNull(taggedTemplate);
+        assertEquals(root, taggedTemplate.getAstRoot());
+        assertEquals(root, taggedTemplate.getTarget().getAstRoot());
+        assertEquals(root, taggedTemplate.getTemplateLiteral().getAstRoot());
+    }
+
+    /**
+     * AST nodes, which are descendants of a tagged template node should resolve the AST root.
+     *
+     * See <a href="https://github.com/mozilla/rhino/issues/1238">#1238</a> for details.
+     */
+    @Test
+    public void testInnerNodeHasAstRoot() {
+        String script = "someObj.property()`template`";
+
+        AstRoot root = new Parser().parse(script, "test", 0);
+        NameFinder finder = new NameFinder("property");
+        root.visit(finder);
+        Name nameNode = finder.getNode();
+
+        assertNotNull(nameNode);
+        assertEquals(root, nameNode.getAstRoot());
+    }
+
+    /**
+     * Finds first {@link TaggedTemplateLiteral} node in the AST.
+     */
+    private static class TaggedTemplateFinder implements NodeVisitor {
+        private TaggedTemplateLiteral node;
+
+        public TaggedTemplateLiteral getNode() {
+            return node;
+        }
+
+        @Override
+        public boolean visit(AstNode node) {
+            if (node instanceof TaggedTemplateLiteral) {
+                this.node = (TaggedTemplateLiteral) node;
+                return false;
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Finds first {@link Name} node for given identifier.
+     */
+    private static class NameFinder implements NodeVisitor {
+        private Name node;
+        private String name;
+
+        public NameFinder(String name) {
+            this.name = name;
+        }
+
+        public Name getNode() {
+            return node;
+        }
+
+        @Override
+        public boolean visit(AstNode node) {
+            if (node instanceof Name) {
+                Name nameNode = (Name) node;
+                if (nameNode.getIdentifier().equals(name)) {
+                    this.node = nameNode;
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds parent references to target and string template nodes of `TaggedTemplateLiteral` node (see #1238)

Since string templates are introduced in ES6, I placed tests into _org.mozilla.javascript.tests.es6_ package. Please let me know if there is a more suitable place for these tests.