### PR TITLE
BigIntLiteral.toSource includes suffix

### DIFF
--- a/src/org/mozilla/javascript/ast/BigIntLiteral.java
+++ b/src/org/mozilla/javascript/ast/BigIntLiteral.java
@@ -71,7 +71,7 @@ public class BigIntLiteral extends AstNode {
 
     @Override
     public String toSource(int depth) {
-        return makeIndent(depth) + (bigInt == null ? "<null>" : bigInt.toString());
+        return makeIndent(depth) + (bigInt == null ? "<null>" : bigInt.toString() + "n");
     }
 
     /** Visits this node. There are no children to visit. */

--- a/testsrc/org/mozilla/javascript/tests/BigIntTest.java
+++ b/testsrc/org/mozilla/javascript/tests/BigIntTest.java
@@ -1,0 +1,47 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Parser;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.tools.shell.Global;
+
+/** This is a set of tests for parsing and using BigInts. */
+public class BigIntTest {
+
+    private Context cx;
+    private Scriptable global;
+
+    @Before
+    public void init() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        cx.getWrapFactory().setJavaPrimitiveWrap(false);
+        global = new Global(cx);
+    }
+
+    @After
+    public void terminate() {
+        Context.exit();
+    }
+
+    @Test
+    public void parse() throws IOException {
+        String[] INPUTS =
+                new String[] {"0n", "12n", "-12n", "1234567890987654321n", "-1234567890987654321n"};
+        CompilerEnvirons env = new CompilerEnvirons();
+        env.setLanguageVersion(Context.VERSION_ES6);
+        for (String input : INPUTS) {
+            String stmt = "x = " + input + ";\n";
+            AstRoot root = new Parser(env).parse(stmt, "bigint.js", 1);
+            assertEquals(stmt, root.toSource());
+        }
+    }
+}


### PR DESCRIPTION
I noticed that the `toSource` method for **BigIntLiteral** was losing the `n` suffix, which meant that parsing and toSource turned it into a **Number** instead.