### PR TITLE
FEAT: Implement Symbol.unscopables

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -36,4 +36,14 @@ public class ScriptRuntimeES6 {
                                 thisObj));
         constructor.defineOwnProperty(cx, SymbolKey.SPECIES, speciesDescriptor, false);
     }
+
+    /** Registers the symbol <code>[Symbol.unscopables]</code> on the given constructor function. */
+    public static void addSymbolUnscopables(
+            Context cx, Scriptable scope, IdScriptableObject constructor) {
+        ScriptableObject unScopablesDescriptor = (ScriptableObject) cx.newObject(scope);
+        ScriptableObject.putProperty(unScopablesDescriptor, "enumerable", false);
+        ScriptableObject.putProperty(unScopablesDescriptor, "configurable", false);
+        ScriptableObject.putProperty(unScopablesDescriptor, "writable", false);
+        constructor.defineOwnProperty(cx, SymbolKey.UNSCOPABLES, unScopablesDescriptor, false);
+    }
 }

--- a/tests/testsrc/jstests/es6/array.js
+++ b/tests/testsrc/jstests/es6/array.js
@@ -22,4 +22,32 @@ assertEquals(a.map(_ => 'a'), ['a', 'a']);
 	assertEquals(Array, symbolSpeciesValue);
 })();
 
+(function TestSymbolUnScopables() {
+	var symbolUnscopablesValue = Array[Symbol.unscopables];
+	assertEquals(undefined, symbolUnscopablesValue);
+})();
+
+(function TestSymbolUnScopablesOnArray() {
+	var symbolValuesToAssert = '{' +
+								'"at":true,' +
+								'"copyWithin":true,' +
+								'"entries":true,' +
+								'"fill":true,' +
+								'"find":true,' +
+								'"findIndex":true,' +
+								'"findLast":true,' +
+								'"findLastIndex":true,' +
+								'"flat":true,' +
+								'"flatMap":true,' +
+								'"includes":true,' +
+								'"keys":true,' +
+								'"toReversed":true,' +
+								'"toSorted":true,' +
+								'"toSpliced":true,' +
+								'"values":true' +
+							'}';
+	var symbolValues = Array.prototype[Symbol.unscopables];
+	assertEquals(JSON.stringify(symbolValues), symbolValuesToAssert);
+})();
+
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -26,7 +26,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 471/3055 (15.42%)
+built-ins/Array 468/3055 (15.32%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -302,7 +302,7 @@ built-ins/Array 471/3055 (15.42%)
     prototype/splice/target-array-non-extensible.js
     prototype/splice/target-array-with-non-configurable-property.js
     prototype/Symbol.iterator/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/Symbol.unscopables 4/4 (100.0%)
+    prototype/Symbol.unscopables/change-array-by-copy.js
     prototype/toLocaleString/invoke-element-tolocalestring.js
     prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/primitive_this_value.js strict


### PR DESCRIPTION
Implements `Array.prototype[Symbol.unscopables]` from the [spec](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-%symbol.unscopables%).