### PR TITLE
Allow updating of `name` of a function, as required by the standard

### DIFF
--- a/src/org/mozilla/javascript/Arguments.java
+++ b/src/org/mozilla/javascript/Arguments.java
@@ -424,6 +424,7 @@ final class Arguments extends IdScriptableObject {
 
         ThrowTypeError(String propertyName) {
             this.propertyName = propertyName;
+            super.setInstanceIdAttributes(BaseFunction.Id_name, PERMANENT | READONLY | DONTENUM);
         }
 
         @Override

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -100,7 +100,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
         throw ScriptRuntime.typeErrorById("msg.instanceof.bad.prototype", getFunctionName());
     }
 
-    private static final int Id_length = 1,
+    protected static final int Id_length = 1,
             Id_arity = 2,
             Id_name = 3,
             Id_prototype = 4,
@@ -203,8 +203,10 @@ public class BaseFunction extends IdScriptableObject implements Function {
                 if (value == NOT_FOUND) {
                     namePropertyAttributes = -1;
                     nameValue = null;
-                } else {
+                } else if (value instanceof CharSequence) {
                     nameValue = ScriptRuntime.toString(value);
+                } else {
+                    nameValue = "";
                 }
                 return;
             case Id_arity:

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -169,7 +169,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
             case Id_arity:
                 return arityPropertyAttributes >= 0 ? getArity() : NOT_FOUND;
             case Id_name:
-                return namePropertyAttributes >= 0 ? getFunctionName() : NOT_FOUND;
+                return namePropertyAttributes >= 0 ? (nameValue != null ? nameValue : getFunctionName()) : NOT_FOUND;
             case Id_prototype:
                 return getPrototypeProperty();
             case Id_arguments:
@@ -200,6 +200,9 @@ public class BaseFunction extends IdScriptableObject implements Function {
             case Id_name:
                 if (value == NOT_FOUND) {
                     namePropertyAttributes = -1;
+                    nameValue = null;
+                } else {
+                    nameValue = ScriptRuntime.toString(value);
                 }
                 return;
             case Id_arity:
@@ -650,6 +653,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
 
     private Object prototypeProperty;
     private Object argumentsObj = NOT_FOUND;
+    private String nameValue = null;
     private boolean isGeneratorFunction = false;
 
     // For function object instances, attributes are
@@ -658,6 +662,6 @@ public class BaseFunction extends IdScriptableObject implements Function {
     private int prototypePropertyAttributes = PERMANENT | DONTENUM;
     private int argumentsAttributes = PERMANENT | DONTENUM;
     private int arityPropertyAttributes = PERMANENT | READONLY | DONTENUM;
-    private int namePropertyAttributes = PERMANENT | READONLY | DONTENUM;
+    private int namePropertyAttributes = READONLY | DONTENUM;
     private int lengthPropertyAttributes = PERMANENT | READONLY | DONTENUM;
 }

--- a/src/org/mozilla/javascript/BaseFunction.java
+++ b/src/org/mozilla/javascript/BaseFunction.java
@@ -169,7 +169,9 @@ public class BaseFunction extends IdScriptableObject implements Function {
             case Id_arity:
                 return arityPropertyAttributes >= 0 ? getArity() : NOT_FOUND;
             case Id_name:
-                return namePropertyAttributes >= 0 ? (nameValue != null ? nameValue : getFunctionName()) : NOT_FOUND;
+                return namePropertyAttributes >= 0
+                        ? (nameValue != null ? nameValue : getFunctionName())
+                        : NOT_FOUND;
             case Id_prototype:
                 return getPrototypeProperty();
             case Id_arguments:

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -867,13 +867,14 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                     checkPropertyChange(name, current, desc);
                     int attr = (info >>> 16);
                     Object value = getProperty(desc, "value");
+                    attr = applyDescriptorToAttributeBitset(attr, desc);
+                    setAttributes(name, attr);
                     if (value != NOT_FOUND && (attr & READONLY) == 0) {
                         Object currentValue = getInstanceIdValue(id);
                         if (!sameValue(value, currentValue)) {
                             setInstanceIdValue(id, value);
                         }
                     }
-                    setAttributes(name, applyDescriptorToAttributeBitset(attr, desc));
                     return;
                 }
             }

--- a/src/org/mozilla/javascript/IdScriptableObject.java
+++ b/src/org/mozilla/javascript/IdScriptableObject.java
@@ -867,14 +867,14 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                     checkPropertyChange(name, current, desc);
                     int attr = (info >>> 16);
                     Object value = getProperty(desc, "value");
-                    attr = applyDescriptorToAttributeBitset(attr, desc);
-                    setAttributes(name, attr);
-                    if (value != NOT_FOUND && (attr & READONLY) == 0) {
+                    if (value != NOT_FOUND && ((attr & READONLY) == 0 || (attr & PERMANENT) == 0)) {
                         Object currentValue = getInstanceIdValue(id);
                         if (!sameValue(value, currentValue)) {
                             setInstanceIdValue(id, value);
                         }
                     }
+                    attr = applyDescriptorToAttributeBitset(attr, desc);
+                    setAttributes(name, attr);
                     return;
                 }
             }

