### PR TITLE
Fix destructuring assignment errors

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1476,7 +1476,9 @@ public final class IRFactory {
             Node newBody = new Node(Token.BLOCK);
             Node assign;
             if (destructuring != -1) {
-                assign = parser.createDestructuringAssignment(declType, lvalue, id);
+                assign =
+                        parser.createDestructuringAssignment(
+                                declType, lvalue, id, (AstNode node) -> transform(node));
                 if (!isForEach
                         && !isForOf
                         && (destructuring == Token.OBJECTLIT || destructuringLen != 2)) {
@@ -2053,7 +2055,8 @@ public final class IRFactory {
                     parser.reportError("msg.bad.destruct.op");
                     return right;
                 }
-                return parser.createDestructuringAssignment(-1, left, right);
+                return parser.createDestructuringAssignment(
+                        -1, left, right, (AstNode node) -> transform(node));
             }
             parser.reportError("msg.bad.assign.left");
             return right;

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4041,39 +4041,34 @@ public class Parser {
         result.addChildToBack(comma);
         List<String> destructuringNames = new ArrayList<>();
         boolean empty = true;
-        switch (left.getType()) {
-            case Token.ARRAYLIT:
-                empty =
-                        destructuringArray(
-                                (ArrayLiteral) left,
-                                variableType,
-                                tempName,
-                                comma,
-                                destructuringNames,
-                                transformer);
-                break;
-            case Token.OBJECTLIT:
-                empty =
-                        destructuringObject(
-                                (ObjectLiteral) left,
-                                variableType,
-                                tempName,
-                                comma,
-                                destructuringNames,
-                                transformer);
-                break;
-            case Token.GETPROP:
-            case Token.GETELEM:
-                switch (variableType) {
-                    case Token.CONST:
-                    case Token.LET:
-                    case Token.VAR:
-                        reportError("msg.bad.assign.left");
-                }
-                comma.addChildToBack(simpleAssignment(left, createName(tempName), transformer));
-                break;
-            default:
-                reportError("msg.bad.assign.left");
+        if (left instanceof ArrayLiteral) {
+            empty =
+                    destructuringArray(
+                            (ArrayLiteral) left,
+                            variableType,
+                            tempName,
+                            comma,
+                            destructuringNames,
+                            transformer);
+        } else if (left instanceof ObjectLiteral) {
+            empty =
+                    destructuringObject(
+                            (ObjectLiteral) left,
+                            variableType,
+                            tempName,
+                            comma,
+                            destructuringNames,
+                            transformer);
+        } else if (left.getType() == Token.GETPROP || left.getType() == Token.GETELEM) {
+            switch (variableType) {
+                case Token.CONST:
+                case Token.LET:
+                case Token.VAR:
+                    reportError("msg.bad.assign.left");
+            }
+            comma.addChildToBack(simpleAssignment(left, createName(tempName), transformer));
+        } else {
+            reportError("msg.bad.assign.left");
         }
         if (empty) {
             // Don't want a COMMA node with no children. Just add a zero.

--- a/tests/testsrc/jstests/harmony/destructuring.js
+++ b/tests/testsrc/jstests/harmony/destructuring.js
@@ -16,4 +16,15 @@ var e;
 for ([e] = d; false; );
 assertEquals(e, 234);
 
+var arr = [];
+[arr[+false + 1]] = [123];
+assertEquals(arr[1], 123);
+
+[(NaN, arr)[1]] = [234];
+assertEquals(arr[1], 234);
+
+var obj = {};
+[(NaN, obj).b] = [345];
+assertEquals(obj.b, 345);
+
 "success";

--- a/tests/testsrc/jstests/harmony/destructuring.js
+++ b/tests/testsrc/jstests/harmony/destructuring.js
@@ -27,4 +27,7 @@ var obj = {};
 [(NaN, obj).b] = [345];
 assertEquals(obj.b, 345);
 
+assertThrows("(1 ? {} : 490) = 1", SyntaxError);
+assertThrows("(1 ? [] : 490) = 1", SyntaxError);
+
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -3245,7 +3245,7 @@ language/expressions/arrow-function 209/333 (62.76%)
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
 
-language/expressions/assignment 202/468 (43.16%)
+language/expressions/assignment 200/468 (42.74%)
     destructuring 3/3 (100.0%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
@@ -3276,7 +3276,6 @@ language/expressions/assignment 202/468 (43.16%)
     dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
     dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
-    dstr/array-elem-put-obj-literal-prop-ref.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
     dstr/array-elem-target-simple-strict.js strict
@@ -3401,7 +3400,6 @@ language/expressions/assignment 202/468 (43.16%)
     dstr/obj-prop-elem-init-let.js
     dstr/obj-prop-elem-init-yield-expr.js
     dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
-    dstr/obj-prop-elem-target-obj-literal-prop-ref.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
     dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
@@ -5930,7 +5928,7 @@ language/statements/for-in 39/114 (34.21%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 471/725 (64.97%)
+language/statements/for-of 469/725 (64.69%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -5960,7 +5958,6 @@ language/statements/for-of 471/725 (64.97%)
     dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
     dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
-    dstr/array-elem-put-obj-literal-prop-ref.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
     dstr/array-elem-target-simple-strict.js strict
@@ -6246,7 +6243,6 @@ language/statements/for-of 471/725 (64.97%)
     dstr/obj-prop-elem-init-let.js
     dstr/obj-prop-elem-init-yield-expr.js
     dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
-    dstr/obj-prop-elem-target-obj-literal-prop-ref.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
     dstr/obj-prop-elem-target-yield-ident-valid.js non-strict


### PR DESCRIPTION
### Closes #1187
```
js> var a = []; var b = 0; [a[b+1]] = [123];
Exception in thread "main" java.lang.NullPointerException
	at org.mozilla.javascript.optimizer.BodyCodegen.generateExpression(BodyCodegen.java:967)
	at org.mozilla.javascript.optimizer.BodyCodegen.generateExpression(BodyCodegen.java:1233)
	at org.mozilla.javascript.optimizer.BodyCodegen.visitSetElem(BodyCodegen.java:4143)
```
This error has been corrected in [this commit](https://github.com/mozilla/rhino/pull/1529/commits/1fd026f0207ac54ac7c40bdcdd60c6501f16589b).

### Closes #406
```
js> (1 ? {} : 490) = 1
Exception in thread "main" java.lang.ClassCastException: class org.mozilla.javascript.Node cannot be cast to class org.mozilla.javascript.ast.ObjectLiteral (org.mozilla.javascript.Node and org.mozilla.javascript.ast.ObjectLiteral are in unnamed module of loader 'app')
	at org.mozilla.javascript.Parser.destructuringAssignmentHelper(Parser.java:4046)
	at org.mozilla.javascript.Parser.createDestructuringAssignment(Parser.java:4016)
	at org.mozilla.javascript.IRFactory.createAssignment(IRFactory.java:2056)

```
This error has been corrected in [this commit](https://github.com/mozilla/rhino/pull/1529/commits/5f55f04fe4082bcb5e8f35a47b910562574491e8).
