### PR TITLE
Add `Array.findLast` and `findLastIndex` from ES2023

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -169,6 +169,8 @@ public class NativeArray extends IdScriptableObject implements List {
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_some, "some", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_find, "find", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findIndex, "findIndex", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findLast, "findLast", 1);
+        addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_findLastIndex, "findLastIndex", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduce, "reduce", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_reduceRight, "reduceRight", 1);
         addIdFunctionProperty(ctor, ARRAY_TAG, ConstructorId_isArray, "isArray", 1);
@@ -279,6 +281,14 @@ public class NativeArray extends IdScriptableObject implements List {
                 arity = 1;
                 s = "findIndex";
                 break;
+            case Id_findLast:
+                arity = 1;
+                s = "findLast";
+                break;
+            case Id_findLastIndex:
+                arity = 1;
+                s = "findLastIndex";
+                break;
             case Id_reduce:
                 arity = 1;
                 s = "reduce";
@@ -359,6 +369,8 @@ public class NativeArray extends IdScriptableObject implements List {
                 case ConstructorId_some:
                 case ConstructorId_find:
                 case ConstructorId_findIndex:
+                case ConstructorId_findLast:
+                case ConstructorId_findLastIndex:
                 case ConstructorId_reduce:
                 case ConstructorId_reduceRight:
                     {
@@ -491,6 +503,13 @@ public class NativeArray extends IdScriptableObject implements List {
                 case Id_findIndex:
                     return ArrayLikeAbstractOperations.iterativeMethod(
                             cx, f, IterativeOperation.FIND_INDEX, scope, thisObj, args);
+                case Id_findLast:
+                    return ArrayLikeAbstractOperations.iterativeMethod(
+                            cx, f, IterativeOperation.FIND_LAST, scope, thisObj, args);
+                case Id_findLastIndex:
+                    return ArrayLikeAbstractOperations.iterativeMethod(
+                            cx, f, IterativeOperation.FIND_LAST_INDEX, scope, thisObj, args);
+
                 case Id_reduce:
                     return ArrayLikeAbstractOperations.reduceMethod(
                             cx, ReduceOperation.REDUCE, scope, thisObj, args);
@@ -2504,6 +2523,12 @@ public class NativeArray extends IdScriptableObject implements List {
             case "findIndex":
                 id = Id_findIndex;
                 break;
+            case "findLast":
+                id = Id_findLast;
+                break;
+            case "findLastIndex":
+                id = Id_findLastIndex;
+                break;
             case "reduce":
                 id = Id_reduce;
                 break;
@@ -2567,18 +2592,20 @@ public class NativeArray extends IdScriptableObject implements List {
             Id_some = 21,
             Id_find = 22,
             Id_findIndex = 23,
-            Id_reduce = 24,
-            Id_reduceRight = 25,
-            Id_fill = 26,
-            Id_keys = 27,
-            Id_values = 28,
-            Id_entries = 29,
-            Id_includes = 30,
-            Id_copyWithin = 31,
-            Id_at = 32,
-            Id_flat = 33,
-            Id_flatMap = 34,
-            SymbolId_unscopables = 35,
+            Id_findLast = 24,
+            Id_findLastIndex = 25,
+            Id_reduce = 26,
+            Id_reduceRight = 27,
+            Id_fill = 28,
+            Id_keys = 29,
+            Id_values = 30,
+            Id_entries = 31,
+            Id_includes = 32,
+            Id_copyWithin = 33,
+            Id_at = 34,
+            Id_flat = 35,
+            Id_flatMap = 36,
+            SymbolId_unscopables = 37,
             MAX_PROTOTYPE_ID = SymbolId_unscopables;
     private static final int ConstructorId_join = -Id_join,
             ConstructorId_reverse = -Id_reverse,
@@ -2599,11 +2626,13 @@ public class NativeArray extends IdScriptableObject implements List {
             ConstructorId_some = -Id_some,
             ConstructorId_find = -Id_find,
             ConstructorId_findIndex = -Id_findIndex,
+            ConstructorId_findLast = -Id_findLast,
+            ConstructorId_findLastIndex = -Id_findLastIndex,
             ConstructorId_reduce = -Id_reduce,
             ConstructorId_reduceRight = -Id_reduceRight,
-            ConstructorId_isArray = -26,
-            ConstructorId_of = -27,
-            ConstructorId_from = -28;
+            ConstructorId_isArray = -28,
+            ConstructorId_of = -29,
+            ConstructorId_from = -30;
 
     /** Internal representation of the JavaScript array's length property. */
     private long length;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -771,6 +771,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             case Id_findIndex:
                 return ArrayLikeAbstractOperations.iterativeMethod(
                         cx, f, IterativeOperation.FIND_INDEX, scope, thisObj, args);
+            case Id_findLast:
+                return ArrayLikeAbstractOperations.iterativeMethod(
+                        cx, f, IterativeOperation.FIND_LAST, scope, thisObj, args);
+            case Id_findLastIndex:
+                return ArrayLikeAbstractOperations.iterativeMethod(
+                        cx, f, IterativeOperation.FIND_LAST_INDEX, scope, thisObj, args);
             case Id_reduce:
                 return ArrayLikeAbstractOperations.reduceMethod(
                         cx, ReduceOperation.REDUCE, scope, thisObj, args);
@@ -898,6 +904,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 arity = 1;
                 s = "findIndex";
                 break;
+            case Id_findLast:
+                arity = 1;
+                s = "findLast";
+                break;
+            case Id_findLastIndex:
+                arity = 1;
+                s = "findLastIndex";
+                break;
             case Id_reduce:
                 arity = 1;
                 s = "reduce";
@@ -1002,6 +1016,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             case "findIndex":
                 id = Id_findIndex;
                 break;
+            case "findLast":
+                id = Id_findLast;
+                break;
+            case "findLastIndex":
+                id = Id_findLastIndex;
+                break;
             case "reduce":
                 id = Id_reduce;
                 break;
@@ -1042,9 +1062,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             Id_some = 24,
             Id_find = 25,
             Id_findIndex = 26,
-            Id_reduce = 27,
-            Id_reduceRight = 28,
-            SymbolId_iterator = 29;
+            Id_findLast = 27,
+            Id_findLastIndex = 28,
+            Id_reduce = 29,
+            Id_reduceRight = 30,
+            SymbolId_iterator = 31;
 
     protected static final int MAX_PROTOTYPE_ID = SymbolId_iterator;
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayFindLastIndexTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayFindLastIndexTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-findLastIndex.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayFindLastIndexTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayFindLastTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayFindLastTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-findLast.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayFindLastTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayFindLastIndexTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayFindLastIndexTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/typed-array-find-last-index.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayFindLastIndexTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayFindLastTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayFindLastTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/typed-array-find-last.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayFindLastTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/es2023/array-findLast.js
+++ b/tests/testsrc/jstests/es2023/array-findLast.js
@@ -1,0 +1,346 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+//
+// Test The length of 'Array.prototype.findLast' is 1
+// (22.1.3.8)
+(function () {
+    assertEquals(1, Array.prototype.findLast.length);
+})();
+
+//
+// Quick check for base cases
+//
+(function () {
+    var a = [21, 22, 23, 24];
+
+    // well, it works
+    assertEquals(a[3], a.findLast(function () { return true; }));
+
+    // predicate is called with current value, index and object on which `findLast()` was called
+    assertEquals(a[3], a.findLast(function (val, i, array) { return array === a && i === 3; }));
+
+    // 'this' can be augmented by second optional parameter
+    var thisArg = {};
+    assertEquals(a[3], a.findLast(function () { return this === thisArg; }, thisArg));
+
+    // when nothing found, `undefined` is returned
+    assertEquals(undefined, a.findLast(function () { return false; }));
+
+    // it is not required to return Boolean, it will be automatically casted
+    assertEquals(a[2], a.findLast(function (val) { return (val === a[2] ? "true" : null); }));
+})();
+
+//
+// Test predicate is anything that has [[Call]] internal method
+//
+(function () {
+    var a = [21, 22, 23, 24];
+
+    // `InterpretedFunction` or `? extends NativeFunction`
+    assertEquals(a[3], a.findLast(function () { return true; }));
+    // `IdScriptableObject`
+    assertEquals(a[3], a.findLast(Object.prototype.toString));
+    assertEquals(a[3], a.findLast(String));
+    // `BoundFunction`
+    assertEquals(a[3], a.findLast((function () { return true; }).bind({})))
+})();
+
+//
+// Test predicate is not called when array is empty
+//
+(function () {
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+
+    [].findLast(function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return false;
+    });
+
+    assertEquals(-1, l);
+    assertEquals(-1, o);
+    assertEquals(-1, v);
+    assertEquals(-1, k);
+})();
+
+//
+// Test predicate is called with correct arguments
+//
+(function () {
+    var a = ["b"];
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+
+    var found = a.findLast(function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return false;
+    });
+
+    assertArrayEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("b", v);
+    assertEquals(0, k);
+    assertEquals(undefined, found);
+})();
+
+//
+// Test predicate is called array.length times
+//
+(function () {
+    var a = [1, 2, 3, 4, 5];
+    var l = 0;
+    var sawUndefined = false;
+    var predicate = function p(v) {
+        l++;
+        sawUndefined = sawUndefined || (v === undefined);
+    };
+
+    a.findLast(predicate);
+    assertEquals(a.length, l);
+    assertFalse(sawUndefined);
+
+    // even for sparse arrays
+    a = new Array(10);
+    l = 0;
+    a.findLast(predicate);
+    assertEquals(a.length, l);
+    assertTrue(sawUndefined);
+
+    a = [];
+    a[10] = 1;
+    l = 0;
+    sawUndefined = false;
+    a.findLast(predicate);
+    assertEquals(a.length, l);
+    assertTrue(sawUndefined);
+})();
+
+
+//
+// Test Array.prototype.findLast is generic and works with String
+//
+(function () {
+    var a = "abcd";
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+    var found = Array.prototype.findLast.call(a, function (val, key, obj) {
+        o = obj.toString();
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return false;
+    });
+
+    assertEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("a", v);
+    assertEquals(0, k);
+    assertEquals(undefined, found);
+
+    found = Array.prototype.findLast.apply(a, [function (val, key, obj) {
+        o = obj.toString();
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return true;
+    }]);
+
+    assertEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("d", v);
+    assertEquals(3, k);
+    assertEquals("d", found);
+})();
+
+//
+// Test Array.prototype.findLast works with simple arraylike objects
+//
+(function () {
+    var o = {0: 0, 1: 1, 2: 2, length: 3};
+    assertEquals(o[2], Array.prototype.findLast.call(o, function (v) { return v == o[2]; }));
+    assertEquals(o[1], Array.prototype.findLast.apply(o, [function (v) { return v == o[1]; }]));
+
+    // object without `length` property defined,
+    // behaves as if it has `length` set 0
+    var empty = {0: 0, 1: 1, 2: 2};
+    var called = false;
+    Array.prototype.findLast.call(empty, function () { called = true; });
+    assertEquals(false, called);
+})();
+
+//
+// Test Array.prototype.findLast works with mixed arraylike objects
+//
+(function () {
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+    var a = {
+        prop1: "val1",
+        prop2: "val2",
+        isValid: function () {
+            return this.prop1 === "val1" && this.prop2 === "val2";
+        },
+        length: 0
+    };
+
+    Array.prototype.push.apply(a, [30, 31, 32]);
+    var found = Array.prototype.findLast.call(a, function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return !obj.isValid();
+    });
+
+    assertArrayEquals(a, o);
+    assertEquals(3, l);
+    assertEquals(30, v);
+    assertEquals(0, k);
+    assertEquals(undefined, found);
+})();
+
+//
+// Test Array.prototype.findLast works with arraylike object with getters
+//
+(function () {
+    var count = 0;
+    var a = {get 0() { return count++; }, length: 1};
+    // FIXME: right now, Rhino will get raw getter function
+    //        during iteration and use it as a value passed to predicate
+    //Array.prototype.findLast.call(a, (function () { return true; }));
+    //assertEquals(1, count);
+})();
+
+//
+// Test Array.prototype.findLast iteration includes inherited properties
+//
+(function () {
+    var o1 = {0: 0, 1: 1};
+    var o2 = {2: 2, length: 3};
+    // FIXME: use Object.setPrototypeOf instead
+    o2.__proto__ = o1;
+    var a = [];
+    Array.prototype.findLast.call(o2, function (v) { a.push(v); });
+    assertEquals([2, 1, 0], a);
+    assertEquals(2, Array.prototype.findLast.call(o2, function () { return true; }));
+})();
+
+//
+// Test array modifications
+//
+(function () {
+    var a = [1, 2, 3];
+    var found = a.findLast(function (val) {
+        a.push(val);
+        return false;
+    });
+    assertArrayEquals([1, 2, 3, 3, 2, 1], a);
+    assertEquals(6, a.length);
+    assertEquals(undefined, found);
+
+    a = [1, 2, 3];
+    found = a.findLast(function (val, key) {
+        a[key] = ++val;
+        return false;
+    });
+    assertArrayEquals([2, 3, 4], a);
+    assertEquals(3, a.length);
+    assertEquals(undefined, found);
+})();
+
+//
+// Test thisArg
+//
+(function () {
+    // If thisArg is not provided, predicate is invoked with this set to `undefined`
+    // FIXME:
+    // var o = -1;
+    //[1,2].findLast(function () { o = this; });
+    //assertEquals(undefined, o);
+
+    // Test String as a thisArg
+    var found = [1, 2, 3].findLast(function (val, key) {
+        return this.charAt(Number(key)) === String(val);
+    }, "321");
+    assertEquals(2, found);
+
+    // Test object as a thisArg
+    var thisArg = {
+        elementAt: function (key) {
+            return this[key];
+        }
+    };
+    Array.prototype.push.apply(thisArg, ["c", "b", "a"]);
+
+    found = ["a", "b", "c"].findLast(function (val, key) {
+        return this.elementAt(key) === val;
+    }, thisArg);
+    assertEquals("b", found);
+
+    // Test array itself as thisArg
+    var o;
+    var a = [1, 2];
+    a.findLast(function () { o = this; }, a);
+    assertEquals(a, o);
+})();
+
+// Test exceptions
+assertThrows('Array.prototype.findLast.call(null, function() { })', TypeError);
+assertThrows('Array.prototype.findLast.call(undefined, function() { })', TypeError);
+assertThrows('Array.prototype.findLast.apply(null, function() { }, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply(undefined, function() { }, [])', TypeError);
+
+assertThrows('[].findLast(null)', TypeError);
+assertThrows('[].findLast(undefined)', TypeError);
+assertThrows('[].findLast(0)', TypeError);
+assertThrows('[].findLast(true)', TypeError);
+assertThrows('[].findLast(false)', TypeError);
+assertThrows('[].findLast("")', TypeError);
+assertThrows('[].findLast({})', TypeError);
+assertThrows('[].findLast([])', TypeError);
+assertThrows('[].findLast(/\d+/)', TypeError);
+
+assertThrows('Array.prototype.findLast.call({}, null)', TypeError);
+assertThrows('Array.prototype.findLast.call({}, undefined)', TypeError);
+assertThrows('Array.prototype.findLast.call({}, 0)', TypeError);
+assertThrows('Array.prototype.findLast.call({}, true)', TypeError);
+assertThrows('Array.prototype.findLast.call({}, false)', TypeError);
+assertThrows('Array.prototype.findLast.call({}, "")', TypeError);
+assertThrows('Array.prototype.findLast.call({}, {})', TypeError);
+assertThrows('Array.prototype.findLast.call({}, [])', TypeError);
+assertThrows('Array.prototype.findLast.call({}, /\d+/)', TypeError);
+
+assertThrows('Array.prototype.findLast.apply({}, null, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, undefined, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, 0, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, true, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, false, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, "", [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, {}, [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, [], [])', TypeError);
+assertThrows('Array.prototype.findLast.apply({}, /\d+/, [])', TypeError);
+
+"success";

--- a/tests/testsrc/jstests/es2023/array-findLastIndex.js
+++ b/tests/testsrc/jstests/es2023/array-findLastIndex.js
@@ -1,0 +1,346 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+//
+// Test The length of 'Array.prototype.findLastIndex' is 1
+// (22.1.3.9)
+(function () {
+    assertEquals(1, Array.prototype.findLastIndex.length);
+})();
+
+//
+// Quick check for base cases
+//
+(function () {
+    var a = [21, 22, 23, 24];
+
+    // well, it works
+    assertEquals(3, a.findLastIndex(function () { return true; }));
+
+    // predicate is called with current value, index and object on which `findLastIndex()` was called
+    assertEquals(3, a.findLastIndex(function (val, i, array) { return array === a && i === 3; }));
+
+    // 'this' can be augmented by second optional parameter
+    var thisArg = {};
+    assertEquals(3, a.findLastIndex(function () { return this === thisArg; }, thisArg));
+
+    // when nothing found, `-1` is returned
+    assertEquals(-1, a.findLastIndex(function () { return false; }));
+
+    // it is not required to return Boolean, it will be automatically casted
+    assertEquals(2, a.findLastIndex(function (val) { return (val === a[2] ? "true" : null); }));
+})();
+
+//
+// Test predicate is anything that has [[Call]] internal method
+//
+(function () {
+    var a = [21, 22, 23, 24];
+
+    // `InterpretedFunction` or `? extends NativeFunction`
+    assertEquals(3, a.findLastIndex(function () { return true; }));
+    // `IdScriptableObject`
+    assertEquals(3, a.findLastIndex(Object.prototype.toString));
+    assertEquals(3, a.findLastIndex(String));
+    // `BoundFunction`
+    assertEquals(3, a.findLastIndex((function () { return true; }).bind({})))
+})();
+
+//
+// Test predicate is not called when array is empty
+//
+(function () {
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+
+    [].findLastIndex(function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return false;
+    });
+
+    assertEquals(-1, l);
+    assertEquals(-1, o);
+    assertEquals(-1, v);
+    assertEquals(-1, k);
+})();
+
+//
+// Test predicate is called with correct arguments
+//
+(function () {
+    var a = ["b"];
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+
+    var found = a.findLastIndex(function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return false;
+    });
+
+    assertArrayEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("b", v);
+    assertEquals(0, k);
+    assertEquals(-1, found);
+})();
+
+//
+// Test predicate is called array.length times
+//
+(function () {
+    var a = [1, 2, 3, 4, 5];
+    var l = 0;
+    var sawUndefined = false;
+    var predicate = function p(v) {
+        l++;
+        sawUndefined = sawUndefined || (v === undefined);
+    };
+
+    a.findLastIndex(predicate);
+    assertEquals(a.length, l);
+    assertFalse(sawUndefined);
+
+    // even for sparse arrays
+    a = new Array(10);
+    l = 0;
+    a.findLastIndex(predicate);
+    assertEquals(a.length, l);
+    assertTrue(sawUndefined);
+
+    a = [];
+    a[10] = 1;
+    l = 0;
+    sawUndefined = false;
+    a.findLastIndex(predicate);
+    assertEquals(a.length, l);
+    assertTrue(sawUndefined);
+})();
+
+
+//
+// Test Array.prototype.findLastIndex is generic and works with String
+//
+(function () {
+    var a = "abcd";
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+    var found = Array.prototype.findLastIndex.call(a, function (val, key, obj) {
+        o = obj.toString();
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return false;
+    });
+
+    assertEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("a", v);
+    assertEquals(0, k);
+    assertEquals(-1, found);
+
+    found = Array.prototype.findLastIndex.apply(a, [function (val, key, obj) {
+        o = obj.toString();
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return true;
+    }]);
+
+    assertEquals(a, o);
+    assertEquals(a.length, l);
+    assertEquals("d", v);
+    assertEquals(3, k);
+    assertEquals(3, found);
+})();
+
+//
+// Test Array.prototype.findLastIndex works with simple arraylike objects
+//
+(function () {
+    var o = {0: 0, 1: 1, 2: 2, length: 3};
+    assertEquals(2, Array.prototype.findLastIndex.call(o, function (v) { return v == o[2]; }));
+    assertEquals(1, Array.prototype.findLastIndex.apply(o, [function (v) { return v == o[1]; }]));
+
+    // object without `length` property defined,
+    // behaves as if it has `length` set 0
+    var empty = {0: 0, 1: 1, 2: 2};
+    var called = false;
+    Array.prototype.findLastIndex.call(empty, function () { called = true; });
+    assertEquals(false, called);
+})();
+
+//
+// Test Array.prototype.findLastIndex works with mixed arraylike objects
+//
+(function () {
+    var l = -1;
+    var o = -1;
+    var v = -1;
+    var k = -1;
+    var a = {
+        prop1: "val1",
+        prop2: "val2",
+        isValid: function () {
+            return this.prop1 === "val1" && this.prop2 === "val2";
+        },
+        length: 0
+    };
+
+    Array.prototype.push.apply(a, [30, 31, 32]);
+    var found = Array.prototype.findLastIndex.call(a, function (val, key, obj) {
+        o = obj;
+        l = obj.length;
+        v = val;
+        k = key;
+
+        return !obj.isValid();
+    });
+
+    assertArrayEquals(a, o);
+    assertEquals(3, l);
+    assertEquals(30, v);
+    assertEquals(0, k);
+    assertEquals(-1, found);
+})();
+
+//
+// Test Array.prototype.findLastIndex works with arraylike object with getters
+//
+(function () {
+    var count = 0;
+    var a = {get 0() { return count++; }, length: 1};
+    // FIXME: right now, Rhino will get raw getter function
+    //        during iteration and use it as a value passed to predicate
+    //Array.prototype.findLastIndex.call(a, (function () { return true; }));
+    //assertEquals(1, count);
+})();
+
+//
+// Test Array.prototype.findLastIndex iteration includes inherited properties
+//
+(function () {
+    var o1 = {0: 0, 1: 1};
+    var o2 = {2: 2, length: 3};
+    // FIXME: use Object.setPrototypeOf instead
+    o2.__proto__ = o1;
+    var a = [];
+    Array.prototype.findLastIndex.call(o2, function (v) { a.push(v); });
+    assertEquals([2, 1, 0], a);
+    assertEquals(2, Array.prototype.findLastIndex.call(o2, function () { return true; }));
+})();
+
+//
+// Test array modifications
+//
+(function () {
+    var a = [1, 2, 3];
+    var found = a.findLastIndex(function (val) {
+        a.push(val);
+        return false;
+    });
+    assertArrayEquals([1, 2, 3, 3, 2, 1], a);
+    assertEquals(6, a.length);
+    assertEquals(-1, found);
+
+    a = [1, 2, 3];
+    found = a.findLastIndex(function (val, key) {
+        a[key] = ++val;
+        return false;
+    });
+    assertArrayEquals([2, 3, 4], a);
+    assertEquals(3, a.length);
+    assertEquals(-1, found);
+})();
+
+//
+// Test thisArg
+//
+(function () {
+    // If thisArg is not provided, predicate is invoked with this set to `undefined`
+    // FIXME:
+    // var o = -1;
+    //[1,2].findLastIndex(function () { o = this; });
+    //assertEquals(undefined, o);
+
+    // Test String as a thisArg
+    var found = [1, 2, 3].findLastIndex(function (val, key) {
+        return this.charAt(Number(key)) === String(val);
+    }, "321");
+    assertEquals(1, found);
+
+    // Test object as a thisArg
+    var thisArg = {
+        elementAt: function (key) {
+            return this[key];
+        }
+    };
+    Array.prototype.push.apply(thisArg, ["c", "b", "a"]);
+
+    found = ["a", "b", "c"].findLastIndex(function (val, key) {
+        return this.elementAt(key) === val;
+    }, thisArg);
+    assertEquals(1, found);
+
+    // Test array itself as thisArg
+    var o;
+    var a = [1, 2];
+    a.findLastIndex(function () { o = this; }, a);
+    assertEquals(a, o);
+})();
+
+// Test exceptions
+assertThrows('Array.prototype.findLastIndex.call(null, function() { })', TypeError);
+assertThrows('Array.prototype.findLastIndex.call(undefined, function() { })', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply(null, function() { }, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply(undefined, function() { }, [])', TypeError);
+
+assertThrows('[].findLastIndex(null)', TypeError);
+assertThrows('[].findLastIndex(undefined)', TypeError);
+assertThrows('[].findLastIndex(0)', TypeError);
+assertThrows('[].findLastIndex(true)', TypeError);
+assertThrows('[].findLastIndex(false)', TypeError);
+assertThrows('[].findLastIndex("")', TypeError);
+assertThrows('[].findLastIndex({})', TypeError);
+assertThrows('[].findLastIndex([])', TypeError);
+assertThrows('[].findLastIndex(/\d+/)', TypeError);
+
+assertThrows('Array.prototype.findLastIndex.call({}, null)', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, undefined)', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, 0)', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, true)', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, false)', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, "")', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, {})', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.call({}, /\d+/)', TypeError);
+
+assertThrows('Array.prototype.findLastIndex.apply({}, null, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, undefined, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, 0, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, true, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, false, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, "", [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, {}, [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, [], [])', TypeError);
+assertThrows('Array.prototype.findLastIndex.apply({}, /\d+/, [])', TypeError);
+
+"success";

--- a/tests/testsrc/jstests/es2023/typed-array-find-last-index.js
+++ b/tests/testsrc/jstests/es2023/typed-array-find-last-index.js
@@ -1,0 +1,16 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([1, 2, 3]);
+    assertEquals(1, arr.findLastIndex(n => n % 2 === 0));
+    assertEquals(-1, arr.findLastIndex(n => n < 0));
+}
+ 
+"success";

--- a/tests/testsrc/jstests/es2023/typed-array-find-last.js
+++ b/tests/testsrc/jstests/es2023/typed-array-find-last.js
@@ -1,0 +1,16 @@
+load("testsrc/assert.js");
+
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+    Float64Array];
+
+for (var t = 0; t < types.length; t++) {
+    var type = types[t];
+       
+    var arr = new type([1, 2, 3]);
+    assertEquals(2, arr.findLast(n => n % 2 === 0));
+    assertEquals(undefined, arr.findLast(n => n < 0));
+}
+ 
+"success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -26,7 +26,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 468/3055 (15.32%)
+built-ins/Array 438/3055 (14.34%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -116,48 +116,18 @@ built-ins/Array 468/3055 (15.32%)
     prototype/findIndex/resizable-buffer.js
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/array-altered-during-loop.js
-    prototype/findLastIndex/call-with-boolean.js
     prototype/findLastIndex/callbackfn-resize-arraybuffer.js
-    prototype/findLastIndex/length.js
-    prototype/findLastIndex/maximum-index.js
-    prototype/findLastIndex/name.js
     prototype/findLastIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/findLastIndex/predicate-call-parameters.js
-    prototype/findLastIndex/predicate-call-this-non-strict.js non-strict
     prototype/findLastIndex/predicate-call-this-strict.js strict
-    prototype/findLastIndex/predicate-called-for-each-array-property.js
-    prototype/findLastIndex/predicate-not-called-on-empty-array.js
-    prototype/findLastIndex/prop-desc.js
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/return-abrupt-from-predicate-call.js
-    prototype/findLastIndex/return-abrupt-from-property.js
-    prototype/findLastIndex/return-abrupt-from-this-length.js
-    prototype/findLastIndex/return-index-predicate-result-is-true.js
-    prototype/findLastIndex/return-negative-one-if-predicate-returns-false-value.js
-    prototype/findLast/array-altered-during-loop.js
-    prototype/findLast/call-with-boolean.js
     prototype/findLast/callbackfn-resize-arraybuffer.js
-    prototype/findLast/length.js
-    prototype/findLast/maximum-index.js
-    prototype/findLast/name.js
     prototype/findLast/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/findLast/predicate-call-parameters.js
-    prototype/findLast/predicate-call-this-non-strict.js non-strict
     prototype/findLast/predicate-call-this-strict.js strict
-    prototype/findLast/predicate-called-for-each-array-property.js
-    prototype/findLast/predicate-not-called-on-empty-array.js
-    prototype/findLast/prop-desc.js
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/return-abrupt-from-predicate-call.js
-    prototype/findLast/return-abrupt-from-property.js
-    prototype/findLast/return-abrupt-from-this-length.js
-    prototype/findLast/return-found-value-predicate-result-is-true.js
-    prototype/findLast/return-undefined-if-predicate-returns-false-value.js
     prototype/find/callbackfn-resize-arraybuffer.js
     prototype/find/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/find/predicate-call-this-strict.js strict
@@ -2471,7 +2441,7 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 1078/1386 (77.78%)
+built-ins/TypedArray 1064/1386 (76.77%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/from-array-mapper-detaches-result.js
@@ -2649,20 +2619,13 @@ built-ins/TypedArray 1078/1386 (77.78%)
     prototype/findLastIndex/length.js
     prototype/findLastIndex/name.js
     prototype/findLastIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/findLastIndex/predicate-call-changes-value.js
-    prototype/findLastIndex/predicate-call-parameters.js
-    prototype/findLastIndex/predicate-call-this-non-strict.js non-strict
     prototype/findLastIndex/predicate-call-this-strict.js strict
     prototype/findLastIndex/predicate-may-detach-buffer.js
-    prototype/findLastIndex/predicate-not-called-on-empty-array.js
     prototype/findLastIndex/prop-desc.js
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/return-abrupt-from-predicate-call.js
     prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
-    prototype/findLastIndex/return-index-predicate-result-is-true.js
-    prototype/findLastIndex/return-negative-one-if-predicate-returns-false-value.js
     prototype/findLastIndex/this-is-not-object.js
     prototype/findLastIndex/this-is-not-typedarray-instance.js
     prototype/findLast/callbackfn-resize.js
@@ -2673,20 +2636,13 @@ built-ins/TypedArray 1078/1386 (77.78%)
     prototype/findLast/length.js
     prototype/findLast/name.js
     prototype/findLast/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/findLast/predicate-call-changes-value.js
-    prototype/findLast/predicate-call-parameters.js
-    prototype/findLast/predicate-call-this-non-strict.js non-strict
     prototype/findLast/predicate-call-this-strict.js strict
     prototype/findLast/predicate-may-detach-buffer.js
-    prototype/findLast/predicate-not-called-on-empty-array.js
     prototype/findLast/prop-desc.js
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/return-abrupt-from-predicate-call.js
     prototype/findLast/return-abrupt-from-this-out-of-bounds.js
-    prototype/findLast/return-found-value-predicate-result-is-true.js
-    prototype/findLast/return-undefined-if-predicate-returns-false-value.js
     prototype/findLast/this-is-not-object.js
     prototype/findLast/this-is-not-typedarray-instance.js
     prototype/find/callbackfn-resize.js


### PR DESCRIPTION
Also implement it for the typed arrays variants.
There are no test262 changes because our version of test262 is old and does not contain them yet. 🙂

The tests I've added are basically adaptation of the existing tests for `find` and `findIndex`.

Should fix #1241.