### PR TITLE
Implement ES2023 copy methods on Array and TypedArray

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -2236,7 +2236,7 @@ public class NativeArray extends IdScriptableObject implements List {
         Scriptable result = cx.newArray(scope, (int) len);
 
         for (int k = 0; k < len; ++k) {
-            int from = (int) (len) - k - 1;
+            int from = (int) len - k - 1;
             Object fromValue = getElem(cx, source, from);
             setElem(cx, result, k, fromValue);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -334,13 +334,13 @@ public class NativeArray extends IdScriptableObject implements List {
                 arity = 1;
                 s = "flatMap";
                 break;
-            case Id_toSorted:
-                arity = 1;
-                s = "toSorted";
-                break;
             case Id_toReversed:
                 arity = 0;
                 s = "toReversed";
+                break;
+            case Id_toSorted:
+                arity = 1;
+                s = "toSorted";
                 break;
             case Id_toSpliced:
                 arity = 2;
@@ -549,10 +549,10 @@ public class NativeArray extends IdScriptableObject implements List {
                     return new NativeArrayIterator(
                             scope, thisObj, NativeArrayIterator.ARRAY_ITERATOR_TYPE.VALUES);
 
-                case Id_toSorted:
-                    return js_toSorted(cx, scope, thisObj, args);
                 case Id_toReversed:
                     return js_toReversed(cx, scope, thisObj, args);
+                case Id_toSorted:
+                    return js_toSorted(cx, scope, thisObj, args);
                 case Id_toSpliced:
                     return js_toSpliced(cx, scope, thisObj, args);
                 case Id_with:
@@ -2720,11 +2720,11 @@ public class NativeArray extends IdScriptableObject implements List {
             case "flatMap":
                 id = Id_flatMap;
                 break;
-            case "toSorted":
-                id = Id_toSorted;
-                break;
             case "toReversed":
                 id = Id_toReversed;
+                break;
+            case "toSorted":
+                id = Id_toSorted;
                 break;
             case "toSpliced":
                 id = Id_toSpliced;
@@ -2775,8 +2775,8 @@ public class NativeArray extends IdScriptableObject implements List {
             Id_at = 34,
             Id_flat = 35,
             Id_flatMap = 36,
-            Id_toSorted = 37,
-            Id_toReversed = 38,
+            Id_toReversed = 37,
+            Id_toSorted = 38,
             Id_toSpliced = 39,
             Id_with = 40,
             SymbolId_unscopables = 41,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -2209,14 +2209,16 @@ public class NativeArray extends IdScriptableObject implements List {
     private static Object js_toReversed(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
-        Scriptable result = cx.newArray(scope, 0);
-        long length = getLengthProperty(cx, source);
-        setLengthProperty(cx, result, length);
+        long len = getLengthProperty(cx, source);
 
-        // Can't rely on any dense optimization or we would break the spec
-        // (see test262 holes-not-preserved.js)
-        for (int k = 0; k < length; ++k) {
-            int from = (int)(length) - k - 1;
+        if (len > Integer.MAX_VALUE) {
+            String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
+            throw ScriptRuntime.rangeError(msg);
+        }
+        Scriptable result = cx.newArray(scope, (int)len);
+
+        for (int k = 0; k < len; ++k) {
+            int from = (int)(len) - k - 1;
             Object fromValue = getElem(cx, source, from);
             setElem(cx, result, k, fromValue);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -2208,8 +2208,19 @@ public class NativeArray extends IdScriptableObject implements List {
 
     private static Object js_toReversed(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        Scriptable result = copyArray(cx, scope, thisObj);
-        js_reverse(cx, scope, result, args);
+        Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
+        Scriptable result = cx.newArray(scope, 0);
+
+        long length = getLengthProperty(cx, source);
+        setLengthProperty(cx, result, length);
+
+        // Can't rely on any dense optimization or we would break the spec
+        // (see test262 holes-not-preserved.js)
+        for (int k = 0; k < length; ++k) {
+            int from = (int)(length) - k - 1;
+            Object fromValue = getElem(cx, source, from);
+            setElem(cx, result, k, fromValue);
+        }
         return result;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -1375,7 +1375,8 @@ public class NativeArray extends IdScriptableObject implements List {
             final Scriptable thisObj,
             final Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-        Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
+        Comparator<Object> comparator =
+                ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
         return sort(cx, o, comparator);
     }
 
@@ -2202,7 +2203,8 @@ public class NativeArray extends IdScriptableObject implements List {
 
     private static Object js_toSorted(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
+        Comparator<Object> comparator =
+                ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);
 
         Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
         long len = getLengthProperty(cx, source);
@@ -2211,13 +2213,13 @@ public class NativeArray extends IdScriptableObject implements List {
             String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
-        Scriptable result = cx.newArray(scope, (int)len);
-        
+        Scriptable result = cx.newArray(scope, (int) len);
+
         for (int k = 0; k < len; ++k) {
             Object fromValue = getElem(cx, source, k);
             setElem(cx, result, k, fromValue);
         }
-        
+
         sort(cx, result, comparator);
         return result;
     }
@@ -2231,10 +2233,10 @@ public class NativeArray extends IdScriptableObject implements List {
             String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
-        Scriptable result = cx.newArray(scope, (int)len);
+        Scriptable result = cx.newArray(scope, (int) len);
 
         for (int k = 0; k < len; ++k) {
-            int from = (int)(len) - k - 1;
+            int from = (int) (len) - k - 1;
             Object fromValue = getElem(cx, source, from);
             setElem(cx, result, k, fromValue);
         }
@@ -2246,14 +2248,15 @@ public class NativeArray extends IdScriptableObject implements List {
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
         long len = getLengthProperty(cx, source);
-        
+
         long actualStart = 0;
         if (args.length > 0) {
-            actualStart = ArrayLikeAbstractOperations.toSliceIndex(ScriptRuntime.toInteger(args[0]), len);
+            actualStart =
+                    ArrayLikeAbstractOperations.toSliceIndex(ScriptRuntime.toInteger(args[0]), len);
         }
-        
+
         long insertCount = args.length > 2 ? args.length - 2 : 0;
-        
+
         long actualSkipCount;
         if (args.length == 0) {
             actualSkipCount = 0;
@@ -2261,7 +2264,7 @@ public class NativeArray extends IdScriptableObject implements List {
             actualSkipCount = len - actualStart;
         } else {
             long sc = ScriptRuntime.toLength(args, 1);
-            actualSkipCount = Math.max(0, Math.min(sc, len-actualStart));
+            actualSkipCount = Math.max(0, Math.min(sc, len - actualStart));
         }
 
         long newLen = len + insertCount - actualSkipCount;
@@ -2272,9 +2275,9 @@ public class NativeArray extends IdScriptableObject implements List {
             String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
-        
-        Scriptable result = cx.newArray(scope, (int)newLen);
-        
+
+        Scriptable result = cx.newArray(scope, (int) newLen);
+
         long i = 0;
         long r = actualStart + actualSkipCount;
 
@@ -2283,19 +2286,19 @@ public class NativeArray extends IdScriptableObject implements List {
             setElem(cx, result, i, e);
             i++;
         }
-        
+
         for (int j = 2; j < args.length; j++) {
             setElem(cx, result, i, args[j]);
             i++;
         }
-        
+
         while (i < newLen) {
             Object e = getElem(cx, source, r);
             setElem(cx, result, i, e);
             i++;
             r++;
         }
-        
+
         return result;
     }
 
@@ -2303,9 +2306,9 @@ public class NativeArray extends IdScriptableObject implements List {
         Scriptable source = ScriptRuntime.toObject(cx, scope, thisObj);
 
         long len = getLengthProperty(cx, source);
-        long relativeIndex = args.length > 0 ? (int)ScriptRuntime.toInteger(args[0]) : 0;
+        long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(args[0]) : 0;
         long actualIndex = relativeIndex >= 0 ? relativeIndex : len + relativeIndex;
-        
+
         if (actualIndex < 0 || actualIndex >= len) {
             throw ScriptRuntime.rangeError("index out of range");
         }
@@ -2313,17 +2316,17 @@ public class NativeArray extends IdScriptableObject implements List {
             String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
         }
-        
-        Scriptable result = cx.newArray(scope, (int)len);
+
+        Scriptable result = cx.newArray(scope, (int) len);
         for (long k = 0; k < len; ++k) {
             Object value;
             if (k == actualIndex) {
-	            value = args.length > 1 ? args[1] : Undefined.instance;	                
+                value = args.length > 1 ? args[1] : Undefined.instance;
             } else {
                 value = getElem(cx, source, k);
             }
             setElem(cx, result, k, value);
-        }        
+        }
 
         return result;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -665,7 +665,25 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private Object js_with(Context cx, Scriptable scope, Object[] args) {
-        throw new UnsupportedOperationException("TODO");
+        long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(args[0]) : 0;
+        long actualIndex = relativeIndex >= 0 ? relativeIndex : length + relativeIndex;
+
+        Object argsValue = args.length > 1 ? ScriptRuntime.toNumber(args[1]) : 0.0; 
+        
+        if (actualIndex < 0 || actualIndex >= length) {
+            throw ScriptRuntime.rangeError("index out of range");
+        }
+
+        NativeArrayBuffer newBuffer = new NativeArrayBuffer(length * getBytesPerElement());
+        Scriptable result = cx.newObject(scope, getClassName(),
+                new Object[]{newBuffer, 0, length, getBytesPerElement()});
+
+        for (int k = 0; k < length; ++k) {
+            Object fromValue = (k == actualIndex) ? argsValue : js_get(k);
+	        result.put(k, result, fromValue);
+        }
+
+        return result;
     }
 
     // Dispatcher

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -633,9 +633,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private Object js_toReversed(Context cx, Scriptable scope) {
-	    NativeArrayBuffer newBuffer = new NativeArrayBuffer(length * getBytesPerElement());
-        Scriptable result = cx.newObject(scope, getClassName(),
-                new Object[]{newBuffer, 0, length, getBytesPerElement()});
+        NativeArrayBuffer newBuffer = new NativeArrayBuffer(length * getBytesPerElement());
+        Scriptable result =
+                cx.newObject(
+                        scope,
+                        getClassName(),
+                        new Object[] {newBuffer, 0, length, getBytesPerElement()});
 
         for (int k = 0; k < length; ++k) {
             int from = length - k - 1;
@@ -648,11 +651,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private Object js_toSorted(Context cx, Scriptable scope, Object[] args) {
         Object[] working = sortTemporaryArray(cx, scope, args);
- 
+
         // Move value in a new typed array of the same type
         NativeArrayBuffer newBuffer = new NativeArrayBuffer(length * getBytesPerElement());
-        Scriptable result = cx.newObject(scope, getClassName(),
-                new Object[]{newBuffer, 0, length, getBytesPerElement()});
+        Scriptable result =
+                cx.newObject(
+                        scope,
+                        getClassName(),
+                        new Object[] {newBuffer, 0, length, getBytesPerElement()});
         for (int k = 0; k < length; ++k) {
             result.put(k, result, working[k]);
         }
@@ -660,27 +666,26 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private Object js_toSpliced(Context cx, Scriptable scope, Object[] args) {
-        throw new UnsupportedOperationException("TODO");
-    }
-
     private Object js_with(Context cx, Scriptable scope, Object[] args) {
         long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(args[0]) : 0;
         long actualIndex = relativeIndex >= 0 ? relativeIndex : length + relativeIndex;
 
-        Object argsValue = args.length > 1 ? ScriptRuntime.toNumber(args[1]) : 0.0; 
-        
+        Object argsValue = args.length > 1 ? ScriptRuntime.toNumber(args[1]) : 0.0;
+
         if (actualIndex < 0 || actualIndex >= length) {
             throw ScriptRuntime.rangeError("index out of range");
         }
 
         NativeArrayBuffer newBuffer = new NativeArrayBuffer(length * getBytesPerElement());
-        Scriptable result = cx.newObject(scope, getClassName(),
-                new Object[]{newBuffer, 0, length, getBytesPerElement()});
+        Scriptable result =
+                cx.newObject(
+                        scope,
+                        getClassName(),
+                        new Object[] {newBuffer, 0, length, getBytesPerElement()});
 
         for (int k = 0; k < length; ++k) {
             Object fromValue = (k == actualIndex) ? argsValue : js_get(k);
-	        result.put(k, result, fromValue);
+            result.put(k, result, fromValue);
         }
 
         return result;
@@ -845,8 +850,6 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 return realThis(thisObj, f).js_toReversed(cx, scope);
             case Id_toSorted:
                 return realThis(thisObj, f).js_toSorted(cx, scope, args);
-            case Id_toSpliced:
-                return realThis(thisObj, f).js_toSpliced(cx, scope, args);
             case Id_with:
                 return realThis(thisObj, f).js_with(cx, scope, args);
 
@@ -994,10 +997,6 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 arity = 0;
                 s = "toReversed";
                 break;
-            case Id_toSpliced:
-                arity = 2;
-                s = "toSpliced";
-                break;
             case Id_with:
                 arity = 2;
                 s = "with";
@@ -1116,9 +1115,6 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             case "toReversed":
                 id = Id_toReversed;
                 break;
-            case "toSpliced":
-                id = Id_toSpliced;
-                break;
             case "with":
                 id = Id_with;
                 break;
@@ -1159,12 +1155,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             Id_findLast = 27,
             Id_findLastIndex = 28,
             Id_reduce = 29,
-            Id_reduceRight = 30, 
+            Id_reduceRight = 30,
             Id_toReversed = 31,
             Id_toSorted = 32,
-            Id_toSpliced = 33,
-            Id_with = 34,
-            SymbolId_iterator = 35;
+            Id_with = 33,
+            SymbolId_iterator = 34;
 
     protected static final int MAX_PROTOTYPE_ID = SymbolId_iterator;
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -628,6 +628,33 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return newArray;
     }
 
+    private Object js_toReversed(Context cx, Scriptable scope) {
+	    NativeArrayBuffer newBuffer = new NativeArrayBuffer(length * getBytesPerElement());
+
+        Scriptable result = cx.newObject(scope, getClassName(),
+                new Object[]{newBuffer, 0, length, getBytesPerElement()});
+
+        for (int k = 0; k < length; ++k) {
+            int from = length - k - 1;
+            Object fromValue = js_get(from);
+            result.put(k, result, fromValue);
+        }
+
+        return result;
+    }
+
+    private Object js_toSorted(Context cx, Scriptable scope, Object[] args) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    private Object js_toSpliced(Context cx, Scriptable scope, Object[] args) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    private Object js_with(Context cx, Scriptable scope, Object[] args) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
     // Dispatcher
 
     @Override
@@ -783,6 +810,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             case Id_reduceRight:
                 return ArrayLikeAbstractOperations.reduceMethod(
                         cx, ReduceOperation.REDUCE_RIGHT, scope, thisObj, args);
+            case Id_toReversed:
+                return realThis(thisObj, f).js_toReversed(cx, scope);
+            case Id_toSorted:
+                return realThis(thisObj, f).js_toSorted(cx, scope, args);
+            case Id_toSpliced:
+                return realThis(thisObj, f).js_toSpliced(cx, scope, args);
+            case Id_with:
+                return realThis(thisObj, f).js_with(cx, scope, args);
 
             case SymbolId_iterator:
                 return new NativeArrayIterator(scope, thisObj, ARRAY_ITERATOR_TYPE.VALUES);
@@ -920,6 +955,22 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 arity = 1;
                 s = "reduceRight";
                 break;
+            case Id_toSorted:
+                arity = 1;
+                s = "toSorted";
+                break;
+            case Id_toReversed:
+                arity = 0;
+                s = "toReversed";
+                break;
+            case Id_toSpliced:
+                arity = 2;
+                s = "toSpliced";
+                break;
+            case Id_with:
+                arity = 2;
+                s = "with";
+                break;
             default:
                 throw new IllegalArgumentException(String.valueOf(id));
         }
@@ -1028,6 +1079,18 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             case "reduceRight":
                 id = Id_reduceRight;
                 break;
+            case "toSorted":
+                id = Id_toSorted;
+                break;
+            case "toReversed":
+                id = Id_toReversed;
+                break;
+            case "toSpliced":
+                id = Id_toSpliced;
+                break;
+            case "with":
+                id = Id_with;
+                break;
             default:
                 id = 0;
                 break;
@@ -1065,8 +1128,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             Id_findLast = 27,
             Id_findLastIndex = 28,
             Id_reduce = 29,
-            Id_reduceRight = 30,
-            SymbolId_iterator = 31;
+            Id_reduceRight = 30, 
+            Id_toReversed = 31,
+            Id_toSorted = 32,
+            Id_toSpliced = 33,
+            Id_with = 34,
+            SymbolId_iterator = 35;
 
     protected static final int MAX_PROTOTYPE_ID = SymbolId_iterator;
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayToReversedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayToReversedTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-toReversed.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayToReversedTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayToSortedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayToSortedTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-toSorted.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayToSortedTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayToSplicedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayToSplicedTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-toSpliced.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayToSplicedTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayWithTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/ArrayWithTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/array-with.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayWithTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayToReversedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayToReversedTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/typedArray-toReversed.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayToReversedTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayToSortedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayToSortedTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/typedArray-toSorted.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayToSortedTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayWithTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2023/TypedArrayWithTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2023;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2023/typedArray-with.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class TypedArrayWithTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/es2023/array-toReversed.js
+++ b/tests/testsrc/jstests/es2023/array-toReversed.js
@@ -3,9 +3,13 @@ load("testsrc/assert.js");
 (function reversingArray() {
     var arr = [1, 2, 3];
     var reversed = arr.toReversed();
+    
     assertTrue(Array.isArray(reversed));
     assertEquals(3, reversed.length);
     assertEquals("3,2,1", reversed.toString());
+
+    assertEquals(3, arr.length);
+    assertEquals("1,2,3", arr.toString());
 })();
 
 "success";

--- a/tests/testsrc/jstests/es2023/array-toReversed.js
+++ b/tests/testsrc/jstests/es2023/array-toReversed.js
@@ -1,6 +1,6 @@
 load("testsrc/assert.js");
 
-(function reversingArray() {
+(function toReversedBasic() {
     var arr = [1, 2, 3];
     var reversed = arr.toReversed();
     
@@ -10,6 +10,22 @@ load("testsrc/assert.js");
 
     assertEquals(3, arr.length);
     assertEquals("1,2,3", arr.toString());
+})();
+
+(function toReversedArrayPreservesHoles() {
+    var arr = [0, /* hole */, 2, /* hole */, 4];
+    Array.prototype[3] = 3;
+    var reversed = arr.toReversed();
+    assertEquals("4,3,2,,0", reversed.toString());
+    assertTrue(reversed.hasOwnProperty(3));
+})();
+
+(function toReversedMaxLengthExceedingArrayLengthLimit() {
+    var arr = {length: 2**32};
+    assertThrows(
+        () => Array.prototype.toReversed.call(arr, 0, 0),
+        RangeError
+    );
 })();
 
 "success";

--- a/tests/testsrc/jstests/es2023/array-toReversed.js
+++ b/tests/testsrc/jstests/es2023/array-toReversed.js
@@ -1,0 +1,11 @@
+load("testsrc/assert.js");
+
+(function reversingArray() {
+    var arr = [1, 2, 3];
+    var reversed = arr.toReversed();
+    assertTrue(Array.isArray(reversed));
+    assertEquals(3, reversed.length);
+    assertEquals("3,2,1", reversed.toString());
+})();
+
+"success";

--- a/tests/testsrc/jstests/es2023/array-toSorted.js
+++ b/tests/testsrc/jstests/es2023/array-toSorted.js
@@ -1,6 +1,6 @@
 load("testsrc/assert.js");
 
-(function basicSorting() {
+(function toSortedBasic() {
     var arr = [3, 1, 2, 4, 5, 6, 0, 7];
     var sorted = arr.toSorted();
     assertTrue(Array.isArray(sorted));
@@ -8,16 +8,32 @@ load("testsrc/assert.js");
     assertEquals("0,1,2,3,4,5,6,7", sorted.toString());
 })();
 
-(function passingComparatorFunction() {
+(function toSortedPassingComparatorFunction() {
     var arr = [-1, -3, -2, -4, -1, -3, 0, 3, 1];
     var sorted = arr.toSorted((a, b) => b.toString().length - a.toString().length);
     assertEquals("-1,-3,-2,-4,-1,-3,0,3,1", sorted.toString());
 })();
 
-(function sortIsStable() {
+(function toSortedIsStable() {
     var arr = [3, 1, 2, 4, 5, 6, 0, 7];
     var sorted = arr.toSorted((a, b) => a % 2 - b % 2);
     assertEquals("2,4,6,0,3,1,5,7", sorted.toString());
+})();
+
+(function toSortedMaxLengthExceedingArrayLengthLimit() {
+    var arr = {length: 2**32};
+    assertThrows(
+        () => Array.prototype.toSorted.call(arr, (a, b) => b - a),
+        RangeError
+    );
+})();
+
+(function toSortedComparatorIsNotFunction() {
+    var arr = [1, 2, 3]
+    assertThrows(
+        () => Array.prototype.toSorted.call(arr, 42),
+        TypeError
+    );
 })();
 
 "success";

--- a/tests/testsrc/jstests/es2023/array-toSorted.js
+++ b/tests/testsrc/jstests/es2023/array-toSorted.js
@@ -1,0 +1,23 @@
+load("testsrc/assert.js");
+
+(function basicSorting() {
+    var arr = [3, 1, 2, 4, 5, 6, 0, 7];
+    var sorted = arr.toSorted();
+    assertTrue(Array.isArray(sorted));
+    assertEquals(8, sorted.length);
+    assertEquals("0,1,2,3,4,5,6,7", sorted.toString());
+})();
+
+(function passingComparatorFunction() {
+    var arr = [-1, -3, -2, -4, -1, -3, 0, 3, 1];
+    var sorted = arr.toSorted((a, b) => b.toString().length - a.toString().length);
+    assertEquals("-1,-3,-2,-4,-1,-3,0,3,1", sorted.toString());
+})();
+
+(function sortIsStable() {
+    var arr = [3, 1, 2, 4, 5, 6, 0, 7];
+    var sorted = arr.toSorted((a, b) => a % 2 - b % 2);
+    assertEquals("2,4,6,0,3,1,5,7", sorted.toString());
+})();
+
+"success";

--- a/tests/testsrc/jstests/es2023/array-toSpliced.js
+++ b/tests/testsrc/jstests/es2023/array-toSpliced.js
@@ -1,0 +1,35 @@
+load("testsrc/assert.js");
+
+(function toSplicedNoArgument() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced();
+    assertTrue(Array.isArray(spliced));
+    assertEquals(3, spliced.length);
+    assertEquals("1,2,3", spliced.toString());
+})();
+
+(function toSplicedOneElement() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(2);
+    assertEquals("1,2", spliced.toString());
+})();
+
+(function toSplicedAfterLength() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(3);
+    assertEquals("1,2,3", spliced.toString());
+})();
+
+(function toSplicedStartAndCount() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(0, 1);
+    assertEquals("2,3", spliced.toString());
+})();
+
+(function toSplicedItemsToInsert() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(0, 1, 4, 5);
+    assertEquals("4,5,2,3", spliced.toString());
+})();
+
+"success";

--- a/tests/testsrc/jstests/es2023/array-toSpliced.js
+++ b/tests/testsrc/jstests/es2023/array-toSpliced.js
@@ -8,13 +8,25 @@ load("testsrc/assert.js");
     assertEquals("1,2,3", spliced.toString());
 })();
 
-(function toSplicedOneElement() {
+(function toSplicedStart() {
     var arr = [1, 2, 3];
     var spliced = arr.toSpliced(2);
     assertEquals("1,2", spliced.toString());
 })();
 
-(function toSplicedAfterLength() {
+(function toSplicedNegativeStart() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(-1);
+    assertEquals("1,2", spliced.toString());
+})();
+
+(function toSplicedStartUndefined() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(undefined);
+    assertEquals("", spliced.toString());
+})();
+
+(function toSplicedStartAfterMaxLength() {
     var arr = [1, 2, 3];
     var spliced = arr.toSpliced(3);
     assertEquals("1,2,3", spliced.toString());
@@ -26,10 +38,24 @@ load("testsrc/assert.js");
     assertEquals("2,3", spliced.toString());
 })();
 
+(function toSplicedStartAndUndefinedCount() {
+    var arr = [1, 2, 3];
+    var spliced = arr.toSpliced(2, undefined);
+    assertEquals("1,2,3", spliced.toString());
+})();
+
 (function toSplicedItemsToInsert() {
     var arr = [1, 2, 3];
     var spliced = arr.toSpliced(0, 1, 4, 5);
     assertEquals("4,5,2,3", spliced.toString());
+})();
+
+(function toSplicedMaxLengthExceedingArrayLengthLimit() {
+    var arr = {length: 2**32};
+    assertThrows(
+        () => Array.prototype.toSpliced.call(arr, 0, 0),
+        RangeError
+    );
 })();
 
 "success";

--- a/tests/testsrc/jstests/es2023/array-with.js
+++ b/tests/testsrc/jstests/es2023/array-with.js
@@ -14,15 +14,34 @@ load("testsrc/assert.js");
     assertEquals("1,,3", arrWith.toString());
 })();
 
-(function withIndexValue() {
+(function withIndexAndValue() {
     var arr = [1, 2, 3];
     var arrWith = arr.with(1, 4);
     assertEquals("1,4,3", arrWith.toString());
 })();
 
-(function withInvalidIndex() {
+(function withNegativeIndexAndValue() {
     var arr = [1, 2, 3];
-    assertThrows(() => arr.with(42), RangeError);
+    var arrWith = arr.with(-2, 5);
+    assertEquals("1,5,3", arrWith.toString());
+})();
+
+(function withIndexTooLarge() {
+    var arr = [1, 2, 3];
+    assertThrows(() => arr.with(3), RangeError);
+})();
+
+(function withIndexTooLarge() {
+    var arr = [1, 2, 3];
+    assertThrows(() => arr.with(3), RangeError);
+})();
+
+(function withMaxLengthExceedingArrayLengthLimit() {
+    var arr = {length: 2**32};
+    assertThrows(
+        () => Array.prototype.with.call(arr, 0, 0),
+        RangeError
+    );
 })();
 
 "success";

--- a/tests/testsrc/jstests/es2023/array-with.js
+++ b/tests/testsrc/jstests/es2023/array-with.js
@@ -1,0 +1,28 @@
+load("testsrc/assert.js");
+
+(function withNoArgument() {
+    var arr = [1, 2, 3];
+    var arrWith = arr.with();
+    assertTrue(Array.isArray(arrWith));
+    assertEquals(3, arrWith.length);
+    assertEquals(",2,3", arrWith.toString());
+})();
+
+(function withIndex() {
+    var arr = [1, 2, 3];
+    var arrWith = arr.with(1);
+    assertEquals("1,,3", arrWith.toString());
+})();
+
+(function withIndexValue() {
+    var arr = [1, 2, 3];
+    var arrWith = arr.with(1, 4);
+    assertEquals("1,4,3", arrWith.toString());
+})();
+
+(function withInvalidIndex() {
+    var arr = [1, 2, 3];
+    assertThrows(() => arr.with(42), RangeError);
+})();
+
+"success";

--- a/tests/testsrc/jstests/es2023/typedArray-toReversed.js
+++ b/tests/testsrc/jstests/es2023/typedArray-toReversed.js
@@ -1,0 +1,30 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+	Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+	Float64Array];
+
+(function toReversedBasic() {
+	for (var t = 0; t < types.length; t++) {
+		var type = types[t];
+		var arr = new type([1, 2, 3]);
+	
+		var reversed = arr.toReversed();
+		assertFalse(arr === reversed);
+		assertSame(Object.getPrototypeOf(arr), Object.getPrototypeOf(reversed));
+		assertEquals(3, reversed.length);
+		assertEquals("3,2,1", reversed.toString());
+	}
+})();
+
+(function toReversedIgnoresSymbolSpecies() {
+	var ta = new Int8Array();
+	ta.constructor = {
+		[Symbol.species]: Uint8Array,
+	};
+	
+	var reversed = ta.toReversed();
+	assertEquals(Object.getPrototypeOf(reversed), Int8Array.prototype);
+})();
+
+"success";

--- a/tests/testsrc/jstests/es2023/typedArray-toSorted.js
+++ b/tests/testsrc/jstests/es2023/typedArray-toSorted.js
@@ -1,0 +1,56 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+	Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+	Float64Array];
+
+
+load("testsrc/assert.js");
+
+var signedTypes = [Int8Array, Int16Array, Int32Array, Float32Array, Float64Array];
+var unsignedTypes = [Uint8Array, Uint16Array, Uint32Array, Uint8ClampedArray];
+
+(function toSortedSigned() {
+	for (var t = 0; t < signedTypes.length; t++) {
+		var type = signedTypes[t];
+		var arr = new type([3, -1, 2, -4, 5, -6, 0, 7]);
+		var sorted = arr.toSorted();
+		assertEquals("3,-1,2,-4,5,-6,0,7", arr.toString());
+		assertFalse(arr === sorted);
+		assertSame(Object.getPrototypeOf(arr), Object.getPrototypeOf(sorted));
+		assertEquals("-6,-4,-1,0,2,3,5,7", sorted.toString());
+		
+		// Check stability
+		arr = new type([-1, -3, -2, -4, -1, -3, 0, 3, 1]);
+		sorted = arr.toSorted((a, b) => b.toString().length - a.toString().length)
+		assertEquals("-1,-3,-2,-4,-1,-3,0,3,1", sorted.toString());
+	}
+})();
+
+(function toSortedUnsigned() {
+	for (var t = 0; t < unsignedTypes.length; t++) {
+		var type = unsignedTypes[t];
+		var arr = new type([3, 1, 2, 4, 5, 6, 0, 7]);
+		var sorted = arr.toSorted();
+		assertEquals("3,1,2,4,5,6,0,7", arr.toString());
+		assertFalse(arr === sorted);
+		assertSame(Object.getPrototypeOf(arr), Object.getPrototypeOf(sorted));
+		assertEquals("0,1,2,3,4,5,6,7", sorted.toString());
+
+		// Check stability
+		sorted = arr.toSorted((a, b) => a % 2 - b % 2);
+		assertEquals("2,4,6,0,3,1,5,7", sorted.toString());
+	}
+})();
+
+(function toSortedIgnoresSymbolSpecies() {
+	var ta = new Int8Array();
+	ta.constructor = {
+		[Symbol.species]: Uint8Array,
+	};
+
+	var reversed = ta.toSorted();
+	assertEquals(Object.getPrototypeOf(reversed), Int8Array.prototype);
+})();
+
+"success";

--- a/tests/testsrc/jstests/es2023/typedArray-with.js
+++ b/tests/testsrc/jstests/es2023/typedArray-with.js
@@ -1,0 +1,71 @@
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+	Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+	Float64Array];
+
+
+load("testsrc/assert.js");
+
+var types = [Int8Array, Uint8Array, Int16Array, Uint16Array,
+	Int32Array, Uint32Array, Uint8ClampedArray, Float32Array,
+	Float64Array];
+
+(function withNoArguments() {
+	for (var t = 0; t < types.length; t++) {
+		var type = types[t];
+		var arr = new type([1, 2, 3]);
+		var res = arr.with();
+		assertEquals("1,2,3", arr.toString());
+		assertFalse(arr === res);
+		assertSame(Object.getPrototypeOf(arr), Object.getPrototypeOf(res));
+		assertEquals("0,2,3", res.toString());
+	}
+})();
+
+(function withIndex() {
+	for (var t = 0; t < types.length; t++) {
+		var type = types[t];
+		var arr = new type([1, 2, 3]);
+		var res = arr.with(1);
+		assertEquals("1,0,3", res.toString());
+	}
+})();
+
+(function withIndexValue() {
+	for (var t = 0; t < types.length; t++) {
+		var type = types[t];
+		var arr = new type([1, 2, 3]);
+		var res = arr.with(1, 4);
+		assertEquals("1,4,3", res.toString());
+	}
+})();
+
+(function withNegativeIndex() {
+	for (var t = 0; t < types.length; t++) {
+		var type = types[t];
+		var arr = new type([1, 2, 3]);
+		var res = arr.with(-2, 4);
+		assertEquals("1,4,3", res.toString());
+	}
+})();
+
+(function withIndexTooLarge() {
+	for (var t = 0; t < types.length; t++) {
+		var type = types[t];
+		var arr = new type([1, 2, 3]);
+		assertThrows(() => arr.with(3), RangeError);
+	}
+})();
+
+(function withIgnoresSymbolSpecies() {
+	var ta = new Int8Array([1, 2, 3]);
+	ta.constructor = {
+		[Symbol.species]: Uint8Array,
+	};
+
+	var res = ta.with(0, 4);
+	assertEquals(Object.getPrototypeOf(res), Int8Array.prototype);
+})();
+
+"success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2373,7 +2373,7 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 1060/1386 (76.48%)
+built-ins/TypedArray 1053/1386 (75.97%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/from-array-mapper-detaches-result.js
@@ -2945,13 +2945,6 @@ built-ins/TypedArray 1060/1386 (76.48%)
     prototype/values/this-is-not-typedarray-instance.js
     prototype/with/BigInt/early-type-coercion-bigint.js
     prototype/with/metadata 3/3 (100.0%)
-    prototype/with/early-type-coercion.js
-    prototype/with/ignores-species.js
-    prototype/with/immutable.js
-    prototype/with/index-bigger-or-eq-than-length.js
-    prototype/with/index-casted-to-number.js
-    prototype/with/index-negative.js
-    prototype/with/index-smaller-than-minus-length.js
     prototype/with/index-validated-against-current-length.js
     prototype/with/length-property-ignored.js
     prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -26,7 +26,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 380/3055 (12.44%)
+built-ins/Array 370/3055 (12.11%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -298,17 +298,7 @@ built-ins/Array 380/3055 (12.44%)
     prototype/unshift/set-length-zero-array-length-is-non-writable.js
     prototype/unshift/throws-with-string-receiver.js
     prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/with/frozen-this-value.js
-    prototype/with/holes-not-preserved.js
-    prototype/with/index-bigger-or-eq-than-length.js
-    prototype/with/index-casted-to-number.js
-    prototype/with/index-negative.js
-    prototype/with/index-smaller-than-minus-length.js
-    prototype/with/length-exceeding-array-length-limit.js
-    prototype/with/length-tolength.js
-    prototype/with/no-get-replaced-index.js
     prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/with/this-value-boolean.js
     prototype/methods-called-as-functions.js
     is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm-one.js {unsupported: [Reflect]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -26,7 +26,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 389/3055 (12.73%)
+built-ins/Array 380/3055 (12.44%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -287,16 +287,7 @@ built-ins/Array 389/3055 (12.73%)
     prototype/toSorted/length-tolength.js
     prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toSorted/this-value-boolean.js
-    prototype/toSpliced/discarded-element-not-read.js
-    prototype/toSpliced/elements-read-in-order.js
-    prototype/toSpliced/frozen-this-value.js
-    prototype/toSpliced/holes-not-preserved.js
-    prototype/toSpliced/length-casted-to-zero.js
-    prototype/toSpliced/length-clamped-to-2pow53minus1.js
-    prototype/toSpliced/length-exceeding-array-length-limit.js
-    prototype/toSpliced/length-tolength.js
     prototype/toSpliced/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toSpliced/this-value-boolean.js
     prototype/toString/call-with-boolean.js
     prototype/toString/non-callable-join-string-tag.js {unsupported: [Proxy, Reflect]}
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2373,7 +2373,7 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 1064/1386 (76.77%)
+built-ins/TypedArray 1060/1386 (76.48%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/from-array-mapper-detaches-result.js
@@ -2925,7 +2925,9 @@ built-ins/TypedArray 1064/1386 (76.77%)
     prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toReversed/this-value-invalid.js
     prototype/toSorted/metadata 3/3 (100.0%)
-    prototype/toSorted 7/7 (100.0%)
+    prototype/toSorted/length-property-ignored.js
+    prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toSorted/this-value-invalid.js
     prototype/toString/BigInt/detached-buffer.js
     prototype/toString 2/2 (100.0%)
     prototype/values/BigInt 4/4 (100.0%)

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -26,7 +26,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 438/3055 (14.34%)
+built-ins/Array 389/3055 (12.73%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -277,62 +277,26 @@ built-ins/Array 438/3055 (14.34%)
     prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
-    prototype/toReversed/metadata 3/3 (100.0%)
-    prototype/toReversed/frozen-this-value.js
-    prototype/toReversed/get-descending-order.js
-    prototype/toReversed/holes-not-preserved.js
-    prototype/toReversed/ignores-species.js
-    prototype/toReversed/immutable.js
-    prototype/toReversed/length-casted-to-zero.js
-    prototype/toReversed/length-decreased-while-iterating.js
-    prototype/toReversed/length-exceeding-array-length-limit.js
-    prototype/toReversed/length-increased-while-iterating.js
-    prototype/toReversed/length-tolength.js
     prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toReversed/this-value-boolean.js
-    prototype/toReversed/zero-or-one-element.js
-    prototype/toSorted/metadata 3/3 (100.0%)
     prototype/toSorted/comparefn-called-after-get-elements.js
     prototype/toSorted/comparefn-stop-after-error.js
     prototype/toSorted/frozen-this-value.js
     prototype/toSorted/holes-not-preserved.js
-    prototype/toSorted/ignores-species.js
-    prototype/toSorted/immutable.js
     prototype/toSorted/length-casted-to-zero.js
-    prototype/toSorted/length-decreased-while-iterating.js
     prototype/toSorted/length-exceeding-array-length-limit.js
-    prototype/toSorted/length-increased-while-iterating.js
     prototype/toSorted/length-tolength.js
     prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toSorted/this-value-boolean.js
-    prototype/toSorted/zero-or-one-element.js
-    prototype/toSpliced/metadata 3/3 (100.0%)
-    prototype/toSpliced/deleteCount-clamped-between-zero-and-remaining-count.js
-    prototype/toSpliced/deleteCount-missing.js
-    prototype/toSpliced/deleteCount-undefined.js
     prototype/toSpliced/discarded-element-not-read.js
     prototype/toSpliced/elements-read-in-order.js
     prototype/toSpliced/frozen-this-value.js
     prototype/toSpliced/holes-not-preserved.js
-    prototype/toSpliced/ignores-species.js
-    prototype/toSpliced/immutable.js
     prototype/toSpliced/length-casted-to-zero.js
     prototype/toSpliced/length-clamped-to-2pow53minus1.js
-    prototype/toSpliced/length-decreased-while-iterating.js
     prototype/toSpliced/length-exceeding-array-length-limit.js
-    prototype/toSpliced/length-increased-while-iterating.js
     prototype/toSpliced/length-tolength.js
-    prototype/toSpliced/mutate-while-iterating.js
     prototype/toSpliced/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toSpliced/start-and-deleteCount-missing.js
-    prototype/toSpliced/start-and-deleteCount-undefineds.js
-    prototype/toSpliced/start-bigger-than-length.js
-    prototype/toSpliced/start-neg-infinity-is-zero.js
-    prototype/toSpliced/start-neg-less-than-minus-length-is-zero.js
-    prototype/toSpliced/start-neg-subtracted-from-length.js
-    prototype/toSpliced/start-undefined-and-deleteCount-missing.js
     prototype/toSpliced/this-value-boolean.js
-    prototype/toSpliced/unmodified.js
     prototype/toString/call-with-boolean.js
     prototype/toString/non-callable-join-string-tag.js {unsupported: [Proxy, Reflect]}
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -343,18 +307,13 @@ built-ins/Array 438/3055 (14.34%)
     prototype/unshift/set-length-zero-array-length-is-non-writable.js
     prototype/unshift/throws-with-string-receiver.js
     prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/with/metadata 3/3 (100.0%)
     prototype/with/frozen-this-value.js
     prototype/with/holes-not-preserved.js
-    prototype/with/ignores-species.js
-    prototype/with/immutable.js
     prototype/with/index-bigger-or-eq-than-length.js
     prototype/with/index-casted-to-number.js
     prototype/with/index-negative.js
     prototype/with/index-smaller-than-minus-length.js
-    prototype/with/length-decreased-while-iterating.js
     prototype/with/length-exceeding-array-length-limit.js
-    prototype/with/length-increased-while-iterating.js
     prototype/with/length-tolength.js
     prototype/with/no-get-replaced-index.js
     prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -26,7 +26,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 370/3055 (12.11%)
+built-ins/Array 362/3055 (11.85%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -278,15 +278,7 @@ built-ins/Array 370/3055 (12.11%)
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toSorted/comparefn-called-after-get-elements.js
-    prototype/toSorted/comparefn-stop-after-error.js
-    prototype/toSorted/frozen-this-value.js
-    prototype/toSorted/holes-not-preserved.js
-    prototype/toSorted/length-casted-to-zero.js
-    prototype/toSorted/length-exceeding-array-length-limit.js
-    prototype/toSorted/length-tolength.js
     prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toSorted/this-value-boolean.js
     prototype/toSpliced/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/call-with-boolean.js
     prototype/toString/non-callable-join-string-tag.js {unsupported: [Proxy, Reflect]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2921,13 +2921,11 @@ built-ins/TypedArray 1064/1386 (76.77%)
     prototype/toLocaleString/this-is-not-object.js
     prototype/toLocaleString/this-is-not-typedarray-instance.js
     prototype/toReversed/metadata 3/3 (100.0%)
-    prototype/toReversed 5/5 (100.0%)
+    prototype/toReversed/length-property-ignored.js
+    prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/toReversed/this-value-invalid.js
     prototype/toSorted/metadata 3/3 (100.0%)
-    prototype/toSorted/ignores-species.js
-    prototype/toSorted/immutable.js
-    prototype/toSorted/length-property-ignored.js
-    prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toSorted/this-value-invalid.js
+    prototype/toSorted 7/7 (100.0%)
     prototype/toString/BigInt/detached-buffer.js
     prototype/toString 2/2 (100.0%)
     prototype/values/BigInt 4/4 (100.0%)
@@ -4899,7 +4897,7 @@ language/expressions/function 214/264 (81.06%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 239/290 (82.41%)
+language/expressions/generators 232/290 (80.0%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7807,7 +7805,7 @@ language/statements/function 230/451 (51.0%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 224/266 (84.21%)
+language/statements/generators 217/266 (81.58%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js


### PR DESCRIPTION
This PR adds:
- `Array.prototype.toReversed`
- `Array.prototype.toSorted`
- `Array.prototype.toSpliced`
- `Array.prototype.with`
- `TypedArray.prototype.toReversed`
- `TypedArray.prototype.toSorted`
- `TypedArray.prototype.with`

(There is no `TypedArray.prototype.toSpliced` in the standard).
I tried to follow the spec very closely, even matching (most) variable names.

For arrays, it passes all test262 cases except those marked with `Reflect.construct`. Note that, to do so, I couldn't rely on some optimization, for example the `denseOnly` flag.

For typed arrays, in addition to the cases marked with `Reflect.construct`, there are some other test262 cases that don't pass:
- `prototype/xxx/metadata` - caused by https://github.com/mozilla/rhino/issues/1565 as far as I can tell. There's already https://github.com/mozilla/rhino/issues/1528 which tracks similar problems.
- `prototype/xxx/length-property-ignored.js` - do not pass because rhino does not allow to configure `TypedArray.prototype.length` - tracked by https://github.com/mozilla/rhino/issues/1572
- `prototype/toReversed/this-value-invalid.js` and `prototype/toSorted/this-value-invalid.js` - these try to call `$DETACHBUFFER`, which we do not support - see https://github.com/mozilla/rhino/issues/1527
- `prototype/toString/BigInt/detached-buffer.js` and `prototype/with/BigInt/early-type-coercion-bigint.js - tracked https://github.com/mozilla/rhino/issues/1410
- `prototype/with/index-validated-against-current-length.js` - we do not support `ArrayBuffer.prototype.resize`; https://github.com/mozilla/rhino/issues/1397 tracks this

Should fix https://github.com/mozilla/rhino/issues/1307

I ended up with a single PR that does both `Array` and `TypedArray` because I imagined they would share part of the implementation... but in the end, they are completely separate. Let me know if you would prefer two separate PRs.

Please squash this if accepted! 🙂 