### PR TITLE
take care of SymbolKey before casting

### DIFF
--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -917,9 +917,15 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         ScriptableObject desc = super.getOwnPropertyDescriptor(cx, id);
         if (desc == null) {
             if (id instanceof String) {
-                desc = getBuiltInDescriptor((String) id);
-            } else if (ScriptRuntime.isSymbol(id)) {
-                desc = getBuiltInDescriptor(((NativeSymbol) id).getKey());
+                return getBuiltInDescriptor((String) id);
+            }
+
+            if (ScriptRuntime.isSymbol(id)) {
+                if (id instanceof SymbolKey) {
+                    return getBuiltInDescriptor((SymbolKey) id);
+                }
+
+                return getBuiltInDescriptor(((NativeSymbol) id).getKey());
             }
         }
         return desc;


### PR DESCRIPTION
again (see https://github.com/mozilla/rhino/pull/1357) take care of ScriptRuntime.isSymbol() == true; the object might be a NativeSymbol or a SymbolKey
(found while working on https://github.com/mozilla/rhino/pull/1332)