### PR TITLE
Ensure that generator functions pass parameters properly

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
@@ -283,6 +283,10 @@ public class FunctionNode extends ScriptNode {
     public void setIsES6Generator() {
         isES6Generator = true;
         isGenerator = true;
+        // Generators always need activation, because their calling convention is always
+        // different. Make sure that this is set now, even if the generator does not
+        // have any "yield" statements.
+        needsActivation = true;
     }
 
     @Override

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4971,7 +4971,6 @@ language/expressions/generators 239/290 (82.41%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
-    dstr/ary-name-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
@@ -4992,9 +4991,7 @@ language/expressions/generators 239/290 (82.41%)
     dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
-    dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
-    dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
@@ -5122,11 +5119,9 @@ language/expressions/generators 239/290 (82.41%)
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
-    dstr/obj-ptrn-id-trailing-comma.js non-interpreted
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
-    dstr/obj-ptrn-prop-ary-trailing-comma.js non-interpreted
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
@@ -5177,8 +5172,6 @@ language/expressions/generators 239/290 (82.41%)
     param-dflt-yield.js {unsupported: [default-parameters]}
     params-dflt-args-unmapped.js {unsupported: [default-parameters]}
     params-dflt-ref-arguments.js {unsupported: [default-parameters]}
-    params-trailing-comma-multiple.js non-interpreted
-    params-trailing-comma-single.js non-interpreted
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js
@@ -7886,7 +7879,6 @@ language/statements/generators 224/266 (84.21%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
-    dstr/ary-name-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
@@ -7907,9 +7899,7 @@ language/statements/generators 224/266 (84.21%)
     dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
-    dstr/ary-ptrn-elem-id-iter-done.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-step-err.js
-    dstr/ary-ptrn-elem-id-iter-val.js non-interpreted
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
     dstr/ary-ptrn-elem-obj-id.js
@@ -8037,11 +8027,9 @@ language/statements/generators 224/266 (84.21%)
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
-    dstr/obj-ptrn-id-trailing-comma.js non-interpreted
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
-    dstr/obj-ptrn-prop-ary-trailing-comma.js non-interpreted
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
@@ -8080,8 +8068,6 @@ language/statements/generators 224/266 (84.21%)
     param-dflt-yield.js {unsupported: [default-parameters]}
     params-dflt-args-unmapped.js {unsupported: [default-parameters]}
     params-dflt-ref-arguments.js {unsupported: [default-parameters]}
-    params-trailing-comma-multiple.js non-interpreted
-    params-trailing-comma-single.js non-interpreted
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js


### PR DESCRIPTION
Generators use a different calling convention and require "activation" in order to pick up the right parameters. This wasn't being triggered unless the generator function had a "yield" statement, resulting in some very strange results. Make sure that it always happens for ES6 generators.

Fixes https://github.com/mozilla/rhino/issues/1412
