### PR TITLE
Update test262 suite + include resizable-arraybuffer in unsupported feature list

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -110,6 +110,7 @@ public class Test262SuiteTest {
                             "regexp-lookbehind",
                             "regexp-named-groups",
                             "regexp-unicode-property-escapes",
+                            "resizable-arraybuffer",
                             "super",
                             "String.prototype.matchAll",
                             "Symbol.matchAll",

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2,7 +2,7 @@
 
 ~annexB
 
-harness 22/115 (19.13%)
+harness 23/115 (20.0%)
     assert-notsamevalue-tostring.js {unsupported: [async-functions]}
     assert-samevalue-tostring.js {unsupported: [async-functions]}
     assert-tostring.js {unsupported: [async-functions]}
@@ -11,6 +11,7 @@ harness 22/115 (19.13%)
     asyncHelpers-asyncTest-then-resolves.js {unsupported: [async]}
     asyncHelpers-throwsAsync-custom.js {unsupported: [async]}
     asyncHelpers-throwsAsync-custom-typeerror.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-func-never-settles.js {unsupported: [async]}
     asyncHelpers-throwsAsync-func-throws-sync.js {unsupported: [async]}
     asyncHelpers-throwsAsync-incorrect-ctor.js {unsupported: [async]}
     asyncHelpers-throwsAsync-invalid-func.js {unsupported: [async]}
@@ -26,7 +27,7 @@ harness 22/115 (19.13%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 362/3055 (11.85%)
+built-ins/Array 383/3074 (12.46%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -49,8 +50,8 @@ built-ins/Array 362/3055 (11.85%)
     of/not-a-constructor.js {unsupported: [Reflect.construct]}
     of/proto-from-ctor-realm.js
     of/return-abrupt-from-data-property-using-proxy.js {unsupported: [Proxy]}
-    prototype/at/coerced-index-resize.js
-    prototype/at/typed-array-resizable-buffer.js
+    prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/typed-array-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/concat/arg-length-exceeding-integer-limit.js {unsupported: [Proxy]}
     prototype/concat/Array.prototype.concat_large-typed-array.js new
     prototype/concat/Array.prototype.concat_non-array.js
@@ -76,25 +77,25 @@ built-ins/Array 362/3055 (11.85%)
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
     prototype/copyWithin/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/copyWithin/resizable-buffer.js
+    prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/return-abrupt-from-delete-proxy-target.js {unsupported: [Proxy]}
     prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
     prototype/copyWithin/return-abrupt-from-has-start.js {unsupported: [Proxy]}
     prototype/entries/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/entries/resizable-buffer.js
-    prototype/entries/resizable-buffer-grow-mid-iteration.js
-    prototype/entries/resizable-buffer-shrink-mid-iteration.js
+    prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/every/15.4.4.16-5-1-s.js non-strict
-    prototype/every/callbackfn-resize-arraybuffer.js
+    prototype/every/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/every/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/every/resizable-buffer.js
-    prototype/every/resizable-buffer-grow-mid-iteration.js
-    prototype/every/resizable-buffer-shrink-mid-iteration.js
+    prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/fill/resizable-buffer.js
-    prototype/fill/typed-array-resize.js
+    prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/typed-array-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/15.4.4.20-5-1-s.js non-strict
-    prototype/filter/callbackfn-resize-arraybuffer.js
+    prototype/filter/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/create-ctor-non-object.js
     prototype/filter/create-ctor-poisoned.js
     prototype/filter/create-proto-from-ctor-realm-non-array.js
@@ -105,35 +106,35 @@ built-ins/Array 362/3055 (11.85%)
     prototype/filter/create-species-non-ctor.js {unsupported: [Reflect.construct]}
     prototype/filter/create-species-poisoned.js
     prototype/filter/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/filter/resizable-buffer.js
-    prototype/filter/resizable-buffer-grow-mid-iteration.js
-    prototype/filter/resizable-buffer-shrink-mid-iteration.js
+    prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/target-array-non-extensible.js
     prototype/filter/target-array-with-non-configurable-property.js
-    prototype/findIndex/callbackfn-resize-arraybuffer.js
+    prototype/findIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/findIndex/predicate-call-this-strict.js strict
-    prototype/findIndex/resizable-buffer.js
-    prototype/findIndex/resizable-buffer-grow-mid-iteration.js
-    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/callbackfn-resize-arraybuffer.js
+    prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/findLastIndex/predicate-call-this-strict.js strict
-    prototype/findLastIndex/resizable-buffer.js
-    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
-    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/callbackfn-resize-arraybuffer.js
+    prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/findLast/predicate-call-this-strict.js strict
-    prototype/findLast/resizable-buffer.js
-    prototype/findLast/resizable-buffer-grow-mid-iteration.js
-    prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/find/callbackfn-resize-arraybuffer.js
+    prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/find/predicate-call-this-strict.js strict
-    prototype/find/resizable-buffer.js
-    prototype/find/resizable-buffer-grow-mid-iteration.js
-    prototype/find/resizable-buffer-shrink-mid-iteration.js
+    prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/flatMap/array-like-objects-poisoned-length.js
     prototype/flatMap/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/flatMap/proxy-access-count.js
@@ -151,39 +152,39 @@ built-ins/Array 362/3055 (11.85%)
     prototype/flat/target-array-non-extensible.js
     prototype/flat/target-array-with-non-configurable-property.js
     prototype/forEach/15.4.4.18-5-1-s.js non-strict
-    prototype/forEach/callbackfn-resize-arraybuffer.js
+    prototype/forEach/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/forEach/resizable-buffer.js
-    prototype/forEach/resizable-buffer-grow-mid-iteration.js
-    prototype/forEach/resizable-buffer-shrink-mid-iteration.js
-    prototype/includes/coerced-searchelement-fromindex-resize.js
+    prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/get-prop.js {unsupported: [Proxy]}
     prototype/includes/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/includes/resizable-buffer.js
-    prototype/includes/resizable-buffer-special-float-values.js
+    prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
-    prototype/indexOf/coerced-searchelement-fromindex-grow.js
-    prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+    prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/length-zero-returns-minus-one.js
     prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/indexOf/resizable-buffer.js
-    prototype/indexOf/resizable-buffer-special-float-values.js
-    prototype/join/coerced-separator-grow.js
-    prototype/join/coerced-separator-shrink.js
+    prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/join/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/join/resizable-buffer.js
+    prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/keys/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/keys/resizable-buffer.js
-    prototype/keys/resizable-buffer-grow-mid-iteration.js
-    prototype/keys/resizable-buffer-shrink-mid-iteration.js
+    prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js {unsupported: [Proxy]}
-    prototype/lastIndexOf/coerced-position-grow.js
-    prototype/lastIndexOf/coerced-position-shrink.js
+    prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/lastIndexOf/resizable-buffer.js
+    prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/15.4.4.19-5-1-s.js non-strict
-    prototype/map/callbackfn-resize-arraybuffer.js
+    prototype/map/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/create-ctor-non-object.js
     prototype/map/create-ctor-poisoned.js
     prototype/map/create-proto-from-ctor-realm-non-array.js
@@ -195,9 +196,9 @@ built-ins/Array 362/3055 (11.85%)
     prototype/map/create-species-poisoned.js
     prototype/map/create-species-undef-invalid-len.js {unsupported: [Proxy]}
     prototype/map/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/map/resizable-buffer.js
-    prototype/map/resizable-buffer-grow-mid-iteration.js
-    prototype/map/resizable-buffer-shrink-mid-iteration.js
+    prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/map/target-array-non-extensible.js
     prototype/map/target-array-with-non-configurable-property.js
     prototype/pop/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -216,21 +217,28 @@ built-ins/Array 362/3055 (11.85%)
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
     prototype/push/throws-with-string-receiver.js
     prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
+    prototype/reduceRight/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/reduceRight/resizable-buffer.js
-    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
-    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
+    prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
+    prototype/reduce/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
     prototype/reverse/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/reverse/resizable-buffer.js
+    prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/shift/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/shift/set-length-array-is-frozen.js
     prototype/shift/set-length-array-length-is-non-writable.js
     prototype/shift/set-length-zero-array-is-frozen.js
     prototype/shift/set-length-zero-array-length-is-non-writable.js
     prototype/shift/throws-when-this-value-length-is-writable-false.js
+    prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/create-ctor-non-object.js
     prototype/slice/create-ctor-poisoned.js
     prototype/slice/create-proto-from-ctor-realm-non-array.js
@@ -244,12 +252,20 @@ built-ins/Array 362/3055 (11.85%)
     prototype/slice/create-species-poisoned.js
     prototype/slice/length-exceeding-integer-limit-proxied-array.js
     prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/target-array-non-extensible.js
     prototype/slice/target-array-with-non-configurable-property.js
     prototype/some/15.4.4.17-5-1-s.js non-strict
-    prototype/some/callbackfn-resize-arraybuffer.js
+    prototype/some/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/some/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-ctor-non-object.js
@@ -277,6 +293,9 @@ built-ins/Array 362/3055 (11.85%)
     prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toSorted/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toSpliced/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -290,6 +309,9 @@ built-ins/Array 362/3055 (11.85%)
     prototype/unshift/set-length-zero-array-length-is-non-writable.js
     prototype/unshift/throws-with-string-receiver.js
     prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/methods-called-as-functions.js
     is-a-constructor.js {unsupported: [Reflect.construct]}
@@ -332,16 +354,16 @@ built-ins/ArrayBuffer 142/191 (74.35%)
     data-allocation-after-object-creation.js {unsupported: [Reflect.construct]}
     is-a-constructor.js {unsupported: [Reflect.construct]}
     newtarget-prototype-is-not-object.js {unsupported: [Reflect.construct]}
-    options-maxbytelength-allocation-limit.js
-    options-maxbytelength-compared-before-object-creation.js {unsupported: [Reflect.construct]}
-    options-maxbytelength-data-allocation-after-object-creation.js {unsupported: [Reflect.construct]}
-    options-maxbytelength-diminuitive.js
-    options-maxbytelength-excessive.js
-    options-maxbytelength-negative.js
-    options-maxbytelength-object.js
-    options-maxbytelength-poisoned.js
-    options-maxbytelength-undefined.js
-    options-non-object.js
+    options-maxbytelength-allocation-limit.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-compared-before-object-creation.js {unsupported: [Reflect.construct, resizable-arraybuffer]}
+    options-maxbytelength-data-allocation-after-object-creation.js {unsupported: [Reflect.construct, resizable-arraybuffer]}
+    options-maxbytelength-diminuitive.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-excessive.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-negative.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-object.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-poisoned.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-undefined.js {unsupported: [resizable-arraybuffer]}
+    options-non-object.js {unsupported: [resizable-arraybuffer]}
     proto-from-ctor-realm.js {unsupported: [Reflect]}
     prototype-from-newtarget.js {unsupported: [Reflect.construct]}
     undefined-newtarget-throws.js
@@ -404,8 +426,8 @@ built-ins/DataView 254/550 (46.18%)
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
-    prototype/byteLength/resizable-array-buffer-auto.js
-    prototype/byteLength/resizable-array-buffer-fixed.js
+    prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/return-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteLength/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/detached-buffer.js
@@ -413,8 +435,8 @@ built-ins/DataView 254/550 (46.18%)
     prototype/byteOffset/length.js
     prototype/byteOffset/name.js
     prototype/byteOffset/prop-desc.js
-    prototype/byteOffset/resizable-array-buffer-auto.js
-    prototype/byteOffset/resizable-array-buffer-fixed.js
+    prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getBigInt64/detached-buffer.js
@@ -425,7 +447,7 @@ built-ins/DataView 254/550 (46.18%)
     prototype/getBigInt64/name.js
     prototype/getBigInt64/negative-byteoffset-throws.js
     prototype/getBigInt64/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getBigInt64/resizable-buffer.js
+    prototype/getBigInt64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigInt64/return-value-clean-arraybuffer.js
     prototype/getBigInt64/return-values.js
@@ -443,7 +465,7 @@ built-ins/DataView 254/550 (46.18%)
     prototype/getBigUint64/name.js
     prototype/getBigUint64/negative-byteoffset-throws.js
     prototype/getBigUint64/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getBigUint64/resizable-buffer.js
+    prototype/getBigUint64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigUint64/return-value-clean-arraybuffer.js
     prototype/getBigUint64/return-values.js
@@ -462,7 +484,7 @@ built-ins/DataView 254/550 (46.18%)
     prototype/getFloat16/name.js
     prototype/getFloat16/negative-byteoffset-throws.js
     prototype/getFloat16/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getFloat16/resizable-buffer.js
+    prototype/getFloat16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getFloat16/return-abrupt-from-tonumber-byteoffset.js
     prototype/getFloat16/return-infinity.js
     prototype/getFloat16/return-nan.js
@@ -475,24 +497,24 @@ built-ins/DataView 254/550 (46.18%)
     prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getFloat32/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getFloat32/resizable-buffer.js
+    prototype/getFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getFloat64/detached-buffer.js
     prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
     prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
     prototype/getFloat64/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getFloat64/resizable-buffer.js
+    prototype/getFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getInt16/detached-buffer.js
     prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt16/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getInt16/resizable-buffer.js
+    prototype/getInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getInt32/detached-buffer.js
     prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getInt32/resizable-buffer.js
+    prototype/getInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/return-value-clean-arraybuffer-sab.js {unsupported: [SharedArrayBuffer]}
@@ -505,22 +527,22 @@ built-ins/DataView 254/550 (46.18%)
     prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt8/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getInt8/resizable-buffer.js
+    prototype/getInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getUint16/detached-buffer.js
     prototype/getUint16/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js
     prototype/getUint16/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getUint16/resizable-buffer.js
+    prototype/getUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getUint32/detached-buffer.js
     prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getUint32/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getUint32/resizable-buffer.js
+    prototype/getUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getUint8/detached-buffer.js
     prototype/getUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js
     prototype/getUint8/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/getUint8/resizable-buffer.js
+    prototype/getUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setBigInt64/detached-buffer.js
     prototype/setBigInt64/detached-buffer-after-bigint-value.js
     prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
@@ -532,7 +554,7 @@ built-ins/DataView 254/550 (46.18%)
     prototype/setBigInt64/negative-byteoffset-throws.js
     prototype/setBigInt64/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/setBigInt64/range-check-after-value-conversion.js
-    prototype/setBigInt64/resizable-buffer.js
+    prototype/setBigInt64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setBigInt64/return-abrupt-from-tobigint-value.js
     prototype/setBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/setBigInt64/set-values-little-endian-order.js
@@ -552,7 +574,7 @@ built-ins/DataView 254/550 (46.18%)
     prototype/setFloat16/no-value-arg.js
     prototype/setFloat16/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/setFloat16/range-check-after-value-conversion.js
-    prototype/setFloat16/resizable-buffer.js
+    prototype/setFloat16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setFloat16/return-abrupt-from-tonumber-byteoffset.js
     prototype/setFloat16/return-abrupt-from-tonumber-value.js
     prototype/setFloat16/set-values-little-endian-order.js
@@ -564,59 +586,59 @@ built-ins/DataView 254/550 (46.18%)
     prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js
     prototype/setFloat32/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setFloat32/resizable-buffer.js
+    prototype/setFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setFloat64/detached-buffer.js
     prototype/setFloat64/detached-buffer-after-number-value.js
     prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
     prototype/setFloat64/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setFloat64/resizable-buffer.js
+    prototype/setFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setInt16/detached-buffer.js
     prototype/setInt16/detached-buffer-after-number-value.js
     prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
     prototype/setInt16/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setInt16/resizable-buffer.js
+    prototype/setInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setInt32/detached-buffer.js
     prototype/setInt32/detached-buffer-after-number-value.js
     prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
     prototype/setInt32/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setInt32/resizable-buffer.js
+    prototype/setInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setInt8/detached-buffer.js
     prototype/setInt8/detached-buffer-after-number-value.js
     prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
     prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
     prototype/setInt8/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setInt8/resizable-buffer.js
+    prototype/setInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setUint16/detached-buffer.js
     prototype/setUint16/detached-buffer-after-number-value.js
     prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint16/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setUint16/resizable-buffer.js
+    prototype/setUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setUint32/detached-buffer.js
     prototype/setUint32/detached-buffer-after-number-value.js
     prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint32/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setUint32/resizable-buffer.js
+    prototype/setUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setUint8/detached-buffer.js
     prototype/setUint8/detached-buffer-after-number-value.js
     prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint8/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/setUint8/resizable-buffer.js
+    prototype/setUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/Symbol.toStringTag.js
     buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
     buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
     byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     byteOffset-validated-against-initial-buffer-length.js {unsupported: [Reflect.construct]}
     custom-proto-access-detaches-buffer.js {unsupported: [Reflect.construct]}
-    custom-proto-access-resizes-buffer-invalid-by-length.js
-    custom-proto-access-resizes-buffer-invalid-by-offset.js
-    custom-proto-access-resizes-buffer-valid-by-length.js
-    custom-proto-access-resizes-buffer-valid-by-offset.js
+    custom-proto-access-resizes-buffer-invalid-by-length.js {unsupported: [resizable-arraybuffer]}
+    custom-proto-access-resizes-buffer-invalid-by-offset.js {unsupported: [resizable-arraybuffer]}
+    custom-proto-access-resizes-buffer-valid-by-length.js {unsupported: [resizable-arraybuffer]}
+    custom-proto-access-resizes-buffer-valid-by-offset.js {unsupported: [resizable-arraybuffer]}
     custom-proto-access-throws.js {unsupported: [Reflect.construct]}
     custom-proto-access-throws-sab.js {unsupported: [Reflect.construct, SharedArrayBuffer]}
     custom-proto-if-not-object-fallbacks-to-default-prototype.js {unsupported: [Reflect.construct]}
@@ -747,7 +769,7 @@ built-ins/Error 6/41 (14.63%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 186/507 (36.69%)
+built-ins/Function 187/508 (36.81%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -760,6 +782,7 @@ built-ins/Function 186/507 (36.69%)
     prototype/apply/argarray-not-object.js
     prototype/apply/argarray-not-object-realm.js
     prototype/apply/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/apply/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/apply/S15.3.4.3_A3_T1.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T2.js non-interpreted
     prototype/apply/S15.3.4.3_A3_T3.js non-interpreted
@@ -1008,7 +1031,7 @@ built-ins/Map 13/171 (7.6%)
 
 built-ins/MapIteratorPrototype 0/11 (0.0%)
 
-built-ins/Math 51/326 (15.64%)
+built-ins/Math 51/327 (15.6%)
     abs/not-a-constructor.js {unsupported: [Reflect.construct]}
     acosh/not-a-constructor.js {unsupported: [Reflect.construct]}
     acos/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -1050,7 +1073,7 @@ built-ins/Math 51/326 (15.64%)
 
 built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors 25/117 (21.37%)
+built-ins/NativeErrors 31/123 (25.2%)
     AggregateError/errors-iterabletolist-failures.js
     AggregateError/is-a-constructor.js {unsupported: [Reflect.construct]}
     AggregateError/message-tostring-abrupt.js
@@ -1067,6 +1090,8 @@ built-ins/NativeErrors 25/117 (21.37%)
     ReferenceError/prototype/not-error-object.js
     ReferenceError/is-a-constructor.js {unsupported: [Reflect.construct]}
     ReferenceError/proto-from-ctor-realm.js {unsupported: [Reflect]}
+    SuppressedError/prototype 2/2 (100.0%)
+    SuppressedError 4/4 (100.0%)
     SyntaxError/prototype/not-error-object.js
     SyntaxError/is-a-constructor.js {unsupported: [Reflect.construct]}
     SyntaxError/proto-from-ctor-realm.js {unsupported: [Reflect]}
@@ -1103,7 +1128,7 @@ built-ins/Number 24/335 (7.16%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 217/3403 (6.38%)
+built-ins/Object 222/3408 (6.51%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/not-a-constructor.js {unsupported: [Reflect.construct]}
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
@@ -1139,6 +1164,7 @@ built-ins/Object 217/3403 (6.38%)
     defineProperties/not-a-constructor.js {unsupported: [Reflect.construct]}
     defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy]}
+    defineProperties/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     defineProperty/15.2.3.6-4-116.js non-strict
     defineProperty/15.2.3.6-4-117.js non-strict
     defineProperty/15.2.3.6-4-122.js
@@ -1157,8 +1183,11 @@ built-ins/Object 217/3403 (6.38%)
     defineProperty/15.2.3.6-4-293-3.js non-strict
     defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
+    defineProperty/coerced-P-grow.js {unsupported: [resizable-arraybuffer]}
+    defineProperty/coerced-P-shrink.js {unsupported: [resizable-arraybuffer]}
     defineProperty/not-a-constructor.js {unsupported: [Reflect.construct]}
     defineProperty/property-description-must-be-an-object-not-symbol.js
+    defineProperty/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     entries/not-a-constructor.js {unsupported: [Reflect.construct]}
     entries/observable-operations.js {unsupported: [Proxy]}
     entries/order-after-define-property-with-function.js
@@ -1167,6 +1196,7 @@ built-ins/Object 217/3403 (6.38%)
     freeze/proxy-no-ownkeys-returned-keys-order.js {unsupported: [Proxy, Reflect]}
     freeze/proxy-with-defineProperty-handler.js {unsupported: [Proxy, Reflect]}
     freeze/throws-when-false.js
+    freeze/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     fromEntries/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromEntries/to-property-key.js
     fromEntries/uses-keys-not-iterator.js
@@ -1720,7 +1750,7 @@ built-ins/Promise 406/631 (64.34%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 1169/1853 (63.09%)
+built-ins/RegExp 1169/1854 (63.05%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -2280,8 +2310,10 @@ built-ins/String 140/1182 (11.84%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 34/92 (36.96%)
+built-ins/Symbol 36/94 (38.3%)
+    asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
+    dispose/prop-desc.js
     for/cross-realm.js
     for/description.js
     for/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2325,15 +2357,15 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 1053/1386 (75.97%)
+built-ins/TypedArray 1091/1422 (76.72%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/from-array-mapper-detaches-result.js
-    from/from-array-mapper-makes-result-out-of-bounds.js
+    from/from-array-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     from/from-typedarray-into-itself-mapper-detaches-result.js
-    from/from-typedarray-into-itself-mapper-makes-result-out-of-bounds.js
+    from/from-typedarray-into-itself-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     from/from-typedarray-mapper-detaches-result.js
-    from/from-typedarray-mapper-makes-result-out-of-bounds.js
+    from/from-typedarray-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     from/iter-access-error.js
     from/iter-invoke-error.js
     from/iter-next-error.js
@@ -2347,8 +2379,8 @@ built-ins/TypedArray 1053/1386 (75.97%)
     of/name.js
     of/not-a-constructor.js {unsupported: [Reflect.construct]}
     of/prop-desc.js
-    of/resized-with-out-of-bounds-and-in-bounds-indices.js
-    prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js
+    of/resized-with-out-of-bounds-and-in-bounds-indices.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/at 14/14 (100.0%)
     prototype/buffer/BigInt 2/2 (100.0%)
     prototype/buffer/detached-buffer.js
@@ -2365,11 +2397,11 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/byteLength/length.js
     prototype/byteLength/name.js
     prototype/byteLength/prop-desc.js
-    prototype/byteLength/resizable-array-buffer-auto.js
-    prototype/byteLength/resizable-array-buffer-fixed.js
-    prototype/byteLength/resizable-buffer-assorted.js
-    prototype/byteLength/resized-out-of-bounds-1.js
-    prototype/byteLength/resized-out-of-bounds-2.js
+    prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/this-has-no-typedarrayname-internal.js
     prototype/byteLength/this-is-not-object.js
     prototype/byteOffset/BigInt 4/4 (100.0%)
@@ -2378,14 +2410,14 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/byteOffset/length.js
     prototype/byteOffset/name.js
     prototype/byteOffset/prop-desc.js
-    prototype/byteOffset/resizable-array-buffer-auto.js
-    prototype/byteOffset/resizable-array-buffer-fixed.js
-    prototype/byteOffset/resized-out-of-bounds.js
+    prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resized-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/this-has-no-typedarrayname-internal.js
     prototype/byteOffset/this-is-not-object.js
     prototype/copyWithin/BigInt 24/24 (100.0%)
-    prototype/copyWithin/coerced-target-start-end-shrink.js
-    prototype/copyWithin/coerced-target-start-grow.js
+    prototype/copyWithin/coerced-target-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/coerced-target-start-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/coerced-values-end-detached.js
     prototype/copyWithin/coerced-values-end-detached-prototype.js
     prototype/copyWithin/coerced-values-start-detached.js
@@ -2397,8 +2429,8 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/copyWithin/name.js
     prototype/copyWithin/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/copyWithin/prop-desc.js
-    prototype/copyWithin/resizable-buffer.js
-    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
+    prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/this-is-not-object.js
     prototype/copyWithin/this-is-not-typedarray-instance.js
     prototype/entries/BigInt 4/4 (100.0%)
@@ -2409,15 +2441,15 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/entries/name.js
     prototype/entries/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/entries/prop-desc.js
-    prototype/entries/resizable-buffer.js
-    prototype/entries/resizable-buffer-grow-mid-iteration.js
-    prototype/entries/resizable-buffer-shrink-mid-iteration.js
-    prototype/entries/return-abrupt-from-this-out-of-bounds.js
+    prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/this-is-not-object.js
     prototype/entries/this-is-not-typedarray-instance.js
     prototype/every/BigInt 16/16 (100.0%)
     prototype/every/callbackfn-detachbuffer.js
-    prototype/every/callbackfn-resize.js
+    prototype/every/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/every/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/every/detached-buffer.js
     prototype/every/get-length-uses-internal-arraylength.js
@@ -2427,18 +2459,18 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/every/name.js
     prototype/every/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/every/prop-desc.js
-    prototype/every/resizable-buffer.js
-    prototype/every/resizable-buffer-grow-mid-iteration.js
-    prototype/every/resizable-buffer-shrink-mid-iteration.js
-    prototype/every/return-abrupt-from-this-out-of-bounds.js
+    prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/every/this-is-not-object.js
     prototype/every/this-is-not-typedarray-instance.js
     prototype/fill/BigInt 18/18 (100.0%)
-    prototype/fill/absent-indices-computed-from-initial-length.js
+    prototype/fill/absent-indices-computed-from-initial-length.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/coerced-end-detach.js
     prototype/fill/coerced-start-detach.js
     prototype/fill/coerced-value-detach.js
-    prototype/fill/coerced-value-start-end-resize.js
+    prototype/fill/coerced-value-start-end-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/detached-buffer.js
     prototype/fill/fill-values-conversion-once.js
     prototype/fill/get-length-ignores-length-prop.js
@@ -2448,14 +2480,14 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/fill/name.js
     prototype/fill/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/fill/prop-desc.js
-    prototype/fill/resizable-buffer.js
-    prototype/fill/return-abrupt-from-this-out-of-bounds.js
+    prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/this-is-not-object.js
     prototype/fill/this-is-not-typedarray-instance.js
     prototype/filter/BigInt 36/36 (100.0%)
     prototype/filter/arraylength-internal.js
     prototype/filter/callbackfn-detachbuffer.js
-    prototype/filter/callbackfn-resize.js
+    prototype/filter/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/filter/detached-buffer.js
     prototype/filter/invoked-as-func.js
@@ -2464,19 +2496,19 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/filter/name.js
     prototype/filter/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/filter/prop-desc.js
-    prototype/filter/resizable-buffer.js
-    prototype/filter/resizable-buffer-grow-mid-iteration.js
-    prototype/filter/resizable-buffer-shrink-mid-iteration.js
-    prototype/filter/return-abrupt-from-this-out-of-bounds.js
-    prototype/filter/speciesctor-destination-resizable.js
+    prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js
+    prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/this-is-not-object.js
     prototype/filter/this-is-not-typedarray-instance.js
     prototype/find/BigInt 13/13 (100.0%)
     prototype/findIndex/BigInt 13/13 (100.0%)
-    prototype/findIndex/callbackfn-resize.js
+    prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/detached-buffer.js
     prototype/findIndex/get-length-ignores-length-prop.js
     prototype/findIndex/invoked-as-func.js
@@ -2487,15 +2519,15 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/predicate-may-detach-buffer.js
     prototype/findIndex/prop-desc.js
-    prototype/findIndex/resizable-buffer.js
-    prototype/findIndex/resizable-buffer-grow-mid-iteration.js
-    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js
+    prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/this-is-not-object.js
     prototype/findIndex/this-is-not-typedarray-instance.js
     prototype/findLast/BigInt 13/13 (100.0%)
     prototype/findLastIndex/BigInt 13/13 (100.0%)
-    prototype/findLastIndex/callbackfn-resize.js
+    prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/detached-buffer.js
     prototype/findLastIndex/get-length-ignores-length-prop.js
     prototype/findLastIndex/invoked-as-func.js
@@ -2506,13 +2538,13 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/findLastIndex/predicate-call-this-strict.js strict
     prototype/findLastIndex/predicate-may-detach-buffer.js
     prototype/findLastIndex/prop-desc.js
-    prototype/findLastIndex/resizable-buffer.js
-    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
-    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
+    prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/this-is-not-object.js
     prototype/findLastIndex/this-is-not-typedarray-instance.js
-    prototype/findLast/callbackfn-resize.js
+    prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/detached-buffer.js
     prototype/findLast/get-length-ignores-length-prop.js
     prototype/findLast/invoked-as-func.js
@@ -2523,13 +2555,13 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/findLast/predicate-call-this-strict.js strict
     prototype/findLast/predicate-may-detach-buffer.js
     prototype/findLast/prop-desc.js
-    prototype/findLast/resizable-buffer.js
-    prototype/findLast/resizable-buffer-grow-mid-iteration.js
-    prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/return-abrupt-from-this-out-of-bounds.js
+    prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/this-is-not-object.js
     prototype/findLast/this-is-not-typedarray-instance.js
-    prototype/find/callbackfn-resize.js
+    prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/find/detached-buffer.js
     prototype/find/get-length-ignores-length-prop.js
     prototype/find/invoked-as-func.js
@@ -2540,16 +2572,16 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/find/predicate-call-this-strict.js strict
     prototype/find/predicate-may-detach-buffer.js
     prototype/find/prop-desc.js
-    prototype/find/resizable-buffer.js
-    prototype/find/resizable-buffer-grow-mid-iteration.js
-    prototype/find/resizable-buffer-shrink-mid-iteration.js
-    prototype/find/return-abrupt-from-this-out-of-bounds.js
+    prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/find/this-is-not-object.js
     prototype/find/this-is-not-typedarray-instance.js
     prototype/forEach/BigInt 15/15 (100.0%)
     prototype/forEach/arraylength-internal.js
     prototype/forEach/callbackfn-detachbuffer.js
-    prototype/forEach/callbackfn-resize.js
+    prototype/forEach/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/forEach/detached-buffer.js
     prototype/forEach/invoked-as-func.js
@@ -2558,34 +2590,34 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/forEach/name.js
     prototype/forEach/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/forEach/prop-desc.js
-    prototype/forEach/resizable-buffer.js
-    prototype/forEach/resizable-buffer-grow-mid-iteration.js
-    prototype/forEach/resizable-buffer-shrink-mid-iteration.js
-    prototype/forEach/return-abrupt-from-this-out-of-bounds.js
+    prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/this-is-not-object.js
     prototype/forEach/this-is-not-typedarray-instance.js
     prototype/includes/BigInt 14/14 (100.0%)
-    prototype/includes/coerced-searchelement-fromindex-resize.js
+    prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/detached-buffer.js
     prototype/includes/detached-buffer-during-fromIndex-returns-false-for-zero.js
     prototype/includes/detached-buffer-during-fromIndex-returns-true-for-undefined.js
     prototype/includes/get-length-uses-internal-arraylength.js
-    prototype/includes/index-compared-against-initial-length.js
-    prototype/includes/index-compared-against-initial-length-out-of-bounds.js
+    prototype/includes/index-compared-against-initial-length.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/index-compared-against-initial-length-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/invoked-as-func.js
     prototype/includes/invoked-as-method.js
     prototype/includes/length.js
     prototype/includes/name.js
     prototype/includes/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/includes/prop-desc.js
-    prototype/includes/resizable-buffer.js
-    prototype/includes/resizable-buffer-special-float-values.js
-    prototype/includes/return-abrupt-from-this-out-of-bounds.js
+    prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/this-is-not-object.js
     prototype/includes/this-is-not-typedarray-instance.js
     prototype/indexOf/BigInt 15/15 (100.0%)
-    prototype/indexOf/coerced-searchelement-fromindex-grow.js
-    prototype/indexOf/coerced-searchelement-fromindex-shrink.js
+    prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/detached-buffer.js
     prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
     prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
@@ -2596,14 +2628,14 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/indexOf/name.js
     prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/indexOf/prop-desc.js
-    prototype/indexOf/resizable-buffer.js
-    prototype/indexOf/resizable-buffer-special-float-values.js
-    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js
+    prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/this-is-not-object.js
     prototype/indexOf/this-is-not-typedarray-instance.js
     prototype/join/BigInt 9/9 (100.0%)
-    prototype/join/coerced-separator-grow.js
-    prototype/join/coerced-separator-shrink.js
+    prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/join/detached-buffer.js
     prototype/join/detached-buffer-during-fromIndex-returns-single-comma.js
     prototype/join/get-length-uses-internal-arraylength.js
@@ -2613,9 +2645,9 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/join/name.js
     prototype/join/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/join/prop-desc.js
-    prototype/join/resizable-buffer.js
-    prototype/join/return-abrupt-from-this-out-of-bounds.js
-    prototype/join/separator-tostring-once-after-resized.js
+    prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/separator-tostring-once-after-resized.js {unsupported: [resizable-arraybuffer]}
     prototype/join/this-is-not-object.js
     prototype/join/this-is-not-typedarray-instance.js
     prototype/keys/BigInt 4/4 (100.0%)
@@ -2626,15 +2658,15 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/keys/name.js
     prototype/keys/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/keys/prop-desc.js
-    prototype/keys/resizable-buffer.js
-    prototype/keys/resizable-buffer-grow-mid-iteration.js
-    prototype/keys/resizable-buffer-shrink-mid-iteration.js
-    prototype/keys/return-abrupt-from-this-out-of-bounds.js
+    prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/keys/this-is-not-object.js
     prototype/keys/this-is-not-typedarray-instance.js
     prototype/lastIndexOf/BigInt 14/14 (100.0%)
-    prototype/lastIndexOf/coerced-position-grow.js
-    prototype/lastIndexOf/coerced-position-shrink.js
+    prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/detached-buffer.js
     prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
     prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
@@ -2645,9 +2677,9 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/lastIndexOf/name.js
     prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/lastIndexOf/prop-desc.js
-    prototype/lastIndexOf/resizable-buffer.js
-    prototype/lastIndexOf/resizable-buffer-special-float-values.js
-    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js
+    prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/this-is-not-object.js
     prototype/lastIndexOf/this-is-not-typedarray-instance.js
     prototype/length/BigInt 4/4 (100.0%)
@@ -2656,17 +2688,17 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/length/length.js
     prototype/length/name.js
     prototype/length/prop-desc.js
-    prototype/length/resizable-array-buffer-auto.js
-    prototype/length/resizable-array-buffer-fixed.js
-    prototype/length/resizable-buffer-assorted.js
-    prototype/length/resized-out-of-bounds-1.js
-    prototype/length/resized-out-of-bounds-2.js
+    prototype/length/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
     prototype/length/this-has-no-typedarrayname-internal.js
     prototype/length/this-is-not-object.js
     prototype/map/BigInt 34/34 (100.0%)
     prototype/map/arraylength-internal.js
     prototype/map/callbackfn-detachbuffer.js
-    prototype/map/callbackfn-resize.js
+    prototype/map/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/map/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/map/detached-buffer.js
     prototype/map/invoked-as-func.js
@@ -2675,23 +2707,24 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/map/name.js
     prototype/map/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/map/prop-desc.js
-    prototype/map/resizable-buffer.js
-    prototype/map/resizable-buffer-grow-mid-iteration.js
-    prototype/map/resizable-buffer-shrink-mid-iteration.js
-    prototype/map/return-abrupt-from-this-out-of-bounds.js
-    prototype/map/speciesctor-destination-resizable.js
+    prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/map/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js
+    prototype/map/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/speciesctor-resizable-buffer-grow.js
-    prototype/map/speciesctor-resizable-buffer-shrink.js
+    prototype/map/speciesctor-resizable-buffer-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/speciesctor-resizable-buffer-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/map/this-is-not-object.js
     prototype/map/this-is-not-typedarray-instance.js
     prototype/reduce/BigInt 19/19 (100.0%)
     prototype/reduceRight/BigInt 19/19 (100.0%)
     prototype/reduceRight/callbackfn-detachbuffer.js
+    prototype/reduceRight/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/reduceRight/detached-buffer.js
     prototype/reduceRight/get-length-uses-internal-arraylength.js
@@ -2701,13 +2734,14 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/reduceRight/name.js
     prototype/reduceRight/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reduceRight/prop-desc.js
-    prototype/reduceRight/resizable-buffer.js
-    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
-    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
-    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js
+    prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/this-is-not-object.js
     prototype/reduceRight/this-is-not-typedarray-instance.js
     prototype/reduce/callbackfn-detachbuffer.js
+    prototype/reduce/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/callbackfn-set-value-during-iteration.js {unsupported: [Reflect.set]}
     prototype/reduce/detached-buffer.js
     prototype/reduce/get-length-uses-internal-arraylength.js
@@ -2717,7 +2751,10 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/reduce/name.js
     prototype/reduce/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reduce/prop-desc.js
-    prototype/reduce/return-abrupt-from-this-out-of-bounds.js
+    prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/this-is-not-object.js
     prototype/reduce/this-is-not-typedarray-instance.js
     prototype/reverse/BigInt 6/6 (100.0%)
@@ -2729,8 +2766,8 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/reverse/name.js
     prototype/reverse/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/reverse/prop-desc.js
-    prototype/reverse/resizable-buffer.js
-    prototype/reverse/return-abrupt-from-this-out-of-bounds.js
+    prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reverse/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/reverse/this-is-not-object.js
     prototype/reverse/this-is-not-typedarray-instance.js
     prototype/set/BigInt 49/49 (100.0%)
@@ -2751,6 +2788,7 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/set/array-arg-targetbuffer-detached-on-get-src-value-no-throw.js
     prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
     prototype/set/array-arg-targetbuffer-detached-throws.js
+    prototype/set/array-arg-value-conversion-resizes-array-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/set/invoked-as-func.js
     prototype/set/invoked-as-method.js
     prototype/set/length.js
@@ -2758,6 +2796,11 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/set/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/set/prop-desc.js
     prototype/set/src-typedarray-big-throws.js
+    prototype/set/target-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-grow-source-length-getter.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-shrink-source-length-getter.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/this-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/set/this-is-not-object.js
     prototype/set/this-is-not-typedarray-instance.js
     prototype/set/typedarray-arg-negative-integer-offset-throws.js
@@ -2765,18 +2808,21 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
-    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-arraylength-internal.js
+    prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/set/typedarray-arg-src-byteoffset-internal.js
     prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
     prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
     prototype/set/typedarray-arg-target-arraylength-internal.js
     prototype/set/typedarray-arg-target-byteoffset-internal.js
-    prototype/set/typedarray-arg-target-out-of-bounds.js
+    prototype/set/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
     prototype/slice/BigInt 38/38 (100.0%)
     prototype/slice/arraylength-internal.js
+    prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/detached-buffer.js
     prototype/slice/detached-buffer-custom-ctor-other-targettype.js
     prototype/slice/detached-buffer-custom-ctor-same-targettype.js
@@ -2790,18 +2836,20 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/slice/name.js
     prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/slice/prop-desc.js
-    prototype/slice/return-abrupt-from-this-out-of-bounds.js
+    prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/set-values-from-different-ctor-type.js
-    prototype/slice/speciesctor-destination-resizable.js
+    prototype/slice/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/speciesctor-get-species-custom-ctor.js
     prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js
+    prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/speciesctor-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/some/BigInt 16/16 (100.0%)
     prototype/some/callbackfn-detachbuffer.js
-    prototype/some/callbackfn-resize.js
+    prototype/some/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/some/callbackfn-set-value-during-interaction.js {unsupported: [Reflect.set]}
     prototype/some/detached-buffer.js
     prototype/some/get-length-uses-internal-arraylength.js
@@ -2811,11 +2859,17 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/some/name.js
     prototype/some/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/some/prop-desc.js
-    prototype/some/return-abrupt-from-this-out-of-bounds.js
+    prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/some/this-is-not-object.js
     prototype/some/this-is-not-typedarray-instance.js
     prototype/sort/BigInt 10/10 (100.0%)
     prototype/sort/arraylength-internal.js
+    prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/detached-buffer.js
     prototype/sort/invoked-as-func.js
     prototype/sort/invoked-as-method.js
@@ -2823,11 +2877,14 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/sort/name.js
     prototype/sort/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/sort/prop-desc.js
-    prototype/sort/return-abrupt-from-this-out-of-bounds.js
+    prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/sort-tonumber.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
     prototype/subarray/BigInt 27/27 (100.0%)
+    prototype/subarray/coerced-begin-end-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/subarray/coerced-begin-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/detached-buffer.js
     prototype/subarray/infinity.js
     prototype/subarray/invoked-as-func.js
@@ -2836,7 +2893,8 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/subarray/name.js
     prototype/subarray/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/subarray/prop-desc.js
-    prototype/subarray/result-byteOffset-from-out-of-bounds.js
+    prototype/subarray/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/subarray/result-byteOffset-from-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/speciesctor-get-ctor.js
     prototype/subarray/speciesctor-get-ctor-abrupt.js
     prototype/subarray/speciesctor-get-ctor-inherited.js
@@ -2869,9 +2927,12 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/toLocaleString/name.js
     prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/prop-desc.js
-    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js
+    prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/this-is-not-object.js
     prototype/toLocaleString/this-is-not-typedarray-instance.js
+    prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/toReversed/metadata 3/3 (100.0%)
     prototype/toReversed/length-property-ignored.js
     prototype/toReversed/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2887,26 +2948,34 @@ built-ins/TypedArray 1053/1386 (75.97%)
     prototype/values/invoked-as-func.js
     prototype/values/invoked-as-method.js
     prototype/values/length.js
-    prototype/values/make-in-bounds-after-exhausted.js
-    prototype/values/make-out-of-bounds-after-exhausted.js
+    prototype/values/make-in-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/make-out-of-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
     prototype/values/name.js
     prototype/values/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/values/prop-desc.js
-    prototype/values/return-abrupt-from-this-out-of-bounds.js
+    prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/values/this-is-not-object.js
     prototype/values/this-is-not-typedarray-instance.js
     prototype/with/BigInt/early-type-coercion-bigint.js
     prototype/with/metadata 3/3 (100.0%)
-    prototype/with/index-validated-against-current-length.js
+    prototype/with/index-validated-against-current-length.js {unsupported: [resizable-arraybuffer]}
     prototype/with/length-property-ignored.js
     prototype/with/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype 3/3 (100.0%)
+    prototype 4/4 (100.0%)
     Symbol.species 4/4 (100.0%)
     invoked.js
     name.js
+    out-of-bounds-behaves-like-detached.js {unsupported: [resizable-arraybuffer]}
+    out-of-bounds-get-and-set.js {unsupported: [resizable-arraybuffer]}
+    out-of-bounds-has.js {unsupported: [resizable-arraybuffer]}
     prototype.js
+    resizable-buffer-length-tracking-1.js {unsupported: [resizable-arraybuffer]}
+    resizable-buffer-length-tracking-2.js {unsupported: [resizable-arraybuffer]}
 
-built-ins/TypedArrayConstructors 582/721 (80.72%)
+built-ins/TypedArrayConstructors 597/735 (81.22%)
     BigInt64Array/prototype 4/4 (100.0%)
     BigInt64Array 8/8 (100.0%)
     BigUint64Array/prototype 4/4 (100.0%)
@@ -2933,6 +3002,7 @@ built-ins/TypedArrayConstructors 582/721 (80.72%)
     ctors/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/detachedbuffer.js
     ctors/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/excessive-offset-throws-resizable-ab.js {unsupported: [resizable-arraybuffer]}
     ctors/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2942,6 +3012,7 @@ built-ins/TypedArrayConstructors 582/721 (80.72%)
     ctors/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/proto-from-ctor-realm.js {unsupported: [Reflect]}
     ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer, Reflect]}
+    ctors/buffer-arg/resizable-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     ctors/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2986,6 +3057,7 @@ built-ins/TypedArrayConstructors 582/721 (80.72%)
     ctors/typedarray-arg/custom-proto-access-throws.js {unsupported: [Reflect]}
     ctors/typedarray-arg/proto-from-ctor-realm.js {unsupported: [Reflect]}
     ctors/typedarray-arg/src-typedarray-big-throws.js
+    ctors/typedarray-arg/src-typedarray-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     ctors/typedarray-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
     ctors/typedarray-arg/use-default-proto-if-custom-proto-is-not-object.js
     ctors/no-species.js
@@ -3101,19 +3173,27 @@ built-ins/TypedArrayConstructors 582/721 (80.72%)
     internals/HasProperty 17/17 (100.0%)
     internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
     internals/OwnPropertyKeys 6/6 (100.0%)
-    internals/Set/BigInt 23/23 (100.0%)
+    internals/Set/BigInt 27/27 (100.0%)
     internals/Set/detached-buffer.js
     internals/Set/detached-buffer-key-is-not-numeric-index.js {unsupported: [Reflect]}
     internals/Set/detached-buffer-key-is-symbol.js {unsupported: [Reflect]}
     internals/Set/detached-buffer-realm.js
     internals/Set/indexed-value.js {unsupported: [Reflect]}
+    internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js {unsupported: [Proxy]}
+    internals/Set/key-is-canonical-invalid-index-reflect-set.js {unsupported: [Reflect]}
+    internals/Set/key-is-in-bounds-receiver-is-not-typed-array.js {unsupported: [Reflect.set]}
     internals/Set/key-is-minus-zero.js {unsupported: [Reflect]}
     internals/Set/key-is-not-canonical-index.js {unsupported: [Reflect]}
     internals/Set/key-is-not-integer.js {unsupported: [Reflect]}
     internals/Set/key-is-not-numeric-index.js {unsupported: [Reflect]}
     internals/Set/key-is-out-of-bounds.js {unsupported: [Reflect]}
+    internals/Set/key-is-out-of-bounds-receiver-is-not-object.js {unsupported: [Reflect.set]}
+    internals/Set/key-is-out-of-bounds-receiver-is-not-typed-array.js {unsupported: [Reflect.set]}
+    internals/Set/key-is-out-of-bounds-receiver-is-proto.js {unsupported: [Reflect.set]}
     internals/Set/key-is-symbol.js {unsupported: [Reflect]}
-    internals/Set/resized-out-of-bounds-to-in-bounds-index.js
+    internals/Set/key-is-valid-index-prototype-chain-set.js {unsupported: [Proxy]}
+    internals/Set/key-is-valid-index-reflect-set.js {unsupported: [Reflect]}
+    internals/Set/resized-out-of-bounds-to-in-bounds-index.js {unsupported: [resizable-arraybuffer]}
     internals/Set/tonumber-value-detached-buffer.js {unsupported: [Reflect]}
     internals/Set/tonumber-value-throws.js
     of/BigInt 12/12 (100.0%)
@@ -3535,18 +3615,20 @@ language/comments 9/52 (17.31%)
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
 
-language/computed-property-names 35/48 (72.92%)
+language/computed-property-names 37/48 (77.08%)
     class/accessor 4/4 (100.0%)
     class/method 11/11 (100.0%)
     class/static 14/14 (100.0%)
+    object/accessor/getter.js
     object/accessor/getter-super.js
+    object/accessor/setter.js
     object/accessor/setter-super.js
     object/method/generator.js
     object/method/super.js
     to-name-side-effects/class.js
     to-name-side-effects/numbers-class.js
 
-language/destructuring 11/17 (64.71%)
+language/destructuring 12/18 (66.67%)
     binding/syntax/array-elements-with-initializer.js
     binding/syntax/array-elements-with-object-patterns.js
     binding/syntax/array-rest-elements.js
@@ -3558,6 +3640,7 @@ language/destructuring 11/17 (64.71%)
     binding/syntax/recursive-array-and-object-patterns.js
     binding/initialization-requires-object-coercible-null.js
     binding/initialization-requires-object-coercible-undefined.js
+    binding/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
 
 language/directive-prologue 18/62 (29.03%)
     14.1-1-s.js {non-strict: [-1]}
@@ -5253,7 +5336,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 865/1169 (73.99%)
+language/expressions/object 863/1169 (73.82%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -6989,7 +7072,7 @@ language/statements/for 264/385 (68.57%)
 
 ~language/statements/for-await-of
 
-language/statements/for-in 39/114 (34.21%)
+language/statements/for-in 40/115 (34.78%)
     dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
@@ -7022,6 +7105,7 @@ language/statements/for-in 39/114 (34.21%)
     let-block-with-newline.js non-strict
     let-identifier-with-newline.js non-strict
     order-enumerable-shadowed.js
+    resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     scope-body-lex-boundary.js
     scope-body-lex-close.js
     scope-body-lex-open.js
@@ -7030,7 +7114,7 @@ language/statements/for-in 39/114 (34.21%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 477/736 (64.81%)
+language/statements/for-of 482/741 (65.05%)
     dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -7508,6 +7592,11 @@ language/statements/for-of 477/736 (64.81%)
     scope-head-lex-close.js
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
+    typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-grow-before-end.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
 language/statements/function 230/451 (51.0%)
     dstr/ary-init-iter-close.js
@@ -8416,7 +8505,7 @@ language/statements/while 13/38 (34.21%)
     let-identifier-with-newline.js non-strict
     tco-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/with 20/169 (11.83%)
+language/statements/with 26/175 (14.86%)
     12.10.1-8-s.js non-strict
     binding-blocked-by-unscopables.js non-strict
     cptn-abrupt-empty.js non-strict
@@ -8427,10 +8516,16 @@ language/statements/with 20/169 (11.83%)
     decl-fun.js non-strict
     decl-gen.js non-strict
     decl-let.js non-strict
+    get-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
+    get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
     has-property-err.js {unsupported: [Proxy]}
     labelled-fn-stmt.js non-strict
     let-array-with-newline.js non-strict
     let-block-with-newline.js non-strict
+    set-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
+    set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
+    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js non-strict
+    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js non-strict
     strict-fn-decl-nested-1.js non-strict
     strict-fn-expr.js strict
     strict-fn-method.js strict


### PR DESCRIPTION
test262 update brings tests for AggregateError constructor w/o mandatory 1st Iterable argument and tests for #1614