### PR TITLE
Support unicode codepoint escape

### DIFF
--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -722,7 +722,8 @@ class TokenStream {
                 ungetChar(c);
 
                 String str = getStringFromBuffer();
-                if (!containsEscape) {
+                if (!containsEscape
+                        || parser.compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
                     // OPT we shouldn't have to make a string (object!) to
                     // check if it's a keyword.
 

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -576,6 +576,25 @@ class TokenStream {
         return id & 0xff;
     }
 
+    private static boolean isValidIdentifierName(String str) {
+        int i = 0;
+        for (int c : str.codePoints().toArray()) {
+            if (i++ == 0) {
+                if (c != '$' && c != '_' && !Character.isUnicodeIdentifierStart(c)) {
+                    return false;
+                }
+            } else {
+                if (c != '$'
+                        && c != '\u200c'
+                        && c != '\u200d'
+                        && !Character.isUnicodeIdentifierPart(c)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     final String getSourceString() {
         return sourceString;
     }
@@ -779,6 +798,14 @@ class TokenStream {
                     // we convert the last character back to unicode
                     str = convertLastCharToHex(str);
                 }
+
+                if (containsEscape
+                        && parser.compilerEnv.getLanguageVersion() >= Context.VERSION_ES6
+                        && !isValidIdentifierName(str)) {
+                    parser.reportError("msg.invalid.escape");
+                    return Token.ERROR;
+                }
+
                 this.string = (String) allStrings.intern(str);
                 return Token.NAME;
             }

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -684,12 +684,32 @@ class TokenStream {
                         // escape sequence in an identifier, we can report
                         // an error here.
                         int escapeVal = 0;
-                        for (int i = 0; i != 4; ++i) {
-                            c = getChar();
-                            escapeVal = Kit.xDigitToInt(c, escapeVal);
-                            // Next check takes care about c < 0 and bad escape
-                            if (escapeVal < 0) {
+                        if (matchTemplateLiteralChar('{')) {
+                            for (; ; ) {
+                                c = getTemplateLiteralChar();
+
+                                if (c == '}') {
+                                    break;
+                                }
+                                escapeVal = Kit.xDigitToInt(c, escapeVal);
+                                if (escapeVal < 0) {
+                                    break;
+                                }
+                            }
+
+                            if (escapeVal < 0 || escapeVal > 0x10FFFF) {
+                                parser.reportError("msg.invalid.escape");
                                 break;
+                            }
+                        } else {
+                            for (int i = 0; i != 4; ++i) {
+                                c = getChar();
+                                escapeVal = Kit.xDigitToInt(c, escapeVal);
+                                // Next check takes care about c < 0 and bad escape
+                                if (escapeVal < 0) {
+                                    parser.reportError("msg.invalid.escape");
+                                    break;
+                                }
                             }
                         }
                         if (escapeVal < 0) {

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -980,6 +980,10 @@ class TokenStream {
                                     c = getChar();
                                     escapeVal = Kit.xDigitToInt(c, escapeVal);
                                     if (escapeVal < 0) {
+                                        if (parser.compilerEnv.getLanguageVersion()
+                                                >= Context.VERSION_ES6) {
+                                            parser.reportError("msg.invalid.escape");
+                                        }
                                         continue strLoop;
                                     }
                                     addToString(c);

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -977,17 +977,38 @@ class TokenStream {
                                 int escapeStart = stringBufferTop;
                                 addToString('u');
                                 escapeVal = 0;
-                                for (int i = 0; i != 4; ++i) {
-                                    c = getChar();
-                                    escapeVal = Kit.xDigitToInt(c, escapeVal);
-                                    if (escapeVal < 0) {
-                                        if (parser.compilerEnv.getLanguageVersion()
-                                                >= Context.VERSION_ES6) {
-                                            parser.reportError("msg.invalid.escape");
+                                if (matchChar('{')) {
+                                    for (; ; ) {
+                                        c = getChar();
+
+                                        if (c == '}') {
+                                            addToString(c);
+                                            break;
                                         }
+                                        escapeVal = Kit.xDigitToInt(c, escapeVal);
+                                        if (escapeVal < 0) {
+                                            break;
+                                        }
+                                        addToString(c);
+                                    }
+
+                                    if (escapeVal < 0 || escapeVal > 0x10FFFF) {
+                                        parser.reportError("msg.invalid.escape");
                                         continue strLoop;
                                     }
-                                    addToString(c);
+                                } else {
+                                    for (int i = 0; i != 4; ++i) {
+                                        c = getChar();
+                                        escapeVal = Kit.xDigitToInt(c, escapeVal);
+                                        if (escapeVal < 0) {
+                                            if (parser.compilerEnv.getLanguageVersion()
+                                                    >= Context.VERSION_ES6) {
+                                                parser.reportError("msg.invalid.escape");
+                                            }
+                                            continue strLoop;
+                                        }
+                                        addToString(c);
+                                    }
                                 }
                                 // prepare for replace of stored 'u' sequence
                                 // by escape value

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -5069,31 +5069,48 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 28/188 (14.89%)
+language/identifiers 45/188 (23.94%)
     other_id_continue.js
+    other_id_continue-escaped.js
     other_id_start.js
+    other_id_start-escaped.js
     part-unicode-10.0.0.js
+    part-unicode-10.0.0-escaped.js
     part-unicode-11.0.0.js
+    part-unicode-11.0.0-escaped.js
     part-unicode-12.0.0.js
+    part-unicode-12.0.0-escaped.js
     part-unicode-13.0.0.js
+    part-unicode-13.0.0-escaped.js
     part-unicode-5.2.0.js
+    part-unicode-5.2.0-escaped.js
     part-unicode-6.0.0.js
     part-unicode-6.1.0.js
     part-unicode-7.0.0.js
+    part-unicode-7.0.0-escaped.js
     part-unicode-8.0.0.js
+    part-unicode-8.0.0-escaped.js
     part-unicode-9.0.0.js
+    part-unicode-9.0.0-escaped.js
     start-unicode-10.0.0.js
+    start-unicode-10.0.0-escaped.js
     start-unicode-11.0.0.js
+    start-unicode-11.0.0-escaped.js
     start-unicode-12.0.0.js
+    start-unicode-12.0.0-escaped.js
     start-unicode-13.0.0.js
+    start-unicode-13.0.0-escaped.js
     start-unicode-5.2.0.js
+    start-unicode-5.2.0-escaped.js
     start-unicode-6.0.0.js
     start-unicode-6.1.0.js
+    start-unicode-6.1.0-escaped.js
     start-unicode-7.0.0.js
+    start-unicode-7.0.0-escaped.js
     start-unicode-8.0.0.js
+    start-unicode-8.0.0-escaped.js
     start-unicode-9.0.0.js
-    start-zwj-escaped.js
-    start-zwnj-escaped.js
+    start-unicode-9.0.0-escaped.js
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js
@@ -5103,11 +5120,7 @@ language/identifiers 28/188 (14.89%)
 
 language/keywords 0/25 (0.0%)
 
-language/line-terminators 4/41 (9.76%)
-    S7.3_A6_T1.js
-    S7.3_A6_T2.js
-    S7.3_A6_T3.js
-    S7.3_A6_T4.js
+language/line-terminators 0/41 (0.0%)
 
 language/literals 96/434 (22.12%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
@@ -5154,12 +5167,7 @@ language/literals 96/434 (22.12%)
 
 ~language/module-code
 
-language/punctuators 5/11 (45.45%)
-    S7.7_A2_T1.js
-    S7.7_A2_T2.js
-    S7.7_A2_T3.js
-    S7.7_A2_T4.js
-    S7.7_A2_T5.js
+language/punctuators 0/11 (0.0%)
 
 language/reserved-words 2/27 (7.41%)
     await-module.js {unsupported: [module]}
@@ -6303,11 +6311,6 @@ language/types 9/113 (7.96%)
     undefined/S8.1_A3_T1.js
     undefined/S8.1_A3_T2.js non-strict
 
-language/white-space 7/42 (16.67%)
+language/white-space 2/42 (4.76%)
     mongolian-vowel-separator.js {unsupported: [u180e]}
     mongolian-vowel-separator-eval.js {unsupported: [u180e]}
-    S7.2_A5_T1.js
-    S7.2_A5_T2.js
-    S7.2_A5_T3.js
-    S7.2_A5_T4.js
-    S7.2_A5_T5.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3041,7 +3041,7 @@ language/expressions/addition 9/48 (18.75%)
     get-symbol-to-prim-err.js
     order-of-evaluation.js
 
-language/expressions/arrow-function 253/333 (75.98%)
+language/expressions/arrow-function 212/333 (63.66%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3206,47 +3206,6 @@ language/expressions/arrow-function 253/333 (75.98%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    dstr/syntax-error-ident-ref-break-escaped.js
-    dstr/syntax-error-ident-ref-case-escaped.js
-    dstr/syntax-error-ident-ref-catch-escaped.js
-    dstr/syntax-error-ident-ref-class-escaped.js
-    dstr/syntax-error-ident-ref-const-escaped.js
-    dstr/syntax-error-ident-ref-continue-escaped.js
-    dstr/syntax-error-ident-ref-debugger-escaped.js
-    dstr/syntax-error-ident-ref-default-escaped.js
-    dstr/syntax-error-ident-ref-delete-escaped.js
-    dstr/syntax-error-ident-ref-do-escaped.js
-    dstr/syntax-error-ident-ref-else-escaped.js
-    dstr/syntax-error-ident-ref-enum-escaped.js
-    dstr/syntax-error-ident-ref-export-escaped.js
-    dstr/syntax-error-ident-ref-extends-escaped.js
-    dstr/syntax-error-ident-ref-finally-escaped.js
-    dstr/syntax-error-ident-ref-for-escaped.js
-    dstr/syntax-error-ident-ref-function-escaped.js
-    dstr/syntax-error-ident-ref-if-escaped.js
-    dstr/syntax-error-ident-ref-implements-escaped.js strict
-    dstr/syntax-error-ident-ref-import-escaped.js
-    dstr/syntax-error-ident-ref-in-escaped.js
-    dstr/syntax-error-ident-ref-instanceof-escaped.js
-    dstr/syntax-error-ident-ref-interface-escaped.js strict
-    dstr/syntax-error-ident-ref-let-escaped.js strict
-    dstr/syntax-error-ident-ref-new-escaped.js
-    dstr/syntax-error-ident-ref-package-escaped.js strict
-    dstr/syntax-error-ident-ref-private-escaped.js strict
-    dstr/syntax-error-ident-ref-protected-escaped.js strict
-    dstr/syntax-error-ident-ref-public-escaped.js strict
-    dstr/syntax-error-ident-ref-return-escaped.js
-    dstr/syntax-error-ident-ref-static-escaped.js strict
-    dstr/syntax-error-ident-ref-super-escaped.js
-    dstr/syntax-error-ident-ref-switch-escaped.js
-    dstr/syntax-error-ident-ref-this-escaped.js
-    dstr/syntax-error-ident-ref-throw-escaped.js
-    dstr/syntax-error-ident-ref-try-escaped.js
-    dstr/syntax-error-ident-ref-typeof-escaped.js
-    dstr/syntax-error-ident-ref-var-escaped.js
-    dstr/syntax-error-ident-ref-void-escaped.js
-    dstr/syntax-error-ident-ref-while-escaped.js
-    dstr/syntax-error-ident-ref-with-escaped.js
     syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
@@ -3720,7 +3679,7 @@ language/expressions/function 205/248 (82.66%)
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/generators 233/275 (84.73%)
+language/expressions/generators 227/275 (82.55%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3914,9 +3873,6 @@ language/expressions/generators 233/275 (84.73%)
     implicit-name.js
     invoke-as-constructor.js
     length-dflt.js {unsupported: [default-parameters]}
-    named-yield-as-binding-identifier-escaped.js
-    named-yield-as-identifier-reference-escaped.js
-    named-yield-as-label-identifier-escaped.js
     named-yield-identifier-non-strict.js non-strict
     named-yield-identifier-spread-non-strict.js non-strict
     named-yield-spread-arr-multiple.js
@@ -3942,11 +3898,8 @@ language/expressions/generators 233/275 (84.73%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
-    yield-as-binding-identifier-escaped.js
     yield-as-function-expression-binding-identifier.js non-strict
     yield-as-identifier-in-nested-function.js non-strict
-    yield-as-identifier-reference-escaped.js
-    yield-as-label-identifier-escaped.js
     yield-identifier-non-strict.js non-strict
     yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
@@ -4009,7 +3962,7 @@ language/expressions/multiplication 4/40 (10.0%)
     bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/object 970/1081 (89.73%)
+language/expressions/object 847/1081 (78.35%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4799,49 +4752,8 @@ language/expressions/object 970/1081 (89.73%)
     computed-__proto__.js
     computed-property-evaluation-order.js
     concise-generator.js
-    covered-ident-name-prop-name-literal-break-escaped.js
-    covered-ident-name-prop-name-literal-case-escaped.js
-    covered-ident-name-prop-name-literal-catch-escaped.js
-    covered-ident-name-prop-name-literal-class-escaped.js
-    covered-ident-name-prop-name-literal-const-escaped.js
-    covered-ident-name-prop-name-literal-continue-escaped.js
-    covered-ident-name-prop-name-literal-debugger-escaped.js
-    covered-ident-name-prop-name-literal-default-escaped.js
     covered-ident-name-prop-name-literal-default-escaped-ext.js
-    covered-ident-name-prop-name-literal-delete-escaped.js
-    covered-ident-name-prop-name-literal-do-escaped.js
-    covered-ident-name-prop-name-literal-else-escaped.js
-    covered-ident-name-prop-name-literal-enum-escaped.js
-    covered-ident-name-prop-name-literal-export-escaped.js
-    covered-ident-name-prop-name-literal-extends-escaped.js
     covered-ident-name-prop-name-literal-extends-escaped-ext.js
-    covered-ident-name-prop-name-literal-finally-escaped.js
-    covered-ident-name-prop-name-literal-for-escaped.js
-    covered-ident-name-prop-name-literal-function-escaped.js
-    covered-ident-name-prop-name-literal-if-escaped.js
-    covered-ident-name-prop-name-literal-implements-escaped.js strict
-    covered-ident-name-prop-name-literal-import-escaped.js
-    covered-ident-name-prop-name-literal-in-escaped.js
-    covered-ident-name-prop-name-literal-instanceof-escaped.js
-    covered-ident-name-prop-name-literal-interface-escaped.js strict
-    covered-ident-name-prop-name-literal-let-escaped.js
-    covered-ident-name-prop-name-literal-new-escaped.js
-    covered-ident-name-prop-name-literal-package-escaped.js strict
-    covered-ident-name-prop-name-literal-private-escaped.js strict
-    covered-ident-name-prop-name-literal-protected-escaped.js strict
-    covered-ident-name-prop-name-literal-public-escaped.js strict
-    covered-ident-name-prop-name-literal-return-escaped.js
-    covered-ident-name-prop-name-literal-static-escaped.js strict
-    covered-ident-name-prop-name-literal-super-escaped.js
-    covered-ident-name-prop-name-literal-switch-escaped.js
-    covered-ident-name-prop-name-literal-this-escaped.js
-    covered-ident-name-prop-name-literal-throw-escaped.js
-    covered-ident-name-prop-name-literal-try-escaped.js
-    covered-ident-name-prop-name-literal-typeof-escaped.js
-    covered-ident-name-prop-name-literal-var-escaped.js
-    covered-ident-name-prop-name-literal-void-escaped.js
-    covered-ident-name-prop-name-literal-while-escaped.js
-    covered-ident-name-prop-name-literal-with-escaped.js
     fn-name-accessor-get.js
     fn-name-accessor-set.js
     fn-name-arrow.js
@@ -4853,92 +4765,10 @@ language/expressions/object 970/1081 (89.73%)
     getter-body-strict-outside.js strict
     getter-param-dflt.js {unsupported: [default-parameters]}
     getter-super-prop.js
-    ident-name-method-def-break-escaped.js
-    ident-name-method-def-case-escaped.js
-    ident-name-method-def-catch-escaped.js
-    ident-name-method-def-class-escaped.js
-    ident-name-method-def-const-escaped.js
-    ident-name-method-def-continue-escaped.js
-    ident-name-method-def-debugger-escaped.js
-    ident-name-method-def-default-escaped.js
     ident-name-method-def-default-escaped-ext.js
-    ident-name-method-def-delete-escaped.js
-    ident-name-method-def-do-escaped.js
-    ident-name-method-def-else-escaped.js
-    ident-name-method-def-enum-escaped.js
-    ident-name-method-def-export-escaped.js
-    ident-name-method-def-extends-escaped.js
     ident-name-method-def-extends-escaped-ext.js
-    ident-name-method-def-finally-escaped.js
-    ident-name-method-def-for-escaped.js
-    ident-name-method-def-function-escaped.js
-    ident-name-method-def-if-escaped.js
-    ident-name-method-def-implements-escaped.js strict
-    ident-name-method-def-import-escaped.js
-    ident-name-method-def-in-escaped.js
-    ident-name-method-def-instanceof-escaped.js
-    ident-name-method-def-interface-escaped.js strict
-    ident-name-method-def-let-escaped.js
-    ident-name-method-def-new-escaped.js
-    ident-name-method-def-package-escaped.js strict
-    ident-name-method-def-private-escaped.js strict
-    ident-name-method-def-protected-escaped.js strict
-    ident-name-method-def-public-escaped.js strict
-    ident-name-method-def-return-escaped.js
-    ident-name-method-def-static-escaped.js strict
-    ident-name-method-def-super-escaped.js
-    ident-name-method-def-switch-escaped.js
-    ident-name-method-def-this-escaped.js
-    ident-name-method-def-throw-escaped.js
-    ident-name-method-def-try-escaped.js
-    ident-name-method-def-typeof-escaped.js
-    ident-name-method-def-var-escaped.js
-    ident-name-method-def-void-escaped.js
-    ident-name-method-def-while-escaped.js
-    ident-name-method-def-with-escaped.js
-    ident-name-prop-name-literal-break-escaped.js
-    ident-name-prop-name-literal-case-escaped.js
-    ident-name-prop-name-literal-catch-escaped.js
-    ident-name-prop-name-literal-class-escaped.js
-    ident-name-prop-name-literal-const-escaped.js
-    ident-name-prop-name-literal-continue-escaped.js
-    ident-name-prop-name-literal-debugger-escaped.js
-    ident-name-prop-name-literal-default-escaped.js
     ident-name-prop-name-literal-default-escaped-ext.js
-    ident-name-prop-name-literal-delete-escaped.js
-    ident-name-prop-name-literal-do-escaped.js
-    ident-name-prop-name-literal-else-escaped.js
-    ident-name-prop-name-literal-enum-escaped.js
-    ident-name-prop-name-literal-export-escaped.js
-    ident-name-prop-name-literal-extends-escaped.js
     ident-name-prop-name-literal-extends-escaped-ext.js
-    ident-name-prop-name-literal-finally-escaped.js
-    ident-name-prop-name-literal-for-escaped.js
-    ident-name-prop-name-literal-function-escaped.js
-    ident-name-prop-name-literal-if-escaped.js
-    ident-name-prop-name-literal-implements-escaped.js strict
-    ident-name-prop-name-literal-import-escaped.js
-    ident-name-prop-name-literal-in-escaped.js
-    ident-name-prop-name-literal-instanceof-escaped.js
-    ident-name-prop-name-literal-interface-escaped.js strict
-    ident-name-prop-name-literal-let-escaped.js
-    ident-name-prop-name-literal-new-escaped.js
-    ident-name-prop-name-literal-package-escaped.js strict
-    ident-name-prop-name-literal-private-escaped.js strict
-    ident-name-prop-name-literal-protected-escaped.js strict
-    ident-name-prop-name-literal-public-escaped.js strict
-    ident-name-prop-name-literal-return-escaped.js
-    ident-name-prop-name-literal-static-escaped.js strict
-    ident-name-prop-name-literal-super-escaped.js
-    ident-name-prop-name-literal-switch-escaped.js
-    ident-name-prop-name-literal-this-escaped.js
-    ident-name-prop-name-literal-throw-escaped.js
-    ident-name-prop-name-literal-try-escaped.js
-    ident-name-prop-name-literal-typeof-escaped.js
-    ident-name-prop-name-literal-var-escaped.js
-    ident-name-prop-name-literal-void-escaped.js
-    ident-name-prop-name-literal-while-escaped.js
-    ident-name-prop-name-literal-with-escaped.js
     let-non-strict-access.js non-strict
     let-non-strict-syntax.js non-strict
     literal-property-name-bigint.js {unsupported: [class]}
@@ -5245,7 +5075,7 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 91/188 (48.4%)
+language/identifiers 55/188 (29.26%)
     other_id_continue.js
     other_id_start.js
     part-digits-via-escape-hex.js
@@ -5291,44 +5121,8 @@ language/identifiers 91/188 (48.4%)
     start-unicode-9.0.0-escaped.js
     start-zwj-escaped.js
     start-zwnj-escaped.js
-    val-break-via-escape-hex4.js
-    val-case-via-escape-hex4.js
-    val-catch-via-escape-hex4.js
-    val-class-via-escape-hex4.js
-    val-const-via-escape-hex4.js
-    val-continue-via-escape-hex4.js
-    val-debugger-via-escape-hex4.js
-    val-default-via-escape-hex4.js
-    val-delete-via-escape-hex4.js
-    val-do-via-escape-hex4.js
     val-dollar-sign-via-escape-hex.js
-    val-else-via-escape-hex4.js
-    val-enum-via-escape-hex4.js
-    val-export-via-escape-hex4.js
-    val-extends-via-escape-hex4.js
-    val-false-via-escape-hex4.js
-    val-finally-via-escape-hex4.js
-    val-for-via-escape-hex4.js
-    val-function-via-escape-hex4.js
-    val-if-via-escape-hex4.js
-    val-import-via-escape-hex4.js
-    val-in-via-escape-hex4.js
-    val-instanceof-via-escape-hex4.js
-    val-new-via-escape-hex4.js
-    val-null-via-escape-hex4.js
-    val-return-via-escape-hex4.js
-    val-super-via-escape-hex4.js
-    val-switch-via-escape-hex4.js
-    val-this-via-escape-hex4.js
-    val-throw-via-escape-hex4.js
-    val-true-via-escape-hex4.js
-    val-try-via-escape-hex4.js
-    val-typeof-via-escape-hex4.js
     val-underscore-via-escape-hex.js
-    val-var-via-escape-hex4.js
-    val-void-via-escape-hex4.js
-    val-while-via-escape-hex4.js
-    val-with-via-escape-hex4.js
     vals-eng-alpha-lower-via-escape-hex.js
     vals-eng-alpha-upper-via-escape-hex.js
     vals-rus-alpha-lower-via-escape-hex.js
@@ -5400,15 +5194,9 @@ language/punctuators 5/11 (45.45%)
     S7.7_A2_T4.js
     S7.7_A2_T5.js
 
-language/reserved-words 8/27 (29.63%)
+language/reserved-words 2/27 (7.41%)
     await-module.js {unsupported: [module]}
     await-script.js
-    ident-reference-false-escaped.js
-    ident-reference-null-escaped.js
-    ident-reference-true-escaped.js
-    label-ident-false-escaped.js
-    label-ident-null-escaped.js
-    label-ident-true-escaped.js
 
 language/rest-parameters 10/11 (90.91%)
     array-pattern.js
@@ -6203,7 +5991,7 @@ language/statements/for-of 471/725 (64.97%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/generators 223/259 (86.1%)
+language/statements/generators 220/259 (84.94%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6414,12 +6202,9 @@ language/statements/generators 223/259 (86.1%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
-    yield-as-binding-identifier-escaped.js
     yield-as-function-expression-binding-identifier.js non-strict
     yield-as-generator-declaration-binding-identifier.js non-strict
     yield-as-identifier-in-nested-function.js non-strict
-    yield-as-identifier-reference-escaped.js
-    yield-as-label-identifier-escaped.js
     yield-identifier-non-strict.js non-strict
     yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -3962,7 +3962,7 @@ language/expressions/multiplication 4/40 (10.0%)
     bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/object 847/1081 (78.35%)
+language/expressions/object 841/1081 (77.8%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4752,8 +4752,6 @@ language/expressions/object 847/1081 (78.35%)
     computed-__proto__.js
     computed-property-evaluation-order.js
     concise-generator.js
-    covered-ident-name-prop-name-literal-default-escaped-ext.js
-    covered-ident-name-prop-name-literal-extends-escaped-ext.js
     fn-name-accessor-get.js
     fn-name-accessor-set.js
     fn-name-arrow.js
@@ -4765,10 +4763,6 @@ language/expressions/object 847/1081 (78.35%)
     getter-body-strict-outside.js strict
     getter-param-dflt.js {unsupported: [default-parameters]}
     getter-super-prop.js
-    ident-name-method-def-default-escaped-ext.js
-    ident-name-method-def-extends-escaped-ext.js
-    ident-name-prop-name-literal-default-escaped-ext.js
-    ident-name-prop-name-literal-extends-escaped-ext.js
     let-non-strict-access.js non-strict
     let-non-strict-syntax.js non-strict
     literal-property-name-bigint.js {unsupported: [class]}
@@ -5075,58 +5069,31 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 55/188 (29.26%)
+language/identifiers 28/188 (14.89%)
     other_id_continue.js
     other_id_start.js
-    part-digits-via-escape-hex.js
     part-unicode-10.0.0.js
-    part-unicode-10.0.0-escaped.js
     part-unicode-11.0.0.js
-    part-unicode-11.0.0-escaped.js
     part-unicode-12.0.0.js
-    part-unicode-12.0.0-escaped.js
     part-unicode-13.0.0.js
-    part-unicode-13.0.0-escaped.js
     part-unicode-5.2.0.js
-    part-unicode-5.2.0-escaped.js
     part-unicode-6.0.0.js
-    part-unicode-6.0.0-escaped.js
     part-unicode-6.1.0.js
-    part-unicode-6.1.0-escaped.js
     part-unicode-7.0.0.js
-    part-unicode-7.0.0-escaped.js
     part-unicode-8.0.0.js
-    part-unicode-8.0.0-escaped.js
     part-unicode-9.0.0.js
-    part-unicode-9.0.0-escaped.js
     start-unicode-10.0.0.js
-    start-unicode-10.0.0-escaped.js
     start-unicode-11.0.0.js
-    start-unicode-11.0.0-escaped.js
     start-unicode-12.0.0.js
-    start-unicode-12.0.0-escaped.js
     start-unicode-13.0.0.js
-    start-unicode-13.0.0-escaped.js
     start-unicode-5.2.0.js
-    start-unicode-5.2.0-escaped.js
     start-unicode-6.0.0.js
-    start-unicode-6.0.0-escaped.js
     start-unicode-6.1.0.js
-    start-unicode-6.1.0-escaped.js
     start-unicode-7.0.0.js
-    start-unicode-7.0.0-escaped.js
     start-unicode-8.0.0.js
-    start-unicode-8.0.0-escaped.js
     start-unicode-9.0.0.js
-    start-unicode-9.0.0-escaped.js
     start-zwj-escaped.js
     start-zwnj-escaped.js
-    val-dollar-sign-via-escape-hex.js
-    val-underscore-via-escape-hex.js
-    vals-eng-alpha-lower-via-escape-hex.js
-    vals-eng-alpha-upper-via-escape-hex.js
-    vals-rus-alpha-lower-via-escape-hex.js
-    vals-rus-alpha-upper-via-escape-hex.js
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -5348,7 +5348,7 @@ language/line-terminators 4/41 (9.76%)
     S7.3_A6_T3.js
     S7.3_A6_T4.js
 
-language/literals 107/434 (24.65%)
+language/literals 96/434 (22.12%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     bigint/legacy-octal-like-invalid-00n.js non-strict
@@ -5390,17 +5390,6 @@ language/literals 107/434 (24.65%)
     string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     string/S7.8.4_A4.3_T1.js strict
     string/S7.8.4_A4.3_T2.js strict
-    string/S7.8.4_A7.1_T4.js
-    string/S7.8.4_A7.2_T1.js
-    string/S7.8.4_A7.2_T2.js
-    string/S7.8.4_A7.2_T3.js
-    string/S7.8.4_A7.2_T4.js
-    string/S7.8.4_A7.2_T5.js
-    string/S7.8.4_A7.2_T6.js
-    string/unicode-escape-nls-err-double.js
-    string/unicode-escape-nls-err-single.js
-    string/unicode-escape-no-hex-err-double.js
-    string/unicode-escape-no-hex-err-single.js
 
 ~language/module-code
 


### PR DESCRIPTION
ref. #917
```js
var \u{61} = 1 // var a = 1
```

## Breaking change
All errors occur only when version is 200.
### Incomplete unicode escape
ref. 495a74ed9fb3228a8affc382f50ff8e5c5198740
```js
"\u"; // invalid Unicode escape sequence
```
### Escaped reserved words
ref. 32c76f848fa294eaa4a4cc0365e621288bee759b
```js
var \u0069\u0066 = 1; // `var if = 1` is syntax error
```
### Characters that cannot be used as identifiers
ref. a1c57b501707cf674aeca427d5d561780535885e
```js
var \u000A = 1; // invalid Unicode escape sequence
```
In this Pull Request, the determination of characters that cannot be used as identifiers differs from the specification. The reason is that `isUnicodeIdentifierStart` and `isUnicodeIdentifierPart` are wrong in Java (old spec?). Java20 seems to be the same as the ECMA specification.
```java
java.lang.Character.isUnicodeIdentifierPart(0x2118)
// Java 11.0.20 => false
// Java 20.0.2 => true
```