### PR TITLE
NativeError: Add ES2022 `cause`

### DIFF
--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -805,15 +805,11 @@ built-ins/Date 90/770 (11.69%)
     value-to-primitive-result-string.js
     year-zero.js
 
-built-ins/Error 10/41 (24.39%)
-    prototype/toString/called-as-function.js
-    prototype/toString/invalid-receiver.js
+built-ins/Error 6/41 (14.63%)
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/no-error-data.js
     prototype/S15.11.4_A2.js
     cause_abrupt.js
-    cause_property.js
-    constructor.js
     is-a-constructor.js {unsupported: [Reflect.construct]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
 
@@ -1134,7 +1130,7 @@ built-ins/Math 51/326 (15.64%)
 
 built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors 44/117 (37.61%)
+built-ins/NativeErrors 43/117 (36.75%)
     AggregateError/prototype 6/6 (100.0%)
     AggregateError 19/19 (100.0%)
     EvalError/prototype/not-error-object.js
@@ -1155,7 +1151,6 @@ built-ins/NativeErrors 44/117 (37.61%)
     URIError/prototype/not-error-object.js
     URIError/is-a-constructor.js {unsupported: [Reflect.construct]}
     URIError/proto-from-ctor-realm.js {unsupported: [Reflect]}
-    cause_property_native_error.js
 
 built-ins/Number 24/335 (7.16%)
     isFinite/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -4967,7 +4962,7 @@ language/expressions/function 214/264 (81.06%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 239/290 (82.41%)
+language/expressions/generators 232/290 (80.0%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7875,7 +7870,7 @@ language/statements/function 230/451 (51.0%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 224/266 (84.21%)
+language/statements/generators 217/266 (81.58%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js


### PR DESCRIPTION
This fixes a couple other test cases involving toString() as well. `cause_abrupt` fails because it requires Proxy.

As mentioned in https://github.com/mozilla/rhino/issues/1091#issuecomment-2298010780, I haven't changed toSource(), but I can add that functionality if that is wanted.

Resolves #1091 