### PR TITLE
Make regexp execution loop interruptible #1189

### DIFF
--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1878,6 +1878,9 @@ public class NativeRegExp extends IdScriptableObject {
 
         for (; ; ) {
 
+            if (Thread.currentThread().isInterrupted()) {
+                throw new RuntimeException("Received interrupt while executing regexp");
+            }
             if (reopIsSimple(op)) {
                 int match = simpleMatch(gData, input, op, program, pc, end, true);
                 result = match >= 0;

--- a/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -8,17 +8,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
-
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 
 public class NativeRegExpTest {
 
@@ -63,12 +61,16 @@ public class NativeRegExpTest {
     public void interruptLongRunningRegExpEvaluation() throws Exception {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         try {
-            Future<?> future = executorService.submit(() -> test("false", "/(.*){1,32000}[bc]/.test(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\");"));
+            Future<?> future =
+                    executorService.submit(
+                            () ->
+                                    test(
+                                            "false",
+                                            "/(.*){1,32000}[bc]/.test(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\");"));
             assertThrows(TimeoutException.class, () -> future.get(1, TimeUnit.SECONDS));
             executorService.shutdownNow();
             assertTrue(executorService.awaitTermination(30, TimeUnit.SECONDS));
-        }
-        finally {
+        } finally {
             executorService.shutdown();
         }
     }

--- a/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -5,14 +5,7 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
@@ -54,25 +47,6 @@ public class NativeRegExpTest {
     @Test
     public void ignoreCase() throws Exception {
         testEvaluate("i-false-true-false-false", "/foo/i;");
-    }
-
-    /** @throws Exception if an error occurs */
-    @Test
-    public void interruptLongRunningRegExpEvaluation() throws Exception {
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        try {
-            Future<?> future =
-                    executorService.submit(
-                            () ->
-                                    test(
-                                            "false",
-                                            "/(.*){1,32000}[bc]/.test(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\");"));
-            assertThrows(TimeoutException.class, () -> future.get(1, TimeUnit.SECONDS));
-            executorService.shutdownNow();
-            assertTrue(executorService.awaitTermination(30, TimeUnit.SECONDS));
-        } finally {
-            executorService.shutdown();
-        }
     }
 
     /** @throws Exception if an error occurs */

--- a/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/testsrc/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -5,11 +5,20 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class NativeRegExpTest {
 
@@ -47,6 +56,21 @@ public class NativeRegExpTest {
     @Test
     public void ignoreCase() throws Exception {
         testEvaluate("i-false-true-false-false", "/foo/i;");
+    }
+
+    /** @throws Exception if an error occurs */
+    @Test
+    public void interruptLongRunningRegExpEvaluation() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> future = executorService.submit(() -> test("false", "/(.*){1,32000}[bc]/.test(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\");"));
+            assertThrows(TimeoutException.class, () -> future.get(1, TimeUnit.SECONDS));
+            executorService.shutdownNow();
+            assertTrue(executorService.awaitTermination(30, TimeUnit.SECONDS));
+        }
+        finally {
+            executorService.shutdown();
+        }
     }
 
     /** @throws Exception if an error occurs */

--- a/testsrc/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
@@ -118,4 +118,11 @@ public class ObserveInstructionCountTest {
         String source = "for(;;);";
         baseCase(source);
     }
+
+    @Test
+    public void longRunningRegExp() {
+        String source =
+                "/(.*){1,32000}[bc]/.test(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\");";
+        baseCase(source);
+    }
 }


### PR DESCRIPTION
#1189

Uses `Thread.currentThread.isInterrupted()` so that the interruption flag remains set to true, we only terminate the RegExp evaluation loop, but other (potentially third-party calling) code may still have to check for the interrupted flag to stop its execution as well.

I also added a test with a long-running regexp that fails without the interrupt check.

Perhaps it would have been better to throw an `InterruptedException`, but that would require changing the signature of many methods.