### PR TITLE
Implement Symbol.prototype.description and refactor Symbol to use LambdaConstructor

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -35,7 +35,7 @@ public class LambdaConstructor extends LambdaFunction {
     public static final int CONSTRUCTOR_DEFAULT = CONSTRUCTOR_FUNCTION | CONSTRUCTOR_NEW;
 
     // Lambdas should not be serialized.
-    private final transient Constructable targetConstructor;
+    protected final transient Constructable targetConstructor;
     private final int flags;
 
     /**
@@ -107,6 +107,23 @@ public class LambdaConstructor extends LambdaFunction {
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
+        f.setStandardPropertyAttributes(propertyAttributes);
+        ScriptableObject proto = getPrototypeScriptable();
+        proto.defineProperty(name, f, attributes);
+    }
+
+    /**
+     * Define a function property on the prototype of the constructor using a LambdaFunction under
+     * the covers.
+     */
+    public void definePrototypeMethod(
+            Scriptable scope,
+            SymbolKey name,
+            int length,
+            Callable target,
+            int attributes,
+            int propertyAttributes) {
+        LambdaFunction f = new LambdaFunction(scope, "[" + name.getName() + "]", length, target);
         f.setStandardPropertyAttributes(propertyAttributes);
         ScriptableObject proto = getPrototypeScriptable();
         proto.defineProperty(name, f, attributes);

--- a/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
@@ -25,14 +25,27 @@ public class SymbolKey implements Symbol, Serializable {
     public static final SymbolKey SPLIT = new SymbolKey("Symbol.split");
     public static final SymbolKey UNSCOPABLES = new SymbolKey("Symbol.unscopables");
 
-    private String name;
+    // If passed a javascript undefined, this will be a (java) null
+    private final String name;
 
     public SymbolKey(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the symbol's name. Returns empty string for anonymous symbol (i.e. something created
+     * with <code>Symbol()</code>).
+     */
     public String getName() {
-        return name;
+        return name != null ? name : "";
+    }
+
+    /**
+     * Returns the symbol's description - will return {@link Undefined#instance} if we have an
+     * anonymous symbol (i.e. something created with <code>Symbol()</code>).
+     */
+    public Object getDescription() {
+        return name != null ? name : Undefined.instance;
     }
 
     @Override

--- a/tests/testsrc/jstests/es6/symbols.js
+++ b/tests/testsrc/jstests/es6/symbols.js
@@ -571,4 +571,19 @@ TestStringify('{}', symbol_wrapper);
 symbol_wrapper.a = 1;
 TestStringify('{"a":1}', symbol_wrapper);
 
+
+function TestDescription() {
+  assertEquals(Symbol("abc").description, "abc");
+  assertEquals(Symbol.iterator.description, "Symbol.iterator");
+  assertEquals(Symbol().description, undefined);
+
+  assertFalse(Symbol("abc").hasOwnProperty("description"));
+  assertTrue(Symbol.prototype.hasOwnProperty("description"));
+  assertTrue(Object.getOwnPropertyDescriptor(Symbol.prototype, "description").configurable);
+  assertFalse(Object.getOwnPropertyDescriptor(Symbol.prototype, "description").enumerable);
+  assertTrue(Object.getOwnPropertyDescriptor(Symbol.prototype, "description").get !== null);
+}
+TestDescription();
+
+
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2299,27 +2299,17 @@ built-ins/String 140/1182 (11.84%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 34/92 (36.96%)
+built-ins/Symbol 24/92 (26.09%)
     asyncIterator/prop-desc.js
-    for/cross-realm.js
-    for/description.js
     for/not-a-constructor.js {unsupported: [Reflect.construct]}
     hasInstance/cross-realm.js
     isConcatSpreadable/cross-realm.js
     iterator/cross-realm.js
     keyFor/arg-non-symbol.js
-    keyFor/cross-realm.js
     keyFor/not-a-constructor.js {unsupported: [Reflect.construct]}
     matchAll 2/2 (100.0%)
     match/cross-realm.js
-    prototype/description/description-symboldescriptivestring.js
-    prototype/description/descriptor.js
-    prototype/description/get.js
     prototype/description/this-val-non-symbol.js
-    prototype/description/this-val-symbol.js
-    prototype/description/wrapper.js
-    prototype/Symbol.toPrimitive/name.js
-    prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js
     prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}


### PR DESCRIPTION
In draft, because it's stacked on top of both https://github.com/mozilla/rhino/pull/1577 and https://github.com/mozilla/rhino/pull/1578 and will need to be rebases.

This PR changes `NativeSymbol` so that it does not extend `IdScriptableObject` anymore, but rather uses the `LambdaConstructor` APIs. This, combined with https://github.com/mozilla/rhino/pull/1577, allows for easily adding the `Symbol.prototype.descriptor` slot (which is a getter function).
It makes all relevant test262 cases pass (and a few other unrelated ones). The one that does not pass, `prototype/description/this-val-non-symbol.js`, does not because it uses `Proxy`.