### PR TITLE
Modified `DoctestsTest` to include optimization level

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/DoctestsTest.java
+++ b/testsrc/org/mozilla/javascript/tests/DoctestsTest.java
@@ -64,7 +64,7 @@ public class DoctestsTest {
         return new String(buf);
     }
 
-    @Parameters(name = "{0}")
+    @Parameters(name = "{0} opt:{2}")
     public static Collection<Object[]> doctestValues() throws IOException {
         File[] doctests = getDoctestFiles();
         List<Object[]> result = new ArrayList<Object[]>();


### PR DESCRIPTION
The current behavior is a bit misleading, because the test case name includes only the javascript source file, but not the optimization level. So, you get three tests with the exact same names, for levels -1, 0, and 9. This change simply adds the optimization level in the name of the test.