### PR TITLE
Support ES2019 Array.prototype.flat

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1971,7 +1971,7 @@ public class NativeArray extends IdScriptableObject implements List {
     private static Object js_flat(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
         double depth;
-        if (args.length < 1) {
+        if (args.length < 1 || Undefined.isUndefined(args[0])) {
             depth = 1;
         } else {
             depth = ScriptRuntime.toInteger(args[0]);

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -151,7 +151,6 @@ public class NativeArray extends IdScriptableObject implements List {
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findIndex, "findIndex", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduce, "reduce", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduceRight, "reduceRight", 1);
-        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_flat, "flat", 0);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_isArray, "isArray", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_of, "of", 0);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_from, "from", 1);
@@ -334,7 +333,6 @@ public class NativeArray extends IdScriptableObject implements List {
                 case ConstructorId_findIndex:
                 case ConstructorId_reduce:
                 case ConstructorId_reduceRight:
-                case ConstructorId_flat:
                     {
                         // this is a small trick; we will handle all the ConstructorId_xxx calls
                         // the same way the object calls are processed
@@ -2658,7 +2656,6 @@ public class NativeArray extends IdScriptableObject implements List {
             ConstructorId_findIndex = -Id_findIndex,
             ConstructorId_reduce = -Id_reduce,
             ConstructorId_reduceRight = -Id_reduceRight,
-            ConstructorId_flat = -Id_flat,
             ConstructorId_isArray = -26,
             ConstructorId_of = -27,
             ConstructorId_from = -28;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1009,6 +1009,14 @@ public class NativeArray extends IdScriptableObject implements List {
         }
     }
 
+    private static void defineElemOrThrow(Context cx, Scriptable target, long index, Object value) {
+        if (index > NativeNumber.MAX_SAFE_INTEGER) {
+            throw ScriptRuntime.typeErrorById("msg.arraylength.too.big", String.valueOf(index));
+        } else {
+            defineElem(cx, target, index, value);
+        }
+    }
+
     private static void setElem(Context cx, Scriptable target, long index, Object value) {
         if (index > Integer.MAX_VALUE) {
             String id = Long.toString(index);
@@ -1996,10 +2004,10 @@ public class NativeArray extends IdScriptableObject implements List {
                 long arrLength = getLengthProperty(cx, arr);
                 for (long k = 0; k < arrLength; k++) {
                     Object temp = getRawElem(arr, k);
-                    defineElem(cx, result, j++, temp);
+                    defineElemOrThrow(cx, result, j++, temp);
                 }
             } else {
-              defineElem(cx, result, j++, elem);
+                defineElemOrThrow(cx, result, j++, elem);
             }
         }
         setLengthProperty(cx, result, j);

--- a/testsrc/jstests/harmony/array-flat.js
+++ b/testsrc/jstests/harmony/array-flat.js
@@ -1,0 +1,71 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Taken from https://github.com/v8/v8/blob/main/test/mjsunit/harmony/array-flat.js and changed due to Rhino errors
+// TypeError: redeclaration of const input
+load("testsrc/assert.js");
+
+assertEquals(Array.prototype.flat.length, 0);
+assertEquals(Array.prototype.flat.name, 'flat');
+
+let input;
+
+{
+  input = [1, [2], [[3]]];
+
+  assertEquals(input.flat(),          [1, 2, [3]]);
+  assertEquals(input.flat(1),         [1, 2, [3]]);
+  assertEquals(input.flat(true),      [1, 2, [3]]);
+  assertEquals(input.flat(undefined), [1, 2, [3]]);
+
+  assertEquals(input.flat(-Infinity), [1, [2], [[3]]]);
+  assertEquals(input.flat(-1),        [1, [2], [[3]]]);
+  assertEquals(input.flat(-0),        [1, [2], [[3]]]);
+  assertEquals(input.flat(0),         [1, [2], [[3]]]);
+  assertEquals(input.flat(false),     [1, [2], [[3]]]);
+  assertEquals(input.flat(null),      [1, [2], [[3]]]);
+  assertEquals(input.flat(''),        [1, [2], [[3]]]);
+  assertEquals(input.flat('foo'),     [1, [2], [[3]]]);
+  assertEquals(input.flat(/./),       [1, [2], [[3]]]);
+  assertEquals(input.flat([]),        [1, [2], [[3]]]);
+  assertEquals(input.flat({}),        [1, [2], [[3]]]);
+  //assertEquals(
+  //  input.flat(new Proxy({}, {})),    [1, [2], [[3]]]);
+  assertEquals(input.flat((x) => x),  [1, [2], [[3]]]);
+  assertEquals(
+    input.flat(String),               [1, [2], [[3]]]);
+
+  assertEquals(input.flat(2),         [1, 2, 3]);
+  assertEquals(input.flat(Infinity),  [1, 2, 3]);
+
+  assertThrows(() => { input.flat(Symbol()); }, TypeError);
+  assertThrows(() => { input.flat(Object.create(null)); }, TypeError);
+}
+
+{
+  input = { 0: 'a', 1: 'b', 2: 'c', length: 'wat' };
+  assertEquals(Array.prototype.flat.call(input, Infinity), []);
+}
+
+{
+  let count = 0;
+  input = {
+    get length() { ++count; return 0; }
+  };
+  const result = Array.prototype.flat.call(input, Infinity);
+  assertEquals(count, 1);
+}
+
+{
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Array.prototype,
+    'flat'
+  );
+  assertEquals(descriptor.value, Array.prototype.flat);
+  assertEquals(descriptor.writable, true);
+  assertEquals(descriptor.enumerable, false);
+  assertEquals(descriptor.configurable, true);
+}
+
+"success";

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -89,7 +89,6 @@ public class Test262SuiteTest {
             new HashSet<>(
                     Arrays.asList(
                             "Array.prototype.flatMap",
-                            "Array.prototype.flat",
                             "Atomics",
                             "IsHTMLDDA",
                             "Proxy",

--- a/testsrc/org/mozilla/javascript/tests/harmony/ArrayFlatTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/ArrayFlatTest.java
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/array-flat.js")
+// TODO: ES2019?
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayFlatTest extends ScriptTestsBase {}

--- a/testsrc/org/mozilla/javascript/tests/harmony/ArrayFlatTest.java
+++ b/testsrc/org/mozilla/javascript/tests/harmony/ArrayFlatTest.java
@@ -10,6 +10,5 @@ import org.mozilla.javascript.drivers.RhinoTest;
 import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 @RhinoTest("testsrc/jstests/harmony/array-flat.js")
-// TODO: ES2019?
 @LanguageVersion(Context.VERSION_ES6)
 public class ArrayFlatTest extends ScriptTestsBase {}

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,6 +1,6 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array 238/2670 (8.91%)
+built-ins/Array 233/2670 (8.73%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
@@ -106,7 +106,18 @@ built-ins/Array 238/2670 (8.91%)
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
     prototype/flatMap 21/21 (100.0%)
-    prototype/flat 17/17 (100.0%)
+    prototype/flat/array-like-objects.js
+    prototype/flat/bound-function-call.js
+    prototype/flat/empty-array-elements.js
+    prototype/flat/empty-object-elements.js
+    prototype/flat/non-numeric-depth-should-not-throw.js
+    prototype/flat/non-object-ctor-throws.js
+    prototype/flat/null-undefined-elements.js
+    prototype/flat/positive-infinity.js
+    prototype/flat/proxy-access-count.js
+    prototype/flat/target-array-non-extensible.js {unsupported: [Symbol.species]}
+    prototype/flat/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
+    prototype/flat/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
     prototype/includes/get-prop.js {unsupported: [Proxy]}
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
@@ -193,7 +204,7 @@ built-ins/Array 238/2670 (8.91%)
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/unshift/throws-with-string-receiver.js
-    prototype/methods-called-as-functions.js {unsupported: [Symbol.species, Array.prototype.flat, Array.prototype.flatMap]}
+    prototype/methods-called-as-functions.js {unsupported: [Symbol.species, Array.prototype.flatMap]}
     prototype/Symbol.iterator.js Expects a particular string value
     Symbol.species 4/4 (100.0%)
     proto-from-ctor-realm-one.js {unsupported: [Reflect]}


### PR DESCRIPTION
Closes #948.

I'm not sure whether the implementation of the various ids are correct: I just copied the surrounding code.

I took the harmony test from https://github.com/v8/v8/blob/main/test/mjsunit/harmony/array-flat.js, added `load("testsrc/assert.js");` to the start and `"success";` to the end, and then made adjustments as Rhino doesn't supported redeclared `const`s in blocks or the `Proxy` object.

The language version in the test I have set to ES6, but as `flat` is part of ES2019, perhaps there should be a new version? Perhaps not, and I should just remove the comment?

By [spec](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat), we should throw a `TypeError` if the index `j` passed to `defineElem` is greater than 2<sup>53</sup> - 1. I have reused the message `msg.arraylength.too.big` here, but let me know if you'd like me to do something different.