### PR TITLE
Update to latest version of test262

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -5,7 +5,6 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mozilla.javascript.drivers.TestUtils.JS_FILE_FILTER;
 import static org.mozilla.javascript.drivers.TestUtils.recursiveListFilesHelper;
@@ -250,9 +249,7 @@ public class Test262SuiteTest {
                         }
 
                         // Determine if switching to another directory and if so whether all files
-                        // in
-                        // the
-                        // previous directory failed
+                        // in the previous directory failed
                         // If so, don't list all failing files, but list only the folder path
                         if (rollUpEnabled
                                 && (!testFilePath.startsWith(previousTestFileParentPath)
@@ -498,30 +495,6 @@ public class Test262SuiteTest {
                                 try (Reader reader = new FileReader(harnessPath)) {
                                     String script = Kit.readReader(reader);
 
-                                    // fix for missing features in Rhino
-                                    if ("compareArray.js".equalsIgnoreCase(harnessFile)) {
-                                        assertTrue(
-                                                UNSUPPORTED_FEATURES.contains(
-                                                        "default-parameters"));
-                                        script =
-                                                script.replace(
-                                                        "assert.compareArray = function(actual, expected, message = '')",
-                                                        "assert.compareArray = function(actual, expected, message)");
-                                    }
-                                    // fix for missing features in Rhino
-                                    if ("nativeFunctionMatcher.js".equalsIgnoreCase(harnessFile)) {
-                                        assertTrue(
-                                                UNSUPPORTED_FEATURES.contains(
-                                                        "regexp-unicode-property-escapes"));
-                                        script =
-                                                script.replace(
-                                                        "const isNewline = (c) => /[\\u000A\\u000D\\u2028\\u2029]/u.test(c);",
-                                                        "const isNewline = (c) => /[\\u000A\\u000D\\u2028\\u2029]/.test(c);");
-                                        script =
-                                                script.replace(
-                                                        "const isWhitespace = (c) => /[\\u0009\\u000B\\u000C\\u0020\\u00A0\\uFEFF]/u.test(c)",
-                                                        "const isWhitespace = (c) => /[\\u0009\\u000B\\u000C\\u0020\\u00A0\\uFEFF]/.test(c)");
-                                    }
                                     return cx.compileString(script, harnessPath, 1, null);
                                 } catch (IOException ioe) {
                                     throw new RuntimeException(

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -238,7 +238,10 @@ public class Test262SuiteTest {
                                                                 .toString()
                                                                 .equals("statements"))
                                         ? 5
-                                        : Math.min(4, testFilePath.getNameCount());
+                                        : Math.min(
+                                                4,
+                                                testFilePath.getNameCount()
+                                                        - (testFile.isDirectory() ? 0 : 1));
                         currentReportingDir = testFilePath.subpath(0, reportDepth);
 
                         if (previousReportingDir == null) {

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2,24 +2,31 @@
 
 ~annexB
 
-built-ins/Array 144/2670 (5.39%)
+built-ins/Array 471/3055 (15.42%)
+    fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
     from/iter-set-elem-prop-err.js Error propagation needs work in general
     from/iter-set-elem-prop-non-writable.js
+    from/not-a-constructor.js {unsupported: [Reflect.construct]}
     from/proto-from-ctor-realm.js
     from/source-object-constructor.js Error propagation needs work in general
     from/source-object-length-set-elem-prop-err.js
     from/source-object-length-set-elem-prop-non-writable.js
+    isArray/not-a-constructor.js {unsupported: [Reflect.construct]}
     isArray/proxy.js {unsupported: [Proxy]}
     isArray/proxy-revoked.js {unsupported: [Proxy]}
     length/define-own-prop-length-coercion-order.js {unsupported: [Reflect]}
     length/define-own-prop-length-coercion-order-set.js {unsupported: [Reflect, Reflect.set]}
+    length/define-own-prop-length-error.js
     length/define-own-prop-length-no-value-order.js {unsupported: [Reflect]}
     length/define-own-prop-length-overflow-order.js
+    of/not-a-constructor.js {unsupported: [Reflect.construct]}
     of/proto-from-ctor-realm.js
     of/return-abrupt-from-data-property-using-proxy.js {unsupported: [Proxy]}
+    prototype/at/coerced-index-resize.js
+    prototype/at/typed-array-resizable-buffer.js
     prototype/concat/arg-length-exceeding-integer-limit.js {unsupported: [Proxy]}
     prototype/concat/Array.prototype.concat_large-typed-array.js new
     prototype/concat/Array.prototype.concat_non-array.js
@@ -31,7 +38,7 @@ built-ins/Array 144/2670 (5.39%)
     prototype/concat/create-revoked-proxy.js {unsupported: [Proxy]}
     prototype/concat/create-species.js
     prototype/concat/create-species-abrupt.js
-    prototype/concat/create-species-non-ctor.js
+    prototype/concat/create-species-non-ctor.js {unsupported: [Reflect.construct]}
     prototype/concat/create-species-non-extensible.js
     prototype/concat/create-species-non-extensible-spreadable.js
     prototype/concat/create-species-poisoned.js
@@ -41,13 +48,29 @@ built-ins/Array 144/2670 (5.39%)
     prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js {unsupported: [Proxy]}
     prototype/concat/is-concat-spreadable-proxy.js {unsupported: [Proxy]}
     prototype/concat/is-concat-spreadable-proxy-revoked.js {unsupported: [Proxy]}
+    prototype/concat/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
+    prototype/copyWithin/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/copyWithin/resizable-buffer.js
     prototype/copyWithin/return-abrupt-from-delete-proxy-target.js {unsupported: [Proxy]}
     prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
     prototype/copyWithin/return-abrupt-from-has-start.js {unsupported: [Proxy]}
+    prototype/entries/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/entries/resizable-buffer.js
+    prototype/entries/resizable-buffer-grow-mid-iteration.js
+    prototype/entries/resizable-buffer-shrink-mid-iteration.js
     prototype/every/15.4.4.16-5-1-s.js non-strict
+    prototype/every/callbackfn-resize-arraybuffer.js
+    prototype/every/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/every/resizable-buffer.js
+    prototype/every/resizable-buffer-grow-mid-iteration.js
+    prototype/every/resizable-buffer-shrink-mid-iteration.js
+    prototype/fill/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/fill/resizable-buffer.js
+    prototype/fill/typed-array-resize.js
     prototype/filter/15.4.4.20-5-1-s.js non-strict
+    prototype/filter/callbackfn-resize-arraybuffer.js
     prototype/filter/create-ctor-non-object.js
     prototype/filter/create-ctor-poisoned.js
     prototype/filter/create-proto-from-ctor-realm-non-array.js
@@ -55,13 +78,70 @@ built-ins/Array 144/2670 (5.39%)
     prototype/filter/create-revoked-proxy.js {unsupported: [Proxy]}
     prototype/filter/create-species.js
     prototype/filter/create-species-abrupt.js
-    prototype/filter/create-species-non-ctor.js
+    prototype/filter/create-species-non-ctor.js {unsupported: [Reflect.construct]}
     prototype/filter/create-species-poisoned.js
+    prototype/filter/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/filter/resizable-buffer.js
+    prototype/filter/resizable-buffer-grow-mid-iteration.js
+    prototype/filter/resizable-buffer-shrink-mid-iteration.js
     prototype/filter/target-array-non-extensible.js
     prototype/filter/target-array-with-non-configurable-property.js
+    prototype/findIndex/callbackfn-resize-arraybuffer.js
+    prototype/findIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/findIndex/predicate-call-this-strict.js strict
+    prototype/findIndex/resizable-buffer.js
+    prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLastIndex/array-altered-during-loop.js
+    prototype/findLastIndex/call-with-boolean.js
+    prototype/findLastIndex/callbackfn-resize-arraybuffer.js
+    prototype/findLastIndex/length.js
+    prototype/findLastIndex/maximum-index.js
+    prototype/findLastIndex/name.js
+    prototype/findLastIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/findLastIndex/predicate-call-parameters.js
+    prototype/findLastIndex/predicate-call-this-non-strict.js non-strict
+    prototype/findLastIndex/predicate-call-this-strict.js strict
+    prototype/findLastIndex/predicate-called-for-each-array-property.js
+    prototype/findLastIndex/predicate-not-called-on-empty-array.js
+    prototype/findLastIndex/prop-desc.js
+    prototype/findLastIndex/resizable-buffer.js
+    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
+    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLastIndex/return-abrupt-from-predicate-call.js
+    prototype/findLastIndex/return-abrupt-from-property.js
+    prototype/findLastIndex/return-abrupt-from-this-length.js
+    prototype/findLastIndex/return-index-predicate-result-is-true.js
+    prototype/findLastIndex/return-negative-one-if-predicate-returns-false-value.js
+    prototype/findLast/array-altered-during-loop.js
+    prototype/findLast/call-with-boolean.js
+    prototype/findLast/callbackfn-resize-arraybuffer.js
+    prototype/findLast/length.js
+    prototype/findLast/maximum-index.js
+    prototype/findLast/name.js
+    prototype/findLast/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/findLast/predicate-call-parameters.js
+    prototype/findLast/predicate-call-this-non-strict.js non-strict
+    prototype/findLast/predicate-call-this-strict.js strict
+    prototype/findLast/predicate-called-for-each-array-property.js
+    prototype/findLast/predicate-not-called-on-empty-array.js
+    prototype/findLast/prop-desc.js
+    prototype/findLast/resizable-buffer.js
+    prototype/findLast/resizable-buffer-grow-mid-iteration.js
+    prototype/findLast/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLast/return-abrupt-from-predicate-call.js
+    prototype/findLast/return-abrupt-from-property.js
+    prototype/findLast/return-abrupt-from-this-length.js
+    prototype/findLast/return-found-value-predicate-result-is-true.js
+    prototype/findLast/return-undefined-if-predicate-returns-false-value.js
+    prototype/find/callbackfn-resize-arraybuffer.js
+    prototype/find/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/find/predicate-call-this-strict.js strict
+    prototype/find/resizable-buffer.js
+    prototype/find/resizable-buffer-grow-mid-iteration.js
+    prototype/find/resizable-buffer-shrink-mid-iteration.js
     prototype/flatMap/array-like-objects-poisoned-length.js
+    prototype/flatMap/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/flatMap/proxy-access-count.js
     prototype/flatMap/target-array-non-extensible.js
     prototype/flatMap/target-array-with-non-configurable-property.js
@@ -72,16 +152,44 @@ built-ins/Array 144/2670 (5.39%)
     prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
     prototype/flatMap/thisArg-argument.js strict
     prototype/flat/non-object-ctor-throws.js
+    prototype/flat/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/flat/proxy-access-count.js
     prototype/flat/target-array-non-extensible.js
     prototype/flat/target-array-with-non-configurable-property.js
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
+    prototype/forEach/callbackfn-resize-arraybuffer.js
+    prototype/forEach/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/forEach/resizable-buffer.js
+    prototype/forEach/resizable-buffer-grow-mid-iteration.js
+    prototype/forEach/resizable-buffer-shrink-mid-iteration.js
+    prototype/includes/coerced-searchelement-fromindex-resize.js
     prototype/includes/get-prop.js {unsupported: [Proxy]}
+    prototype/includes/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/includes/resizable-buffer.js
+    prototype/includes/resizable-buffer-special-float-values.js
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
+    prototype/indexOf/coerced-searchelement-fromindex-grow.js
+    prototype/indexOf/coerced-searchelement-fromindex-shrink.js
     prototype/indexOf/length-zero-returns-minus-one.js
+    prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/indexOf/resizable-buffer.js
+    prototype/indexOf/resizable-buffer-special-float-values.js
+    prototype/join/coerced-separator-grow.js
+    prototype/join/coerced-separator-shrink.js
+    prototype/join/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/join/resizable-buffer.js
+    prototype/keys/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/keys/resizable-buffer.js
+    prototype/keys/resizable-buffer-grow-mid-iteration.js
+    prototype/keys/resizable-buffer-shrink-mid-iteration.js
     prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
+    prototype/lastIndexOf/coerced-position-grow.js
+    prototype/lastIndexOf/coerced-position-shrink.js
     prototype/lastIndexOf/length-zero-returns-minus-one.js
+    prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/lastIndexOf/resizable-buffer.js
     prototype/map/15.4.4.19-5-1-s.js non-strict
+    prototype/map/callbackfn-resize-arraybuffer.js
     prototype/map/create-ctor-non-object.js
     prototype/map/create-ctor-poisoned.js
     prototype/map/create-proto-from-ctor-realm-non-array.js
@@ -89,19 +197,45 @@ built-ins/Array 144/2670 (5.39%)
     prototype/map/create-revoked-proxy.js {unsupported: [Proxy]}
     prototype/map/create-species.js
     prototype/map/create-species-abrupt.js
-    prototype/map/create-species-non-ctor.js
+    prototype/map/create-species-non-ctor.js {unsupported: [Reflect.construct]}
     prototype/map/create-species-poisoned.js
     prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
+    prototype/map/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/map/resizable-buffer.js
+    prototype/map/resizable-buffer-grow-mid-iteration.js
+    prototype/map/resizable-buffer-shrink-mid-iteration.js
     prototype/map/target-array-non-extensible.js
     prototype/map/target-array-with-non-configurable-property.js
+    prototype/pop/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/pop/set-length-array-is-frozen.js
+    prototype/pop/set-length-array-length-is-non-writable.js
+    prototype/pop/set-length-zero-array-is-frozen.js
+    prototype/pop/set-length-zero-array-length-is-non-writable.js
     prototype/pop/throws-with-string-receiver.js
     prototype/push/length-near-integer-limit-set-failure.js non-strict
+    prototype/push/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
+    prototype/push/set-length-array-is-frozen.js
+    prototype/push/set-length-array-length-is-non-writable.js
+    prototype/push/set-length-zero-array-is-frozen.js
+    prototype/push/set-length-zero-array-length-is-non-writable.js
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
     prototype/push/throws-with-string-receiver.js
     prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
+    prototype/reduceRight/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/reduceRight/resizable-buffer.js
+    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
+    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
     prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
+    prototype/reduce/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+    prototype/reverse/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/reverse/resizable-buffer.js
+    prototype/shift/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/shift/set-length-array-is-frozen.js
+    prototype/shift/set-length-array-length-is-non-writable.js
+    prototype/shift/set-length-zero-array-is-frozen.js
+    prototype/shift/set-length-zero-array-length-is-non-writable.js
     prototype/shift/throws-when-this-value-length-is-writable-false.js
     prototype/slice/create-ctor-non-object.js
     prototype/slice/create-ctor-poisoned.js
@@ -112,12 +246,16 @@ built-ins/Array 144/2670 (5.39%)
     prototype/slice/create-species.js
     prototype/slice/create-species-abrupt.js
     prototype/slice/create-species-neg-zero.js
-    prototype/slice/create-species-non-ctor.js
+    prototype/slice/create-species-non-ctor.js {unsupported: [Reflect.construct]}
     prototype/slice/create-species-poisoned.js
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
+    prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/slice/target-array-non-extensible.js
     prototype/slice/target-array-with-non-configurable-property.js
     prototype/some/15.4.4.17-5-1-s.js non-strict
+    prototype/some/callbackfn-resize-arraybuffer.js
+    prototype/some/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/sort/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-ctor-non-object.js
@@ -129,33 +267,126 @@ built-ins/Array 144/2670 (5.39%)
     prototype/splice/create-species-abrupt.js
     prototype/splice/create-species-length-exceeding-integer-limit.js
     prototype/splice/create-species-neg-zero.js
-    prototype/splice/create-species-non-ctor.js
+    prototype/splice/create-species-non-ctor.js {unsupported: [Reflect.construct]}
     prototype/splice/create-species-poisoned.js
     prototype/splice/create-species-undef-invalid-len.js {unsupported: [Proxy]}
+    prototype/splice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/splice/property-traps-order-with-species.js {unsupported: [Proxy]}
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
     prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
     prototype/splice/target-array-non-extensible.js
     prototype/splice/target-array-with-non-configurable-property.js
-    prototype/Symbol.unscopables 2/2 (100.0%)
+    prototype/Symbol.iterator/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/Symbol.unscopables 4/4 (100.0%)
+    prototype/toLocaleString/invoke-element-tolocalestring.js
+    prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/toReversed/metadata 3/3 (100.0%)
+    prototype/toReversed/frozen-this-value.js
+    prototype/toReversed/get-descending-order.js
+    prototype/toReversed/holes-not-preserved.js
+    prototype/toReversed/ignores-species.js
+    prototype/toReversed/immutable.js
+    prototype/toReversed/length-casted-to-zero.js
+    prototype/toReversed/length-decreased-while-iterating.js
+    prototype/toReversed/length-exceeding-array-length-limit.js
+    prototype/toReversed/length-increased-while-iterating.js
+    prototype/toReversed/length-tolength.js
+    prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toReversed/this-value-boolean.js
+    prototype/toReversed/zero-or-one-element.js
+    prototype/toSorted/metadata 3/3 (100.0%)
+    prototype/toSorted/comparefn-called-after-get-elements.js
+    prototype/toSorted/comparefn-stop-after-error.js
+    prototype/toSorted/frozen-this-value.js
+    prototype/toSorted/holes-not-preserved.js
+    prototype/toSorted/ignores-species.js
+    prototype/toSorted/immutable.js
+    prototype/toSorted/length-casted-to-zero.js
+    prototype/toSorted/length-decreased-while-iterating.js
+    prototype/toSorted/length-exceeding-array-length-limit.js
+    prototype/toSorted/length-increased-while-iterating.js
+    prototype/toSorted/length-tolength.js
+    prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toSorted/this-value-boolean.js
+    prototype/toSorted/zero-or-one-element.js
+    prototype/toSpliced/metadata 3/3 (100.0%)
+    prototype/toSpliced/deleteCount-clamped-between-zero-and-remaining-count.js
+    prototype/toSpliced/deleteCount-missing.js
+    prototype/toSpliced/deleteCount-undefined.js
+    prototype/toSpliced/discarded-element-not-read.js
+    prototype/toSpliced/elements-read-in-order.js
+    prototype/toSpliced/frozen-this-value.js
+    prototype/toSpliced/holes-not-preserved.js
+    prototype/toSpliced/ignores-species.js
+    prototype/toSpliced/immutable.js
+    prototype/toSpliced/length-casted-to-zero.js
+    prototype/toSpliced/length-clamped-to-2pow53minus1.js
+    prototype/toSpliced/length-decreased-while-iterating.js
+    prototype/toSpliced/length-exceeding-array-length-limit.js
+    prototype/toSpliced/length-increased-while-iterating.js
+    prototype/toSpliced/length-tolength.js
+    prototype/toSpliced/mutate-while-iterating.js
+    prototype/toSpliced/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toSpliced/start-and-deleteCount-missing.js
+    prototype/toSpliced/start-and-deleteCount-undefineds.js
+    prototype/toSpliced/start-bigger-than-length.js
+    prototype/toSpliced/start-neg-infinity-is-zero.js
+    prototype/toSpliced/start-neg-less-than-minus-length-is-zero.js
+    prototype/toSpliced/start-neg-subtracted-from-length.js
+    prototype/toSpliced/start-undefined-and-deleteCount-missing.js
+    prototype/toSpliced/this-value-boolean.js
+    prototype/toSpliced/unmodified.js
+    prototype/toString/call-with-boolean.js
+    prototype/toString/non-callable-join-string-tag.js {unsupported: [Proxy, Reflect]}
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/unshift/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/unshift/set-length-array-is-frozen.js
+    prototype/unshift/set-length-array-length-is-non-writable.js
+    prototype/unshift/set-length-zero-array-is-frozen.js
+    prototype/unshift/set-length-zero-array-length-is-non-writable.js
     prototype/unshift/throws-with-string-receiver.js
+    prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/with/metadata 3/3 (100.0%)
+    prototype/with/frozen-this-value.js
+    prototype/with/holes-not-preserved.js
+    prototype/with/ignores-species.js
+    prototype/with/immutable.js
+    prototype/with/index-bigger-or-eq-than-length.js
+    prototype/with/index-casted-to-number.js
+    prototype/with/index-negative.js
+    prototype/with/index-smaller-than-minus-length.js
+    prototype/with/length-decreased-while-iterating.js
+    prototype/with/length-exceeding-array-length-limit.js
+    prototype/with/length-increased-while-iterating.js
+    prototype/with/length-tolength.js
+    prototype/with/no-get-replaced-index.js
+    prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/with/this-value-boolean.js
     prototype/methods-called-as-functions.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm-one.js {unsupported: [Reflect]}
     proto-from-ctor-realm-two.js {unsupported: [Reflect]}
     proto-from-ctor-realm-zero.js {unsupported: [Reflect]}
 
-built-ins/ArrayBuffer 30/80 (37.5%)
+built-ins/ArrayBuffer 142/191 (74.35%)
     isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
     isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
+    isView/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-accessor.js
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
     prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/detached 11/11 (100.0%)
+    prototype/maxByteLength 11/11 (100.0%)
+    prototype/resizable 10/10 (100.0%)
+    prototype/resize 20/20 (100.0%)
+    prototype/slice/nonconstructor.js {unsupported: [Reflect.construct]}
+    prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/slice/species.js
     prototype/slice/species-constructor-is-not-object.js
     prototype/slice/species-constructor-is-undefined.js
@@ -168,10 +399,23 @@ built-ins/ArrayBuffer 30/80 (37.5%)
     prototype/slice/species-returns-same-arraybuffer.js
     prototype/slice/species-returns-smaller-arraybuffer.js
     prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/transferToFixedLength 23/23 (100.0%)
+    prototype/transfer 23/23 (100.0%)
     prototype/Symbol.toStringTag.js
     Symbol.species 4/4 (100.0%)
     data-allocation-after-object-creation.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     newtarget-prototype-is-not-object.js {unsupported: [Reflect.construct]}
+    options-maxbytelength-allocation-limit.js
+    options-maxbytelength-compared-before-object-creation.js {unsupported: [Reflect.construct]}
+    options-maxbytelength-data-allocation-after-object-creation.js {unsupported: [Reflect.construct]}
+    options-maxbytelength-diminuitive.js
+    options-maxbytelength-excessive.js
+    options-maxbytelength-negative.js
+    options-maxbytelength-object.js
+    options-maxbytelength-poisoned.js
+    options-maxbytelength-undefined.js
+    options-non-object.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     prototype-from-newtarget.js {unsupported: [Reflect.construct]}
     undefined-newtarget-throws.js
@@ -191,25 +435,36 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 13/68 (19.12%)
+built-ins/BigInt 21/75 (28.0%)
     asIntN/bigint-tobigint-errors.js
     asIntN/bigint-tobigint-toprimitive.js
     asIntN/bigint-tobigint-wrapped-values.js
     asIntN/bits-toindex-errors.js
     asIntN/bits-toindex-toprimitive.js
     asIntN/bits-toindex-wrapped-values.js
+    asIntN/not-a-constructor.js {unsupported: [Reflect.construct]}
     asUintN/bigint-tobigint-errors.js
     asUintN/bigint-tobigint-toprimitive.js
     asUintN/bigint-tobigint-wrapped-values.js
     asUintN/bits-toindex-errors.js
     asUintN/bits-toindex-toprimitive.js
     asUintN/bits-toindex-wrapped-values.js
+    asUintN/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    constructor-coercion.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
+    wrapper-object-ordinary-toprimitive.js
 
-built-ins/Boolean 1/49 (2.04%)
+built-ins/Boolean 4/51 (7.84%)
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
-built-ins/DataView 166/455 (36.48%)
+built-ins/DataView 254/550 (46.18%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-accessor.js
     prototype/buffer/length.js
@@ -218,10 +473,13 @@ built-ins/DataView 166/455 (36.48%)
     prototype/buffer/return-buffer-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/buffer/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteLength/detached-buffer.js
+    prototype/byteLength/instance-has-detached-buffer.js
     prototype/byteLength/invoked-as-accessor.js
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
+    prototype/byteLength/resizable-array-buffer-auto.js
+    prototype/byteLength/resizable-array-buffer-fixed.js
     prototype/byteLength/return-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteLength/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/detached-buffer.js
@@ -229,6 +487,8 @@ built-ins/DataView 166/455 (36.48%)
     prototype/byteOffset/length.js
     prototype/byteOffset/name.js
     prototype/byteOffset/prop-desc.js
+    prototype/byteOffset/resizable-array-buffer-auto.js
+    prototype/byteOffset/resizable-array-buffer-fixed.js
     prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getBigInt64/detached-buffer.js
@@ -238,6 +498,8 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getBigInt64/length.js
     prototype/getBigInt64/name.js
     prototype/getBigInt64/negative-byteoffset-throws.js
+    prototype/getBigInt64/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getBigInt64/resizable-buffer.js
     prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigInt64/return-value-clean-arraybuffer.js
     prototype/getBigInt64/return-values.js
@@ -254,6 +516,8 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getBigUint64/length.js
     prototype/getBigUint64/name.js
     prototype/getBigUint64/negative-byteoffset-throws.js
+    prototype/getBigUint64/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getBigUint64/resizable-buffer.js
     prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigUint64/return-value-clean-arraybuffer.js
     prototype/getBigUint64/return-values.js
@@ -263,20 +527,46 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getBigUint64/toindex-byteoffset-errors.js
     prototype/getBigUint64/toindex-byteoffset-toprimitive.js
     prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
+    prototype/getFloat16/detached-buffer.js
+    prototype/getFloat16/detached-buffer-after-toindex-byteoffset.js
+    prototype/getFloat16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getFloat16/index-is-out-of-range.js
+    prototype/getFloat16/length.js
+    prototype/getFloat16/minus-zero.js
+    prototype/getFloat16/name.js
+    prototype/getFloat16/negative-byteoffset-throws.js
+    prototype/getFloat16/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getFloat16/resizable-buffer.js
+    prototype/getFloat16/return-abrupt-from-tonumber-byteoffset.js
+    prototype/getFloat16/return-infinity.js
+    prototype/getFloat16/return-nan.js
+    prototype/getFloat16/return-value-clean-arraybuffer.js
+    prototype/getFloat16/return-values.js
+    prototype/getFloat16/return-values-custom-offset.js
+    prototype/getFloat16/to-boolean-littleendian.js
+    prototype/getFloat16/toindex-byteoffset.js
     prototype/getFloat32/detached-buffer.js
     prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getFloat32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getFloat32/resizable-buffer.js
     prototype/getFloat64/detached-buffer.js
     prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getFloat64/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getFloat64/resizable-buffer.js
     prototype/getInt16/detached-buffer.js
     prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getInt16/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getInt16/resizable-buffer.js
     prototype/getInt32/detached-buffer.js
     prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getInt32/resizable-buffer.js
     prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/return-value-clean-arraybuffer-sab.js {unsupported: [SharedArrayBuffer]}
@@ -288,15 +578,23 @@ built-ins/DataView 166/455 (36.48%)
     prototype/getInt8/detached-buffer.js
     prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getInt8/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getInt8/resizable-buffer.js
     prototype/getUint16/detached-buffer.js
     prototype/getUint16/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getUint16/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUint16/resizable-buffer.js
     prototype/getUint32/detached-buffer.js
     prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getUint32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUint32/resizable-buffer.js
     prototype/getUint8/detached-buffer.js
     prototype/getUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/getUint8/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUint8/resizable-buffer.js
     prototype/setBigInt64/detached-buffer.js
     prototype/setBigInt64/detached-buffer-after-bigint-value.js
     prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
@@ -306,50 +604,93 @@ built-ins/DataView 166/455 (36.48%)
     prototype/setBigInt64/length.js
     prototype/setBigInt64/name.js
     prototype/setBigInt64/negative-byteoffset-throws.js
+    prototype/setBigInt64/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/setBigInt64/range-check-after-value-conversion.js
+    prototype/setBigInt64/resizable-buffer.js
     prototype/setBigInt64/return-abrupt-from-tobigint-value.js
     prototype/setBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/setBigInt64/set-values-little-endian-order.js
     prototype/setBigInt64/set-values-return-undefined.js
     prototype/setBigInt64/to-boolean-littleendian.js
     prototype/setBigInt64/toindex-byteoffset.js
+    prototype/setBigUint64 2/2 (100.0%)
+    prototype/setFloat16/detached-buffer.js
+    prototype/setFloat16/detached-buffer-after-number-value.js
+    prototype/setFloat16/detached-buffer-after-toindex-byteoffset.js
+    prototype/setFloat16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setFloat16/index-check-before-value-conversion.js
+    prototype/setFloat16/index-is-out-of-range.js
+    prototype/setFloat16/length.js
+    prototype/setFloat16/name.js
+    prototype/setFloat16/negative-byteoffset-throws.js
+    prototype/setFloat16/no-value-arg.js
+    prototype/setFloat16/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setFloat16/range-check-after-value-conversion.js
+    prototype/setFloat16/resizable-buffer.js
+    prototype/setFloat16/return-abrupt-from-tonumber-byteoffset.js
+    prototype/setFloat16/return-abrupt-from-tonumber-value.js
+    prototype/setFloat16/set-values-little-endian-order.js
+    prototype/setFloat16/set-values-return-undefined.js
+    prototype/setFloat16/to-boolean-littleendian.js
+    prototype/setFloat16/toindex-byteoffset.js
     prototype/setFloat32/detached-buffer.js
     prototype/setFloat32/detached-buffer-after-number-value.js
     prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setFloat32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setFloat32/resizable-buffer.js
     prototype/setFloat64/detached-buffer.js
     prototype/setFloat64/detached-buffer-after-number-value.js
     prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setFloat64/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setFloat64/resizable-buffer.js
     prototype/setInt16/detached-buffer.js
     prototype/setInt16/detached-buffer-after-number-value.js
     prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setInt16/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setInt16/resizable-buffer.js
     prototype/setInt32/detached-buffer.js
     prototype/setInt32/detached-buffer-after-number-value.js
     prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setInt32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setInt32/resizable-buffer.js
     prototype/setInt8/detached-buffer.js
     prototype/setInt8/detached-buffer-after-number-value.js
     prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setInt8/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setInt8/resizable-buffer.js
     prototype/setUint16/detached-buffer.js
     prototype/setUint16/detached-buffer-after-number-value.js
     prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setUint16/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUint16/resizable-buffer.js
     prototype/setUint32/detached-buffer.js
     prototype/setUint32/detached-buffer-after-number-value.js
     prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setUint32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUint32/resizable-buffer.js
     prototype/setUint8/detached-buffer.js
     prototype/setUint8/detached-buffer-after-number-value.js
     prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
+    prototype/setUint8/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUint8/resizable-buffer.js
     prototype/Symbol.toStringTag.js
     buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
     buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
     byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    byteOffset-validated-against-initial-buffer-length.js {unsupported: [Reflect.construct]}
     custom-proto-access-detaches-buffer.js {unsupported: [Reflect.construct]}
+    custom-proto-access-resizes-buffer-invalid-by-length.js
+    custom-proto-access-resizes-buffer-invalid-by-offset.js
+    custom-proto-access-resizes-buffer-valid-by-length.js
+    custom-proto-access-resizes-buffer-valid-by-offset.js
     custom-proto-access-throws.js {unsupported: [Reflect.construct]}
     custom-proto-access-throws-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
     custom-proto-if-not-object-fallbacks-to-default-prototype.js {unsupported: [Reflect.construct]}
@@ -363,6 +704,7 @@ built-ins/DataView 166/455 (36.48%)
     excessive-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
     excessive-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     negative-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
     negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     newtarget-undefined-throws.js
@@ -377,8 +719,44 @@ built-ins/DataView 166/455 (36.48%)
     toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
 
-built-ins/Date 39/707 (5.52%)
+built-ins/Date 90/770 (11.69%)
+    now/not-a-constructor.js {unsupported: [Reflect.construct]}
+    parse/not-a-constructor.js {unsupported: [Reflect.construct]}
+    parse/year-zero.js
+    prototype/getDate/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getDay/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getFullYear/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getHours/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getMilliseconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getMinutes/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getMonth/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getSeconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getTimezoneOffset/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getTime/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCDate/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCDay/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCFullYear/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCHours/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCMilliseconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCMinutes/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCMonth/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/getUTCSeconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setDate/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/setFullYear/15.9.5.40_1.js
+    prototype/setFullYear/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setHours/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setMilliseconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setMinutes/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setMonth/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setSeconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setTime/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCDate/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCFullYear/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCHours/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCMilliseconds/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCMinutes/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCMonth/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/setUTCSeconds/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/Symbol.toPrimitive/hint-default-first-invalid.js
     prototype/Symbol.toPrimitive/hint-default-first-non-callable.js
     prototype/Symbol.toPrimitive/hint-default-first-valid.js
@@ -393,15 +771,29 @@ built-ins/Date 39/707 (5.52%)
     prototype/Symbol.toPrimitive/name.js
     prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/this-val-non-obj.js
+    prototype/toDateString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toISOString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toJSON/builtin.js {unsupported: [Reflect.construct]}
     prototype/toJSON/called-as-function.js
     prototype/toJSON/invoke-result.js
+    prototype/toJSON/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toJSON/to-primitive-symbol.js
     prototype/toJSON/to-primitive-value-of.js
+    prototype/toLocaleDateString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toLocaleTimeString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/non-date-receiver.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toTimeString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toUTCString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/valueOf/S9.4_A3_T1.js
     prototype/no-date-value.js
     UTC/coercion-order.js
+    UTC/fp-evaluation-order.js
+    UTC/not-a-constructor.js {unsupported: [Reflect.construct]}
     coercion-order.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm-one.js {unsupported: [Reflect]}
     proto-from-ctor-realm-two.js {unsupported: [Reflect]}
     proto-from-ctor-realm-zero.js {unsupported: [Reflect]}
@@ -417,17 +809,23 @@ built-ins/Date 39/707 (5.52%)
     value-to-primitive-result-faulty.js
     value-to-primitive-result-non-string-prim.js
     value-to-primitive-result-string.js
+    year-zero.js
 
-built-ins/Error 5/42 (11.9%)
+built-ins/Error 10/41 (24.39%)
     prototype/toString/called-as-function.js
     prototype/toString/invalid-receiver.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/no-error-data.js
     prototype/S15.11.4_A2.js
+    cause_abrupt.js
+    cause_property.js
+    constructor.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 179/505 (35.45%)
+built-ins/Function 186/507 (36.69%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -439,6 +837,7 @@ built-ins/Function 179/505 (35.45%)
     prototype/apply/15.3.4.3-3-s.js strict
     prototype/apply/argarray-not-object.js
     prototype/apply/argarray-not-object-realm.js
+    prototype/apply/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/apply/S15.3.4.3_A3_T1.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T2.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T3.js non-interpreted
@@ -465,10 +864,12 @@ built-ins/Function 179/505 (35.45%)
     prototype/bind/instance-name.js
     prototype/bind/instance-name-chained.js
     prototype/bind/instance-name-error.js
+    prototype/bind/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/bind/proto-from-ctor-realm.js {unsupported: [Reflect]}
     prototype/call/15.3.4.4-1-s.js strict
     prototype/call/15.3.4.4-2-s.js strict
     prototype/call/15.3.4.4-3-s.js strict
+    prototype/call/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/call/S15.3.4.4_A3_T1.js non-interpreted
     prototype/call/S15.3.4.4_A3_T2.js non-interpreted
     prototype/call/S15.3.4.4_A3_T3.js non-interpreted
@@ -533,6 +934,7 @@ built-ins/Function 179/505 (35.45%)
     prototype/toString/method-class-statement-static.js
     prototype/toString/method-computed-property-name.js
     prototype/toString/method-object.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/private-method-class-expression.js
     prototype/toString/private-method-class-statement.js
     prototype/toString/private-static-method-class-expression.js
@@ -554,6 +956,7 @@ built-ins/Function 179/505 (35.45%)
     prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
+    prototype/property-order.js
     prototype/restricted-property-arguments.js
     prototype/restricted-property-caller.js
     prototype/S15.3.4_A5.js
@@ -597,24 +1000,28 @@ built-ins/Function 179/505 (35.45%)
     15.3.5.4_2-9gs.js strict
     call-bind-this-realm-undef.js
     call-bind-this-realm-value.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
+    property-order.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     proto-from-ctor-realm-prototype.js {unsupported: [Reflect]}
     StrictFunction_restricted-properties.js strict
 
 ~built-ins/GeneratorFunction
 
-built-ins/GeneratorPrototype 35/57 (61.4%)
+built-ins/GeneratorPrototype 38/60 (63.33%)
     next/from-state-executing.js non-interpreted
     next/length.js
     next/name.js
+    next/not-a-constructor.js {unsupported: [Reflect.construct]}
     next/property-descriptor.js
     next/this-val-not-generator.js
     next/this-val-not-object.js
-    return 21/21 (100.0%)
+    return 22/22 (100.0%)
     throw/from-state-executing.js non-interpreted
     throw/length.js
     throw/name.js
+    throw/not-a-constructor.js {unsupported: [Reflect.construct]}
     throw/property-descriptor.js
     throw/this-val-not-generator.js
     throw/this-val-not-object.js
@@ -623,10 +1030,10 @@ built-ins/GeneratorPrototype 35/57 (61.4%)
 
 built-ins/Infinity 0/6 (0.0%)
 
-~built-ins/IteratorPrototype
-
-built-ins/JSON 33/140 (23.57%)
+built-ins/JSON 37/144 (25.69%)
     parse/builtin.js {unsupported: [Reflect.construct]}
+    parse/duplicate-proto.js
+    parse/not-a-constructor.js {unsupported: [Reflect.construct]}
     parse/revived-proxy.js {unsupported: [Proxy]}
     parse/revived-proxy-revoked.js {unsupported: [Proxy]}
     parse/reviver-array-define-prop-err.js {unsupported: [Proxy]}
@@ -641,8 +1048,10 @@ built-ins/JSON 33/140 (23.57%)
     parse/reviver-object-non-configurable-prop-create.js
     parse/reviver-object-non-configurable-prop-delete.js strict
     parse/reviver-object-own-keys-err.js {unsupported: [Proxy]}
+    parse/S15.12.2_A1.js
     parse/text-negative-zero.js
     stringify/builtin.js {unsupported: [Reflect.construct]}
+    stringify/not-a-constructor.js {unsupported: [Reflect.construct]}
     stringify/replacer-array-abrupt.js {unsupported: [Proxy]}
     stringify/replacer-array-proxy.js {unsupported: [Proxy]}
     stringify/replacer-array-proxy-revoked.js {unsupported: [Proxy]}
@@ -660,49 +1069,143 @@ built-ins/JSON 33/140 (23.57%)
     stringify/value-object-proxy-revoked.js {unsupported: [Proxy]}
     stringify/value-string-escape-unicode.js
 
-built-ins/Map 1/145 (0.69%)
+built-ins/Map 25/171 (14.62%)
+    groupBy/callback-arg.js
+    groupBy/callback-throws.js
+    groupBy/emptyList.js
+    groupBy/evenOdd.js
+    groupBy/groupLength.js
+    groupBy/iterator-next-throws.js
+    groupBy/length.js
+    groupBy/map-instance.js
+    groupBy/name.js
+    groupBy/negativeZero.js
+    groupBy/string.js
+    groupBy/toPropertyKey.js
+    prototype/clear/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/delete/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/entries/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/forEach/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/get/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/has/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/keys/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/set/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/Symbol.iterator/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
+    valid-keys.js
 
 built-ins/MapIteratorPrototype 0/11 (0.0%)
 
-built-ins/Math 1/273 (0.37%)
+built-ins/Math 51/326 (15.64%)
+    abs/not-a-constructor.js {unsupported: [Reflect.construct]}
+    acosh/not-a-constructor.js {unsupported: [Reflect.construct]}
+    acos/not-a-constructor.js {unsupported: [Reflect.construct]}
+    asinh/not-a-constructor.js {unsupported: [Reflect.construct]}
+    asin/not-a-constructor.js {unsupported: [Reflect.construct]}
+    atan2/not-a-constructor.js {unsupported: [Reflect.construct]}
+    atanh/not-a-constructor.js {unsupported: [Reflect.construct]}
+    atan/not-a-constructor.js {unsupported: [Reflect.construct]}
+    cbrt/not-a-constructor.js {unsupported: [Reflect.construct]}
+    ceil/not-a-constructor.js {unsupported: [Reflect.construct]}
+    clz32/not-a-constructor.js {unsupported: [Reflect.construct]}
+    cosh/not-a-constructor.js {unsupported: [Reflect.construct]}
+    cos/not-a-constructor.js {unsupported: [Reflect.construct]}
+    expm1/not-a-constructor.js {unsupported: [Reflect.construct]}
+    exp/not-a-constructor.js {unsupported: [Reflect.construct]}
+    f16round 5/5 (100.0%)
+    floor/not-a-constructor.js {unsupported: [Reflect.construct]}
+    fround/not-a-constructor.js {unsupported: [Reflect.construct]}
+    hypot/not-a-constructor.js {unsupported: [Reflect.construct]}
+    imul/not-a-constructor.js {unsupported: [Reflect.construct]}
+    log10/not-a-constructor.js {unsupported: [Reflect.construct]}
+    log1p/not-a-constructor.js {unsupported: [Reflect.construct]}
     log2/log2-basicTests.js calculation is not exact
+    log2/not-a-constructor.js {unsupported: [Reflect.construct]}
+    log/not-a-constructor.js {unsupported: [Reflect.construct]}
+    max/not-a-constructor.js {unsupported: [Reflect.construct]}
+    min/not-a-constructor.js {unsupported: [Reflect.construct]}
+    pow/not-a-constructor.js {unsupported: [Reflect.construct]}
+    random/not-a-constructor.js {unsupported: [Reflect.construct]}
+    round/not-a-constructor.js {unsupported: [Reflect.construct]}
+    sign/not-a-constructor.js {unsupported: [Reflect.construct]}
+    sinh/not-a-constructor.js {unsupported: [Reflect.construct]}
+    sin/not-a-constructor.js {unsupported: [Reflect.construct]}
+    sqrt/not-a-constructor.js {unsupported: [Reflect.construct]}
+    sumPrecise 10/10 (100.0%)
+    tanh/not-a-constructor.js {unsupported: [Reflect.construct]}
+    tan/not-a-constructor.js {unsupported: [Reflect.construct]}
+    trunc/not-a-constructor.js {unsupported: [Reflect.construct]}
 
 built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors 35/108 (32.41%)
+built-ins/NativeErrors 44/117 (37.61%)
     AggregateError/prototype 6/6 (100.0%)
-    AggregateError 17/17 (100.0%)
+    AggregateError 19/19 (100.0%)
     EvalError/prototype/not-error-object.js
+    EvalError/is-a-constructor.js {unsupported: [Reflect.construct]}
     EvalError/proto-from-ctor-realm.js {unsupported: [Reflect]}
     RangeError/prototype/not-error-object.js
+    RangeError/is-a-constructor.js {unsupported: [Reflect.construct]}
     RangeError/proto-from-ctor-realm.js {unsupported: [Reflect]}
     ReferenceError/prototype/not-error-object.js
+    ReferenceError/is-a-constructor.js {unsupported: [Reflect.construct]}
     ReferenceError/proto-from-ctor-realm.js {unsupported: [Reflect]}
     SyntaxError/prototype/not-error-object.js
+    SyntaxError/is-a-constructor.js {unsupported: [Reflect.construct]}
     SyntaxError/proto-from-ctor-realm.js {unsupported: [Reflect]}
     TypeError/prototype/not-error-object.js
+    TypeError/is-a-constructor.js {unsupported: [Reflect.construct]}
     TypeError/proto-from-ctor-realm.js {unsupported: [Reflect]}
     URIError/prototype/not-error-object.js
+    URIError/is-a-constructor.js {unsupported: [Reflect.construct]}
     URIError/proto-from-ctor-realm.js {unsupported: [Reflect]}
+    cause_property_native_error.js
 
-built-ins/Number 9/283 (3.18%)
+built-ins/Number 24/335 (7.16%)
+    isFinite/not-a-constructor.js {unsupported: [Reflect.construct]}
+    isInteger/not-a-constructor.js {unsupported: [Reflect.construct]}
+    isNaN/not-a-constructor.js {unsupported: [Reflect.construct]}
+    isSafeInteger/not-a-constructor.js {unsupported: [Reflect.construct]}
+    parseFloat/not-a-constructor.js {unsupported: [Reflect.construct]}
+    parseInt/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toExponential/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/undefined-fractiondigits.js
+    prototype/toFixed/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/length.js
+    prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toPrecision/nan.js
+    prototype/toPrecision/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toString/numeric-literal-tostring-radix-1.js
+    prototype/toString/numeric-literal-tostring-radix-37.js
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     S9.3.1_A2_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 117/3150 (3.71%)
+built-ins/Object 230/3403 (6.76%)
+    assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
+    assign/not-a-constructor.js {unsupported: [Reflect.construct]}
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
     assign/source-own-prop-error.js {unsupported: [Proxy]}
     assign/source-own-prop-keys-error.js {unsupported: [Proxy]}
     assign/strings-and-symbol-order.js
     assign/strings-and-symbol-order-proxy.js {unsupported: [Proxy]}
+    assign/target-is-frozen-accessor-property-set-succeeds.js
+    assign/target-is-frozen-data-property-set-throws.js {unsupported: [Reflect]}
+    assign/target-is-non-extensible-existing-accessor-property.js
+    assign/target-is-non-extensible-existing-data-property.js
+    assign/target-is-non-extensible-property-creation-throws.js
+    assign/target-is-sealed-existing-accessor-property.js
+    assign/target-is-sealed-existing-data-property.js
+    assign/target-is-sealed-property-creation-throws.js {unsupported: [Reflect]}
+    create/not-a-constructor.js {unsupported: [Reflect.construct]}
     defineProperties/15.2.3.7-6-a-112.js non-strict
     defineProperties/15.2.3.7-6-a-113.js non-strict
     defineProperties/15.2.3.7-6-a-118.js
@@ -719,6 +1222,8 @@ built-ins/Object 117/3150 (3.71%)
     defineProperties/15.2.3.7-6-a-184.js
     defineProperties/15.2.3.7-6-a-185.js
     defineProperties/15.2.3.7-6-a-282.js
+    defineProperties/not-a-constructor.js {unsupported: [Reflect.construct]}
+    defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
     defineProperty/15.2.3.6-4-116.js non-strict
     defineProperty/15.2.3.6-4-117.js non-strict
@@ -738,13 +1243,20 @@ built-ins/Object 117/3150 (3.71%)
     defineProperty/15.2.3.6-4-293-3.js non-strict
     defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
+    defineProperty/not-a-constructor.js {unsupported: [Reflect.construct]}
+    defineProperty/property-description-must-be-an-object-not-symbol.js
+    entries/not-a-constructor.js {unsupported: [Reflect.construct]}
     entries/observable-operations.js {unsupported: [Proxy]}
-    entries/order-after-define-property.js
+    entries/order-after-define-property-with-function.js
     freeze/abrupt-completion.js {unsupported: [Proxy]}
+    freeze/not-a-constructor.js {unsupported: [Reflect.construct]}
     freeze/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    freeze/proxy-with-defineProperty-handler.js {unsupported: [Proxy, Reflect]}
     freeze/throws-when-false.js
+    fromEntries/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromEntries/to-property-key.js
     fromEntries/uses-keys-not-iterator.js
+    getOwnPropertyDescriptors/not-a-constructor.js {unsupported: [Reflect.construct]}
     getOwnPropertyDescriptors/observable-operations.js {unsupported: [Proxy]}
     getOwnPropertyDescriptors/order-after-define-property.js {unsupported: [Reflect]}
     getOwnPropertyDescriptors/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
@@ -754,69 +1266,148 @@ built-ins/Object 117/3150 (3.71%)
     getOwnPropertyDescriptor/15.2.3.3-4-214.js
     getOwnPropertyDescriptor/15.2.3.3-4-215.js
     getOwnPropertyDescriptor/15.2.3.3-4-250.js
+    getOwnPropertyDescriptor/not-a-constructor.js {unsupported: [Reflect.construct]}
+    getOwnPropertyNames/not-a-constructor.js {unsupported: [Reflect.construct]}
     getOwnPropertyNames/order-after-define-property.js
     getOwnPropertyNames/proxy-invariant-absent-not-configurable-symbol-key.js {unsupported: [Proxy]}
     getOwnPropertyNames/proxy-invariant-duplicate-symbol-entry.js {unsupported: [Proxy]}
     getOwnPropertyNames/proxy-invariant-not-extensible-absent-symbol-key.js {unsupported: [Proxy]}
     getOwnPropertyNames/proxy-invariant-not-extensible-extra-symbol-key.js {unsupported: [Proxy]}
+    getOwnPropertySymbols/not-a-constructor.js {unsupported: [Reflect.construct]}
     getOwnPropertySymbols/proxy-invariant-absent-not-configurable-string-key.js {unsupported: [Proxy]}
     getOwnPropertySymbols/proxy-invariant-duplicate-string-entry.js {unsupported: [Proxy]}
     getOwnPropertySymbols/proxy-invariant-not-extensible-absent-string-key.js {unsupported: [Proxy]}
     getOwnPropertySymbols/proxy-invariant-not-extensible-extra-string-key.js {unsupported: [Proxy]}
+    getPrototypeOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    groupBy/callback-arg.js
+    groupBy/callback-throws.js
+    groupBy/emptyList.js
+    groupBy/evenOdd.js
+    groupBy/groupLength.js
+    groupBy/invalid-property-key.js
+    groupBy/iterator-next-throws.js
+    groupBy/length.js
+    groupBy/name.js
+    groupBy/null-prototype.js
+    groupBy/string.js
+    groupBy/toPropertyKey.js
+    hasOwn/length.js
+    hasOwn/not-a-constructor.js {unsupported: [Reflect.construct]}
+    hasOwn/symbol_property_toPrimitive.js
+    hasOwn/symbol_property_toString.js
+    hasOwn/symbol_property_valueOf.js
     internals/DefineOwnProperty/consistent-value-function-arguments.js
     internals/DefineOwnProperty/consistent-value-function-caller.js
     internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
     internals/DefineOwnProperty/consistent-writable-regexp-dollar1.js
+    isExtensible/not-a-constructor.js {unsupported: [Reflect.construct]}
+    isFrozen/not-a-constructor.js {unsupported: [Reflect.construct]}
     isFrozen/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    isSealed/not-a-constructor.js {unsupported: [Reflect.construct]}
     isSealed/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
-    keys/order-after-define-property.js {unsupported: [Proxy]}
+    is/not-a-constructor.js {unsupported: [Reflect.construct]}
+    keys/not-a-constructor.js {unsupported: [Reflect.construct]}
+    keys/order-after-define-property-with-function.js
     keys/property-traps-order-with-proxied-array.js {unsupported: [Proxy]}
     keys/proxy-keys.js
     keys/proxy-non-enumerable-prop-invariant-1.js {unsupported: [Proxy]}
     keys/proxy-non-enumerable-prop-invariant-2.js {unsupported: [Proxy]}
     keys/proxy-non-enumerable-prop-invariant-3.js {unsupported: [Proxy]}
     preventExtensions/abrupt-completion.js {unsupported: [Proxy]}
+    preventExtensions/not-a-constructor.js {unsupported: [Reflect.construct]}
     preventExtensions/throws-when-false.js
+    prototype/__defineGetter__/define-abrupt.js {unsupported: [Proxy]}
+    prototype/__defineGetter__/define-existing.js
+    prototype/__defineGetter__/define-non-configurable.js
+    prototype/__defineGetter__/define-non-extensible.js
+    prototype/__defineGetter__/this-non-obj.js
+    prototype/__defineSetter__/define-abrupt.js {unsupported: [Proxy]}
+    prototype/__defineSetter__/define-existing.js
+    prototype/__defineSetter__/define-non-configurable.js
+    prototype/__defineSetter__/define-non-extensible.js
+    prototype/__defineSetter__/this-non-obj.js
+    prototype/__lookupGetter__/lookup-own-get-err.js {unsupported: [Proxy]}
+    prototype/__lookupGetter__/lookup-own-proto-err.js {unsupported: [Proxy]}
+    prototype/__lookupGetter__/lookup-proto-get-err.js {unsupported: [Proxy]}
+    prototype/__lookupGetter__/lookup-proto-proto-err.js {unsupported: [Proxy]}
+    prototype/__lookupGetter__/this-non-obj.js
+    prototype/__lookupSetter__/lookup-own-get-err.js {unsupported: [Proxy]}
+    prototype/__lookupSetter__/lookup-own-proto-err.js {unsupported: [Proxy]}
+    prototype/__lookupSetter__/lookup-proto-get-err.js {unsupported: [Proxy]}
+    prototype/__lookupSetter__/lookup-proto-proto-err.js {unsupported: [Proxy]}
+    prototype/__lookupSetter__/this-non-obj.js
+    prototype/__proto__ 15/15 (100.0%)
+    prototype/hasOwnProperty/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/hasOwnProperty/symbol_property_toPrimitive.js
     prototype/hasOwnProperty/symbol_property_toString.js
     prototype/hasOwnProperty/symbol_property_valueOf.js
     prototype/hasOwnProperty/topropertykey_before_toobject.js
     prototype/isPrototypeOf/arg-is-proxy.js {unsupported: [Proxy]}
     prototype/isPrototypeOf/builtin.js {unsupported: [Reflect.construct]}
+    prototype/isPrototypeOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/isPrototypeOf/null-this-and-primitive-arg-returns-false.js
     prototype/isPrototypeOf/undefined-this-and-primitive-arg-returns-false.js
+    prototype/propertyIsEnumerable/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
+    prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/toString/get-symbol-tag-err.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/proxy-array.js {unsupported: [Proxy]}
     prototype/toString/proxy-function.js {unsupported: [Proxy, async-functions]}
     prototype/toString/proxy-function-async.js {unsupported: [Proxy, async-functions]}
     prototype/toString/proxy-revoked.js {unsupported: [Proxy]}
     prototype/toString/proxy-revoked-during-get-call.js {unsupported: [Proxy]}
+    prototype/toString/symbol-tag-array-builtin.js
+    prototype/toString/symbol-tag-generators-builtin.js
+    prototype/toString/symbol-tag-map-builtin.js
     prototype/toString/symbol-tag-non-str-bigint.js
     prototype/toString/symbol-tag-non-str-builtin.js
     prototype/toString/symbol-tag-non-str-proxy-function.js {unsupported: [Proxy, async-functions]}
     prototype/toString/symbol-tag-override-bigint.js
     prototype/toString/symbol-tag-override-instances.js
     prototype/toString/symbol-tag-override-primitives.js
+    prototype/toString/symbol-tag-promise-builtin.js
+    prototype/toString/symbol-tag-set-builtin.js
     prototype/toString/symbol-tag-str.js
+    prototype/toString/symbol-tag-string-builtin.js
+    prototype/toString/symbol-tag-weakmap-builtin.js
+    prototype/toString/symbol-tag-weakset-builtin.js
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/valueOf/S15.2.4.4_A14.js
     prototype/valueOf/S15.2.4.4_A15.js
     prototype/setPrototypeOf-with-different-values.js {unsupported: [Reflect.setPrototypeOf]}
     prototype/setPrototypeOf-with-same-value.js {unsupported: [Reflect.setPrototypeOf]}
     seal/abrupt-completion.js {unsupported: [Proxy]}
+    seal/not-a-constructor.js {unsupported: [Reflect.construct]}
     seal/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
+    seal/proxy-with-defineProperty-handler.js {unsupported: [Proxy, Reflect]}
+    seal/seal-aggregateerror.js
+    seal/seal-asyncarrowfunction.js
+    seal/seal-asyncfunction.js
+    seal/seal-asyncgeneratorfunction.js
+    seal/seal-bigint64array.js
+    seal/seal-biguint64array.js
+    seal/seal-finalizationregistry.js
+    seal/seal-generatorfunction.js
+    seal/seal-proxy.js
+    seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    seal/seal-weakref.js
     seal/throws-when-false.js
+    setPrototypeOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     setPrototypeOf/set-error.js {unsupported: [Proxy]}
+    values/not-a-constructor.js {unsupported: [Reflect.construct]}
     values/observable-operations.js {unsupported: [Proxy]}
     values/order-after-define-property.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
+    property-order.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     subclass-object-arg.js {unsupported: [Reflect.construct, Reflect, class]}
 
-built-ins/Promise 397/599 (66.28%)
+built-ins/Promise 429/631 (67.99%)
     allSettled/capability-resolve-throws-reject.js {unsupported: [async]}
     allSettled/ctx-ctor.js {unsupported: [class]}
     allSettled/does-not-invoke-array-setters.js {unsupported: [async]}
@@ -853,10 +1444,13 @@ built-ins/Promise 397/599 (66.28%)
     allSettled/iter-returns-true-reject.js {unsupported: [async]}
     allSettled/iter-returns-undefined-reject.js {unsupported: [async]}
     allSettled/iter-step-err-reject.js {unsupported: [async]}
+    allSettled/not-a-constructor.js {unsupported: [Reflect.construct]}
     allSettled/reject-deferred.js {unsupported: [async]}
+    allSettled/reject-element-function-property-order.js
     allSettled/reject-ignored-deferred.js {unsupported: [async]}
     allSettled/reject-ignored-immed.js {unsupported: [async]}
     allSettled/reject-immed.js {unsupported: [async]}
+    allSettled/resolve-element-function-property-order.js
     allSettled/resolve-ignores-late-rejection.js {unsupported: [async]}
     allSettled/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
     allSettled/resolve-non-callable.js {unsupported: [async]}
@@ -909,10 +1503,12 @@ built-ins/Promise 397/599 (66.28%)
     all/iter-returns-true-reject.js {unsupported: [async]}
     all/iter-returns-undefined-reject.js {unsupported: [async]}
     all/iter-step-err-reject.js {unsupported: [async]}
+    all/not-a-constructor.js {unsupported: [Reflect.construct]}
     all/reject-deferred.js {unsupported: [async]}
     all/reject-ignored-deferred.js {unsupported: [async]}
     all/reject-ignored-immed.js {unsupported: [async]}
     all/reject-immed.js {unsupported: [async]}
+    all/resolve-element-function-property-order.js
     all/resolve-ignores-late-rejection.js {unsupported: [async]}
     all/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
     all/resolve-non-callable.js {unsupported: [async]}
@@ -994,6 +1590,7 @@ built-ins/Promise 397/599 (66.28%)
     any/length.js
     any/name.js
     any/new-reject-function.js
+    any/not-a-constructor.js {unsupported: [Reflect.construct]}
     any/prop-desc.js
     any/reject-all-mixed.js {unsupported: [async]}
     any/reject-deferred.js {unsupported: [async]}
@@ -1001,6 +1598,7 @@ built-ins/Promise 397/599 (66.28%)
     any/reject-element-function-length.js
     any/reject-element-function-name.js
     any/reject-element-function-nonconstructor.js
+    any/reject-element-function-property-order.js
     any/reject-element-function-prototype.js
     any/reject-from-same-thenable.js
     any/reject-ignored-deferred.js {unsupported: [async]}
@@ -1022,11 +1620,13 @@ built-ins/Promise 397/599 (66.28%)
     any/resolved-sequence-with-rejections.js {unsupported: [async]}
     any/returns-promise.js
     any/species-get-error.js
+    prototype/catch/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/catch/S25.4.5.1_A3.1_T1.js {unsupported: [async]}
     prototype/catch/S25.4.5.1_A3.1_T2.js {unsupported: [async]}
     prototype/finally/invokes-then-with-function.js {unsupported: [Reflect.construct]}
+    prototype/finally/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/finally/rejected-observable-then-calls.js {unsupported: [async]}
-    prototype/finally/rejected-observable-then-calls-argument.js {unsupported: [Reflect.construct, async]}
+    prototype/finally/rejected-observable-then-calls-argument.js {unsupported: [Reflect.construct, class, async]}
     prototype/finally/rejected-observable-then-calls-PromiseResolve.js {unsupported: [async]}
     prototype/finally/rejection-reason-no-fulfill.js {unsupported: [async]}
     prototype/finally/rejection-reason-override-with-throw.js {unsupported: [async]}
@@ -1045,6 +1645,7 @@ built-ins/Promise 397/599 (66.28%)
     prototype/then/ctor-access-count.js {unsupported: [async]}
     prototype/then/ctor-custom.js {unsupported: [class]}
     prototype/then/deferred-is-resolved-value.js {unsupported: [class, async]}
+    prototype/then/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/then/prfm-fulfilled.js {unsupported: [async]}
     prototype/then/prfm-pending-fulfulled.js {unsupported: [async]}
     prototype/then/prfm-pending-rejected.js {unsupported: [async]}
@@ -1134,6 +1735,7 @@ built-ins/Promise 397/599 (66.28%)
     race/iter-returns-true-reject.js {unsupported: [async]}
     race/iter-returns-undefined-reject.js {unsupported: [async]}
     race/iter-step-err-reject.js {unsupported: [async]}
+    race/not-a-constructor.js {unsupported: [Reflect.construct]}
     race/reject-deferred.js {unsupported: [async]}
     race/reject-ignored-deferred.js {unsupported: [async]}
     race/reject-ignored-immed.js {unsupported: [async]}
@@ -1168,10 +1770,12 @@ built-ins/Promise 397/599 (66.28%)
     race/S25.4.4.3_A7.3_T2.js {unsupported: [async]}
     reject/capability-invocation.js
     reject/ctx-ctor.js {unsupported: [class]}
+    reject/not-a-constructor.js {unsupported: [Reflect.construct]}
     reject/S25.4.4.4_A2.1_T1.js {unsupported: [async]}
     resolve/arg-non-thenable.js {unsupported: [async]}
     resolve/arg-poisoned-then.js {unsupported: [async]}
     resolve/ctx-ctor.js {unsupported: [class]}
+    resolve/not-a-constructor.js {unsupported: [Reflect.construct]}
     resolve/resolve-from-promise-capability.js
     resolve/resolve-non-obj.js {unsupported: [async]}
     resolve/resolve-non-thenable.js {unsupported: [async]}
@@ -1184,14 +1788,32 @@ built-ins/Promise 397/599 (66.28%)
     resolve/S25.4.4.5_A4.1_T1.js {unsupported: [async]}
     resolve/S25.Promise_resolve_foreign_thenable_1.js {unsupported: [async]}
     resolve/S25.Promise_resolve_foreign_thenable_2.js {unsupported: [async]}
+    try/args.js {unsupported: [async]}
+    try/ctx-ctor.js {unsupported: [class]}
+    try/ctx-ctor-throws.js
+    try/length.js
+    try/name.js
+    try/not-a-constructor.js {unsupported: [Reflect.construct]}
+    try/promise.js
+    try/prop-desc.js
+    try/return-value.js {unsupported: [async]}
+    try/throws.js {unsupported: [async]}
+    withResolvers/ctx-ctor.js {unsupported: [class]}
+    withResolvers/promise.js
+    withResolvers/resolvers.js
+    withResolvers/result.js
     create-resolving-functions-reject.js {unsupported: [Reflect.construct, async]}
     create-resolving-functions-resolve.js {unsupported: [Reflect.construct, async]}
     exception-after-resolve-in-executor.js {unsupported: [async]}
     exception-after-resolve-in-thenable-job.js {unsupported: [async]}
-    executor-function-nonconstructor.js {unsupported: [Reflect.construct]}
+    executor-function-not-a-constructor.js {unsupported: [Reflect.construct]}
+    executor-function-property-order.js
     get-prototype-abrupt.js {unsupported: [Reflect.construct, Reflect]}
     get-prototype-abrupt-executor-not-callable.js {unsupported: [Reflect.construct, Reflect]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
+    property-order.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
+    reject-function-property-order.js
     reject-ignored-via-abrupt.js {unsupported: [async]}
     reject-ignored-via-fn-deferred.js {unsupported: [async]}
     reject-ignored-via-fn-immed.js {unsupported: [async]}
@@ -1201,6 +1823,7 @@ built-ins/Promise 397/599 (66.28%)
     reject-via-fn-deferred-queue.js {unsupported: [async]}
     reject-via-fn-immed.js {unsupported: [async]}
     reject-via-fn-immed-queue.js {unsupported: [async]}
+    resolve-function-property-order.js
     resolve-ignored-via-fn-deferred.js {unsupported: [async]}
     resolve-ignored-via-fn-immed.js {unsupported: [async]}
     resolve-non-obj-deferred.js {unsupported: [async]}
@@ -1219,16 +1842,33 @@ built-ins/Promise 397/599 (66.28%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 893/1464 (61.0%)
+built-ins/RegExp 1174/1853 (63.36%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
+    escape 20/20 (100.0%)
     lookBehind 17/17 (100.0%)
-    match-indices 13/13 (100.0%)
-    named-groups 26/26 (100.0%)
-    property-escapes/generated 403/403 (100.0%)
+    match-indices/indices-array.js
+    match-indices/indices-array-element.js
+    match-indices/indices-array-matched.js
+    match-indices/indices-array-non-unicode-match.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-array-properties.js
+    match-indices/indices-array-unicode-match.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-array-unicode-property-names.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-array-unmatched.js
+    match-indices/indices-groups-object.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-groups-object-undefined.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-groups-object-unmatched.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-groups-properties.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-property.js
+    named-groups 36/36 (100.0%)
+    property-escapes/generated/strings 28/28 (100.0%)
+    property-escapes/generated 417/417 (100.0%)
     property-escapes 143/143 (100.0%)
     prototype/dotAll 8/8 (100.0%)
+    prototype/exec/duplicate-named-groups-properties.js
+    prototype/exec/duplicate-named-indices-groups-properties.js
     prototype/exec/failure-lastindex-access.js
+    prototype/exec/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
     prototype/exec/u-captured-value.js
@@ -1236,6 +1876,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/exec/u-lastindex-value.js
     prototype/flags/coercion-dotall.js {unsupported: [regexp-dotall]}
     prototype/flags/coercion-global.js
+    prototype/flags/coercion-hasIndices.js
     prototype/flags/coercion-ignoreCase.js
     prototype/flags/coercion-multiline.js
     prototype/flags/coercion-sticky.js
@@ -1254,6 +1895,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/global/name.js
     prototype/global/S15.10.7.2_A9.js
     prototype/global/this-val-regexp-prototype.js
+    prototype/hasIndices 8/8 (100.0%)
     prototype/ignoreCase/15.10.7.3-2.js
     prototype/ignoreCase/cross-realm.js
     prototype/ignoreCase/length.js
@@ -1279,7 +1921,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/sticky/name.js
     prototype/sticky/prop-desc.js
     prototype/sticky/this-val-regexp-prototype.js
-    prototype/Symbol.matchAll 25/25 (100.0%)
+    prototype/Symbol.matchAll 26/26 (100.0%)
     prototype/Symbol.match/builtin-infer-unicode.js
     prototype/Symbol.match/builtin-success-g-set-lastindex.js
     prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
@@ -1289,6 +1931,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.match/exec-invocation.js
     prototype/Symbol.match/exec-return-type-invalid.js
     prototype/Symbol.match/exec-return-type-valid.js
+    prototype/Symbol.match/flags-tostring-error.js
     prototype/Symbol.match/g-coerce-result-err.js
     prototype/Symbol.match/g-get-exec-err.js
     prototype/Symbol.match/g-get-result-err.js
@@ -1298,8 +1941,10 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.match/g-match-empty-set-lastindex-err.js
     prototype/Symbol.match/g-success-return-val.js
     prototype/Symbol.match/get-exec-err.js
+    prototype/Symbol.match/get-flags-err.js
     prototype/Symbol.match/get-global-err.js
     prototype/Symbol.match/get-unicode-error.js
+    prototype/Symbol.match/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/Symbol.match/this-val-non-regexp.js
     prototype/Symbol.match/u-advance-after-empty.js
     prototype/Symbol.match/y-fail-global-return.js
@@ -1313,6 +1958,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.replace/coerce-unicode.js
     prototype/Symbol.replace/exec-err.js
     prototype/Symbol.replace/exec-invocation.js
+    prototype/Symbol.replace/flags-tostring-error.js
     prototype/Symbol.replace/fn-coerce-replacement.js
     prototype/Symbol.replace/fn-coerce-replacement-err.js
     prototype/Symbol.replace/fn-err.js
@@ -1325,6 +1971,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.replace/g-pos-decrement.js
     prototype/Symbol.replace/g-pos-increment.js
     prototype/Symbol.replace/get-exec-err.js
+    prototype/Symbol.replace/get-flags-err.js
     prototype/Symbol.replace/get-global-err.js
     prototype/Symbol.replace/get-unicode-error.js
     prototype/Symbol.replace/length.js
@@ -1332,6 +1979,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.replace/name.js
     prototype/Symbol.replace/named-groups.js {unsupported: [regexp-named-groups]}
     prototype/Symbol.replace/named-groups-fn.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/Symbol.replace/poisoned-stdlib.js {unsupported: [regexp-named-groups]}
     prototype/Symbol.replace/prop-desc.js
     prototype/Symbol.replace/replace-with-trailing.js
@@ -1372,6 +2020,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.search/get-lastindex-err.js
     prototype/Symbol.search/lastindex-no-restore.js
     prototype/Symbol.search/match-err.js
+    prototype/Symbol.search/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/Symbol.search/set-lastindex-init.js
     prototype/Symbol.search/set-lastindex-init-err.js
     prototype/Symbol.search/set-lastindex-init-samevalue.js
@@ -1391,6 +2040,7 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.split/length.js
     prototype/Symbol.split/limit-0-bail.js
     prototype/Symbol.split/name.js
+    prototype/Symbol.split/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/Symbol.split/prop-desc.js
     prototype/Symbol.split/species-ctor.js
     prototype/Symbol.split/species-ctor-ctor-get-err.js
@@ -1422,22 +2072,39 @@ built-ins/RegExp 893/1464 (61.0%)
     prototype/Symbol.split/str-trailing-chars.js
     prototype/Symbol.split/u-lastindex-adv-thru-failure.js
     prototype/Symbol.split/u-lastindex-adv-thru-match.js
+    prototype/test/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/test/S15.10.6.3_A1_T22.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toString/S15.10.6.4_A6.js {unsupported: [Reflect.construct]}
+    prototype/toString/S15.10.6.4_A7.js {unsupported: [Reflect.construct]}
+    prototype/unicodeSets/cross-realm.js
+    prototype/unicodeSets/length.js
+    prototype/unicodeSets/name.js
+    prototype/unicodeSets/prop-desc.js
+    prototype/unicodeSets/this-val-invalid-obj.js
+    prototype/unicodeSets/this-val-non-obj.js
+    prototype/unicodeSets/this-val-regexp.js
+    prototype/unicodeSets/this-val-regexp-prototype.js
     prototype/unicode 8/8 (100.0%)
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
+    regexp-modifiers/syntax/valid 8/8 (100.0%)
+    regexp-modifiers 53/53 (100.0%)
+    unicodeSets/generated 112/112 (100.0%)
     15.10.4.1-1.js
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
     call_with_regexp_not_same_constructor.js
     character-class-escape-non-whitespace-u180e.js {unsupported: [u180e]}
     duplicate-flags.js {unsupported: [regexp-dotall]}
+    duplicate-named-capturing-groups-syntax.js
     from-regexp-like.js
     from-regexp-like-flag-override.js
     from-regexp-like-get-ctor-err.js
     from-regexp-like-get-flags-err.js
     from-regexp-like-get-source-err.js
     from-regexp-like-short-circuit.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     quantifier-integer-limit.js
     S15.10.1_A1_T13.js
@@ -1450,21 +2117,197 @@ built-ins/RegExp 893/1464 (61.0%)
     S15.10.4.1_A2_T2.js
     u180e.js {unsupported: [u180e]}
     unicode_character_class_backspace_escape.js
+    unicode_full_case_folding.js
     unicode_identity_escape.js
     valid-flags-y.js
 
 built-ins/RegExpStringIteratorPrototype 17/17 (100.0%)
 
-built-ins/Set 1/188 (0.53%)
+built-ins/Set 167/381 (43.83%)
+    prototype/add/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/clear/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/delete/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/difference/add-not-called.js
+    prototype/difference/allows-set-like-class.js
+    prototype/difference/allows-set-like-object.js
+    prototype/difference/builtins.js
+    prototype/difference/combines-empty-sets.js
+    prototype/difference/combines-itself.js
+    prototype/difference/combines-Map.js
+    prototype/difference/combines-same-sets.js
+    prototype/difference/combines-sets.js
+    prototype/difference/converts-negative-zero.js
+    prototype/difference/difference.js
+    prototype/difference/length.js
+    prototype/difference/name.js
+    prototype/difference/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/difference/receiver-not-set.js
+    prototype/difference/require-internal-slot.js
+    prototype/difference/result-order.js
+    prototype/difference/set-like-array.js
+    prototype/difference/set-like-class-mutation.js
+    prototype/difference/set-like-class-order.js
+    prototype/difference/size-is-a-number.js
+    prototype/difference/subclass.js
+    prototype/difference/subclass-receiver-methods.js
+    prototype/difference/subclass-symbol-species.js
+    prototype/entries/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/forEach/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/has/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/intersection/add-not-called.js
+    prototype/intersection/allows-set-like-class.js
+    prototype/intersection/allows-set-like-object.js
+    prototype/intersection/builtins.js
+    prototype/intersection/combines-empty-sets.js
+    prototype/intersection/combines-itself.js
+    prototype/intersection/combines-Map.js
+    prototype/intersection/combines-same-sets.js
+    prototype/intersection/combines-sets.js
+    prototype/intersection/converts-negative-zero.js
+    prototype/intersection/intersection.js
+    prototype/intersection/length.js
+    prototype/intersection/name.js
+    prototype/intersection/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/intersection/receiver-not-set.js
+    prototype/intersection/require-internal-slot.js
+    prototype/intersection/result-order.js
+    prototype/intersection/set-like-array.js
+    prototype/intersection/set-like-class-mutation.js
+    prototype/intersection/set-like-class-order.js
+    prototype/intersection/size-is-a-number.js
+    prototype/intersection/subclass.js
+    prototype/intersection/subclass-receiver-methods.js
+    prototype/intersection/subclass-symbol-species.js
+    prototype/isDisjointFrom/allows-set-like-class.js
+    prototype/isDisjointFrom/allows-set-like-object.js
+    prototype/isDisjointFrom/builtins.js
+    prototype/isDisjointFrom/compares-empty-sets.js
+    prototype/isDisjointFrom/compares-itself.js
+    prototype/isDisjointFrom/compares-Map.js
+    prototype/isDisjointFrom/compares-same-sets.js
+    prototype/isDisjointFrom/compares-sets.js
+    prototype/isDisjointFrom/converts-negative-zero.js
+    prototype/isDisjointFrom/isDisjointFrom.js
+    prototype/isDisjointFrom/length.js
+    prototype/isDisjointFrom/name.js
+    prototype/isDisjointFrom/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/isDisjointFrom/receiver-not-set.js
+    prototype/isDisjointFrom/require-internal-slot.js
+    prototype/isDisjointFrom/set-like-array.js
+    prototype/isDisjointFrom/set-like-class-mutation.js
+    prototype/isDisjointFrom/set-like-class-order.js
+    prototype/isDisjointFrom/size-is-a-number.js
+    prototype/isDisjointFrom/subclass-receiver-methods.js
+    prototype/isSubsetOf/allows-set-like-class.js
+    prototype/isSubsetOf/allows-set-like-object.js
+    prototype/isSubsetOf/builtins.js
+    prototype/isSubsetOf/compares-empty-sets.js
+    prototype/isSubsetOf/compares-itself.js
+    prototype/isSubsetOf/compares-Map.js
+    prototype/isSubsetOf/compares-same-sets.js
+    prototype/isSubsetOf/compares-sets.js
+    prototype/isSubsetOf/isSubsetOf.js
+    prototype/isSubsetOf/length.js
+    prototype/isSubsetOf/name.js
+    prototype/isSubsetOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/isSubsetOf/receiver-not-set.js
+    prototype/isSubsetOf/require-internal-slot.js
+    prototype/isSubsetOf/set-like-array.js
+    prototype/isSubsetOf/set-like-class-mutation.js
+    prototype/isSubsetOf/set-like-class-order.js
+    prototype/isSubsetOf/size-is-a-number.js
+    prototype/isSubsetOf/subclass-receiver-methods.js
+    prototype/isSupersetOf/allows-set-like-class.js
+    prototype/isSupersetOf/allows-set-like-object.js
+    prototype/isSupersetOf/builtins.js
+    prototype/isSupersetOf/compares-empty-sets.js
+    prototype/isSupersetOf/compares-itself.js
+    prototype/isSupersetOf/compares-Map.js
+    prototype/isSupersetOf/compares-same-sets.js
+    prototype/isSupersetOf/compares-sets.js
+    prototype/isSupersetOf/converts-negative-zero.js
+    prototype/isSupersetOf/isSupersetOf.js
+    prototype/isSupersetOf/length.js
+    prototype/isSupersetOf/name.js
+    prototype/isSupersetOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/isSupersetOf/receiver-not-set.js
+    prototype/isSupersetOf/require-internal-slot.js
+    prototype/isSupersetOf/set-like-array.js
+    prototype/isSupersetOf/set-like-class-mutation.js
+    prototype/isSupersetOf/set-like-class-order.js
+    prototype/isSupersetOf/size-is-a-number.js
+    prototype/isSupersetOf/subclass-receiver-methods.js
+    prototype/Symbol.iterator/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/symmetricDifference/add-not-called.js
+    prototype/symmetricDifference/allows-set-like-class.js
+    prototype/symmetricDifference/allows-set-like-object.js
+    prototype/symmetricDifference/builtins.js
+    prototype/symmetricDifference/combines-empty-sets.js
+    prototype/symmetricDifference/combines-itself.js
+    prototype/symmetricDifference/combines-Map.js
+    prototype/symmetricDifference/combines-same-sets.js
+    prototype/symmetricDifference/combines-sets.js
+    prototype/symmetricDifference/converts-negative-zero.js
+    prototype/symmetricDifference/length.js
+    prototype/symmetricDifference/name.js
+    prototype/symmetricDifference/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/symmetricDifference/receiver-not-set.js
+    prototype/symmetricDifference/require-internal-slot.js
+    prototype/symmetricDifference/result-order.js
+    prototype/symmetricDifference/set-like-array.js
+    prototype/symmetricDifference/set-like-class-mutation.js
+    prototype/symmetricDifference/set-like-class-order.js
+    prototype/symmetricDifference/size-is-a-number.js
+    prototype/symmetricDifference/subclass.js
+    prototype/symmetricDifference/subclass-receiver-methods.js
+    prototype/symmetricDifference/subclass-symbol-species.js
+    prototype/symmetricDifference/symmetricDifference.js
+    prototype/union/add-not-called.js
+    prototype/union/allows-set-like-class.js
+    prototype/union/allows-set-like-object.js
+    prototype/union/appends-new-values.js
+    prototype/union/builtins.js
+    prototype/union/combines-empty-sets.js
+    prototype/union/combines-itself.js
+    prototype/union/combines-Map.js
+    prototype/union/combines-same-sets.js
+    prototype/union/combines-sets.js
+    prototype/union/converts-negative-zero.js
+    prototype/union/length.js
+    prototype/union/name.js
+    prototype/union/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/union/receiver-not-set.js
+    prototype/union/require-internal-slot.js
+    prototype/union/result-order.js
+    prototype/union/set-like-array.js
+    prototype/union/set-like-class-mutation.js
+    prototype/union/set-like-class-order.js
+    prototype/union/size-is-a-number.js
+    prototype/union/subclass.js
+    prototype/union/subclass-receiver-methods.js
+    prototype/union/subclass-symbol-species.js
+    prototype/union/union.js
+    prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
+    valid-values.js
 
 built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 85/1114 (7.63%)
+built-ins/String 140/1182 (11.84%)
+    fromCharCode/not-a-constructor.js {unsupported: [Reflect.construct]}
+    fromCodePoint/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/charAt/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/charCodeAt/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/codePointAt/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/concat/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/endsWith/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
+    prototype/includes/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
+    prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/indexOf/position-tointeger-bigint.js
     prototype/indexOf/position-tointeger-errors.js
     prototype/indexOf/position-tointeger-toprimitive.js
@@ -1473,13 +2316,24 @@ built-ins/String 85/1114 (7.63%)
     prototype/indexOf/searchstring-tostring-errors.js
     prototype/indexOf/searchstring-tostring-toprimitive.js
     prototype/indexOf/searchstring-tostring-wrapped-values.js
-    prototype/matchAll 19/19 (100.0%)
+    prototype/isWellFormed 8/8 (100.0%)
+    prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/localeCompare/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/matchAll 20/20 (100.0%)
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
+    prototype/match/duplicate-named-groups-properties.js
+    prototype/match/duplicate-named-indices-groups-properties.js
     prototype/match/invoke-builtin-match.js
+    prototype/match/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/normalize/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/padEnd/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/padStart/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/repeat/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/replaceAll/getSubstitution-0x0024-0x003C.js
     prototype/replaceAll/getSubstitution-0x0024N.js
     prototype/replaceAll/getSubstitution-0x0024NN.js
+    prototype/replaceAll/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/replaceAll/replaceValue-call-each-match-position.js
     prototype/replaceAll/replaceValue-call-matching-empty.js
     prototype/replaceAll/replaceValue-value-tostring.js
@@ -1498,49 +2352,72 @@ built-ins/String 85/1114 (7.63%)
     prototype/replaceAll/this-tostring.js
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
+    prototype/replace/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/replace/S15.5.4.11_A12.js non-strict
     prototype/search/cstm-search-get-err.js
     prototype/search/cstm-search-invocation.js
     prototype/search/invoke-builtin-search.js
     prototype/search/invoke-builtin-search-searcher-undef.js
+    prototype/search/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js
     prototype/split/limit-touint32-error.js
+    prototype/split/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/split/separator-regexp.js
     prototype/split/separator-tostring-error.js
     prototype/split/this-value-tostring-error.js
+    prototype/startsWith/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
+    prototype/substring/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/substring/S15.5.4.15_A1_T5.js
+    prototype/Symbol.iterator/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
+    prototype/toLocaleLowerCase/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleLowerCase/special_casing_conditional.js
+    prototype/toLocaleUpperCase/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
+    prototype/toLowerCase/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLowerCase/special_casing_conditional.js
     prototype/toString/non-generic-realm.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toUpperCase/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toWellFormed 8/8 (100.0%)
+    prototype/trimEnd/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/trimEnd/this-value-object-toprimitive-call-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
     prototype/trimEnd/this-value-object-toprimitive-returns-object-err.js
     prototype/trimEnd/this-value-object-tostring-meth-priority.js
     prototype/trimEnd/this-value-object-valueof-meth-priority.js
+    prototype/trimStart/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/trimStart/this-value-object-toprimitive-call-err.js
     prototype/trimStart/this-value-object-toprimitive-meth-err.js
     prototype/trimStart/this-value-object-toprimitive-meth-priority.js
     prototype/trimStart/this-value-object-toprimitive-returns-object-err.js
     prototype/trimStart/this-value-object-tostring-meth-priority.js
     prototype/trimStart/this-value-object-valueof-meth-priority.js
+    prototype/trim/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/trim/u180e.js {unsupported: [u180e]}
     prototype/valueOf/non-generic-realm.js
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
+    raw/not-a-constructor.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 27/85 (31.76%)
+built-ins/Symbol 34/92 (36.96%)
     asyncIterator/prop-desc.js
     for/cross-realm.js
+    for/description.js
+    for/not-a-constructor.js {unsupported: [Reflect.construct]}
     hasInstance/cross-realm.js
     isConcatSpreadable/cross-realm.js
     iterator/cross-realm.js
     keyFor/arg-non-symbol.js
     keyFor/cross-realm.js
+    keyFor/not-a-constructor.js {unsupported: [Reflect.construct]}
     matchAll 2/2 (100.0%)
     match/cross-realm.js
     prototype/description/description-symboldescriptivestring.js
@@ -1551,6 +2428,10 @@ built-ins/Symbol 27/85 (31.76%)
     prototype/description/wrapper.js
     prototype/Symbol.toPrimitive/name.js
     prototype/Symbol.toPrimitive/prop-desc.js
+    prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js
+    prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js
+    prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     replace/cross-realm.js
     search/cross-realm.js
     species/cross-realm.js
@@ -1561,28 +2442,41 @@ built-ins/Symbol 27/85 (31.76%)
     unscopables/cross-realm.js
     is-constructor.js {unsupported: [Reflect.construct]}
 
-built-ins/ThrowTypeError 7/13 (53.85%)
+built-ins/ThrowTypeError 8/14 (57.14%)
     extensible.js
     forbidden-arguments.js
     frozen.js
+    property-order.js
     prototype.js
     unique-per-realm-function-proto.js
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 771/1070 (72.06%)
+built-ins/TypedArray 1078/1386 (77.78%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
+    from/from-array-mapper-detaches-result.js
+    from/from-array-mapper-makes-result-out-of-bounds.js
+    from/from-typedarray-into-itself-mapper-detaches-result.js
+    from/from-typedarray-into-itself-mapper-makes-result-out-of-bounds.js
+    from/from-typedarray-mapper-detaches-result.js
+    from/from-typedarray-mapper-makes-result-out-of-bounds.js
     from/iter-access-error.js
     from/iter-invoke-error.js
     from/iter-next-error.js
     from/iter-next-value-error.js
+    from/iterated-array-changed-by-tonumber.js
     from/length.js
     from/name.js
+    from/not-a-constructor.js {unsupported: [Reflect.construct]}
     from/prop-desc.js
     of/length.js
     of/name.js
+    of/not-a-constructor.js {unsupported: [Reflect.construct]}
     of/prop-desc.js
+    of/resized-with-out-of-bounds-and-in-bounds-indices.js
+    prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js
+    prototype/at 14/14 (100.0%)
     prototype/buffer/BigInt 2/2 (100.0%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-func.js
@@ -1592,23 +2486,33 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/buffer/this-has-no-typedarrayname-internal.js
     prototype/buffer/this-inherits-typedarray.js
     prototype/buffer/this-is-not-object.js
-    prototype/byteLength/BigInt 2/2 (100.0%)
+    prototype/byteLength/BigInt 4/4 (100.0%)
     prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-func.js
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
+    prototype/byteLength/resizable-array-buffer-auto.js
+    prototype/byteLength/resizable-array-buffer-fixed.js
+    prototype/byteLength/resizable-buffer-assorted.js
+    prototype/byteLength/resized-out-of-bounds-1.js
+    prototype/byteLength/resized-out-of-bounds-2.js
     prototype/byteLength/this-has-no-typedarrayname-internal.js
     prototype/byteLength/this-is-not-object.js
-    prototype/byteOffset/BigInt 2/2 (100.0%)
+    prototype/byteOffset/BigInt 4/4 (100.0%)
     prototype/byteOffset/detached-buffer.js
     prototype/byteOffset/invoked-as-func.js
     prototype/byteOffset/length.js
     prototype/byteOffset/name.js
     prototype/byteOffset/prop-desc.js
+    prototype/byteOffset/resizable-array-buffer-auto.js
+    prototype/byteOffset/resizable-array-buffer-fixed.js
+    prototype/byteOffset/resized-out-of-bounds.js
     prototype/byteOffset/this-has-no-typedarrayname-internal.js
     prototype/byteOffset/this-is-not-object.js
-    prototype/copyWithin/BigInt 23/23 (100.0%)
+    prototype/copyWithin/BigInt 24/24 (100.0%)
+    prototype/copyWithin/coerced-target-start-end-shrink.js
+    prototype/copyWithin/coerced-target-start-grow.js
     prototype/copyWithin/coerced-values-end-detached.js
     prototype/copyWithin/coerced-values-end-detached-prototype.js
     prototype/copyWithin/coerced-values-start-detached.js
@@ -1618,20 +2522,29 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/copyWithin/invoked-as-method.js
     prototype/copyWithin/length.js
     prototype/copyWithin/name.js
+    prototype/copyWithin/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/copyWithin/prop-desc.js
+    prototype/copyWithin/resizable-buffer.js
+    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
     prototype/copyWithin/this-is-not-object.js
     prototype/copyWithin/this-is-not-typedarray-instance.js
-    prototype/entries/BigInt 3/3 (100.0%)
+    prototype/entries/BigInt 4/4 (100.0%)
     prototype/entries/detached-buffer.js
     prototype/entries/invoked-as-func.js
     prototype/entries/invoked-as-method.js
     prototype/entries/length.js
     prototype/entries/name.js
+    prototype/entries/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/entries/prop-desc.js
+    prototype/entries/resizable-buffer.js
+    prototype/entries/resizable-buffer-grow-mid-iteration.js
+    prototype/entries/resizable-buffer-shrink-mid-iteration.js
+    prototype/entries/return-abrupt-from-this-out-of-bounds.js
     prototype/entries/this-is-not-object.js
     prototype/entries/this-is-not-typedarray-instance.js
-    prototype/every/BigInt 15/15 (100.0%)
+    prototype/every/BigInt 16/16 (100.0%)
     prototype/every/callbackfn-detachbuffer.js
+    prototype/every/callbackfn-resize.js
     prototype/every/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/every/detached-buffer.js
     prototype/every/get-length-uses-internal-arraylength.js
@@ -1639,13 +2552,20 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/every/invoked-as-method.js
     prototype/every/length.js
     prototype/every/name.js
+    prototype/every/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/every/prop-desc.js
+    prototype/every/resizable-buffer.js
+    prototype/every/resizable-buffer-grow-mid-iteration.js
+    prototype/every/resizable-buffer-shrink-mid-iteration.js
+    prototype/every/return-abrupt-from-this-out-of-bounds.js
     prototype/every/this-is-not-object.js
     prototype/every/this-is-not-typedarray-instance.js
-    prototype/fill/BigInt 17/17 (100.0%)
+    prototype/fill/BigInt 18/18 (100.0%)
+    prototype/fill/absent-indices-computed-from-initial-length.js
     prototype/fill/coerced-end-detach.js
     prototype/fill/coerced-start-detach.js
     prototype/fill/coerced-value-detach.js
+    prototype/fill/coerced-value-start-end-resize.js
     prototype/fill/detached-buffer.js
     prototype/fill/fill-values-conversion-once.js
     prototype/fill/get-length-ignores-length-prop.js
@@ -1653,135 +2573,265 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/fill/invoked-as-method.js
     prototype/fill/length.js
     prototype/fill/name.js
+    prototype/fill/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/fill/prop-desc.js
+    prototype/fill/resizable-buffer.js
+    prototype/fill/return-abrupt-from-this-out-of-bounds.js
     prototype/fill/this-is-not-object.js
     prototype/fill/this-is-not-typedarray-instance.js
-    prototype/filter/BigInt 33/33 (100.0%)
+    prototype/filter/BigInt 36/36 (100.0%)
     prototype/filter/arraylength-internal.js
     prototype/filter/callbackfn-detachbuffer.js
+    prototype/filter/callbackfn-resize.js
     prototype/filter/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/filter/detached-buffer.js
     prototype/filter/invoked-as-func.js
     prototype/filter/invoked-as-method.js
     prototype/filter/length.js
     prototype/filter/name.js
+    prototype/filter/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/filter/prop-desc.js
+    prototype/filter/resizable-buffer.js
+    prototype/filter/resizable-buffer-grow-mid-iteration.js
+    prototype/filter/resizable-buffer-shrink-mid-iteration.js
+    prototype/filter/return-abrupt-from-this-out-of-bounds.js
+    prototype/filter/speciesctor-destination-resizable.js
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
-    prototype/find/BigInt 12/12 (100.0%)
-    prototype/findIndex/BigInt 12/12 (100.0%)
+    prototype/find/BigInt 13/13 (100.0%)
+    prototype/findIndex/BigInt 13/13 (100.0%)
+    prototype/findIndex/callbackfn-resize.js
     prototype/findIndex/detached-buffer.js
     prototype/findIndex/get-length-ignores-length-prop.js
     prototype/findIndex/invoked-as-func.js
     prototype/findIndex/invoked-as-method.js
     prototype/findIndex/length.js
     prototype/findIndex/name.js
+    prototype/findIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/predicate-may-detach-buffer.js
     prototype/findIndex/prop-desc.js
+    prototype/findIndex/resizable-buffer.js
+    prototype/findIndex/resizable-buffer-grow-mid-iteration.js
+    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js
     prototype/findIndex/this-is-not-object.js
     prototype/findIndex/this-is-not-typedarray-instance.js
+    prototype/findLast/BigInt 13/13 (100.0%)
+    prototype/findLastIndex/BigInt 13/13 (100.0%)
+    prototype/findLastIndex/callbackfn-resize.js
+    prototype/findLastIndex/detached-buffer.js
+    prototype/findLastIndex/get-length-ignores-length-prop.js
+    prototype/findLastIndex/invoked-as-func.js
+    prototype/findLastIndex/invoked-as-method.js
+    prototype/findLastIndex/length.js
+    prototype/findLastIndex/name.js
+    prototype/findLastIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/findLastIndex/predicate-call-changes-value.js
+    prototype/findLastIndex/predicate-call-parameters.js
+    prototype/findLastIndex/predicate-call-this-non-strict.js non-strict
+    prototype/findLastIndex/predicate-call-this-strict.js strict
+    prototype/findLastIndex/predicate-may-detach-buffer.js
+    prototype/findLastIndex/predicate-not-called-on-empty-array.js
+    prototype/findLastIndex/prop-desc.js
+    prototype/findLastIndex/resizable-buffer.js
+    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
+    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLastIndex/return-abrupt-from-predicate-call.js
+    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
+    prototype/findLastIndex/return-index-predicate-result-is-true.js
+    prototype/findLastIndex/return-negative-one-if-predicate-returns-false-value.js
+    prototype/findLastIndex/this-is-not-object.js
+    prototype/findLastIndex/this-is-not-typedarray-instance.js
+    prototype/findLast/callbackfn-resize.js
+    prototype/findLast/detached-buffer.js
+    prototype/findLast/get-length-ignores-length-prop.js
+    prototype/findLast/invoked-as-func.js
+    prototype/findLast/invoked-as-method.js
+    prototype/findLast/length.js
+    prototype/findLast/name.js
+    prototype/findLast/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/findLast/predicate-call-changes-value.js
+    prototype/findLast/predicate-call-parameters.js
+    prototype/findLast/predicate-call-this-non-strict.js non-strict
+    prototype/findLast/predicate-call-this-strict.js strict
+    prototype/findLast/predicate-may-detach-buffer.js
+    prototype/findLast/predicate-not-called-on-empty-array.js
+    prototype/findLast/prop-desc.js
+    prototype/findLast/resizable-buffer.js
+    prototype/findLast/resizable-buffer-grow-mid-iteration.js
+    prototype/findLast/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLast/return-abrupt-from-predicate-call.js
+    prototype/findLast/return-abrupt-from-this-out-of-bounds.js
+    prototype/findLast/return-found-value-predicate-result-is-true.js
+    prototype/findLast/return-undefined-if-predicate-returns-false-value.js
+    prototype/findLast/this-is-not-object.js
+    prototype/findLast/this-is-not-typedarray-instance.js
+    prototype/find/callbackfn-resize.js
     prototype/find/detached-buffer.js
     prototype/find/get-length-ignores-length-prop.js
     prototype/find/invoked-as-func.js
     prototype/find/invoked-as-method.js
     prototype/find/length.js
     prototype/find/name.js
+    prototype/find/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/find/predicate-call-this-strict.js strict
     prototype/find/predicate-may-detach-buffer.js
     prototype/find/prop-desc.js
+    prototype/find/resizable-buffer.js
+    prototype/find/resizable-buffer-grow-mid-iteration.js
+    prototype/find/resizable-buffer-shrink-mid-iteration.js
+    prototype/find/return-abrupt-from-this-out-of-bounds.js
     prototype/find/this-is-not-object.js
     prototype/find/this-is-not-typedarray-instance.js
-    prototype/forEach/BigInt 14/14 (100.0%)
+    prototype/forEach/BigInt 15/15 (100.0%)
     prototype/forEach/arraylength-internal.js
     prototype/forEach/callbackfn-detachbuffer.js
+    prototype/forEach/callbackfn-resize.js
     prototype/forEach/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/forEach/detached-buffer.js
     prototype/forEach/invoked-as-func.js
     prototype/forEach/invoked-as-method.js
     prototype/forEach/length.js
     prototype/forEach/name.js
+    prototype/forEach/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/forEach/prop-desc.js
+    prototype/forEach/resizable-buffer.js
+    prototype/forEach/resizable-buffer-grow-mid-iteration.js
+    prototype/forEach/resizable-buffer-shrink-mid-iteration.js
+    prototype/forEach/return-abrupt-from-this-out-of-bounds.js
     prototype/forEach/this-is-not-object.js
     prototype/forEach/this-is-not-typedarray-instance.js
-    prototype/includes/BigInt 11/11 (100.0%)
+    prototype/includes/BigInt 14/14 (100.0%)
+    prototype/includes/coerced-searchelement-fromindex-resize.js
     prototype/includes/detached-buffer.js
-    prototype/includes/detached-buffer-tointeger.js
+    prototype/includes/detached-buffer-during-fromIndex-returns-false-for-zero.js
+    prototype/includes/detached-buffer-during-fromIndex-returns-true-for-undefined.js
     prototype/includes/get-length-uses-internal-arraylength.js
+    prototype/includes/index-compared-against-initial-length.js
+    prototype/includes/index-compared-against-initial-length-out-of-bounds.js
     prototype/includes/invoked-as-func.js
     prototype/includes/invoked-as-method.js
     prototype/includes/length.js
     prototype/includes/name.js
+    prototype/includes/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/includes/prop-desc.js
+    prototype/includes/resizable-buffer.js
+    prototype/includes/resizable-buffer-special-float-values.js
+    prototype/includes/return-abrupt-from-this-out-of-bounds.js
     prototype/includes/this-is-not-object.js
     prototype/includes/this-is-not-typedarray-instance.js
-    prototype/indexOf/BigInt 12/12 (100.0%)
+    prototype/indexOf/BigInt 15/15 (100.0%)
+    prototype/indexOf/coerced-searchelement-fromindex-grow.js
+    prototype/indexOf/coerced-searchelement-fromindex-shrink.js
     prototype/indexOf/detached-buffer.js
+    prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+    prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
     prototype/indexOf/get-length-uses-internal-arraylength.js
     prototype/indexOf/invoked-as-func.js
     prototype/indexOf/invoked-as-method.js
     prototype/indexOf/length.js
     prototype/indexOf/name.js
+    prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/indexOf/prop-desc.js
+    prototype/indexOf/resizable-buffer.js
+    prototype/indexOf/resizable-buffer-special-float-values.js
+    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js
     prototype/indexOf/this-is-not-object.js
     prototype/indexOf/this-is-not-typedarray-instance.js
-    prototype/join/BigInt 7/7 (100.0%)
+    prototype/join/BigInt 9/9 (100.0%)
+    prototype/join/coerced-separator-grow.js
+    prototype/join/coerced-separator-shrink.js
     prototype/join/detached-buffer.js
+    prototype/join/detached-buffer-during-fromIndex-returns-single-comma.js
     prototype/join/get-length-uses-internal-arraylength.js
     prototype/join/invoked-as-func.js
     prototype/join/invoked-as-method.js
     prototype/join/length.js
     prototype/join/name.js
+    prototype/join/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/join/prop-desc.js
+    prototype/join/resizable-buffer.js
+    prototype/join/return-abrupt-from-this-out-of-bounds.js
+    prototype/join/separator-tostring-once-after-resized.js
     prototype/join/this-is-not-object.js
     prototype/join/this-is-not-typedarray-instance.js
-    prototype/keys/BigInt 3/3 (100.0%)
+    prototype/keys/BigInt 4/4 (100.0%)
     prototype/keys/detached-buffer.js
     prototype/keys/invoked-as-func.js
     prototype/keys/invoked-as-method.js
     prototype/keys/length.js
     prototype/keys/name.js
+    prototype/keys/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/keys/prop-desc.js
+    prototype/keys/resizable-buffer.js
+    prototype/keys/resizable-buffer-grow-mid-iteration.js
+    prototype/keys/resizable-buffer-shrink-mid-iteration.js
+    prototype/keys/return-abrupt-from-this-out-of-bounds.js
     prototype/keys/this-is-not-object.js
     prototype/keys/this-is-not-typedarray-instance.js
-    prototype/lastIndexOf/BigInt 11/11 (100.0%)
+    prototype/lastIndexOf/BigInt 14/14 (100.0%)
+    prototype/lastIndexOf/coerced-position-grow.js
+    prototype/lastIndexOf/coerced-position-shrink.js
     prototype/lastIndexOf/detached-buffer.js
+    prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+    prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
     prototype/lastIndexOf/get-length-uses-internal-arraylength.js
     prototype/lastIndexOf/invoked-as-func.js
     prototype/lastIndexOf/invoked-as-method.js
     prototype/lastIndexOf/length.js
     prototype/lastIndexOf/name.js
+    prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/lastIndexOf/prop-desc.js
+    prototype/lastIndexOf/resizable-buffer.js
+    prototype/lastIndexOf/resizable-buffer-special-float-values.js
+    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js
     prototype/lastIndexOf/this-is-not-object.js
     prototype/lastIndexOf/this-is-not-typedarray-instance.js
-    prototype/length/BigInt 2/2 (100.0%)
+    prototype/length/BigInt 4/4 (100.0%)
     prototype/length/detached-buffer.js
     prototype/length/invoked-as-func.js
     prototype/length/length.js
     prototype/length/name.js
     prototype/length/prop-desc.js
+    prototype/length/resizable-array-buffer-auto.js
+    prototype/length/resizable-array-buffer-fixed.js
+    prototype/length/resizable-buffer-assorted.js
+    prototype/length/resized-out-of-bounds-1.js
+    prototype/length/resized-out-of-bounds-2.js
     prototype/length/this-has-no-typedarrayname-internal.js
     prototype/length/this-is-not-object.js
-    prototype/map/BigInt 31/31 (100.0%)
+    prototype/map/BigInt 34/34 (100.0%)
     prototype/map/arraylength-internal.js
     prototype/map/callbackfn-detachbuffer.js
+    prototype/map/callbackfn-resize.js
     prototype/map/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/map/detached-buffer.js
     prototype/map/invoked-as-func.js
     prototype/map/invoked-as-method.js
     prototype/map/length.js
     prototype/map/name.js
+    prototype/map/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/map/prop-desc.js
+    prototype/map/resizable-buffer.js
+    prototype/map/resizable-buffer-grow-mid-iteration.js
+    prototype/map/resizable-buffer-shrink-mid-iteration.js
+    prototype/map/return-abrupt-from-this-out-of-bounds.js
+    prototype/map/speciesctor-destination-resizable.js
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/map/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/map/speciesctor-resizable-buffer-grow.js
+    prototype/map/speciesctor-resizable-buffer-shrink.js
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
-    prototype/reduce/BigInt 18/18 (100.0%)
-    prototype/reduceRight/BigInt 18/18 (100.0%)
+    prototype/reduce/BigInt 19/19 (100.0%)
+    prototype/reduceRight/BigInt 19/19 (100.0%)
     prototype/reduceRight/callbackfn-detachbuffer.js
     prototype/reduceRight/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/reduceRight/detached-buffer.js
@@ -1790,7 +2840,12 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/reduceRight/invoked-as-method.js
     prototype/reduceRight/length.js
     prototype/reduceRight/name.js
+    prototype/reduceRight/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reduceRight/prop-desc.js
+    prototype/reduceRight/resizable-buffer.js
+    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
+    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
+    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js
     prototype/reduceRight/this-is-not-object.js
     prototype/reduceRight/this-is-not-typedarray-instance.js
     prototype/reduce/callbackfn-detachbuffer.js
@@ -1801,20 +2856,25 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/reduce/invoked-as-method.js
     prototype/reduce/length.js
     prototype/reduce/name.js
+    prototype/reduce/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reduce/prop-desc.js
+    prototype/reduce/return-abrupt-from-this-out-of-bounds.js
     prototype/reduce/this-is-not-object.js
     prototype/reduce/this-is-not-typedarray-instance.js
-    prototype/reverse/BigInt 5/5 (100.0%)
+    prototype/reverse/BigInt 6/6 (100.0%)
     prototype/reverse/detached-buffer.js
     prototype/reverse/get-length-uses-internal-arraylength.js
     prototype/reverse/invoked-as-func.js
     prototype/reverse/invoked-as-method.js
     prototype/reverse/length.js
     prototype/reverse/name.js
+    prototype/reverse/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reverse/prop-desc.js
+    prototype/reverse/resizable-buffer.js
+    prototype/reverse/return-abrupt-from-this-out-of-bounds.js
     prototype/reverse/this-is-not-object.js
     prototype/reverse/this-is-not-typedarray-instance.js
-    prototype/set/BigInt 48/48 (100.0%)
+    prototype/set/BigInt 49/49 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-primitive-toobject.js
     prototype/set/array-arg-return-abrupt-from-src-get-length.js
@@ -1829,13 +2889,14 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/set/array-arg-src-tonumber-value-conversions.js
     prototype/set/array-arg-src-values-are-not-cached.js
     prototype/set/array-arg-target-arraylength-internal.js
-    prototype/set/array-arg-targetbuffer-detached-on-get-src-value-throws.js
+    prototype/set/array-arg-targetbuffer-detached-on-get-src-value-no-throw.js
     prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
     prototype/set/array-arg-targetbuffer-detached-throws.js
     prototype/set/invoked-as-func.js
     prototype/set/invoked-as-method.js
     prototype/set/length.js
     prototype/set/name.js
+    prototype/set/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/set/prop-desc.js
     prototype/set/src-typedarray-big-throws.js
     prototype/set/this-is-not-object.js
@@ -1845,6 +2906,7 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-arraylength-internal.js
     prototype/set/typedarray-arg-src-byteoffset-internal.js
@@ -1852,8 +2914,9 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
     prototype/set/typedarray-arg-target-arraylength-internal.js
     prototype/set/typedarray-arg-target-byteoffset-internal.js
+    prototype/set/typedarray-arg-target-out-of-bounds.js
     prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    prototype/slice/BigInt 35/35 (100.0%)
+    prototype/slice/BigInt 38/38 (100.0%)
     prototype/slice/arraylength-internal.js
     prototype/slice/detached-buffer.js
     prototype/slice/detached-buffer-custom-ctor-other-targettype.js
@@ -1866,15 +2929,20 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/slice/invoked-as-method.js
     prototype/slice/length.js
     prototype/slice/name.js
+    prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/slice/prop-desc.js
+    prototype/slice/return-abrupt-from-this-out-of-bounds.js
     prototype/slice/set-values-from-different-ctor-type.js
+    prototype/slice/speciesctor-destination-resizable.js
     prototype/slice/speciesctor-get-species-custom-ctor.js
     prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
-    prototype/some/BigInt 15/15 (100.0%)
+    prototype/some/BigInt 16/16 (100.0%)
     prototype/some/callbackfn-detachbuffer.js
+    prototype/some/callbackfn-resize.js
     prototype/some/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/some/detached-buffer.js
     prototype/some/get-length-uses-internal-arraylength.js
@@ -1882,19 +2950,21 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/some/invoked-as-method.js
     prototype/some/length.js
     prototype/some/name.js
+    prototype/some/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/some/prop-desc.js
+    prototype/some/return-abrupt-from-this-out-of-bounds.js
     prototype/some/this-is-not-object.js
     prototype/some/this-is-not-typedarray-instance.js
-    prototype/sort/BigInt 9/9 (100.0%)
+    prototype/sort/BigInt 10/10 (100.0%)
     prototype/sort/arraylength-internal.js
     prototype/sort/detached-buffer.js
-    prototype/sort/detached-buffer-comparefn.js
-    prototype/sort/detached-buffer-comparefn-coerce.js
     prototype/sort/invoked-as-func.js
     prototype/sort/invoked-as-method.js
     prototype/sort/length.js
     prototype/sort/name.js
+    prototype/sort/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/sort/prop-desc.js
+    prototype/sort/return-abrupt-from-this-out-of-bounds.js
     prototype/sort/sort-tonumber.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
@@ -1905,7 +2975,9 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/subarray/invoked-as-method.js
     prototype/subarray/length.js
     prototype/subarray/name.js
+    prototype/subarray/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/subarray/prop-desc.js
+    prototype/subarray/result-byteOffset-from-out-of-bounds.js
     prototype/subarray/speciesctor-get-ctor.js
     prototype/subarray/speciesctor-get-ctor-abrupt.js
     prototype/subarray/speciesctor-get-ctor-inherited.js
@@ -1919,6 +2991,7 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/subarray/speciesctor-get-species-returns-throws.js
     prototype/subarray/this-is-not-object.js
     prototype/subarray/this-is-not-typedarray-instance.js
+    prototype/Symbol.iterator/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
     prototype/Symbol.toStringTag/detached-buffer.js
     prototype/Symbol.toStringTag/invoked-as-accessor.js
@@ -1928,43 +3001,69 @@ built-ins/TypedArray 771/1070 (72.06%)
     prototype/Symbol.toStringTag/prop-desc.js
     prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
     prototype/Symbol.toStringTag/this-is-not-object.js
-    prototype/toLocaleString/BigInt 13/13 (100.0%)
+    prototype/toLocaleString/BigInt 14/14 (100.0%)
     prototype/toLocaleString/detached-buffer.js
     prototype/toLocaleString/get-length-uses-internal-arraylength.js
     prototype/toLocaleString/invoked-as-func.js
     prototype/toLocaleString/invoked-as-method.js
     prototype/toLocaleString/length.js
     prototype/toLocaleString/name.js
+    prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/prop-desc.js
+    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js
     prototype/toLocaleString/this-is-not-object.js
     prototype/toLocaleString/this-is-not-typedarray-instance.js
+    prototype/toReversed/metadata 3/3 (100.0%)
+    prototype/toReversed 5/5 (100.0%)
+    prototype/toSorted/metadata 3/3 (100.0%)
+    prototype/toSorted/ignores-species.js
+    prototype/toSorted/immutable.js
+    prototype/toSorted/length-property-ignored.js
+    prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toSorted/this-value-invalid.js
     prototype/toString/BigInt/detached-buffer.js
-    prototype/toString/detached-buffer.js
-    prototype/values/BigInt 3/3 (100.0%)
+    prototype/toString 2/2 (100.0%)
+    prototype/values/BigInt 4/4 (100.0%)
     prototype/values/detached-buffer.js
     prototype/values/invoked-as-func.js
     prototype/values/invoked-as-method.js
     prototype/values/length.js
+    prototype/values/make-in-bounds-after-exhausted.js
+    prototype/values/make-out-of-bounds-after-exhausted.js
     prototype/values/name.js
+    prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/values/prop-desc.js
+    prototype/values/return-abrupt-from-this-out-of-bounds.js
     prototype/values/this-is-not-object.js
     prototype/values/this-is-not-typedarray-instance.js
+    prototype/with/BigInt/early-type-coercion-bigint.js
+    prototype/with/metadata 3/3 (100.0%)
+    prototype/with/early-type-coercion.js
+    prototype/with/ignores-species.js
+    prototype/with/immutable.js
+    prototype/with/index-bigger-or-eq-than-length.js
+    prototype/with/index-casted-to-number.js
+    prototype/with/index-negative.js
+    prototype/with/index-smaller-than-minus-length.js
+    prototype/with/index-validated-against-current-length.js
+    prototype/with/length-property-ignored.js
+    prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype 3/3 (100.0%)
     Symbol.species 4/4 (100.0%)
     invoked.js
     name.js
     prototype.js
 
-built-ins/TypedArrayConstructors 546/684 (79.82%)
+built-ins/TypedArrayConstructors 582/721 (80.72%)
     BigInt64Array/prototype 4/4 (100.0%)
-    BigInt64Array 7/7 (100.0%)
+    BigInt64Array 8/8 (100.0%)
     BigUint64Array/prototype 4/4 (100.0%)
-    BigUint64Array 7/7 (100.0%)
+    BigUint64Array 8/8 (100.0%)
     ctors-bigint/buffer-arg 52/52 (100.0%)
     ctors-bigint/length-arg 12/12 (100.0%)
     ctors-bigint/no-args 7/7 (100.0%)
     ctors-bigint/object-arg 31/31 (100.0%)
-    ctors-bigint/typedarray-arg 27/27 (100.0%)
+    ctors-bigint/typedarray-arg 11/11 (100.0%)
     ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-throws.js
     ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2013,6 +3112,8 @@ built-ins/TypedArrayConstructors 546/684 (79.82%)
     ctors/no-args/use-default-proto-if-custom-proto-is-not-object.js
     ctors/object-arg/as-generator-iterable-returns.js
     ctors/object-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
+    ctors/object-arg/iterated-array-changed-by-tonumber.js
+    ctors/object-arg/iterated-array-with-modified-array-iterator.js
     ctors/object-arg/iterating-throws.js
     ctors/object-arg/iterator-is-null-as-array-like.js
     ctors/object-arg/iterator-not-callable-throws.js
@@ -2031,30 +3132,17 @@ built-ins/TypedArrayConstructors 546/684 (79.82%)
     ctors/object-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/object-arg/use-default-proto-if-custom-proto-is-not-object.js
     ctors/typedarray-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
-    ctors/typedarray-arg/detached-when-species-retrieved-different-type.js
-    ctors/typedarray-arg/detached-when-species-retrieved-same-type.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-custom-species-proto-from-ctor-realm.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-not-object-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-access-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js
-    ctors/typedarray-arg/other-ctor-buffer-ctor-species-prototype-throws.js
     ctors/typedarray-arg/proto-from-ctor-realm.js {unsupported: [Reflect]}
-    ctors/typedarray-arg/same-ctor-buffer-ctor-access-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-custom-proto-from-ctor-realm.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-not-ctor.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-prototype-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-throws.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-value-not-obj-throws.js
     ctors/typedarray-arg/src-typedarray-big-throws.js
     ctors/typedarray-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
+    ctors/no-species.js
     Float32Array/prototype/not-typedarray-object.js
     Float32Array/prototype/proto.js
+    Float32Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     Float64Array/prototype/not-typedarray-object.js
     Float64Array/prototype/proto.js
+    Float64Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     from/BigInt 28/28 (100.0%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
@@ -2081,12 +3169,61 @@ built-ins/TypedArrayConstructors 546/684 (79.82%)
     from/set-value-abrupt-completion.js
     Int16Array/prototype/not-typedarray-object.js
     Int16Array/prototype/proto.js
+    Int16Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     Int32Array/prototype/not-typedarray-object.js
     Int32Array/prototype/proto.js
+    Int32Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     Int8Array/prototype/not-typedarray-object.js
     Int8Array/prototype/proto.js
-    internals/DefineOwnProperty/BigInt 20/20 (100.0%)
-    internals/DefineOwnProperty 22/22 (100.0%)
+    Int8Array/is-a-constructor.js {unsupported: [Reflect.construct]}
+    internals/DefineOwnProperty/BigInt 26/26 (100.0%)
+    internals/DefineOwnProperty/conversion-operation.js
+    internals/DefineOwnProperty/conversion-operation-consistent-nan.js
+    internals/DefineOwnProperty/desc-value-throws.js
+    internals/DefineOwnProperty/detached-buffer.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/detached-buffer-throws.js
+    internals/DefineOwnProperty/detached-buffer-throws-realm.js
+    internals/DefineOwnProperty/key-is-greater-than-last-index.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-lower-than-zero.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-minus-zero.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-not-canonical-index.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-not-integer.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-not-numeric-index.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-numericindex.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-numericindex-accessor-desc.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-numericindex-accessor-desc-throws.js
+    internals/DefineOwnProperty/key-is-numericindex-desc-configurable.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-numericindex-desc-not-configurable-throws.js
+    internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable-throws.js
+    internals/DefineOwnProperty/key-is-numericindex-desc-not-writable.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/key-is-numericindex-desc-not-writable-throws.js
+    internals/DefineOwnProperty/key-is-symbol.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/non-extensible-new-key.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/non-extensible-redefine-key.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/set-value.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/this-is-not-extensible.js {unsupported: [Reflect]}
+    internals/DefineOwnProperty/tonumber-value-detached-buffer.js {unsupported: [Reflect]}
+    internals/Delete/BigInt 19/19 (100.0%)
+    internals/Delete/detached-buffer.js
+    internals/Delete/detached-buffer-key-is-not-numeric-index.js
+    internals/Delete/detached-buffer-key-is-symbol.js
+    internals/Delete/detached-buffer-realm.js
+    internals/Delete/indexed-value-ab-non-strict.js non-strict
+    internals/Delete/indexed-value-ab-strict.js strict
+    internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/infinity-detached-buffer.js
+    internals/Delete/key-is-not-canonical-index-non-strict.js non-strict
+    internals/Delete/key-is-not-canonical-index-strict.js strict
+    internals/Delete/key-is-not-integer.js
+    internals/Delete/key-is-not-minus-zero-non-strict.js non-strict
+    internals/Delete/key-is-not-minus-zero-strict.js strict
+    internals/Delete/key-is-not-numeric-index-non-strict.js non-strict
+    internals/Delete/key-is-not-numeric-index-strict.js strict
+    internals/Delete/key-is-out-of-bounds-non-strict.js non-strict
+    internals/Delete/key-is-out-of-bounds-strict.js strict
+    internals/Delete/key-is-symbol.js
     internals/Get/BigInt 14/14 (100.0%)
     internals/GetOwnProperty/BigInt 12/12 (100.0%)
     internals/GetOwnProperty/detached-buffer.js
@@ -2109,9 +3246,9 @@ built-ins/TypedArrayConstructors 546/684 (79.82%)
     internals/Get/key-is-out-of-bounds.js
     internals/Get/key-is-symbol.js
     internals/HasProperty/BigInt 15/15 (100.0%)
-    internals/HasProperty 15/15 (100.0%)
+    internals/HasProperty 17/17 (100.0%)
     internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
-    internals/OwnPropertyKeys 4/4 (100.0%)
+    internals/OwnPropertyKeys 6/6 (100.0%)
     internals/Set/BigInt 23/23 (100.0%)
     internals/Set/detached-buffer.js
     internals/Set/detached-buffer-key-is-not-numeric-index.js {unsupported: [Reflect]}
@@ -2124,6 +3261,7 @@ built-ins/TypedArrayConstructors 546/684 (79.82%)
     internals/Set/key-is-not-numeric-index.js {unsupported: [Reflect]}
     internals/Set/key-is-out-of-bounds.js {unsupported: [Reflect]}
     internals/Set/key-is-symbol.js {unsupported: [Reflect]}
+    internals/Set/resized-out-of-bounds-to-in-bounds-index.js
     internals/Set/tonumber-value-detached-buffer.js {unsupported: [Reflect]}
     internals/Set/tonumber-value-throws.js
     of/BigInt 12/12 (100.0%)
@@ -2167,43 +3305,78 @@ built-ins/TypedArrayConstructors 546/684 (79.82%)
     prototype 2/2 (100.0%)
     Uint16Array/prototype/not-typedarray-object.js
     Uint16Array/prototype/proto.js
+    Uint16Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     Uint32Array/prototype/not-typedarray-object.js
     Uint32Array/prototype/proto.js
+    Uint32Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     Uint8Array/prototype/not-typedarray-object.js
     Uint8Array/prototype/proto.js
+    Uint8Array/is-a-constructor.js {unsupported: [Reflect.construct]}
     Uint8ClampedArray/prototype/not-typedarray-object.js
     Uint8ClampedArray/prototype/proto.js
+    Uint8ClampedArray/is-a-constructor.js {unsupported: [Reflect.construct]}
 
-built-ins/WeakMap 1/88 (1.14%)
+built-ins/WeakMap 15/102 (14.71%)
+    prototype/delete/delete-entry-with-symbol-key.js
+    prototype/delete/delete-entry-with-symbol-key-initial-iterable.js
+    prototype/delete/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/delete/returns-false-when-symbol-key-not-present.js
+    prototype/get/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/get/returns-undefined-with-symbol-key.js
+    prototype/get/returns-value-with-symbol-key.js
+    prototype/has/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/has/returns-false-when-symbol-key-not-present.js
+    prototype/has/returns-true-when-symbol-key-present.js
+    prototype/set/adds-symbol-element.js
+    prototype/set/not-a-constructor.js {unsupported: [Reflect.construct]}
+    is-a-constructor.js {unsupported: [Reflect.construct]}
+    iterable-with-symbol-keys.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
 ~built-ins/WeakRef
 
-built-ins/WeakSet 1/75 (1.33%)
+built-ins/WeakSet 12/85 (14.12%)
+    prototype/add/adds-symbol-element.js
+    prototype/add/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/add/returns-this-symbol.js
+    prototype/add/returns-this-when-ignoring-duplicate-symbol.js
+    prototype/delete/delete-symbol-entry.js
+    prototype/delete/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/has/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/has/returns-false-when-symbol-value-not-present.js
+    prototype/has/returns-true-when-symbol-value-present.js
+    is-a-constructor.js {unsupported: [Reflect.construct]}
+    iterable-with-symbol-values.js
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
-built-ins/decodeURI 2/54 (3.7%)
+built-ins/decodeURI 3/55 (5.45%)
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     S15.1.3.1_A2.4_T1.js
     S15.1.3.1_A5.2.js
 
-built-ins/decodeURIComponent 2/54 (3.7%)
+built-ins/decodeURIComponent 3/55 (5.45%)
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     S15.1.3.2_A2.4_T1.js
     S15.1.3.2_A5.2.js
 
-built-ins/encodeURI 1/30 (3.33%)
+built-ins/encodeURI 2/31 (6.45%)
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     S15.1.3.3_A5.2.js
 
-built-ins/encodeURIComponent 1/30 (3.33%)
+built-ins/encodeURIComponent 2/31 (6.45%)
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     S15.1.3.4_A5.2.js
 
-built-ins/eval 2/9 (22.22%)
+built-ins/eval 3/10 (30.0%)
     length-non-configurable.js
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
 built-ins/global 0/29 (0.0%)
 
-built-ins/isFinite 7/16 (43.75%)
+built-ins/isFinite 8/17 (47.06%)
     length.js
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     toprimitive-call-abrupt.js
     toprimitive-get-abrupt.js
     toprimitive-not-callable-throws.js
@@ -2211,8 +3384,9 @@ built-ins/isFinite 7/16 (43.75%)
     toprimitive-result-is-symbol-throws.js
     toprimitive-valid-result.js
 
-built-ins/isNaN 7/16 (43.75%)
+built-ins/isNaN 8/17 (47.06%)
     length.js
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     toprimitive-call-abrupt.js
     toprimitive-get-abrupt.js
     toprimitive-not-callable-throws.js
@@ -2220,11 +3394,13 @@ built-ins/isNaN 7/16 (43.75%)
     toprimitive-result-is-symbol-throws.js
     toprimitive-valid-result.js
 
-built-ins/parseFloat 2/58 (3.45%)
+built-ins/parseFloat 3/59 (5.08%)
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     S15.1.2.3_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.3_A7.2.js
 
-built-ins/parseInt 2/60 (3.33%)
+built-ins/parseInt 3/60 (5.0%)
+    not-a-constructor.js {unsupported: [Reflect.construct]}
     S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
     S15.1.2.2_A9.2.js
 
@@ -2232,7 +3408,7 @@ built-ins/undefined 0/8 (0.0%)
 
 ~intl402
 
-language/arguments-object 189/260 (72.69%)
+language/arguments-object 190/263 (72.24%)
     mapped/mapped-arguments-nonconfigurable-3.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
@@ -2271,6 +3447,7 @@ language/arguments-object 189/260 (72.69%)
     unmapped/via-params-dflt.js
     unmapped/via-params-dstr.js non-strict
     unmapped/via-params-rest.js non-strict
+    10.6-11-b-1.js
     arguments-caller.js
     async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
     async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
@@ -2506,10 +3683,10 @@ language/comments 9/52 (17.31%)
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
 
-language/computed-property-names 32/45 (71.11%)
+language/computed-property-names 35/48 (72.92%)
     class/accessor 4/4 (100.0%)
     class/method 11/11 (100.0%)
-    class/static 11/11 (100.0%)
+    class/static 14/14 (100.0%)
     object/accessor/getter-super.js
     object/accessor/setter-super.js
     object/method/generator.js
@@ -2517,10 +3694,12 @@ language/computed-property-names 32/45 (71.11%)
     to-name-side-effects/class.js
     to-name-side-effects/numbers-class.js
 
-language/destructuring 9/15 (60.0%)
+language/destructuring 11/17 (64.71%)
     binding/syntax/array-elements-with-initializer.js
     binding/syntax/array-elements-with-object-patterns.js
     binding/syntax/array-rest-elements.js
+    binding/syntax/destructuring-array-parameters-function-arguments-length.js
+    binding/syntax/destructuring-object-parameters-function-arguments-length.js
     binding/syntax/property-list-bindings-elements.js
     binding/syntax/property-list-single-name-bindings.js
     binding/syntax/property-list-with-property-list.js
@@ -2548,13 +3727,11 @@ language/directive-prologue 18/62 (29.03%)
     14.1-9-s.js {non-strict: [-1]}
     func-decl-inside-func-decl-parse.js non-strict
 
-language/eval-code 259/349 (74.21%)
+language/eval-code 257/347 (74.06%)
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-body-cntns-arguments-fn-decl-params-cntns-dflt-assignment-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js non-strict
@@ -2865,7 +4042,7 @@ language/expressions/array 41/52 (78.85%)
     spread-sngl-literal.js
     spread-sngl-obj-ident.js
 
-language/expressions/arrow-function 209/333 (62.76%)
+language/expressions/arrow-function 213/343 (62.1%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3030,6 +4207,7 @@ language/expressions/arrow-function 209/333 (62.76%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    forbidden-ext/b1 2/2 (100.0%)
     syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
@@ -3075,8 +4253,10 @@ language/expressions/arrow-function 209/333 (62.76%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/assignment 200/468 (42.74%)
+language/expressions/assignment 207/480 (43.13%)
     destructuring 3/3 (100.0%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
@@ -3248,6 +4428,13 @@ language/expressions/assignment 200/468 (42.74%)
     dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
     dstr/obj-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-string-1.js {unsupported: [object-rest]}
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     dstr/obj-rest-number.js {unsupported: [object-rest]}
     dstr/obj-rest-order.js {unsupported: [object-rest]}
@@ -3270,13 +4457,15 @@ language/expressions/assignment 200/468 (42.74%)
     fn-name-cover.js
     fn-name-fn.js
     fn-name-gen.js
-    S11.13.1_A7_T1.js
-    S11.13.1_A7_T2.js
-    S11.13.1_A7_T3.js
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
+    target-super-computed-reference.js
+    target-super-computed-reference-null.js
+    target-super-identifier-reference-null.js
 
-language/expressions/async-arrow-function 31/52 (59.62%)
+language/expressions/async-arrow-function 44/60 (73.33%)
+    forbidden-ext/b1 2/2 (100.0%)
+    forbidden-ext/b2 3/3 (100.0%)
     arrow-returns-promise.js {unsupported: [async]}
     await-as-binding-identifier.js {unsupported: [async-functions]}
     await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
@@ -3284,6 +4473,10 @@ language/expressions/async-arrow-function 31/52 (59.62%)
     await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
     await-as-label-identifier.js {unsupported: [async-functions]}
     await-as-label-identifier-escaped.js {unsupported: [async-functions]}
+    await-as-param-ident-nested-arrow-parameter-position.js {unsupported: [async-functions]}
+    await-as-param-nested-arrow-body-position.js {unsupported: [async-functions]}
+    await-as-param-nested-arrow-parameter-position.js {unsupported: [async-functions]}
+    await-as-param-rest-nested-arrow-parameter-position.js {unsupported: [async-functions]}
     dflt-params-abrupt.js {unsupported: [default-parameters, async-functions, async]}
     dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-functions, async]}
     dflt-params-arg-val-undefined.js {unsupported: [default-parameters, async-functions, async]}
@@ -3293,12 +4486,14 @@ language/expressions/async-arrow-function 31/52 (59.62%)
     dflt-params-ref-self.js {unsupported: [default-parameters, async-functions, async]}
     dflt-params-rest.js {unsupported: [default-parameters]}
     dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
+    early-errors-arrow-duplicate-parameters.js {unsupported: [async-functions]}
     escaped-async.js {unsupported: [async-functions]}
     escaped-async-line-terminator.js {unsupported: [async-functions]}
     eval-var-scope-syntax-err.js {unsupported: [default-parameters, async-functions, async]}
     name.js
     params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
     params-trailing-comma-single.js {unsupported: [async-functions, async]}
+    prototype.js
     try-reject-finally-reject.js {unsupported: [async]}
     try-reject-finally-return.js {unsupported: [async]}
     try-reject-finally-throw.js {unsupported: [async]}
@@ -3308,6 +4503,8 @@ language/expressions/async-arrow-function 31/52 (59.62%)
     try-throw-finally-reject.js {unsupported: [async]}
     try-throw-finally-return.js {unsupported: [async]}
     try-throw-finally-throw.js {unsupported: [async]}
+    unscopables-with.js {unsupported: [async-functions, async]}
+    unscopables-with-in-nested-fn.js {unsupported: [async-functions, async]}
 
 ~language/expressions/async-function
 
@@ -3338,7 +4535,7 @@ language/expressions/bitwise-xor 4/30 (13.33%)
     bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/call 64/96 (66.67%)
+language/expressions/call 60/92 (65.22%)
     11.2.3-3_1.js
     11.2.3-3_2.js
     11.2.3-3_4.js
@@ -3393,10 +4590,6 @@ language/expressions/call 64/96 (66.67%)
     spread-sngl-literal.js
     spread-sngl-obj-ident.js
     tco-call-args.js {unsupported: [tail-call-optimization]}
-    tco-cross-realm-class-construct.js {unsupported: [tail-call-optimization, class]}
-    tco-cross-realm-class-derived-construct.js {unsupported: [tail-call-optimization, class]}
-    tco-cross-realm-fun-call.js {unsupported: [tail-call-optimization, class]}
-    tco-cross-realm-fun-construct.js {unsupported: [tail-call-optimization, class]}
     tco-member-args.js {unsupported: [tail-call-optimization]}
     tco-non-eval-function.js {unsupported: [tail-call-optimization]}
     tco-non-eval-function-dynamic.js {unsupported: [tail-call-optimization]}
@@ -3411,7 +4604,7 @@ language/expressions/call 64/96 (66.67%)
 language/expressions/comma 1/6 (16.67%)
     tco-final.js {unsupported: [tail-call-optimization]}
 
-language/expressions/compound-assignment 89/406 (21.92%)
+language/expressions/compound-assignment 137/454 (30.18%)
     11.13.2-34-s.js strict
     11.13.2-35-s.js strict
     11.13.2-36-s.js strict
@@ -3452,6 +4645,54 @@ language/expressions/compound-assignment 89/406 (21.92%)
     compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
     div-arguments-strict.js strict
     div-eval-strict.js strict
+    left-hand-side-private-reference-accessor-property-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-sub.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-sub.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-sub.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-sub.js {unsupported: [class-fields-private]}
     lshift-arguments-strict.js strict
     lshift-eval-strict.js strict
     mod-arguments-strict.js strict
@@ -3509,10 +4750,12 @@ language/expressions/conditional 3/22 (13.64%)
     tco-cond.js {unsupported: [tail-call-optimization]}
     tco-pos.js {unsupported: [tail-call-optimization]}
 
-language/expressions/delete 3/61 (4.92%)
+language/expressions/delete 5/67 (7.46%)
     identifier-strict.js strict
+    identifier-strict-recursive.js strict
     super-property.js {unsupported: [class]}
     super-property-method.js {unsupported: [class]}
+    super-property-null-base.js {unsupported: [class]}
 
 language/expressions/division 3/45 (6.67%)
     bigint-toprimitive.js
@@ -3536,7 +4779,7 @@ language/expressions/exponentiation 3/44 (6.82%)
     bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/function 203/248 (81.85%)
+language/expressions/function 214/264 (81.06%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3702,6 +4945,7 @@ language/expressions/function 203/248 (81.85%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
+    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
@@ -3718,6 +4962,12 @@ language/expressions/function 203/248 (81.85%)
     length-dflt.js {unsupported: [default-parameters]}
     name-arguments-strict-body.js non-strict
     name-eval-strict-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
+    named-strict-error-reassign-fn-name-in-body.js strict
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
     object-destructuring-param-strict-body.js
     param-dflt-yield-non-strict.js {unsupported: [default-parameters]}
     param-dflt-yield-strict.js {unsupported: [default-parameters]}
@@ -3737,8 +4987,12 @@ language/expressions/function 203/248 (81.85%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
+    static-init-await-binding.js
+    static-init-await-reference.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 227/275 (82.55%)
+language/expressions/generators 239/290 (82.41%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3912,6 +5166,7 @@ language/expressions/generators 227/275 (82.55%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    forbidden-ext/b1 2/2 (100.0%)
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
@@ -3932,6 +5187,12 @@ language/expressions/generators 227/275 (82.55%)
     implicit-name.js
     invoke-as-constructor.js
     length-dflt.js {unsupported: [default-parameters]}
+    named-no-strict-reassign-fn-name-in-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
+    named-strict-error-reassign-fn-name-in-body.js strict
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
     named-yield-identifier-non-strict.js non-strict
     named-yield-identifier-spread-non-strict.js non-strict
     named-yield-spread-arr-multiple.js
@@ -3957,6 +5218,10 @@ language/expressions/generators 227/275 (82.55%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
+    static-init-await-binding.js
+    static-init-await-reference.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
     yield-as-function-expression-binding-identifier.js non-strict
     yield-as-identifier-in-nested-function.js non-strict
     yield-identifier-non-strict.js non-strict
@@ -3978,7 +5243,27 @@ language/expressions/grouping 0/9 (0.0%)
 
 ~language/expressions/import.meta
 
-language/expressions/in 0/14 (0.0%)
+language/expressions/in 20/36 (55.56%)
+    private-field-in.js {unsupported: [class-fields-private]}
+    private-field-in-nested.js {unsupported: [class-fields-private]}
+    private-field-invalid-assignment-reference.js {unsupported: [class-fields-private]}
+    private-field-invalid-assignment-target.js {unsupported: [class-fields-private]}
+    private-field-invalid-identifier-complex.js {unsupported: [class-fields-private]}
+    private-field-invalid-identifier-simple.js {unsupported: [class-fields-private]}
+    private-field-invalid-rhs.js {unsupported: [class-fields-private]}
+    private-field-presence-accessor.js
+    private-field-presence-accessor-shadowed.js
+    private-field-presence-field.js {unsupported: [class-fields-private]}
+    private-field-presence-field-shadowed.js {unsupported: [class-fields-private]}
+    private-field-presence-method.js
+    private-field-presence-method-shadowed.js
+    private-field-rhs-await-absent.js {unsupported: [class-fields-private]}
+    private-field-rhs-await-present.js {unsupported: [class-fields-private, async]}
+    private-field-rhs-non-object.js {unsupported: [class-fields-private]}
+    private-field-rhs-unresolvable.js {unsupported: [class-fields-private]}
+    private-field-rhs-yield-absent.js {unsupported: [class-fields-private]}
+    private-field-rhs-yield-present.js {unsupported: [class-fields-private]}
+    rhs-yield-absent-non-strict.js non-strict
 
 language/expressions/instanceof 7/43 (16.28%)
     S11.8.6_A6_T1.js
@@ -4005,7 +5290,28 @@ language/expressions/less-than-or-equal 2/47 (4.26%)
 language/expressions/logical-and 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/logical-assignment 45/57 (78.95%)
+language/expressions/logical-assignment 66/78 (84.62%)
+    left-hand-side-private-reference-accessor-property-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-short-circuit-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-short-circuit-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-short-circuit-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
     lgcl-and-assignment-operator.js
     lgcl-and-assignment-operator-bigint.js
     lgcl-and-assignment-operator-lhs-before-rhs.js
@@ -4112,7 +5418,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 818/1081 (75.67%)
+language/expressions/object 869/1169 (74.34%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4643,7 +5949,25 @@ language/expressions/object 818/1081 (75.67%)
     dstr/meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    dstr/object-rest-proxy-get-not-called-on-dontenum-keys.js {unsupported: [Proxy, object-rest]}
+    dstr/object-rest-proxy-gopd-not-called-on-excluded-keys.js {unsupported: [Proxy, object-rest]}
     dstr/object-rest-proxy-ownkeys-returned-keys-order.js {unsupported: [Proxy, object-rest]}
+    method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-caller.js non-strict
+    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b2/gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js non-strict
+    method-definition/forbidden-ext/b2/gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js non-strict
+    method-definition/forbidden-ext/b2/gen-meth-forbidden-ext-indirect-access-prop-caller.js non-strict
     method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
     method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
     method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
@@ -4765,9 +6089,22 @@ language/expressions/object 818/1081 (75.67%)
     method-definition/async-meth-params-trailing-comma-single.js {unsupported: [async-functions, async]}
     method-definition/async-meth-rest-param-strict-body.js {unsupported: [async-iteration]}
     method-definition/async-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
+    method-definition/async-returns-async-arrow.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-arrow-returns-arguments-from-parent-function.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-arrow-returns-newtarget.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-function.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-function-returns-arguments-from-own-function.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-function-returns-newtarget.js {unsupported: [async-functions, async]}
     method-definition/async-super-call-body.js {unsupported: [async]}
     method-definition/async-super-call-param.js {unsupported: [async]}
+    method-definition/computed-property-name-yield-expression.js non-interpreted
+    method-definition/early-errors-object-method-arguments-in-formal-parameters.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-await-in-formals.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-await-in-formals-default.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-body-contains-super-call.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-duplicate-parameters.js non-strict
+    method-definition/early-errors-object-method-eval-in-formal-parameters.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-formals-body-duplicate.js {unsupported: [async-functions]}
     method-definition/escaped-get.js
     method-definition/escaped-get-e.js
     method-definition/escaped-get-g.js
@@ -4839,7 +6176,7 @@ language/expressions/object 818/1081 (75.67%)
     method-definition/name-prototype-prop.js
     method-definition/name-super-prop-body.js {unsupported: [super]}
     method-definition/name-super-prop-param.js {unsupported: [super]}
-    method-definition/object-method-returns-promise.js
+    method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
     method-definition/params-dflt-gen-meth-args-unmapped.js {unsupported: [default-parameters]}
     method-definition/params-dflt-gen-meth-ref-arguments.js {unsupported: [default-parameters]}
     method-definition/params-dflt-meth-args-unmapped.js {unsupported: [default-parameters]}
@@ -4852,6 +6189,12 @@ language/expressions/object 818/1081 (75.67%)
     method-definition/private-name-early-error-get-method-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/private-name-early-error-method-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/private-name-early-error-set-method-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/static-init-await-binding-accessor.js
+    method-definition/static-init-await-binding-generator.js
+    method-definition/static-init-await-binding-normal.js
+    method-definition/static-init-await-reference-accessor.js
+    method-definition/static-init-await-reference-generator.js
+    method-definition/static-init-await-reference-normal.js
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
     method-definition/yield-as-function-expression-binding-identifier.js non-strict
@@ -4867,6 +6210,8 @@ language/expressions/object 818/1081 (75.67%)
     11.1.5-2gs.js strict
     11.1.5_4-4-a-3.js strict
     11.1.5_4-4-b-1.js strict
+    __proto__-duplicate.js non-strict
+    __proto__-duplicate-computed.js
     __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
@@ -4879,6 +6224,13 @@ language/expressions/object 818/1081 (75.67%)
     accessor-name-literal-numeric-zero.js
     computed-__proto__.js
     concise-generator.js
+    cpn-obj-lit-computed-property-name-from-assignment-expression-coalesce.js
+    cpn-obj-lit-computed-property-name-from-assignment-expression-logical-and.js
+    cpn-obj-lit-computed-property-name-from-assignment-expression-logical-or.js
+    cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
+    cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
+    cpn-obj-lit-computed-property-name-from-expression-coalesce.js
+    cpn-obj-lit-computed-property-name-from-yield-expression.js
     fn-name-accessor-get.js
     fn-name-accessor-set.js
     fn-name-arrow.js
@@ -4890,10 +6242,15 @@ language/expressions/object 818/1081 (75.67%)
     getter-body-strict-outside.js strict
     getter-param-dflt.js {unsupported: [default-parameters]}
     getter-super-prop.js
+    ident-name-prop-name-literal-await-static-init.js
+    identifier-shorthand-await-strict-mode.js non-strict
+    identifier-shorthand-static-init-await-valid.js
     let-non-strict-access.js non-strict
     let-non-strict-syntax.js non-strict
     literal-property-name-bigint.js {unsupported: [class]}
     method.js
+    object-spread-proxy-get-not-called-on-dontenum-keys.js {unsupported: [Proxy]}
+    object-spread-proxy-no-excluded-keys.js {unsupported: [Proxy]}
     object-spread-proxy-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
     prop-def-id-eval-error.js non-strict
     prop-def-id-eval-error-2.js {unsupported: [Proxy]}
@@ -4934,7 +6291,7 @@ language/expressions/object 818/1081 (75.67%)
 
 ~language/expressions/optional-chaining
 
-language/expressions/postfix-decrement 9/36 (25.0%)
+language/expressions/postfix-decrement 9/37 (24.32%)
     arguments.js strict
     eval.js strict
     operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
@@ -4945,7 +6302,7 @@ language/expressions/postfix-decrement 9/36 (25.0%)
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/postfix-increment 10/37 (27.03%)
+language/expressions/postfix-increment 10/38 (26.32%)
     11.3.1-2-1gs.js strict
     arguments.js strict
     eval.js strict
@@ -4957,7 +6314,7 @@ language/expressions/postfix-increment 10/37 (27.03%)
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-decrement 10/33 (30.3%)
+language/expressions/prefix-decrement 10/34 (29.41%)
     11.4.5-2-2gs.js strict
     arguments.js strict
     eval.js strict
@@ -4969,7 +6326,7 @@ language/expressions/prefix-decrement 10/33 (30.3%)
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-increment 9/32 (28.13%)
+language/expressions/prefix-increment 9/33 (27.27%)
     arguments.js strict
     eval.js strict
     operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
@@ -5159,9 +6516,16 @@ language/function-code 123/217 (56.68%)
     switch-case-decl-onlystrict.js strict
     switch-dflt-decl-onlystrict.js strict
 
-language/future-reserved-words 0/55 (0.0%)
+language/future-reserved-words 7/55 (12.73%)
+    implements.js non-strict
+    interface.js non-strict
+    package.js non-strict
+    private.js non-strict
+    protected.js non-strict
+    public.js non-strict
+    static.js non-strict
 
-language/global-code 29/41 (70.73%)
+language/global-code 30/42 (71.43%)
     block-decl-strict.js strict
     decl-lex.js
     decl-lex-configurable-global.js
@@ -5181,6 +6545,7 @@ language/global-code 29/41 (70.73%)
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
+    script-decl-lex-var-declared-via-eval.js
     script-decl-var.js
     script-decl-var-collision.js
     script-decl-var-err.js non-strict
@@ -5192,27 +6557,89 @@ language/global-code 29/41 (70.73%)
     switch-dflt-decl-strict.js strict
     yield-non-strict.js non-strict
 
-language/identifier-resolution 0/13 (0.0%)
+language/identifier-resolution 0/14 (0.0%)
 
-language/identifiers 22/188 (11.7%)
+language/identifiers 84/248 (33.87%)
     other_id_continue.js
     other_id_continue-escaped.js
     other_id_start.js
     other_id_start-escaped.js
+    part-unicode-10.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-10.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-11.0.0.js
+    part-unicode-11.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-11.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-11.0.0-escaped.js
     part-unicode-12.0.0.js
+    part-unicode-12.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-12.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-12.0.0-escaped.js
     part-unicode-13.0.0.js
+    part-unicode-13.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-13.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-13.0.0-escaped.js
+    part-unicode-14.0.0.js
+    part-unicode-14.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-14.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-14.0.0-escaped.js
+    part-unicode-15.0.0.js
+    part-unicode-15.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-15.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-15.0.0-escaped.js
+    part-unicode-15.1.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-15.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-5.2.0.js
+    part-unicode-5.2.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-5.2.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-5.2.0-escaped.js
+    part-unicode-6.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-6.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-6.1.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-6.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-7.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-7.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-8.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-8.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-9.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-9.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-10.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-10.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-11.0.0.js
+    start-unicode-11.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-11.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-11.0.0-escaped.js
     start-unicode-12.0.0.js
+    start-unicode-12.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-12.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-12.0.0-escaped.js
     start-unicode-13.0.0.js
+    start-unicode-13.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-13.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-13.0.0-escaped.js
+    start-unicode-14.0.0.js
+    start-unicode-14.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-14.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-14.0.0-escaped.js
+    start-unicode-15.0.0.js
+    start-unicode-15.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-15.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-15.0.0-escaped.js
+    start-unicode-5.2.0.js
+    start-unicode-5.2.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-5.2.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.1.0.js
+    start-unicode-6.1.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-7.0.0.js
+    start-unicode-7.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-7.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-8.0.0.js
+    start-unicode-8.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-8.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-9.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-9.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js
@@ -5224,7 +6651,7 @@ language/keywords 0/25 (0.0%)
 
 language/line-terminators 0/41 (0.0%)
 
-language/literals 96/434 (22.12%)
+language/literals 108/534 (20.22%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     bigint/legacy-octal-like-invalid-00n.js non-strict
@@ -5234,6 +6661,9 @@ language/literals 96/434 (22.12%)
     bigint/non-octal-like-invalid-012348n.js non-strict
     bigint/non-octal-like-invalid-08n.js non-strict
     bigint/non-octal-like-invalid-09n.js non-strict
+    boolean/false-with-unicode.js
+    boolean/true-with-unicode.js
+    null/null-with-unicode.js
     numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
     numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     numeric/numeric-followed-by-ident.js
@@ -5257,8 +6687,17 @@ language/literals 96/434 (22.12%)
     regexp/u-surrogate-pairs-atom-escape-char-class.js
     regexp/u-surrogate-pairs-atom-escape-decimal.js
     regexp/u-unicode-esc.js
+    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict
     string/legacy-non-octal-escape-sequence-8-strict.js strict
+    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict
     string/legacy-non-octal-escape-sequence-9-strict.js strict
+    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict
     string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
     string/legacy-octal-escape-sequence-strict.js strict
@@ -5313,16 +6752,17 @@ language/statementList 21/80 (26.25%)
 
 ~language/statements/async-generator
 
-language/statements/block 6/20 (30.0%)
+language/statements/block 7/21 (33.33%)
     early-errors 4/4 (100.0%)
+    labeled-continue.js
     tco-stmt.js {unsupported: [tail-call-optimization]}
     tco-stmt-list.js {unsupported: [tail-call-optimization]}
 
-language/statements/break 0/19 (0.0%)
+language/statements/break 0/20 (0.0%)
 
 ~language/statements/class
 
-language/statements/const 107/134 (79.85%)
+language/statements/const 108/136 (79.41%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5430,8 +6870,9 @@ language/statements/const 107/134 (79.85%)
     global-closure-get-before-initialization.js
     global-use-before-initialization-in-declaration-statement.js
     global-use-before-initialization-in-prior-statement.js
+    static-init-await-binding-valid.js
 
-language/statements/continue 0/22 (0.0%)
+language/statements/continue 0/24 (0.0%)
 
 language/statements/debugger 0/2 (0.0%)
 
@@ -5451,7 +6892,7 @@ language/statements/empty 0/2 (0.0%)
 
 language/statements/expression 0/3 (0.0%)
 
-language/statements/for 263/384 (68.49%)
+language/statements/for 264/385 (68.57%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -5698,6 +7139,7 @@ language/statements/for 263/384 (68.49%)
     decl-fun.js
     decl-gen.js
     head-const-fresh-binding-per-iteration.js
+    head-init-async-of.js
     head-init-expr-check-empty-inc-empty-completion.js
     head-init-var-check-empty-inc-empty-completion.js
     head-let-bound-names-in-stmt.js
@@ -5759,7 +7201,7 @@ language/statements/for-in 39/114 (34.21%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 469/725 (64.69%)
+language/statements/for-of 477/736 (64.81%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -6091,6 +7533,13 @@ language/statements/for-of 469/725 (64.69%)
     dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
     dstr/obj-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-string-1.js {unsupported: [object-rest]}
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     dstr/obj-rest-number.js {unsupported: [object-rest]}
     dstr/obj-rest-order.js {unsupported: [object-rest]}
@@ -6202,6 +7651,7 @@ language/statements/for-of 469/725 (64.69%)
     head-let-bound-names-in-stmt.js
     head-let-fresh-binding-per-iteration.js
     head-let-init.js
+    head-lhs-async-invalid.js
     head-var-bound-names-let.js non-strict
     head-var-init.js
     head-var-no-expr.js
@@ -6230,7 +7680,7 @@ language/statements/for-of 469/725 (64.69%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/function 226/441 (51.25%)
+language/statements/function 230/451 (51.0%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6396,6 +7846,7 @@ language/statements/function 226/441 (51.25%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
+    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
     13.0-12-s.js strict
     13.0-13-s.js non-strict
     13.0-14-s.js non-strict
@@ -6454,8 +7905,11 @@ language/statements/function 226/441 (51.25%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
+    static-init-await-binding-valid.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 220/259 (84.94%)
+language/statements/generators 224/266 (84.21%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6629,6 +8083,7 @@ language/statements/generators 220/259 (84.94%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    forbidden-ext/b1 2/2 (100.0%)
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
@@ -6666,6 +8121,8 @@ language/statements/generators 220/259 (84.94%)
     scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
     yield-as-function-expression-binding-identifier.js non-strict
     yield-as-generator-declaration-binding-identifier.js non-strict
     yield-as-identifier-in-nested-function.js non-strict
@@ -6721,7 +8178,7 @@ language/statements/if 42/69 (60.87%)
     tco-else-body.js {unsupported: [tail-call-optimization]}
     tco-if-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/labeled 15/23 (65.22%)
+language/statements/labeled 15/24 (62.5%)
     decl-async-function.js {unsupported: [async-functions]}
     decl-async-generator.js {unsupported: [async-iteration]}
     decl-const.js
@@ -6738,7 +8195,7 @@ language/statements/labeled 15/23 (65.22%)
     value-yield-non-strict.js non-strict
     value-yield-non-strict-escaped.js non-strict
 
-language/statements/let 100/143 (69.93%)
+language/statements/let 101/145 (69.66%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6839,6 +8296,7 @@ language/statements/let 100/143 (69.93%)
     global-closure-set-before-initialization.js
     global-use-before-initialization-in-declaration-statement.js
     global-use-before-initialization-in-prior-statement.js
+    static-init-await-binding-valid.js
 
 language/statements/return 1/16 (6.25%)
     tco.js {unsupported: [tail-call-optimization]}
@@ -6909,7 +8367,7 @@ language/statements/switch 62/111 (55.86%)
 
 language/statements/throw 0/14 (0.0%)
 
-language/statements/try 110/195 (56.41%)
+language/statements/try 113/201 (56.22%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7001,6 +8459,8 @@ language/statements/try 110/195 (56.41%)
     12.14-14.js non-strict
     12.14-15.js non-strict
     12.14-16.js non-strict
+    completion-values.js
+    completion-values-fn-finally-abrupt.js non-interpreted
     cptn-catch.js
     cptn-catch-empty-break.js
     cptn-catch-empty-continue.js
@@ -7017,11 +8477,12 @@ language/statements/try 110/195 (56.41%)
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js
     scope-catch-param-var-none.js non-strict
+    static-init-await-binding-valid.js
     tco-catch.js {unsupported: [tail-call-optimization]}
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable 92/172 (53.49%)
+language/statements/variable 95/178 (53.37%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7047,6 +8508,7 @@ language/statements/variable 92/172 (53.49%)
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
+    dstr/ary-ptrn-elem-id-static-init-await-valid.js
     dstr/ary-ptrn-elem-obj-id.js
     dstr/ary-ptrn-elem-obj-id-init.js
     dstr/ary-ptrn-elem-obj-prop-id.js
@@ -7068,6 +8530,7 @@ language/statements/variable 92/172 (53.49%)
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
+    dstr/obj-ptrn-elem-id-static-init-await-valid.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
     dstr/obj-ptrn-id-init-fn-name-class.js
     dstr/obj-ptrn-id-init-fn-name-cover.js
@@ -7114,6 +8577,7 @@ language/statements/variable 92/172 (53.49%)
     fn-name-cover.js
     fn-name-fn.js
     fn-name-gen.js
+    static-init-await-binding-valid.js
 
 language/statements/while 13/38 (34.21%)
     cptn-abrupt-empty.js
@@ -7163,6 +8627,6 @@ language/types 9/113 (7.96%)
     undefined/S8.1_A3_T1.js
     undefined/S8.1_A3_T2.js non-strict
 
-language/white-space 2/42 (4.76%)
+language/white-space 2/67 (2.99%)
     mongolian-vowel-separator.js {unsupported: [u180e]}
     mongolian-vowel-separator-eval.js {unsupported: [u180e]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2,6 +2,30 @@
 
 ~annexB
 
+harness 22/115 (19.13%)
+    assert-notsamevalue-tostring.js {unsupported: [async-functions]}
+    assert-samevalue-tostring.js {unsupported: [async-functions]}
+    assert-tostring.js {unsupported: [async-functions]}
+    asyncHelpers-asyncTest-returns-undefined.js {unsupported: [async]}
+    asyncHelpers-asyncTest-then-rejects.js {unsupported: [async]}
+    asyncHelpers-asyncTest-then-resolves.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-custom.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-custom-typeerror.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-func-throws-sync.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-incorrect-ctor.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-invalid-func.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-native.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-no-arg.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-no-error.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-null.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-primitive.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-resolved-error.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-same-realm.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-single-arg.js {unsupported: [async]}
+    compare-array-arguments.js
+    isConstructor.js {unsupported: [Reflect.construct]}
+    nativeFunctionMatcher.js
+
 built-ins/Array 471/3055 (15.42%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined


### PR DESCRIPTION
Worked with the maintainers of test262 to eliminate anything in the harness that prevented us from running the latest version of test262, so now we can be on the latest version

A next step will be to:
- automatically add missing directories, if any, when running with the -DupdateTest262properties flag
- maybe create a GitLab CI Action that automatically create a PR to updates the revision of test262 that is used by the /tests/test22 submodule?

But I think this can be merged as is
