### PR TITLE
fix a missing array limit check

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -1607,6 +1607,10 @@ public class NativeArray extends IdScriptableObject implements List {
         long srclen = getLengthProperty(cx, arg);
         long newlen = srclen + offset;
 
+        if (newlen > NativeNumber.MAX_SAFE_INTEGER) {
+            throw ScriptRuntime.typeErrorById("msg.arraylength.too.big", newlen);
+        }
+
         // First, optimize for a pair of native, dense arrays
         if ((newlen <= Integer.MAX_VALUE) && (result instanceof NativeArray)) {
             final NativeArray denseResult = (NativeArray) result;

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeArray2Test.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeArray2Test.java
@@ -1,0 +1,65 @@
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptableObject;
+
+/** Test for NativeArray. */
+public class NativeArray2Test {
+
+    private Context cx;
+    private ScriptableObject scope;
+
+    @Before
+    public void setUp() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        scope = cx.initStandardObjects();
+    }
+
+    @After
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void concatLimitSpreadable() {
+        String js =
+                "var spreadable = {};\n"
+                        + "spreadable.length = Number.MAX_SAFE_INTEGER;\n"
+                        + "spreadable[Symbol.isConcatSpreadable] = true;\n"
+                        + "try {\n"
+                        + "  [1].concat(spreadable);\n"
+                        + "} catch(e) {"
+                        + " '' + e;\n"
+                        + "};";
+
+        String result = (String) cx.evaluateString(scope, js, "test", 1, null);
+        assertTrue(result.endsWith("exceeds supported capacity limit."));
+    }
+
+    @Test
+    public void concatLimitSpreadable2() {
+        String js =
+                "var spreadable = {\n"
+                        + "  length: Number.MAX_SAFE_INTEGER,\n"
+                        + "  get 0() {\n"
+                        + "    throw new Error('get failed');\n"
+                        + "  },\n"
+                        + "};\n"
+                        + "spreadable[Symbol.isConcatSpreadable] = true;\n"
+                        + "try {\n"
+                        + "  [].concat(spreadable);\n"
+                        + "} catch(e) {"
+                        + " '' + e;\n"
+                        + "};";
+
+        String result = (String) cx.evaluateString(scope, js, "test", 1, null);
+        assertEquals(result, "Error: get failed", result);
+    }
+}


### PR DESCRIPTION
found this while working on the proxy support
see built-ins/Array/prototype/concat/arg-length-exceeding-integer-limit.js