### PR TITLE
force LF as newLine character to let out test suite pass on windows also

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,9 @@
 .project text
 *.html text
 *.htm text
-*.java text
-*.js text
+*.java text eol=lf
+*.js text eol=lf
+*.jstest text eol=lf
 *.jsp text
 *.php text
 *.properties text


### PR DESCRIPTION
This solves all the issues i have on windows when running our test suite. There is only one test from the test262 suite that still fails and something unicode related. Will have a look at this later and maybe prepare a separate PR.

This also fixes https://github.com/mozilla/rhino/issues/918 - did a short test and it looks like spotless leaves the LF untouched.

@gbrail having this merged will be a great help - i already started with the Proxy & Reflect update and therefor having a working test suite is essential