### PR TITLE
Revert "make tests more robust"

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -1204,7 +1204,7 @@ public class ParserTest {
     public void testParseUnicodeMultibyteCharacter() {
         AstRoot root = parse("\uD842\uDFB7");
         AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
-        assertEquals("\uD842\uDFB7", first.getString());
+        assertEquals("𠮷", first.getString());
     }
 
     @Test
@@ -1215,7 +1215,7 @@ public class ParserTest {
         // the unicode methods and not the java methods.
         AstRoot root = parse("a\u9FEB");
         AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
-        assertEquals("a\u9FEB", first.getString());
+        assertEquals("a鿫", first.getString());
     }
 
     @Test


### PR DESCRIPTION
Since we changed the build configuration to force UTF-8, we don't need this change any more. Tested it myself on Windows.

Reverts mozilla/rhino#1588