### PR TITLE
Preserving cause on rethrown exceptions

### DIFF
--- a/src/org/mozilla/javascript/JavaScriptException.java
+++ b/src/org/mozilla/javascript/JavaScriptException.java
@@ -90,24 +90,18 @@ public class JavaScriptException extends RhinoException {
         }
     }
 
-    /**
-     * @return the value wrapped by this exception
-     */
+    /** @return the value wrapped by this exception */
     public Object getValue() {
         return value;
     }
 
-    /**
-     * @deprecated Use {@link RhinoException#sourceName()} from the super class.
-     */
+    /** @deprecated Use {@link RhinoException#sourceName()} from the super class. */
     @Deprecated
     public String getSourceName() {
         return sourceName();
     }
 
-    /**
-     * @deprecated Use {@link RhinoException#lineNumber()} from the super class.
-     */
+    /** @deprecated Use {@link RhinoException#lineNumber()} from the super class. */
     @Deprecated
     public int getLineNumber() {
         return lineNumber();

--- a/testsrc/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.JavaScriptException;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.WrappedException;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Unit tests to check error handling. Especially, we expect to get a correct cause, when
+ * an error happened in Java.
+ *
+ * @author Roland Praml
+ */
+public class ErrorHandlingTest {
+    static final String LS = System.getProperty("line.separator");
+
+    public static void generateJavaError() {
+        throw new java.lang.RuntimeException("foo");
+    }
+
+    // string contains stack element with correct line number. e.g:
+    // ' at org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError(ErrorHandlingTest.java:30)'
+    private static final String EXPECTED_LINE_IN_STACK = findLine();
+
+    @Test
+    public void throwError() {
+        testIt("throw new Error('foo')", e -> {
+            Assert.assertEquals(JavaScriptException.class, e.getClass());
+            Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
+        });
+        testIt("try { throw new Error('foo') } catch (e) { throw e }", e -> {
+            Assert.assertEquals(JavaScriptException.class, e.getClass());
+            Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
+        });
+    }
+
+
+    @Test
+    public void javaErrorFromInvocation() {
+
+        testIt("org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError()", e -> {
+            Assert.assertEquals(WrappedException.class, e.getClass());
+            Assert.assertEquals("Wrapped java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
+            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+            Assert.assertEquals("foo", e.getCause().getMessage());
+            Assert.assertTrue(stackToLines(e).contains(EXPECTED_LINE_IN_STACK));
+        });
+        testIt("try { org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError() } catch (e) { throw e }", e -> {
+            Assert.assertEquals(JavaScriptException.class, e.getClass());
+            Assert.assertEquals("JavaException: java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
+            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+            Assert.assertEquals("foo", e.getCause().getMessage());
+            Assert.assertTrue(stackToLines(e).contains(EXPECTED_LINE_IN_STACK));
+        });
+    }
+
+    @Test
+    public void javaErrorThrown() {
+
+        testIt("throw new java.lang.RuntimeException('foo')", e -> {
+            Assert.assertEquals(JavaScriptException.class, e.getClass());
+            Assert.assertEquals("java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
+            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+            Assert.assertEquals("foo", e.getCause().getMessage());
+        });
+        testIt("try { throw new java.lang.RuntimeException('foo') } catch (e) { throw e }", e -> {
+            Assert.assertEquals(JavaScriptException.class, e.getClass());
+            Assert.assertEquals("java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
+            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+            Assert.assertEquals("foo", e.getCause().getMessage());
+        });
+    }
+
+    private void testIt(final String script, final Consumer<Throwable> exception) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    try {
+                        final ScriptableObject scope = cx.initStandardObjects();
+                        cx.evaluateString(scope, script, "myScript.js", 1, null);
+                        Assert.fail("No error was thrown");
+                    } catch (final Throwable t) {
+                        exception.accept(t);
+                    }
+                    return null;
+                });
+    }
+
+
+    static List<String> stackToLines(Throwable t) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        t.printStackTrace(pw);
+        String[] tmp = sw.toString().replace("\r\n", "\n").split("\n");
+        return Arrays.asList(tmp);
+    }
+
+    private static String findLine() {
+        try {
+            generateJavaError();
+        } catch (Throwable t) {
+            for (String line : stackToLines(t)) {
+                if (line.contains("generateJavaError")) {
+                    System.out.println(line);
+                    return line;
+                }
+            }
+        }
+        throw new UnsupportedOperationException("Did not find expected line");
+    }
+}

--- a/testsrc/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -4,21 +4,20 @@
 
 package org.mozilla.javascript.tests;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.WrappedException;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Consumer;
-
 /**
- * Unit tests to check error handling. Especially, we expect to get a correct cause, when
- * an error happened in Java.
+ * Unit tests to check error handling. Especially, we expect to get a correct cause, when an error
+ * happened in Java.
  *
  * @author Roland Praml
  */
@@ -30,56 +29,74 @@ public class ErrorHandlingTest {
     }
 
     // string contains stack element with correct line number. e.g:
-    // ' at org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError(ErrorHandlingTest.java:30)'
+    // ' at
+    // org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError(ErrorHandlingTest.java:30)'
     private static final String EXPECTED_LINE_IN_STACK = findLine();
 
     @Test
     public void throwError() {
-        testIt("throw new Error('foo')", e -> {
-            Assert.assertEquals(JavaScriptException.class, e.getClass());
-            Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
-        });
-        testIt("try { throw new Error('foo') } catch (e) { throw e }", e -> {
-            Assert.assertEquals(JavaScriptException.class, e.getClass());
-            Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
-        });
+        testIt(
+                "throw new Error('foo')",
+                e -> {
+                    Assert.assertEquals(JavaScriptException.class, e.getClass());
+                    Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
+                });
+        testIt(
+                "try { throw new Error('foo') } catch (e) { throw e }",
+                e -> {
+                    Assert.assertEquals(JavaScriptException.class, e.getClass());
+                    Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
+                });
     }
-
 
     @Test
     public void javaErrorFromInvocation() {
 
-        testIt("org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError()", e -> {
-            Assert.assertEquals(WrappedException.class, e.getClass());
-            Assert.assertEquals("Wrapped java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
-            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
-            Assert.assertEquals("foo", e.getCause().getMessage());
-            Assert.assertTrue(stackToLines(e).contains(EXPECTED_LINE_IN_STACK));
-        });
-        testIt("try { org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError() } catch (e) { throw e }", e -> {
-            Assert.assertEquals(JavaScriptException.class, e.getClass());
-            Assert.assertEquals("JavaException: java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
-            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
-            Assert.assertEquals("foo", e.getCause().getMessage());
-            Assert.assertTrue(stackToLines(e).contains(EXPECTED_LINE_IN_STACK));
-        });
+        testIt(
+                "org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError()",
+                e -> {
+                    Assert.assertEquals(WrappedException.class, e.getClass());
+                    Assert.assertEquals(
+                            "Wrapped java.lang.RuntimeException: foo (myScript.js#1)",
+                            e.getMessage());
+                    Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+                    Assert.assertEquals("foo", e.getCause().getMessage());
+                    Assert.assertTrue(stackToLines(e).contains(EXPECTED_LINE_IN_STACK));
+                });
+        testIt(
+                "try { org.mozilla.javascript.tests.ErrorHandlingTest.generateJavaError() } catch (e) { throw e }",
+                e -> {
+                    Assert.assertEquals(JavaScriptException.class, e.getClass());
+                    Assert.assertEquals(
+                            "JavaException: java.lang.RuntimeException: foo (myScript.js#1)",
+                            e.getMessage());
+                    Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+                    Assert.assertEquals("foo", e.getCause().getMessage());
+                    Assert.assertTrue(stackToLines(e).contains(EXPECTED_LINE_IN_STACK));
+                });
     }
 
     @Test
     public void javaErrorThrown() {
 
-        testIt("throw new java.lang.RuntimeException('foo')", e -> {
-            Assert.assertEquals(JavaScriptException.class, e.getClass());
-            Assert.assertEquals("java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
-            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
-            Assert.assertEquals("foo", e.getCause().getMessage());
-        });
-        testIt("try { throw new java.lang.RuntimeException('foo') } catch (e) { throw e }", e -> {
-            Assert.assertEquals(JavaScriptException.class, e.getClass());
-            Assert.assertEquals("java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
-            Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
-            Assert.assertEquals("foo", e.getCause().getMessage());
-        });
+        testIt(
+                "throw new java.lang.RuntimeException('foo')",
+                e -> {
+                    Assert.assertEquals(JavaScriptException.class, e.getClass());
+                    Assert.assertEquals(
+                            "java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
+                    Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+                    Assert.assertEquals("foo", e.getCause().getMessage());
+                });
+        testIt(
+                "try { throw new java.lang.RuntimeException('foo') } catch (e) { throw e }",
+                e -> {
+                    Assert.assertEquals(JavaScriptException.class, e.getClass());
+                    Assert.assertEquals(
+                            "java.lang.RuntimeException: foo (myScript.js#1)", e.getMessage());
+                    Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
+                    Assert.assertEquals("foo", e.getCause().getMessage());
+                });
     }
 
     private void testIt(final String script, final Consumer<Throwable> exception) {
@@ -95,7 +112,6 @@ public class ErrorHandlingTest {
                     return null;
                 });
     }
-
 
     static List<String> stackToLines(Throwable t) {
         StringWriter sw = new StringWriter();

--- a/testsrc/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -22,7 +22,6 @@ import org.mozilla.javascript.WrappedException;
  * @author Roland Praml
  */
 public class ErrorHandlingTest {
-    static final String LS = System.getProperty("line.separator");
 
     public static void generateJavaError() {
         throw new java.lang.RuntimeException("foo");


### PR DESCRIPTION
We had an issue, that we loose the java stack trace, when we catch the error in javascript and rethrow it.

```javascript
try {
  // call java code
 someJavaObject.doSomething();
} catch (e) {
 // do some error handling and rethrow the error
 throw e;
}

```

In this case, you will get a JavaScriptException with only the message containing of the exception, that is thrown by `someJavaObject.doSomething();`
(So you might get a NPE, but you have no idea, which line of code caused the exception)

In this PR, we try to set the currently processing exception/NativeError and setting it as cause of the JavaScriptException.


Roland