### PR TITLE
Treat String, ConsString, Boolean, and Double as value types

### DIFF
--- a/src/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/src/org/mozilla/javascript/EqualObjectGraphs.java
@@ -63,9 +63,9 @@ final class EqualObjectGraphs {
             return true;
         } else if (o1 == null || o2 == null) {
             return false;
-        // String (and ConsStrings), Booleans, and Doubles are considered
-        // JavaScript primitive values and are thus compared by value and
-        // with no regard to their object identity.
+            // String (and ConsStrings), Booleans, and Doubles are considered
+            // JavaScript primitive values and are thus compared by value and
+            // with no regard to their object identity.
         } else if (o1 instanceof String) {
             if (o2 instanceof ConsString) {
                 return o1.equals(o2.toString());

--- a/src/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/src/org/mozilla/javascript/EqualObjectGraphs.java
@@ -7,6 +7,8 @@
 package org.mozilla.javascript;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -36,6 +38,19 @@ import org.mozilla.javascript.debug.DebuggableObject;
  */
 final class EqualObjectGraphs {
     private static final ThreadLocal<EqualObjectGraphs> instance = new ThreadLocal<>();
+
+    private static final Set<Class<?>> valueClasses =
+            Collections.unmodifiableSet(
+                    new HashSet<>(
+                            Arrays.asList(
+                                    Boolean.class,
+                                    Byte.class,
+                                    Character.class,
+                                    Double.class,
+                                    Float.class,
+                                    Integer.class,
+                                    Long.class,
+                                    Short.class)));
 
     // Object pairs already known to be equal. Used to short-circuit repeated traversals of objects
     // reachable through
@@ -76,7 +91,7 @@ final class EqualObjectGraphs {
                 return o1.toString().equals(o2.toString());
             }
             return false;
-        } else if (o1 instanceof Boolean || o1 instanceof Double) {
+        } else if (valueClasses.contains(o1.getClass())) {
             return o1.equals(o2);
         }
 

--- a/testsrc/org/mozilla/javascript/EqualObjectGraphsTest.java
+++ b/testsrc/org/mozilla/javascript/EqualObjectGraphsTest.java
@@ -31,23 +31,39 @@ public class EqualObjectGraphsTest extends TestCase {
         return o1;
     }
 
+    private static class TestObject {
+        private final int x;
+        TestObject(int x) { this.x = x; }
+
+        @Override public boolean equals(Object o) {
+            if (o instanceof TestObject) {
+                return x == ((TestObject)o).x;
+            }
+            return false;
+        }
+
+        @Override public int hashCode() {
+            return x;
+        }
+    }
+
     public void testSameValueDifferentTopology() {
         Object[] o1 = new Object[2];
         Object[] o2 = new Object[2];
-        String s1 = new String("foo");
-        String s2 = new String("foo");
-        o1[0] = s1;
-        o1[1] = s2;
-        String s3 = new String("foo");
-        String s4 = new String("foo");
-        o2[0] = s3;
-        o2[1] = s4;
+        Object t1 = new TestObject(0);
+        Object t2 = new TestObject(0);
+        o1[0] = t1;
+        o1[1] = t2;
+        Object t3 = new TestObject(0);
+        Object t4 = new TestObject(0);
+        o2[0] = t3;
+        o2[1] = t4;
 
         // Same values, same topology
         assertTrue(equal(o1, o2));
 
         // Same values, different topology
-        o2[1] = s3;
+        o2[1] = t3;
         assertFalse(equal(o1, o2));
     }
 

--- a/testsrc/org/mozilla/javascript/EqualObjectGraphsTest.java
+++ b/testsrc/org/mozilla/javascript/EqualObjectGraphsTest.java
@@ -33,16 +33,21 @@ public class EqualObjectGraphsTest extends TestCase {
 
     private static class TestObject {
         private final int x;
-        TestObject(int x) { this.x = x; }
 
-        @Override public boolean equals(Object o) {
+        TestObject(int x) {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(Object o) {
             if (o instanceof TestObject) {
-                return x == ((TestObject)o).x;
+                return x == ((TestObject) o).x;
             }
             return false;
         }
 
-        @Override public int hashCode() {
+        @Override
+        public int hashCode() {
             return x;
         }
     }


### PR DESCRIPTION
I've been helping some folks that rely heavily in continuations comparisons in their product, and they had weird failures to compare continuations as equal. Turns out it's mostly due to differences in deserialized objects not having their constructor names etc. interned. The solution ultimately is to (correctly) consider JavaScript strings, booleans, and numbers to not have identity but treat them as purely value types, in line with the JS language semantics.