### PR TITLE
Update Shell to use Context.VERSION_ES6 by default

### DIFF
--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellContextFactory.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellContextFactory.java
@@ -13,7 +13,7 @@ import org.mozilla.javascript.ErrorReporter;
 public class ShellContextFactory extends ContextFactory {
     private boolean strictMode;
     private boolean warningAsError;
-    private int languageVersion = Context.VERSION_1_8;
+    private int languageVersion = Context.VERSION_ES6;
     private int optimizationLevel;
     private boolean generatingDebug;
     private boolean allowReservedKeywords = true;

--- a/tests/src/test/java/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.mozilla.javascript.Context;
 import org.mozilla.javascript.drivers.JsTestsBase;
 import org.mozilla.javascript.drivers.ShellTest;
 import org.mozilla.javascript.drivers.TestUtils;
@@ -194,6 +195,7 @@ public class MozillaSuiteTest {
         // optimizationLevel);
         final ShellContextFactory shellContextFactory = new ShellContextFactory();
         shellContextFactory.setOptimizationLevel(optimizationLevel);
+        shellContextFactory.setLanguageVersion(Context.VERSION_1_8);
         ShellTestParameters params = new ShellTestParameters();
         JunitStatus status = new JunitStatus();
         ShellTest.runNoFork(shellContextFactory, jsFile, params, status);


### PR DESCRIPTION
resolves https://github.com/mozilla/rhino/issues/1279