### PR TITLE
Various fixes and implementations to NativeRegExp

### DIFF
--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -469,10 +469,15 @@ final class NativeString extends IdScriptableObject {
                     String thisString =
                             ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, f));
                     if (args.length > 0 && args[0] instanceof NativeRegExp) {
-                        throw ScriptRuntime.typeErrorById(
-                                "msg.first.arg.not.regexp",
-                                String.class.getSimpleName(),
-                                f.getFunctionName());
+                        if (ScriptableObject.isTrue(
+                                ScriptableObject.getProperty(
+                                        ScriptableObject.ensureScriptable(args[0]),
+                                        SymbolKey.MATCH))) {
+                            throw ScriptRuntime.typeErrorById(
+                                    "msg.first.arg.not.regexp",
+                                    String.class.getSimpleName(),
+                                    f.getFunctionName());
+                        }
                     }
 
                     int idx = js_indexOf(id, thisString, args);

--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -98,6 +98,7 @@ final class NativeString extends IdScriptableObject {
         addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_match, "match", 2);
         addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_search, "search", 2);
         addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_replace, "replace", 2);
+        addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_replaceAll, "replaceAll", 2);
         addIdFunctionProperty(ctor, STRING_TAG, ConstructorId_localeCompare, "localeCompare", 2);
         addIdFunctionProperty(
                 ctor, STRING_TAG, ConstructorId_toLocaleLowerCase, "toLocaleLowerCase", 1);
