### PR TITLE
a bit cleanup for the PR

### DIFF
--- a/src/org/mozilla/javascript/Decompiler.java
+++ b/src/org/mozilla/javascript/Decompiler.java
@@ -74,6 +74,8 @@ public class Decompiler {
         return savedOffset;
     }
 
+    /** @deprecated use {@link #markFunctionStart(int, boolean)} instead */
+    @Deprecated
     int markFunctionStart(int functionType) {
         return markFunctionStart(functionType, false);
     }

--- a/src/org/mozilla/javascript/IRFactory.java
+++ b/src/org/mozilla/javascript/IRFactory.java
@@ -687,7 +687,7 @@ public final class IRFactory {
         fn.setRequiresActivation();
 
         int functionType = fn.getFunctionType();
-        int start = decompiler.markFunctionStart(functionType);
+        int start = decompiler.markFunctionStart(functionType, false);
         Node mexpr = decompileFunctionHeader(fn);
         int index = parser.currentScriptOrFn.addFunction(fn);
 

--- a/testsrc/jstests/harmony/generators-basic.js
+++ b/testsrc/jstests/harmony/generators-basic.js
@@ -163,7 +163,6 @@ assertEquals(undefined, r.value);
 assertTrue(r.done);
 
 // toString returns the correct value
-
 assertEquals("\nfunction* gen() {\n    for (var i = 0; i < 3; i++) {\n        yield i;\n    }\n}\n", gen.toString());
 
 "success";


### PR DESCRIPTION
make the old function markFunctionStart(int) deprecated and do not use the old stuff internally