### PR TITLE
Fix regressions introduced to debugger

### DIFF
--- a/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
@@ -1864,7 +1864,7 @@ class FileHeader extends JPanel implements MouseListener {
     /** Called when a mouse button is released. */
     @Override
     public void mouseReleased(MouseEvent e) {
-        if (e.getComponent() == this && (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
+        if (e.getComponent() == this && e.getButton() == MouseEvent.BUTTON1) {
             int y = e.getY();
             Font font = fileWindow.textArea.getFont();
             FontMetrics metrics = getFontMetrics(font);

--- a/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/SwingGui.java
@@ -2473,25 +2473,7 @@ class MyTreeTable extends JTreeTable {
             // selection remaining the same. To avoid this, we
             // only dispatch when the modifiers are 0 (or the left mouse
             // button).
-            if (me.getModifiersEx() == 0
-                    || ((me.getModifiersEx() & (InputEvent.BUTTON1_DOWN_MASK | 1024)) != 0
-                            && (me.getModifiersEx()
-                                            & (InputEvent.SHIFT_DOWN_MASK
-                                                    | InputEvent.CTRL_DOWN_MASK
-                                                    | InputEvent.ALT_DOWN_MASK
-                                                    | InputEvent.BUTTON2_DOWN_MASK
-                                                    | InputEvent.BUTTON3_DOWN_MASK
-                                                    | 64
-                                                    | // SHIFT_DOWN_MASK
-                                                    128
-                                                    | // CTRL_DOWN_MASK
-                                                    512
-                                                    | // ALT_DOWN_MASK
-                                                    2048
-                                                    | // BUTTON2_DOWN_MASK
-                                                    4096 // BUTTON3_DOWN_MASK
-                                            ))
-                                    == 0)) {
+            if (me.getButton() == MouseEvent.BUTTON1 && me.getModifiersEx() == 0) {
                 int row = rowAtPoint(me.getPoint());
                 for (int counter = getColumnCount() - 1; counter >= 0; counter--) {
                     if (TreeTableModel.class == getColumnClass(counter)) {
@@ -2504,7 +2486,8 @@ class MyTreeTable extends JTreeTable {
                                         me.getX() - getCellRect(row, counter, true).x,
                                         me.getY(),
                                         me.getClickCount(),
-                                        me.isPopupTrigger());
+                                        me.isPopupTrigger(),
+                                        me.getButton());
                         MyTreeTable.this.tree.dispatchEvent(newME);
                         break;
                     }

--- a/toolsrc/org/mozilla/javascript/tools/debugger/treetable/JTreeTable.java
+++ b/toolsrc/org/mozilla/javascript/tools/debugger/treetable/JTreeTable.java
@@ -254,7 +254,8 @@ public class JTreeTable extends JTable {
                                         me.getX() - getCellRect(0, counter, true).x,
                                         me.getY(),
                                         me.getClickCount(),
-                                        me.isPopupTrigger());
+                                        me.isPopupTrigger(),
+                                        me.getButton());
                         tree.dispatchEvent(newME);
                         break;
                     }


### PR DESCRIPTION
This PR consolidates a change made by @jonasPoehler with additional changes to fix debugger regressions introduced earlier.

Could regular users of the debugger please try it out? Some obviously-broken functionality seems to be working again compared
to previous releases but there may be more to test.
