### PR TITLE
Fixed deadlock when sealing objects with a LazyCtor

### DIFF
--- a/testsrc/org/mozilla/javascript/ThreadSafeScriptableObjectTest.java
+++ b/testsrc/org/mozilla/javascript/ThreadSafeScriptableObjectTest.java
@@ -1,0 +1,30 @@
+package org.mozilla.javascript;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class ThreadSafeScriptableObjectTest {
+    @Test
+    public void canSealGlobalObjectWithoutDeadlock() {
+        ContextFactory.getGlobalSetter()
+                .setContextFactoryGlobal(
+                        new ContextFactory() {
+                            @Override
+                            protected boolean hasFeature(Context cx, int featureIndex) {
+                                if (featureIndex == Context.FEATURE_THREAD_SAFE_OBJECTS) {
+                                    return true;
+                                }
+                                return super.hasFeature(cx, featureIndex);
+                            }
+                        });
+
+        try (Context cx = Context.enter()) {
+            ScriptableObject global = cx.initStandardObjects();
+            global.sealObject();
+
+            // Registered by NativeJavaTopPackage
+            assertNotNull(global.get("Packages", global));
+        }
+    }
+}


### PR DESCRIPTION
The reason is that ScriptableObject::sealObject will initialize eagerly any LazyLoadedCtor that are stored in the slot map - it needs to that because some of those will actually mutate the object (such as NativeJavaTopPackage), and that cannot work if the object is already sealed. However, it will also acquire a read lock on the slot map before iterating on it. But the mutations will try to acquire a write lock, causing a deadlock with just one thread.

This change fixes it by not holding the read lock while mutating, and also avoids marking the object as sealed until it is certainly correct to do so.