### PR TITLE
fix #1074 Fixed error with yeild in ComputedPropertyName

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -9,7 +9,6 @@ package org.mozilla.javascript;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import org.mozilla.javascript.ast.AstNode;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.Block;
@@ -1154,11 +1153,10 @@ class CodeGenerator extends Icode {
 
     private void visitObjectLiteral(Node node, Node child) {
         Object[] propertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
-        Object[] computedPropertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_COMPUTED_PROP);
         int count = propertyIds == null ? 0 : propertyIds.length;
         boolean hasAnyComputedProperty =
-                computedPropertyIds != null
-                        && Arrays.stream(computedPropertyIds).anyMatch(Objects::nonNull);
+                propertyIds != null
+                        && Arrays.stream(propertyIds).anyMatch(id -> id instanceof Node);
 
         int nextLiteralIndex = literalIds.size();
         literalIds.add(propertyIds);
@@ -1171,10 +1169,10 @@ class CodeGenerator extends Icode {
         int i = 0;
         while (child != null) {
             // Computed key
-            Object computedPropertyId = computedPropertyIds == null ? null : computedPropertyIds[i];
-            if (computedPropertyId != null) {
+            Object propertyId = propertyIds == null ? null : propertyIds[i];
+            if (propertyId instanceof Node) {
                 // Will be a node of type Token.COMPUTED_PROPERTY wrapping the actual expression
-                Node computedPropertyNode = (Node) computedPropertyId;
+                Node computedPropertyNode = (Node) propertyId;
                 visitExpression(computedPropertyNode.first, 0);
                 addIndexOp(Icode_LITERAL_KEY_SET, i);
                 stackChange(-1);

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -825,19 +825,16 @@ public final class IRFactory {
         List<ObjectProperty> elems = node.getElements();
         Node object = new Node(Token.OBJECTLIT);
         Object[] properties;
-        Object[] computedProperties;
         if (elems.isEmpty()) {
             properties = ScriptRuntime.emptyArgs;
-            computedProperties = ScriptRuntime.emptyArgs;
         } else {
             int size = elems.size(), i = 0;
             properties = new Object[size];
-            computedProperties = new Object[size];
             for (ObjectProperty prop : elems) {
                 Object propKey = getPropKey(prop.getLeft());
                 if (propKey == null) {
                     Node theId = transform(prop.getLeft());
-                    computedProperties[i++] = theId;
+                    properties[i++] = theId;
                 } else {
                     properties[i++] = propKey;
                 }
@@ -854,7 +851,6 @@ public final class IRFactory {
             }
         }
         object.putProp(Node.OBJECT_IDS_PROP, properties);
-        object.putProp(Node.OBJECT_IDS_COMPUTED_PROP, computedProperties);
         return object;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Node.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Node.java
@@ -63,8 +63,7 @@ public class Node implements Iterable<Node> {
             ARROW_FUNCTION_PROP = 26,
             TEMPLATE_LITERAL_PROP = 27,
             TRAILING_COMMA = 28,
-            OBJECT_IDS_COMPUTED_PROP = 39,
-            LAST_PROP = 39;
+            LAST_PROP = 28;
 
     // values of ISNUMBER_PROP to specify
     // which of the children are Number types
@@ -432,8 +431,6 @@ public class Node implements Iterable<Node> {
                     return "template_literal";
                 case TRAILING_COMMA:
                     return "trailing comma";
-                case OBJECT_IDS_COMPUTED_PROP:
-                    return "object_ids_computed_prop";
 
                 default:
                     Kit.codeBug();

--- a/rhino/src/main/java/org/mozilla/javascript/NodeTransformer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NodeTransformer.java
@@ -389,6 +389,22 @@ public class NodeTransformer {
                         }
                         break;
                     }
+
+                case Token.OBJECTLIT:
+                    {
+                        Object[] propertyIds = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
+                        if (propertyIds != null) {
+                            for (Object propertyId : propertyIds) {
+                                if (!(propertyId instanceof Node)) continue;
+                                transformCompilationUnit_r(
+                                        tree,
+                                        (Node) propertyId,
+                                        node instanceof Scope ? (Scope) node : scope,
+                                        createScopeObjects,
+                                        inStrictMode);
+                            }
+                        }
+                    }
             }
 
             transformCompilationUnit_r(

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -2084,8 +2084,7 @@ class BodyCodegen {
     }
 
     /** load two arrays with property ids and values */
-    private void addLoadProperty(
-            Node node, Node child, Object[] properties, Object[] computedProperties, int count) {
+    private void addLoadProperty(Node node, Node child, Object[] properties, int count) {
         if (count == 0) {
             addNewObjectArray(0);
             addNewObjectArray(0);
@@ -2099,7 +2098,7 @@ class BodyCodegen {
             // of dup2_x2, swap, and pop... this looks a bit cleaner.
 
             for (int i = 0; i < count; ++i) {
-                addLoadPropertyId(node, properties, computedProperties, i);
+                addLoadPropertyId(node, properties, i);
                 addLoadPropertyValue(node, child);
                 child = child.getNext();
             }
@@ -2144,10 +2143,7 @@ class BodyCodegen {
                 cfw.add(ByteCode.DUP2); // Stack: [values, keys, values, keys]
                 cfw.addLoadConstant(i); // Stack: [values, keys, values, keys, i]
                 addLoadPropertyId(
-                        node,
-                        properties,
-                        computedProperties,
-                        i); // Stack: [values, keys, values, keys, i, Ki]
+                        node, properties, i); // Stack: [values, keys, values, keys, i, Ki]
                 cfw.add(ByteCode.AASTORE); // Stack: [values, keys, values]
 
                 cfw.addLoadConstant(i); // Stack: [values, keys, values, i]
@@ -2170,15 +2166,13 @@ class BodyCodegen {
         }
     }
 
-    private void addLoadPropertyId(
-            Node node, Object[] properties, Object[] computedProperties, int i) {
-        Object computedPropertyId = computedProperties != null ? computedProperties[i] : null;
-        if (computedPropertyId != null) {
+    private void addLoadPropertyId(Node node, Object[] properties, int i) {
+        Object id = properties[i];
+        if (id instanceof Node) {
             // Will be a node of type Token.COMPUTED_PROPERTY wrapping the actual expression
-            Node computedPropertyNode = (Node) computedPropertyId;
+            Node computedPropertyNode = (Node) id;
             generateExpression(computedPropertyNode.getFirstChild(), node);
         } else {
-            Object id = properties[i];
             if (id instanceof String) {
                 cfw.addPush((String) id);
             } else {
@@ -2190,7 +2184,6 @@ class BodyCodegen {
 
     private void visitObjectLiteral(Node node, Node child, boolean topLevel) {
         Object[] properties = (Object[]) node.getProp(Node.OBJECT_IDS_PROP);
-        Object[] computedProperties = (Object[]) node.getProp(Node.OBJECT_IDS_COMPUTED_PROP);
         int count = properties == null ? 0 : properties.length;
 
         // If code budget is tight swap out literals into separate method
@@ -2222,7 +2215,7 @@ class BodyCodegen {
             return;
         }
 
-        addLoadProperty(node, child, properties, computedProperties, count);
+        addLoadProperty(node, child, properties, count);
 
         // check if object literal actually has any getters or setters
         boolean hasGetterSetters = false;

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -5442,7 +5442,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 869/1169 (74.34%)
+language/expressions/object 867/1169 (74.17%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -6121,7 +6121,6 @@ language/expressions/object 869/1169 (74.34%)
     method-definition/async-returns-async-function-returns-newtarget.js {unsupported: [async-functions, async]}
     method-definition/async-super-call-body.js {unsupported: [async]}
     method-definition/async-super-call-param.js {unsupported: [async]}
-    method-definition/computed-property-name-yield-expression.js non-interpreted
     method-definition/early-errors-object-method-arguments-in-formal-parameters.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-await-in-formals.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-await-in-formals-default.js {unsupported: [async-functions]}
@@ -6239,7 +6238,6 @@ language/expressions/object 869/1169 (74.34%)
     __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-expr.js non-interpreted
     accessor-name-computed-yield-id.js non-strict
     accessor-name-literal-numeric-binary.js {strict: [-1], non-strict: [-1]}
     accessor-name-literal-numeric-exponent.js {strict: [-1], non-strict: [-1]}


### PR DESCRIPTION
Closes #1074 

Running the following code in non-interpreted mode will throw `NullPointerException`. ref. https://github.com/mozilla/rhino/issues/1074#issuecomment-2245934095
```js
function* g() {
  var obj = {
    get [yield]() { return 'get yield'; }
  };
}
```

`Test262SuiteTest` does not display the exception, but you can see it by uncommenting this line.
https://github.com/mozilla/rhino/blob/cc302b4f8fac284145c51f5ceea21ec333f7a1c8/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java#L635-L638

There are many exceptions other than `NullPointerException`, so I will leave the comment as they are. For example, `java.lang.RuntimeException: Failed to build a scope with the harness files.` errors seems to be resolved by #1540.