### PR TITLE
Peel known functions in interpreter so they don't break continuations

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ArrowFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrowFunction.java
@@ -36,8 +36,7 @@ public class ArrowFunction extends BaseFunction {
 
     @Override
     public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        Scriptable callThis = boundThis != null ? boundThis : ScriptRuntime.getTopCallScope(cx);
-        return targetFunction.call(cx, scope, callThis, args);
+        return targetFunction.call(cx, scope, getCallThis(cx), args);
     }
 
     @Override
@@ -72,6 +71,14 @@ public class ArrowFunction extends BaseFunction {
             return ((BaseFunction) targetFunction).decompile(indent, flags);
         }
         return super.decompile(indent, flags);
+    }
+
+    Scriptable getCallThis(Context cx) {
+        return boundThis != null ? boundThis : ScriptRuntime.getTopCallScope(cx);
+    }
+
+    Callable getTargetFunction() {
+        return targetFunction;
     }
 
     static boolean equalObjectGraphs(ArrowFunction f1, ArrowFunction f2, EqualObjectGraphs eq) {

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -52,14 +52,7 @@ public class BoundFunction extends BaseFunction {
 
     @Override
     public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] extraArgs) {
-        Scriptable callThis = boundThis;
-        if (callThis == null && ScriptRuntime.hasTopCall(cx)) {
-            callThis = ScriptRuntime.getTopCallScope(cx);
-        }
-        if (callThis == null) {
-            callThis = getTopLevelScope(scope);
-        }
-        return targetFunction.call(cx, scope, callThis, concat(boundArgs, extraArgs));
+        return targetFunction.call(cx, scope, getCallThis(cx, scope), concat(boundArgs, extraArgs));
     }
 
     @Override
@@ -96,6 +89,25 @@ public class BoundFunction extends BaseFunction {
         System.arraycopy(first, 0, args, 0, first.length);
         System.arraycopy(second, 0, args, first.length, second.length);
         return args;
+    }
+
+    Callable getTargetFunction() {
+        return targetFunction;
+    }
+
+    Object[] getBoundArgs() {
+        return boundArgs;
+    }
+
+    Scriptable getCallThis(Context cx, Scriptable scope) {
+        Scriptable callThis = boundThis;
+        if (callThis == null && ScriptRuntime.hasTopCall(cx)) {
+            callThis = ScriptRuntime.getTopCallScope(cx);
+        }
+        if (callThis == null) {
+            callThis = getTopLevelScope(scope);
+        }
+        return callThis;
     }
 
     static boolean equalObjectGraphs(BoundFunction f1, BoundFunction f2, EqualObjectGraphs eq) {

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
@@ -70,4 +70,8 @@ public class LambdaFunction extends BaseFunction {
     public String getFunctionName() {
         return name;
     }
+
+    Callable getTarget() {
+        return target;
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
@@ -1,0 +1,77 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContinuationPending;
+import org.mozilla.javascript.Script;
+import org.mozilla.javascript.Scriptable;
+
+// Tests that continuations work across arrow function, bound function, and apply/call invocations.
+public class InterpreterFunctionPeelingTest {
+    public static final Runnable CAPTURER =
+            () -> {
+                try (var cx = Context.enter()) {
+                    throw cx.captureContinuation();
+                }
+            };
+
+    public static void executeScript(String script) {
+        try (var cx = Context.enter()) {
+            cx.setOptimizationLevel(-1);
+            Script s = cx.compileString(script, "unknown source", 0, null);
+            Scriptable scope = cx.initStandardObjects();
+            scope.put("c", scope, Context.javaToJS(CAPTURER, scope));
+            Assert.assertThrows(
+                    ContinuationPending.class,
+                    () -> {
+                        cx.executeScriptWithContinuations(s, scope);
+                    });
+        }
+    }
+
+    @Test
+    public void testBind() {
+        executeScript("function capture(){c.run()};capture.bind(this)()");
+    }
+
+    @Test
+    public void testBindCall() {
+        executeScript("function capture(){c.run()};capture.bind(this).call()");
+    }
+
+    @Test
+    public void testBindApply() {
+        executeScript("function capture(){c.run()};capture.bind(this).apply()");
+    }
+
+    @Test
+    public void testArrow() {
+        executeScript("capture=()=>{c.run()};capture()");
+    }
+
+    @Test
+    public void testArrowCall() {
+        executeScript("capture=()=>{c.run()};capture.call()");
+    }
+
+    @Test
+    public void testArrowApply() {
+        executeScript("capture=()=>{c.run()};capture.apply()");
+    }
+
+    @Test
+    public void testArrowBindCall() {
+        executeScript("capture=()=>{c.run()};capture.bind(this).call()");
+    }
+
+    @Test
+    public void testArrowBindApply() {
+        executeScript("capture=()=>{c.run()};capture.bind(this).apply()");
+    }
+
+    @Test
+    public void testArrowImmediate() {
+        executeScript("(()=>{c.run()})()");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/rhino/issues/1444

Avoids the interpreter from calling out from its current loop when it needs to invoke an arrow function, a lambda function, a bound function, `Function.apply`, `Function.call`, or a `NoSuchMethodHandleShim`. 

Also handles their combinations. Prior to this change, the best-effort for `Function.apply`, `Function.call`, and `NoSuchMethodHandleShim` only worked if their target was directly an `InterpretedFunction`. With this change, the interpreter will keep drilling down through (or, depending on how you like to visualize it, peel away) the functions (modifying the arguments as those functions would when they're invoked) until it finds an interpreted function to install on its loop stack. If the ultimately invoked function is not interpreted, it will call out to it as before (except it won't call out to the top-level `ArrowFunction`/`BoundFunction`/etc but rather it already did the work for unwrapping them, so it'll only correctly call the final irreducible function.

The net effect is that interpreter will not leave its loop even for combinations of functions such as `(a, b, c) => 


