### PR TITLE
Update NativeArray for toReversed()

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -2752,9 +2752,9 @@ public class NativeArray extends IdScriptableObject implements List {
             Id_at = 32,
             Id_flat = 33,
             Id_flatMap = 34,
-            Id_toReversed = 36,
-            SymbolId_iterator = 37,
-            MAX_PROTOTYPE_ID = Id_toReversed;
+            Id_toReversed = 35,
+            SymbolId_iterator = 36,
+            MAX_PROTOTYPE_ID = SymbolId_iterator;
     private static final int ConstructorId_join = -Id_join,
             ConstructorId_reverse = -Id_reverse,
             ConstructorId_sort = -Id_sort,

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -455,7 +455,7 @@ public class NativeArray extends IdScriptableObject implements List {
                     return js_flatMap(cx, scope, thisObj, args);
 
                 case Id_toReversed:
-                    return js_toReversed(cx, scope, thisObj, args);
+                    return js_toReversed(cx, scope, thisObj);
 
                 case Id_every:
                 case Id_filter:
@@ -2262,15 +2262,14 @@ public class NativeArray extends IdScriptableObject implements List {
     }
 
     private static Scriptable js_toReversed(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, Scriptable scope, Scriptable thisObj) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-        int len = (getLengthProperty(cx, o) > Integer.MAX_VALUE) ? 0 :(int) getLengthProperty(cx, o);
+        long len = (getLengthProperty(cx, o) > Integer.MAX_VALUE) ? 0 : getLengthProperty(cx, o);
 
-        Scriptable result = cx.newArray(scope, len);
-
-        for(int k = len-1; k >= 0; k--){
+        Scriptable result = cx.newArray(scope, (int)len);
+        for(long k = len-1; k >= 0; k--){
             Object temp1 = getRawElem(o, k);
-            setRawElem(cx, result, k, temp1);
+            defineElemOrThrow(cx, result, len-k-1, temp1);
         }
         return result;
     }
@@ -2754,8 +2753,8 @@ public class NativeArray extends IdScriptableObject implements List {
             Id_at = 32,
             Id_flat = 33,
             Id_flatMap = 34,
-            SymbolId_iterator = 35,
             Id_toReversed =36,
+            SymbolId_iterator = 37,
             MAX_PROTOTYPE_ID = SymbolId_iterator;
     private static final int ConstructorId_join = -Id_join,
             ConstructorId_reverse = -Id_reverse,

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -154,6 +154,7 @@ public class NativeArray extends IdScriptableObject implements List {
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_isArray, "isArray", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_of, "of", 0);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_from, "from", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_toReversed, "toReversed", 0);
         super.fillConstructorProperties(ctor);
     }
 
@@ -303,6 +304,10 @@ public class NativeArray extends IdScriptableObject implements List {
                 arity = 1;
                 s = "flatMap";
                 break;
+            case Id_toReversed:
+                arity = 0;
+                s = "toReversed";
+                break;
             default:
                 throw new IllegalArgumentException(String.valueOf(id));
         }
@@ -341,7 +346,8 @@ public class NativeArray extends IdScriptableObject implements List {
                 case ConstructorId_findIndex:
                 case ConstructorId_reduce:
                 case ConstructorId_reduceRight:
-                    {
+                case ConstructorId_toReversed:
+                {
                         // this is a small trick; we will handle all the ConstructorId_xxx calls
                         // the same way the object calls are processed
                         // so we adjust the args, inverting the id and
@@ -447,6 +453,9 @@ public class NativeArray extends IdScriptableObject implements List {
 
                 case Id_flatMap:
                     return js_flatMap(cx, scope, thisObj, args);
+
+                case Id_toReversed:
+                    return js_toReversed(cx, scope, thisObj, args);
 
                 case Id_every:
                 case Id_filter:
@@ -2252,6 +2261,19 @@ public class NativeArray extends IdScriptableObject implements List {
         return "Array".equals(((Scriptable) o).getClassName());
     }
 
+    private static Scriptable js_toReversed(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+        int len = (getLengthProperty(cx, o) > Integer.MAX_VALUE) ? 0 :(int) getLengthProperty(cx, o);
+
+        Scriptable result = cx.newArray(scope, len);
+
+        for(int k = len-1; k >= 0; k--){
+            Object temp1 = getRawElem(o, k);
+            setRawElem(cx, result, k, temp1);
+        }
+        return result;
+    }
     // methods to implement java.util.List
 
     @Override
@@ -2688,6 +2710,9 @@ public class NativeArray extends IdScriptableObject implements List {
             case "flatMap":
                 id = Id_flatMap;
                 break;
+            case "toReversed":
+                id = Id_toReversed;
+                break;
             default:
                 id = 0;
                 break;
@@ -2730,6 +2755,7 @@ public class NativeArray extends IdScriptableObject implements List {
             Id_flat = 33,
             Id_flatMap = 34,
             SymbolId_iterator = 35,
+            Id_toReversed =36,
             MAX_PROTOTYPE_ID = SymbolId_iterator;
     private static final int ConstructorId_join = -Id_join,
             ConstructorId_reverse = -Id_reverse,
@@ -2752,6 +2778,7 @@ public class NativeArray extends IdScriptableObject implements List {
             ConstructorId_findIndex = -Id_findIndex,
             ConstructorId_reduce = -Id_reduce,
             ConstructorId_reduceRight = -Id_reduceRight,
+            ConstructorId_toReversed = -Id_toReversed,
             ConstructorId_isArray = -26,
             ConstructorId_of = -27,
             ConstructorId_from = -28;

--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -347,7 +347,7 @@ public class NativeArray extends IdScriptableObject implements List {
                 case ConstructorId_reduce:
                 case ConstructorId_reduceRight:
                 case ConstructorId_toReversed:
-                {
+                    {
                         // this is a small trick; we will handle all the ConstructorId_xxx calls
                         // the same way the object calls are processed
                         // so we adjust the args, inverting the id and
@@ -2261,15 +2261,14 @@ public class NativeArray extends IdScriptableObject implements List {
         return "Array".equals(((Scriptable) o).getClassName());
     }
 
-    private static Scriptable js_toReversed(
-            Context cx, Scriptable scope, Scriptable thisObj) {
+    private static Scriptable js_toReversed(Context cx, Scriptable scope, Scriptable thisObj) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-        long len = (getLengthProperty(cx, o) > Integer.MAX_VALUE) ? 0 : getLengthProperty(cx, o);
+        long len = getLengthProperty(cx, o);
 
-        Scriptable result = cx.newArray(scope, (int)len);
-        for(long k = len-1; k >= 0; k--){
+        Scriptable result = cx.newArray(scope, (int) len);
+        for (long k = len - 1; k >= 0; k--) {
             Object temp1 = getRawElem(o, k);
-            defineElemOrThrow(cx, result, len-k-1, temp1);
+            defineElemOrThrow(cx, result, len - k - 1, temp1);
         }
         return result;
     }
@@ -2753,9 +2752,9 @@ public class NativeArray extends IdScriptableObject implements List {
             Id_at = 32,
             Id_flat = 33,
             Id_flatMap = 34,
-            Id_toReversed =36,
+            Id_toReversed = 36,
             SymbolId_iterator = 37,
-            MAX_PROTOTYPE_ID = SymbolId_iterator;
+            MAX_PROTOTYPE_ID = Id_toReversed;
     private static final int ConstructorId_join = -Id_join,
             ConstructorId_reverse = -Id_reverse,
             ConstructorId_sort = -Id_sort,

--- a/testsrc/jstests/es2023/array-toReversed.js
+++ b/testsrc/jstests/es2023/array-toReversed.js
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+const array1=[1,2,3];
+assertArrayEquals([3,2,1], array1.toReversed());
+assertFalse(arrayEquals(array1,array1.toReversed()));
+
+const array2 = ["321","abc", "def","fgh"];
+assertArrayEquals(["fgh", "def","abc","321"], array2.toReversed());
+assertFalse(arrayEquals(array2,array2.toReversed()));
+
+function arrayEquals(a, b) {
+    return Array.isArray(a) &&
+        Array.isArray(b) &&
+        a.length === b.length &&
+        a.every((val, index) => val === b[index]);
+}
+
+
+"success"

--- a/testsrc/jstests/es2023/array-toReversed.js
+++ b/testsrc/jstests/es2023/array-toReversed.js
@@ -12,6 +12,14 @@ const array2 = ["321","abc", "def","fgh"];
 assertArrayEquals(["fgh", "def","abc","321"], array2.toReversed());
 assertFalse(arrayEquals(array2,array2.toReversed()));
 
+const array3 = ["321","", "","o"];
+assertArrayEquals(["o", "","","321"], array3.toReversed());
+assertFalse(arrayEquals(array3,array3.toReversed()));
+
+const array4 = ["1",,,"d"];
+assertArrayEquals(["d",,,"1"], array4.toReversed());
+assertFalse(arrayEquals(array4,array4.toReversed()));
+
 function arrayEquals(a, b) {
     return Array.isArray(a) &&
         Array.isArray(b) &&

--- a/testsrc/org/mozilla/javascript/tests/es2023/ArrayToReversedTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es2023/ArrayToReversedTest.java
@@ -1,6 +1,5 @@
 package org.mozilla.javascript.tests.es2023;
 
-
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.drivers.LanguageVersion;
 import org.mozilla.javascript.drivers.RhinoTest;
@@ -8,5 +7,4 @@ import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 @RhinoTest("testsrc/jstests/es2023/array-toReversed.js")
 @LanguageVersion(Context.VERSION_ES6)
-public class ArrayToReversedTest extends ScriptTestsBase {
-}
+public class ArrayToReversedTest extends ScriptTestsBase {}

--- a/testsrc/org/mozilla/javascript/tests/es2023/ArrayToReversedTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es2023/ArrayToReversedTest.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript.tests.es2023;
+
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-toReversed.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayToReversedTest extends ScriptTestsBase {
+}


### PR DESCRIPTION
Hi, 
I get the below error when testing the method manually from the console. I don't see NativeArray invoked in the exception stack trace. What's going wrong in the code? Any ideas please

js> const items = [1, 2, 3];
js> items
1,2,3
js> items.toReversed()
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 70 out of bounds for length 70
        at org.mozilla.javascript.IdScriptableObject$PrototypeValues.ensureId(IdScriptableObject.java:284)
        at org.mozilla.javascript.IdScriptableObject$PrototypeValues.get(IdScriptableObject.java:162)
        at org.mozilla.javascript.IdScriptableObject.get(IdScriptableObject.java:380)
        at org.mozilla.javascript.ScriptableObject.getProperty(ScriptableObject.java:2037)
        at org.mozilla.javascript.ScriptRuntime.getPropFunctionAndThisHelper(ScriptRuntime.java:2584)
        at org.mozilla.javascript.ScriptRuntime.getPropFunctionAndThis(ScriptRuntime.java:2575)
        at org.mozilla.javascript.optimizer.OptRuntime.callProp0(OptRuntime.java:71)
        at org.mozilla.javascript.gen._stdin__3._c_script_0(<stdin>:4)
        at org.mozilla.javascript.gen._stdin__3.call(<stdin>)
        at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:383)
        at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3876)
        at org.mozilla.javascript.gen._stdin__3.call(<stdin>)
        at org.mozilla.javascript.gen._stdin__3.exec(<stdin>)
        at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:482)
        at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:180)
        at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:98)
        at org.mozilla.javascript.Context.call(Context.java:544)
        at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:475)
        at org.mozilla.javascript.tools.shell.Main.exec(Main.java:164)
        at org.mozilla.javascript.tools.shell.Main.main(Main.java:142)