### PR TITLE
Non deterministic behaviour with vararg methods

### DIFF
--- a/src/org/mozilla/javascript/JavaMembers.java
+++ b/src/org/mozilla/javascript/JavaMembers.java
@@ -21,6 +21,7 @@ import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -308,7 +309,8 @@ class JavaMembers {
      */
     private Method[] discoverAccessibleMethods(
             Class<?> clazz, boolean includeProtected, boolean includePrivate) {
-        Map<MethodSignature, Method> map = new HashMap<>();
+        Map<MethodSignature, Method> map =
+                new LinkedHashMap<>(); // use linked hash map for deterministic discovery
         discoverAccessibleMethods(clazz, map, includeProtected, includePrivate);
         return map.values().toArray(new Method[0]);
     }

--- a/src/org/mozilla/javascript/NativeJavaMethod.java
+++ b/src/org/mozilla/javascript/NativeJavaMethod.java
@@ -496,6 +496,15 @@ public class NativeJavaMethod extends BaseFunction {
                 break;
             }
         }
+        if (totalPreference == PREFERENCE_EQUAL && vararg1 != vararg2) {
+            // It could happen that we have found two methods, that may fit
+            // In this case, we will take the no-vararg one, if possible
+            if (vararg1) {
+                totalPreference = PREFERENCE_SECOND_ARG;
+            } else {
+                totalPreference = PREFERENCE_FIRST_ARG;
+            }
+        }
         return totalPreference;
     }
 

--- a/testsrc/org/mozilla/javascript/tests/OverloadTestVarArgs.java
+++ b/testsrc/org/mozilla/javascript/tests/OverloadTestVarArgs.java
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** */
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+
+public class OverloadTestVarArgs {
+
+    public String args(String arg1) {
+        return "arg1";
+    }
+
+    public String args(String arg1, String arg2) {
+        return "arg1 + arg2";
+    }
+
+    public String args(String arg1, String... args) {
+        return "arg1 + args";
+    }
+
+    public String args2(String arg1, String... args) {
+        return "arg1 + args";
+    }
+
+    public String args2(String arg1, String arg2) {
+        return "arg1 + arg2";
+    }
+
+    public String args2(String arg1) {
+        return "arg1";
+    }
+
+    @Test
+    public void argsTestJavaReference() {
+        // this is java reference
+        assertEquals("arg1", this.args("foo"));
+        assertEquals("arg1 + arg2", this.args("foo", "bar"));
+        assertEquals("arg1 + args", this.args("foo", "bar", "baz"));
+    }
+
+    @Test
+    public void argsTestJs() {
+        assertEvaluates("arg1", "self.args('foo');");
+        assertEvaluates("arg1 + arg2", "self.args('foo', 'bar');");
+        assertEvaluates("arg1 + args", "self.args('foo', 'bar', 'baz');");
+    }
+
+    @Test
+    public void args2TestJs() {
+        assertEvaluates("arg1", "self.args2('foo');");
+        assertEvaluates("arg1 + arg2", "self.args2('foo', 'bar');");
+        assertEvaluates("arg1 + args", "self.args2('foo', 'bar', 'baz');");
+    }
+
+    private void assertEvaluates(final Object expected, final String source) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    scope.put("self", scope, this);
+                    final Object rep = cx.evaluateString(scope, source, "test.js", 0, null);
+                    assertEquals(expected, Context.jsToJava(rep, String.class));
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
**Summary**
If there are two methods, one with varargs and an other without, for example
- `String args(String arg1, String... args)`
- `String args(String arg1)`
rhino considers these two methods as `PREFERENCE_EQUAL` when it is invoked with `args('foo')` from javascript. This may result in a non deterministic behaviour as one of the two was taken.

**Details**
In the case described above, all methods are compared and it is tried to find the best matchin one. So after `preferSignature`we will run into this code part in
[NativeJavaMethod](https://github.com/mozilla/rhino/blob/Rhino1_7_14_Release/src/org/mozilla/javascript/NativeJavaMethod.java#L359)
```java
                            if (preference != PREFERENCE_EQUAL) Kit.codeBug();
                            // This should not happen in theory
                            // but on some JVMs, Class.getMethods will return all
                            // static methods of the class hierarchy, even if
                            // a derived class's parameters match exactly.
                            // We want to call the derived class's method.
                            if (bestFit.isStatic()
                                    && bestFit.getDeclaringClass()
                                            .isAssignableFrom(member.getDeclaringClass())) {
                                // ... 
                            } else {
                                if (debug)
                                    printDebug("Ignoring same signature member ", member, args); // CASE 2
                            }
```

In our application, where the bug occured, we run in the `Ignoring same signature member` code path and one (not really deterministic - because of HashMap) method was taken. So the code sometimes works and sometimes not.

It was also not easy to provide a deterministic failing test, that's why (and maybe to add more determinism) I've changed the map in `discoverAccessibleMethods` to a LinkedHashMap (and yet the test depends heavily on the order of the JVM's `getDeclaredMethods` implementation)

**Fix**
When there are two candidates, the no-vararg method is taken. This is the same behaviour, as it is in Java.
