### PR TITLE
remove some obsolete code and add another test

### DIFF
--- a/src/org/mozilla/javascript/CodeGenerator.java
+++ b/src/org/mozilla/javascript/CodeGenerator.java
@@ -8,15 +8,10 @@ package org.mozilla.javascript;
 
 import java.math.BigInteger;
 import java.util.List;
-import org.mozilla.javascript.ast.AstNode;
-import org.mozilla.javascript.ast.AstRoot;
-import org.mozilla.javascript.ast.Block;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
-import org.mozilla.javascript.ast.Scope;
 import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.ast.TemplateCharacters;
-import org.mozilla.javascript.ast.VariableInitializer;
 
 /** Generates bytecode for the Interpreter. */
 class CodeGenerator extends Icode {
@@ -115,8 +110,6 @@ class CodeGenerator extends Icode {
             itsData.isES6Generator = true;
         }
 
-        itsData.declaredAsVar = (theFunction.getParent() instanceof VariableInitializer);
-
         generateICodeFromTree(theFunction.getLastChild());
     }
 
@@ -210,13 +203,6 @@ class CodeGenerator extends Icode {
             gen.itsData = new InterpreterData(itsData);
             gen.generateFunctionICode();
             array[i] = gen.itsData;
-
-            final AstNode fnParent = fn.getParent();
-            if (!(fnParent instanceof AstRoot
-                    || fnParent instanceof Scope
-                    || fnParent instanceof Block)) {
-                gen.itsData.declaredAsFunctionExpression = true;
-            }
         }
         itsData.itsNestedFunctions = array;
     }

--- a/src/org/mozilla/javascript/InterpretedFunction.java
+++ b/src/org/mozilla/javascript/InterpretedFunction.java
@@ -150,15 +150,4 @@ final class InterpretedFunction extends NativeFunction implements Script {
     protected boolean getParamOrVarConst(int index) {
         return idata.argIsConst[index];
     }
-
-    boolean hasFunctionNamed(String name) {
-        for (int f = 0; f < idata.getFunctionCount(); f++) {
-            InterpreterData functionData = (InterpreterData) idata.getFunction(f);
-            if (!functionData.declaredAsFunctionExpression
-                    && name.equals(functionData.getFunctionName())) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/src/org/mozilla/javascript/InterpreterData.java
+++ b/src/org/mozilla/javascript/InterpreterData.java
@@ -93,12 +93,6 @@ final class InterpreterData implements Serializable, DebuggableScript {
 
     private int icodeHashCode = 0;
 
-    /** true if the function has been declared like "var foo = function() {...}" */
-    boolean declaredAsVar;
-
-    /** true if the function has been declared like "!function() {}". */
-    boolean declaredAsFunctionExpression;
-
     @Override
     public boolean isTopLevel() {
         return topLevel;

--- a/src/org/mozilla/javascript/NativeCall.java
+++ b/src/org/mozilla/javascript/NativeCall.java
@@ -64,8 +64,7 @@ public final class NativeCall extends IdScriptableObject {
                 if (!super.has(name, this)) {
                     if (function.getParamOrVarConst(i)) {
                         defineProperty(name, Undefined.instance, CONST);
-                    } else if (!(function instanceof InterpretedFunction)
-                            || ((InterpretedFunction) function).hasFunctionNamed(name)) {
+                    } else {
                         defineProperty(name, Undefined.instance, PERMANENT);
                     }
                 }

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -3940,12 +3940,9 @@ public class ScriptRuntime {
                     if (isConst) {
                         ScriptableObject.defineConstProperty(varScope, name);
                     } else if (!evalScript) {
-                        if (!(funObj instanceof InterpretedFunction)
-                                || ((InterpretedFunction) funObj).hasFunctionNamed(name)) {
-                            // Global var definitions are supposed to be DONTDELETE
-                            ScriptableObject.defineProperty(
-                                    varScope, name, Undefined.instance, ScriptableObject.PERMANENT);
-                        }
+                        // Global var definitions are supposed to be DONTDELETE
+                        ScriptableObject.defineProperty(
+                                varScope, name, Undefined.instance, ScriptableObject.PERMANENT);
                     } else {
                         varScope.put(name, varScope, Undefined.instance);
                     }

--- a/testsrc/org/mozilla/javascript/tests/FunctionTest.java
+++ b/testsrc/org/mozilla/javascript/tests/FunctionTest.java
@@ -30,8 +30,7 @@ public class FunctionTest {
     @Test
     public void functionHasNameOfVarStrictMode() throws Exception {
         final String script =
-                ""
-                        + "'use strict';\n"
+                "'use strict';\n"
                         + "var result = '';\n"
                         + "var abc = 1;\n"
                         + "var foo = function abc() { result += '-inner abc = ' + typeof abc; };\n"
@@ -45,8 +44,7 @@ public class FunctionTest {
     @Test
     public void innerFunctionWithSameName() throws Exception {
         final String script =
-                ""
-                        + "var result = '';\n"
+                "var result = '';\n"
                         + "var a = function () {\n"
                         + "  var x = (function x () { result += 'a'; });\n"
                         + "  return function () { x(); };\n"
@@ -65,8 +63,7 @@ public class FunctionTest {
     @Test
     public void innerFunctionWithSameNameAsOutsideStrict() throws Exception {
         final String script =
-                ""
-                        + "var result = '';\n"
+                "var result = '';\n"
                         + "'use strict';\n"
                         + "var a = function () {\n"
                         + "  var x = (function x () { result += 'a'; });\n"
@@ -82,8 +79,7 @@ public class FunctionTest {
     @Test
     public void secondFunctionWithSameNameStrict() throws Exception {
         final String script =
-                ""
-                        + "var result = '';\n"
+                "var result = '';\n"
                         + "'use strict';\n"
                         + "function norm(foo) { return ('' + foo).replace(/(\\s)/gm,''); }\n"
                         + "function func () { result += 'outer'; }\n"
@@ -140,7 +136,18 @@ public class FunctionTest {
         assertEvaluates("f1f2f3!f4f5!f6!f7!f8f10f11f12f11f12f13", script);
     }
 
-    private void assertEvaluates(final Object expected, final String source) {
+    @Test
+    public void conditionallyCreatedFunction() {
+        final String script =
+                "var log = 'foo = ' + foo;\n"
+                        + "if (false) {\n"
+                        + "  function foo() { return 1; }\n"
+                        + "}\n"
+                        + "log";
+        assertEvaluates("foo = undefined", script);
+    }
+
+    private static void assertEvaluates(final Object expected, final String source) {
         Utils.runWithAllOptimizationLevels(
                 cx -> {
                     final Scriptable scope = cx.initStandardObjects();


### PR DESCRIPTION
Looks like this code was part of backward sync from HtmlUnit changes into Rhino.
But the code
* produces different results when running with/without optimization
* produces wrong results without optimization
* is no longer needed from HtmlUnit's point of view
* consumes some memory

see also https://github.com/HtmlUnit/htmlunit/issues/354