### PR TITLE
Fixed handling of unicode characters in the lexer

### DIFF
--- a/testsrc/org/mozilla/javascript/tests/ParserTest.java
+++ b/testsrc/org/mozilla/javascript/tests/ParserTest.java
@@ -1201,6 +1201,24 @@ public class ParserTest {
     }
 
     @Test
+    public void testParseUnicodeMultibyteCharacter() {
+        AstRoot root = parse("\uD842\uDFB7");
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
+        assertEquals("𠮷", first.getString());
+    }
+
+    @Test
+    public void testParseUnicodeIdentifierPartWhichIsNotJavaIdentifierPart() {
+        // On the JDK 11 I'm using, Character.isUnicodeIdentifierPart(U+9FEB) returns true
+        // but Character.isJavaIdentifierPart(U+9FEB) returns false. On a JDK 17 results
+        // seem to vary, but I think it's enough to verify that TokenStream uses
+        // the unicode methods and not the java methods.
+        AstRoot root = parse("a\u9FEB");
+        AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
+        assertEquals("a鿫", first.getString());
+    }
+
+    @Test
     public void parseUnicodeReservedKeywords1() {
         AstRoot root = parse("\\u0069\\u0066");
         AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -5027,7 +5027,41 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 4/188 (2.13%)
+language/identifiers 38/188 (20.21%)
+    other_id_continue.js
+    other_id_continue-escaped.js
+    other_id_start.js
+    other_id_start-escaped.js
+    part-unicode-10.0.0.js
+    part-unicode-10.0.0-escaped.js
+    part-unicode-11.0.0.js
+    part-unicode-11.0.0-escaped.js
+    part-unicode-12.0.0.js
+    part-unicode-12.0.0-escaped.js
+    part-unicode-13.0.0.js
+    part-unicode-13.0.0-escaped.js
+    part-unicode-5.2.0.js
+    part-unicode-5.2.0-escaped.js
+    part-unicode-7.0.0.js
+    part-unicode-7.0.0-escaped.js
+    part-unicode-8.0.0.js
+    part-unicode-8.0.0-escaped.js
+    part-unicode-9.0.0.js
+    part-unicode-9.0.0-escaped.js
+    start-unicode-10.0.0.js
+    start-unicode-10.0.0-escaped.js
+    start-unicode-11.0.0.js
+    start-unicode-11.0.0-escaped.js
+    start-unicode-12.0.0.js
+    start-unicode-12.0.0-escaped.js
+    start-unicode-13.0.0.js
+    start-unicode-13.0.0-escaped.js
+    start-unicode-7.0.0.js
+    start-unicode-7.0.0-escaped.js
+    start-unicode-8.0.0.js
+    start-unicode-8.0.0-escaped.js
+    start-unicode-9.0.0.js
+    start-unicode-9.0.0-escaped.js
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js

--- a/testsrc/test262.properties
+++ b/testsrc/test262.properties
@@ -5027,48 +5027,7 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 45/188 (23.94%)
-    other_id_continue.js
-    other_id_continue-escaped.js
-    other_id_start.js
-    other_id_start-escaped.js
-    part-unicode-10.0.0.js
-    part-unicode-10.0.0-escaped.js
-    part-unicode-11.0.0.js
-    part-unicode-11.0.0-escaped.js
-    part-unicode-12.0.0.js
-    part-unicode-12.0.0-escaped.js
-    part-unicode-13.0.0.js
-    part-unicode-13.0.0-escaped.js
-    part-unicode-5.2.0.js
-    part-unicode-5.2.0-escaped.js
-    part-unicode-6.0.0.js
-    part-unicode-6.1.0.js
-    part-unicode-7.0.0.js
-    part-unicode-7.0.0-escaped.js
-    part-unicode-8.0.0.js
-    part-unicode-8.0.0-escaped.js
-    part-unicode-9.0.0.js
-    part-unicode-9.0.0-escaped.js
-    start-unicode-10.0.0.js
-    start-unicode-10.0.0-escaped.js
-    start-unicode-11.0.0.js
-    start-unicode-11.0.0-escaped.js
-    start-unicode-12.0.0.js
-    start-unicode-12.0.0-escaped.js
-    start-unicode-13.0.0.js
-    start-unicode-13.0.0-escaped.js
-    start-unicode-5.2.0.js
-    start-unicode-5.2.0-escaped.js
-    start-unicode-6.0.0.js
-    start-unicode-6.1.0.js
-    start-unicode-6.1.0-escaped.js
-    start-unicode-7.0.0.js
-    start-unicode-7.0.0-escaped.js
-    start-unicode-8.0.0.js
-    start-unicode-8.0.0-escaped.js
-    start-unicode-9.0.0.js
-    start-unicode-9.0.0-escaped.js
+language/identifiers 4/188 (2.13%)
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js


### PR DESCRIPTION
The lexer was not handling correctly surrogate pairs. References:
- https://tc39.es/ecma262/#prod-IdentifierName
- https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF