### PR TITLE
Turn forking off in gradle tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,9 +96,6 @@ test {
     }
     maxHeapSize = "1g"
     testLogging.showStandardStreams = true
-    // Many tests do not clean up contexts properly. This makes the tests much
-    // more resilient at the expense of performance.
-    forkEvery = 1
     maxParallelForks = 64
 }
 


### PR DESCRIPTION
This was on previously because some tests didn't always close their Rhino Context, but now it looks like they all do. This speeds up the tests a lot, save for the MozillaSuiteTest which continues to be a slow one.