### PR TITLE
fix: toString() on generator

### DIFF
--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -64,13 +64,18 @@ public class Decompiler {
         return sourceTop;
     }
 
-    int markFunctionStart(int functionType) {
+    int markFunctionStart(int functionType, boolean isGenerator) {
         int savedOffset = getCurrentOffset();
         if (functionType != FunctionNode.ARROW_FUNCTION) {
             addToken(Token.FUNCTION);
+            if (isGenerator) addToken(Token.MUL);
             append((char) functionType);
         }
         return savedOffset;
+    }
+
+    int markFunctionStart(int functionType) {
+        return markFunctionStart(functionType, false);
     }
 
     int markFunctionEnd(int functionStart) {
@@ -340,7 +345,10 @@ public class Decompiler {
 
                 case Token.FUNCTION:
                     ++i; // skip function type
-                    result.append("function ");
+                    if (source.charAt(i) == Token.MUL) {
+                        result.append("function* ");
+                        ++i;
+                    } else result.append("function ");
                     break;
 
                 case FUNCTION_END:

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -615,7 +615,7 @@ public final class IRFactory {
 
     private Node transformFunction(FunctionNode fn) {
         int functionType = fn.getFunctionType();
-        int start = decompiler.markFunctionStart(functionType);
+        int start = decompiler.markFunctionStart(functionType, fn.isES6Generator());
         Node mexpr = decompileFunctionHeader(fn);
         int index = parser.currentScriptOrFn.addFunction(fn);
 

--- a/testsrc/jstests/harmony/generators-basic.js
+++ b/testsrc/jstests/harmony/generators-basic.js
@@ -162,4 +162,8 @@ r = g.next();
 assertEquals(undefined, r.value);
 assertTrue(r.done);
 
+// toString returns the correct value
+
+assertEquals("\nfunction* gen() {\n    for (var i = 0; i < 3; i++) {\n        yield i;\n    }\n}\n", gen.toString());
+
 "success";

--- a/testsrc/org/mozilla/javascript/tests/es5/GeneratorToStringTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es5/GeneratorToStringTest.java
@@ -1,0 +1,46 @@
+package org.mozilla.javascript.tests.es5;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.tests.Utils;
+
+public class GeneratorToStringTest {
+    private Context cx;
+
+    @Before
+    public void setUp() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+    }
+
+    @After
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void generatorsTest() {
+        String code = "  function* f() {\n" + "    yield 1;\n" + "  }; f.toString();";
+        test("\n" + "function* f() {\n" + "    yield 1;\n" + "}\n", code);
+    }
+
+    private static void test(Object expected, String js) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    ScriptableObject scope = new TopLevel();
+                    cx.initStandardObjects(scope);
+
+                    Object result = cx.evaluateString(scope, js, "test", 1, null);
+                    assertEquals(expected, result);
+
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
`toString()` on a generator misses the `*`. This change adds that to the encodedSource.

For example,
```javascript
  function* f() {
    yield 1;
  }; f.toString();
```

returns,

Before:
```
  function f() {
    yield 1;
  }
```

After:
```javascript
  function* f() {
    yield 1;
  }
```