### PR TITLE
Add a benchmark to measure Rhino startup time

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/StartupBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/StartupBenchmark.java
@@ -1,0 +1,15 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+import org.mozilla.javascript.Context;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class StartupBenchmark {
+    @Benchmark
+    public Object startUpRhino() {
+        try (Context cx = Context.enter()) {
+            return cx.initStandardObjects();
+        }
+    }
+}


### PR DESCRIPTION
I'm a bit worried about changes I'm making with lambdas and how that will impact how long it will take Rhino to initialize all the standard objects, so let's create a microbenchmark for that.