### PR TITLE
Remove Icode_SWAP as it was unused

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Icode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Icode.java
@@ -20,9 +20,6 @@ abstract class Icode {
             // Stack: ... value2 value1 -> ... value2 value1 value2 value1
             Icode_DUP2 = -2,
 
-            // Stack: ... value2 value1 -> ... value1 value2
-            Icode_SWAP = -3,
-
             // Stack: ... value1 -> ...
             Icode_POP = -4,
 
@@ -167,8 +164,6 @@ abstract class Icode {
                 return "DUP";
             case Icode_DUP2:
                 return "DUP2";
-            case Icode_SWAP:
-                return "SWAP";
             case Icode_POP:
                 return "POP";
             case Icode_POP_RESULT:

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -1467,16 +1467,6 @@ public final class Interpreter extends Icode implements Evaluator {
                                 sDbl[stackTop + 2] = sDbl[stackTop];
                                 stackTop += 2;
                                 continue Loop;
-                            case Icode_SWAP:
-                                {
-                                    Object o = stack[stackTop];
-                                    stack[stackTop] = stack[stackTop - 1];
-                                    stack[stackTop - 1] = o;
-                                    double d = sDbl[stackTop];
-                                    sDbl[stackTop] = sDbl[stackTop - 1];
-                                    sDbl[stackTop - 1] = d;
-                                    continue Loop;
-                                }
                             case Token.RETURN:
                                 frame.result = stack[stackTop];
                                 frame.resultDbl = sDbl[stackTop];


### PR DESCRIPTION
While examining our code coverage tests I noticed that even after running the full ECMA and Mozilla test suites, the `Icode_SWAP` branch in the interpreter never executed. Turns out it is never emitted, so I removed it; it's dead code.