### PR TITLE
cleanup as follow up of pr 1284

### DIFF
--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -283,21 +283,39 @@ public class FunctionObject extends BaseFunction {
      * @see org.mozilla.javascript.Scriptable#getClassName
      */
     public void addAsConstructor(Scriptable scope, Scriptable prototype) {
-        initAsConstructor(scope, prototype);
+        initAsConstructor(
+                scope,
+                prototype,
+                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
         defineProperty(scope, prototype.getClassName(), this, ScriptableObject.DONTENUM);
     }
 
-    void initAsConstructor(Scriptable scope, Scriptable prototype) {
+    /**
+     * Define this function as a JavaScript constructor.
+     *
+     * <p>Sets up the "prototype" and "constructor" properties. Also calls setParent and
+     * setPrototype with appropriate values. Then adds the function object as a property of the
+     * given scope, using <code>prototype.getClassName()</code> as the name of the property.
+     *
+     * @param scope the scope in which to define the constructor (typically the global object)
+     * @param prototype the prototype object
+     * @param attributes the attributes of the constructor property
+     * @see org.mozilla.javascript.Scriptable#setParentScope
+     * @see org.mozilla.javascript.Scriptable#setPrototype
+     * @see org.mozilla.javascript.Scriptable#getClassName
+     */
+    public void addAsConstructor(Scriptable scope, Scriptable prototype, int attributes) {
+        initAsConstructor(scope, prototype, attributes);
+        defineProperty(scope, prototype.getClassName(), this, ScriptableObject.DONTENUM);
+    }
+
+    void initAsConstructor(Scriptable scope, Scriptable prototype, int attributes) {
         ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
         setImmunePrototypeProperty(prototype);
 
         prototype.setParentScope(this);
 
-        defineProperty(
-                prototype,
-                "constructor",
-                this,
-                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
+        defineProperty(prototype, "constructor", this, attributes);
         setParentScope(scope);
     }
 

--- a/src/org/mozilla/javascript/FunctionObject.java
+++ b/src/org/mozilla/javascript/FunctionObject.java
@@ -288,7 +288,7 @@ public class FunctionObject extends BaseFunction {
     }
 
     void initAsConstructor(Scriptable scope, Scriptable prototype) {
-        ScriptRuntime.setFunctionProtoAndParent(this, scope);
+        ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
         setImmunePrototypeProperty(prototype);
 
         prototype.setParentScope(this);

--- a/src/org/mozilla/javascript/LambdaFunction.java
+++ b/src/org/mozilla/javascript/LambdaFunction.java
@@ -34,7 +34,7 @@ public class LambdaFunction extends BaseFunction {
         this.target = target;
         this.name = name;
         this.length = length;
-        ScriptRuntime.setFunctionProtoAndParent(this, scope);
+        ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
         setupDefaultPrototype();
     }
 
@@ -43,7 +43,7 @@ public class LambdaFunction extends BaseFunction {
         this.target = target;
         this.length = length;
         this.name = "";
-        ScriptRuntime.setFunctionProtoAndParent(this, scope);
+        ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
     }
 
     @Override

--- a/src/org/mozilla/javascript/NativePromise.java
+++ b/src/org/mozilla/javascript/NativePromise.java
@@ -35,7 +35,6 @@ public class NativePromise extends ScriptableObject {
                         1,
                         LambdaConstructor.CONSTRUCTOR_NEW,
                         NativePromise::constructor);
-        constructor.setStandardPropertyAttributes(DONTENUM | READONLY);
         constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
 
         constructor.defineConstructorMethod(
@@ -541,7 +540,6 @@ public class NativePromise extends ScriptableObject {
                                             scope,
                                             promise,
                                             (args.length > 0 ? args[0] : Undefined.instance)));
-            resolve.setStandardPropertyAttributes(DONTENUM | READONLY);
             reject =
                     new LambdaFunction(
                             topScope,
@@ -552,7 +550,6 @@ public class NativePromise extends ScriptableObject {
                                             scope,
                                             promise,
                                             (args.length > 0 ? args[0] : Undefined.instance)));
-            reject.setStandardPropertyAttributes(DONTENUM | READONLY);
         }
 
         private Object reject(Context cx, Scriptable scope, NativePromise promise, Object reason) {
@@ -664,7 +661,6 @@ public class NativePromise extends ScriptableObject {
                             2,
                             (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) ->
                                     executor(args));
-            executorFunc.setStandardPropertyAttributes(DONTENUM | READONLY);
 
             promise = promiseConstructor.construct(topCx, topScope, new Object[] {executorFunc});
 
@@ -777,7 +773,6 @@ public class NativePromise extends ScriptableObject {
                                     }
                                     return eltResolver.resolve(cx, scope, value, this);
                                 });
-                resolveFunc.setStandardPropertyAttributes(DONTENUM | READONLY);
 
                 Callable rejectFunc = capability.reject;
                 if (!failFast) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -4249,23 +4249,36 @@ public class ScriptRuntime {
         return nw.getParentScope();
     }
 
+    /**
+     * @deprecated Use {@link #setFunctionProtoAndParent(BaseFunction, Context, Scriptable)} instead
+     */
+    @Deprecated
     public static void setFunctionProtoAndParent(BaseFunction fn, Scriptable scope) {
-        setFunctionProtoAndParent(fn, scope, false);
+        setFunctionProtoAndParent(fn, Context.getCurrentContext(), scope, false);
+    }
+
+    public static void setFunctionProtoAndParent(BaseFunction fn, Context cx, Scriptable scope) {
+        setFunctionProtoAndParent(fn, cx, scope, false);
+    }
+
+    /**
+     * @deprecated Use {@link #setFunctionProtoAndParent(BaseFunction, Context, Scriptable,
+     *     boolean)} instead
+     */
+    @Deprecated
+    public static void setFunctionProtoAndParent(
+            BaseFunction fn, Scriptable scope, boolean es6GeneratorFunction) {
+        setFunctionProtoAndParent(fn, Context.getCurrentContext(), scope, es6GeneratorFunction);
     }
 
     public static void setFunctionProtoAndParent(
-            BaseFunction fn, Scriptable scope, boolean es6GeneratorFunction) {
+            BaseFunction fn, Context cx, Scriptable scope, boolean es6GeneratorFunction) {
         fn.setParentScope(scope);
         if (es6GeneratorFunction) {
             fn.setPrototype(ScriptableObject.getGeneratorFunctionPrototype(scope));
         } else {
             fn.setPrototype(ScriptableObject.getFunctionPrototype(scope));
         }
-    }
-
-    public static void setFunctionProtoAndParent(
-            BaseFunction fn, Context cx, Scriptable scope, boolean es6GeneratorFunction) {
-        setFunctionProtoAndParent(fn, scope, es6GeneratorFunction);
 
         if (cx != null && cx.getLanguageVersion() >= Context.VERSION_ES6) {
             fn.setStandardPropertyAttributes(ScriptableObject.READONLY | ScriptableObject.DONTENUM);

--- a/src/org/mozilla/javascript/ScriptableObject.java
+++ b/src/org/mozilla/javascript/ScriptableObject.java
@@ -1108,7 +1108,10 @@ public abstract class ScriptableObject
         if (ctor.isVarArgsMethod()) {
             throw Context.reportRuntimeErrorById("msg.varargs.ctor", ctorMember.getName());
         }
-        ctor.initAsConstructor(scope, proto);
+        ctor.initAsConstructor(
+                scope,
+                proto,
+                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
 
         Method finishInit = null;
         HashSet<String> staticNames = new HashSet<String>(), instanceNames = new HashSet<String>();

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -122,7 +122,7 @@ public class NativeRegExp extends IdScriptableObject {
         // RegExp.prototype.constructor is the builtin RegExp constructor."
         proto.defineProperty("constructor", ctor, ScriptableObject.DONTENUM);
 
-        ScriptRuntime.setFunctionProtoAndParent(ctor, scope);
+        ScriptRuntime.setFunctionProtoAndParent(ctor, cx, scope);
 
         ctor.setImmunePrototypeProperty(proto);
 

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3542,8 +3542,7 @@ language/expressions/conditional 3/22 (13.64%)
     tco-cond.js {unsupported: [tail-call-optimization]}
     tco-pos.js {unsupported: [tail-call-optimization]}
 
-language/expressions/delete 4/61 (6.56%)
-    11.4.1-5-a-28-s.js strict
+language/expressions/delete 3/61 (4.92%)
     identifier-strict.js strict
     super-property.js {unsupported: [class]}
     super-property-method.js {unsupported: [class]}


### PR DESCRIPTION
make setFunctionProtoAndParent context aware,
deprecate the old versions
cleanup promise because the setup is now correct done by the ctor