### PR TITLE
Fix publishing scripts

### DIFF
--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'adopt'
         server-id: github
         settings-path: ${{ github.workspace }}

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'adopt'
         server-id: github
         settings-path: ${{ github.workspace }}


### PR DESCRIPTION
Going to see if we can publish snapshots to GitHub. (Maven Central no longer supports them.)