### PR TITLE
Implement computed properties

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1153,19 +1153,21 @@ class CodeGenerator extends Icode {
     }
 
     private void visitObjectLiteral(Node node, Node child) {
-	    Object[] propertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
-	    Object[] computedPropertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_COMPUTED_PROP);
-	    int count = propertyIds == null ? 0 : propertyIds.length;
-        boolean hasAnyComputedProperty = computedPropertyIds != null && Arrays.stream(computedPropertyIds).anyMatch(Objects::nonNull);
+        Object[] propertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
+        Object[] computedPropertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_COMPUTED_PROP);
+        int count = propertyIds == null ? 0 : propertyIds.length;
+        boolean hasAnyComputedProperty =
+                computedPropertyIds != null
+                        && Arrays.stream(computedPropertyIds).anyMatch(Objects::nonNull);
 
         int nextLiteralIndex = literalIds.size();
         literalIds.add(propertyIds);
-        
+
         addIndexOp(Icode_LITERAL_KEYS, nextLiteralIndex);
         addUint8(hasAnyComputedProperty ? 1 : 0);
         addIndexOp(Icode_LITERAL_NEW, count);
         stackChange(3);
-        
+
         int i = 0;
         while (child != null) {
             // Computed key
@@ -1183,7 +1185,7 @@ class CodeGenerator extends Icode {
             child = child.getNext();
             i++;
         }
-        
+
         addToken(Token.OBJECTLIT);
 
         stackChange(-2);

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2524,6 +2524,9 @@ public final class IRFactory {
             case Token.THIS:
                 decompiler.addToken(node.getType());
                 break;
+            case Token.COMPUTED_PROPERTY:
+                parser.reportError("msg.bad.computed.property.in.destruct");
+                break;
             default:
                 Kit.codeBug("unexpected token: " + Token.typeToName(node.getType()));
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Icode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Icode.java
@@ -143,9 +143,11 @@ abstract class Icode {
 
             // Call to GetTemplateLiteralCallSite
             Icode_TEMPLATE_LITERAL_CALLSITE = -74,
+            Icode_LITERAL_KEYS = -75,
+            Icode_LITERAL_KEY_SET = -76,
 
             // Last icode
-            MIN_ICODE = -74;
+            MIN_ICODE = -76;
 
     static String bytecodeName(int bytecode) {
         if (!validBytecode(bytecode)) {
@@ -309,6 +311,10 @@ abstract class Icode {
                 return "LOAD_BIGINT4";
             case Icode_TEMPLATE_LITERAL_CALLSITE:
                 return "TEMPLATE_LITERAL_CALLSITE";
+            case Icode_LITERAL_KEYS:
+                return "LITERAL_KEYS";
+            case Icode_LITERAL_KEY_SET:
+                return "LITERAL_KEY_SET";
         }
 
         // icode without name

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2292,19 +2292,17 @@ public final class Interpreter extends Icode implements Evaluator {
                                     if (key == DBL_MRK)
                                         key = ScriptRuntime.wrapNumber(sDbl[stackTop]);
                                     --stackTop;
-                                    Object[] ids = (Object[]) stack[stackTop];
+                                    Object[] ids = (Object[]) stack[stackTop - 2];
                                     ids[indexReg] = key;
                                     continue Loop;
                                 }
-
                             case Token.OBJECTLIT:
                                 {
-                                    Object[] ids = (Object[]) stack[stackTop];
-                                    --stackTop;
                                     Object[] data = (Object[]) stack[stackTop];
                                     --stackTop;
                                     int[] getterSetters = (int[]) stack[stackTop];
-                                    Object val =
+    --stackTop;
+                                    Object[] ids = (Object[]) stack[stackTop];                                Object val =
                                             ScriptRuntime.newObjectLiteral(
                                                     ids, data, getterSetters, cx, frame.scope);
                                     stack[stackTop] = val;

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2301,8 +2301,9 @@ public final class Interpreter extends Icode implements Evaluator {
                                     Object[] data = (Object[]) stack[stackTop];
                                     --stackTop;
                                     int[] getterSetters = (int[]) stack[stackTop];
-    --stackTop;
-                                    Object[] ids = (Object[]) stack[stackTop];                                Object val =
+                                    --stackTop;
+                                    Object[] ids = (Object[]) stack[stackTop];
+                                    Object val =
                                             ScriptRuntime.newObjectLiteral(
                                                     ids, data, getterSetters, cx, frame.scope);
                                     stack[stackTop] = val;

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -575,7 +575,13 @@ public final class Interpreter extends Icode implements Evaluator {
                 case Token.REGEXP:
                     out.println(tname + " " + idata.itsRegExpLiterals[indexReg]);
                     break;
-                case Token.OBJECTLIT:
+                case Icode_LITERAL_KEYS:
+                    {
+                        boolean copyArray = iCode[pc++] != 0;
+                        Object[] keys = (Object[]) idata.literalIds[indexReg];
+                        out.println(tname + " " + Arrays.toString(keys) + " " + copyArray);
+                        break;
+                    }
                 case Icode_SPARE_ARRAYLIT:
                     out.println(tname + " " + idata.literalIds[indexReg]);
                     break;

--- a/rhino/src/main/java/org/mozilla/javascript/Node.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Node.java
@@ -64,7 +64,8 @@ public class Node implements Iterable<Node> {
             ARROW_FUNCTION_PROP = 27,
             TEMPLATE_LITERAL_PROP = 28,
             TRAILING_COMMA = 29,
-            LAST_PROP = 29;
+            OBJECT_IDS_COMPUTED_PROP = 30,
+            LAST_PROP = 30;
 
     // values of ISNUMBER_PROP to specify
     // which of the children are Number types
@@ -432,6 +433,8 @@ public class Node implements Iterable<Node> {
                     return "template_literal";
                 case TRAILING_COMMA:
                     return "trailing comma";
+                case OBJECT_IDS_COMPUTED_PROP:
+                    return "object_ids_computed_prop";
 
                 default:
                     Kit.codeBug();

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4154,6 +4154,9 @@ public class Parser {
             } else if (id instanceof NumberLiteral) {
                 Node s = createNumber((int) ((NumberLiteral) id).getNumber());
                 rightElem = new Node(Token.GETELEM, createName(tempName), s);
+            } else if (id instanceof ComputedPropertyKey) {
+                reportError("msg.bad.computed.property.in.destruct");
+                return false;
             } else {
                 throw codeBug();
             }

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -3645,7 +3645,6 @@ public class Parser {
                 if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
                     int pos = ts.tokenBeg;
                     int lineno = ts.lineno;
-                    int col = ts.tokenBeg;
                     nextToken();
                     AstNode expr = assignExpr();
                     if (peekToken() != Token.RB) {

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -25,6 +25,7 @@ import org.mozilla.javascript.ast.Block;
 import org.mozilla.javascript.ast.BreakStatement;
 import org.mozilla.javascript.ast.CatchClause;
 import org.mozilla.javascript.ast.Comment;
+import org.mozilla.javascript.ast.ComputedPropertyKey;
 import org.mozilla.javascript.ast.ConditionalExpression;
 import org.mozilla.javascript.ast.ContinueStatement;
 import org.mozilla.javascript.ast.DestructuringForm;
@@ -3636,6 +3637,27 @@ public class Parser {
             case Token.NUMBER:
             case Token.BIGINT:
                 pname = createNumericLiteral(tt, true);
+                break;
+
+            case Token.LB:
+                if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
+                    int pos = ts.tokenBeg;
+                    int lineno = ts.lineno;
+                    int col = ts.tokenBeg;
+                    nextToken();
+                    AstNode expr = assignExpr();
+                    if (peekToken() != Token.RB) {
+                        reportError("msg.bad.prop");
+                    }
+                    nextToken();
+
+                    pname = new ComputedPropertyKey(pos, ts.tokenEnd - pos);
+                    pname.setLineno(lineno);
+                    ((ComputedPropertyKey) pname).setExpression(expr);
+                } else {
+                    reportError("msg.bad.prop");
+                    return null;
+                }
                 break;
 
             default:

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -3576,7 +3576,9 @@ public class Parser {
                 }
             }
 
-            if (this.inUseStrictDirective && propertyName != null && !(pname instanceof ComputedPropertyKey)) {
+            if (this.inUseStrictDirective
+                    && propertyName != null
+                    && !(pname instanceof ComputedPropertyKey)) {
                 switch (entryKind) {
                     case PROP_ENTRY:
                     case METHOD_ENTRY:

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -3576,7 +3576,7 @@ public class Parser {
                 }
             }
 
-            if (this.inUseStrictDirective && propertyName != null) {
+            if (this.inUseStrictDirective && propertyName != null && !(pname instanceof ComputedPropertyKey)) {
                 switch (entryKind) {
                     case PROP_ENTRY:
                     case METHOD_ENTRY:

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4518,23 +4518,23 @@ public class ScriptRuntime {
                     int index = ((Integer) id).intValue();
                     object.put(index, object, value);
                 } else {
-                    String stringId = ScriptRuntime.toString(id);
-                    if (isSpecialProperty(stringId)) {
-                        Ref ref = specialRef(object, stringId, cx, scope);
+                    StringIdOrIndex s = toStringIdOrIndex(id);
+                    if (s.stringId == null) {
+                        object.put(s.index, object, value);
+                    } else if (isSpecialProperty(s.stringId)) {
+                        Ref ref = specialRef(object, s.stringId, cx, scope);
                         ref.set(cx, scope, value);
                     } else {
-                        object.put(stringId, object, value);
+                        object.put(s.stringId, object, value);
                     }
                 }
             } else {
                 ScriptableObject so = (ScriptableObject) object;
                 Callable getterOrSetter = (Callable) value;
                 boolean isSetter = getterSetter == 1;
-                // XXX: Do we have to handle Symbol here.
-                // This will be required, when conputedprops are supported.
-                String key = id instanceof String ? (String) id : null;
-                int index = key == null ? ((Integer) id).intValue() : 0;
-                so.setGetterOrSetter(key, index, getterOrSetter, isSetter);
+                Integer index = id instanceof Integer ? (Integer) id : null;
+                String key = index == null ? ScriptRuntime.toString(id) : null;
+                so.setGetterOrSetter(key, index == null ? 0 : index, getterOrSetter, isSetter);
             }
         }
         return object;

--- a/rhino/src/main/java/org/mozilla/javascript/Token.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Token.java
@@ -510,6 +510,8 @@ public class Token {
                 return "RESERVED";
             case EMPTY:
                 return "EMPTY";
+            case COMPUTED_PROPERTY:
+                return "COMPUTED_PROPERTY";
             case BLOCK:
                 return "BLOCK";
             case LABEL:

--- a/rhino/src/main/java/org/mozilla/javascript/Token.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Token.java
@@ -175,58 +175,59 @@ public class Token {
             VOID = 130, // void keyword
             RESERVED = 131, // reserved keywords
             EMPTY = 132,
+            COMPUTED_PROPERTY = 133, // computed property in object initializer [x]
 
             /* types used for the parse tree - these never get returned
              * by the scanner.
              */
 
-            BLOCK = 133, // statement block
-            LABEL = 134, // label
-            TARGET = 135,
-            LOOP = 136,
-            EXPR_VOID = 137, // expression statement in functions
-            EXPR_RESULT = 138, // expression statement in scripts
-            JSR = 139,
-            SCRIPT = 140, // top-level node for entire script
-            TYPEOFNAME = 141, // for typeof(simple-name)
-            USE_STACK = 142,
-            SETPROP_OP = 143, // x.y op= something
-            SETELEM_OP = 144, // x[y] op= something
-            LOCAL_BLOCK = 145,
-            SET_REF_OP = 146, // *reference op= something
+            BLOCK = 134, // statement block
+            LABEL = 135, // label
+            TARGET = 136,
+            LOOP = 137,
+            EXPR_VOID = 138, // expression statement in functions
+            EXPR_RESULT = 139, // expression statement in scripts
+            JSR = 140,
+            SCRIPT = 141, // top-level node for entire script
+            TYPEOFNAME = 142, // for typeof(simple-name)
+            USE_STACK = 143,
+            SETPROP_OP = 144, // x.y op= something
+            SETELEM_OP = 145, // x[y] op= something
+            LOCAL_BLOCK = 146,
+            SET_REF_OP = 147, // *reference op= something
 
             // For XML support:
-            DOTDOT = 147, // member operator (..)
-            COLONCOLON = 148, // namespace::name
-            XML = 149, // XML type
-            DOTQUERY = 150, // .() -- e.g., x.emps.emp.(name == "terry")
-            XMLATTR = 151, // @
-            XMLEND = 152,
+            DOTDOT = 148, // member operator (..)
+            COLONCOLON = 149, // namespace::name
+            XML = 150, // XML type
+            DOTQUERY = 151, // .() -- e.g., x.emps.emp.(name == "terry")
+            XMLATTR = 152, // @
+            XMLEND = 153,
 
             // Optimizer-only-tokens
-            TO_OBJECT = 153,
-            TO_DOUBLE = 154,
-            GET = 155, // JS 1.5 get pseudo keyword
-            SET = 156, // JS 1.5 set pseudo keyword
-            LET = 157, // JS 1.7 let pseudo keyword
-            CONST = 158,
-            SETCONST = 159,
-            SETCONSTVAR = 160,
-            ARRAYCOMP = 161, // array comprehension
-            LETEXPR = 162,
-            WITHEXPR = 163,
-            DEBUGGER = 164,
-            COMMENT = 165,
-            GENEXPR = 166,
-            METHOD = 167, // ES6 MethodDefinition
-            ARROW = 168, // ES6 ArrowFunction
-            YIELD_STAR = 169, // ES6 "yield *", a specialization of yield
-            TEMPLATE_LITERAL = 170, // template literal
-            TEMPLATE_CHARS = 171, // template literal - literal section
-            TEMPLATE_LITERAL_SUBST = 172, // template literal - substitution
-            TAGGED_TEMPLATE_LITERAL = 173, // template literal - tagged/handler
-            DOTDOTDOT = 174, // spread/rest ...
-            LAST_TOKEN = 174;
+            TO_OBJECT = 154,
+            TO_DOUBLE = 155,
+            GET = 156, // JS 1.5 get pseudo keyword
+            SET = 157, // JS 1.5 set pseudo keyword
+            LET = 158, // JS 1.7 let pseudo keyword
+            CONST = 159,
+            SETCONST = 160,
+            SETCONSTVAR = 161,
+            ARRAYCOMP = 162, // array comprehension
+            LETEXPR = 163,
+            WITHEXPR = 164,
+            DEBUGGER = 165,
+            COMMENT = 166,
+            GENEXPR = 167,
+            METHOD = 168, // ES6 MethodDefinition
+            ARROW = 169, // ES6 ArrowFunction
+            YIELD_STAR = 170, // ES6 "yield *", a specialization of yield
+            TEMPLATE_LITERAL = 171, // template literal
+            TEMPLATE_CHARS = 172, // template literal - literal section
+            TEMPLATE_LITERAL_SUBST = 173, // template literal - substitution
+            TAGGED_TEMPLATE_LITERAL = 174, // template literal - tagged/handler
+            DOTDOTDOT = 175, // spread/rest ...
+            LAST_TOKEN = 175;
 
     /**
      * Returns a name for the token. If Rhino is compiled with certain hardcoded debugging flags in

--- a/rhino/src/main/java/org/mozilla/javascript/ast/ComputedPropertyKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/ComputedPropertyKey.java
@@ -1,0 +1,56 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import org.mozilla.javascript.Token;
+
+/** AST node for a computed property key, i.e. `[ Expression ]` in an object literal. */
+public class ComputedPropertyKey extends AstNode {
+
+    private AstNode expression;
+
+    {
+        type = Token.COMPUTED_PROPERTY;
+    }
+
+    public ComputedPropertyKey(int pos, int len) {
+        super(pos, len);
+    }
+
+    public AstNode getExpression() {
+        return expression;
+    }
+
+    public void setExpression(AstNode expression) {
+        assertNotNull(expression);
+        this.expression = expression;
+        expression.setParent(this);
+    }
+
+    @Override
+    public boolean hasSideEffects() {
+        if (expression == null) codeBug();
+        return expression.hasSideEffects();
+    }
+
+    @Override
+    public String toSource(int depth) {
+        return new StringBuilder(makeIndent(depth))
+                .append('[')
+                .append(expression.toSource(depth))
+                .append(']')
+                .toString();
+    }
+
+    /** Visits this node, then the expression. */
+    @Override
+    public void visit(NodeVisitor v) {
+        if (v.visit(this)) {
+            expression.visit(v);
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -2084,8 +2084,8 @@ class BodyCodegen {
     }
 
     /** load two arrays with property ids and values */
-    private void addLoadProperty(Node node, Node child,
-            Object[] properties, Object[] computedProperties, int count) {
+    private void addLoadProperty(
+            Node node, Node child, Object[] properties, Object[] computedProperties, int count) {
         if (count == 0) {
             addNewObjectArray(0);
             addNewObjectArray(0);
@@ -2119,16 +2119,16 @@ class BodyCodegen {
             for (int i = count - 1; i >= 0; --i) {
 
                 // Stack: [k0, v0, ..., ki, vi]
-                cfw.addALoad(valuesArrayLocal); // Stack: [k0, v0, ..., ki, vi, values_array]
-                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., ki, values_array, vi]
-                cfw.addLoadConstant(i); // Stack: [k0, v0, ..., ki, values_array, vi, i]
-                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., ki, values_array, i, vi]
+                cfw.addALoad(valuesArrayLocal); // Stack: [k0, v0, ..., ki, vi, values]
+                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., ki, values, vi]
+                cfw.addLoadConstant(i); // Stack: [k0, v0, ..., ki, values, vi, i]
+                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., ki, values, i, vi]
                 cfw.add(ByteCode.AASTORE); // Stack: [k0, v0, ..., ki]
 
-                cfw.addALoad(keysArrayLocal); // Stack: [k0, v0, ..., ki, keys_array]
-                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., keys_array, ki]
-                cfw.addLoadConstant(i); // Stack: [k0, v0, ..., keys_array, ki, i]
-                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., keys_array, ki, i]
+                cfw.addALoad(keysArrayLocal); // Stack: [k0, v0, ..., ki, keys]
+                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., keys, ki]
+                cfw.addLoadConstant(i); // Stack: [k0, v0, ..., keys, ki, i]
+                cfw.add(ByteCode.SWAP); // Stack: [k0, v0, ..., keys, ki, i]
                 cfw.add(ByteCode.AASTORE); // Stack: [k0, v0, ...]
             }
 
@@ -2137,23 +2137,27 @@ class BodyCodegen {
         } else {
             // Simpler bytecode in the normal case (no generator, and thus no "yield" in the middle)
 
-            addNewObjectArray(count); // Stack: [values_array]
-            addNewObjectArray(count); // Stack: [values_array, keys_array]
+            addNewObjectArray(count); // Stack: [values]
+            addNewObjectArray(count); // Stack: [values, keys]
 
             for (int i = 0; i < count; ++i) {
-                cfw.add(ByteCode.DUP2); // Stack: [values_array, keys_array, values_array, keys_array]
-                cfw.addLoadConstant(i); // Stack: [values_array, keys_array, values_array, keys_array, i]
-                addLoadPropertyId(node, properties, computedProperties, i); // Stack: [values_array, keys_array, values_array, keys_array, i, Ki]
-                cfw.add(ByteCode.AASTORE); // Stack: [values_array, keys_array, values_array]
+                cfw.add(ByteCode.DUP2); // Stack: [values, keys, values, keys]
+                cfw.addLoadConstant(i); // Stack: [values, keys, values, keys, i]
+                addLoadPropertyId(
+                        node,
+                        properties,
+                        computedProperties,
+                        i); // Stack: [values, keys, values, keys, i, Ki]
+                cfw.add(ByteCode.AASTORE); // Stack: [values, keys, values]
 
-                cfw.addLoadConstant(i); // Stack: [values_array, keys_array, values_array, i]
-                addLoadPropertyValue(node, child); // Stack: [values_array, keys_array, values_array, i, Vi]
-                cfw.add(ByteCode.AASTORE); // Stack: [values_array, keys_array]
+                cfw.addLoadConstant(i); // Stack: [values, keys, values, i]
+                addLoadPropertyValue(node, child); // Stack: [values, keys, values, i, Vi]
+                cfw.add(ByteCode.AASTORE); // Stack: [values, keys]
 
                 child = child.getNext();
             }
 
-            cfw.add(ByteCode.SWAP); // Caller expect to have [keys_array, values_array]
+            cfw.add(ByteCode.SWAP); // Caller expect to have [keys, values]
         }
     }
 
@@ -2166,7 +2170,8 @@ class BodyCodegen {
         }
     }
 
-    private void addLoadPropertyId(Node node, Object[] properties, Object[] computedProperties, int i) {
+    private void addLoadPropertyId(
+            Node node, Object[] properties, Object[] computedProperties, int i) {
         Object computedPropertyId = computedProperties != null ? computedProperties[i] : null;
         if (computedPropertyId != null) {
             // Will be a node of type Token.COMPUTED_PROPERTY wrapping the actual expression
@@ -2216,7 +2221,7 @@ class BodyCodegen {
                             + ")Lorg/mozilla/javascript/Scriptable;");
             return;
         }
-        
+
         addLoadProperty(node, child, properties, computedProperties, count);
 
         // check if object literal actually has any getters or setters

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -100,6 +100,9 @@ msg.mult.index =\
 msg.bad.for.in.destruct =\
     Left hand side of for..in loop must be an array of length 2 to accept \
     key/value pair.
+
+msg.bad.computed.property.in.destruct =\
+    Unsupported computed property in destructuring.
     
 msg.cant.convert =\
     Can''t convert to type "{0}".

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.ScriptableObject;
+
+public class ComputedPropertiesTest {
+    @Test
+    public void objectWithComputedPropertiesWorkInInterpretedMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(-1);
+            assertObjectWithMixedPropertiesWorks(cx);
+        }
+    }
+
+    @Test
+    public void objectWithComputedPropertiesWorkInCompiledMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(0);
+            assertObjectWithMixedPropertiesWorks(cx);
+        }
+    }
+
+    @Test
+    public void objectWithComputedPropertiesWorkInOptimizedMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(9);
+            assertObjectWithMixedPropertiesWorks(cx);
+        }
+    }
+
+    private static void assertObjectWithMixedPropertiesWorks(Context cx) {
+        String script =
+                "\n"
+                        + "function f(x) { return x; }\n"
+                        + "\n"
+                        + "var o = {\n"
+                        + "  a: 1,\n"
+                        + "  0: 2,\n"
+                        + "  [1]: 3\n,"
+                        + "  [f('b')]: 4\n"
+                        + "};\n"
+                        + "o.a + o[0] + o['1'] + o.b";
+
+        ScriptableObject scope = cx.initStandardObjects();
+        Object value = cx.evaluateString(scope, script, "test", 1, null);
+        assertTrue(value instanceof Number);
+        assertEquals(10, ((Number) value).intValue());
+    }
+
+    @Test
+    public void canCoerceFunctionToStringInInterpretedMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(-1);
+            assertCanCoerceFunctionWithComputedPropertiesToString(cx);
+        }
+    }
+
+    @Test
+    public void canCoerceFunctionToStringInCompiledMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(0);
+            assertCanCoerceFunctionWithComputedPropertiesToString(cx);
+        }
+    }
+
+    private static void assertCanCoerceFunctionWithComputedPropertiesToString(Context cx) {
+        String script =
+                "\n"
+                        + "function f(x) {\n"
+                        + "  var o = {\n"
+                        + "    1: true,\n"
+                        + "    [2]: false,\n"
+                        + "    [g(x)]: 3\n"
+                        + "  };\n"
+                        + "}\n"
+                        + "f.toString()";
+
+        ScriptableObject scope = cx.initStandardObjects();
+        Object value = cx.evaluateString(scope, script, "test", 1, null);
+        assertTrue(value instanceof String);
+        assertEquals(
+                "\nfunction f(x) {\n" + "    var o = {1: true, [2]: false, [g(x)]: 3};\n" + "}\n",
+                value);
+    }
+
+    @Test
+    public void cannotParseInvalidUnclosedBracket() {
+        String script = "o = { [3 : 2 }";
+
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            EvaluatorException ex =
+                    assertThrows(
+                            EvaluatorException.class,
+                            () -> cx.compileString(script, "test", 1, null));
+            assertEquals("invalid property id (test#1)", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void notSupportedUnderVersionLesserThanEsLatest() {
+        String script = "o = { [1] : 2 }";
+
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_1_8);
+            EvaluatorException ex =
+                    assertThrows(
+                            EvaluatorException.class,
+                            () -> cx.compileString(script, "test", 1, null));
+            assertEquals("invalid property id (test#1)", ex.getMessage());
+        }
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
@@ -246,4 +246,30 @@ public class ComputedPropertiesTest {
             assertEquals("invalid property id (test#1)", ex.getMessage());
         }
     }
+
+    @Test
+    public void unsupportedInDestructuringInFunctionArguments() {
+        String script = "function({ [a]: b }) {};";
+        assertComputedPropertiesAreUnsupportedInDestructuring(
+                script, "Unsupported computed property in destructuring. (test#1)");
+    }
+
+    @Test
+    public void unsupportedInDestructuringInVariableDeclaration() {
+        String script = "var { [a]: b } = {};";
+        assertComputedPropertiesAreUnsupportedInDestructuring(
+                script, "Unsupported computed property in destructuring.");
+    }
+
+    private void assertComputedPropertiesAreUnsupportedInDestructuring(
+            String script, String message) {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            EvaluatorException ex =
+                    assertThrows(
+                            EvaluatorException.class,
+                            () -> cx.compileString(script, "test", 1, null));
+            assertEquals(message, ex.getMessage());
+        }
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
@@ -42,16 +42,17 @@ public class ComputedPropertiesTest {
     }
 
     private static void assertObjectWithMixedPropertiesWorks(Context cx) {
-        String script = "\n" +
-                "function f(x) { return x; }\n" +
-                "\n" +
-                "var o = {\n" +
-                "  a: 1,\n" +
-                "  0: 2,\n" +
-                "  [1]: 3\n," +
-                "  [f('b')]: 4\n" +
-                "};\n" +
-                "o.a + o[0] + o['1'] + o.b";
+        String script =
+                "\n"
+                        + "function f(x) { return x; }\n"
+                        + "\n"
+                        + "var o = {\n"
+                        + "  a: 1,\n"
+                        + "  0: 2,\n"
+                        + "  [1]: 3\n,"
+                        + "  [f('b')]: 4\n"
+                        + "};\n"
+                        + "o.a + o[0] + o['1'] + o.b";
 
         ScriptableObject scope = cx.initStandardObjects();
         Object value = cx.evaluateString(scope, script, "test", 1, null);
@@ -78,22 +79,22 @@ public class ComputedPropertiesTest {
     }
 
     private static void assertCanCoerceFunctionWithComputedPropertiesToString(Context cx) {
-        String script = "\n" +
-                "function f(x) {\n" +
-                "  var o = {\n" +
-                "    1: true,\n" +
-                "    [2]: false,\n" +
-                "    [g(x)]: 3\n" +
-                "  };\n" +
-                "}\n" +
-                "f.toString()";
+        String script =
+                "\n"
+                        + "function f(x) {\n"
+                        + "  var o = {\n"
+                        + "    1: true,\n"
+                        + "    [2]: false,\n"
+                        + "    [g(x)]: 3\n"
+                        + "  };\n"
+                        + "}\n"
+                        + "f.toString()";
 
         ScriptableObject scope = cx.initStandardObjects();
         Object value = cx.evaluateString(scope, script, "test", 1, null);
         assertTrue(value instanceof String);
-        assertEquals("\nfunction f(x) {\n" +
-                "    var o = {1: true, [2]: false, [g(x)]: 3};\n" +
-                "}\n", value);
+        assertEquals(
+                "\nfunction f(x) {\n    var o = {1: true, [2]: false, [g(x)]: 3};\n}\n", value);
     }
 
     @Test
@@ -124,14 +125,15 @@ public class ComputedPropertiesTest {
     }
 
     private static void assertComputedPropertiesWithSideEffectsWork(Context cx) {
-        String script = "'use strict';\n" +
-                "var x = 0;\n" +
-                "var o = {\n" +
-                "  [++x]: 'x',\n" +
-                "  a: ++x,\n" +
-                "  [++x]: 'y'\n" +
-                "};\n" +
-                "o[1] + o.a + o[3]";
+        String script =
+                "'use strict';\n"
+                        + "var x = 0;\n"
+                        + "var o = {\n"
+                        + "  [++x]: 'x',\n"
+                        + "  a: ++x,\n"
+                        + "  [++x]: 'y'\n"
+                        + "};\n"
+                        + "o[1] + o.a + o[3]";
 
         ScriptableObject scope = cx.initStandardObjects();
         Object value = cx.evaluateString(scope, script, "test", 1, null);
@@ -166,11 +168,7 @@ public class ComputedPropertiesTest {
     }
 
     private static void assertComputedPropertyNameForGetterSetterWorks(Context cx) {
-        String script = "\n" +
-                "var o = {\n" +
-                " get ['x' + 1]() { return 42; }\n" +
-                "};\n" +
-                "o.x1";
+        String script = "var o = { get ['x' + 1]() { return 42; }}; o.x1";
 
         ScriptableObject scope = cx.initStandardObjects();
         Object value = cx.evaluateString(scope, script, "test", 1, null);
@@ -227,8 +225,10 @@ public class ComputedPropertiesTest {
 
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            EvaluatorException ex = assertThrows(EvaluatorException.class, () ->
-                    cx.compileString(script, "test", 1, null));
+            EvaluatorException ex =
+                    assertThrows(
+                            EvaluatorException.class,
+                            () -> cx.compileString(script, "test", 1, null));
             assertEquals("invalid property id (test#1)", ex.getMessage());
         }
     }
@@ -239,8 +239,10 @@ public class ComputedPropertiesTest {
 
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_1_8);
-            EvaluatorException ex = assertThrows(EvaluatorException.class, () ->
-                    cx.compileString(script, "test", 1, null));
+            EvaluatorException ex =
+                    assertThrows(
+                            EvaluatorException.class,
+                            () -> cx.compileString(script, "test", 1, null));
             assertEquals("invalid property id (test#1)", ex.getMessage());
         }
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
@@ -179,6 +179,49 @@ public class ComputedPropertiesTest {
     }
 
     @Test
+    public void yieldWorksForPropertyValuesInInterpretedMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(-1);
+            assertYieldWorksForPropertyValues(cx);
+        }
+    }
+
+    @Test
+    public void yieldWorksForPropertyValuesInCompiledMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(0);
+            assertYieldWorksForPropertyValues(cx);
+        }
+    }
+
+    @Test
+    public void yieldWorksForPropertyValuesInOptimizedMode() {
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.setOptimizationLevel(9);
+            assertYieldWorksForPropertyValues(cx);
+        }
+    }
+
+    private static void assertYieldWorksForPropertyValues(Context cx) {
+        String script =
+                "\n"
+                        + "function *gen() {\n"
+                        + " ({x: yield 1});\n"
+                        + "}\n"
+                        + "var g = gen()\n"
+                        + "var res1 = g.next();\n"
+                        + "var res2 = g.next();\n"
+                        + "res1.value === 1 && !res1.done && res2.done\n";
+
+        ScriptableObject scope = cx.initStandardObjects();
+        Object value = cx.evaluateString(scope, script, "test", 1, null);
+        assertEquals(Boolean.TRUE, value);
+    }
+
+    @Test
     public void cannotParseInvalidUnclosedBracket() {
         String script = "o = { [3 : 2 }";
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -101,7 +101,6 @@ public class Test262SuiteTest {
                             "class",
                             "class-fields-private",
                             "class-fields-public",
-                            "computed-property-names",
                             "default-arg",
                             "default-parameters",
                             "new.target",

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1,6 +1,6 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array 149/2670 (5.58%)
+built-ins/Array 146/2670 (5.47%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
@@ -8,8 +8,6 @@ built-ins/Array 149/2670 (5.58%)
     from/iter-set-elem-prop-non-writable.js
     from/proto-from-ctor-realm.js
     from/source-object-constructor.js Error propagation needs work in general
-    from/source-object-iterator-1.js Uses "get" syntax that's not implemented
-    from/source-object-iterator-2.js Uses "get" syntax that's not implemented
     from/source-object-length-set-elem-prop-err.js
     from/source-object-length-set-elem-prop-non-writable.js
     isArray/proxy.js {unsupported: [Proxy]}
@@ -61,7 +59,6 @@ built-ins/Array 149/2670 (5.58%)
     prototype/filter/target-array-with-non-configurable-property.js
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/find/predicate-call-this-strict.js strict
-    prototype/flatMap/array-like-objects.js
     prototype/flatMap/array-like-objects-poisoned-length.js
     prototype/flatMap/proxy-access-count.js
     prototype/flatMap/target-array-non-extensible.js
@@ -186,7 +183,7 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 14/68 (20.59%)
+built-ins/BigInt 13/68 (19.12%)
     asIntN/bigint-tobigint-errors.js {unsupported: [computed-property-names]}
     asIntN/bigint-tobigint-toprimitive.js {unsupported: [computed-property-names]}
     asIntN/bigint-tobigint-wrapped-values.js {unsupported: [computed-property-names]}
@@ -200,7 +197,6 @@ built-ins/BigInt 14/68 (20.59%)
     asUintN/bits-toindex-toprimitive.js {unsupported: [computed-property-names]}
     asUintN/bits-toindex-wrapped-values.js {unsupported: [computed-property-names]}
     prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
-    prototype/toString/thisbigintvalue-not-valid-throws.js Computed property is not support
 
 built-ins/Boolean 1/49 (2.04%)
     proto-from-ctor-realm.js {unsupported: [Reflect]}
@@ -666,7 +662,7 @@ built-ins/isNaN 7/16 (43.75%)
 
 ~built-ins/IteratorPrototype
 
-built-ins/JSON 34/140 (24.29%)
+built-ins/JSON 33/140 (23.57%)
     parse/builtin.js {unsupported: [Reflect.construct]}
     parse/revived-proxy.js {unsupported: [Proxy]}
     parse/revived-proxy-revoked.js {unsupported: [Proxy]}
@@ -699,11 +695,9 @@ built-ins/JSON 34/140 (24.29%)
     stringify/value-bigint-tojson-receiver.js
     stringify/value-object-proxy.js {unsupported: [Proxy]}
     stringify/value-object-proxy-revoked.js {unsupported: [Proxy]}
-    stringify/value-string-escape-ascii.js
     stringify/value-string-escape-unicode.js
 
-built-ins/Map 2/145 (1.38%)
-    iterator-is-undefined-throws.js
+built-ins/Map 1/145 (0.69%)
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
 built-ins/MapIteratorPrototype 0/11 (0.0%)
@@ -740,7 +734,7 @@ built-ins/Number 9/283 (3.18%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 127/3150 (4.03%)
+built-ins/Object 117/3150 (3.71%)
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
     assign/source-own-prop-error.js {unsupported: [Proxy]}
     assign/source-own-prop-keys-error.js {unsupported: [Proxy]}
@@ -786,16 +780,6 @@ built-ins/Object 127/3150 (4.03%)
     freeze/abrupt-completion.js {unsupported: [Proxy]}
     freeze/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
     freeze/throws-when-false.js
-    fromEntries/evaluation-order.js
-    fromEntries/iterator-closed-for-null-entry.js
-    fromEntries/iterator-closed-for-string-entry.js
-    fromEntries/iterator-closed-for-throwing-entry-key-accessor.js
-    fromEntries/iterator-closed-for-throwing-entry-key-tostring.js
-    fromEntries/iterator-closed-for-throwing-entry-value-accessor.js
-    fromEntries/iterator-not-closed-for-next-returning-non-object.js
-    fromEntries/iterator-not-closed-for-throwing-done-accessor.js
-    fromEntries/iterator-not-closed-for-throwing-next.js
-    fromEntries/iterator-not-closed-for-uncallable-next.js
     fromEntries/to-property-key.js
     fromEntries/uses-keys-not-iterator.js
     getOwnPropertyDescriptors/observable-operations.js {unsupported: [Proxy]}
@@ -1521,7 +1505,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 99/1114 (8.89%)
+built-ins/String 85/1114 (7.63%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-bigint.js {unsupported: [computed-property-names]}
@@ -1574,32 +1558,18 @@ built-ins/String 99/1114 (8.89%)
     prototype/toLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLowerCase/special_casing_conditional.js
     prototype/toString/non-generic-realm.js
-    prototype/trimEnd/this-value-object-cannot-convert-to-primitive-err.js
     prototype/trimEnd/this-value-object-toprimitive-call-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
     prototype/trimEnd/this-value-object-toprimitive-returns-object-err.js
-    prototype/trimEnd/this-value-object-tostring-call-err.js
-    prototype/trimEnd/this-value-object-tostring-meth-err.js
     prototype/trimEnd/this-value-object-tostring-meth-priority.js
-    prototype/trimEnd/this-value-object-tostring-returns-object-err.js
-    prototype/trimEnd/this-value-object-valueof-call-err.js
-    prototype/trimEnd/this-value-object-valueof-meth-err.js
     prototype/trimEnd/this-value-object-valueof-meth-priority.js
-    prototype/trimEnd/this-value-object-valueof-returns-object-err.js
-    prototype/trimStart/this-value-object-cannot-convert-to-primitive-err.js
     prototype/trimStart/this-value-object-toprimitive-call-err.js
     prototype/trimStart/this-value-object-toprimitive-meth-err.js
     prototype/trimStart/this-value-object-toprimitive-meth-priority.js
     prototype/trimStart/this-value-object-toprimitive-returns-object-err.js
-    prototype/trimStart/this-value-object-tostring-call-err.js
-    prototype/trimStart/this-value-object-tostring-meth-err.js
     prototype/trimStart/this-value-object-tostring-meth-priority.js
-    prototype/trimStart/this-value-object-tostring-returns-object-err.js
-    prototype/trimStart/this-value-object-valueof-call-err.js
-    prototype/trimStart/this-value-object-valueof-meth-err.js
     prototype/trimStart/this-value-object-valueof-meth-priority.js
-    prototype/trimStart/this-value-object-valueof-returns-object-err.js
     prototype/trim/u180e.js {unsupported: [u180e]}
     prototype/valueOf/non-generic-realm.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
@@ -3921,7 +3891,7 @@ language/expressions/multiplication 4/40 (10.0%)
     bigint-wrapped-values.js {unsupported: [computed-property-names]}
     order-of-evaluation.js
 
-language/expressions/object 836/1081 (77.34%)
+language/expressions/object 819/1081 (75.76%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4643,7 +4613,6 @@ language/expressions/object 836/1081 (77.34%)
     method-definition/name-param-id-yield.js non-strict
     method-definition/name-param-init-yield.js non-strict
     method-definition/name-param-redecl.js
-    method-definition/name-prop-name-eval-error.js
     method-definition/name-prop-name-yield-expr.js non-strict
     method-definition/name-prop-name-yield-id.js non-strict
     method-definition/name-prototype-prop.js
@@ -4679,30 +4648,14 @@ language/expressions/object 836/1081 (77.34%)
     11.1.5_4-4-b-1.js strict
     __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
-    accessor-name-computed.js
-    accessor-name-computed-err-evaluation.js
-    accessor-name-computed-err-to-prop-key.js
-    accessor-name-computed-err-unresolvable.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-expr.js
+    accessor-name-computed-yield-expr.js non-interpreted
     accessor-name-computed-yield-id.js non-strict
-    accessor-name-literal-numeric-binary.js
-    accessor-name-literal-numeric-exponent.js
-    accessor-name-literal-numeric-hex.js
-    accessor-name-literal-numeric-leading-decimal.js
-    accessor-name-literal-numeric-non-canonical.js
-    accessor-name-literal-numeric-octal.js
+    accessor-name-literal-numeric-binary.js {strict: [-1], non-strict: [-1]}
+    accessor-name-literal-numeric-exponent.js {strict: [-1], non-strict: [-1]}
+    accessor-name-literal-numeric-hex.js {strict: [-1], non-strict: [-1]}
+    accessor-name-literal-numeric-octal.js {strict: [-1], non-strict: [-1]}
     accessor-name-literal-numeric-zero.js
-    accessor-name-literal-string-char-escape.js
-    accessor-name-literal-string-default.js
-    accessor-name-literal-string-default-escaped.js
-    accessor-name-literal-string-default-escaped-ext.js
-    accessor-name-literal-string-double-quote.js
-    accessor-name-literal-string-empty.js
-    accessor-name-literal-string-hex-escape.js
-    accessor-name-literal-string-line-continuation.js
-    accessor-name-literal-string-single-quote.js
-    accessor-name-literal-string-unicode-escape.js
     computed-__proto__.js
     computed-property-evaluation-order.js
     concise-generator.js
@@ -5023,7 +4976,7 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 38/188 (20.21%)
+language/identifiers 22/188 (11.7%)
     other_id_continue.js
     other_id_continue-escaped.js
     other_id_start.js
@@ -5107,7 +5060,7 @@ language/reserved-words 2/27 (7.41%)
 language/rest-parameters 5/11 (45.45%)
     array-pattern.js
     arrow-function.js
-    no-alias-arguments.js
+    no-alias-arguments.js non-strict
     object-pattern.js
     with-new-target.js
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -184,18 +184,18 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 ~built-ins/Atomics
 
 built-ins/BigInt 13/68 (19.12%)
-    asIntN/bigint-tobigint-errors.js {unsupported: [computed-property-names]}
-    asIntN/bigint-tobigint-toprimitive.js {unsupported: [computed-property-names]}
-    asIntN/bigint-tobigint-wrapped-values.js {unsupported: [computed-property-names]}
-    asIntN/bits-toindex-errors.js {unsupported: [computed-property-names]}
-    asIntN/bits-toindex-toprimitive.js {unsupported: [computed-property-names]}
-    asIntN/bits-toindex-wrapped-values.js {unsupported: [computed-property-names]}
-    asUintN/bigint-tobigint-errors.js {unsupported: [computed-property-names]}
-    asUintN/bigint-tobigint-toprimitive.js {unsupported: [computed-property-names]}
-    asUintN/bigint-tobigint-wrapped-values.js {unsupported: [computed-property-names]}
-    asUintN/bits-toindex-errors.js {unsupported: [computed-property-names]}
-    asUintN/bits-toindex-toprimitive.js {unsupported: [computed-property-names]}
-    asUintN/bits-toindex-wrapped-values.js {unsupported: [computed-property-names]}
+    asIntN/bigint-tobigint-errors.js
+    asIntN/bigint-tobigint-toprimitive.js
+    asIntN/bigint-tobigint-wrapped-values.js
+    asIntN/bits-toindex-errors.js
+    asIntN/bits-toindex-toprimitive.js
+    asIntN/bits-toindex-wrapped-values.js
+    asUintN/bigint-tobigint-errors.js
+    asUintN/bigint-tobigint-toprimitive.js
+    asUintN/bigint-tobigint-wrapped-values.js
+    asUintN/bits-toindex-errors.js
+    asUintN/bits-toindex-toprimitive.js
+    asUintN/bits-toindex-wrapped-values.js
     prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
 
 built-ins/Boolean 1/49 (2.04%)
@@ -236,9 +236,9 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getBigInt64/return-values-custom-offset.js
     prototype/getBigInt64/to-boolean-littleendian.js
     prototype/getBigInt64/toindex-byteoffset.js
-    prototype/getBigInt64/toindex-byteoffset-errors.js {unsupported: [computed-property-names]}
-    prototype/getBigInt64/toindex-byteoffset-toprimitive.js {unsupported: [computed-property-names]}
-    prototype/getBigInt64/toindex-byteoffset-wrapped-values.js {unsupported: [computed-property-names]}
+    prototype/getBigInt64/toindex-byteoffset-errors.js
+    prototype/getBigInt64/toindex-byteoffset-toprimitive.js
+    prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
     prototype/getBigUint64/detached-buffer.js
     prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
@@ -252,9 +252,9 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getBigUint64/return-values-custom-offset.js
     prototype/getBigUint64/to-boolean-littleendian.js
     prototype/getBigUint64/toindex-byteoffset.js
-    prototype/getBigUint64/toindex-byteoffset-errors.js {unsupported: [computed-property-names]}
-    prototype/getBigUint64/toindex-byteoffset-toprimitive.js {unsupported: [computed-property-names]}
-    prototype/getBigUint64/toindex-byteoffset-wrapped-values.js {unsupported: [computed-property-names]}
+    prototype/getBigUint64/toindex-byteoffset-errors.js
+    prototype/getBigUint64/toindex-byteoffset-toprimitive.js
+    prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
     prototype/getFloat32/detached-buffer.js
     prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
@@ -989,7 +989,7 @@ built-ins/Promise 397/599 (66.28%)
     any/ctx-ctor-throws.js
     any/ctx-non-ctor.js
     any/invoke-resolve.js {unsupported: [async]}
-    any/invoke-resolve-error-close.js {unsupported: [computed-property-names, async]}
+    any/invoke-resolve-error-close.js {unsupported: [async]}
     any/invoke-resolve-error-reject.js {unsupported: [async]}
     any/invoke-resolve-get-error.js {unsupported: [async]}
     any/invoke-resolve-get-error-reject.js {unsupported: [async]}
@@ -1001,9 +1001,9 @@ built-ins/Promise 397/599 (66.28%)
     any/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
     any/invoke-resolve-return.js
     any/invoke-then.js {unsupported: [async]}
-    any/invoke-then-error-close.js {unsupported: [computed-property-names, async]}
+    any/invoke-then-error-close.js {unsupported: [async]}
     any/invoke-then-error-reject.js {unsupported: [async]}
-    any/invoke-then-get-error-close.js {unsupported: [computed-property-names, async]}
+    any/invoke-then-get-error-close.js {unsupported: [async]}
     any/invoke-then-get-error-reject.js {unsupported: [async]}
     any/invoke-then-on-promises-every-iteration.js {unsupported: [async]}
     any/is-function.js
@@ -1018,13 +1018,13 @@ built-ins/Promise 397/599 (66.28%)
     any/iter-arg-is-symbol-reject.js {unsupported: [async]}
     any/iter-arg-is-true-reject.js {unsupported: [async]}
     any/iter-arg-is-undefined-reject.js {unsupported: [async]}
-    any/iter-assigned-false-reject.js {unsupported: [computed-property-names, async]}
-    any/iter-assigned-null-reject.js {unsupported: [computed-property-names, async]}
-    any/iter-assigned-number-reject.js {unsupported: [computed-property-names, async]}
-    any/iter-assigned-string-reject.js {unsupported: [computed-property-names, async]}
-    any/iter-assigned-symbol-reject.js {unsupported: [computed-property-names, async]}
-    any/iter-assigned-true-reject.js {unsupported: [computed-property-names, async]}
-    any/iter-assigned-undefined-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-assigned-false-reject.js {unsupported: [async]}
+    any/iter-assigned-null-reject.js {unsupported: [async]}
+    any/iter-assigned-number-reject.js {unsupported: [async]}
+    any/iter-assigned-string-reject.js {unsupported: [async]}
+    any/iter-assigned-symbol-reject.js {unsupported: [async]}
+    any/iter-assigned-true-reject.js {unsupported: [async]}
+    any/iter-assigned-undefined-reject.js {unsupported: [async]}
     any/iter-next-val-err-no-close.js {unsupported: [async]}
     any/iter-next-val-err-reject.js {unsupported: [async]}
     any/iter-returns-false-reject.js {unsupported: [async]}
@@ -1034,8 +1034,8 @@ built-ins/Promise 397/599 (66.28%)
     any/iter-returns-symbol-reject.js {unsupported: [async]}
     any/iter-returns-true-reject.js {unsupported: [async]}
     any/iter-returns-undefined-reject.js {unsupported: [async]}
-    any/iter-step-err-no-close.js {unsupported: [computed-property-names, async]}
-    any/iter-step-err-reject.js {unsupported: [computed-property-names, async]}
+    any/iter-step-err-no-close.js {unsupported: [async]}
+    any/iter-step-err-reject.js {unsupported: [async]}
     any/length.js
     any/name.js
     any/new-reject-function.js
@@ -1508,14 +1508,14 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 built-ins/String 85/1114 (7.63%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
-    prototype/indexOf/position-tointeger-bigint.js {unsupported: [computed-property-names]}
-    prototype/indexOf/position-tointeger-errors.js {unsupported: [computed-property-names]}
-    prototype/indexOf/position-tointeger-toprimitive.js {unsupported: [computed-property-names]}
-    prototype/indexOf/position-tointeger-wrapped-values.js {unsupported: [computed-property-names]}
-    prototype/indexOf/searchstring-tostring-bigint.js {unsupported: [computed-property-names]}
-    prototype/indexOf/searchstring-tostring-errors.js {unsupported: [computed-property-names]}
-    prototype/indexOf/searchstring-tostring-toprimitive.js {unsupported: [computed-property-names]}
-    prototype/indexOf/searchstring-tostring-wrapped-values.js {unsupported: [computed-property-names]}
+    prototype/indexOf/position-tointeger-bigint.js
+    prototype/indexOf/position-tointeger-errors.js
+    prototype/indexOf/position-tointeger-toprimitive.js
+    prototype/indexOf/position-tointeger-wrapped-values.js
+    prototype/indexOf/searchstring-tostring-bigint.js
+    prototype/indexOf/searchstring-tostring-errors.js
+    prototype/indexOf/searchstring-tostring-toprimitive.js
+    prototype/indexOf/searchstring-tostring-wrapped-values.js
     prototype/matchAll 19/19 (100.0%)
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
@@ -2965,9 +2965,9 @@ language/eval-code 259/349 (74.21%)
 ~language/export
 
 language/expressions/addition 9/48 (18.75%)
-    bigint-errors.js {unsupported: [computed-property-names]}
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-errors.js
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     coerce-symbol-to-prim-err.js
     coerce-symbol-to-prim-invocation.js
     coerce-symbol-to-prim-return-obj.js
@@ -3186,28 +3186,25 @@ language/expressions/arrow-function 209/333 (62.76%)
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/bitwise-and 5/30 (16.67%)
-    bigint-errors.js {unsupported: [computed-property-names]}
+language/expressions/bitwise-and 4/30 (13.33%)
     bigint-non-primitive.js
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/bitwise-not 1/16 (6.25%)
     bigint-non-primitive.js
 
-language/expressions/bitwise-or 5/30 (16.67%)
-    bigint-errors.js {unsupported: [computed-property-names]}
+language/expressions/bitwise-or 4/30 (13.33%)
     bigint-non-primitive.js
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/bitwise-xor 5/30 (16.67%)
-    bigint-errors.js {unsupported: [computed-property-names]}
+language/expressions/bitwise-xor 4/30 (13.33%)
     bigint-non-primitive.js
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/call 64/96 (66.67%)
@@ -3384,10 +3381,9 @@ language/expressions/delete 3/61 (4.92%)
     super-property.js {unsupported: [class]}
     super-property-method.js {unsupported: [class]}
 
-language/expressions/division 4/45 (8.89%)
-    bigint-errors.js {unsupported: [computed-property-names]}
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+language/expressions/division 3/45 (6.67%)
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/does-not-equals 0/38 (0.0%)
@@ -3400,10 +3396,9 @@ language/expressions/equals 6/47 (12.77%)
     get-symbol-to-prim-err.js
     to-prim-hint.js
 
-language/expressions/exponentiation 4/44 (9.09%)
-    bigint-errors.js {unsupported: [computed-property-names]}
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+language/expressions/exponentiation 3/44 (6.82%)
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/function 203/248 (81.85%)
@@ -3857,11 +3852,10 @@ language/expressions/instanceof 7/43 (16.28%)
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift 5/45 (11.11%)
-    bigint-errors.js {unsupported: [computed-property-names]}
+language/expressions/left-shift 4/45 (8.89%)
     bigint-non-primitive.js
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/less-than 1/45 (2.22%)
@@ -3879,19 +3873,17 @@ language/expressions/logical-not 0/19 (0.0%)
 language/expressions/logical-or 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/modulus 4/40 (10.0%)
-    bigint-errors.js {unsupported: [computed-property-names]}
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+language/expressions/modulus 3/40 (7.5%)
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/multiplication 4/40 (10.0%)
-    bigint-errors.js {unsupported: [computed-property-names]}
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+language/expressions/multiplication 3/40 (7.5%)
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/object 819/1081 (75.76%)
+language/expressions/object 818/1081 (75.67%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4657,7 +4649,6 @@ language/expressions/object 819/1081 (75.76%)
     accessor-name-literal-numeric-octal.js {strict: [-1], non-strict: [-1]}
     accessor-name-literal-numeric-zero.js
     computed-__proto__.js
-    computed-property-evaluation-order.js
     concise-generator.js
     fn-name-accessor-get.js
     fn-name-accessor-set.js
@@ -4762,21 +4753,19 @@ language/expressions/property-accessors 0/21 (0.0%)
 
 language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift 5/37 (13.51%)
-    bigint-errors.js {unsupported: [computed-property-names]}
+language/expressions/right-shift 4/37 (10.81%)
     bigint-non-primitive.js
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/strict-does-not-equals 0/30 (0.0%)
 
 language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction 4/38 (10.53%)
-    bigint-errors.js {unsupported: [computed-property-names]}
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+language/expressions/subtraction 3/38 (7.89%)
+    bigint-toprimitive.js
+    bigint-wrapped-values.js
     order-of-evaluation.js
 
 ~language/expressions/super
@@ -4801,11 +4790,9 @@ language/expressions/unary-minus 1/14 (7.14%)
 
 language/expressions/unary-plus 0/17 (0.0%)
 
-language/expressions/unsigned-right-shift 5/45 (11.11%)
-    bigint-errors.js {unsupported: [computed-property-names]}
+language/expressions/unsigned-right-shift 3/45 (6.67%)
     bigint-non-primitive.js
-    bigint-toprimitive.js {unsupported: [computed-property-names]}
-    bigint-wrapped-values.js {unsupported: [computed-property-names]}
+    bigint-toprimitive.js
     order-of-evaluation.js
 
 language/expressions/void 0/9 (0.0%)
@@ -4976,25 +4963,7 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 22/188 (11.7%)
-    other_id_continue.js
-    other_id_continue-escaped.js
-    other_id_start.js
-    other_id_start-escaped.js
-    part-unicode-11.0.0.js
-    part-unicode-11.0.0-escaped.js
-    part-unicode-12.0.0.js
-    part-unicode-12.0.0-escaped.js
-    part-unicode-13.0.0.js
-    part-unicode-13.0.0-escaped.js
-    part-unicode-5.2.0.js
-    part-unicode-5.2.0-escaped.js
-    start-unicode-11.0.0.js
-    start-unicode-11.0.0-escaped.js
-    start-unicode-12.0.0.js
-    start-unicode-12.0.0-escaped.js
-    start-unicode-13.0.0.js
-    start-unicode-13.0.0-escaped.js
+language/identifiers 4/188 (2.13%)
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2668,7 +2668,16 @@ language/comments 9/52 (17.31%)
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
 
-~language/computed-property-names
+language/computed-property-names 32/45 (71.11%)
+    class/accessor 4/4 (100.0%)
+    class/method 11/11 (100.0%)
+    class/static 11/11 (100.0%)
+    object/accessor/getter-super.js
+    object/accessor/setter-super.js
+    object/method/generator.js
+    object/method/super.js
+    to-name-side-effects/class.js
+    to-name-side-effects/numbers-class.js
 
 language/destructuring 9/15 (60.0%)
     binding/syntax/array-elements-with-initializer.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4963,7 +4963,25 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 4/188 (2.13%)
+language/identifiers 22/188 (11.7%)
+    other_id_continue.js
+    other_id_continue-escaped.js
+    other_id_start.js
+    other_id_start-escaped.js
+    part-unicode-11.0.0.js
+    part-unicode-11.0.0-escaped.js
+    part-unicode-12.0.0.js
+    part-unicode-12.0.0-escaped.js
+    part-unicode-13.0.0.js
+    part-unicode-13.0.0-escaped.js
+    part-unicode-5.2.0.js
+    part-unicode-5.2.0-escaped.js
+    start-unicode-11.0.0.js
+    start-unicode-11.0.0-escaped.js
+    start-unicode-12.0.0.js
+    start-unicode-12.0.0-escaped.js
+    start-unicode-13.0.0.js
+    start-unicode-13.0.0-escaped.js
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js


### PR DESCRIPTION
This (rather large) PR implements computed properties, i.e. you can do things like:

```js
o = {
  [f(x, y, z)] = 42
}
```

A more obvious use case is something like `o = { [Symbol.iterator]: () => { ... } }`. Quite a few more test262 cases now pass (around 50).

I'm going to go into some details about the implementation to help the review, since there are a lot of changes. My apologies for the wall of text. 🙂 

Closes #913

# Background

Spec reference: https://tc39.es/ecma262/#sec-object-initializer

An important detail, per the spec, is that JS requires that the evaluation of the expressions for computed property keys and values are interleaved, e.g.:

```js
x = 0;
o = {
    [++x]: ++x,
    [++x]: ++x,
};
JSON.stringify(o);
```

should print `{"1":2,"3":4}`.

# Implementation notes

## Parser

The changes to `Parser` are simple. The only noteworthy detail is that I have created a new subclass of `AstNode` called `ComputedPropertyKey`. This is useful for two things:

- we want to treat [andrea] as a lookup of the name `andrea` in the scope, not a property called `andrea` in the object - having a wrapper node simplifies this;
- it's useful when preparing the "encoded source".

## IR Factory

In `IRFactory` the existing fragment of code was generating the array of property keys and store it in a property called `OBJECT_IDS_PROP` of the node. The new code also stores the computed properties in a new property `OBJECT_IDS_COMPUTED_PROP`. The two arrays have the same length, and there is a `null` element in the position of properties where we have a computed property, whose expression is at the corresponding index in the other array.

There are also some simple changes to handle the new ast node.

## Interpreter

The existing code, for an object such as `o = { x: 11, 2: 12 }`, would generate the following bytecode:

```
[   5] REG_IND_C2 
[   6] LITERAL_NEW 
[   7] SHORTNUMBER 11
[  10] LITERAL_SET 
[  11] SHORTNUMBER 12
[  14] LITERAL_SET 
[  15] REG_IND_C0 
[  16] OBJECTLIT [x, 2]
```

Let's go through this:

- first we have a `LITERAL_NEW`, which is pushing an array of length 2 (reading the index register) on the stack for the properties' values (not the keys!);
- then we have a sequence of instructions to fill that array: push `11` and set it, push `12` and set it;
- then we set the index register to 0, because the first entry in the literal array of the `InterpreterData` was used to store a java array containing the property keys (i.e. `new Object[]{"x", 2}`)
- and finally there is the instruction `OBJECTLIT`, which reads the property keys from the literal array and the property values from the stack and initializes the object.

(There is a small additional detail: there is a third array on the stack that records whether a property is standard, a setter, a getter, or a method. This was not touched by this PR).

However, this approach doesn't work anymore if we need to replace an entry in the property keys. Therefore, I have changed the bytecode to do the following:

- first we push on the stack _two_ arrays, one for the keys and one for values;
- the keys array is pre-initialized with the literal, so that all non-computed properties are already filled;
- then we loop over each entry:
  - if it has a computed key, we compute the expression and set it in the keys array;
  - otherwise we do nothing for the key, because it will already be present in the literal array and thus doesn't need to change;
  - next, we compute the value and put it in the values array;
- finally, we build the object.

To implement this I have done some changes in the interpreter:

- there is a new instruction `LITERAL_KEYS`, that pushes the literal array with the property keys onto the stack. It is followed by one byte (0/1) which specifies whether we have to copy the literal array or not (if we don't have computed properties we save an array copy and just push the one in the literal table, since we won't change it);
- there is another new instruction named `LITERAL_KEY_SET` to replace an entry of the property keys array (which is assumed to be already on the stack), similar to the the existing `LITERAL_SET`;
- finally, the `OBJECTLIT` instruction will now read both arrays from the stack.

Given this code:

```js
function f(x) { return x; }
o = {
    a: 1,
    [f('x')]: 42,
    x2: f(2),
};
```

this is the generated bytecode:

```
[   8] REG_IND_C0 
[   9] LITERAL_KEYS [a, null, x2] true
[  11] REG_IND_C3 
[  12] LITERAL_NEW 
[  13] ONE 
[  14] LITERAL_SET 
[  15] LINE 4
[  18] REG_STR_C1 "f"
[  19] NAME_AND_THIS 
[  20] REG_STR_C2 "x"
[  21] STRING 
[  22] REG_IND_C1 
[  23] CALL 1
[  24] REG_IND_C1 
[  25] LITERAL_KEY_SET 
[  26] SHORTNUMBER 42
[  29] LITERAL_SET 
[  30] LINE 5
[  33] REG_STR_C1 "f"
[  34] NAME_AND_THIS 
[  35] SHORTNUMBER 2
[  38] REG_IND_C1 
[  39] CALL 1
[  40] LITERAL_SET 
[  41] OBJECTLIT 
```

You can see that we execute in order the expressions `1` (first value), then `f(x)` (second key), then `42` (second value), and finally the value `f(2)` (third value).

## Compiled classes

For the compiled classes, the existing code would do something like this: for the JS fragment `{ x: 11, 2: 12 }` the following java bytecode would be generated:

```
// Create array for keys
      25: iconst_2
      26: anewarray     #51                 // class java/lang/Object
// Fill key 0
      29: dup
      30: iconst_0
      31: ldc           #120                // String x
      33: aastore
// Fill key 1
      34: dup
      35: iconst_1
      36: iconst_2
      37: invokestatic  #124                // Method org/mozilla/javascript/ScriptRuntime.wrapInt:(I)Ljava/lang/Integer;
      40: aastore
// Create array for values
      41: iconst_2
      42: anewarray     #51                 // class java/lang/Object
// Fill value 0
      45: dup
      46: iconst_0
      47: getstatic     #128                // Field _k0:Ljava/lang/Integer;
      50: aastore
// Fill value 1
      51: dup
      52: iconst_1
      53: getstatic     #131                // Field _k1:Ljava/lang/Integer;
      56: aastore
```

It's pretty simple: we simply create an array with two elements, set the first one to the constant x and the second one to the constant 2. In general, the code would first fill the array with all the keys, and then the array with all the values, evaluating each key and value's expression. However, to implement the interleaved evaluation required by the spec, the  changes in `BodyCodegen` are a bit bigger.

First, I split the implementation of an object literal and an array literal in two functions for clarity. Then, we create both arrays and fill them one entry at a time, so the code becomes something like:

```
create array keys
create array values
compute key #0
set in array keys at position 0
compute value #0
set in array values at position 0
compute key #1
set in array keys at position 1
compute value #1
set in array values at position 1
...
```

As an example, for the following JS:

```js
function f(x) { return x; }
o = {
    a: 1,
    [f('x')]: 42,
    x2: f(2),
};
```

we get the following JVM bytecode:

```
// Create both arrays
      41: iconst_3
      42: anewarray     #49                 // class java/lang/Object
      45: iconst_3
      46: anewarray     #49                 // class java/lang/Object
// Prepare for entry 0
      49: dup2
// Set key 0
      50: iconst_0
      51: ldc           #130                // String a
      53: aastore
// Set value 0
      54: iconst_0
      55: getstatic     #134                // Field org/mozilla/javascript/optimizer/OptRuntime.oneObj:Ljava/lang/Double;
      58: aastore
// Prepare for entry 1
      59: dup2
// Set key 1
      60: iconst_1
      61: iconst_1
      62: anewarray     #49                 // class java/lang/Object
      65: dup
      66: iconst_0
      67: ldc           #84                 // String x
      69: aastore
      70: ldc           #76                 // String f
      72: aload_1
      73: aload_2
      74: invokestatic  #138                // Method org/mozilla/javascript/optimizer/OptRuntime.callName:([Ljava/lang/Object;Ljava/lang/String;Lorg/mozilla/javascript/Context;Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;
      77: aastore
// Set value 1
      78: iconst_1
      79: getstatic     #142                // Field _k0:Ljava/lang/Integer;
      82: aastore
// Prepare for entry 2
      83: dup2
// Set key 2
      84: iconst_2
      85: ldc           #144                // String x2
      87: aastore
// Set value 2
      88: iconst_2
      89: iconst_1
      90: anewarray     #49                 // class java/lang/Object
      93: dup
      94: iconst_0
      95: getstatic     #147                // Field _k1:Ljava/lang/Integer;
      98: aastore
      99: ldc           #76                 // String f
     101: aload_1
     102: aload_2
     103: invokestatic  #138                // Method org/mozilla/javascript/optimizer/OptRuntime.callName:([Ljava/lang/Object;Ljava/lang/String;Lorg/mozilla/javascript/Context;Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;
     106: aastore
// Swap key/value arrays on the stack
     107: swap
```

There is a special case for handling [Rhino bug 757410](https://bugzilla.mozilla.org/show_bug.cgi?id=757410) - if we are inside a generator, we instead do something like this:

```
compute key #0
compute value #0
...
compute key #n-1
compute value #n-1
create array keys
create array values
set in array values at position n-1
set in array keys at position n-1
...
set in array values at position 0
set in array keys at position 0
```

The reasons for this are explained in https://github.com/mozilla/rhino/pull/70

## Other changes

The last interesting change is the one in `ScriptRuntime` - the old code knew that a property key was always a string or an integer. Now, it can be any JS object, so we have to use `ScriptRuntime.toString` rather than just an `instanceof String`.

# Further enhancements

There are some improvements that could be done on this, but they will come in separated PR. This one is big enough as it is. 🙂

1) Currently we generate a literal array for the static keys. We could generate one also for the static values and use the same approach of filling only the "missing" values in interpreted mode.
2) We could use the literal array that we have (at least for the keys, maybe also for the values if we introduce it) in compiled mode, by storing it in the constant pool and copying it before filling only the computed values, similarly to what we do in the interpreter.
3) We should refactor the code to use just one array for both keys and values, to allow for better cache locality (and simplify the generated bytecode).