### PR TITLE
Stop IRFactory from inheriting Parser

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -3949,6 +3949,10 @@ public class Parser {
         }
     }
 
+    PerFunctionVariables createPerFunctionVariables(FunctionNode fnNode) {
+        return new PerFunctionVariables(fnNode);
+    }
+
     /**
      * Given a destructuring assignment with a left hand side parsed as an array or object literal
      * and a right hand side expression, rewrite as a series of assignments to the variables defined


### PR DESCRIPTION
- ref. #1188

`IRFactory` no longer inherits from `Parser`. This eliminates Code reuse via inheritance.