### PR TITLE
Add Byte to list of java Numbers

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
@@ -57,6 +57,7 @@ public class WrapFactory {
             if (obj instanceof String
                     || obj instanceof Boolean
                     || obj instanceof Integer
+                    || obj instanceof Byte
                     || obj instanceof Short
                     || obj instanceof Long
                     || obj instanceof Float

--- a/rhino/src/test/java/org/mozilla/javascript/tests/WrapFactoryTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/WrapFactoryTest.java
@@ -23,6 +23,7 @@ public class WrapFactoryTest {
         test(true, Boolean.FALSE, "boolean", "object", "object");
         test(true, Integer.valueOf(1), "number", "object", "object");
         test(true, Long.valueOf(2L), "number", "object", "object");
+        test(true, Byte.valueOf((byte) 5), "number", "object", "object");
         test(true, new BigInteger("3"), "bigint", "object", "object");
         test(true, new BigDecimal("4.0"), "number", "object", "object");
     }
@@ -34,6 +35,7 @@ public class WrapFactoryTest {
         test(false, Boolean.FALSE, "boolean", "boolean", "boolean");
         test(false, Integer.valueOf(1), "number", "number", "number");
         test(false, Long.valueOf(2L), "number", "number", "number");
+        test(false, Byte.valueOf((byte) 5), "number", "number", "number");
 
         test(false, new BigInteger("30"), "bigint", "bigint", "bigint");
 


### PR DESCRIPTION
I think it was just an oversight that `Byte` was missing from the list. Originally, it applied to all java.lang.Numbers.


