### PR TITLE
Set initial line number to -1 and fix StackTraceTests

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -38,7 +38,7 @@ class CodeGenerator extends Icode {
     private ScriptNode scriptOrFn;
     private int iCodeTop;
     private int stackDepth;
-    private int lineNumber;
+    private int lineNumber = -1;
     private int doubleTableTop;
 
     private final HashMap<String, Integer> strings = new HashMap<>();

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceTest.java
@@ -32,7 +32,7 @@ public class StackTraceTest {
             final String source2 = "function f2() { 'H'.toLowerCase(); throw 'hello'; }; f2();";
             final String source3 =
                     "function f2() { new java.lang.String('H').toLowerCase(); throw 'hello'; }; f2();";
-            final String result = "\tat test.js (f2)" + LS + "\tat test.js" + LS;
+            final String result = "\tat test.js:0 (f2)" + LS + "\tat test.js:0" + LS;
 
             runWithExpectedStackTrace(source1, result);
             runWithExpectedStackTrace(source2, result);
@@ -56,7 +56,7 @@ public class StackTraceTest {
             final String source2 = "function f2() { 'H'.toLowerCase(); throw 'hello'; }; f2();";
             final String source3 =
                     "function f2() { new java.lang.String('H').toLowerCase(); throw 'hello'; }; f2();";
-            final String result = "f2()@test.js" + LS + "@test.js" + LS;
+            final String result = "f2()@test.js:0" + LS + "@test.js:0" + LS;
 
             runWithExpectedStackTrace(source1, result);
             runWithExpectedStackTrace(source2, result);
@@ -80,7 +80,7 @@ public class StackTraceTest {
             final String source2 = "function f2() { 'H'.toLowerCase(); throw 'hello'; }; f2();";
             final String source3 =
                     "function f2() { new java.lang.String('H').toLowerCase(); throw 'hello'; }; f2();";
-            final String result = "f2()@test.js\n@test.js\n";
+            final String result = "f2()@test.js:0\n@test.js:0\n";
 
             runWithExpectedStackTrace(source1, result);
             runWithExpectedStackTrace(source2, result);


### PR DESCRIPTION
This fixes https://github.com/mozilla/rhino/issues/477. I also changed the tests to match the comments in [`StackStyle`](https://github.com/mozilla/rhino/blob/master/rhino/src/main/java/org/mozilla/javascript/StackStyle.java), so they all show the line number in them.