### PR TITLE
Change root project name to "rhino-root"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-rootProject.name=rhino
+rootProject.name=rhino-root
 group=org.mozilla
 version=1.7.16-SNAPSHOT
 mavenSnapshotRepo=https://oss.sonatype.org/content/repositories/snapshots

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'rhino'
+rootProject.name = 'rhino-root'
 include 'rhino', 'rhino-engine', 'rhino-tools', 'rhino-xml', 'rhino-all', 'examples', 'tests', 'benchmarks'


### PR DESCRIPTION
VS Code (and maybe other IDEs) get very confused when the root project name matches the name of one of the subprojects. Name the root project "rhino-root" to avoid this conflict.