### PR TITLE
pass ScriptRuntime.emptyArgs in getApplyArguments()

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -2853,7 +2853,7 @@ public class ScriptRuntime {
     }
 
     static Object[] getApplyArguments(Context cx, Object arg1) {
-        if (arg1 == null || Undefined.isUndefined(arg1)) {
+        if (arg1 == null || Undefined.isUndefined(arg1) || arg1 == ScriptRuntime.emptyArgs) {
             return ScriptRuntime.emptyArgs;
         } else if (arg1 instanceof Scriptable && isArrayLike((Scriptable) arg1)) {
             return cx.getElements((Scriptable) arg1);


### PR DESCRIPTION
Sorry folks, but i have no test case for this - but i found this in a complex script scenario. Maybe someone has an idea how to test this.

What is this about: the parameter handling for the apply function replaces many args with emptyArgs. But this replacements does not check for emptyArgs itself - in this case the call throws an error. Therefore i added the check and the js code now runs fine.