### PR TITLE
special handling for NativeError instances when generating the console output

### DIFF
--- a/src/org/mozilla/javascript/NativeConsole.java
+++ b/src/org/mozilla/javascript/NativeConsole.java
@@ -327,6 +327,14 @@ public class NativeConsole extends IdScriptableObject {
             return Undefined.SCRIPTABLE_UNDEFINED.toString();
         }
 
+        if (arg instanceof NativeError) {
+            NativeError err = (NativeError) arg;
+            String msg = err.toString();
+            msg += "\n";
+            msg += err.get("stack");
+            return msg;
+        }
+
         try {
             // NativeJSON.stringify outputs Callable's as null, convert to string
             // to make the output less confusing
@@ -351,6 +359,9 @@ public class NativeConsole extends IdScriptableObject {
                             }
                             if (value instanceof Callable) {
                                 return ScriptRuntime.toString(value);
+                            }
+                            if (arg instanceof NativeError) {
+                                return ((NativeError) arg).toString();
                             }
                             return value;
                         }

--- a/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -518,6 +518,31 @@ public class NativeConsoleTest {
         assertPrintMsg(js, "[1234]");
     }
 
+    @Test
+    public void printError() {
+        String js =
+                "try {\n"
+                        + "  JSON.parse('{\"abc');\n"
+                        + "} catch (e) {\n"
+                        + "  console.log(e);\n"
+                        + "}";
+        assertPrintMsg(js, "SyntaxError: Unterminated string literal\n\tat source:2\r\n");
+    }
+
+    @Test
+    public void printErrorProperty() {
+        String js =
+                "try {\n"
+                        + "  JSON.parse('{\"abc');\n"
+                        + "} catch (e) {\n"
+                        + "  var obj = { msg: 'Something is wrong', err: e };\n"
+                        + "  console.log(obj);\n"
+                        + "}";
+        assertPrintMsg(
+                js,
+                "{\"msg\":\"Something is wrong\",\"err\":{\"fileName\":\"source\",\"lineNumber\":2}}");
+    }
+
     private static void assertFormat(Object[] args, String expected) {
         try (Context cx = Context.enter()) {
             Scriptable scope = cx.initStandardObjects();

--- a/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -18,6 +18,7 @@ import org.mozilla.javascript.NativeConsole;
 import org.mozilla.javascript.NativeConsole.Level;
 import org.mozilla.javascript.ScriptStackElement;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.SecurityUtilities;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 
@@ -520,13 +521,14 @@ public class NativeConsoleTest {
 
     @Test
     public void printError() {
+        String lf = SecurityUtilities.getSystemProperty("line.separator");
         String js =
                 "try {\n"
                         + "  JSON.parse('{\"abc');\n"
                         + "} catch (e) {\n"
                         + "  console.log(e);\n"
                         + "}";
-        assertPrintMsg(js, "SyntaxError: Unterminated string literal\n\tat source:2\r\n");
+        assertPrintMsg(js, "SyntaxError: Unterminated string literal\n\tat source:2" + lf);
     }
 
     @Test


### PR DESCRIPTION
Without this, the output is generated by the json serializer ending up in something like this '{"fileName":"source.js","lineNumber":426}'; means the whole message is missing. This fix brings the output closer to the output of real browsers by writing the message and the stack trace.