### PR TITLE
Disallow anonymous function declarations

### DIFF
--- a/src/org/mozilla/javascript/Parser.java
+++ b/src/org/mozilla/javascript/Parser.java
@@ -888,11 +888,13 @@ public class Parser {
             syntheticType = FunctionNode.FUNCTION_EXPRESSION;
         }
 
-        if (syntheticType != FunctionNode.FUNCTION_EXPRESSION
-                && name != null
-                && name.length() > 0) {
-            // Function statements define a symbol in the enclosing scope
-            defineSymbol(Token.FUNCTION, name.getIdentifier());
+        if (syntheticType != FunctionNode.FUNCTION_EXPRESSION) {
+            if (name != null && name.length() > 0) {
+                // Function statements define a symbol in the enclosing scope
+                defineSymbol(Token.FUNCTION, name.getIdentifier());
+            } else {
+                reportError("msg.fn.missing.name");
+            }
         }
 
         FunctionNode fnNode = new FunctionNode(functionSourceStart, name);

--- a/src/org/mozilla/javascript/resources/Messages.properties
+++ b/src/org/mozilla/javascript/resources/Messages.properties
@@ -283,6 +283,9 @@ msg.let.decl.not.in.block =\
 msg.bad.object.init =\
     SyntaxError: invalid object initializer
 
+msg.fn.missing.name =\
+    SyntaxError: function statements require a function name
+
 # NodeTransformer
 msg.dup.label =\
     duplicated label


### PR DESCRIPTION
EcmaScript doesn't allow anonymous function declarations, only function expressions can be anonymous.

Rhino does allow anonymous function declarations, but this PR fixes it.

Test262 doesn't have any test for this (or at least not the test262 version we're currently on), so tests are missing

More importantly though, should this fix be tied to a specific language version? If so, everyone OK with >= ES6?