### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (No need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    # Disable version updates, making dependabot act only for Security Updates
+    open-pull-requests-limit: 0
+
+  # Maintain Gradle Dependencies
+  - package-ecosystem: "gradle"
+    directory: "/"
+    # Disable version updates, making dependabot act only for Security Updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Enable dependabot for security updates for github actions and gradle, as requested on https://github.com/mozilla/rhino/pull/1405#issuecomment-1787314091.