### PR TITLE
feat: bump spotless plugin so it works without flags in JDK16+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'jacoco'
     id 'distribution'
     id 'checkstyle'
-    id 'com.diffplug.spotless' version "5.12.1"
+    id 'com.diffplug.spotless' version "5.17.1"
     id 'com.github.spotbugs' version "4.7.1"
 }
 


### PR DESCRIPTION
Running 5.12.1 gives an `IllegalAccessError`:
```
java.lang.IllegalAccessError: class com.google.googlejavaformat.java.JavaInput (in unnamed module @0x7f85e8d3) cannot access class com.sun.tools.javac.parser.Tokens$TokenKind (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.parser to unnamed module @0x7f85e8d3
```
5.17.1 just works, and should still work on Java 8.