### PR TITLE
Streamline object operations through a better SlotMap interface

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -10,12 +10,12 @@ dependencies {
 
 jmh {
     // use this to include only some
-    //includes = ['V8']
+    //includes = ['SlotMap']
     benchmarkMode = ['avgt']
     fork = 1
-    timeUnit = 'us'
-    iterations = 5
+    //timeUnit = 'ns'
+    iterations = 3
     timeOnIteration = '5s'
-    warmupIterations = 5
+    warmupIterations = 3
     warmup = '5s'
 }

--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -8,6 +8,10 @@ package org.mozilla.javascript;
 public class AccessorSlot extends Slot {
     private static final long serialVersionUID = 1677840254177335827L;
 
+    AccessorSlot(Object name, int index) {
+        super(name, index, 0);
+    }
+
     AccessorSlot(Slot oldSlot) {
         super(oldSlot);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
@@ -14,6 +14,10 @@ import java.util.function.Supplier;
 public class LambdaSlot extends Slot {
     private static final long serialVersionUID = -3046681698806493052L;
 
+    LambdaSlot(Object name, int index) {
+        super(name, index, 0);
+    }
+
     LambdaSlot(Slot oldSlot) {
         super(oldSlot);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/LazyLoadSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazyLoadSlot.java
@@ -5,6 +5,10 @@ package org.mozilla.javascript;
  * functions. It's used to load built-in objects more efficiently.
  */
 public class LazyLoadSlot extends Slot {
+    LazyLoadSlot(Object name, int index) {
+        super(name, index, 0);
+    }
+
     LazyLoadSlot(Slot oldSlot) {
         super(oldSlot);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -350,7 +350,7 @@ public abstract class ScriptableObject
     @Override
     public void delete(String name) {
         checkNotSealed(name, 0);
-        slotMap.remove(name, 0);
+        slotMap.compute(name, 0, ScriptableObject::checkSlotRemoval);
     }
 
     /**
@@ -363,14 +363,27 @@ public abstract class ScriptableObject
     @Override
     public void delete(int index) {
         checkNotSealed(null, index);
-        slotMap.remove(null, index);
+        slotMap.compute(null, index, ScriptableObject::checkSlotRemoval);
     }
 
     /** Removes an object like the others, but using a Symbol as the key. */
     @Override
     public void delete(Symbol key) {
         checkNotSealed(key, 0);
-        slotMap.remove(key, 0);
+        slotMap.compute(key, 0, ScriptableObject::checkSlotRemoval);
+    }
+
+    private static Slot checkSlotRemoval(Object key, int index, Slot slot) {
+        if ((slot != null) && ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0)) {
+            Context cx = Context.getContext();
+            if (cx.isStrictMode()) {
+                throw ScriptRuntime.typeErrorById(
+                        "msg.delete.property.with.configurable.false", key);
+            }
+            // This will cause removal to not happen
+            return slot;
+        }
+        return null;
     }
 
     /**
@@ -551,13 +564,8 @@ public abstract class ScriptableObject
 
         AccessorSlot aSlot;
         if (isExtensible()) {
-            Slot slot = slotMap.modify(name, index, 0);
-            if (slot instanceof AccessorSlot) {
-                aSlot = (AccessorSlot) slot;
-            } else {
-                aSlot = new AccessorSlot(slot);
-                slotMap.replace(slot, aSlot);
-            }
+            // Create a new AccessorSlot, or cast it if it's already set
+            aSlot = slotMap.compute(name, index, ScriptableObject::ensureAccessorSlot);
         } else {
             Slot slot = slotMap.query(name, index);
             if (slot instanceof AccessorSlot) {
@@ -648,15 +656,7 @@ public abstract class ScriptableObject
     void addLazilyInitializedValue(String name, int index, LazilyLoadedCtor init, int attributes) {
         if (name != null && index != 0) throw new IllegalArgumentException(name);
         checkNotSealed(name, index);
-        Slot slot = slotMap.modify(name, index, 0);
-        LazyLoadSlot lslot;
-        if (slot instanceof LazyLoadSlot) {
-            lslot = (LazyLoadSlot) slot;
-        } else {
-            lslot = new LazyLoadSlot(slot);
-            slotMap.replace(slot, lslot);
-        }
-
+        LazyLoadSlot lslot = slotMap.compute(name, index, ScriptableObject::ensureLazySlot);
         lslot.setAttributes(attributes);
         lslot.value = init;
     }
@@ -1537,15 +1537,7 @@ public abstract class ScriptableObject
             }
         }
 
-        Slot slot = slotMap.modify(propertyName, 0, 0);
-        AccessorSlot aSlot;
-        if (slot instanceof AccessorSlot) {
-            aSlot = (AccessorSlot) slot;
-        } else {
-            aSlot = new AccessorSlot(slot);
-            slotMap.replace(slot, aSlot);
-        }
-
+        AccessorSlot aSlot = slotMap.compute(propertyName, 0, ScriptableObject::ensureAccessorSlot);
         aSlot.setAttributes(attributes);
         if (getterBox != null) {
             aSlot.getter = new AccessorSlot.MemberBoxGetter(getterBox);
@@ -1613,59 +1605,67 @@ public abstract class ScriptableObject
             }
         }
 
-        Slot slot = slotMap.query(key, index);
-        boolean isNew = slot == null;
+        // Do some complex stuff depending on whether or not the key
+        // already exists in a single hash map operation
+        slotMap.compute(
+                key,
+                index,
+                (k, ix, existing) -> {
+                    if (checkValid) {
+                        ScriptableObject current =
+                                existing == null ? null : existing.getPropertyDescriptor(cx, this);
+                        checkPropertyChange(id, current, desc);
+                    }
 
-        if (checkValid) {
-            ScriptableObject current = slot == null ? null : slot.getPropertyDescriptor(cx, this);
-            checkPropertyChange(id, current, desc);
-        }
+                    Slot slot;
+                    int attributes;
 
-        boolean isAccessor = isAccessorDescriptor(desc);
-        final int attributes;
+                    if (existing == null) {
+                        slot = new Slot(k, ix, 0);
+                        attributes =
+                                applyDescriptorToAttributeBitset(
+                                        DONTENUM | READONLY | PERMANENT, desc);
+                    } else {
+                        slot = existing;
+                        attributes =
+                                applyDescriptorToAttributeBitset(existing.getAttributes(), desc);
+                    }
 
-        if (slot == null) {
-            slot = slotMap.modify(key, index, 0);
-            attributes = applyDescriptorToAttributeBitset(DONTENUM | READONLY | PERMANENT, desc);
-        } else {
-            attributes = applyDescriptorToAttributeBitset(slot.getAttributes(), desc);
-        }
+                    if (isAccessorDescriptor(desc)) {
+                        AccessorSlot fslot;
+                        if (slot instanceof AccessorSlot) {
+                            fslot = (AccessorSlot) slot;
+                        } else {
+                            fslot = new AccessorSlot(slot);
+                            slot = fslot;
+                        }
+                        Object getter = getProperty(desc, "get");
+                        if (getter != NOT_FOUND) {
+                            fslot.getter = new AccessorSlot.FunctionGetter(getter);
+                        }
+                        Object setter = getProperty(desc, "set");
+                        if (setter != NOT_FOUND) {
+                            fslot.setter = new AccessorSlot.FunctionSetter(setter);
+                        }
+                        fslot.value = Undefined.instance;
+                    } else {
+                        if (!slot.isValueSlot() && isDataDescriptor(desc)) {
+                            // Replace a non-base slot with a regular slot
+                            slot = new Slot(slot);
+                        }
+                        Object value = getProperty(desc, "value");
+                        if (value != NOT_FOUND) {
+                            slot.value = value;
+                        } else if (existing == null) {
+                            // Ensure we don't get a zombie value if we have switched a lot
+                            slot.value = Undefined.instance;
+                        }
+                    }
 
-        if (isAccessor) {
-            AccessorSlot fslot;
-
-            if (slot instanceof AccessorSlot) {
-                fslot = (AccessorSlot) slot;
-            } else {
-                fslot = new AccessorSlot(slot);
-                slotMap.replace(slot, fslot);
-            }
-
-            Object getter = getProperty(desc, "get");
-            if (getter != NOT_FOUND) {
-                fslot.getter = new AccessorSlot.FunctionGetter(getter);
-            }
-            Object setter = getProperty(desc, "set");
-            if (setter != NOT_FOUND) {
-                fslot.setter = new AccessorSlot.FunctionSetter(setter);
-            }
-
-            fslot.value = Undefined.instance;
-            fslot.setAttributes(attributes);
-        } else {
-            if (!slot.isValueSlot() && isDataDescriptor(desc)) {
-                Slot newSlot = new Slot(slot);
-                slotMap.replace(slot, newSlot);
-                slot = newSlot;
-            }
-            Object value = getProperty(desc, "value");
-            if (value != NOT_FOUND) {
-                slot.value = value;
-            } else if (isNew) {
-                slot.value = Undefined.instance;
-            }
-            slot.setAttributes(attributes);
-        }
+                    // After all that, whatever we return now ends up in the map
+                    slot.setAttributes(attributes);
+                    return slot;
+                });
     }
 
     /**
@@ -1684,19 +1684,10 @@ public abstract class ScriptableObject
      */
     public void defineProperty(
             String name, Supplier<Object> getter, Consumer<Object> setter, int attributes) {
-        Slot slot = slotMap.modify(name, 0, attributes);
-
-        LambdaSlot lSlot;
-        if (slot instanceof LambdaSlot) {
-            lSlot = (LambdaSlot) slot;
-        } else {
-            lSlot = new LambdaSlot(slot);
-            slotMap.replace(slot, lSlot);
-        }
-
-        lSlot.getter = getter;
-        lSlot.setter = setter;
-        setAttributes(name, attributes);
+        LambdaSlot slot = slotMap.compute(name, 0, ScriptableObject::ensureLambdaSlot);
+        slot.setAttributes(attributes);
+        slot.getter = getter;
+        slot.setter = setter;
     }
 
     protected void checkPropertyDefinition(ScriptableObject desc) {
@@ -2669,6 +2660,39 @@ public abstract class ScriptableObject
         }
 
         return result;
+    }
+
+    /*
+     * These are handy for changing slot types in one "compute" operation.
+     */
+    private static AccessorSlot ensureAccessorSlot(Object name, int index, Slot existing) {
+        if (existing == null) {
+            return new AccessorSlot(name, index);
+        } else if (existing instanceof AccessorSlot) {
+            return (AccessorSlot) existing;
+        } else {
+            return new AccessorSlot(existing);
+        }
+    }
+
+    private static LazyLoadSlot ensureLazySlot(Object name, int index, Slot existing) {
+        if (existing == null) {
+            return new LazyLoadSlot(name, index);
+        } else if (existing instanceof LazyLoadSlot) {
+            return (LazyLoadSlot) existing;
+        } else {
+            return new LazyLoadSlot(existing);
+        }
+    }
+
+    private static LambdaSlot ensureLambdaSlot(Object name, int index, Slot existing) {
+        if (existing == null) {
+            return new LambdaSlot(name, index);
+        } else if (existing instanceof LambdaSlot) {
+            return (LambdaSlot) existing;
+        } else {
+            return new LambdaSlot(existing);
+        }
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {

--- a/rhino/src/main/java/org/mozilla/javascript/Slot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Slot.java
@@ -19,9 +19,9 @@ public class Slot implements Serializable {
     transient Slot next; // next in hash table bucket
     transient Slot orderedNext; // next in linked list
 
-    Slot(Object name, int indexOrHash, int attributes) {
+    Slot(Object name, int index, int attributes) {
         this.name = name;
-        this.indexOrHash = indexOrHash;
+        this.indexOrHash = name == null ? index : name.hashCode();
         this.attributes = (short) attributes;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
@@ -17,6 +17,11 @@ package org.mozilla.javascript;
  */
 public interface SlotMap extends Iterable<Slot> {
 
+    @FunctionalInterface
+    public interface SlotComputer<S extends Slot> {
+        S compute(Object key, int index, Slot existing);
+    }
+
     /** Return the size of the map. */
     int size();
 
@@ -44,20 +49,19 @@ public interface SlotMap extends Iterable<Slot> {
      */
     Slot query(Object key, int index);
 
-    /** Replace "slot" with a new slot. This is used to change slot types. */
-    void replace(Slot oldSlot, Slot newSlot);
+    /**
+     * Replace the value of key with the slot computed by the "compute" method. If "compute" throws
+     * an exception, make no change. If "compute" returns null, remove the mapping, otherwise,
+     * replace any existing mapping with the result of "compute", and create a new mapping if none
+     * exists. This is equivalant to the "compute" method on the Map interface, which simplifies
+     * code and is more efficient than making multiple calls to this interface. In order to allow
+     * use of multiple Slot subclasses, this function is templatized.
+     */
+    <S extends Slot> S compute(Object key, int index, SlotComputer<S> compute);
 
     /**
      * Insert a new slot to the map. Both "name" and "indexOrHash" must be populated. Note that
      * ScriptableObject generally adds slots via the "modify" method.
      */
     void add(Slot newSlot);
-
-    /**
-     * Remove the slot at either "key" or "index".
-     *
-     * @param key The key for the slot, which should be a String or a Symbol.
-     * @param index if key is zero, then this will be used as the key instead.
-     */
-    void remove(Object key, int index);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
@@ -58,8 +58,8 @@ class SlotMapContainer implements SlotMap {
     }
 
     @Override
-    public void replace(Slot oldSlot, Slot newSlot) {
-        map.replace(oldSlot, newSlot);
+    public <S extends Slot> S compute(Object key, int index, SlotComputer<S> c) {
+        return map.compute(key, index, c);
     }
 
     @Override
@@ -71,11 +71,6 @@ class SlotMapContainer implements SlotMap {
     public void add(Slot newSlot) {
         checkMapSize();
         map.add(newSlot);
-    }
-
-    @Override
-    public void remove(Object key, int index) {
-        map.remove(key, index);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeSlotMapContainer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeSlotMapContainer.java
@@ -73,10 +73,10 @@ class ThreadSafeSlotMapContainer extends SlotMapContainer {
     }
 
     @Override
-    public void replace(Slot oldSlot, Slot newSlot) {
+    public <S extends Slot> S compute(Object key, int index, SlotComputer<S> c) {
         final long stamp = lock.writeLock();
         try {
-            map.replace(oldSlot, newSlot);
+            return map.compute(key, index, c);
         } finally {
             lock.unlockWrite(stamp);
         }
@@ -104,16 +104,6 @@ class ThreadSafeSlotMapContainer extends SlotMapContainer {
         try {
             checkMapSize();
             map.add(newSlot);
-        } finally {
-            lock.unlockWrite(stamp);
-        }
-    }
-
-    @Override
-    public void remove(Object key, int index) {
-        final long stamp = lock.writeLock();
-        try {
-            map.remove(key, index);
         } finally {
             lock.unlockWrite(stamp);
         }


### PR DESCRIPTION
Implement a "compute" method which allows a bunch of the logic in ScriptableObject work without as many slot map operations, especially when changing slot instance types.

Also, get a particular check out of the slot map implementations that has always bothered me and move it to ScriptableObject for better encapsulation of language-specific behavior.