### PR TITLE
fix #1074 Fixed error with yeild in ComputedPropertyName

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Node.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Node.java
@@ -1165,11 +1165,16 @@ public class Node implements Iterable<Node> {
                         }
                         break;
                     case OBJECT_IDS_PROP:
+                    case OBJECT_IDS_COMPUTED_PROP:
                         {
                             Object[] a = (Object[]) x.objectValue;
                             sb.append("[");
                             for (int i = 0; i < a.length; i++) {
-                                sb.append(a[i].toString());
+                                if (a[i] != null) {
+                                    sb.append(a[i].toString());
+                                } else {
+                                    sb.append("<empty>");
+                                }
                                 if (i + 1 < a.length) sb.append(", ");
                             }
                             sb.append("]");

--- a/rhino/src/main/java/org/mozilla/javascript/NodeTransformer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NodeTransformer.java
@@ -389,6 +389,23 @@ public class NodeTransformer {
                         }
                         break;
                     }
+
+                case Token.OBJECTLIT:
+                    {
+                        Object[] computedPropertyIds =
+                                (Object[]) node.getProp(Node.OBJECT_IDS_COMPUTED_PROP);
+                        if (computedPropertyIds != null) {
+                            for (Object computedPropertyId : computedPropertyIds) {
+                                if (computedPropertyId == null) continue;
+                                transformCompilationUnit_r(
+                                        tree,
+                                        (Node) computedPropertyId,
+                                        node instanceof Scope ? (Scope) node : scope,
+                                        createScopeObjects,
+                                        inStrictMode);
+                            }
+                        }
+                    }
             }
 
             transformCompilationUnit_r(

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4112,7 +4112,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 818/1081 (75.67%)
+language/expressions/object 817/1081 (75.58%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4870,7 +4870,6 @@ language/expressions/object 818/1081 (75.67%)
     __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-expr.js non-interpreted
     accessor-name-computed-yield-id.js non-strict
     accessor-name-literal-numeric-binary.js {strict: [-1], non-strict: [-1]}
     accessor-name-literal-numeric-exponent.js {strict: [-1], non-strict: [-1]}


### PR DESCRIPTION
Closes #1074 

Running the following code in non-interpreted mode will throw `NullPointerException`. ref. https://github.com/mozilla/rhino/issues/1074#issuecomment-2245934095
```js
function* g() {
  var obj = {
    get [yield]() { return 'get yield'; }
  };
}
```

`Test262SuiteTest` does not display the exception, but you can see it by uncommenting this line.
https://github.com/mozilla/rhino/blob/cc302b4f8fac284145c51f5ceea21ec333f7a1c8/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java#L635-L638

There are many exceptions other than `NullPointerException`, so I will leave the comment as they are. For example, `java.lang.RuntimeException: Failed to build a scope with the harness files.` errors seems to be resolved by #1540.