### PR TITLE
fix #989 Redeclaration errors should be SyntaxError, not TypeError.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/DefaultErrorReporter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/DefaultErrorReporter.java
@@ -39,19 +39,8 @@ class DefaultErrorReporter implements ErrorReporter {
     @Override
     public void error(String message, String sourceURI, int line, String lineText, int lineOffset) {
         if (forEval) {
-            // Assume error message strings that start with "TypeError: "
-            // should become TypeError exceptions. A bit of a hack, but we
-            // don't want to change the ErrorReporter interface.
-            String error = "SyntaxError";
-            final String TYPE_ERROR_NAME = "TypeError";
-            final String DELIMETER = ": ";
-            final String prefix = TYPE_ERROR_NAME + DELIMETER;
-            if (message.startsWith(prefix)) {
-                error = TYPE_ERROR_NAME;
-                message = message.substring(prefix.length());
-            }
             throw ScriptRuntime.constructError(
-                    error, message, sourceURI, line, lineText, lineOffset);
+                    "SyntaxError", message, sourceURI, line, lineText, lineOffset);
         }
         if (chainedReporter != null) {
             chainedReporter.error(message, sourceURI, line, lineText, lineOffset);

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -266,25 +266,25 @@ msg.got.syntax.errors = \
     Compilation produced {0} syntax errors.
 
 msg.var.redecl =\
-    TypeError: redeclaration of var {0}.
+    redeclaration of var {0}.
 
 msg.const.redecl =\
-    TypeError: redeclaration of const {0}.
-    
+    redeclaration of const {0}.
+
 msg.let.redecl =\
-    TypeError: redeclaration of variable {0}.
+    redeclaration of variable {0}.
 
 msg.parm.redecl =\
-    TypeError: redeclaration of formal parameter {0}.
+    redeclaration of formal parameter {0}.
 
 msg.fn.redecl =\
-    TypeError: redeclaration of function {0}.
+    redeclaration of function {0}.
 
 msg.let.decl.not.in.block =\
-    SyntaxError: let declaration not directly within block
+    let declaration not directly within block
 
 msg.bad.object.init =\
-    SyntaxError: invalid object initializer
+    invalid object initializer
 
 # NodeTransformer
 msg.dup.label =\
@@ -472,10 +472,10 @@ msg.return.inconsistent =\
   return statement is inconsistent with previous usage
 
 msg.generator.returns =\
-  TypeError: generator function {0} returns a value
+  generator function {0} returns a value
 
 msg.anon.generator.returns =\
-  TypeError: anonymous generator function returns a value
+  anonymous generator function returns a value
 
 msg.syntax =\
     syntax error

--- a/tests/src/test/java/org/mozilla/javascript/tests/ErrorReporterTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ErrorReporterTest.java
@@ -111,7 +111,7 @@ public class ErrorReporterTest {
         assertEquals(1, errorCollector.errors.size());
 
         ErrorInfo errorInfo = errorCollector.errors.get(0);
-        assertEquals("TypeError: redeclaration of variable x.", errorInfo.message);
+        assertEquals("redeclaration of variable x.", errorInfo.message);
         assertEquals(3, errorInfo.line);
         assertEquals("for (let [x, x] in {}) {}", errorInfo.lineSource);
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -538,12 +538,6 @@ public class Test262SuiteTest {
 
     private static String extractJSErrorName(RhinoException ex) {
         if (ex instanceof EvaluatorException) {
-            // See. DefaultErrorReporter#error
-            String message = ex.details();
-            if (message.startsWith("TypeError:")) {
-                return "TypeError";
-            }
-
             // there's no universal format to EvaluatorException's
             // for now, just assume that it's a SyntaxError
             return "SyntaxError";

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -538,6 +538,12 @@ public class Test262SuiteTest {
 
     private static String extractJSErrorName(RhinoException ex) {
         if (ex instanceof EvaluatorException) {
+            // See. DefaultErrorReporter#error
+            String message = ex.details();
+            if (message.startsWith("TypeError:")) {
+                return "TypeError";
+            }
+
             // there's no universal format to EvaluatorException's
             // for now, just assume that it's a SyntaxError
             return "SyntaxError";

--- a/tests/testsrc/doctests/433878.doctest
+++ b/tests/testsrc/doctests/433878.doctest
@@ -18,4 +18,4 @@ js> try {
   > } catch (e) {
   >   e;
   > }
-SyntaxError: SyntaxError: let declaration not directly within block
+SyntaxError: let declaration not directly within block

--- a/tests/testsrc/jstests/es6/desctructuring-assignment.js
+++ b/tests/testsrc/jstests/es6/desctructuring-assignment.js
@@ -27,10 +27,10 @@ load("testsrc/assert.js");
   assertEquals(2, a);
 
   // let
-  assertThrows("let [b, b] = [3, 4];", TypeError);
+  assertThrows("let [b, b] = [3, 4];", SyntaxError);
 
   // const
-  assertThrows("const [c, c] = [5, 6];", TypeError);
+  assertThrows("const [c, c] = [5, 6];", SyntaxError);
 })();
 
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2578,7 +2578,7 @@ language/arguments-object 189/260 (72.69%)
 
 language/asi 0/102 (0.0%)
 
-language/block-scope 87/145 (60.0%)
+language/block-scope 68/145 (46.9%)
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -2609,63 +2609,44 @@ language/block-scope 87/145 (60.0%)
     syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/const-name-redeclaration-attempt-with-const.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-function.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-generator.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-let.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/let-name-redeclaration-attempt-with-const.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-function.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-generator.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-let.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/var-redeclaration-attempt-after-const.js
     syntax/redeclaration/var-redeclaration-attempt-after-function.js
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
-    syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
 language/comments 9/52 (17.31%)
     hashbang/function-constructor.js
@@ -5085,7 +5066,7 @@ language/statements/break 0/19 (0.0%)
 
 ~language/statements/class
 
-language/statements/const 108/134 (80.6%)
+language/statements/const 107/134 (79.85%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5193,7 +5174,6 @@ language/statements/const 108/134 (80.6%)
     global-closure-get-before-initialization.js
     global-use-before-initialization-in-declaration-statement.js
     global-use-before-initialization-in-prior-statement.js
-    redeclaration-error-from-within-strict-mode-function-const.js non-strict
 
 language/statements/continue 0/22 (0.0%)
 
@@ -5480,7 +5460,7 @@ language/statements/for 263/384 (68.49%)
     tco-lhs-body.js {unsupported: [tail-call-optimization]}
     tco-var-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/for-in 40/114 (35.09%)
+language/statements/for-in 39/114 (34.21%)
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
@@ -5498,7 +5478,6 @@ language/statements/for-in 40/114 (35.09%)
     decl-gen.js
     head-const-bound-names-fordecl-tdz.js
     head-const-fresh-binding-per-iteration.js
-    head-let-bound-names-dup.js
     head-let-bound-names-fordecl-tdz.js
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
@@ -5522,7 +5501,7 @@ language/statements/for-in 40/114 (35.09%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 472/725 (65.1%)
+language/statements/for-of 471/725 (64.97%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -5963,7 +5942,6 @@ language/statements/for-of 472/725 (65.1%)
     head-const-fresh-binding-per-iteration.js
     head-decl-no-expr.js
     head-expr-no-expr.js
-    head-let-bound-names-dup.js
     head-let-bound-names-fordecl-tdz.js
     head-let-bound-names-in-stmt.js
     head-let-fresh-binding-per-iteration.js
@@ -6504,7 +6482,7 @@ language/statements/labeled 15/23 (65.22%)
     value-yield-non-strict.js non-strict
     value-yield-non-strict-escaped.js non-strict
 
-language/statements/let 101/143 (70.63%)
+language/statements/let 100/143 (69.93%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6605,12 +6583,11 @@ language/statements/let 101/143 (70.63%)
     global-closure-set-before-initialization.js
     global-use-before-initialization-in-declaration-statement.js
     global-use-before-initialization-in-prior-statement.js
-    redeclaration-error-from-within-strict-mode-function.js non-strict
 
 language/statements/return 1/16 (6.25%)
     tco.js {unsupported: [tail-call-optimization]}
 
-language/statements/switch 75/111 (67.57%)
+language/statements/switch 62/111 (55.86%)
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
@@ -6631,35 +6608,22 @@ language/statements/switch 75/111 (67.57%)
     syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/const-name-redeclaration-attempt-with-const.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-function.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-generator.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-let.js
-    syntax/redeclaration/const-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/let-name-redeclaration-attempt-with-const.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-function.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-generator.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-let.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1,6 +1,6 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-built-ins/Array 146/2670 (5.47%)
+built-ins/Array 144/2670 (5.39%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
@@ -5053,6 +5053,148 @@ language/rest-parameters 5/11 (45.45%)
 
 language/source-text 0/1 (0.0%)
 
+~language/statements/async-function
+
+~language/statements/async-generator
+
+language/statements/block 6/20 (30.0%)
+    early-errors 4/4 (100.0%)
+    tco-stmt.js {unsupported: [tail-call-optimization]}
+    tco-stmt-list.js {unsupported: [tail-call-optimization]}
+
+language/statements/break 0/19 (0.0%)
+
+~language/statements/class
+
+language/statements/const 107/134 (79.85%)
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    syntax/block-scope-syntax-const-declarations-mixed-with-without-initialiser.js
+    syntax/block-scope-syntax-const-declarations-mixed-without-with-initialiser.js
+    syntax/block-scope-syntax-const-declarations-without-initialiser.js
+    syntax/const.js
+    syntax/const-invalid-assignment-next-expression-for.js
+    syntax/const-invalid-assignment-statement-body-for-in.js
+    syntax/const-invalid-assignment-statement-body-for-of.js
+    syntax/const-outer-inner-let-bindings.js
+    syntax/with-initializer-do-statement-while-expression.js
+    syntax/with-initializer-for-statement.js
+    syntax/with-initializer-if-expression-statement.js
+    syntax/with-initializer-if-expression-statement-else-statement.js
+    syntax/with-initializer-label-statement.js
+    syntax/with-initializer-while-expression-statement.js
+    syntax/without-initializer-case-expression-statement-list.js
+    syntax/without-initializer-default-statement-list.js
+    syntax/without-initializer-do-statement-while-expression.js
+    syntax/without-initializer-for-statement.js
+    syntax/without-initializer-if-expression-statement.js
+    syntax/without-initializer-if-expression-statement-else-statement.js
+    syntax/without-initializer-label-statement.js
+    syntax/without-initializer-while-expression-statement.js
+    block-local-closure-get-before-initialization.js
+    block-local-use-before-initialization-in-declaration-statement.js
+    block-local-use-before-initialization-in-prior-statement.js
+    fn-name-arrow.js
+    fn-name-class.js {unsupported: [class]}
+    fn-name-cover.js
+    fn-name-fn.js
+    fn-name-gen.js
+    function-local-closure-get-before-initialization.js
+    function-local-use-before-initialization-in-declaration-statement.js
+    function-local-use-before-initialization-in-prior-statement.js
+    global-closure-get-before-initialization.js
+    global-use-before-initialization-in-declaration-statement.js
+    global-use-before-initialization-in-prior-statement.js
+
+language/statements/continue 0/22 (0.0%)
+
+language/statements/debugger 0/2 (0.0%)
+
+language/statements/do-while 10/36 (27.78%)
+    cptn-abrupt-empty.js
+    cptn-normal.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
+    decl-const.js
+    decl-fun.js
+    decl-gen.js
+    labelled-fn-stmt.js
+    let-array-with-newline.js non-strict
+    tco-body.js {unsupported: [tail-call-optimization]}
+
+language/statements/empty 0/2 (0.0%)
+
+language/statements/expression 0/3 (0.0%)
+
 language/statements/for 263/384 (68.49%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
@@ -5832,6 +5974,231 @@ language/statements/for-of 471/725 (64.97%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
+language/statements/function 226/441 (51.25%)
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    early-errors 4/4 (100.0%)
+    13.0-12-s.js strict
+    13.0-13-s.js non-strict
+    13.0-14-s.js non-strict
+    13.0_4-17gs.js strict
+    13.1-22-s.js non-strict
+    13.2-10-s.js
+    13.2-13-s.js
+    13.2-14-s.js
+    13.2-17-s.js
+    13.2-18-s.js
+    13.2-19-b-3gs.js strict
+    13.2-2-s.js strict
+    13.2-21-s.js non-strict
+    13.2-22-s.js non-strict
+    13.2-25-s.js non-strict
+    13.2-26-s.js non-strict
+    13.2-30-s.js
+    13.2-4-s.js strict
+    13.2-5-s.js non-strict
+    13.2-6-s.js non-strict
+    13.2-9-s.js non-strict
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
+    array-destructuring-param-strict-body.js
+    cptn-decl.js
+    dflt-params-abrupt.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
+    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js {unsupported: [default-parameters]}
+    dflt-params-ref-later.js {unsupported: [default-parameters]}
+    dflt-params-ref-prior.js {unsupported: [default-parameters]}
+    dflt-params-ref-self.js {unsupported: [default-parameters]}
+    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-trailing-comma.js
+    enable-strict-via-body.js non-strict
+    enable-strict-via-outer-body.js non-strict
+    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
+    length-dflt.js {unsupported: [default-parameters]}
+    name-arguments-strict-body.js non-strict
+    name-eval-strict-body.js non-strict
+    object-destructuring-param-strict-body.js
+    param-arguments-strict-body.js non-strict
+    param-dflt-yield-non-strict.js {unsupported: [default-parameters]}
+    param-dflt-yield-strict.js {unsupported: [default-parameters]}
+    param-duplicated-strict-body-1.js non-strict
+    param-duplicated-strict-body-2.js non-strict
+    param-duplicated-strict-body-3.js non-strict
+    param-eval-strict-body.js non-strict
+    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
+    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
+    rest-param-strict-body.js
+    scope-body-lex-distinct.js non-strict
+    scope-param-elem-var-close.js non-strict
+    scope-param-elem-var-open.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
+    scope-paramsbody-var-close.js
+    scope-paramsbody-var-open.js
+
 language/statements/generators 220/259 (84.94%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
@@ -6054,6 +6421,238 @@ language/statements/generators 220/259 (84.94%)
     yield-star-after-newline.js
     yield-star-before-newline.js
 
+language/statements/if 42/69 (60.87%)
+    cptn-else-false-abrupt-empty.js
+    cptn-else-false-nrml.js
+    cptn-else-true-abrupt-empty.js
+    cptn-else-true-nrml.js
+    cptn-no-else-false.js
+    cptn-no-else-true-abrupt-empty.js
+    cptn-no-else-true-nrml.js
+    if-async-fun-else-async-fun.js {unsupported: [async-functions]}
+    if-async-fun-else-stmt.js {unsupported: [async-functions]}
+    if-async-fun-no-else.js {unsupported: [async-functions]}
+    if-async-gen-else-async-gen.js {unsupported: [async-iteration]}
+    if-async-gen-else-stmt.js {unsupported: [async-iteration]}
+    if-async-gen-no-else.js {unsupported: [async-iteration]}
+    if-const-else-const.js
+    if-const-else-stmt.js
+    if-const-no-else.js
+    if-decl-else-decl-strict.js strict
+    if-decl-else-stmt-strict.js strict
+    if-decl-no-else-strict.js strict
+    if-fun-else-fun-strict.js strict
+    if-fun-else-stmt-strict.js strict
+    if-fun-no-else-strict.js strict
+    if-gen-else-gen.js
+    if-gen-else-stmt.js
+    if-gen-no-else.js
+    if-let-else-let.js
+    if-let-else-stmt.js
+    if-let-no-else.js
+    if-stmt-else-async-fun.js {unsupported: [async-functions]}
+    if-stmt-else-async-gen.js {unsupported: [async-iteration]}
+    if-stmt-else-const.js
+    if-stmt-else-decl-strict.js strict
+    if-stmt-else-fun-strict.js strict
+    if-stmt-else-gen.js
+    if-stmt-else-let.js
+    labelled-fn-stmt-first.js
+    labelled-fn-stmt-lone.js
+    labelled-fn-stmt-second.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    tco-else-body.js {unsupported: [tail-call-optimization]}
+    tco-if-body.js {unsupported: [tail-call-optimization]}
+
+language/statements/labeled 15/23 (65.22%)
+    decl-async-function.js {unsupported: [async-functions]}
+    decl-async-generator.js {unsupported: [async-iteration]}
+    decl-const.js
+    decl-fun-strict.js strict
+    decl-gen.js
+    decl-let.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    tco.js {unsupported: [tail-call-optimization]}
+    value-await-module.js {unsupported: [module]}
+    value-await-module-escaped.js {unsupported: [module]}
+    value-await-non-module.js
+    value-await-non-module-escaped.js
+    value-yield-non-strict.js non-strict
+    value-yield-non-strict-escaped.js non-strict
+
+language/statements/let 100/143 (69.93%)
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    syntax/escaped-let.js non-strict
+    syntax/let-closure-inside-condition.js
+    syntax/let-closure-inside-initialization.js
+    syntax/let-closure-inside-next-expression.js
+    syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-multi-let-binding.js
+    syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-single-let-binding.js
+    syntax/with-initialisers-in-statement-positions-if-expression-statement.js
+    syntax/with-initialisers-in-statement-positions-if-expression-statement-else-statement.js
+    syntax/with-initialisers-in-statement-positions-label-statement.js
+    syntax/without-initialisers-in-statement-positions-if-expression-statement.js
+    syntax/without-initialisers-in-statement-positions-if-expression-statement-else-statement.js
+    syntax/without-initialisers-in-statement-positions-label-statement.js
+    block-local-closure-get-before-initialization.js
+    block-local-closure-set-before-initialization.js
+    block-local-use-before-initialization-in-declaration-statement.js
+    block-local-use-before-initialization-in-prior-statement.js
+    fn-name-arrow.js
+    fn-name-class.js {unsupported: [class]}
+    fn-name-cover.js
+    fn-name-fn.js
+    fn-name-gen.js
+    function-local-closure-get-before-initialization.js
+    function-local-closure-set-before-initialization.js
+    function-local-use-before-initialization-in-declaration-statement.js
+    function-local-use-before-initialization-in-prior-statement.js
+    global-closure-get-before-initialization.js
+    global-closure-set-before-initialization.js
+    global-use-before-initialization-in-declaration-statement.js
+    global-use-before-initialization-in-prior-statement.js
+
+language/statements/return 1/16 (6.25%)
+    tco.js {unsupported: [tail-call-optimization]}
+
+language/statements/switch 62/111 (55.86%)
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js {unsupported: [async-iteration]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
+    syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
+    cptn-a-abrupt-empty.js
+    cptn-abrupt-empty.js
+    cptn-b-abrupt-empty.js
+    cptn-b-final.js
+    cptn-dflt-abrupt-empty.js
+    cptn-dflt-b-abrupt-empty.js
+    cptn-dflt-b-final.js
+    cptn-dflt-final.js
+    cptn-no-dflt-match-abrupt-empty.js
+    cptn-no-dflt-match-final.js
+    cptn-no-dflt-no-match.js
+    scope-lex-async-function.js
+    scope-lex-async-generator.js
+    scope-lex-class.js
+    scope-lex-close-case.js
+    scope-lex-close-dflt.js
+    scope-lex-const.js
+    scope-lex-generator.js
+    scope-lex-open-case.js
+    scope-lex-open-dflt.js
+    tco-case-body.js {unsupported: [tail-call-optimization]}
+    tco-case-body-dflt.js {unsupported: [tail-call-optimization]}
+    tco-dftl-body.js {unsupported: [tail-call-optimization]}
+
+language/statements/throw 0/14 (0.0%)
+
 language/statements/try 110/195 (56.41%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
@@ -6165,6 +6764,137 @@ language/statements/try 110/195 (56.41%)
     tco-catch.js {unsupported: [tail-call-optimization]}
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
+
+language/statements/variable 92/172 (53.49%)
+    dstr/ary-init-iter-close.js
+    dstr/ary-init-iter-get-err.js
+    dstr/ary-init-iter-get-err-array-prototype.js
+    dstr/ary-ptrn-elem-ary-elem-init.js
+    dstr/ary-ptrn-elem-ary-elem-iter.js
+    dstr/ary-ptrn-elem-ary-elision-init.js
+    dstr/ary-ptrn-elem-ary-elision-iter.js
+    dstr/ary-ptrn-elem-ary-empty-init.js
+    dstr/ary-ptrn-elem-ary-empty-iter.js
+    dstr/ary-ptrn-elem-ary-rest-init.js
+    dstr/ary-ptrn-elem-ary-rest-iter.js
+    dstr/ary-ptrn-elem-id-init-exhausted.js
+    dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/ary-ptrn-elem-id-init-hole.js
+    dstr/ary-ptrn-elem-id-init-skipped.js
+    dstr/ary-ptrn-elem-id-init-throws.js
+    dstr/ary-ptrn-elem-id-init-undef.js
+    dstr/ary-ptrn-elem-id-init-unresolvable.js
+    dstr/ary-ptrn-elem-id-iter-step-err.js
+    dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-obj-id.js
+    dstr/ary-ptrn-elem-obj-id-init.js
+    dstr/ary-ptrn-elem-obj-prop-id.js
+    dstr/ary-ptrn-elem-obj-prop-id-init.js
+    dstr/ary-ptrn-elision.js
+    dstr/ary-ptrn-elision-step-err.js
+    dstr/ary-ptrn-rest-ary-elem.js
+    dstr/ary-ptrn-rest-ary-elision.js
+    dstr/ary-ptrn-rest-ary-empty.js
+    dstr/ary-ptrn-rest-ary-rest.js
+    dstr/ary-ptrn-rest-id.js
+    dstr/ary-ptrn-rest-id-direct.js
+    dstr/ary-ptrn-rest-id-elision.js
+    dstr/ary-ptrn-rest-id-elision-next-err.js
+    dstr/ary-ptrn-rest-id-exhausted.js
+    dstr/ary-ptrn-rest-id-iter-step-err.js
+    dstr/ary-ptrn-rest-id-iter-val-err.js
+    dstr/ary-ptrn-rest-obj-id.js
+    dstr/ary-ptrn-rest-obj-prop-id.js
+    dstr/obj-init-null.js
+    dstr/obj-init-undefined.js
+    dstr/obj-ptrn-id-init-fn-name-arrow.js
+    dstr/obj-ptrn-id-init-fn-name-class.js
+    dstr/obj-ptrn-id-init-fn-name-cover.js
+    dstr/obj-ptrn-id-init-fn-name-fn.js
+    dstr/obj-ptrn-id-init-fn-name-gen.js
+    dstr/obj-ptrn-id-init-skipped.js
+    dstr/obj-ptrn-id-init-throws.js
+    dstr/obj-ptrn-id-init-unresolvable.js
+    dstr/obj-ptrn-list-err.js
+    dstr/obj-ptrn-prop-ary.js
+    dstr/obj-ptrn-prop-ary-init.js
+    dstr/obj-ptrn-prop-ary-value-null.js
+    dstr/obj-ptrn-prop-eval-err.js
+    dstr/obj-ptrn-prop-id-get-value-err.js
+    dstr/obj-ptrn-prop-id-init.js
+    dstr/obj-ptrn-prop-id-init-skipped.js
+    dstr/obj-ptrn-prop-id-init-throws.js
+    dstr/obj-ptrn-prop-id-init-unresolvable.js
+    dstr/obj-ptrn-prop-obj.js
+    dstr/obj-ptrn-prop-obj-init.js
+    dstr/obj-ptrn-prop-obj-value-null.js
+    dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    12.2.1-10-s.js strict
+    12.2.1-17-s.js strict
+    12.2.1-20-s.js strict
+    12.2.1-21-s.js strict
+    12.2.1-3-s.js strict
+    12.2.1-6-s.js strict
+    12.2.1-9-s.js strict
+    arguments-fn-strict-list-final.js strict
+    arguments-fn-strict-list-final-init.js strict
+    arguments-fn-strict-list-first.js strict
+    arguments-fn-strict-list-first-init.js strict
+    arguments-fn-strict-list-middle.js strict
+    arguments-fn-strict-list-middle-init.js strict
+    arguments-fn-strict-list-repeated.js strict
+    arguments-fn-strict-single.js strict
+    arguments-fn-strict-single-init.js strict
+    fn-name-arrow.js
+    fn-name-class.js {unsupported: [class]}
+    fn-name-cover.js
+    fn-name-fn.js
+    fn-name-gen.js
+
+language/statements/while 13/38 (34.21%)
+    cptn-abrupt-empty.js
+    cptn-iter.js
+    cptn-no-iter.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
+    decl-const.js
+    decl-fun.js
+    decl-gen.js
+    labelled-fn-stmt.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
+    tco-body.js {unsupported: [tail-call-optimization]}
+
+language/statements/with 20/169 (11.83%)
+    12.10.1-8-s.js non-strict
+    binding-blocked-by-unscopables.js non-strict
+    cptn-abrupt-empty.js non-strict
+    cptn-nrml.js non-strict
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
+    decl-const.js non-strict
+    decl-fun.js non-strict
+    decl-gen.js non-strict
+    decl-let.js non-strict
+    has-property-err.js {unsupported: [Proxy]}
+    labelled-fn-stmt.js non-strict
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    strict-fn-decl-nested-1.js non-strict
+    strict-fn-expr.js strict
+    strict-fn-method.js strict
+    unscopables-get-err.js non-strict
+    unscopables-inc-dec.js non-strict
+    unscopables-prop-get-err.js non-strict
 
 language/types 9/113 (7.96%)
     number/S8.5_A10_T1.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2578,7 +2578,7 @@ language/arguments-object 189/260 (72.69%)
 
 language/asi 0/102 (0.0%)
 
-language/block-scope 68/145 (46.9%)
+language/block-scope 87/145 (60.0%)
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -2609,44 +2609,63 @@ language/block-scope 68/145 (46.9%)
     syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-const.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/let-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-redeclaration-attempt-after-const.js
     syntax/redeclaration/var-redeclaration-attempt-after-function.js
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
+    syntax/redeclaration/var-redeclaration-attempt-after-let.js
 
 language/comments 9/52 (17.31%)
     hashbang/function-constructor.js
@@ -5066,7 +5085,7 @@ language/statements/break 0/19 (0.0%)
 
 ~language/statements/class
 
-language/statements/const 107/134 (79.85%)
+language/statements/const 108/134 (80.6%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5174,6 +5193,7 @@ language/statements/const 107/134 (79.85%)
     global-closure-get-before-initialization.js
     global-use-before-initialization-in-declaration-statement.js
     global-use-before-initialization-in-prior-statement.js
+    redeclaration-error-from-within-strict-mode-function-const.js non-strict
 
 language/statements/continue 0/22 (0.0%)
 
@@ -5460,7 +5480,7 @@ language/statements/for 263/384 (68.49%)
     tco-lhs-body.js {unsupported: [tail-call-optimization]}
     tco-var-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/for-in 39/114 (34.21%)
+language/statements/for-in 40/114 (35.09%)
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
@@ -5478,6 +5498,7 @@ language/statements/for-in 39/114 (34.21%)
     decl-gen.js
     head-const-bound-names-fordecl-tdz.js
     head-const-fresh-binding-per-iteration.js
+    head-let-bound-names-dup.js
     head-let-bound-names-fordecl-tdz.js
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
@@ -5501,7 +5522,7 @@ language/statements/for-in 39/114 (34.21%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 471/725 (64.97%)
+language/statements/for-of 472/725 (65.1%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -5942,6 +5963,7 @@ language/statements/for-of 471/725 (64.97%)
     head-const-fresh-binding-per-iteration.js
     head-decl-no-expr.js
     head-expr-no-expr.js
+    head-let-bound-names-dup.js
     head-let-bound-names-fordecl-tdz.js
     head-let-bound-names-in-stmt.js
     head-let-fresh-binding-per-iteration.js
@@ -6482,7 +6504,7 @@ language/statements/labeled 15/23 (65.22%)
     value-yield-non-strict.js non-strict
     value-yield-non-strict-escaped.js non-strict
 
-language/statements/let 100/143 (69.93%)
+language/statements/let 101/143 (70.63%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6583,11 +6605,12 @@ language/statements/let 100/143 (69.93%)
     global-closure-set-before-initialization.js
     global-use-before-initialization-in-declaration-statement.js
     global-use-before-initialization-in-prior-statement.js
+    redeclaration-error-from-within-strict-mode-function.js non-strict
 
 language/statements/return 1/16 (6.25%)
     tco.js {unsupported: [tail-call-optimization]}
 
-language/statements/switch 62/111 (55.86%)
+language/statements/switch 75/111 (67.57%)
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
@@ -6608,22 +6631,35 @@ language/statements/switch 62/111 (55.86%)
     syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/const-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/let-name-redeclaration-attempt-with-const.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-generator.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-var.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-const.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js

--- a/tests/testsrc/tests/js1_7/block/regress-349507.js
+++ b/tests/testsrc/tests/js1_7/block/regress-349507.js
@@ -21,7 +21,7 @@ function test()
   printBugNumber(BUGNUMBER);
   printStatus (summary);
 
-  expect = /TypeError: redeclaration of const b/;
+  expect = /SyntaxError: redeclaration of const b/;
   try
   {
     eval('(function() { let(x = 1) { const b = 2 }; let b = 3; })');

--- a/tests/testsrc/tests/js1_7/geniter/regress-352197.js
+++ b/tests/testsrc/tests/js1_7/geniter/regress-352197.js
@@ -6,7 +6,7 @@
 var gTestfile = 'regress-352197.js';
 //-----------------------------------------------------------------------------
 var BUGNUMBER = 352197;
-var summary = 'TypeError if yield after return value in a block';
+var summary = 'SyntaxError if yield after return value in a block';
 var actual = '';
 var expect = '';
 
@@ -21,7 +21,7 @@ function test()
   printBugNumber(BUGNUMBER);
   printStatus (summary);
 
-  expect = /TypeError: anonymous generator function returns a value/;
+  expect = /SyntaxError: anonymous generator function returns a value/;
   try
   {
     var gen = eval('(function() { { return 5; } yield 3; })');


### PR DESCRIPTION
Closes #989
I fixed it with 0832dc59193e5b052c653e25d034c35caffe6aad. To make it easier to see the improvement, I added tests with f0906a9066f75d355679486c8e0bcdd657fd60dd and 7dbadd7d9028f77d52d1c84e35ec94729ee2acc6 in advance. After modification, `TypeError` was not thrown, so 7dbadd7d9028f77d52d1c84e35ec94729ee2acc6 was erased with 9fc4e78b5983371d3149bd35da7b6da6f6e379d9. Once the review is complete, I will rebase the commits before merging.