### PR TITLE
fix #1300 Support ES2019 Function.toString()

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -463,9 +463,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
             sb.append(getFunctionName());
             sb.append("() {\n\t");
         }
-        sb.append("[native code, arity=");
-        sb.append(getArity());
-        sb.append("]\n");
+        sb.append("[native code]\n");
         if (!justbody) {
             sb.append("}\n");
         }

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -106,15 +106,7 @@ public class IdFunctionObject extends BaseFunction {
             sb.append(getFunctionName());
             sb.append("() { ");
         }
-        sb.append("[native code for ");
-        if (idcall instanceof Scriptable) {
-            Scriptable sobj = (Scriptable) idcall;
-            sb.append(sobj.getClassName());
-            sb.append('.');
-        }
-        sb.append(getFunctionName());
-        sb.append(", arity=");
-        sb.append(getArity());
+        sb.append("[native code");
         sb.append(justbody ? "]\n" : "] }\n");
         return sb.toString();
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -9,7 +9,6 @@ package org.mozilla.javascript;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -84,21 +83,6 @@ public class NativeJavaMethod extends BaseFunction {
             sig.append(s);
         }
         return sig.toString();
-    }
-
-    @Override
-    String decompile(int indent, EnumSet<DecompilerFlag> flags) {
-        StringBuilder sb = new StringBuilder();
-        boolean justbody = flags.contains(DecompilerFlag.ONLY_BODY);
-        if (!justbody) {
-            sb.append("function ");
-            sb.append(getFunctionName());
-            sb.append("() {");
-        }
-        sb.append("/*\n");
-        sb.append(toString());
-        sb.append(justbody ? "*/\n" : "*/}\n");
-        return sb.toString();
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -3528,6 +3528,7 @@ public class Parser {
                 // So we check a whitelist of tokens to check if we're at the
                 // first case. (Because of keywords, the second case may be
                 // many tokens.)
+                int functionSourceStart = pname.getPosition();
                 int peeked = peekToken();
                 if (peeked != Token.COMMA && peeked != Token.COLON && peeked != Token.RC) {
                     if (peeked == Token.LP) {
@@ -3550,7 +3551,8 @@ public class Parser {
                         propertyName = null;
                     } else {
                         propertyName = ts.getString();
-                        ObjectProperty objectProp = methodDefinition(ppos, pname, entryKind);
+                        ObjectProperty objectProp =
+                                methodDefinition(ppos, pname, entryKind, functionSourceStart);
                         pname.setJsDocNode(jsdocNode);
                         elems.add(objectProp);
                     }
@@ -3685,9 +3687,11 @@ public class Parser {
         return pn;
     }
 
-    private ObjectProperty methodDefinition(int pos, AstNode propName, int entryKind)
-            throws IOException {
+    private ObjectProperty methodDefinition(
+            int pos, AstNode propName, int entryKind, int functionSourceStart) throws IOException {
         FunctionNode fn = function(FunctionNode.FUNCTION_EXPRESSION);
+        fn.setRawSourceStart(functionSourceStart);
+
         // We've already parsed the function name, so fn should be anonymous.
         Name name = fn.getFunctionName();
         if (name != null && name.length() != 0) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -44,9 +44,7 @@ public class LookupSetterTest {
 
     @Test
     public void lookedUpGetter_toString() throws Exception {
-        test(
-                "function s() {\n\t[native code, arity=0]\n}\n",
-                "new Foo().__lookupGetter__('s').toString()");
+        test("function s() {\n\t[native code]\n}\n", "new Foo().__lookupGetter__('s').toString()");
     }
 
     @Test
@@ -85,9 +83,7 @@ public class LookupSetterTest {
 
     @Test
     public void lookedUpSetter_toString() throws Exception {
-        test(
-                "function s() {\n\t[native code, arity=0]\n}\n",
-                "new Foo().__lookupSetter__('s').toString()");
+        test("function s() {\n\t[native code]\n}\n", "new Foo().__lookupSetter__('s').toString()");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -1,0 +1,29 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptableObject;
+
+public class NativeJavaMethodTest {
+
+    @Test
+    public void toStringOfJS() throws Exception {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    ScriptableObject scope = cx.initStandardObjects();
+
+                    final String expected = "function valueOf() {\n\t[native code]\n}\n";
+                    final String script = "java.math.BigInteger.valueOf.toString()";
+
+                    final String result =
+                            (String) cx.evaluateString(scope, script, "myScript", 1, null);
+
+                    assertEquals(expected, result);
+
+                    return null;
+                });
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -498,6 +498,23 @@ public class Test262SuiteTest {
                                 try (Reader reader = new FileReader(harnessPath)) {
                                     String script = Kit.readReader(reader);
 
+                                    if ("nativeFunctionMatcher.js".equalsIgnoreCase(harnessFile)) {
+                                        // If block-scoped const is implemented, please delete this
+                                        // code.
+                                        script =
+                                                script.replace(
+                                                        "const c = source[pos];",
+                                                        "let c = source[pos];");
+                                        script =
+                                                script.replace(
+                                                        "const end = source.indexOf('*/', pos);",
+                                                        "let end = source.indexOf('*/', pos);");
+                                        script =
+                                                script.replace(
+                                                        "const c = source[end];",
+                                                        "let c = source[end];");
+                                    }
+
                                     return cx.compileString(script, harnessPath, 1, null);
                                 } catch (IOException ioe) {
                                     throw new RuntimeException(

--- a/tests/testsrc/doctests/array.every.doctest
+++ b/tests/testsrc/doctests/array.every.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> Array.every;
-function every() { [native code for Array.every, arity=1] }
+function every() { [native code] }
 
 js> function isSmall(n) { return n < 10; };
 

--- a/tests/testsrc/doctests/array.filter.doctest
+++ b/tests/testsrc/doctests/array.filter.doctest
@@ -5,13 +5,13 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [1, 13, 4, 16, 42].filter;
-function filter() { [native code for Array.filter, arity=1] }
+function filter() { [native code] }
 
 js> "" + [1, 13, 4, 16, 42].filter(isSmall);
 1,4
 
 js> Array.filter;
-function filter() { [native code for Array.filter, arity=1] }
+function filter() { [native code] }
 
 js> "" + Array.filter([1, 13, 4, 16, 42], isSmall);
 1,4

--- a/tests/testsrc/doctests/array.find.doctest
+++ b/tests/testsrc/doctests/array.find.doctest
@@ -5,13 +5,13 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [13, 4, 17].find;
-function find() { [native code for Array.find, arity=1] }
+function find() { [native code] }
 
 js> [13, 4, 17].find(isSmall);
 4
 
 js> Array.find;
-function find() { [native code for Array.find, arity=1] }
+function find() { [native code] }
 
 js> res = '';
 js> Array.find([13, 4, 17], isSmall);

--- a/tests/testsrc/doctests/array.findIndex.doctest
+++ b/tests/testsrc/doctests/array.findIndex.doctest
@@ -5,13 +5,13 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [13, 4, 17].findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
+function findIndex() { [native code] }
 
 js> [13, 4, 17].findIndex(isSmall);
 1
 
 js> Array.findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
+function findIndex() { [native code] }
 
 js> Array.findIndex([13, 4, 17], isSmall);
 1

--- a/tests/testsrc/doctests/array.forEach.doctest
+++ b/tests/testsrc/doctests/array.forEach.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> [1, 13, 4].forEach;
-function forEach() { [native code for Array.forEach, arity=1] }
+function forEach() { [native code] }
 
 js> res = '';
 js> [1, 13, 4].forEach(function(elem) { res += elem });
@@ -11,7 +11,7 @@ js> res
 1134
 
 js> Array.forEach;
-function forEach() { [native code for Array.forEach, arity=1] }
+function forEach() { [native code] }
 
 js> res = '';
 js> Array.forEach([1, 13, 4], function(elem) { res += elem });

--- a/tests/testsrc/doctests/array.isarray.doctest
+++ b/tests/testsrc/doctests/array.isarray.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> Array.isArray;
-function isArray() { [native code for Array.isArray, arity=1] }
+function isArray() { [native code] }
 
 js> Array.isArray()
 false

--- a/tests/testsrc/doctests/array.map.doctest
+++ b/tests/testsrc/doctests/array.map.doctest
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> [9, 16, 25].map;
-function map() { [native code for Array.map, arity=1] }
+function map() { [native code] }
 
 js> "" + [9, 16, 25].map(Math.sqrt);
 3,4,5
 
 js> Array.map;
-function map() { [native code for Array.map, arity=1] }
+function map() { [native code] }
 
 js> "" + Array.map([9, 16, 25], Math.sqrt);
 3,4,5

--- a/tests/testsrc/doctests/array.reduce.doctest
+++ b/tests/testsrc/doctests/array.reduce.doctest
@@ -5,13 +5,13 @@
 js> function sum(acc, val) { return acc + val; };
 
 js> [1, 4, 9, 16].reduce;
-function reduce() { [native code for Array.reduce, arity=1] }
+function reduce() { [native code] }
 
 js> [1, 4, 9, 16].reduce(sum);
 30
 
 js> Array.reduce;
-function reduce() { [native code for Array.reduce, arity=1] }
+function reduce() { [native code] }
 
 js> Array.reduce([1, 4, 9, 16], sum);
 30

--- a/tests/testsrc/doctests/array.reduceRight.doctest
+++ b/tests/testsrc/doctests/array.reduceRight.doctest
@@ -5,13 +5,13 @@
 js> function diff(acc, val) { return acc - val; };
 
 js> [1, 4, 9, 16].reduceRight;
-function reduceRight() { [native code for Array.reduceRight, arity=1] }
+function reduceRight() { [native code] }
 
 js> [1, 4, 9, 16].reduceRight(diff);
 2
 
 js> Array.reduceRight;
-function reduceRight() { [native code for Array.reduceRight, arity=1] }
+function reduceRight() { [native code] }
 
 js> Array.reduceRight([1, 4, 9, 16], diff);
 2

--- a/tests/testsrc/doctests/array.some.doctest
+++ b/tests/testsrc/doctests/array.some.doctest
@@ -5,7 +5,7 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [1, 4, 9, 16].some;
-function some() { [native code for Array.some, arity=1] }
+function some() { [native code] }
 
 js> [1, 4, 9, 16].some(isSmall);
 true
@@ -14,7 +14,7 @@ js> [19, 42].some(isSmall);
 false
 
 js> Array.some;
-function some() { [native code for Array.some, arity=1] }
+function some() { [native code] }
 
 js> Array.some([1, 4, 9, 16], isSmall);
 true

--- a/tests/testsrc/doctests/date.toisostring.doctest
+++ b/tests/testsrc/doctests/date.toisostring.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Date.prototype.toISOString;
-function toISOString() { [native code for Date.toISOString, arity=0] }
+function toISOString() { [native code] }
 
 js> expectError(function() { 
   >   new Date(Infinity).toISOString() 

--- a/tests/testsrc/doctests/date.tojson.doctest
+++ b/tests/testsrc/doctests/date.tojson.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Date.prototype.toJSON;
-function toJSON() { [native code for Date.toJSON, arity=1] }
+function toJSON() { [native code] }
 
 js> Date.prototype.toJSON.call({
   >   valueOf: function() { return Infinity; }

--- a/tests/testsrc/doctests/function.bind.doctest
+++ b/tests/testsrc/doctests/function.bind.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Function.prototype.bind
-function bind() { [native code for Function.bind, arity=1] }
+function bind() { [native code] }
 
 js> expectTypeError(function() {
   >   Function.prototype.bind.call({})

--- a/tests/testsrc/doctests/object.create.doctest
+++ b/tests/testsrc/doctests/object.create.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.create;
-function create() { [native code for Object.create, arity=2] }
+function create() { [native code] }
 
 js> expectTypeError(function() { Object.create() });
 js> [undefined, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.defineproperties.doctest
+++ b/tests/testsrc/doctests/object.defineproperties.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.defineProperties
-function defineProperties() { [native code for Object.defineProperties, arity=2] }
+function defineProperties() { [native code] }
 
 js> expectTypeError(function() { Object.defineProperties() });
 js> expectTypeError(function() { Object.defineProperties({}) });

--- a/tests/testsrc/doctests/object.defineproperty.doctest
+++ b/tests/testsrc/doctests/object.defineproperty.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.defineProperty
-function defineProperty() { [native code for Object.defineProperty, arity=3] }
+function defineProperty() { [native code] }
 
 js> expectTypeError(function() { Object.defineProperty() });
 js> expectTypeError(function() { Object.defineProperty({}) });

--- a/tests/testsrc/doctests/object.extensible.doctest
+++ b/tests/testsrc/doctests/object.extensible.doctest
@@ -5,14 +5,14 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isExtensible;
-function isExtensible() { [native code for Object.isExtensible, arity=1] }
+function isExtensible() { [native code] }
 js> expectTypeError(function() { Object.isExtensible() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.isExtensible(value) }) 
   > })
 
 js> Object.preventExtensions;
-function preventExtensions() { [native code for Object.preventExtensions, arity=1] }
+function preventExtensions() { [native code] }
 js> expectTypeError(function() { Object.preventExtensions() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.preventExtensions(value) }) 

--- a/tests/testsrc/doctests/object.freeze.doctest
+++ b/tests/testsrc/doctests/object.freeze.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.freeze;
-function freeze() { [native code for Object.freeze, arity=1] }
+function freeze() { [native code] }
 
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.freeze(value) }) 

--- a/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
+++ b/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getOwnPropertyDescriptor;
-function getOwnPropertyDescriptor() { [native code for Object.getOwnPropertyDescriptor, arity=2] }
+function getOwnPropertyDescriptor() { [native code] }
 
 js> expectTypeError(function() { Object.getOwnPropertyDescriptor() })
 

--- a/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
+++ b/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
@@ -34,9 +34,9 @@ js> desc.value === undefined;
 true
 js> desc.writable
 js> desc.get.toSource()
-p() {}
+get p() {}
 js> desc.set.toSource()
-p() {}
+set p() {}
 js> desc.enumerable
 true
 js> desc.configurable

--- a/tests/testsrc/doctests/object.getownpropertynames.doctest
+++ b/tests/testsrc/doctests/object.getownpropertynames.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getOwnPropertyNames;
-function getOwnPropertyNames() { [native code for Object.getOwnPropertyNames, arity=1] }
+function getOwnPropertyNames() { [native code] }
 
 js> expectTypeError(function() { Object.getOwnPropertyNames() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.getprototypeof.doctest
+++ b/tests/testsrc/doctests/object.getprototypeof.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getPrototypeOf;
-function getPrototypeOf() { [native code for Object.getPrototypeOf, arity=1] }
+function getPrototypeOf() { [native code] }
 
 js> expectTypeError(function() { Object.getPrototypeOf() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.isfrozen.doctest
+++ b/tests/testsrc/doctests/object.isfrozen.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isFrozen
-function isFrozen() { [native code for Object.isFrozen, arity=1] }
+function isFrozen() { [native code] }
 
 js> expectTypeError(function() { Object.isFrozen() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.issealed.doctest
+++ b/tests/testsrc/doctests/object.issealed.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isSealed
-function isSealed() { [native code for Object.isSealed, arity=1] }
+function isSealed() { [native code] }
 
 js> expectTypeError(function() { Object.isSealed() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.keys.doctest
+++ b/tests/testsrc/doctests/object.keys.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.keys;
-function keys() { [native code for Object.keys, arity=1] }
+function keys() { [native code] }
 
 js> expectTypeError(function() { Object.keys() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.seal.doctest
+++ b/tests/testsrc/doctests/object.seal.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.seal;
-function seal() { [native code for Object.seal, arity=1] }
+function seal() { [native code] }
 
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.seal(value) }) 

--- a/tests/testsrc/doctests/parseint.doctest
+++ b/tests/testsrc/doctests/parseint.doctest
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> parseInt
-function parseInt() { [native code for parseInt, arity=2] }
+function parseInt() { [native code] }
 js> parseInt("0");
 0
 js> parseInt("1")

--- a/tests/testsrc/doctests/string.trim.doctest
+++ b/tests/testsrc/doctests/string.trim.doctest
@@ -5,7 +5,7 @@
 js> load('testsrc/doctests/util.js');
 
 js> String.prototype.trim;
-function trim() { [native code for String.trim, arity=0] }
+function trim() { [native code] }
 
 js> String.prototype.trim.call({toString: function() { return "a" }});
 a

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2,7 +2,7 @@
 
 ~annexB
 
-harness 22/115 (19.13%)
+harness 21/115 (18.26%)
     assert-notsamevalue-tostring.js {unsupported: [async-functions]}
     assert-samevalue-tostring.js {unsupported: [async-functions]}
     assert-tostring.js {unsupported: [async-functions]}
@@ -24,7 +24,6 @@ harness 22/115 (19.13%)
     asyncHelpers-throwsAsync-single-arg.js {unsupported: [async]}
     compare-array-arguments.js
     isConstructor.js {unsupported: [Reflect.construct]}
-    nativeFunctionMatcher.js
 
 built-ins/Array 471/3055 (15.42%)
     fromAsync 94/94 (100.0%)
@@ -849,7 +848,7 @@ built-ins/Error 10/41 (24.39%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 186/507 (36.69%)
+built-ins/Function 184/507 (36.29%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -934,7 +933,6 @@ built-ins/Function 186/507 (36.69%)
     prototype/toString/async-method-object.js {unsupported: [async-functions]}
     prototype/toString/AsyncFunction.js {unsupported: [async-functions]}
     prototype/toString/AsyncGenerator.js {unsupported: [async-iteration]}
-    prototype/toString/bound-function.js
     prototype/toString/built-in-function-object.js {unsupported: [Reflect]}
     prototype/toString/class-declaration-complex-heritage.js
     prototype/toString/class-declaration-explicit-ctor.js
@@ -979,7 +977,6 @@ built-ins/Function 186/507 (36.69%)
     prototype/toString/setter-class-statement.js
     prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
-    prototype/toString/symbol-named-builtins.js
     prototype/property-order.js
     prototype/restricted-property-arguments.js
     prototype/restricted-property-caller.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -848,7 +848,7 @@ built-ins/Error 10/41 (24.39%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 184/507 (36.29%)
+built-ins/Function 180/507 (35.5%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -949,13 +949,10 @@ built-ins/Function 184/507 (36.29%)
     prototype/toString/getter-class-expression-static.js
     prototype/toString/getter-class-statement.js
     prototype/toString/getter-class-statement-static.js
-    prototype/toString/getter-object.js
     prototype/toString/method-class-expression.js
     prototype/toString/method-class-expression-static.js
     prototype/toString/method-class-statement.js
     prototype/toString/method-class-statement-static.js
-    prototype/toString/method-computed-property-name.js
-    prototype/toString/method-object.js
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/private-method-class-expression.js
     prototype/toString/private-method-class-statement.js
@@ -976,7 +973,6 @@ built-ins/Function 184/507 (36.29%)
     prototype/toString/setter-class-expression-static.js
     prototype/toString/setter-class-statement.js
     prototype/toString/setter-class-statement-static.js
-    prototype/toString/setter-object.js
     prototype/property-order.js
     prototype/restricted-property-arguments.js
     prototype/restricted-property-caller.js


### PR DESCRIPTION
Closes #1300
I have changed the result of calling `toString` for the following functions as specified.
```js
/* built-in function */
Math.pow.toString()
// function pow() {
// 	[native code]
// }
//

/* bound function */
(function(){}).bind().toString()
// function bound () {
// 	[native code]
// }
//

/* Java Method */
java.math.BigInteger.valueOf.toString()
// function valueOf() {
// 	[native code]
// }
//

/* getter/setter */
Object.getOwnPropertyDescriptor({ get p() {} }, 'p').get.toString()
// get p() {}
```

Previously, the results were as follows.
```js
/* built-in function */
Math.pow.toString()
// function pow() {
// 	[native code, arity=2]
// }
//

/* bound function */
(function(){}).bind().toString()
// function bound () {
// 	[native code, arity=0]
// }
//

/* Java Method */
java.math.BigInteger.valueOf.toString()
// function valueOf() {/*
// java.math.BigInteger valueOf(long)
// */}
// 

/* getter/setter */
Object.getOwnPropertyDescriptor({ get p() {} }, 'p').get.toString()
// p() {}
```