### PR TITLE
Add ES2019 Symbol.prototype.description

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -235,12 +235,12 @@ public class NativeSymbol extends IdScriptableObject implements Symbol {
         String desc;
         if (args.length > 0) {
             if (Undefined.instance.equals(args[0])) {
-                desc = "";
+                desc = null;
             } else {
                 desc = ScriptRuntime.toString(args[0]);
             }
         } else {
-            desc = "";
+            desc = null;
         }
 
         if (args.length > 1) {
@@ -288,8 +288,12 @@ public class NativeSymbol extends IdScriptableObject implements Symbol {
         return Undefined.instance;
     }
 
-    private String js_getDescription() {
-        return key.getName();
+    private Object js_getDescription() {
+        String name = key.getName();
+        if (name == null) {
+            return Undefined.instance;
+        }
+        return name;
     }
 
     @Override

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2426,10 +2426,9 @@ built-ins/String 140/1182 (11.84%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 34/92 (36.96%)
+built-ins/Symbol 28/92 (30.43%)
     asyncIterator/prop-desc.js
     for/cross-realm.js
-    for/description.js
     for/not-a-constructor.js {unsupported: [Reflect.construct]}
     hasInstance/cross-realm.js
     isConcatSpreadable/cross-realm.js
@@ -2439,12 +2438,7 @@ built-ins/Symbol 34/92 (36.96%)
     keyFor/not-a-constructor.js {unsupported: [Reflect.construct]}
     matchAll 2/2 (100.0%)
     match/cross-realm.js
-    prototype/description/description-symboldescriptivestring.js
-    prototype/description/descriptor.js
-    prototype/description/get.js
-    prototype/description/this-val-non-symbol.js
-    prototype/description/this-val-symbol.js
-    prototype/description/wrapper.js
+    prototype/description/this-val-non-symbol.js {unsupported: [Proxy]}
     prototype/Symbol.toPrimitive/name.js
     prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js


### PR DESCRIPTION
This is my first contribution to this repository so please let me know if I need to change anything! I mainly looked at how NativeMap and NativeSet had their `size` properties implemented as mentioned in #963, but I'm not too sure if I did it correctly here.

This resolves #962 