@@ -246,6 +247,10 @@ final class NativeString extends IdScriptableObject {
                 arity = 2;
                 s = "replace";
                 break;
+            case Id_replaceAll:
+                arity = 2;
+                s = "replaceAll";
+                break;
             case Id_at:
                 arity = 1;
                 s = "at";
@@ -345,6 +350,7 @@ final class NativeString extends IdScriptableObject {
                 case ConstructorId_match:
                 case ConstructorId_search:
                 case ConstructorId_replace:
+                case ConstructorId_replaceAll:
                 case ConstructorId_localeCompare:
                 case ConstructorId_toLocaleLowerCase:
                     {
@@ -599,14 +605,17 @@ final class NativeString extends IdScriptableObject {
                 case Id_match:
                 case Id_search:
                 case Id_replace:
+                case Id_replaceAll:
                     {
                         int actionType;
                         if (id == Id_match) {
                             actionType = RegExpProxy.RA_MATCH;
                         } else if (id == Id_search) {
                             actionType = RegExpProxy.RA_SEARCH;
-                        } else {
+                        } else if (id == Id_replace) {
                             actionType = RegExpProxy.RA_REPLACE;
+                        } else {
+                            actionType = RegExpProxy.RA_REPLACE_ALL;
                         }
 
                         requireObjectCoercible(cx, thisObj, f);
@@ -1286,6 +1295,9 @@ final class NativeString extends IdScriptableObject {
             case "replace":
                 id = Id_replace;
                 break;
+            case "replaceAll":
+                id = Id_replaceAll;
+                break;
             case "localeCompare":
                 id = Id_localeCompare;
                 break;
@@ -1380,24 +1392,25 @@ final class NativeString extends IdScriptableObject {
             Id_match = 31,
             Id_search = 32,
             Id_replace = 33,
-            Id_localeCompare = 34,
-            Id_toLocaleLowerCase = 35,
-            Id_toLocaleUpperCase = 36,
-            Id_trim = 37,
-            Id_trimLeft = 38,
-            Id_trimRight = 39,
-            Id_includes = 40,
-            Id_startsWith = 41,
-            Id_endsWith = 42,
-            Id_normalize = 43,
-            Id_repeat = 44,
-            Id_codePointAt = 45,
-            Id_padStart = 46,
-            Id_padEnd = 47,
-            SymbolId_iterator = 48,
-            Id_trimStart = 49,
-            Id_trimEnd = 50,
-            Id_at = 51,
+            Id_replaceAll = 34,
+            Id_localeCompare = 35,
+            Id_toLocaleLowerCase = 36,
+            Id_toLocaleUpperCase = 37,
+            Id_trim = 38,
+            Id_trimLeft = 39,
+            Id_trimRight = 40,
+            Id_includes = 41,
+            Id_startsWith = 42,
+            Id_endsWith = 43,
+            Id_normalize = 44,
+            Id_repeat = 45,
+            Id_codePointAt = 46,
+            Id_padStart = 47,
+            Id_padEnd = 48,
+            SymbolId_iterator = 49,
+            Id_trimStart = 50,
+            Id_trimEnd = 51,
+            Id_at = 52,
             MAX_PROTOTYPE_ID = Id_at;
     private static final int ConstructorId_charAt = -Id_charAt,
             ConstructorId_charCodeAt = -Id_charCodeAt,
@@ -1414,6 +1427,7 @@ final class NativeString extends IdScriptableObject {
             ConstructorId_match = -Id_match,
             ConstructorId_search = -Id_search,
             ConstructorId_replace = -Id_replace,
+            ConstructorId_replaceAll = -Id_replaceAll,
             ConstructorId_localeCompare = -Id_localeCompare,
             ConstructorId_toLocaleLowerCase = -Id_toLocaleLowerCase;
 

--- a/src/org/mozilla/javascript/RegExpProxy.java
+++ b/src/org/mozilla/javascript/RegExpProxy.java
@@ -15,7 +15,8 @@ public interface RegExpProxy {
     // Types of regexp actions
     public static final int RA_MATCH = 1;
     public static final int RA_REPLACE = 2;
-    public static final int RA_SEARCH = 3;
+    public static final int RA_REPLACE_ALL = 3;
+    public static final int RA_SEARCH = 4;
 
     public boolean isRegExp(Scriptable obj);
 

--- a/src/org/mozilla/javascript/TokenStream.java
+++ b/src/org/mozilla/javascript/TokenStream.java
@@ -1496,8 +1496,8 @@ class TokenStream {
             if (matchChar('g')) addToString('g');
             else if (matchChar('i')) addToString('i');
             else if (matchChar('m')) addToString('m');
-            else if (matchChar('y')) // FireFox 3
-            addToString('y');
+            else if (matchChar('s')) addToString('s');
+            else if (matchChar('y')) addToString('y');
             else break;
         }
         tokenEnd = start + stringBufferTop + 2; // include slashes

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2743,6 +2743,8 @@ public class NativeRegExp extends IdScriptableObject {
 
                     return "/" + source + "/" + flags;
                 }
+                return realThis(thisObj, f).toString();
+
             case Id_toSource:
                 return realThis(thisObj, f).toString();
 

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -38,7 +38,8 @@ public class NativeRegExp extends IdScriptableObject {
     public static final int JSREG_GLOB = 0x1; // 'g' flag: global
     public static final int JSREG_FOLD = 0x2; // 'i' flag: fold
     public static final int JSREG_MULTILINE = 0x4; // 'm' flag: multiline
-    public static final int JSREG_STICKY = 0x8; // 'y' flag: sticky
+    public static final int JSREG_DOTALL = 0x8; // 's' flag: dotAll
+    public static final int JSREG_STICKY = 0x10; // 'y' flag: sticky
 
     // type of match to perform
     public static final int TEST = 0;
@@ -197,6 +198,7 @@ public class NativeRegExp extends IdScriptableObject {
         if ((re.flags & JSREG_GLOB) != 0) buf.append('g');
         if ((re.flags & JSREG_FOLD) != 0) buf.append('i');
         if ((re.flags & JSREG_MULTILINE) != 0) buf.append('m');
+        if ((re.flags & JSREG_DOTALL) != 0) buf.append('s');
         if ((re.flags & JSREG_STICKY) != 0) buf.append('y');
     }
 
@@ -279,6 +281,8 @@ public class NativeRegExp extends IdScriptableObject {
                     f = JSREG_FOLD;
                 } else if (c == 'm') {
                     f = JSREG_MULTILINE;
+                } else if (c == 's') {
+                    f = JSREG_DOTALL;
                 } else if (c == 'y') {
                     f = JSREG_STICKY;
                 } else {
@@ -1710,7 +1714,9 @@ public class NativeRegExp extends IdScriptableObject {
                                 ^ ((gData.cp < end) && isWord(input.charAt(gData.cp))));
                 break;
             case REOP_DOT:
-                if (gData.cp != end && !isLineTerm(input.charAt(gData.cp))) {
+                if (gData.cp != end
+                        && ((gData.regexp.flags & JSREG_DOTALL) != 0
+                                || !isLineTerm(input.charAt(gData.cp)))) {
                     result = true;
                     gData.cp++;
                 }
@@ -2522,8 +2528,9 @@ public class NativeRegExp extends IdScriptableObject {
             Id_global = 4,
             Id_ignoreCase = 5,
             Id_multiline = 6,
-            Id_sticky = 7,
-            MAX_INSTANCE_ID = 7;
+            Id_dotAll = 7,
+            Id_sticky = 8,
+            MAX_INSTANCE_ID = 8;
 
     @Override
     protected int getMaxInstanceId() {
@@ -2552,6 +2559,9 @@ public class NativeRegExp extends IdScriptableObject {
             case "multiline":
                 id = Id_multiline;
                 break;
+            case "dotAll":
+                id = Id_dotAll;
+                break;
             case "sticky":
                 id = Id_sticky;
                 break;
@@ -2572,6 +2582,7 @@ public class NativeRegExp extends IdScriptableObject {
             case Id_global:
             case Id_ignoreCase:
             case Id_multiline:
+            case Id_dotAll:
             case Id_sticky:
                 attr = PERMANENT | READONLY | DONTENUM;
                 break;
@@ -2596,6 +2607,8 @@ public class NativeRegExp extends IdScriptableObject {
                 return "ignoreCase";
             case Id_multiline:
                 return "multiline";
+            case Id_dotAll:
+                return "dotAll";
             case Id_sticky:
                 return "sticky";
         }
@@ -2621,6 +2634,8 @@ public class NativeRegExp extends IdScriptableObject {
                 return ScriptRuntime.wrapBoolean((re.flags & JSREG_FOLD) != 0);
             case Id_multiline:
                 return ScriptRuntime.wrapBoolean((re.flags & JSREG_MULTILINE) != 0);
+            case Id_dotAll:
+                return ScriptRuntime.wrapBoolean((re.flags & JSREG_DOTALL) != 0);
             case Id_sticky:
                 return ScriptRuntime.wrapBoolean((re.flags & JSREG_STICKY) != 0);
         }
@@ -2645,6 +2660,7 @@ public class NativeRegExp extends IdScriptableObject {
             case Id_global:
             case Id_ignoreCase:
             case Id_multiline:
+            case Id_dotAll:
             case Id_sticky:
                 return;
         }

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.IdFunctionObject;
 import org.mozilla.javascript.IdScriptableObject;
 import org.mozilla.javascript.Kit;
+import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
@@ -2716,6 +2717,16 @@ public class NativeRegExp extends IdScriptableObject {
                 return realThis(thisObj, f).compile(cx, scope, args);
 
             case Id_toString:
+                // thisObj != scope is a strange hack but i had no better idea for the moment
+                if (thisObj != scope && thisObj instanceof NativeObject) {
+                    Object sourceObj = thisObj.get("source", thisObj);
+                    String source =
+                            sourceObj.equals(NOT_FOUND) ? "undefined" : escapeRegExp(sourceObj);
+                    Object flagsObj = thisObj.get("flags", thisObj);
+                    String flags = flagsObj.equals(NOT_FOUND) ? "undefined" : flagsObj.toString();
+
+                    return "/" + source + "/" + flags;
+                }
             case Id_toSource:
                 return realThis(thisObj, f).toString();
 

--- a/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -328,6 +328,26 @@ public class NativeRegExpTest {
         test("0-undefined-true-false-undefined", script);
     }
 
+    /** @throws Exception if an error occurs */
+    @Test
+    public void objectToString() throws Exception {
+        test("/undefined/undefined", "RegExp.prototype.toString.call({})");
+        test("/Foo/undefined", "RegExp.prototype.toString.call({source: 'Foo'})");
+        test("/undefined/gy", "RegExp.prototype.toString.call({flags: 'gy'})");
+        test("/Foo/g", "RegExp.prototype.toString.call({source: 'Foo', flags: 'g'})");
+        test("/Foo/g", "RegExp.prototype.toString.call({source: 'Foo', flags: 'g', sticky: true})");
+
+        test(
+                "TypeError: Method \"toString\" called on incompatible object",
+                "try { RegExp.prototype.toString.call(''); } catch (e) { ('' + e).substr(0, 58) }");
+        test(
+                "TypeError: Method \"toString\" called on incompatible object",
+                "try { RegExp.prototype.toString.call(undefined); } catch (e) { ('' + e).substr(0, 58) }");
+        test(
+                "TypeError: Method \"toString\" called on incompatible object",
+                "var toString = RegExp.prototype.toString; try { toString(); } catch (e) { ('' + e).substr(0, 58) }");
+    }
+
     private static void test(final String expected, final String script) {
         Utils.runWithAllOptimizationLevels(
                 cx -> {

--- a/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -28,157 +28,223 @@ public class NativeRegExpTest {
     /** @throws Exception if an error occurs */
     @Test
     public void globalCtor() throws Exception {
-        testEvaluate("g-true-false-false-false", "new RegExp('foo', 'g');");
+        testEvaluate("g-true-false-false-false-false", "new RegExp('foo', 'g');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void global() throws Exception {
-        testEvaluate("g-true-false-false-false", "/foo/g;");
+        testEvaluate("g-true-false-false-false-false", "/foo/g;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void ignoreCaseCtor() throws Exception {
-        testEvaluate("i-false-true-false-false", "new RegExp('foo', 'i');");
+        testEvaluate("i-false-true-false-false-false", "new RegExp('foo', 'i');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void ignoreCase() throws Exception {
-        testEvaluate("i-false-true-false-false", "/foo/i;");
+        testEvaluate("i-false-true-false-false-false", "/foo/i;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void multilineCtor() throws Exception {
-        testEvaluate("m-false-false-true-false", "new RegExp('foo', 'm');");
+        testEvaluate("m-false-false-true-false-false", "new RegExp('foo', 'm');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void multiline() throws Exception {
-        testEvaluate("m-false-false-true-false", "/foo/m;");
+        testEvaluate("m-false-false-true-false-false", "/foo/m;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void dotAllCtor() throws Exception {
+        testEvaluate("s-false-false-false-true-false", "new RegExp('foo', 's');");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void dotAll() throws Exception {
+        testEvaluate("s-false-false-false-true-false", "/foo/s;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void stickyCtor() throws Exception {
-        testEvaluate("y-false-false-false-true", "new RegExp('foo', 'y');");
+        testEvaluate("y-false-false-false-false-true", "new RegExp('foo', 'y');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void sticky() throws Exception {
-        testEvaluate("y-false-false-false-true", "/foo/y;");
+        testEvaluate("y-false-false-false-false-true", "/foo/y;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalMultilineCtor() throws Exception {
-        testEvaluate("gm-true-false-true-false", "new RegExp('foo', 'gm');");
+        testEvaluate("gm-true-false-true-false-false", "new RegExp('foo', 'gm');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalMultiline() throws Exception {
-        testEvaluate("gm-true-false-true-false", "/foo/gm;");
+        testEvaluate("gm-true-false-true-false-false", "/foo/gm;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void globalDotAll() throws Exception {
+        testEvaluate("gs-true-false-false-true-false", "/foo/gs;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalIgnoreCaseCtor() throws Exception {
-        testEvaluate("gi-true-true-false-false", "new RegExp('foo', 'ig');");
+        testEvaluate("gi-true-true-false-false-false", "new RegExp('foo', 'ig');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalIgnoreCase() throws Exception {
-        testEvaluate("gi-true-true-false-false", "/foo/ig;");
+        testEvaluate("gi-true-true-false-false-false", "/foo/ig;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalStickyCtor() throws Exception {
-        testEvaluate("gy-true-false-false-true", "new RegExp('foo', 'gy');");
+        testEvaluate("gy-true-false-false-false-true", "new RegExp('foo', 'gy');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalSticky() throws Exception {
-        testEvaluate("gy-true-false-false-true", "/foo/gy;");
+        testEvaluate("gy-true-false-false-false-true", "/foo/gy;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalMultilineIgnoreCaseCtor() throws Exception {
-        testEvaluate("gim-true-true-true-false", "new RegExp('foo', 'mig');");
+        testEvaluate("gim-true-true-true-false-false", "new RegExp('foo', 'mig');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalMultilineIgnoreCase() throws Exception {
-        testEvaluate("gim-true-true-true-false", "/foo/gmi;");
+        testEvaluate("gim-true-true-true-false-false", "/foo/gmi;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void globalDotAllIgnoreCaseCtor() throws Exception {
+        testEvaluate("gis-true-true-false-true-false", "new RegExp('foo', 'gsi');");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void globalDotAllIgnoreCase() throws Exception {
+        testEvaluate("gis-true-true-false-true-false", "/foo/gsi;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalIgnoreCaseStickyCtor() throws Exception {
-        testEvaluate("giy-true-true-false-true", "new RegExp('foo', 'yig');");
+        testEvaluate("giy-true-true-false-false-true", "new RegExp('foo', 'yig');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalIgnoreCaseSticky() throws Exception {
-        testEvaluate("giy-true-true-false-true", "/foo/ygi;");
+        testEvaluate("giy-true-true-false-false-true", "/foo/ygi;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalMultilineStickyCtor() throws Exception {
-        testEvaluate("gmy-true-false-true-true", "new RegExp('foo', 'gmy');");
+        testEvaluate("gmy-true-false-true-false-true", "new RegExp('foo', 'gmy');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void globalMultilineSticky() throws Exception {
-        testEvaluate("gmy-true-false-true-true", "/foo/gmy;");
+        testEvaluate("gmy-true-false-true-false-true", "/foo/gmy;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void globalDotAllStickyCtor() throws Exception {
+        testEvaluate("gsy-true-false-false-true-true", "new RegExp('foo', 'gys');");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void globalDotAllSticky() throws Exception {
+        testEvaluate("gsy-true-false-false-true-true", "/foo/gys;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void ignoreCaseMultilineCtor() throws Exception {
-        testEvaluate("im-false-true-true-false", "new RegExp('foo', 'im');");
+        testEvaluate("im-false-true-true-false-false", "new RegExp('foo', 'im');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void ignoreCaseMultiline() throws Exception {
-        testEvaluate("im-false-true-true-false", "/foo/mi;");
+        testEvaluate("im-false-true-true-false-false", "/foo/mi;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void ignoreCaseDotAllCtor() throws Exception {
+        testEvaluate("is-false-true-false-true-false", "new RegExp('foo', 'si');");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void ignoreCaseDotAll() throws Exception {
+        testEvaluate("is-false-true-false-true-false", "/foo/si;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void ignoreCaseStickyCtor() throws Exception {
-        testEvaluate("iy-false-true-false-true", "new RegExp('foo', 'yi');");
+        testEvaluate("iy-false-true-false-false-true", "new RegExp('foo', 'yi');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void ignoreCaseSticky() throws Exception {
-        testEvaluate("iy-false-true-false-true", "/foo/iy;");
+        testEvaluate("iy-false-true-false-false-true", "/foo/iy;");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void multilineStickyCtor() throws Exception {
-        testEvaluate("my-false-false-true-true", "new RegExp('foo', 'my');");
+        testEvaluate("my-false-false-true-false-true", "new RegExp('foo', 'my');");
     }
 
     /** @throws Exception if an error occurs */
     @Test
     public void multilineSticky() throws Exception {
-        testEvaluate("my-false-false-true-true", "/foo/my;");
+        testEvaluate("my-false-false-true-false-true", "/foo/my;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void dotAllStickyCtor() throws Exception {
+        testEvaluate("sy-false-false-false-true-true", "new RegExp('foo', 'ys');");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void dotAllSticky() throws Exception {
+        testEvaluate("sy-false-false-false-true-true", "/foo/ys;");
     }
 
     private static void testEvaluate(final String expected, final String regex) {
@@ -194,6 +260,8 @@ public class NativeRegExpTest {
                         + "res += regex.ignoreCase;\n"
                         + "res += '-';\n"
                         + "res += regex.multiline;\n"
+                        + "res += '-';\n"
+                        + "res += regex.dotAll;\n"
                         + "res += '-';\n"
                         + "res += regex.sticky;\n"
                         + "res";
@@ -266,6 +334,17 @@ public class NativeRegExpTest {
                         + "res = res + '-' + result[2];\n"
                         + "res;";
         test("3-a-a-a", script);
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void matchDotAll() throws Exception {
+        final String script =
+                "var result = 'bar\\nfoo'.match(/bar.foo/s);\n"
+                        + "var res = '' + result.length;\n"
+                        + "res = res + '-' + result[0];\n"
+                        + "res;";
+        test("1-bar\nfoo", script);
     }
 
     /** @throws Exception if an error occurs */

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeString2Test.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeString2Test.java
@@ -8,12 +8,10 @@
 package org.mozilla.javascript.tests.es6;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.tests.Utils;
 
 /** Test for handling const variables. */
@@ -21,380 +19,200 @@ public class NativeString2Test {
 
     @Test
     public void getOwnPropertyDescriptorWithIndex() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result =
-                            cx.evaluateString(
-                                    scope,
-                                    "  var res = 'hello'.hasOwnProperty('0');"
-                                            + "  res += ';';"
-                                            + "  desc = Object.getOwnPropertyDescriptor('hello', '0');"
-                                            + "  res += desc.value;"
-                                            + "  res += ';';"
-                                            + "  res += desc.writable;"
-                                            + "  res += ';';"
-                                            + "  res += desc.enumerable;"
-                                            + "  res += ';';"
-                                            + "  res += desc.configurable;"
-                                            + "  res += ';';"
-                                            + "  res;",
-                                    "test",
-                                    1,
-                                    null);
-                    assertEquals("true;h;false;true;false;", result);
-
-                    return null;
-                });
+        String js =
+                "  var res = 'hello'.hasOwnProperty('0');"
+                        + "  res += ';';"
+                        + "  desc = Object.getOwnPropertyDescriptor('hello', '0');"
+                        + "  res += desc.value;"
+                        + "  res += ';';"
+                        + "  res += desc.writable;"
+                        + "  res += ';';"
+                        + "  res += desc.enumerable;"
+                        + "  res += ';';"
+                        + "  res += desc.configurable;"
+                        + "  res += ';';"
+                        + "  res;";
+        assertEvaluatesES6("true;h;false;true;false;", js);
     }
 
     @Test
     public void normalizeNoParam() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result = cx.evaluateString(scope, "'123'.normalize()", "test", 1, null);
-                    assertEquals("123", result);
-
-                    return null;
-                });
+        assertEvaluates("123", "'123'.normalize()");
     }
 
     @Test
     public void normalizeNoUndefined() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result =
-                            cx.evaluateString(scope, "'123'.normalize(undefined)", "test", 1, null);
-                    assertEquals("123", result);
-
-                    return null;
-                });
+        assertEvaluates("123", "'123'.normalize(undefined)");
     }
 
     @Test
     public void normalizeNoNull() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result =
-                            cx.evaluateString(
-                                    scope,
-                                    "try { "
-                                            + "  '123'.normalize(null);"
-                                            + "} catch (e) { e.message }",
-                                    "test",
-                                    1,
-                                    null);
-                    assertEquals(
-                            "The normalization form should be one of 'NFC', 'NFD', 'NFKC', 'NFKD'.",
-                            result);
-
-                    return null;
-                });
+        String js = "try { " + "  '123'.normalize(null);" + "} catch (e) { e.message }";
+        assertEvaluates(
+                "The normalization form should be one of 'NFC', 'NFD', 'NFKC', 'NFKD'.", js);
     }
 
     @Test
     public void replaceReplacementAsString() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result =
-                            cx.evaluateString(scope, "'123'.replace('2', /x/);", "test", 1, null);
-                    assertEquals("1/x/3", result);
-
-                    return null;
-                });
+        assertEvaluates("1null3", "'123'.replace('2', /x/);");
+        assertEvaluatesES6("1/x/3", "'123'.replace('2', /x/);");
     }
 
     @Test
     public void indexOfEmpty() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result =
-                            cx.evaluateString(scope, "'1234'.indexOf('', 0);", "test", 1, null);
-                    assertEquals(0, result);
-
-                    result = cx.evaluateString(scope, "'1234'.indexOf('', 1);", "test", 1, null);
-                    assertEquals(1, result);
-
-                    result = cx.evaluateString(scope, "'1234'.indexOf('', 4);", "test", 1, null);
-                    assertEquals(4, result);
-
-                    result = cx.evaluateString(scope, "'1234'.indexOf('', 5);", "test", 1, null);
-                    assertEquals(4, result);
-
-                    result = cx.evaluateString(scope, "'1234'.indexOf('', 42);", "test", 1, null);
-                    assertEquals(4, result);
-
-                    return null;
-                });
+        assertEvaluates(0, "'1234'.indexOf('', 0);");
+        assertEvaluates(1, "'1234'.indexOf('', 1);");
+        assertEvaluates(4, "'1234'.indexOf('', 4);");
+        assertEvaluates(4, "'1234'.indexOf('', 5);");
+        assertEvaluates(4, "'1234'.indexOf('', 42);");
     }
 
     @Test
     public void includesEmpty() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+        assertEvaluates(true, "'1234'.includes('');");
+        assertEvaluates(true, "'1234'.includes('', 0);");
+        assertEvaluates(true, "'1234'.includes('', 1);");
+        assertEvaluates(true, "'1234'.includes('', 4);");
+        assertEvaluates(true, "'1234'.includes('', 5);");
+        assertEvaluates(true, "'1234'.includes('', 42);");
+    }
 
-                    Boolean result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.includes('');", "test", 1, null);
-                    assertTrue(result);
+    @Test
+    public void includesRegExpMatch() {
+        String js =
+                "var regExp = /./;\n"
+                        + "var res = '';\n"
+                        + "try {\n"
+                        + "  res += '/./'.includes(regExp);\n"
+                        + "} catch (e) {\n"
+                        + "  res += e;\n"
+                        + "}\n"
+                        + "regExp[Symbol.match] = false;\n"
+                        + "res += ' # ' + '/./'.includes(regExp);\n"
+                        + "res;";
 
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.includes('', 0);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.includes('', 1);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.includes('', 4);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.includes('', 5);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.includes('', 42);", "test", 1, null);
-                    assertTrue(result);
-
-                    return null;
-                });
+        assertEvaluatesES6(
+                "TypeError: First argument to String.prototype.includes must not be a regular expression # true",
+                js);
     }
 
     @Test
     public void startsWithEmpty() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+        assertEvaluates(true, "'1234'.startsWith('');");
+        assertEvaluates(true, "'1234'.startsWith('', 0);");
+        assertEvaluates(true, "'1234'.startsWith('', 1);");
+        assertEvaluates(true, "'1234'.startsWith('', 4);");
+        assertEvaluates(true, "'1234'.startsWith('', 5);");
+        assertEvaluates(true, "'1234'.startsWith('', 42);");
+    }
 
-                    Boolean result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.startsWith('');", "test", 1, null);
-                    assertTrue(result);
+    @Test
+    public void startsWithRegExpMatch() {
+        String js =
+                "var regExp = /./;\n"
+                        + "var res = '';\n"
+                        + "try {\n"
+                        + "  res += '/./'.startsWith(regExp);\n"
+                        + "} catch (e) {\n"
+                        + "  res += e;\n"
+                        + "}\n"
+                        + "regExp[Symbol.match] = false;\n"
+                        + "res += ' # ' + '/./'.includes(regExp);\n"
+                        + "res;";
 
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.startsWith('', 0);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.startsWith('', 1);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.startsWith('', 4);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.startsWith('', 5);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.startsWith('', 42);", "test", 1, null);
-                    assertTrue(result);
-
-                    return null;
-                });
+        assertEvaluatesES6(
+                "TypeError: First argument to String.prototype.startsWith must not be a regular expression # true",
+                js);
     }
 
     @Test
     public void endsWithEmpty() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+        assertEvaluates(true, "'1234'.endsWith('');");
+        assertEvaluates(true, "'1234'.endsWith('', 0);");
+        assertEvaluates(true, "'1234'.endsWith('', 1);");
+        assertEvaluates(true, "'1234'.endsWith('', 4);");
+        assertEvaluates(true, "'1234'.endsWith('', 5);");
+        assertEvaluates(true, "'1234'.endsWith('', 42);");
+    }
 
-                    Boolean result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.endsWith('');", "test", 1, null);
-                    assertTrue(result);
+    @Test
+    public void endsWithRegExpMatch() {
+        String js =
+                "var regExp = /./;\n"
+                        + "var res = '';\n"
+                        + "try {\n"
+                        + "  res += '/./'.startsWith(regExp);\n"
+                        + "} catch (e) {\n"
+                        + "  res += e;\n"
+                        + "}\n"
+                        + "regExp[Symbol.match] = false;\n"
+                        + "res += ' # ' + '/./'.includes(regExp);\n"
+                        + "res;";
 
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.endsWith('', 0);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.endsWith('', 1);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.endsWith('', 4);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.endsWith('', 5);", "test", 1, null);
-                    assertTrue(result);
-
-                    result =
-                            (Boolean)
-                                    cx.evaluateString(
-                                            scope, "'1234'.endsWith('', 42);", "test", 1, null);
-                    assertTrue(result);
-
-                    return null;
-                });
+        assertEvaluatesES6(
+                "TypeError: First argument to String.prototype.startsWith must not be a regular expression # true",
+                js);
     }
 
     @Test
     public void tagify() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
-
-                    Object result = cx.evaluateString(scope, "'tester'.big()", "test", 1, null);
-                    assertEquals("<big>tester</big>", result);
-
-                    result = cx.evaluateString(scope, "'\"tester\"'.big()", "test", 1, null);
-                    assertEquals("<big>\"tester\"</big>", result);
-
-                    result = cx.evaluateString(scope, "'\"tester\"'.big()", "test", 1, null);
-                    assertEquals("<big>\"tester\"</big>", result);
-
-                    result = cx.evaluateString(scope, "'tester'.fontsize()", "test", 1, null);
-                    assertEquals("<font size=\"undefined\">tester</font>", result);
-
-                    result = cx.evaluateString(scope, "'tester'.fontsize(null)", "test", 1, null);
-                    assertEquals("<font size=\"null\">tester</font>", result);
-
-                    result =
-                            cx.evaluateString(
-                                    scope, "'tester'.fontsize(undefined)", "test", 1, null);
-                    assertEquals("<font size=\"undefined\">tester</font>", result);
-
-                    result = cx.evaluateString(scope, "'tester'.fontsize(123)", "test", 1, null);
-                    assertEquals("<font size=\"123\">tester</font>", result);
-
-                    result =
-                            cx.evaluateString(
-                                    scope, "'tester'.fontsize('\"123\"')", "test", 1, null);
-                    assertEquals("<font size=\"&quot;123&quot;\">tester</font>", result);
-
-                    return null;
-                });
+        assertEvaluates("<big>tester</big>", "'tester'.big()");
+        assertEvaluates("<big>\"tester\"</big>", "'\"tester\"'.big()");
+        assertEvaluates("<font size=\"undefined\">tester</font>", "'tester'.fontsize()");
+        assertEvaluates("<font size=\"null\">tester</font>", "'tester'.fontsize(null)");
+        assertEvaluates("<font size=\"undefined\">tester</font>", "'tester'.fontsize(undefined)");
+        assertEvaluates("<font size=\"123\">tester</font>", "'tester'.fontsize(123)");
+        assertEvaluates(
+                "<font size=\"&quot;123&quot;\">tester</font>", "'tester'.fontsize('\"123\"')");
     }
 
     @Test
     public void tagifyPrototypeNull() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+        for (String call :
+                new String[] {
+                    "big",
+                    "blink",
+                    "bold",
+                    "fixed",
+                    "fontcolor",
+                    "fontsize",
+                    "italics",
+                    "link",
+                    "small",
+                    "strike",
+                    "sub",
+                    "sup"
+                }) {
+            String js = "try { String.prototype." + call + ".call(null);} catch (e) { e.message }";
+            String expected = "String.prototype." + call + " method called on null or undefined";
 
-                    for (String call :
-                            new String[] {
-                                "big",
-                                "blink",
-                                "bold",
-                                "fixed",
-                                "fontcolor",
-                                "fontsize",
-                                "italics",
-                                "link",
-                                "small",
-                                "strike",
-                                "sub",
-                                "sup"
-                            }) {
-                        String code =
-                                "try { String.prototype."
-                                        + call
-                                        + ".call(null);} catch (e) { e.message }";
-                        Object result = cx.evaluateString(scope, code, "test", 1, null);
-                        assertEquals(
-                                "String.prototype." + call + " method called on null or undefined",
-                                result);
-                    }
-
-                    return null;
-                });
+            assertEvaluatesES6(expected, js);
+        }
     }
 
     @Test
     public void tagifyPrototypeUndefined() {
-        Utils.runWithAllOptimizationLevels(
-                cx -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+        for (String call :
+                new String[] {
+                    "big",
+                    "blink",
+                    "bold",
+                    "fixed",
+                    "fontcolor",
+                    "fontsize",
+                    "italics",
+                    "link",
+                    "small",
+                    "strike",
+                    "sub",
+                    "sup"
+                }) {
+            String js =
+                    "try { String.prototype." + call + ".call(undefined);} catch (e) { e.message }";
+            String expected = "String.prototype." + call + " method called on null or undefined";
 
-                    for (String call :
-                            new String[] {
-                                "big",
-                                "blink",
-                                "bold",
-                                "fixed",
-                                "fontcolor",
-                                "fontsize",
-                                "italics",
-                                "link",
-                                "small",
-                                "strike",
-                                "sub",
-                                "sup"
-                            }) {
-                        String code =
-                                "try { String.prototype."
-                                        + call
-                                        + ".call(undefined);} catch (e) { e.message }";
-                        Object result = cx.evaluateString(scope, code, "test", 1, null);
-                        assertEquals(
-                                "String.prototype." + call + " method called on null or undefined",
-                                result);
-                    }
-
-                    return null;
-                });
+            assertEvaluatesES6(expected, js);
+        }
     }
 
     @Test
@@ -462,6 +280,17 @@ public class NativeString2Test {
     private static void assertEvaluates(final Object expected, final String source) {
         Utils.runWithAllOptimizationLevels(
                 cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    final Object rep = cx.evaluateString(scope, source, "test.js", 0, null);
+                    assertEquals(expected, rep);
+                    return null;
+                });
+    }
+
+    private static void assertEvaluatesES6(final Object expected, final String source) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
                     final Scriptable scope = cx.initStandardObjects();
                     final Object rep = cx.evaluateString(scope, source, "test.js", 0, null);
                     assertEquals(expected, rep);

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1553,7 +1553,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 120/1114 (10.77%)
+built-ins/String 99/1114 (8.89%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-bigint.js {unsupported: [computed-property-names]}
@@ -1568,7 +1568,25 @@ built-ins/String 120/1114 (10.77%)
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/invoke-builtin-match.js
-    prototype/replaceAll 40/40 (100.0%)
+    prototype/replaceAll/getSubstitution-0x0024-0x003C.js
+    prototype/replaceAll/getSubstitution-0x0024N.js
+    prototype/replaceAll/getSubstitution-0x0024NN.js
+    prototype/replaceAll/replaceValue-call-each-match-position.js
+    prototype/replaceAll/replaceValue-call-matching-empty.js
+    prototype/replaceAll/replaceValue-value-tostring.js
+    prototype/replaceAll/searchValue-flags-no-g-throws.js
+    prototype/replaceAll/searchValue-flags-null-undefined-throws.js
+    prototype/replaceAll/searchValue-flags-toString-abrupt.js
+    prototype/replaceAll/searchValue-get-flags-abrupt.js
+    prototype/replaceAll/searchValue-isRegExp-abrupt.js
+    prototype/replaceAll/searchValue-replacer-before-tostring.js
+    prototype/replaceAll/searchValue-replacer-call.js
+    prototype/replaceAll/searchValue-replacer-call-abrupt.js
+    prototype/replaceAll/searchValue-replacer-method-abrupt.js
+    prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
+    prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
+    prototype/replaceAll/searchValue-tostring-regexp.js
+    prototype/replaceAll/this-tostring.js
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
     prototype/replace/S15.5.4.11_A12.js non-strict


### PR DESCRIPTION
Slightly modified (improved) PR from @duonglaiquang. See https://github.com/HtmlUnit/htmlunit-rhino-fork/pull/12

----

### This PR does the following:

1. Handle the case where [RegExp.prototype.toString](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.tostring) is called on `NativeObject` instead of `NativeRegExp` object (currently throwing `TypeError: Method "toString" called on incompatible object`)
  - These tests showcase the expected behavior of this method
    ```html
    <!DOCTYPE html>
    <html>
    <head>
    <script>
    console.log(RegExp.prototype.toString.call({})) // "/undefined/undefined"
    console.log(RegExp.prototype.toString.call({source: "Foo"})) // "/Foo/undefined"
    console.log(RegExp.prototype.toString.call({flags: "gy"})) // "/undefined/gy"
    console.log(RegExp.prototype.toString.call({source: "Foo", flags: "g"})) // "/Foo/g"
    console.log(RegExp.prototype.toString.call({source: "Foo", flags: "g", sticky: true})) // "/Foo/g"
    </script>
    </head>
    <body>
    </body>
    </html>
    ```
 
2. Implement [RegExp.dotAll](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll) flag

3. Implement [String.prototype.replaceAll](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll)

4. Fix an issue when `String.includes/startsWith/endsWith` throw `TypeError` when the first argument is a regex, even if [Symbol.match](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match) of that regex has been set to false.

    > This function is also used to identify [if objects have the behavior of regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#special_handling_for_regexes). For example, the methods [String.prototype.startsWith()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith), [String.prototype.endsWith()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) and [String.prototype.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes), check if their first argument is a regular expression and will throw a [TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if they are. Now, if the match symbol is set to false (or a [Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value except undefined), it indicates that the object is not intended to be used as a regular expression object.


  - These tests showcase the buggy behavior of the current implementation.
    ```html
    <!DOCTYPE html>
    <html>
    <head>
    <script>
    var regExp = /./;
    try {
      console.log("/./".includes(regExp))
    } catch (e) {
      console.log(e); // TypeError: First argument to String.prototype.includes must not be a regular expression
      regExp[Symbol.match] = false;
      console.log("/./".includes(regExp)) // expected: true, got TypeError
    }
    </script>
    </head>
    <body>
    </body>
    </html>
    ```