### PR TITLE
Fix hasOwnProperty on NativeJavaObject

### DIFF
--- a/src/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/src/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -34,7 +34,7 @@ class AbstractEcmaObjectOperations {
      * @see <a href="https://262.ecma-international.org/12.0/#sec-hasownproperty"></a>
      */
     static boolean hasOwnProperty(Context cx, Object o, Object property) {
-        ScriptableObject obj = ScriptableObject.ensureScriptableObject(o);
+        Scriptable obj = ScriptableObject.ensureScriptable(o);
         boolean result;
         if (property instanceof Symbol) {
             result = ScriptableObject.ensureSymbolScriptable(o).has((Symbol) property, obj);

--- a/testsrc/org/mozilla/javascript/tests/NativeObjectTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeObjectTest.java
@@ -4,10 +4,13 @@
 
 package org.mozilla.javascript.tests;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 
 public class NativeObjectTest {
 
@@ -82,5 +85,28 @@ public class NativeObjectTest {
                         null);
         Assert.assertEquals("true true false", result);
         Context.exit();
+    }
+
+    public static class JavaObj {
+        public String name = "test";
+    }
+
+    @Test
+    public void testNativeJavaObject_hasOwnProperty() {
+        Context cx = Context.enter();
+        try {
+            Scriptable scope = cx.initStandardObjects();
+            ScriptableObject.putProperty(scope, "javaObj", Context.javaToJS(new JavaObj(), scope));
+            Object result =
+                    cx.evaluateString(
+                            scope,
+                            "Object.prototype.hasOwnProperty.call(javaObj, \"name\");",
+                            "",
+                            1,
+                            null);
+            assertTrue((Boolean) result);
+        } finally {
+            Context.exit();
+        }
     }
 }


### PR DESCRIPTION
This failed since #1157 with "TypeError: Expected argument of type
object, but instead had type object"

```
org.mozilla.javascript.EcmaError: TypeError: Expected argument of type object, but instead had type object (#1)
	at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.java:4568)
	at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.java:4549)
	at org.mozilla.javascript.ScriptRuntime.typeError(ScriptRuntime.java:4581)
	at org.mozilla.javascript.ScriptRuntime.typeErrorById(ScriptRuntime.java:4586)
	at org.mozilla.javascript.ScriptableObject.ensureScriptableObject(ScriptableObject.java:1845)
	at org.mozilla.javascript.AbstractEcmaObjectOperations.hasOwnProperty(AbstractEcmaObjectOperations.java:37)
	at org.mozilla.javascript.NativeObject.execIdCall(NativeObject.java:216)
	at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:84)
	at org.mozilla.javascript.ScriptRuntime.applyOrCall(ScriptRuntime.java:2769)
	at org.mozilla.javascript.BaseFunction.execIdCall(BaseFunction.java:327)
	at org.mozilla.javascript.IdFunctionObject.call(IdFunctionObject.java:84)
	at org.mozilla.javascript.optimizer.OptRuntime.call2(OptRuntime.java:46)
	at org.mozilla.javascript.gen.c_1._c_script_0(:1)
	at org.mozilla.javascript.gen.c_1.call()
	at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:383)
	at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3871)
	at org.mozilla.javascript.gen.c_1.call()
	at org.mozilla.javascript.gen.c_1.exec()
	at org.mozilla.javascript.Context.evaluateString(Context.java:1170)
	at org.mozilla.javascript.tests.NativeObjectTest.testNativeJavaObject_hasOwnProperty(NativeObjectTest.java:100)
```