### PR TITLE
FIX: publishing to mvn

### DIFF
--- a/buildSrc/src/main/groovy/rhino.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.library-conventions.gradle
@@ -79,3 +79,22 @@ task sourceJar(type: Jar) {
         into 'META-INF'
     }
 }
+
+publishing {
+    if (project.hasProperty("mavenPassword")) {
+        repositories {
+
+            maven {
+                credentials {
+                    username mavenUser
+                    password mavenPassword
+                }
+                if (project.version.endsWith('-SNAPSHOT')) {
+                    url mavenSnapshotRepo
+                } else {
+                    url mavenReleaseRepo
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello,

This PR is a fix for the publishing to a mvn repository (`./gradlex publish`).

In the old project structure it was here: https://github.com/mozilla/rhino/blob/Rhino1_7_15_Release/build.gradle#L408 

Kind regards
Noemi