### PR TITLE
 Catch ParserException in IRFactory

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2520,7 +2520,7 @@ public class Context implements Closeable {
             }
         }
 
-        IRFactory irf = new IRFactory(compilerEnv, compilationErrorReporter);
+        IRFactory irf = new IRFactory(compilerEnv, sourceString, compilationErrorReporter);
         ScriptNode tree = irf.transformTree(ast);
         return tree;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -116,7 +116,14 @@ public final class IRFactory {
             System.out.println("IRFactory.transformTree");
             System.out.println(root.debugPrint());
         }
-        ScriptNode script = (ScriptNode) transform(root);
+
+        ScriptNode script = null;
+        try {
+            script = (ScriptNode) transform(root);
+        } catch (Parser.ParserException e) {
+            parser.reportErrorsIfExists(root.getLineno());
+            return null;
+        }
 
         int sourceEndOffset = decompiler.getCurrentOffset();
         script.setEncodedSourceBounds(sourceStartOffset, sourceEndOffset);

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -157,7 +157,7 @@ public class Parser {
     private boolean defaultUseStrictDirective;
 
     // Exception to unwind
-    private static class ParserException extends RuntimeException {
+    public static class ParserException extends RuntimeException {
         private static final long serialVersionUID = 5882582646773765630L;
     }
 
@@ -652,12 +652,7 @@ public class Parser {
             inUseStrictDirective = savedStrictMode;
         }
 
-        if (this.syntaxErrorCount != 0) {
-            String msg = String.valueOf(this.syntaxErrorCount);
-            msg = lookupMessage("msg.got.syntax.errors", msg);
-            if (!compilerEnv.isIdeMode())
-                throw errorReporter.runtimeError(msg, sourceURI, baseLineno, null, 0);
-        }
+        reportErrorsIfExists(baseLineno);
 
         // add comments to root in lexical order
         if (scannedComments != null) {
@@ -4333,5 +4328,14 @@ public class Parser {
 
     public boolean inUseStrictDirective() {
         return inUseStrictDirective;
+    }
+
+    public void reportErrorsIfExists(int baseLineno) {
+        if (this.syntaxErrorCount != 0) {
+            String msg = String.valueOf(this.syntaxErrorCount);
+            msg = lookupMessage("msg.got.syntax.errors", msg);
+            if (!compilerEnv.isIdeMode())
+                throw errorReporter.runtimeError(msg, sourceURI, baseLineno, null, 0);
+        }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
@@ -19,7 +19,7 @@ import java.math.BigInteger;
  * @author Mike McCabe
  * @author Brendan Eich
  */
-class TokenStream {
+class TokenStream implements Parser.CurrentPositionReporter {
     /*
      * For chars - because we need something out-of-range
      * to check.  (And checking EOF by exception is annoying.)
@@ -599,7 +599,8 @@ class TokenStream {
         return sourceString;
     }
 
-    final int getLineno() {
+    @Override
+    public int getLineno() {
         return lineno;
     }
 
@@ -2190,7 +2191,8 @@ class TokenStream {
     }
 
     /** Returns the offset into the current line. */
-    final int getOffset() {
+    @Override
+    public int getOffset() {
         int n = sourceCursor - lineStart;
         if (lineEndChar >= 0) {
             --n;
@@ -2233,7 +2235,8 @@ class TokenStream {
         return new String(sourceBuffer, beginIndex, count);
     }
 
-    final String getLine() {
+    @Override
+    public String getLine() {
         int lineEnd = sourceCursor;
         if (lineEndChar >= 0) {
             // move cursor before newline sequence
@@ -2384,6 +2387,14 @@ class TokenStream {
         }
         buf.append(hexCode);
         return buf.toString();
+    }
+
+    public int getPosition() {
+        return tokenBeg;
+    }
+
+    public int getLength() {
+        return tokenEnd - tokenBeg;
     }
 
     // stuff other than whitespace since start of line

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -111,7 +111,7 @@ public class ClassCompiler {
             String source, String sourceLocation, int lineno, String mainClassName) {
         Parser p = new Parser(compilerEnv);
         AstRoot ast = p.parse(source, sourceLocation, lineno);
-        IRFactory irf = new IRFactory(compilerEnv);
+        IRFactory irf = new IRFactory(compilerEnv, source);
         ScriptNode tree = irf.transformTree(ast);
 
         // release reference to original parse tree & parser

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug708801Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug708801Test.java
@@ -65,7 +65,7 @@ public class Bug708801Test {
             ErrorReporter compilationErrorReporter = compilerEnv.getErrorReporter();
             Parser p = new Parser(compilerEnv, compilationErrorReporter);
             AstRoot ast = p.parse(source.toString(), "<eval>", 1);
-            IRFactory irf = new IRFactory(compilerEnv);
+            IRFactory irf = new IRFactory(compilerEnv, source.toString());
             ScriptNode tree = irf.transformTree(ast);
 
             Codegen codegen = new Codegen();

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug782363Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug782363Test.java
@@ -56,7 +56,7 @@ public class Bug782363Test {
         compilerEnv.initFromContext(cx);
         Parser p = new Parser(compilerEnv);
         AstRoot ast = p.parse(source.toString(), "<eval>", 1);
-        IRFactory irf = new IRFactory(compilerEnv);
+        IRFactory irf = new IRFactory(compilerEnv, source.toString());
         ScriptNode tree = irf.transformTree(ast);
 
         Codegen codegen = new Codegen();

--- a/tests/src/test/java/org/mozilla/javascript/tests/ErrorReporterTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ErrorReporterTest.java
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ErrorReporter;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.ScriptableObject;
+
+public class ErrorReporterTest {
+
+    private Context cx;
+    private ScriptableObject scope;
+
+    @Before
+    public void setUp() throws Exception {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        scope = cx.initStandardObjects();
+    }
+
+    @After
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void errorInfo() {
+        ErrorCollector errorCollector = new ErrorCollector();
+        cx.setErrorReporter(errorCollector);
+
+        try {
+            cx.evaluateString(scope, "0xGGGG", "", 1, null);
+        } catch (EvaluatorException e) {
+        }
+
+        assertTrue(errorCollector.reportedRuntimeError);
+        assertEquals(1, errorCollector.errors.size());
+
+        ErrorInfo errorInfo = errorCollector.errors.get(0);
+        assertEquals("number format error", errorInfo.message);
+        assertEquals(1, errorInfo.line);
+        assertEquals("0xGGGG", errorInfo.lineSource);
+    }
+
+    @Test
+    public void errorLine() {
+        ErrorCollector errorCollector = new ErrorCollector();
+        cx.setErrorReporter(errorCollector);
+
+        try {
+            cx.evaluateString(
+                    scope,
+                    "var a = 'a';\nvar b = true;\nvar c = 0xGGGG;\n var d = 123;",
+                    "",
+                    1,
+                    null);
+        } catch (EvaluatorException e) {
+        }
+
+        assertTrue(errorCollector.reportedRuntimeError);
+        assertEquals(2, errorCollector.errors.size());
+
+        ErrorInfo error1 = errorCollector.errors.get(0);
+        assertEquals("number format error", error1.message);
+        assertEquals(3, error1.line);
+        assertEquals("var c = 0xGGGG;", error1.lineSource);
+
+        ErrorInfo error2 = errorCollector.errors.get(1);
+        assertEquals("missing ; before statement", error2.message);
+        assertEquals(3, error2.line);
+        assertEquals("var c = 0xGGGG;", error2.lineSource);
+    }
+
+    @Test
+    public void catchParserExceptionInIRFactory() {
+        ErrorCollector errorCollector = new ErrorCollector();
+        cx.setErrorReporter(errorCollector);
+
+        try {
+            // The test for errors in re-parse with IRFactory after parsing with Parser.
+            cx.evaluateString(scope, "var a = 123;\n1=1", "", 1, null);
+        } catch (EvaluatorException e) {
+        }
+
+        assertTrue(errorCollector.reportedRuntimeError);
+        assertEquals(1, errorCollector.errors.size());
+
+        ErrorInfo errorInfo = errorCollector.errors.get(0);
+        assertEquals("Invalid assignment left-hand side.", errorInfo.message);
+        assertEquals(2, errorInfo.line);
+        assertEquals("1=1", errorInfo.lineSource);
+    }
+
+    @Test
+    public void errorLineInIRFactory() {
+        ErrorCollector errorCollector = new ErrorCollector();
+        cx.setErrorReporter(errorCollector);
+
+        cx.evaluateString(scope, "var a = 123;\n\nfor (let [x, x] in {}) {}", "", 1, null);
+
+        assertEquals(1, errorCollector.errors.size());
+
+        ErrorInfo errorInfo = errorCollector.errors.get(0);
+        assertEquals("TypeError: redeclaration of variable x.", errorInfo.message);
+        assertEquals(3, errorInfo.line);
+        assertEquals("for (let [x, x] in {}) {}", errorInfo.lineSource);
+    }
+
+    private static class ErrorInfo {
+        String message;
+        int line;
+        String lineSource;
+
+        ErrorInfo(String message, int line, String lineSource) {
+            this.message = message;
+            this.line = line;
+            this.lineSource = lineSource;
+        }
+    }
+
+    private static class ErrorCollector implements ErrorReporter {
+        ArrayList<ErrorInfo> errors;
+        ArrayList<ErrorInfo> warnings;
+        boolean reportedRuntimeError = false;
+
+        ErrorCollector() {
+            errors = new ArrayList<>();
+            warnings = new ArrayList<>();
+        }
+
+        @Override
+        public void error(
+                String message, String sourceName, int line, String lineSource, int lineOffset) {
+            errors.add(new ErrorInfo(message, line, lineSource));
+        }
+
+        @Override
+        public void warning(
+                String message, String sourceName, int line, String lineSource, int lineOffset) {
+            warnings.add(new ErrorInfo(message, line, lineSource));
+        }
+
+        @Override
+        public EvaluatorException runtimeError(
+                String message, String sourceName, int line, String lineSource, int lineOffset) {
+            reportedRuntimeError = true;
+            return new EvaluatorException(message, sourceName, line, lineSource, lineOffset);
+        }
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/ReadCommentsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ReadCommentsTest.java
@@ -29,7 +29,7 @@ public class ReadCommentsTest {
             testJs = scriptIn.lines().collect(Collectors.joining(System.lineSeparator()));
         }
         AstRoot ast = p.parse(testJs, "test", 1);
-        IRFactory irf = new IRFactory(compilerEnv);
+        IRFactory irf = new IRFactory(compilerEnv, testJs);
         ScriptNode tree = irf.transformTree(ast);
 
         Assert.assertEquals(1, tree.getFunctions().size());


### PR DESCRIPTION
Closes #967
Errors in `IRFactory` have the following issues.

1. `Parser$ParserException` not caught.
   ```
   js> 1=1
   js: line 1: Invalid assignment left-hand side.
   js: 
   js: ^
   Exception in thread "main" org.mozilla.javascript.Parser$ParserException
   	at org.mozilla.javascript.Parser.reportError(Parser.java:340)
   	at org.mozilla.javascript.Parser.reportError(Parser.java:326)
   	at org.mozilla.javascript.Parser.reportError(Parser.java:321)
   	at org.mozilla.javascript.IRFactory.createAssignment(IRFactory.java:2325)
   ```
2. Wrong line position.
   ```
   js> var a = 1;
   var b = 2;
   const [c, c] = [3, 4];

   js> js> js: line 1: TypeError: redeclaration of const c.
   ```

`IRFactory` is re-parsing ASTs that have already been parsed by `Parser`, but the error thrown at that time was not handled properly.
So, I have fixed 0cd0e2b2bc662cbcf560d03a3cc9794792bb40d1 for 1. and 436d3f62f0ff4f92f614ef58fdbc7a1bc887ed8c for 2.