### PR TITLE
Silenced all warnings

### DIFF
--- a/examples/src/main/java/File.java
+++ b/examples/src/main/java/File.java
@@ -210,6 +210,7 @@ public class File extends ScriptableObject {
      *
      * <p>Close the file when this object is collected.
      */
+    @SuppressWarnings("deprecation")
     @Override
     protected void finalize() {
         try {

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -120,7 +120,8 @@ public class ArrayLikeAbstractOperations {
                     break;
                 case FIND_INDEX:
                 case FIND_LAST_INDEX:
-                    if (ScriptRuntime.toBoolean(result)) return ScriptRuntime.wrapNumber(i);
+                    if (ScriptRuntime.toBoolean(result))
+                        return ScriptRuntime.wrapNumber((double) i);
                     break;
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
+++ b/rhino/src/main/java/org/mozilla/javascript/jdk18/VMBridge_jdk18.java
@@ -57,6 +57,7 @@ public class VMBridge_jdk18 extends VMBridge {
         return accessible.trySetAccessible();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Object getInterfaceProxyHelper(ContextFactory cf, Class<?>[] interfaces) {
         // XXX: How to handle interfaces array withclasses from different


### PR DESCRIPTION
Simply silences all warnings printed out in a build from master:

- two by marking them with `@SuppressWarnings("deprecation")`, because I don't think we can change the code without breaking anything:
- one by adding the cast suggested by ErrorProne. It does not change the behavior, since that cast was already being inserted implicitly by the compiler.