### PR TITLE
javascript 'Set' cannot handle wrapped java objects properly

### DIFF
--- a/src/org/mozilla/javascript/NativeJavaArray.java
+++ b/src/org/mozilla/javascript/NativeJavaArray.java
@@ -7,6 +7,7 @@
 package org.mozilla.javascript;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 
 /**
  * This class reflects Java arrays into the JavaScript environment.
@@ -141,6 +142,17 @@ public class NativeJavaArray extends NativeJavaObject implements SymbolScriptabl
             prototype = ScriptableObject.getArrayPrototype(this.getParentScope());
         }
         return prototype;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return (obj instanceof NativeJavaArray)
+                && Objects.equals(((NativeJavaArray) obj).array, array);
+    }
+
+    @Override
+    public int hashCode() {
+        return array == null ? 0 : array.hashCode();
     }
 
     Object array;

--- a/src/org/mozilla/javascript/NativeJavaClass.java
+++ b/src/org/mozilla/javascript/NativeJavaClass.java
@@ -278,4 +278,14 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
     }
 
     private Map<String, FieldAndMethods> staticFieldAndMethods;
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/src/org/mozilla/javascript/NativeJavaList.java
+++ b/src/org/mozilla/javascript/NativeJavaList.java
@@ -183,4 +183,14 @@ public class NativeJavaList extends NativeJavaObject {
     private boolean isWithValidIndex(int index) {
         return index >= 0 && index < list.size();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/src/org/mozilla/javascript/NativeJavaMap.java
+++ b/src/org/mozilla/javascript/NativeJavaMap.java
@@ -142,6 +142,16 @@ public class NativeJavaMap extends NativeJavaObject {
         return super.getIds();
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
     private static Callable symbol_iterator =
             (Context cx, Scriptable scope, Scriptable thisObj, Object[] args) -> {
                 if (!(thisObj instanceof NativeJavaMap)) {

--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -989,16 +989,14 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
     }
 
     @Override
-    public int hashCode() {
-        return javaObject == null ? 0 : javaObject.hashCode();
+    public boolean equals(Object obj) {
+        return obj != null
+                && obj.getClass().equals(getClass())
+                && Objects.equals(((NativeJavaObject) obj).javaObject, javaObject);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof NativeJavaObject) {
-            return Objects.equals(((NativeJavaObject) obj).javaObject, javaObject);
-        } else {
-            return false;
-        }
+    public int hashCode() {
+        return javaObject == null ? 0 : javaObject.hashCode();
     }
 }

--- a/src/org/mozilla/javascript/NativeJavaObject.java
+++ b/src/org/mozilla/javascript/NativeJavaObject.java
@@ -17,6 +17,7 @@ import java.math.BigInteger;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This class reflects non-Array Java objects into the JavaScript environment. It reflect fields
@@ -984,6 +985,20 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                 adapter_writeAdapterObject = null;
                 adapter_readAdapterObject = null;
             }
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return javaObject == null ? 0 : javaObject.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof NativeJavaObject) {
+            return Objects.equals(((NativeJavaObject) obj).javaObject, javaObject);
+        } else {
+            return false;
         }
     }
 }

--- a/testsrc/jstests/es6/set.js
+++ b/testsrc/jstests/es6/set.js
@@ -7,7 +7,7 @@ load("testsrc/assert.js");
 res = "";
 
 function logElement(value, key) {
-    res += "set[" + key + "] (" + this + ") "; 
+    res += "set[" + key + "] (" + this + ") ";
 }
 
 (function TestForEach() {
@@ -79,6 +79,13 @@ function logElement(value, key) {
     mySet.delete(key)
     assertEquals(1, mySet.size);
   }
+})();
+
+(function TestSetAddJavaEnums() {
+  var mySet = new Set();
+  mySet.add(java.nio.file.AccessMode.READ);
+  mySet.add(java.nio.file.AccessMode.READ);
+  assertEquals(1, mySet.size);
 })();
 
 "success";


### PR DESCRIPTION
When adding java objects to a javascript `Set()`, they are not deduplicated.

This is caused, because Java objects are wrapped each time in a new NativeObject. As NativeObject has no hashcode/equals they are inserted multiple times in a `Set`

This PR adds equals+hashcode to NativeObject and a testcase, where the same enum is added twice to a set and the expected size is 1.
