### PR TITLE
(Partial) implementation of `[Symbol.species]`

### DIFF
--- a/src/org/mozilla/javascript/NativeArray.java
+++ b/src/org/mozilla/javascript/NativeArray.java
@@ -46,9 +46,10 @@ public class NativeArray extends IdScriptableObject implements List {
     private static final Object ARRAY_TAG = "Array";
     private static final Long NEGATIVE_ONE = Long.valueOf(-1);
 
-    static void init(Scriptable scope, boolean sealed) {
+    static void init(Context cx, Scriptable scope, boolean sealed) {
         NativeArray obj = new NativeArray(0);
-        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+        IdFunctionObject constructor = obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
     }
 
     static int getMaximumInitialCapacity() {

--- a/src/org/mozilla/javascript/NativeMap.java
+++ b/src/org/mozilla/javascript/NativeMap.java
@@ -17,13 +17,15 @@ public class NativeMap extends IdScriptableObject {
 
     static void init(Context cx, Scriptable scope, boolean sealed) {
         NativeMap obj = new NativeMap();
-        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, false);
+        IdFunctionObject constructor = obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, false);
 
         ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
         desc.put("enumerable", desc, Boolean.FALSE);
         desc.put("configurable", desc, Boolean.TRUE);
         desc.put("get", desc, obj.get(NativeSet.GETSIZE, obj));
         obj.defineOwnProperty(cx, "size", desc);
+
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
 
         if (sealed) {
             obj.sealObject();

--- a/src/org/mozilla/javascript/NativePromise.java
+++ b/src/org/mozilla/javascript/NativePromise.java
@@ -48,19 +48,7 @@ public class NativePromise extends ScriptableObject {
         constructor.defineConstructorMethod(
                 scope, "race", 1, NativePromise::race, DONTENUM, DONTENUM | READONLY);
 
-        ScriptableObject speciesDescriptor = (ScriptableObject) cx.newObject(scope);
-        ScriptableObject.putProperty(speciesDescriptor, "enumerable", false);
-        ScriptableObject.putProperty(speciesDescriptor, "configurable", true);
-        ScriptableObject.putProperty(
-                speciesDescriptor,
-                "get",
-                new LambdaFunction(
-                        scope,
-                        "get [Symbol.species]",
-                        0,
-                        (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) ->
-                                thisObj));
-        constructor.defineOwnProperty(cx, SymbolKey.SPECIES, speciesDescriptor, false);
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
 
         constructor.definePrototypeMethod(
                 scope,

--- a/src/org/mozilla/javascript/NativePromise.java
+++ b/src/org/mozilla/javascript/NativePromise.java
@@ -59,7 +59,7 @@ public class NativePromise extends ScriptableObject {
                         "get [Symbol.species]",
                         0,
                         (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) ->
-                                constructor));
+                                thisObj));
         constructor.defineOwnProperty(cx, SymbolKey.SPECIES, speciesDescriptor, false);
 
         constructor.definePrototypeMethod(

--- a/src/org/mozilla/javascript/NativeSet.java
+++ b/src/org/mozilla/javascript/NativeSet.java
@@ -27,24 +27,8 @@ public class NativeSet extends IdScriptableObject {
         desc.put("get", desc, obj.get(GETSIZE, obj));
         obj.defineOwnProperty(cx, "size", desc);
 
-        // TODO: this code is about the same as for Promise, except for a bug fix -
-        //  here I return "thisObj" and not "constructor". I've made the fix after
-        //  checking the test262 :)
-        //  Need to check what the spec says for Promise and, I hope, unify them
-        //  And then to update also Array, Map, and whatever else is required (see spec)
-        ScriptableObject speciesDescriptor = (ScriptableObject) cx.newObject(scope);
-        ScriptableObject.putProperty(speciesDescriptor, "enumerable", false);
-        ScriptableObject.putProperty(speciesDescriptor, "configurable", true);
-        ScriptableObject.putProperty(
-                speciesDescriptor,
-                "get",
-                new LambdaFunction(
-                        scope,
-                        "get [Symbol.species]",
-                        0,
-                        (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) ->
-                                thisObj));
-        constructor.defineOwnProperty(cx, SymbolKey.SPECIES, speciesDescriptor, false);
+        // TODO And then to update also Array, Map, and whatever else is required (see spec)
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
 
         if (sealed) {
             obj.sealObject();

--- a/src/org/mozilla/javascript/NativeSet.java
+++ b/src/org/mozilla/javascript/NativeSet.java
@@ -27,7 +27,6 @@ public class NativeSet extends IdScriptableObject {
         desc.put("get", desc, obj.get(GETSIZE, obj));
         obj.defineOwnProperty(cx, "size", desc);
 
-        // TODO And then to update also Array, Map, and whatever else is required (see spec)
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
 
         if (sealed) {

--- a/src/org/mozilla/javascript/ScriptRuntime.java
+++ b/src/org/mozilla/javascript/ScriptRuntime.java
@@ -163,7 +163,7 @@ public class ScriptRuntime {
         NativeError.init(scope, sealed);
         NativeGlobal.init(cx, scope, sealed);
 
-        NativeArray.init(scope, sealed);
+        NativeArray.init(cx, scope, sealed);
         if (cx.getOptimizationLevel() > 0) {
             // When optimizing, attempt to fulfill all requests for new Array(N)
             // with a higher threshold before switching to a sparse

--- a/src/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/src/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -18,4 +18,22 @@ public class ScriptRuntimeES6 {
         }
         return val;
     }
+
+    /** Registers the symbol <code>[Symbol.species]</code> on the given constructor function. */
+    public static void addSymbolSpecies(
+            Context cx, Scriptable scope, IdScriptableObject constructor) {
+        ScriptableObject speciesDescriptor = (ScriptableObject) cx.newObject(scope);
+        ScriptableObject.putProperty(speciesDescriptor, "enumerable", false);
+        ScriptableObject.putProperty(speciesDescriptor, "configurable", true);
+        ScriptableObject.putProperty(
+                speciesDescriptor,
+                "get",
+                new LambdaFunction(
+                        scope,
+                        "get [Symbol.species]",
+                        0,
+                        (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) ->
+                                thisObj));
+        constructor.defineOwnProperty(cx, SymbolKey.SPECIES, speciesDescriptor, false);
+    }
 }

--- a/src/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/src/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.IdScriptableObject;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Symbol;
@@ -134,6 +135,8 @@ public class NativeRegExp extends IdScriptableObject {
         }
 
         defineProperty(scope, "RegExp", ctor, ScriptableObject.DONTENUM);
+
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, ctor);
     }
 
     NativeRegExp(Scriptable scope, RECompiled regexpCompiled) {

--- a/testsrc/jstests/es6/array.js
+++ b/testsrc/jstests/es6/array.js
@@ -17,4 +17,9 @@ var a = Array.from(Array(2));
 assertTrue(0 in a);
 assertEquals(a.map(_ => 'a'), ['a', 'a']);
 
+(function TestSymbolSpecies() {
+	var symbolSpeciesValue = Array[Symbol.species];
+	assertEquals(Array, symbolSpeciesValue);
+})();
+
 "success";

--- a/testsrc/jstests/es6/map.js
+++ b/testsrc/jstests/es6/map.js
@@ -130,4 +130,9 @@ function logElement(value, key, m) {
   }
 })();
 
+(function TestSymbolSpecies() {
+  var symbolSpeciesValue = Map[Symbol.species];
+  assertEquals(Map, symbolSpeciesValue);
+})();
+
 "success";

--- a/testsrc/jstests/es6/promises.js
+++ b/testsrc/jstests/es6/promises.js
@@ -998,6 +998,11 @@ function assertAsyncDone(iteration) {
   assertEquals(1, callCount);
 })();
 
-assertAsyncDone()
+assertAsyncDone();
+
+(function TestSymbolSpecies() {
+  var symbolSpeciesValue = Promise[Symbol.species];
+  assertEquals(Promise, symbolSpeciesValue);
+})();
 
 'success';

--- a/testsrc/jstests/es6/regexp.js
+++ b/testsrc/jstests/es6/regexp.js
@@ -1,0 +1,8 @@
+load('testsrc/assert.js');
+
+(function TestSymbolSpecies() {
+  var symbolSpeciesValue = RegExp[Symbol.species];
+  assertEquals(RegExp, symbolSpeciesValue);
+})();
+
+'success';

--- a/testsrc/jstests/es6/set.js
+++ b/testsrc/jstests/es6/set.js
@@ -88,4 +88,9 @@ function logElement(value, key) {
   assertEquals(1, mySet.size);
 })();
 
+(function TestSymbolSpecies() {
+  var symbolSpeciesValue = Set[Symbol.species];
+  assertEquals(Set, symbolSpeciesValue);
+})();
+
 "success";

--- a/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/testsrc/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -96,7 +96,6 @@ public class Test262SuiteTest {
                             "Reflect.set",
                             "Reflect.setPrototypeOf",
                             "SharedArrayBuffer",
-                            "Symbol.species",
                             "async-functions",
                             "async-iteration",
                             "class",

--- a/testsrc/org/mozilla/javascript/tests/es6/RegExpBasicTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/RegExpBasicTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es6;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es6/regexp.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class RegExpBasicTest extends ScriptTestsBase {}

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -1,6 +1,6 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array 176/2670 (6.59%)
+built-ins/Array 149/2670 (5.58%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
@@ -26,22 +26,17 @@ built-ins/Array 176/2670 (6.59%)
     prototype/concat/Array.prototype.concat_small-typed-array.js
     prototype/concat/create-ctor-non-object.js
     prototype/concat/create-ctor-poisoned.js
-    prototype/concat/create-proto-from-ctor-realm-array.js {unsupported: [Symbol.species]}
-    prototype/concat/create-proto-from-ctor-realm-non-array.js {unsupported: [Symbol.species]}
-    prototype/concat/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/concat/create-proto-from-ctor-realm-non-array.js
+    prototype/concat/create-proxy.js {unsupported: [Proxy]}
     prototype/concat/create-revoked-proxy.js {unsupported: [Proxy]}
-    prototype/concat/create-species.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-non-ctor.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-non-extensible-spreadable.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-null.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-with-non-configurable-property-spreadable.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-with-non-writable-property.js {unsupported: [Symbol.species]}
-    prototype/concat/create-species-with-non-writable-property-spreadable.js {unsupported: [Symbol.species]}
+    prototype/concat/create-species.js
+    prototype/concat/create-species-abrupt.js
+    prototype/concat/create-species-non-ctor.js
+    prototype/concat/create-species-non-extensible.js
+    prototype/concat/create-species-non-extensible-spreadable.js
+    prototype/concat/create-species-poisoned.js
+    prototype/concat/create-species-with-non-configurable-property.js
+    prototype/concat/create-species-with-non-configurable-property-spreadable.js
     prototype/concat/is-concat-spreadable-get-order.js
     prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js {unsupported: [Proxy]}
     prototype/concat/is-concat-spreadable-proxy.js {unsupported: [Proxy]}
@@ -55,38 +50,32 @@ built-ins/Array 176/2670 (6.59%)
     prototype/filter/15.4.4.20-5-1-s.js non-strict
     prototype/filter/create-ctor-non-object.js
     prototype/filter/create-ctor-poisoned.js
-    prototype/filter/create-proto-from-ctor-realm-array.js {unsupported: [Symbol.species]}
-    prototype/filter/create-proto-from-ctor-realm-non-array.js {unsupported: [Symbol.species]}
-    prototype/filter/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/filter/create-proto-from-ctor-realm-non-array.js
+    prototype/filter/create-proxy.js {unsupported: [Proxy]}
     prototype/filter/create-revoked-proxy.js {unsupported: [Proxy]}
-    prototype/filter/create-species.js {unsupported: [Symbol.species]}
-    prototype/filter/create-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/filter/create-species-non-ctor.js {unsupported: [Symbol.species]}
-    prototype/filter/create-species-null.js {unsupported: [Symbol.species]}
-    prototype/filter/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/filter/create-species-undef.js {unsupported: [Symbol.species]}
-    prototype/filter/target-array-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/filter/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/filter/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/filter/create-species.js
+    prototype/filter/create-species-abrupt.js
+    prototype/filter/create-species-non-ctor.js
+    prototype/filter/create-species-poisoned.js
+    prototype/filter/target-array-non-extensible.js
+    prototype/filter/target-array-with-non-configurable-property.js
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
     prototype/flatMap/array-like-objects.js
     prototype/flatMap/array-like-objects-poisoned-length.js
     prototype/flatMap/proxy-access-count.js
-    prototype/flatMap/target-array-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/flatMap/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/flatMap/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/flatMap/target-array-non-extensible.js
+    prototype/flatMap/target-array-with-non-configurable-property.js
     prototype/flatMap/this-value-ctor-non-object.js
-    prototype/flatMap/this-value-ctor-object-species.js {unsupported: [Symbol.species]}
-    prototype/flatMap/this-value-ctor-object-species-bad-throws.js {unsupported: [Symbol.species]}
-    prototype/flatMap/this-value-ctor-object-species-custom-ctor.js {unsupported: [Symbol.species]}
-    prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js {unsupported: [Symbol.species]}
+    prototype/flatMap/this-value-ctor-object-species.js
+    prototype/flatMap/this-value-ctor-object-species-bad-throws.js
+    prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
+    prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
     prototype/flatMap/thisArg-argument.js strict
     prototype/flat/non-object-ctor-throws.js
     prototype/flat/proxy-access-count.js
-    prototype/flat/target-array-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/flat/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/flat/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/flat/target-array-non-extensible.js
+    prototype/flat/target-array-with-non-configurable-property.js
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
     prototype/includes/get-prop.js {unsupported: [Proxy]}
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
@@ -96,20 +85,16 @@ built-ins/Array 176/2670 (6.59%)
     prototype/map/15.4.4.19-5-1-s.js non-strict
     prototype/map/create-ctor-non-object.js
     prototype/map/create-ctor-poisoned.js
-    prototype/map/create-proto-from-ctor-realm-array.js {unsupported: [Symbol.species]}
-    prototype/map/create-proto-from-ctor-realm-non-array.js {unsupported: [Symbol.species]}
-    prototype/map/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/map/create-proto-from-ctor-realm-non-array.js
+    prototype/map/create-proxy.js {unsupported: [Proxy]}
     prototype/map/create-revoked-proxy.js {unsupported: [Proxy]}
-    prototype/map/create-species.js {unsupported: [Symbol.species]}
-    prototype/map/create-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/map/create-species-non-ctor.js {unsupported: [Symbol.species]}
-    prototype/map/create-species-null.js {unsupported: [Symbol.species]}
-    prototype/map/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/map/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/map/create-species.js
+    prototype/map/create-species-abrupt.js
+    prototype/map/create-species-non-ctor.js
+    prototype/map/create-species-poisoned.js
     prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
-    prototype/map/target-array-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/map/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/map/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/map/target-array-non-extensible.js
+    prototype/map/target-array-with-non-configurable-property.js
     prototype/pop/throws-with-string-receiver.js
     prototype/push/length-near-integer-limit-set-failure.js non-strict
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
@@ -121,22 +106,18 @@ built-ins/Array 176/2670 (6.59%)
     prototype/shift/throws-when-this-value-length-is-writable-false.js
     prototype/slice/create-ctor-non-object.js
     prototype/slice/create-ctor-poisoned.js
-    prototype/slice/create-proto-from-ctor-realm-array.js {unsupported: [Symbol.species]}
-    prototype/slice/create-proto-from-ctor-realm-non-array.js {unsupported: [Symbol.species]}
+    prototype/slice/create-proto-from-ctor-realm-non-array.js
     prototype/slice/create-proxied-array-invalid-len.js {unsupported: [Proxy]}
-    prototype/slice/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/slice/create-proxy.js {unsupported: [Proxy]}
     prototype/slice/create-revoked-proxy.js {unsupported: [Proxy]}
-    prototype/slice/create-species.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species-neg-zero.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species-non-ctor.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species-null.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/slice/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/slice/create-species.js
+    prototype/slice/create-species-abrupt.js
+    prototype/slice/create-species-neg-zero.js
+    prototype/slice/create-species-non-ctor.js
+    prototype/slice/create-species-poisoned.js
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
-    prototype/slice/target-array-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/slice/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/slice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/slice/target-array-non-extensible.js
+    prototype/slice/target-array-with-non-configurable-property.js
     prototype/some/15.4.4.17-5-1-s.js non-strict
     prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/sort/stability-2048-elements.js
@@ -144,32 +125,27 @@ built-ins/Array 176/2670 (6.59%)
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-ctor-non-object.js
     prototype/splice/create-ctor-poisoned.js
-    prototype/splice/create-proto-from-ctor-realm-array.js {unsupported: [Symbol.species]}
-    prototype/splice/create-proto-from-ctor-realm-non-array.js {unsupported: [Symbol.species]}
-    prototype/splice/create-proxy.js {unsupported: [Proxy, Symbol.species]}
+    prototype/splice/create-proto-from-ctor-realm-non-array.js
+    prototype/splice/create-proxy.js {unsupported: [Proxy]}
     prototype/splice/create-revoked-proxy.js {unsupported: [Proxy]}
-    prototype/splice/create-species.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-length-exceeding-integer-limit.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-neg-zero.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-non-ctor.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-null.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-poisoned.js {unsupported: [Symbol.species]}
-    prototype/splice/create-species-undef.js {unsupported: [Symbol.species]}
+    prototype/splice/create-species.js
+    prototype/splice/create-species-abrupt.js
+    prototype/splice/create-species-length-exceeding-integer-limit.js
+    prototype/splice/create-species-neg-zero.js
+    prototype/splice/create-species-non-ctor.js
+    prototype/splice/create-species-poisoned.js
     prototype/splice/create-species-undef-invalid-len.js {unsupported: [Proxy]}
-    prototype/splice/property-traps-order-with-species.js {unsupported: [Proxy, Symbol.species]}
+    prototype/splice/property-traps-order-with-species.js {unsupported: [Proxy]}
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
     prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
-    prototype/splice/target-array-non-extensible.js {unsupported: [Symbol.species]}
-    prototype/splice/target-array-with-non-configurable-property.js {unsupported: [Symbol.species]}
-    prototype/splice/target-array-with-non-writable-property.js {unsupported: [Symbol.species]}
+    prototype/splice/target-array-non-extensible.js
+    prototype/splice/target-array-with-non-configurable-property.js
     prototype/Symbol.unscopables 2/2 (100.0%)
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/unshift/throws-with-string-receiver.js
-    prototype/methods-called-as-functions.js {unsupported: [Symbol.species]}
-    Symbol.species 4/4 (100.0%)
+    prototype/methods-called-as-functions.js
     proto-from-ctor-realm-one.js {unsupported: [Reflect]}
     proto-from-ctor-realm-two.js {unsupported: [Reflect]}
     proto-from-ctor-realm-zero.js {unsupported: [Reflect]}
@@ -183,17 +159,17 @@ built-ins/ArrayBuffer 30/80 (37.5%)
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
     prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    prototype/slice/species.js {unsupported: [Symbol.species]}
+    prototype/slice/species.js
     prototype/slice/species-constructor-is-not-object.js
     prototype/slice/species-constructor-is-undefined.js
-    prototype/slice/species-is-not-constructor.js {unsupported: [Symbol.species]}
-    prototype/slice/species-is-not-object.js {unsupported: [Symbol.species]}
-    prototype/slice/species-is-null.js {unsupported: [Symbol.species]}
-    prototype/slice/species-is-undefined.js {unsupported: [Symbol.species]}
-    prototype/slice/species-returns-larger-arraybuffer.js {unsupported: [Symbol.species]}
-    prototype/slice/species-returns-not-arraybuffer.js {unsupported: [Symbol.species]}
-    prototype/slice/species-returns-same-arraybuffer.js {unsupported: [Symbol.species]}
-    prototype/slice/species-returns-smaller-arraybuffer.js {unsupported: [Symbol.species]}
+    prototype/slice/species-is-not-constructor.js
+    prototype/slice/species-is-not-object.js
+    prototype/slice/species-is-null.js
+    prototype/slice/species-is-undefined.js
+    prototype/slice/species-returns-larger-arraybuffer.js
+    prototype/slice/species-returns-not-arraybuffer.js
+    prototype/slice/species-returns-same-arraybuffer.js
+    prototype/slice/species-returns-smaller-arraybuffer.js
     prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/Symbol.toStringTag.js
     Symbol.species 4/4 (100.0%)
@@ -726,8 +702,7 @@ built-ins/JSON 34/140 (24.29%)
     stringify/value-string-escape-ascii.js
     stringify/value-string-escape-unicode.js
 
-built-ins/Map 6/145 (4.14%)
-    Symbol.species 4/4 (100.0%)
+built-ins/Map 2/145 (1.38%)
     iterator-is-undefined-throws.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
@@ -902,7 +877,7 @@ built-ins/parseInt 2/60 (3.33%)
     S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.2_A9.2.js
 
-built-ins/Promise 405/599 (67.61%)
+built-ins/Promise 397/599 (66.28%)
     allSettled/capability-resolve-throws-reject.js {unsupported: [async]}
     allSettled/ctx-ctor.js {unsupported: [class]}
     allSettled/does-not-invoke-array-setters.js {unsupported: [async]}
@@ -961,7 +936,6 @@ built-ins/Promise 405/599 (67.61%)
     allSettled/resolved-then-catch-finally.js {unsupported: [async]}
     allSettled/resolves-empty-array.js {unsupported: [async]}
     allSettled/resolves-to-array.js {unsupported: [async]}
-    allSettled/species-get-error.js {unsupported: [Symbol.species]}
     all/capability-resolve-throws-reject.js {unsupported: [async]}
     all/ctx-ctor.js {unsupported: [class]}
     all/does-not-invoke-array-setters.js {unsupported: [async]}
@@ -1020,7 +994,6 @@ built-ins/Promise 405/599 (67.61%)
     all/S25.4.4.1_A8.1_T1.js {unsupported: [async]}
     all/S25.4.4.1_A8.2_T1.js {unsupported: [async]}
     all/S25.4.4.1_A8.2_T2.js {unsupported: [async]}
-    all/species-get-error.js {unsupported: [Symbol.species]}
     any/call-reject-element-after-return.js
     any/call-reject-element-items.js
     any/capability-executor-called-twice.js
@@ -1109,7 +1082,7 @@ built-ins/Promise 405/599 (67.61%)
     any/resolved-sequence-mixed.js {unsupported: [async]}
     any/resolved-sequence-with-rejections.js {unsupported: [async]}
     any/returns-promise.js
-    any/species-get-error.js {unsupported: [Symbol.species]}
+    any/species-get-error.js
     prototype/catch/S25.4.5.1_A3.1_T1.js {unsupported: [async]}
     prototype/catch/S25.4.5.1_A3.1_T2.js {unsupported: [async]}
     prototype/finally/invokes-then-with-function.js {unsupported: [Reflect.construct]}
@@ -1131,7 +1104,7 @@ built-ins/Promise 405/599 (67.61%)
     prototype/then/capability-executor-called-twice.js {unsupported: [class]}
     prototype/then/capability-executor-not-callable.js {unsupported: [class]}
     prototype/then/ctor-access-count.js {unsupported: [async]}
-    prototype/then/ctor-custom.js {unsupported: [Symbol.species, class]}
+    prototype/then/ctor-custom.js {unsupported: [class]}
     prototype/then/deferred-is-resolved-value.js {unsupported: [class, async]}
     prototype/then/prfm-fulfilled.js {unsupported: [async]}
     prototype/then/prfm-pending-fulfulled.js {unsupported: [async]}
@@ -1254,7 +1227,6 @@ built-ins/Promise 405/599 (67.61%)
     race/S25.4.4.3_A7.2_T1.js {unsupported: [async]}
     race/S25.4.4.3_A7.3_T1.js {unsupported: [async]}
     race/S25.4.4.3_A7.3_T2.js {unsupported: [async]}
-    race/species-get-error.js {unsupported: [Symbol.species]}
     reject/capability-invocation.js
     reject/ctx-ctor.js {unsupported: [class]}
     reject/S25.4.4.4_A2.1_T1.js {unsupported: [async]}
@@ -1273,7 +1245,6 @@ built-ins/Promise 405/599 (67.61%)
     resolve/S25.4.4.5_A4.1_T1.js {unsupported: [async]}
     resolve/S25.Promise_resolve_foreign_thenable_1.js {unsupported: [async]}
     resolve/S25.Promise_resolve_foreign_thenable_2.js {unsupported: [async]}
-    Symbol.species 5/5 (100.0%)
     create-resolving-functions-reject.js {unsupported: [Reflect.construct, async]}
     create-resolving-functions-resolve.js {unsupported: [Reflect.construct, async]}
     exception-after-resolve-in-executor.js {unsupported: [async]}
@@ -1309,7 +1280,7 @@ built-ins/Promise 405/599 (67.61%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 897/1464 (61.27%)
+built-ins/RegExp 893/1464 (61.0%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     lookBehind 17/17 (100.0%)
@@ -1470,7 +1441,7 @@ built-ins/RegExp 897/1464 (61.27%)
     prototype/Symbol.search/set-lastindex-restore-samevalue.js
     prototype/Symbol.search/success-get-index-err.js
     prototype/Symbol.search/u-lastindex-advance.js
-    prototype/Symbol.split/coerce-flags.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/coerce-flags.js
     prototype/Symbol.split/coerce-flags-err.js
     prototype/Symbol.split/coerce-limit.js
     prototype/Symbol.split/coerce-limit-err.js
@@ -1479,36 +1450,36 @@ built-ins/RegExp 897/1464 (61.27%)
     prototype/Symbol.split/get-flags-err.js
     prototype/Symbol.split/last-index-exceeds-str-size.js
     prototype/Symbol.split/length.js
-    prototype/Symbol.split/limit-0-bail.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/limit-0-bail.js
     prototype/Symbol.split/name.js
     prototype/Symbol.split/prop-desc.js
-    prototype/Symbol.split/species-ctor.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor.js
     prototype/Symbol.split/species-ctor-ctor-get-err.js
     prototype/Symbol.split/species-ctor-ctor-non-obj.js
     prototype/Symbol.split/species-ctor-ctor-undef.js
-    prototype/Symbol.split/species-ctor-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/species-ctor-species-get-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/species-ctor-species-non-ctor.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/species-ctor-species-undef.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/species-ctor-y.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/splitter-proto-from-ctor-realm.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/species-ctor-err.js
+    prototype/Symbol.split/species-ctor-species-get-err.js
+    prototype/Symbol.split/species-ctor-species-non-ctor.js
+    prototype/Symbol.split/species-ctor-species-undef.js
+    prototype/Symbol.split/species-ctor-y.js
+    prototype/Symbol.split/splitter-proto-from-ctor-realm.js
     prototype/Symbol.split/str-adv-thru-empty-match.js
-    prototype/Symbol.split/str-coerce-lastindex.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-coerce-lastindex-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-coerce-lastindex.js
+    prototype/Symbol.split/str-coerce-lastindex-err.js
     prototype/Symbol.split/str-empty-match.js
-    prototype/Symbol.split/str-empty-match-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-empty-match-err.js
     prototype/Symbol.split/str-empty-no-match.js
-    prototype/Symbol.split/str-get-lastindex-err.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-get-lastindex-err.js
     prototype/Symbol.split/str-limit.js
     prototype/Symbol.split/str-limit-capturing.js
-    prototype/Symbol.split/str-match-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-result-coerce-length.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-result-coerce-length-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-result-get-capture-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-result-get-length-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-set-lastindex-err.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-set-lastindex-match.js {unsupported: [Symbol.species]}
-    prototype/Symbol.split/str-set-lastindex-no-match.js {unsupported: [Symbol.species]}
+    prototype/Symbol.split/str-match-err.js
+    prototype/Symbol.split/str-result-coerce-length.js
+    prototype/Symbol.split/str-result-coerce-length-err.js
+    prototype/Symbol.split/str-result-get-capture-err.js
+    prototype/Symbol.split/str-result-get-length-err.js
+    prototype/Symbol.split/str-set-lastindex-err.js
+    prototype/Symbol.split/str-set-lastindex-match.js
+    prototype/Symbol.split/str-set-lastindex-no-match.js
     prototype/Symbol.split/str-trailing-chars.js
     prototype/Symbol.split/u-lastindex-adv-thru-failure.js
     prototype/Symbol.split/u-lastindex-adv-thru-match.js
@@ -1516,7 +1487,6 @@ built-ins/RegExp 897/1464 (61.27%)
     prototype/unicode 8/8 (100.0%)
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
-    Symbol.species 4/4 (100.0%)
     15.10.4.1-1.js
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
@@ -1544,8 +1514,7 @@ built-ins/RegExp 897/1464 (61.27%)
     unicode_identity_escape.js
     valid-flags-y.js
 
-built-ins/Set 5/188 (2.66%)
-    Symbol.species 4/4 (100.0%)
+built-ins/Set 1/188 (0.53%)
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
 built-ins/SetIteratorPrototype 0/11 (0.0%)
@@ -1637,7 +1606,7 @@ built-ins/String 99/1114 (8.89%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 29/85 (34.12%)
+built-ins/Symbol 27/85 (31.76%)
     asyncIterator/prop-desc.js
     for/cross-realm.js
     hasInstance/cross-realm.js
@@ -1657,7 +1626,8 @@ built-ins/Symbol 29/85 (34.12%)
     prototype/Symbol.toPrimitive/prop-desc.js
     replace/cross-realm.js
     search/cross-realm.js
-    species 4/4 (100.0%)
+    species/cross-realm.js
+    species/subclassing.js
     split/cross-realm.js
     toPrimitive/cross-realm.js
     toStringTag/cross-realm.js
@@ -1673,7 +1643,7 @@ built-ins/ThrowTypeError 7/13 (53.85%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 992/1070 (92.71%)
+built-ins/TypedArray 979/1070 (91.5%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/iter-access-error.js
@@ -1791,8 +1761,8 @@ built-ins/TypedArray 992/1070 (92.71%)
     prototype/filter/arraylength-internal.js
     prototype/filter/callbackfn-arguments-with-thisarg.js
     prototype/filter/callbackfn-arguments-without-thisarg.js
-    prototype/filter/callbackfn-called-before-ctor.js {unsupported: [Symbol.species]}
-    prototype/filter/callbackfn-called-before-species.js {unsupported: [Symbol.species]}
+    prototype/filter/callbackfn-called-before-ctor.js
+    prototype/filter/callbackfn-called-before-species.js
     prototype/filter/callbackfn-detachbuffer.js
     prototype/filter/callbackfn-no-iteration-over-non-integer.js
     prototype/filter/callbackfn-not-called-on-empty.js
@@ -1812,16 +1782,13 @@ built-ins/TypedArray 992/1070 (92.71%)
     prototype/filter/speciesctor-get-ctor.js
     prototype/filter/speciesctor-get-ctor-abrupt.js
     prototype/filter/speciesctor-get-ctor-inherited.js
-    prototype/filter/speciesctor-get-species.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
-    prototype/filter/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/filter/speciesctor-get-species.js
+    prototype/filter/speciesctor-get-species-abrupt.js
+    prototype/filter/speciesctor-get-species-custom-ctor.js
+    prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/filter/speciesctor-get-species-custom-ctor-length.js
+    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/filter/speciesctor-get-species-use-default-ctor.js
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/filter/values-are-not-cached.js
@@ -1996,16 +1963,13 @@ built-ins/TypedArray 992/1070 (92.71%)
     prototype/map/speciesctor-get-ctor.js
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-ctor-inherited.js
-    prototype/map/speciesctor-get-species.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
-    prototype/map/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/map/speciesctor-get-species.js
+    prototype/map/speciesctor-get-species-abrupt.js
+    prototype/map/speciesctor-get-species-custom-ctor.js
+    prototype/map/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/map/speciesctor-get-species-custom-ctor-length.js
+    prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/map/speciesctor-get-species-use-default-ctor.js
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/map/values-are-not-cached.js
@@ -2102,11 +2066,8 @@ built-ins/TypedArray 992/1070 (92.71%)
     prototype/slice/arraylength-internal.js
     prototype/slice/bit-precision.js
     prototype/slice/detached-buffer.js
-    prototype/slice/detached-buffer-custom-ctor-other-targettype.js {unsupported: [Symbol.species]}
-    prototype/slice/detached-buffer-custom-ctor-same-targettype.js {unsupported: [Symbol.species]}
-    prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js {unsupported: [Symbol.species]}
-    prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js {unsupported: [Symbol.species]}
+    prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
+    prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
     prototype/slice/infinity.js
     prototype/slice/invoked-as-func.js
     prototype/slice/invoked-as-method.js
@@ -2120,20 +2081,17 @@ built-ins/TypedArray 992/1070 (92.71%)
     prototype/slice/results-with-same-length.js
     prototype/slice/return-abrupt-from-end.js
     prototype/slice/return-abrupt-from-start.js
-    prototype/slice/set-values-from-different-ctor-type.js {unsupported: [Symbol.species]}
+    prototype/slice/set-values-from-different-ctor-type.js
     prototype/slice/speciesctor-get-ctor.js
     prototype/slice/speciesctor-get-ctor-abrupt.js
     prototype/slice/speciesctor-get-ctor-inherited.js
-    prototype/slice/speciesctor-get-species.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor-length.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
-    prototype/slice/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/slice/speciesctor-get-species.js
+    prototype/slice/speciesctor-get-species-abrupt.js
+    prototype/slice/speciesctor-get-species-custom-ctor.js
+    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/slice/speciesctor-get-species-custom-ctor-length.js
+    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/slice/speciesctor-get-species-use-default-ctor.js
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/slice/tointeger-end.js
@@ -2192,14 +2150,13 @@ built-ins/TypedArray 992/1070 (92.71%)
     prototype/subarray/speciesctor-get-ctor-abrupt.js
     prototype/subarray/speciesctor-get-ctor-inherited.js
     prototype/subarray/speciesctor-get-ctor-returns-throws.js
-    prototype/subarray/speciesctor-get-species.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-abrupt.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-custom-ctor.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-custom-ctor-throws.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-returns-throws.js {unsupported: [Symbol.species]}
-    prototype/subarray/speciesctor-get-species-use-default-ctor.js {unsupported: [Symbol.species]}
+    prototype/subarray/speciesctor-get-species.js
+    prototype/subarray/speciesctor-get-species-abrupt.js
+    prototype/subarray/speciesctor-get-species-custom-ctor.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-throws.js
+    prototype/subarray/speciesctor-get-species-returns-throws.js
     prototype/subarray/this-is-not-object.js
     prototype/subarray/this-is-not-typedarray-instance.js
     prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
@@ -2233,7 +2190,7 @@ built-ins/TypedArray 992/1070 (92.71%)
     name.js
     prototype.js
 
-built-ins/TypedArrayConstructors 529/684 (77.34%)
+built-ins/TypedArrayConstructors 525/684 (76.75%)
     BigInt64Array/prototype 4/4 (100.0%)
     BigInt64Array 7/7 (100.0%)
     BigUint64Array/prototype 4/4 (100.0%)
@@ -2309,26 +2266,22 @@ built-ins/TypedArrayConstructors 529/684 (77.34%)
     ctors/object-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/object-arg/use-default-proto-if-custom-proto-is-not-object.js
     ctors/typedarray-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
-    ctors/typedarray-arg/detached-when-species-retrieved-different-type.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/detached-when-species-retrieved-same-type.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
+    ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
     ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
     ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-null.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-undefined.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
+    ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
     ctors/typedarray-arg/proto-from-ctor-realm.js {unsupported: [Reflect]}
     ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-null.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js {unsupported: [Symbol.species]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js {unsupported: [Symbol.species]}
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
+    ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
     ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
     ctors/typedarray-arg/src-typedarray-big-throws.js
     ctors/typedarray-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}


### PR DESCRIPTION
This PR does:

- add `[Symbol.species]` to various built-in objects, as required by the spec:
  - `Set` (spec [24.2.2.2](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species))
  - `Map` (spec [24.1.2.3](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species))
  - `Regex` (spec [22.2.5.2](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species))
  - `Array` (spec [23.1.2.5](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species))
- fixes a bug in the existing implementation for `Promise` (spec [27.2.4.9](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species))
- changes the test262 runner so that it does not consider `Symbol.species` an ignored feature; this in turn increases the feature coverage because some more tests pass.

Notice that this PR does _not_ implement the behavior of the symbol (spec [7.3.22](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-speciesconstructor)) - it just adds the symbol to some built-ins.