### PR TITLE
unmark non-failing test262 ./language/identifiers tests

### DIFF
--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -5023,25 +5023,7 @@ language/global-code 29/41 (70.73%)
 
 language/identifier-resolution 0/13 (0.0%)
 
-language/identifiers 38/188 (20.21%)
-    other_id_continue.js
-    other_id_continue-escaped.js
-    other_id_start.js
-    other_id_start-escaped.js
-    part-unicode-11.0.0.js
-    part-unicode-11.0.0-escaped.js
-    part-unicode-12.0.0.js
-    part-unicode-12.0.0-escaped.js
-    part-unicode-13.0.0.js
-    part-unicode-13.0.0-escaped.js
-    part-unicode-5.2.0.js
-    part-unicode-5.2.0-escaped.js
-    start-unicode-11.0.0.js
-    start-unicode-11.0.0-escaped.js
-    start-unicode-12.0.0.js
-    start-unicode-12.0.0-escaped.js
-    start-unicode-13.0.0.js
-    start-unicode-13.0.0-escaped.js
+language/identifiers 4/188 (2.13%)
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js
@@ -5107,7 +5089,7 @@ language/reserved-words 2/27 (7.41%)
 language/rest-parameters 5/11 (45.45%)
     array-pattern.js
     arrow-function.js
-    no-alias-arguments.js
+    no-alias-arguments.js non-strict
     object-pattern.js
     with-new-target.js
 


### PR DESCRIPTION
Used to fail on Java 9 as dependent on Unicode version supported by Java version, but no longer failing on Java >= 11