### PR TITLE
ci: set minimal permissions on GitHub Workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -7,6 +7,7 @@ on:
     types: [published]
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -3,6 +3,7 @@ name: Publish to Maven Central
 on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add top-level read-only permissions to all workflows and set specific job-level permissions to jobs that need any write permission.

Closes #1309