### PR TITLE
docs(readme): remove broken MDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ JavaDoc for all the APIs:
 
 [https://javadoc.io/doc/org.mozilla/rhino](https://javadoc.io/doc/org.mozilla/rhino)
 
-More resources if you get stuck:
-
-[https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Community](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Community)
-
 ## Building
 
 ### How to Build


### PR DESCRIPTION
MDN no longer hosts Mozilla project documentations, so the link results in an HTTP 404.