### PR TITLE
FIX: Toggling a breakpoint by clicking on the linenumber in debugger not possible

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
@@ -1864,7 +1864,7 @@ class FileHeader extends JPanel implements MouseListener {
     /** Called when a mouse button is released. */
     @Override
     public void mouseReleased(MouseEvent e) {
-        if (e.getComponent() == this && (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
+        if (e.getComponent() == this && e.getButton() == MouseEvent.BUTTON1) {
             int y = e.getY();
             Font font = fileWindow.textArea.getFont();
             FontMetrics metrics = getFontMetrics(font);


### PR DESCRIPTION
This is a regression introduced through #1343.
With that pull request `getModifiers()` was switched to `getModifiersEx()`. However these two methods are not as easily interchangeable (especially when using the mouse-release-event) as it might seem from the deprecation notice. In this particular case the `MouseEvent` is checked on `mouseRelease`. However when looking at the documentation of `getModifiersEx()` (e.g. https://github.com/openjdk/jdk/blob/dfacda488bfbe2e11e8d607a6d08527710286982/src/java.desktop/share/classes/java/awt/event/InputEvent.java#L506C10-L506C10) it gets clear that at that stage, we cannot detect the button click with the help of the modifiers. I did some debugging and at the point of button release `getModifiersEx()` just returns 0, meaning that no bit is set at all. A possible solution to this is to check which button triggered the release-event with the use of `getButton()` like I did here. This behaviour was also discovered by someone on stackoverflow a while back: https://stackoverflow.com/questions/60518621/mouseevent-getmodifiersex-call-does-not-work-as-expected-or-as-documented.
Note: The PR #1343 touched another spot where `getModifiers()` was replaced. Since I am fairly new to this project, I was not sure if the changed code is correct at this point either: https://github.com/mozilla/rhino/pull/1343/files#diff-5d4e8db22e19b87ef92bbee2473a342f75f2e166ff04d18e07cbc02e46c91514L2477. I only noticed that the enclosing method seemingly is never used, so I can't say where the `MouseEvent` is coming from hence I am unable to tell if that code has to be changed as well.