### PR TITLE
Use UTF-8 decoding for java source files

### DIFF
--- a/buildSrc/src/main/groovy/rhino.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.java-conventions.gradle
@@ -17,7 +17,8 @@ dependencies {
     testImplementation "javax.xml.soap:javax.xml.soap-api:1.4.0"
 }
 
-compileJava {
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
     options.compilerArgs = [
         '-Xlint:deprecation,unchecked'
     ]


### PR DESCRIPTION
This is the default on Linux and Mac, but not on Windows. This should standardize across platforms. I believe this will also allow us to revert https://github.com/mozilla/rhino/pull/1588.

Without ensuring that UTF-8 encoding is always expected, any characters in the java source with a code point above 127 will be read incorrectly by Windows. While we could escape all of those characters, one must remember to do it, and escaping those characters harms readability.