--- a/testsrc/org/mozilla/javascript/tests/Issue1297FunctionNameTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1297FunctionNameTest.java
@@ -20,25 +20,15 @@ public class Issue1297FunctionNameTest {
 			"X.name";
 
 	@Test
-	public void canSetFunctionNameInCompiledClasses() {
-		try (Context cx = Context.enter()) {
-			Scriptable scope = cx.initStandardObjects(null);
-			Object result = cx.evaluateString(scope,
-					source,
-					"test", 1, null);
-			assertEquals("y", result);
-		}
-	}
-
-	@Test
-	public void canSetFunctionNameInInterpreter() {
-		try (Context cx = Context.enter()) {
-			cx.setOptimizationLevel(-1);
-			Scriptable scope = cx.initStandardObjects(null);
-			Object result = cx.evaluateString(scope,
-					source,
-					"test", 1, null);
-			assertEquals("y", result);
-		}
+	public void canSetFunctionName() {
+		Utils.runWithAllOptimizationLevels(
+				cx -> {
+					Scriptable scope = cx.initStandardObjects(null);
+					Object result = cx.evaluateString(scope,
+							source,
+							"test", 1, null);
+					assertEquals("y", result);
+					return null;
+				});
 	}
 }

--- a/testsrc/org/mozilla/javascript/tests/Issue1297FunctionNameTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1297FunctionNameTest.java
@@ -7,28 +7,24 @@ package org.mozilla.javascript.tests;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 
-/**
- * Test that we can redefine a function's name.
- */
+/** Test that we can redefine a function's name. */
 public class Issue1297FunctionNameTest {
-	private static final String source = "'use strict';" +
-			"function X() {};\n" +
-			"Object.defineProperty(X, 'name', {value: 'y', configurable: true, writable: true});" +
-			"X.name";
+    private static final String source =
+            "'use strict';"
+                    + "function X() {};\n"
+                    + "Object.defineProperty(X, 'name', {value: 'y', configurable: true, writable: true});"
+                    + "X.name";
 
-	@Test
-	public void canSetFunctionName() {
-		Utils.runWithAllOptimizationLevels(
-				cx -> {
-					Scriptable scope = cx.initStandardObjects(null);
-					Object result = cx.evaluateString(scope,
-							source,
-							"test", 1, null);
-					assertEquals("y", result);
-					return null;
-				});
-	}
+    @Test
+    public void canSetFunctionName() {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    Scriptable scope = cx.initStandardObjects(null);
+                    Object result = cx.evaluateString(scope, source, "test", 1, null);
+                    assertEquals("y", result);
+                    return null;
+                });
+    }
 }

