### PR TITLE
Implement various missing methods in `TypedArray`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -18,7 +18,7 @@ package org.mozilla.javascript;
  *           will be put in the JavaDoc of each method that implements an Abstract Operations
  *     </ul>
  */
-class AbstractEcmaObjectOperations {
+public class AbstractEcmaObjectOperations {
     enum INTEGRITY_LEVEL {
         FROZEN,
         SEALED
@@ -161,7 +161,7 @@ class AbstractEcmaObjectOperations {
      *     constructor on "s" or if the "species" symbol is not set.
      * @see <a href="https://tc39.es/ecma262/#sec-speciesconstructor"></a>
      */
-    static Constructable speciesConstructor(
+    public static Constructable speciesConstructor(
             Context cx, Scriptable s, Constructable defaultConstructor) {
         /*
         The abstract operation SpeciesConstructor takes arguments O (an Object) and

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -1,0 +1,304 @@
+package org.mozilla.javascript;
+
+import static org.mozilla.javascript.NativeArray.getLengthProperty;
+import static org.mozilla.javascript.ScriptRuntimeES6.requireObjectCoercible;
+import static org.mozilla.javascript.Scriptable.NOT_FOUND;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import org.mozilla.javascript.regexp.NativeRegExp;
+
+/** Contains implementation of shared methods useful for arrays and typed arrays. */
+public class ArrayLikeAbstractOperations {
+    public enum IterativeOperation {
+        EVERY,
+        FILTER,
+        FOR_EACH,
+        MAP,
+        SOME,
+        FIND,
+        FIND_INDEX,
+    }
+
+    public enum ReduceOperation {
+        REDUCE,
+        REDUCE_RIGHT,
+    }
+
+    /** Implements the methods "every", "filter", "forEach", "map", and "some". */
+    public static Object iterativeMethod(
+            Context cx,
+            IdFunctionObject fun,
+            IterativeOperation operation,
+            Scriptable scope,
+            Scriptable thisObj,
+            Object[] args) {
+        Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+
+        if (IterativeOperation.FIND == operation || IterativeOperation.FIND_INDEX == operation) {
+            requireObjectCoercible(cx, o, fun);
+        }
+
+        long length = getLengthProperty(cx, o);
+        if (operation == IterativeOperation.MAP && length > Integer.MAX_VALUE) {
+            String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
+            throw ScriptRuntime.rangeError(msg);
+        }
+
+        Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
+
+        Function f = getCallbackArg(cx, callbackArg);
+        Scriptable parent = ScriptableObject.getTopLevelScope(f);
+        Scriptable thisArg;
+        if (args.length < 2 || args[1] == null || args[1] == Undefined.instance) {
+            thisArg = parent;
+        } else {
+            thisArg = ScriptRuntime.toObject(cx, scope, args[1]);
+        }
+
+        Scriptable array = null;
+        if (operation == IterativeOperation.FILTER || operation == IterativeOperation.MAP) {
+            int resultLength = operation == IterativeOperation.MAP ? (int) length : 0;
+            array = cx.newArray(scope, resultLength);
+        }
+        long j = 0;
+        for (long i = 0; i < length; i++) {
+            Object[] innerArgs = new Object[3];
+            Object elem = getRawElem(o, i);
+            if (elem == NOT_FOUND) {
+                if (operation == IterativeOperation.FIND
+                        || operation == IterativeOperation.FIND_INDEX) {
+                    elem = Undefined.instance;
+                } else {
+                    continue;
+                }
+            }
+            innerArgs[0] = elem;
+            innerArgs[1] = Long.valueOf(i);
+            innerArgs[2] = o;
+            Object result = f.call(cx, parent, thisArg, innerArgs);
+            switch (operation) {
+                case EVERY:
+                    if (!ScriptRuntime.toBoolean(result)) return Boolean.FALSE;
+                    break;
+                case FILTER:
+                    if (ScriptRuntime.toBoolean(result)) defineElem(cx, array, j++, innerArgs[0]);
+                    break;
+                case FOR_EACH:
+                    break;
+                case MAP:
+                    defineElem(cx, array, i, result);
+                    break;
+                case SOME:
+                    if (ScriptRuntime.toBoolean(result)) return Boolean.TRUE;
+                    break;
+                case FIND:
+                    if (ScriptRuntime.toBoolean(result)) return elem;
+                    break;
+                case FIND_INDEX:
+                    if (ScriptRuntime.toBoolean(result)) return ScriptRuntime.wrapNumber(i);
+                    break;
+            }
+        }
+        switch (operation) {
+            case EVERY:
+                return Boolean.TRUE;
+            case FILTER:
+            case MAP:
+                return array;
+            case SOME:
+                return Boolean.FALSE;
+            case FIND_INDEX:
+                return ScriptRuntime.wrapNumber(-1);
+            case FOR_EACH:
+            default:
+                return Undefined.instance;
+        }
+    }
+
+    static Function getCallbackArg(Context cx, Object callbackArg) {
+        if (!(callbackArg instanceof Function)) {
+            throw ScriptRuntime.notFunctionError(callbackArg);
+        }
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6
+                && (callbackArg instanceof NativeRegExp)) {
+            // Previously, it was allowed to pass RegExp instance as a callback (it implements
+            // Function)
+            // But according to ES2015 21.2.6 Properties of RegExp Instances:
+            // > RegExp instances are ordinary objects that inherit properties from the RegExp
+            // prototype object.
+            // > RegExp instances have internal slots [[RegExpMatcher]], [[OriginalSource]], and
+            // [[OriginalFlags]].
+            // so, no [[Call]] for RegExp-s
+            throw ScriptRuntime.notFunctionError(callbackArg);
+        }
+
+        Function f = (Function) callbackArg;
+        return f;
+    }
+
+    static void defineElem(Context cx, Scriptable target, long index, Object value) {
+        if (index > Integer.MAX_VALUE) {
+            String id = Long.toString(index);
+            target.put(id, target, value);
+        } else {
+            target.put((int) index, target, value);
+        }
+    }
+
+    // same as NativeArray::getElem, but without converting NOT_FOUND to undefined
+    static Object getRawElem(Scriptable target, long index) {
+        if (index > Integer.MAX_VALUE) {
+            return ScriptableObject.getProperty(target, Long.toString(index));
+        }
+        return ScriptableObject.getProperty(target, (int) index);
+    }
+
+    public static long toSliceIndex(double value, long length) {
+        long result;
+        if (value < 0.0) {
+            if (value + length < 0.0) {
+                result = 0;
+            } else {
+                result = (long) (value + length);
+            }
+        } else if (value > length) {
+            result = length;
+        } else {
+            result = (long) value;
+        }
+        return result;
+    }
+
+    /** Implements the methods "reduce" and "reduceRight". */
+    public static Object reduceMethod(
+            Context cx,
+            ReduceOperation operation,
+            Scriptable scope,
+            Scriptable thisObj,
+            Object[] args) {
+        Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
+
+        long length = getLengthProperty(cx, o);
+        Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
+        if (callbackArg == null || !(callbackArg instanceof Function)) {
+            throw ScriptRuntime.notFunctionError(callbackArg);
+        }
+        Function f = (Function) callbackArg;
+        Scriptable parent = ScriptableObject.getTopLevelScope(f);
+        // hack to serve both reduce and reduceRight with the same loop
+        boolean movingLeft = operation == ReduceOperation.REDUCE;
+        Object value = args.length > 1 ? args[1] : NOT_FOUND;
+        for (long i = 0; i < length; i++) {
+            long index = movingLeft ? i : (length - 1 - i);
+            Object elem = getRawElem(o, index);
+            if (elem == NOT_FOUND) {
+                continue;
+            }
+            if (value == NOT_FOUND) {
+                // no initial value passed, use first element found as inital value
+                value = elem;
+            } else {
+                Object[] innerArgs = {value, elem, index, o};
+                value = f.call(cx, parent, parent, innerArgs);
+            }
+        }
+        if (value == NOT_FOUND) {
+            // reproduce spidermonkey error message
+            throw ScriptRuntime.typeErrorById("msg.empty.array.reduce");
+        }
+        return value;
+    }
+
+    public static Comparator<Object> getSortComparator(
+            final Context cx, final Scriptable scope, final Object[] args) {
+        if (args.length > 0 && Undefined.instance != args[0]) {
+            return getSortComparatorFromArguments(cx, scope, args);
+        } else {
+            return DEFAULT_COMPARATOR;
+        }
+    }
+
+    public static ElementComparator getSortComparatorFromArguments(
+            Context cx, Scriptable scope, Object[] args) {
+        final Callable jsCompareFunction = ScriptRuntime.getValueFunctionAndThis(args[0], cx);
+        final Scriptable funThis = ScriptRuntime.lastStoredScriptable(cx);
+        final Object[] cmpBuf = new Object[2]; // Buffer for cmp arguments
+        return new ElementComparator(
+                new Comparator<Object>() {
+                    @Override
+                    public int compare(final Object x, final Object y) {
+                        // This comparator is invoked only for non-undefined objects
+                        cmpBuf[0] = x;
+                        cmpBuf[1] = y;
+                        Object ret = jsCompareFunction.call(cx, scope, funThis, cmpBuf);
+                        double d = ScriptRuntime.toNumber(ret);
+                        int cmp = Double.compare(d, 0);
+                        if (cmp < 0) {
+                            return -1;
+                        } else if (cmp > 0) {
+                            return +1;
+                        }
+                        return 0;
+                    }
+                });
+    }
+
+    // Comparators for the js_sort method. Putting them here lets us unit-test them better.
+
+    private static final Comparator<Object> STRING_COMPARATOR = new StringLikeComparator();
+    private static final Comparator<Object> DEFAULT_COMPARATOR = new ElementComparator();
+
+    public static final class StringLikeComparator implements Comparator<Object>, Serializable {
+
+        private static final long serialVersionUID = 5299017659728190979L;
+
+        @Override
+        public int compare(final Object x, final Object y) {
+            final String a = ScriptRuntime.toString(x);
+            final String b = ScriptRuntime.toString(y);
+            return a.compareTo(b);
+        }
+    }
+
+    public static final class ElementComparator implements Comparator<Object>, Serializable {
+
+        private static final long serialVersionUID = -1189948017688708858L;
+
+        private final Comparator<Object> child;
+
+        public ElementComparator() {
+            child = STRING_COMPARATOR;
+        }
+
+        public ElementComparator(Comparator<Object> c) {
+            child = c;
+        }
+
+        @Override
+        public int compare(final Object x, final Object y) {
+            // Sort NOT_FOUND to very end, Undefined before that, exclusively, as per
+            // ECMA 22.1.3.25.1.
+            if (x == Undefined.instance) {
+                if (y == Undefined.instance) {
+                    return 0;
+                }
+                if (y == NOT_FOUND) {
+                    return -1;
+                }
+                return 1;
+            } else if (x == NOT_FOUND) {
+                return y == NOT_FOUND ? 0 : 1;
+            }
+
+            if (y == NOT_FOUND) {
+                return -1;
+            }
+            if (y == Undefined.instance) {
+                return -1;
+            }
+
+            return child.compare(x, y);
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -1490,7 +1490,7 @@ public class ScriptRuntime {
         return ScriptableObject.getProperty(scope, id);
     }
 
-    static Function getExistingCtor(Context cx, Scriptable scope, String constructorName) {
+    public static Function getExistingCtor(Context cx, Scriptable scope, String constructorName) {
         Object ctorVal = ScriptableObject.getProperty(scope, constructorName);
         if (ctorVal instanceof Function) {
             return (Function) ctorVal;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -15,18 +15,22 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
 import java.util.RandomAccess;
+import org.mozilla.javascript.AbstractEcmaObjectOperations;
 import org.mozilla.javascript.ArrayLikeAbstractOperations;
 import org.mozilla.javascript.ArrayLikeAbstractOperations.IterativeOperation;
 import org.mozilla.javascript.ArrayLikeAbstractOperations.ReduceOperation;
 import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.Constructable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ExternalArrayData;
+import org.mozilla.javascript.Function;
 import org.mozilla.javascript.IdFunctionObject;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeArrayIterator;
 import org.mozilla.javascript.NativeArrayIterator.ARRAY_ITERATOR_TYPE;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Symbol;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
@@ -430,13 +434,13 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             throw ScriptRuntime.rangeError(msg);
         }
 
-        return ScriptRuntime.newObject(
+        return typedArraySpeciesCreate(
                 cx,
                 scope,
-                getClassName(),
                 new Object[] {
                     this.arrayBuffer, begin * this.getBytesPerElement(), Math.max(0, end - begin)
-                });
+                },
+                "slice");
     }
 
     private String js_join(Object[] args) {
@@ -609,6 +613,21 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return getProperty(thisObj, (int) k);
     }
 
+    private Scriptable typedArraySpeciesCreate(
+            Context cx, Scriptable scope, Object[] args, String methodName) {
+        Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
+        Function defaultConstructor =
+                ScriptRuntime.getExistingCtor(cx, topLevelScope, getClassName());
+        Constructable constructable =
+                AbstractEcmaObjectOperations.speciesConstructor(cx, this, defaultConstructor);
+
+        Scriptable newArray = constructable.construct(cx, scope, args);
+        if (!(newArray instanceof NativeTypedArrayView<?>)) {
+            throw ScriptRuntime.typeErrorById("msg.typed.array.ctor.incompatible", methodName);
+        }
+        return newArray;
+    }
+
     // Dispatcher
 
     @Override
@@ -727,7 +746,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                     Object array =
                             ArrayLikeAbstractOperations.iterativeMethod(
                                     cx, f, IterativeOperation.FILTER, scope, thisObj, args);
-                    return ScriptRuntime.newObject(cx, scope, getClassName(), new Object[] {array});
+                    return realThis(thisObj, f)
+                            .typedArraySpeciesCreate(cx, scope, new Object[] {array}, "filter");
                 }
             case Id_forEach:
                 return ArrayLikeAbstractOperations.iterativeMethod(
@@ -739,7 +759,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                     Object array =
                             ArrayLikeAbstractOperations.iterativeMethod(
                                     cx, f, IterativeOperation.MAP, scope, thisObj, args);
-                    return ScriptRuntime.newObject(cx, scope, getClassName(), new Object[] {array});
+                    return realThis(thisObj, f)
+                            .typedArraySpeciesCreate(cx, scope, new Object[] {array}, "map");
                 }
             case Id_some:
                 return ArrayLikeAbstractOperations.iterativeMethod(

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -963,3 +963,6 @@ msg.promise.capability.state =\
 
 msg.promise.all.toobig =\
   Too many inputs to Promise.all
+
+msg.typed.array.ctor.incompatible = \
+  Method %TypedArray%.prototype.{0} called on incompatible receiver

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComparatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComparatorTest.java
@@ -1,12 +1,12 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.mozilla.javascript.ArrayLikeAbstractOperations.*;
 
 import java.io.FileReader;
 import java.io.IOException;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
@@ -43,8 +43,8 @@ public class ComparatorTest {
     }
 
     private static void aChk(Object o1, Object o2, int expected) {
-        assertEquals(expected, new NativeArray.ElementComparator().compare(o1, o2));
-        assertEquals(-expected, new NativeArray.ElementComparator().compare(o2, o1));
+        assertEquals(expected, new ElementComparator().compare(o1, o2));
+        assertEquals(-expected, new ElementComparator().compare(o2, o1));
     }
 
     /*

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayCopyWithinTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayCopyWithinTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-copy-within.js")
+public class TypedArrayCopyWithinTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayEveryTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayEveryTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-every.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayEveryTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFillTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFillTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-fill.js")
+public class TypedArrayFillTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFilterTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFilterTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-filter.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayFilterTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFindIndexTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFindIndexTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-find-index.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayFindIndexTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFindTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayFindTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-find.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayFindTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayForEachTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayForEachTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-for-each.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayForEachTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayIncludesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayIncludesTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-includes.js")
+public class TypedArrayIncludesTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayIndexOfTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayIndexOfTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-index-of.js")
+public class TypedArrayIndexOfTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayIteratorsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayIteratorsTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-iterators.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayIteratorsTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayJoinTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayJoinTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-join.js")
+public class TypedArrayJoinTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayLastIndexOfTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayLastIndexOfTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-last-index-of.js")
+public class TypedArrayLastIndexOfTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayMapTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayMapTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-map.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayMapTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayReduceReduceRightTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayReduceReduceRightTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-reduce-reduce-right.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayReduceReduceRightTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayReverseTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayReverseTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-reverse.js")
+public class TypedArrayReverseTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySliceNativeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySliceNativeTest.java
@@ -4,8 +4,11 @@
 
 package org.mozilla.javascript.tests.harmony;
 
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
 import org.mozilla.javascript.drivers.RhinoTest;
 import org.mozilla.javascript.drivers.ScriptTestsBase;
 
 @RhinoTest("testsrc/jstests/harmony/typed-array-slice-native.js")
+@LanguageVersion(Context.VERSION_ES6)
 public class TypedArraySliceNativeTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySliceNativeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySliceNativeTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-slice-native.js")
+public class TypedArraySliceNativeTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySomeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySomeTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-some.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArraySomeTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySortTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArraySortTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-sort.js")
+public class TypedArraySortTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayToLocaleStringTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayToLocaleStringTest.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.harmony;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/harmony/typed-array-to-locale-string.js")
+public class TypedArrayToLocaleStringTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/harmony/typed-array-copy-within.js
+++ b/tests/testsrc/jstests/harmony/typed-array-copy-within.js
@@ -1,0 +1,24 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+    
+    var arr = new type([0, 1, 2, 3, 4, 5, 6]);
+    arr.copyWithin(4, 1);
+    assertEquals("0,1,2,3,1,2,3", arr.toString());
+
+    arr = new type([0, 1, 2, 3, 4, 5, 6]);
+    arr.copyWithin(-2, -5);
+    assertEquals("0,1,2,3,4,2,3", arr.toString());
+
+    arr = new type([0, 1, 2, 3, 4, 5, 6]);
+    arr.copyWithin(3, 1, 4);
+    assertEquals("0,1,2,1,2,3,6", arr.toString());
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-every.js
+++ b/tests/testsrc/jstests/harmony/typed-array-every.js
@@ -1,0 +1,19 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var empty = new type();
+    assertTrue(empty.every(() => false));
+    
+    var arr = new type([1, 2, 3]);
+    assertTrue(arr.every(n => n > 0));
+    assertFalse(arr.every(n => n > 1));
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-fill.js
+++ b/tests/testsrc/jstests/harmony/typed-array-fill.js
@@ -1,0 +1,43 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+var intTypes = types.slice(0, types.indexOf(Float32Array));
+var floatTypes = types.slice(types.indexOf(Float32Array));
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+    var arr = new type([1, 2, 3]);
+
+    arr.fill(4);
+    assertEquals("4,4,4", arr.toString());
+
+    arr.fill(5, 1);
+    assertEquals("4,5,5", arr.toString());
+
+    arr.fill(6, -2);
+    assertEquals("4,6,6", arr.toString());
+
+    arr.fill(7, 0, 1);
+    assertEquals("7,6,6", arr.toString());
+
+    arr.fill(8, 0, -1);
+    assertEquals("8,8,6", arr.toString());
+}
+ 
+for (var t = 0; t < intTypes.length; t++) {
+  var type = intTypes[t];
+  var arr = new type([1, 2, 3]);
+  arr.fill();
+  assertEquals("0,0,0", arr.toString());
+}
+
+for (var t = 0; t < floatTypes.length; t++) {
+  var type = floatTypes[t];
+  var arr = new type([1, 2, 3]);
+  arr.fill();
+  assertEquals("NaN,NaN,NaN", arr.toString());
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-filter.js
+++ b/tests/testsrc/jstests/harmony/typed-array-filter.js
@@ -18,6 +18,30 @@ for (var t = 0; t < types.length; t++) {
     assertTrue(arrFiltered instanceof type);
     assertEquals(2, arrFiltered.length);
     assertEquals("2,3", arrFiltered.toString());
+
+    // Check that the constructor property is used correctly
+    arr.constructor = Int16Array;
+    arrFiltered = arr.filter(n => n > 1);
+    assertTrue(arrFiltered instanceof Int16Array);
+    assertEquals(2, arrFiltered.length);
+    assertEquals("2,3", arrFiltered.toString());
+
+    arr.constructor = 42;
+    try {
+        arr.filter(n => n > 1);
+        assertTrue(false);
+    } catch (e) {
+        assertTrue(e instanceof TypeError);
+    }
+
+    arr.constructor = {};
+    arr.constructor[Symbol.species] = Array;
+    try {
+        arr.filter(n => n > 1);
+        assertTrue(false);
+    } catch (e) {
+        assertTrue(e instanceof TypeError);
+    }
 }
- 
+
 "success";

--- a/tests/testsrc/jstests/harmony/typed-array-filter.js
+++ b/tests/testsrc/jstests/harmony/typed-array-filter.js
@@ -1,0 +1,23 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var empty = new type();
+    var emptyFiltered = empty.filter(() => false);
+    assertTrue(emptyFiltered instanceof type);
+    assertEquals(0, emptyFiltered.length);
+    
+    var arr = new type([1, 2, 3]);
+    var arrFiltered = arr.filter(n => n > 1);
+    assertTrue(arrFiltered instanceof type);
+    assertEquals(2, arrFiltered.length);
+    assertEquals("2,3", arrFiltered.toString());
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-find-index.js
+++ b/tests/testsrc/jstests/harmony/typed-array-find-index.js
@@ -1,0 +1,16 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([1, 2, 3]);
+    assertEquals(1, arr.findIndex(n => n % 2 === 0));
+    assertEquals(-1, arr.findIndex(n => n < 0));
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-find.js
+++ b/tests/testsrc/jstests/harmony/typed-array-find.js
@@ -1,0 +1,16 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([1, 2, 3]);
+    assertEquals(2, arr.find(n => n % 2 === 0));
+    assertEquals(undefined, arr.find(n => n < 0));
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-for-each.js
+++ b/tests/testsrc/jstests/harmony/typed-array-for-each.js
@@ -1,0 +1,18 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([1, 2, 3]);
+    
+    var collected = [];
+    arr.forEach(n => collected.push(n));
+    assertEquals([1, 2, 3], collected);
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-includes.js
+++ b/tests/testsrc/jstests/harmony/typed-array-includes.js
@@ -1,0 +1,25 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+
+  var empty = new type(0);
+  assertFalse(empty.includes(0));
+  
+  var oneTwoThree = new type([1, 2, 3]);
+  assertFalse(oneTwoThree.includes(0));
+  assertTrue(oneTwoThree.includes(1));
+  
+  assertFalse(oneTwoThree.includes(1, 2));
+  
+  assertTrue(oneTwoThree.includes(2, -2));
+  assertTrue(oneTwoThree.includes(2, -100));
+  
+  assertTrue(oneTwoThree.includes(1.0));
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-index-of.js
+++ b/tests/testsrc/jstests/harmony/typed-array-index-of.js
@@ -1,0 +1,28 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+
+  var empty = new type(0);
+  assertEquals(-1, empty.indexOf(0));
+  
+  var oneTwoThree = new type([1, 2, 3]);
+  assertEquals(-1, oneTwoThree.indexOf(0));
+  assertEquals(0, oneTwoThree.indexOf(1));
+
+  assertEquals(-1, oneTwoThree.indexOf(1, 2));
+
+  assertEquals(1, oneTwoThree.indexOf(2, -2));
+  assertEquals(1, oneTwoThree.indexOf(2, -100));
+
+  assertEquals(0, oneTwoThree.indexOf(1.0));
+  
+  var repeated = new type([2, 1, 2]);
+  assertEquals(0, repeated.indexOf(2));
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-iterators.js
+++ b/tests/testsrc/jstests/harmony/typed-array-iterators.js
@@ -1,0 +1,46 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+function checkIterator(it, expected) {
+    for (var e of expected) {
+        var next = it.next();
+        assertEquals(next.values, e.values);
+        assertEquals(next.done, e.done);
+    }
+}
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([4, 5, 6]);
+    checkIterator(arr.entries(), [
+        {value: [0, 4], done: false},
+        {value: [1, 5], done: false},
+        {value: [2, 6], done: false},
+        {value: undefined, done: true}
+    ]);
+    checkIterator(arr.keys(), [
+        {value: 0, done: false},
+        {value: 1, done: false},
+        {value: 2, done: false},
+        {value: undefined, done: true}
+    ]);
+    checkIterator(arr.values(), [
+        {value: 4, done: false},
+        {value: 5, done: false},
+        {value: 6, done: false},
+        {value: undefined, done: true}
+    ]);
+    checkIterator(arr[Symbol.iterator](), [
+        {value: 4, done: false},
+        {value: 5, done: false},
+        {value: 6, done: false},
+        {value: undefined, done: true}
+    ]);
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-join.js
+++ b/tests/testsrc/jstests/harmony/typed-array-join.js
@@ -1,0 +1,15 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+  var arr = new type([1, 2, 3]);
+
+  assertEquals("1,2,3", arr.join());
+  assertEquals("1:2:3", arr.join(':'));
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-last-index-of.js
+++ b/tests/testsrc/jstests/harmony/typed-array-last-index-of.js
@@ -1,0 +1,28 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+
+  var empty = new type(0);
+  assertEquals(-1, empty.lastIndexOf(0));
+  
+  var oneTwoThree = new type([1, 2, 3]);
+  assertEquals(-1, oneTwoThree.lastIndexOf(0));
+  assertEquals(0, oneTwoThree.lastIndexOf(1));
+
+  assertEquals(-1, oneTwoThree.lastIndexOf(3, 1));
+
+  assertEquals(1, oneTwoThree.lastIndexOf(2, -2));
+  assertEquals(-1, oneTwoThree.lastIndexOf(2, -100));
+
+  assertEquals(0, oneTwoThree.lastIndexOf(1.0));
+  
+  var repeated = new type([2, 1, 2]);
+  assertEquals(2, repeated.lastIndexOf(2));
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-map.js
+++ b/tests/testsrc/jstests/harmony/typed-array-map.js
@@ -14,10 +14,34 @@ for (var t = 0; t < types.length; t++) {
     assertEquals(0, emptyFiltered.length);
     
     var arr = new type([1, 2, 3]);
-    var arrFiltered = arr.map(n => n + 1);
-    assertTrue(arrFiltered instanceof type);
-    assertEquals(3, arrFiltered.length);
-    assertEquals("2,3,4", arrFiltered.toString());
+    var arrMapped = arr.map(n => n + 1);
+    assertTrue(arrMapped instanceof type);
+    assertEquals(3, arrMapped.length);
+    assertEquals("2,3,4", arrMapped.toString());
+
+    // Check that the constructor property is used correctly
+    arr.constructor = Int16Array;
+    arrMapped = arr.map(n => n + 1);
+    assertTrue(arrMapped instanceof Int16Array);
+    assertEquals(3, arrMapped.length);
+    assertEquals("2,3,4", arrMapped.toString());
+
+    arr.constructor = 42;
+    try {
+        arr.map(n => n + 1);
+        assertTrue(false);
+    } catch (e) {
+        assertTrue(e instanceof TypeError);
+    }
+
+    arr.constructor = {};
+    arr.constructor[Symbol.species] = Array;
+    try {
+        arr.map(n => n + 1);
+        assertTrue(false);
+    } catch (e) {
+        assertTrue(e instanceof TypeError);
+    }
 }
  
 "success";

--- a/tests/testsrc/jstests/harmony/typed-array-map.js
+++ b/tests/testsrc/jstests/harmony/typed-array-map.js
@@ -1,0 +1,23 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var empty = new type();
+    var emptyFiltered = empty.map(n => n + 1);
+    assertTrue(emptyFiltered instanceof type);
+    assertEquals(0, emptyFiltered.length);
+    
+    var arr = new type([1, 2, 3]);
+    var arrFiltered = arr.map(n => n + 1);
+    assertTrue(arrFiltered instanceof type);
+    assertEquals(3, arrFiltered.length);
+    assertEquals("2,3,4", arrFiltered.toString());
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-reduce-reduce-right.js
+++ b/tests/testsrc/jstests/harmony/typed-array-reduce-reduce-right.js
@@ -1,0 +1,16 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([1, 2, 3]);
+    assertEquals('x123', arr.reduce( (prev, curr) => prev.toString() + curr.toString(), 'x'));
+    assertEquals('x321', arr.reduceRight( (prev, curr) => prev.toString() + curr.toString(), 'x'));
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-reverse.js
+++ b/tests/testsrc/jstests/harmony/typed-array-reverse.js
@@ -1,0 +1,17 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+  var arr = new type([1, 2, 3]);
+
+  var reversed = arr.reverse();
+  assertEquals(arr, reversed);
+  assertEquals(3, reversed.length);
+  assertEquals("3,2,1", reversed.toString());
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-slice-native.js
+++ b/tests/testsrc/jstests/harmony/typed-array-slice-native.js
@@ -1,0 +1,34 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+
+  var oneTwoThreeFour = new type([1, 2, 3, 4]);
+  
+  var slice = oneTwoThreeFour.slice();
+  assertTrue(slice instanceof type);
+  assertEquals(4, slice.length);
+  assertEquals("1,2,3,4", slice.toString());
+  
+  slice = oneTwoThreeFour.slice(1);
+  assertEquals(3, slice.length);
+  assertEquals("2,3,4", slice.toString());
+
+  slice = oneTwoThreeFour.slice(1, 3);
+  assertEquals(2, slice.length);
+  assertEquals("2,3", slice.toString());
+
+  slice = oneTwoThreeFour.slice(42, 0);
+  assertEquals(0, slice.length);
+  assertEquals("", slice.toString());
+
+  slice = oneTwoThreeFour.slice(0, 42);
+  assertEquals(4, slice.length);
+  assertEquals("1,2,3,4", slice.toString());
+}
+
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-slice-native.js
+++ b/tests/testsrc/jstests/harmony/typed-array-slice-native.js
@@ -29,6 +29,24 @@ for (var t = 0; t < types.length; t++) {
   slice = oneTwoThreeFour.slice(0, 42);
   assertEquals(4, slice.length);
   assertEquals("1,2,3,4", slice.toString());
+
+  // Check that the constructor property is used correctly
+  oneTwoThreeFour.constructor = 42;
+  try {
+    slice = oneTwoThreeFour.slice(1, 3);
+    assertTrue(false);
+  } catch (e) {
+    assertTrue(e instanceof TypeError);
+  }
+
+  oneTwoThreeFour.constructor = {};
+  oneTwoThreeFour.constructor[Symbol.species] = Array;
+  try {
+    slice = oneTwoThreeFour.slice(1, 3);
+    assertTrue(false);
+  } catch (e) {
+    assertTrue(e instanceof TypeError);
+  }
 }
 
 "success";

--- a/tests/testsrc/jstests/harmony/typed-array-some.js
+++ b/tests/testsrc/jstests/harmony/typed-array-some.js
@@ -1,0 +1,19 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var empty = new type();
+    assertFalse(empty.some(() => false));
+    
+    var arr = new type([1, 2, 3]);
+    assertTrue(arr.some(n => n > 1));
+    assertFalse(arr.some(n => n > 4));
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-sort.js
+++ b/tests/testsrc/jstests/harmony/typed-array-sort.js
@@ -1,0 +1,27 @@
+load("testsrc/assert.js");
+
+var signedTypes = [Int8Array, Int16Array, Int32Array, Float32Array, Float64Array];
+var unsignedTypes = [Uint8Array, Uint16Array, Uint32Array, Uint8ClampedArray];
+
+for (var t = 0; t < signedTypes.length; t++) {
+    var type = signedTypes[t];
+    var arr = new type([3, -1, 2, -4, 5, -6, 0, 7]);
+    arr.sort();
+    assertEquals("-6,-4,-1,0,2,3,5,7", arr.toString());
+    
+    arr = new type([-1, -3, -2, -4, -1, -3, 0, 3, 1]);
+    arr.sort((a, b) => b.toString().length - a.toString().length)
+    assertEquals("-1,-3,-2,-4,-1,-3,0,3,1", arr.toString());
+}
+
+for (var t = 0; t < unsignedTypes.length; t++) {
+    var type = unsignedTypes[t];
+    var arr = new type([3, 1, 2, 4, 5, 6, 0, 7]);
+    arr.sort();
+    assertEquals("0,1,2,3,4,5,6,7", arr.toString());
+    
+    arr.sort((a, b) => a % 2 - b % 2);
+    assertEquals("0,2,4,6,1,3,5,7", arr.toString());
+}
+ 
+"success";

--- a/tests/testsrc/jstests/harmony/typed-array-to-locale-string.js
+++ b/tests/testsrc/jstests/harmony/typed-array-to-locale-string.js
@@ -1,0 +1,18 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+             Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+             Float64Array];
+
+Number.prototype.toLocaleString = function() {
+  return this.toString() + 't';
+}
+
+for (var t = 0; t < types.length; t++) {
+  var type = types[t];
+  var arr = new type([1, 2, 3]);
+
+  assertEquals(arr.toLocaleString(), "1t,2t,3t");
+}
+
+"success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1613,7 +1613,7 @@ built-ins/ThrowTypeError 7/13 (53.85%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 978/1070 (91.4%)
+built-ins/TypedArray 803/1070 (75.05%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/iter-access-error.js
@@ -1652,46 +1652,30 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/byteOffset/this-has-no-typedarrayname-internal.js
     prototype/byteOffset/this-is-not-object.js
     prototype/copyWithin/BigInt 23/23 (100.0%)
-    prototype/copyWithin/bit-precision.js
-    prototype/copyWithin/coerced-values-end.js
-    prototype/copyWithin/coerced-values-start.js
-    prototype/copyWithin/coerced-values-target.js
+    prototype/copyWithin/coerced-values-end-detached.js
+    prototype/copyWithin/coerced-values-end-detached-prototype.js
+    prototype/copyWithin/coerced-values-start-detached.js
     prototype/copyWithin/detached-buffer.js
     prototype/copyWithin/get-length-ignores-length-prop.js
     prototype/copyWithin/invoked-as-func.js
     prototype/copyWithin/invoked-as-method.js
     prototype/copyWithin/length.js
     prototype/copyWithin/name.js
-    prototype/copyWithin/negative-end.js
-    prototype/copyWithin/negative-out-of-bounds-end.js
-    prototype/copyWithin/negative-out-of-bounds-start.js
-    prototype/copyWithin/negative-out-of-bounds-target.js
-    prototype/copyWithin/negative-start.js
-    prototype/copyWithin/negative-target.js
-    prototype/copyWithin/non-negative-out-of-bounds-end.js
-    prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
-    prototype/copyWithin/non-negative-target-and-start.js
-    prototype/copyWithin/non-negative-target-start-and-end.js
     prototype/copyWithin/prop-desc.js
-    prototype/copyWithin/return-abrupt-from-end.js
-    prototype/copyWithin/return-abrupt-from-start.js
-    prototype/copyWithin/return-abrupt-from-target.js
-    prototype/copyWithin/return-this.js
     prototype/copyWithin/this-is-not-object.js
     prototype/copyWithin/this-is-not-typedarray-instance.js
-    prototype/copyWithin/undefined-end.js
     prototype/entries/BigInt 3/3 (100.0%)
-    prototype/entries 10/10 (100.0%)
+    prototype/entries/detached-buffer.js
+    prototype/entries/invoked-as-func.js
+    prototype/entries/invoked-as-method.js
+    prototype/entries/length.js
+    prototype/entries/name.js
+    prototype/entries/prop-desc.js
+    prototype/entries/this-is-not-object.js
+    prototype/entries/this-is-not-typedarray-instance.js
     prototype/every/BigInt 15/15 (100.0%)
-    prototype/every/callbackfn-arguments-with-thisarg.js
-    prototype/every/callbackfn-arguments-without-thisarg.js
     prototype/every/callbackfn-detachbuffer.js
-    prototype/every/callbackfn-no-interaction-over-non-integer.js
-    prototype/every/callbackfn-not-called-on-empty.js
-    prototype/every/callbackfn-return-does-not-change-instance.js
-    prototype/every/callbackfn-returns-abrupt.js
     prototype/every/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
-    prototype/every/callbackfn-this.js
     prototype/every/detached-buffer.js
     prototype/every/get-length-uses-internal-arraylength.js
     prototype/every/invoked-as-func.js
@@ -1699,70 +1683,49 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/every/length.js
     prototype/every/name.js
     prototype/every/prop-desc.js
-    prototype/every/returns-false-if-any-cb-returns-false.js
-    prototype/every/returns-true-if-every-cb-returns-true.js
     prototype/every/this-is-not-object.js
     prototype/every/this-is-not-typedarray-instance.js
-    prototype/every/values-are-not-cached.js
     prototype/fill/BigInt 17/17 (100.0%)
-    prototype/fill/coerced-indexes.js
+    prototype/fill/coerced-end-detach.js
+    prototype/fill/coerced-start-detach.js
+    prototype/fill/coerced-value-detach.js
     prototype/fill/detached-buffer.js
-    prototype/fill/fill-values.js
     prototype/fill/fill-values-conversion-once.js
-    prototype/fill/fill-values-conversion-operations.js
-    prototype/fill/fill-values-conversion-operations-consistent-nan.js
-    prototype/fill/fill-values-custom-start-and-end.js
-    prototype/fill/fill-values-non-numeric.js
-    prototype/fill/fill-values-relative-end.js
-    prototype/fill/fill-values-relative-start.js
     prototype/fill/get-length-ignores-length-prop.js
     prototype/fill/invoked-as-func.js
     prototype/fill/invoked-as-method.js
     prototype/fill/length.js
     prototype/fill/name.js
     prototype/fill/prop-desc.js
-    prototype/fill/return-abrupt-from-end.js
-    prototype/fill/return-abrupt-from-set-value.js
-    prototype/fill/return-abrupt-from-start.js
-    prototype/fill/return-this.js
     prototype/fill/this-is-not-object.js
     prototype/fill/this-is-not-typedarray-instance.js
     prototype/filter/BigInt 33/33 (100.0%)
     prototype/filter/arraylength-internal.js
-    prototype/filter/callbackfn-arguments-with-thisarg.js
-    prototype/filter/callbackfn-arguments-without-thisarg.js
     prototype/filter/callbackfn-called-before-ctor.js
     prototype/filter/callbackfn-called-before-species.js
     prototype/filter/callbackfn-detachbuffer.js
-    prototype/filter/callbackfn-no-iteration-over-non-integer.js
-    prototype/filter/callbackfn-not-called-on-empty.js
-    prototype/filter/callbackfn-return-does-not-change-instance.js
-    prototype/filter/callbackfn-returns-abrupt.js
     prototype/filter/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
-    prototype/filter/callbackfn-this.js
     prototype/filter/detached-buffer.js
     prototype/filter/invoked-as-func.js
     prototype/filter/invoked-as-method.js
     prototype/filter/length.js
     prototype/filter/name.js
     prototype/filter/prop-desc.js
-    prototype/filter/result-does-not-share-buffer.js
-    prototype/filter/result-empty-callbackfn-returns-false.js
-    prototype/filter/result-full-callbackfn-returns-true.js
     prototype/filter/speciesctor-get-ctor.js
     prototype/filter/speciesctor-get-ctor-abrupt.js
     prototype/filter/speciesctor-get-ctor-inherited.js
+    prototype/filter/speciesctor-get-ctor-returns-throws.js
     prototype/filter/speciesctor-get-species.js
     prototype/filter/speciesctor-get-species-abrupt.js
     prototype/filter/speciesctor-get-species-custom-ctor.js
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/speciesctor-get-species-custom-ctor-length.js
+    prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/filter/speciesctor-get-species-use-default-ctor.js
+    prototype/filter/speciesctor-get-species-custom-ctor-throws.js
+    prototype/filter/speciesctor-get-species-returns-throws.js
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
-    prototype/filter/values-are-not-cached.js
-    prototype/filter/values-are-set.js
     prototype/find/BigInt 12/12 (100.0%)
     prototype/findIndex/BigInt 12/12 (100.0%)
     prototype/findIndex/detached-buffer.js
@@ -1771,16 +1734,9 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/findIndex/invoked-as-method.js
     prototype/findIndex/length.js
     prototype/findIndex/name.js
-    prototype/findIndex/predicate-call-changes-value.js
-    prototype/findIndex/predicate-call-parameters.js
-    prototype/findIndex/predicate-call-this-non-strict.js non-strict
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/predicate-may-detach-buffer.js
-    prototype/findIndex/predicate-not-called-on-empty-array.js
     prototype/findIndex/prop-desc.js
-    prototype/findIndex/return-abrupt-from-predicate-call.js
-    prototype/findIndex/return-index-predicate-result-is-true.js
-    prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
     prototype/findIndex/this-is-not-object.js
     prototype/findIndex/this-is-not-typedarray-instance.js
     prototype/find/detached-buffer.js
@@ -1789,116 +1745,73 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/find/invoked-as-method.js
     prototype/find/length.js
     prototype/find/name.js
-    prototype/find/predicate-call-changes-value.js
-    prototype/find/predicate-call-parameters.js
-    prototype/find/predicate-call-this-non-strict.js non-strict
     prototype/find/predicate-call-this-strict.js strict
     prototype/find/predicate-may-detach-buffer.js
-    prototype/find/predicate-not-called-on-empty-array.js
     prototype/find/prop-desc.js
-    prototype/find/return-abrupt-from-predicate-call.js
-    prototype/find/return-found-value-predicate-result-is-true.js
-    prototype/find/return-undefined-if-predicate-returns-false-value.js
     prototype/find/this-is-not-object.js
     prototype/find/this-is-not-typedarray-instance.js
     prototype/forEach/BigInt 14/14 (100.0%)
     prototype/forEach/arraylength-internal.js
-    prototype/forEach/callbackfn-arguments-with-thisarg.js
-    prototype/forEach/callbackfn-arguments-without-thisarg.js
     prototype/forEach/callbackfn-detachbuffer.js
-    prototype/forEach/callbackfn-no-interaction-over-non-integer.js
-    prototype/forEach/callbackfn-not-called-on-empty.js
-    prototype/forEach/callbackfn-return-does-not-change-instance.js
-    prototype/forEach/callbackfn-returns-abrupt.js
     prototype/forEach/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
-    prototype/forEach/callbackfn-this.js
     prototype/forEach/detached-buffer.js
     prototype/forEach/invoked-as-func.js
     prototype/forEach/invoked-as-method.js
     prototype/forEach/length.js
     prototype/forEach/name.js
     prototype/forEach/prop-desc.js
-    prototype/forEach/returns-undefined.js
     prototype/forEach/this-is-not-object.js
     prototype/forEach/this-is-not-typedarray-instance.js
-    prototype/forEach/values-are-not-cached.js
     prototype/includes/BigInt 11/11 (100.0%)
     prototype/includes/detached-buffer.js
-    prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
-    prototype/includes/fromIndex-infinity.js
-    prototype/includes/fromIndex-minus-zero.js
+    prototype/includes/detached-buffer-tointeger.js
     prototype/includes/get-length-uses-internal-arraylength.js
     prototype/includes/invoked-as-func.js
     prototype/includes/invoked-as-method.js
     prototype/includes/length.js
-    prototype/includes/length-zero-returns-false.js
     prototype/includes/name.js
     prototype/includes/prop-desc.js
-    prototype/includes/return-abrupt-tointeger-fromindex.js
-    prototype/includes/samevaluezero.js
-    prototype/includes/search-found-returns-true.js
-    prototype/includes/search-not-found-returns-false.js
-    prototype/includes/searchelement-not-integer.js
     prototype/includes/this-is-not-object.js
     prototype/includes/this-is-not-typedarray-instance.js
-    prototype/includes/tointeger-fromindex.js
     prototype/indexOf/BigInt 12/12 (100.0%)
     prototype/indexOf/detached-buffer.js
-    prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
-    prototype/indexOf/fromIndex-infinity.js
-    prototype/indexOf/fromIndex-minus-zero.js
     prototype/indexOf/get-length-uses-internal-arraylength.js
     prototype/indexOf/invoked-as-func.js
     prototype/indexOf/invoked-as-method.js
     prototype/indexOf/length.js
-    prototype/indexOf/length-zero-returns-minus-one.js
     prototype/indexOf/name.js
-    prototype/indexOf/no-arg.js
     prototype/indexOf/prop-desc.js
-    prototype/indexOf/return-abrupt-tointeger-fromindex.js
-    prototype/indexOf/search-found-returns-index.js
-    prototype/indexOf/search-not-found-returns-minus-one.js
-    prototype/indexOf/strict-comparison.js
     prototype/indexOf/this-is-not-object.js
     prototype/indexOf/this-is-not-typedarray-instance.js
-    prototype/indexOf/tointeger-fromindex.js
     prototype/join/BigInt 7/7 (100.0%)
-    prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
-    prototype/join/custom-separator-result-from-tostring-on-each-value.js
     prototype/join/detached-buffer.js
-    prototype/join/empty-instance-empty-string.js
     prototype/join/get-length-uses-internal-arraylength.js
     prototype/join/invoked-as-func.js
     prototype/join/invoked-as-method.js
     prototype/join/length.js
     prototype/join/name.js
     prototype/join/prop-desc.js
-    prototype/join/result-from-tostring-on-each-simple-value.js
-    prototype/join/result-from-tostring-on-each-value.js
-    prototype/join/return-abrupt-from-separator.js
     prototype/join/this-is-not-object.js
     prototype/join/this-is-not-typedarray-instance.js
     prototype/keys/BigInt 3/3 (100.0%)
-    prototype/keys 10/10 (100.0%)
+    prototype/keys/detached-buffer.js
+    prototype/keys/invoked-as-func.js
+    prototype/keys/invoked-as-method.js
+    prototype/keys/length.js
+    prototype/keys/name.js
+    prototype/keys/prop-desc.js
+    prototype/keys/this-is-not-object.js
+    prototype/keys/this-is-not-typedarray-instance.js
     prototype/lastIndexOf/BigInt 11/11 (100.0%)
     prototype/lastIndexOf/detached-buffer.js
-    prototype/lastIndexOf/fromIndex-infinity.js
-    prototype/lastIndexOf/fromIndex-minus-zero.js
     prototype/lastIndexOf/get-length-uses-internal-arraylength.js
     prototype/lastIndexOf/invoked-as-func.js
     prototype/lastIndexOf/invoked-as-method.js
     prototype/lastIndexOf/length.js
-    prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/name.js
-    prototype/lastIndexOf/no-arg.js
     prototype/lastIndexOf/prop-desc.js
-    prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
-    prototype/lastIndexOf/search-found-returns-index.js
-    prototype/lastIndexOf/search-not-found-returns-minus-one.js
-    prototype/lastIndexOf/strict-comparison.js
     prototype/lastIndexOf/this-is-not-object.js
     prototype/lastIndexOf/this-is-not-typedarray-instance.js
-    prototype/lastIndexOf/tointeger-fromindex.js
     prototype/length/BigInt 2/2 (100.0%)
     prototype/length/detached-buffer.js
     prototype/length/invoked-as-func.js
@@ -1909,90 +1822,63 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/length/this-is-not-object.js
     prototype/map/BigInt 31/31 (100.0%)
     prototype/map/arraylength-internal.js
-    prototype/map/callbackfn-arguments-with-thisarg.js
-    prototype/map/callbackfn-arguments-without-thisarg.js
     prototype/map/callbackfn-detachbuffer.js
-    prototype/map/callbackfn-no-interaction-over-non-integer-properties.js
-    prototype/map/callbackfn-not-called-on-empty.js
-    prototype/map/callbackfn-return-affects-returned-object.js
-    prototype/map/callbackfn-return-does-not-change-instance.js
-    prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
-    prototype/map/callbackfn-returns-abrupt.js
     prototype/map/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
-    prototype/map/callbackfn-this.js
     prototype/map/detached-buffer.js
     prototype/map/invoked-as-func.js
     prototype/map/invoked-as-method.js
     prototype/map/length.js
     prototype/map/name.js
     prototype/map/prop-desc.js
-    prototype/map/return-new-typedarray-conversion-operation.js
-    prototype/map/return-new-typedarray-conversion-operation-consistent-nan.js
-    prototype/map/return-new-typedarray-from-empty-length.js
-    prototype/map/return-new-typedarray-from-positive-length.js
     prototype/map/speciesctor-get-ctor.js
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-ctor-inherited.js
+    prototype/map/speciesctor-get-ctor-returns-throws.js
     prototype/map/speciesctor-get-species.js
     prototype/map/speciesctor-get-species-abrupt.js
     prototype/map/speciesctor-get-species-custom-ctor.js
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/speciesctor-get-species-custom-ctor-length.js
+    prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/speciesctor-get-species-use-default-ctor.js
+    prototype/map/speciesctor-get-species-custom-ctor-throws.js
+    prototype/map/speciesctor-get-species-returns-throws.js
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
-    prototype/map/values-are-not-cached.js
     prototype/reduce/BigInt 18/18 (100.0%)
     prototype/reduceRight/BigInt 18/18 (100.0%)
-    prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
-    prototype/reduceRight/callbackfn-arguments-default-accumulator.js
     prototype/reduceRight/callbackfn-detachbuffer.js
-    prototype/reduceRight/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduceRight/callbackfn-not-called-on-empty.js
-    prototype/reduceRight/callbackfn-return-does-not-change-instance.js
-    prototype/reduceRight/callbackfn-returns-abrupt.js
     prototype/reduceRight/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
-    prototype/reduceRight/callbackfn-this.js
     prototype/reduceRight/detached-buffer.js
-    prototype/reduceRight/empty-instance-return-initialvalue.js
     prototype/reduceRight/get-length-uses-internal-arraylength.js
     prototype/reduceRight/invoked-as-func.js
     prototype/reduceRight/invoked-as-method.js
     prototype/reduceRight/length.js
     prototype/reduceRight/name.js
     prototype/reduceRight/prop-desc.js
-    prototype/reduceRight/result-is-last-callbackfn-return.js
-    prototype/reduceRight/result-of-any-type.js
-    prototype/reduceRight/return-first-value-without-callbackfn.js
     prototype/reduceRight/this-is-not-object.js
     prototype/reduceRight/this-is-not-typedarray-instance.js
-    prototype/reduceRight/values-are-not-cached.js
-    prototype/reduce/callbackfn-arguments-custom-accumulator.js
-    prototype/reduce/callbackfn-arguments-default-accumulator.js
     prototype/reduce/callbackfn-detachbuffer.js
-    prototype/reduce/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduce/callbackfn-not-called-on-empty.js
-    prototype/reduce/callbackfn-return-does-not-change-instance.js
-    prototype/reduce/callbackfn-returns-abrupt.js
     prototype/reduce/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
-    prototype/reduce/callbackfn-this.js
     prototype/reduce/detached-buffer.js
-    prototype/reduce/empty-instance-return-initialvalue.js
     prototype/reduce/get-length-uses-internal-arraylength.js
     prototype/reduce/invoked-as-func.js
     prototype/reduce/invoked-as-method.js
     prototype/reduce/length.js
     prototype/reduce/name.js
     prototype/reduce/prop-desc.js
-    prototype/reduce/result-is-last-callbackfn-return.js
-    prototype/reduce/result-of-any-type.js
-    prototype/reduce/return-first-value-without-callbackfn.js
     prototype/reduce/this-is-not-object.js
     prototype/reduce/this-is-not-typedarray-instance.js
-    prototype/reduce/values-are-not-cached.js
     prototype/reverse/BigInt 5/5 (100.0%)
-    prototype/reverse 12/12 (100.0%)
+    prototype/reverse/detached-buffer.js
+    prototype/reverse/get-length-uses-internal-arraylength.js
+    prototype/reverse/invoked-as-func.js
+    prototype/reverse/invoked-as-method.js
+    prototype/reverse/length.js
+    prototype/reverse/name.js
+    prototype/reverse/prop-desc.js
+    prototype/reverse/this-is-not-object.js
+    prototype/reverse/this-is-not-typedarray-instance.js
     prototype/set/BigInt 48/48 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-primitive-toobject.js
@@ -2034,48 +1920,37 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
     prototype/slice/BigInt 35/35 (100.0%)
     prototype/slice/arraylength-internal.js
-    prototype/slice/bit-precision.js
     prototype/slice/detached-buffer.js
+    prototype/slice/detached-buffer-custom-ctor-other-targettype.js
+    prototype/slice/detached-buffer-custom-ctor-same-targettype.js
+    prototype/slice/detached-buffer-get-ctor.js
+    prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
     prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
     prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
-    prototype/slice/infinity.js
     prototype/slice/invoked-as-func.js
     prototype/slice/invoked-as-method.js
     prototype/slice/length.js
-    prototype/slice/minus-zero.js
     prototype/slice/name.js
     prototype/slice/prop-desc.js
-    prototype/slice/result-does-not-copy-ordinary-properties.js
-    prototype/slice/results-with-different-length.js
-    prototype/slice/results-with-empty-length.js
-    prototype/slice/results-with-same-length.js
-    prototype/slice/return-abrupt-from-end.js
-    prototype/slice/return-abrupt-from-start.js
     prototype/slice/set-values-from-different-ctor-type.js
     prototype/slice/speciesctor-get-ctor.js
     prototype/slice/speciesctor-get-ctor-abrupt.js
     prototype/slice/speciesctor-get-ctor-inherited.js
+    prototype/slice/speciesctor-get-ctor-returns-throws.js
     prototype/slice/speciesctor-get-species.js
     prototype/slice/speciesctor-get-species-abrupt.js
     prototype/slice/speciesctor-get-species-custom-ctor.js
     prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
     prototype/slice/speciesctor-get-species-custom-ctor-length.js
+    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/slice/speciesctor-get-species-use-default-ctor.js
+    prototype/slice/speciesctor-get-species-custom-ctor-throws.js
+    prototype/slice/speciesctor-get-species-returns-throws.js
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
-    prototype/slice/tointeger-end.js
-    prototype/slice/tointeger-start.js
     prototype/some/BigInt 15/15 (100.0%)
-    prototype/some/callbackfn-arguments-with-thisarg.js
-    prototype/some/callbackfn-arguments-without-thisarg.js
     prototype/some/callbackfn-detachbuffer.js
-    prototype/some/callbackfn-no-interaction-over-non-integer.js
-    prototype/some/callbackfn-not-called-on-empty.js
-    prototype/some/callbackfn-return-does-not-change-instance.js
-    prototype/some/callbackfn-returns-abrupt.js
     prototype/some/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
-    prototype/some/callbackfn-this.js
     prototype/some/detached-buffer.js
     prototype/some/get-length-uses-internal-arraylength.js
     prototype/some/invoked-as-func.js
@@ -2083,15 +1958,10 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/some/length.js
     prototype/some/name.js
     prototype/some/prop-desc.js
-    prototype/some/returns-false-if-every-cb-returns-false.js
-    prototype/some/returns-true-if-any-cb-returns-true.js
     prototype/some/this-is-not-object.js
     prototype/some/this-is-not-typedarray-instance.js
-    prototype/some/values-are-not-cached.js
     prototype/sort/BigInt 9/9 (100.0%)
     prototype/sort/arraylength-internal.js
-    prototype/sort/comparefn-call-throws.js
-    prototype/sort/comparefn-calls.js
     prototype/sort/detached-buffer.js
     prototype/sort/detached-buffer-comparefn.js
     prototype/sort/detached-buffer-comparefn-coerce.js
@@ -2100,12 +1970,7 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/sort/length.js
     prototype/sort/name.js
     prototype/sort/prop-desc.js
-    prototype/sort/return-same-instance.js
     prototype/sort/sort-tonumber.js
-    prototype/sort/sortcompare-with-no-tostring.js
-    prototype/sort/sorted-values.js
-    prototype/sort/sorted-values-nan.js
-    prototype/sort/stability.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
     prototype/subarray/BigInt 27/27 (100.0%)
@@ -2139,9 +2004,6 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
     prototype/Symbol.toStringTag/this-is-not-object.js
     prototype/toLocaleString/BigInt 13/13 (100.0%)
-    prototype/toLocaleString/calls-tolocalestring-from-each-value.js
-    prototype/toLocaleString/calls-tostring-from-each-value.js
-    prototype/toLocaleString/calls-valueof-from-each-value.js
     prototype/toLocaleString/detached-buffer.js
     prototype/toLocaleString/get-length-uses-internal-arraylength.js
     prototype/toLocaleString/invoked-as-func.js
@@ -2149,25 +2011,26 @@ built-ins/TypedArray 978/1070 (91.4%)
     prototype/toLocaleString/length.js
     prototype/toLocaleString/name.js
     prototype/toLocaleString/prop-desc.js
-    prototype/toLocaleString/return-abrupt-from-firstelement-tolocalestring.js
-    prototype/toLocaleString/return-abrupt-from-firstelement-tostring.js
-    prototype/toLocaleString/return-abrupt-from-firstelement-valueof.js
-    prototype/toLocaleString/return-abrupt-from-nextelement-tolocalestring.js
-    prototype/toLocaleString/return-abrupt-from-nextelement-tostring.js
-    prototype/toLocaleString/return-abrupt-from-nextelement-valueof.js
     prototype/toLocaleString/this-is-not-object.js
     prototype/toLocaleString/this-is-not-typedarray-instance.js
     prototype/toString/BigInt/detached-buffer.js
     prototype/toString/detached-buffer.js
     prototype/values/BigInt 3/3 (100.0%)
-    prototype/values 10/10 (100.0%)
+    prototype/values/detached-buffer.js
+    prototype/values/invoked-as-func.js
+    prototype/values/invoked-as-method.js
+    prototype/values/length.js
+    prototype/values/name.js
+    prototype/values/prop-desc.js
+    prototype/values/this-is-not-object.js
+    prototype/values/this-is-not-typedarray-instance.js
     prototype 3/3 (100.0%)
     Symbol.species 4/4 (100.0%)
     invoked.js
     name.js
     prototype.js
 
-built-ins/TypedArrayConstructors 525/684 (76.75%)
+built-ins/TypedArrayConstructors 546/684 (79.82%)
     BigInt64Array/prototype 4/4 (100.0%)
     BigInt64Array 7/7 (100.0%)
     BigUint64Array/prototype 4/4 (100.0%)
@@ -2350,32 +2213,32 @@ built-ins/TypedArrayConstructors 525/684 (76.75%)
     prototype/buffer 2/2 (100.0%)
     prototype/byteLength 2/2 (100.0%)
     prototype/byteOffset 2/2 (100.0%)
-    prototype/copyWithin/bigint-inherited.js
-    prototype/entries/bigint-inherited.js
-    prototype/every/bigint-inherited.js
-    prototype/fill/bigint-inherited.js
-    prototype/filter/bigint-inherited.js
-    prototype/findIndex/bigint-inherited.js
-    prototype/find/bigint-inherited.js
-    prototype/forEach/bigint-inherited.js
-    prototype/indexOf/bigint-inherited.js
-    prototype/join/bigint-inherited.js
-    prototype/keys/bigint-inherited.js
-    prototype/lastIndexOf/bigint-inherited.js
+    prototype/copyWithin 2/2 (100.0%)
+    prototype/entries 2/2 (100.0%)
+    prototype/every 2/2 (100.0%)
+    prototype/fill 2/2 (100.0%)
+    prototype/filter 2/2 (100.0%)
+    prototype/findIndex 2/2 (100.0%)
+    prototype/find 2/2 (100.0%)
+    prototype/forEach 2/2 (100.0%)
+    prototype/indexOf 2/2 (100.0%)
+    prototype/join 2/2 (100.0%)
+    prototype/keys 2/2 (100.0%)
+    prototype/lastIndexOf 2/2 (100.0%)
     prototype/length 2/2 (100.0%)
-    prototype/map/bigint-inherited.js
-    prototype/reduceRight/bigint-inherited.js
-    prototype/reduce/bigint-inherited.js
-    prototype/reverse/bigint-inherited.js
+    prototype/map 2/2 (100.0%)
+    prototype/reduceRight 2/2 (100.0%)
+    prototype/reduce 2/2 (100.0%)
+    prototype/reverse 2/2 (100.0%)
     prototype/set 2/2 (100.0%)
-    prototype/slice/bigint-inherited.js
-    prototype/some/bigint-inherited.js
-    prototype/sort/bigint-inherited.js
+    prototype/slice 2/2 (100.0%)
+    prototype/some 2/2 (100.0%)
+    prototype/sort 2/2 (100.0%)
     prototype/subarray 2/2 (100.0%)
     prototype/Symbol.toStringTag/bigint-inherited.js
-    prototype/toLocaleString/bigint-inherited.js
+    prototype/toLocaleString 2/2 (100.0%)
     prototype/toString 2/2 (100.0%)
-    prototype/values/bigint-inherited.js
+    prototype/values 2/2 (100.0%)
     prototype 2/2 (100.0%)
     Uint16Array/prototype/not-typedarray-object.js
     Uint16Array/prototype/proto.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1613,7 +1613,7 @@ built-ins/ThrowTypeError 7/13 (53.85%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 803/1070 (75.05%)
+built-ins/TypedArray 771/1070 (72.06%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/iter-access-error.js
@@ -1701,8 +1701,6 @@ built-ins/TypedArray 803/1070 (75.05%)
     prototype/fill/this-is-not-typedarray-instance.js
     prototype/filter/BigInt 33/33 (100.0%)
     prototype/filter/arraylength-internal.js
-    prototype/filter/callbackfn-called-before-ctor.js
-    prototype/filter/callbackfn-called-before-species.js
     prototype/filter/callbackfn-detachbuffer.js
     prototype/filter/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/filter/detached-buffer.js
@@ -1711,19 +1709,8 @@ built-ins/TypedArray 803/1070 (75.05%)
     prototype/filter/length.js
     prototype/filter/name.js
     prototype/filter/prop-desc.js
-    prototype/filter/speciesctor-get-ctor.js
-    prototype/filter/speciesctor-get-ctor-abrupt.js
-    prototype/filter/speciesctor-get-ctor-inherited.js
-    prototype/filter/speciesctor-get-ctor-returns-throws.js
-    prototype/filter/speciesctor-get-species.js
-    prototype/filter/speciesctor-get-species-abrupt.js
-    prototype/filter/speciesctor-get-species-custom-ctor.js
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/filter/speciesctor-get-species-custom-ctor-length.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/filter/speciesctor-get-species-custom-ctor-throws.js
-    prototype/filter/speciesctor-get-species-returns-throws.js
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/find/BigInt 12/12 (100.0%)
@@ -1830,19 +1817,10 @@ built-ins/TypedArray 803/1070 (75.05%)
     prototype/map/length.js
     prototype/map/name.js
     prototype/map/prop-desc.js
-    prototype/map/speciesctor-get-ctor.js
     prototype/map/speciesctor-get-ctor-abrupt.js
-    prototype/map/speciesctor-get-ctor-inherited.js
-    prototype/map/speciesctor-get-ctor-returns-throws.js
-    prototype/map/speciesctor-get-species.js
-    prototype/map/speciesctor-get-species-abrupt.js
-    prototype/map/speciesctor-get-species-custom-ctor.js
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/map/speciesctor-get-species-custom-ctor-length.js
     prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/speciesctor-get-species-custom-ctor-throws.js
-    prototype/map/speciesctor-get-species-returns-throws.js
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/reduce/BigInt 18/18 (100.0%)
@@ -1933,19 +1911,9 @@ built-ins/TypedArray 803/1070 (75.05%)
     prototype/slice/name.js
     prototype/slice/prop-desc.js
     prototype/slice/set-values-from-different-ctor-type.js
-    prototype/slice/speciesctor-get-ctor.js
-    prototype/slice/speciesctor-get-ctor-abrupt.js
-    prototype/slice/speciesctor-get-ctor-inherited.js
-    prototype/slice/speciesctor-get-ctor-returns-throws.js
-    prototype/slice/speciesctor-get-species.js
-    prototype/slice/speciesctor-get-species-abrupt.js
     prototype/slice/speciesctor-get-species-custom-ctor.js
     prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length.js
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/slice/speciesctor-get-species-custom-ctor-throws.js
-    prototype/slice/speciesctor-get-species-returns-throws.js
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/some/BigInt 15/15 (100.0%)


### PR DESCRIPTION
Since most methods were already implemented in `NativeArray`, I followed this approach:
- when reasonable, I extracted the implementation in `NativeArray` and moved it to a new class `ArrayLikeAbstractOperations`;
- otherwise, I copy&pasted the code from `NativeArray` into `NativeTypedArrayView` and simplified it.