### PR TITLE
Add support for covariant return types

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -327,18 +327,11 @@ class JavaMembers {
                                 int mods = method.getModifiers();
 
                                 if (isPublic(mods) || isProtected(mods) || includePrivate) {
-                                    MethodSignature sig = new MethodSignature(method);
+                                    Method registered = registerMethod(map, method);
                                     // We don't want to replace the deprecated method here
                                     // because it is not available on Android.
-                                    if (includePrivate && !method.isAccessible()) {
-                                        map.computeIfAbsent(
-                                                sig,
-                                                k -> {
-                                                    method.setAccessible(true);
-                                                    return method;
-                                                });
-                                    } else {
-                                        map.putIfAbsent(sig, method);
+                                    if (includePrivate && !registered.isAccessible()) {
+                                        registered.setAccessible(true);
                                     }
                                 }
                             }
@@ -352,11 +345,7 @@ class JavaMembers {
                             // Some security settings (i.e., applets) disallow
                             // access to Class.getDeclaredMethods. Fall back to
                             // Class.getMethods.
-                            Method[] methods = clazz.getMethods();
-                            for (Method method : methods) {
-                                MethodSignature sig = new MethodSignature(method);
-                                map.putIfAbsent(sig, method);
-                            }
+                            discoverPublicMethods(clazz, map);
                             break; // getMethods gets superclass methods, no
                             // need to loop any more
                         }
@@ -393,10 +382,21 @@ class JavaMembers {
         }
     }
 
-    static void registerMethod(Map<MethodSignature, Method> map, Method method) {
+    static Method registerMethod(Map<MethodSignature, Method> map, Method method) {
         MethodSignature sig = new MethodSignature(method);
-        // Array may contain methods with same signature but different return value!
-        map.putIfAbsent(sig, method);
+        // Array may contain methods with same parameter signature but different return value!
+        // (which is allowed in bytecode, but not in JLS) we will take the best method
+        return map.merge(sig, method, JavaMembers::getMoreConcreteMethod);
+    }
+
+    private static Method getMoreConcreteMethod(Method oldValue, Method newValue) {
+        if (oldValue.getReturnType().equals(newValue.getReturnType())) {
+            return oldValue; // same return type. Do not overwrite existing method
+        } else if (oldValue.getReturnType().isAssignableFrom(newValue.getReturnType())) {
+            return newValue; // more concrete return type. Replace method
+        } else {
+            return oldValue;
+        }
     }
 
     static final class MethodSignature {

--- a/tests/src/test/java/org/mozilla/javascript/tests/CovariantReturnTypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/CovariantReturnTypeTest.java
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.tools.shell.Global;
+
+/**
+ * If you inherit from an abstract class and narrow the return type, you will get both methods on
+ * Class.getMethods() and in the bytecode.
+ *
+ * <p>See explanation of {@link Class#getMethods()} <i> There may be more than one method with a
+ * particular name and parameter types in a class because while the Java language forbids a class to
+ * declare multiple methods with the same signature but different return types, the Java virtual
+ * machine does not. </i>
+ *
+ * <p>Note: It totally depends on the JVM, in which order the methods are returend, so we have a
+ * class here, that tries to simulate that 5 times to increase the probability that rhino will not
+ * detect at least one case as bean property
+ *
+ * @author Roland Praml
+ */
+public class CovariantReturnTypeTest {
+
+    public abstract static class A {
+        public abstract Object getValue1();
+
+        public abstract Object getValue2();
+
+        public abstract Object getValue3();
+
+        public abstract Object getValue4();
+
+        public abstract Object getValue5();
+    }
+
+    public static class B extends A {
+        private Integer value1;
+        private Integer value2;
+        private Integer value3;
+        private Integer value4;
+        private Integer value5;
+
+        // Note: Class B will inherit
+        @Override
+        public Integer getValue1() {
+            return value1;
+        }
+
+        public void setValue1(Integer value1) {
+            this.value1 = value1;
+        }
+
+        @Override
+        public Integer getValue2() {
+            return value2;
+        }
+
+        public void setValue2(Integer value2) {
+            this.value2 = value2;
+        }
+
+        @Override
+        public Integer getValue3() {
+            return value3;
+        }
+
+        public void setValue3(Integer value3) {
+            this.value3 = value3;
+        }
+
+        @Override
+        public Integer getValue4() {
+            return value4;
+        }
+
+        public void setValue4(Integer value4) {
+            this.value4 = value4;
+        }
+
+        @Override
+        public Integer getValue5() {
+            return value5;
+        }
+
+        public void setValue5(Integer value5) {
+            this.value5 = value5;
+        }
+    }
+
+    static final String LS = System.getProperty("line.separator");
+
+    @Test
+    public void checkIt() {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Global scope = new Global();
+                    scope.init(cx);
+                    scope.put("obj", scope, new B());
+                    Object ret =
+                            cx.evaluateString(
+                                    scope,
+                                    "obj.value1 = 1; obj.value2 = 2; obj.value3 = 3; obj.value4 = 4; obj.value5 = 5",
+                                    "myScript.js",
+                                    1,
+                                    null);
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
A few days ago, we discovered also a strange behaviour in the js<->java liveconnect code.

Normally, rhino will detect getters/setters in java classes and allows you, to access them as properties.

e.g. if you have a class like
```java
public class MyBean {
  public String getValue() {return null;}
  public void setValue(String value) {...}
} 
```

you can read/write the value with `myBean.value = "foo"` in javascript. This works if there are matching getters/setters found. (If there is an incompatible setter like `setValue(Integer value)` it will no longer work, as Integer is not an instance of String.
BTW: It will work if there is a `setValue(Object value)`, as this setter accepts also strings.

If you now inherit and narrow the return type, you will get multiple methods with covariant return types, e.g. 
```java
public interface ValueHolder {
   Object getValue();
}
public class MyBean implements ValueHolder {...}
```
will result in the following bytecode:

```java
public getValue()Ljava/lang/String;
public synthetic bridge getValue()Ljava/lang/Object;
```

Note: You get the same method with same signature, but different return types. This is not allowed by the JLS, but at VM/bytecode level and it is explicitly mentioned in https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Class.html#getMethods()

What happens in Rhino now:
- Rhino takes the FIRST method of each signature (signature = method name + parameters)
- So if there are covariant methods, it will either take `getValue()Ljava/lang/String` or `getValue()Ljava/lang/Object`
- After that, it tries to find a compatible setter.
-- If `getValue()Ljava/lang/String` was found, it will find also the `setValue(String)` setter and generates a String-BeanProperty
-- If `getValue()Ljava/lang/Object` was found, it will the `setValue(String)` setter, but cannot use it, because rhino thinks the property is of type Object and the setter is incompatible
- The main problem is, that `Class.getMethods()` does not return the methods in a particular order. (What happened: In our unit tests, the `correct` method was preferred, in production the `wrong` method was preferred)

This PR changes the method discovery in a way that if a method with same signature was found, but a "better" return type, this method is used.