--- a/testsrc/org/mozilla/javascript/tests/Issue1297FunctionNameTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Issue1297FunctionNameTest.java
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Test that we can redefine a function's name.
+ */
+public class Issue1297FunctionNameTest {
+	private static final String source = "'use strict';" +
+			"function X() {};\n" +
+			"Object.defineProperty(X, 'name', {value: 'y', configurable: true, writable: true});" +
+			"X.name";
+
+	@Test
+	public void canSetFunctionNameInCompiledClasses() {
+		try (Context cx = Context.enter()) {
+			Scriptable scope = cx.initStandardObjects(null);
+			Object result = cx.evaluateString(scope,
+					source,
+					"test", 1, null);
+			assertEquals("y", result);
+		}
+	}
+
+	@Test
+	public void canSetFunctionNameInInterpreter() {
+		try (Context cx = Context.enter()) {
+			cx.setOptimizationLevel(-1);
+			Scriptable scope = cx.initStandardObjects(null);
+			Object result = cx.evaluateString(scope,
+					source,
+					"test", 1, null);
+			assertEquals("y", result);
+		}
+	}
+}

--- a/testsrc/org/mozilla/javascript/tests/es6/Issue1297FunctionNameTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/Issue1297FunctionNameTest.java
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.javascript.tests;
+package org.mozilla.javascript.tests.es6;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.tests.Utils;
 
 /** Test that we can redefine a function's name. */
 public class Issue1297FunctionNameTest {

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -449,12 +449,10 @@ built-ins/Date 39/707 (5.52%)
     S15.1.3.2_A2.4_T1.js
     S15.1.3.2_A5.2.js
 
-built-ins/encodeURI 2/30 (6.67%)
-    name.js
+built-ins/encodeURI 1/30 (3.33%)
     S15.1.3.3_A5.2.js
 
-built-ins/encodeURIComponent 2/30 (6.67%)
-    name.js
+built-ins/encodeURIComponent 1/30 (3.33%)
     S15.1.3.4_A5.2.js
 
 built-ins/Error 5/42 (11.9%)
@@ -464,9 +462,8 @@ built-ins/Error 5/42 (11.9%)
     prototype/S15.11.4_A2.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
-built-ins/eval 3/9 (33.33%)
+built-ins/eval 2/9 (22.22%)
     length-non-configurable.js
-    name.js
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
 built-ins/Function 186/505 (36.83%)
@@ -674,9 +671,8 @@ built-ins/global 0/29 (0.0%)
 
 built-ins/Infinity 0/6 (0.0%)
 
-built-ins/isFinite 8/16 (50.0%)
+built-ins/isFinite 7/16 (43.75%)
     length.js
-    name.js
     toprimitive-call-abrupt.js
     toprimitive-get-abrupt.js
     toprimitive-not-callable-throws.js
@@ -684,9 +680,8 @@ built-ins/isFinite 8/16 (50.0%)
     toprimitive-result-is-symbol-throws.js
     toprimitive-valid-result.js
 
-built-ins/isNaN 8/16 (50.0%)
+built-ins/isNaN 7/16 (43.75%)
     length.js
-    name.js
     toprimitive-call-abrupt.js
     toprimitive-get-abrupt.js
     toprimitive-not-callable-throws.js
@@ -901,13 +896,11 @@ built-ins/Object 127/3150 (4.03%)
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     subclass-object-arg.js {unsupported: [Reflect.construct, Reflect, class]}
 
-built-ins/parseFloat 3/58 (5.17%)
-    name.js
+built-ins/parseFloat 2/58 (3.45%)
     S15.1.2.3_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.3_A7.2.js
 
-built-ins/parseInt 3/60 (5.0%)
-    name.js
+built-ins/parseInt 2/60 (3.33%)
     S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.2_A9.2.js
 


### PR DESCRIPTION
See mozilla/rhino#1297

This PR fixes only Function.name, not the whole issue. 🙂 