### PR TITLE
FEAT: Support default parameters

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -120,6 +120,12 @@ final class Arguments extends IdScriptableObject {
             return false;
         }
         NativeFunction f = activation.function;
+
+        // Check if default arguments are present
+        if (f == null || f.hasDefaultParameters()) {
+            return false;
+        }
+
         int definedCount = f.getParamCount();
         if (index < definedCount) {
             // Check if argument is not hidden by later argument with the same

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -70,6 +70,11 @@ public class BaseFunction extends IdScriptableObject implements Function {
         return isGeneratorFunction;
     }
 
+    // Generated code will override this
+    protected boolean hasDefaultParameters() {
+        return false;
+    }
+
     /**
      * Gets the value returned by calling the typeof operator on this object.
      *

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -189,6 +189,7 @@ class CodeGenerator extends Icode {
         itsData.argIsConst = scriptOrFn.getParamAndVarConst();
         itsData.argCount = scriptOrFn.getParamCount();
         itsData.argsHasRest = scriptOrFn.hasRestParameter();
+        itsData.argsHasDefaults = scriptOrFn.getDefaultParams() != null;
 
         itsData.rawSourceStart = scriptOrFn.getRawSourceStart();
         itsData.rawSourceEnd = scriptOrFn.getRawSourceEnd();

--- a/rhino/src/main/java/org/mozilla/javascript/InterpretedFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpretedFunction.java
@@ -164,4 +164,9 @@ final class InterpretedFunction extends NativeFunction implements Script {
         }
         return true;
     }
+
+    @Override
+    public boolean hasDefaultParameters() {
+        return idata.argsHasDefaults;
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -69,6 +69,7 @@ final class InterpreterData implements Serializable, DebuggableScript {
     boolean[] argIsConst;
     int argCount;
     boolean argsHasRest;
+    boolean argsHasDefaults;
 
     int itsMaxCalleeArgs;
 

--- a/rhino/src/main/java/org/mozilla/javascript/Node.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Node.java
@@ -65,7 +65,8 @@ public class Node implements Iterable<Node> {
             ARROW_FUNCTION_PROP = 26,
             TEMPLATE_LITERAL_PROP = 27,
             TRAILING_COMMA = 28,
-            LAST_PROP = 28;
+            OBJECT_LITERAL_DESTRUCTURING = 29,
+            LAST_PROP = 29;
 
     // values of ISNUMBER_PROP to specify
     // which of the children are Number types

--- a/rhino/src/main/java/org/mozilla/javascript/NodeTransformer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NodeTransformer.java
@@ -6,12 +6,15 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.Context.reportError;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
+import org.mozilla.javascript.ast.Name;
 import org.mozilla.javascript.ast.Scope;
 import org.mozilla.javascript.ast.ScriptNode;
 
@@ -343,6 +346,14 @@ public class NodeTransformer {
                 case Token.SETNAME:
                     if (inStrictMode) {
                         node.setType(Token.STRICT_SETNAME);
+                        if (node.getFirstChild().getType() == Token.BINDNAME) {
+                            Node name = node.getFirstChild();
+                            if (name instanceof Name
+                                    && ((Name) name).getIdentifier().equals("eval")) {
+                                // Don't allow set of `eval` in strict mode
+                                reportError("syntax error");
+                            }
+                        }
                     }
                     /* fall through */
                 case Token.NAME:

--- a/rhino/src/main/java/org/mozilla/javascript/Token.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Token.java
@@ -273,6 +273,8 @@ public class Token {
                 return "IFNE";
             case SETNAME:
                 return "SETNAME";
+            case STRICT_SETNAME:
+                return "STRICT_SETNAME";
             case BITOR:
                 return "BITOR";
             case BITXOR:

--- a/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
@@ -82,6 +82,35 @@ public class FunctionNode extends ScriptNode {
     private int rp = -1;
     private boolean hasRestParameter;
 
+    @Override
+    public List<Object> getDefaultParams() {
+        return defaultParams;
+    }
+
+    public void putDefaultParams(Object left, Object right) {
+        if (defaultParams == null) {
+            defaultParams = new ArrayList<>();
+        }
+        defaultParams.add(left);
+        defaultParams.add(right);
+    }
+
+    @Override
+    public List<Node[]> getDestructuringRvalues() {
+        return destructuringRvalues;
+    }
+
+    @Override
+    public void putDestructuringRvalues(Node left, Node right) {
+        if (destructuringRvalues == null) {
+            destructuringRvalues = new ArrayList<>();
+        }
+        destructuringRvalues.add(new Node[] {left, right});
+    }
+
+    ArrayList<Object> defaultParams;
+    ArrayList<Node[]> destructuringRvalues;
+
     // codegen variables
     private int functionType;
     private boolean needsActivation;

--- a/rhino/src/main/java/org/mozilla/javascript/ast/Scope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/Scope.java
@@ -120,7 +120,6 @@ public class Scope extends Jump {
         scope.symbolTable = null;
         result.parent = scope.parent;
         result.setParentScope(scope.getParentScope());
-        result.setParentScope(result);
         scope.parent = result;
         result.top = scope.top;
         return result;

--- a/rhino/src/main/java/org/mozilla/javascript/ast/ScriptNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/ScriptNode.java
@@ -245,6 +245,17 @@ public class ScriptNode extends Scope {
         return false;
     }
 
+    public List<Object> getDefaultParams() {
+        return null;
+    }
+
+    public List<Node[]> getDestructuringRvalues() {
+        return null;
+    }
+
+    // Overridden in FunctionNode
+    public void putDestructuringRvalues(Node left, Node right) {}
+
     void addSymbol(Symbol symbol) {
         if (variableNames != null) codeBug();
         if (symbol.getDeclType() == Token.LP) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -743,7 +743,8 @@ public class Codegen implements Evaluator {
         final int Do_getParamOrVarConst = 5;
         final int Do_isGeneratorFunction = 6;
         final int Do_hasRestParameter = 7;
-        final int SWITCH_COUNT = 8;
+        final int Do_hasDefaultParameters = 8;
+        final int SWITCH_COUNT = 9;
 
         for (int methodIndex = 0; methodIndex != SWITCH_COUNT; ++methodIndex) {
             if (methodIndex == Do_getRawSource && rawSource == null) {
@@ -789,6 +790,10 @@ public class Codegen implements Evaluator {
                 case Do_hasRestParameter:
                     methodLocals = 1; // Only this
                     cfw.startMethod("hasRestParameter", "()Z", ACC_PUBLIC);
+                    break;
+                case Do_hasDefaultParameters:
+                    methodLocals = 1; // Only this
+                    cfw.startMethod("hasDefaultParameters", "()Z", ACC_PUBLIC);
                     break;
                 default:
                     throw Kit.codeBug();
@@ -931,6 +936,15 @@ public class Codegen implements Evaluator {
                     case Do_hasRestParameter:
                         // Push boolean of defined hasRestParameter
                         cfw.addPush(n.hasRestParameter());
+                        cfw.add(ByteCode.IRETURN);
+                        break;
+
+                    case Do_hasDefaultParameters:
+                        if (n instanceof FunctionNode) {
+                            cfw.addPush(n.getDefaultParams() != null);
+                        } else {
+                            cfw.addPush(false);
+                        }
                         cfw.add(ByteCode.IRETURN);
                         break;
 

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -383,7 +383,7 @@ msg.no.semi.for =\
 
 msg.no.semi.for.cond =\
     missing ; after for-loop condition
-    
+
 msg.in.after.for.name =\
     missing in after for
 
@@ -395,7 +395,7 @@ msg.no.paren.with =\
 
 msg.no.paren.after.with =\
     missing ) after with-statement object
-    
+
 msg.no.with.strict =\
     with statements not allowed in strict mode
 
@@ -522,8 +522,8 @@ msg.var.hides.arg =\
 msg.destruct.assign.no.init =\
     Missing = in destructuring declaration
 
-msg.destruct.default.vals =\
-    Default values in destructuring declarations are not supported
+msg.default.args =\
+    Default values are only supported in version >= 200
 
 msg.no.old.octal.strict =\
     Old octal numbers prohibited in strict mode.
@@ -545,7 +545,7 @@ msg.no.unary.expr.on.left.exp =\
 
 # ScriptRuntime
 
-# is there a better message for this? 
+# is there a better message for this?
 # it's currently only used as a poison pill for caller, caller and arguments properties
 msg.op.not.allowed =\
     This operation is not allowed.
@@ -890,7 +890,7 @@ msg.send.newborn =\
 
 msg.already.exec.gen =\
     Already executing generator
-    
+
 msg.StopIteration.invalid =\
     StopIteration may not be changed to an arbitrary object.
 
@@ -916,6 +916,9 @@ msg.arguments.not.access.strict =\
 
 msg.object.cyclic.prototype =\
   Cyclic prototype "{0}" value not allowed.
+
+msg.default.args.use.strict =\
+  A function cannot have "use strict" directive with default arguments
 
 # Symbol support
 msg.object.not.symbolscriptable =\

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Issue385Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Issue385Test.java
@@ -4,9 +4,7 @@
 
 package org.mozilla.javascript.tests;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Scriptable;
@@ -16,6 +14,8 @@ import org.mozilla.javascript.Scriptable;
  * of failing on some later stage (e.g. in the IRFactory).
  *
  * <p>Should be removed when support for default values is added
+ *
+ * <p>Keeping this around, but change the return values
  */
 public class Issue385Test {
     private Context cx;
@@ -37,9 +37,11 @@ public class Issue385Test {
         Context.exit();
     }
 
-    @Test(expected = EvaluatorException.class)
+    @Test()
     public void objDestructSimple() {
-        cx.evaluateString(scope, "var {a: a = 10} = {}", "<eval>", 1, null);
+        Object result = cx.evaluateString(scope, "var {a: a = 10} = {}; a", "<eval>", 1, null);
+        Assert.assertTrue(result instanceof Double);
+        Assert.assertEquals(result, 10.0);
     }
 
     @Test(expected = EvaluatorException.class)
@@ -55,18 +57,29 @@ public class Issue385Test {
         cx.evaluateString(scope, "var {a = 10} = {}", "<eval>", 1, null);
     }
 
-    @Test(expected = EvaluatorException.class)
+    @Test()
+    @Ignore("complex-destructuring-not-supported")
     public void objDestructComplex() {
-        cx.evaluateString(scope, "var {a: {b} = {b: 10}} = {}", "<eval>", 1, null);
+        Object result =
+                cx.evaluateString(scope, "var {a: {b} = {b: 10}} = {}; a + b", "<eval>", 1, null);
+        Assert.assertTrue(result instanceof Double);
+        Assert.assertEquals(result, 20.0);
     }
 
-    @Test(expected = EvaluatorException.class)
+    @Test()
     public void arrDestructSimple() {
-        cx.evaluateString(scope, "var [a = 10] = []", "<eval>", 1, null);
+        Object result = cx.evaluateString(scope, "var [a = 10] = []; a", "<eval>", 1, null);
+        Assert.assertTrue(result instanceof Double);
+        Assert.assertEquals(result, 10.0);
     }
 
-    @Test(expected = EvaluatorException.class)
+    @Test()
+    @Ignore("complex-destructuring-not-supported")
     public void arrDestructComplex() {
-        cx.evaluateString(scope, "var [[a = [b] = [4]] = [2]] = []", "<eval>", 1, null);
+        Object result =
+                cx.evaluateString(
+                        scope, "var [[a = [b] = [4]] = [2]] = []; a + b", "<eval>", 1, null);
+        Assert.assertTrue(result instanceof Double);
+        Assert.assertEquals(result, 10.0);
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
@@ -1,0 +1,449 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mozilla.javascript.*;
+
+/*
+   Many of these are taken from examples at developer.mozilla.org
+*/
+public class DefaultParametersTest {
+    @Test
+    public void functionDefaultArgsBasic() throws Exception {
+        final String script = "function foo(a = 2) { return a; }";
+        assertIntEvaluates(32, script + "\nfoo(32)");
+        assertIntEvaluates(2, script + "\nfoo()");
+        assertIntEvaluates(2, script + "\nfoo(undefined)");
+    }
+
+    @Test
+    public void functionDefaultArgsBasicCall() throws Exception {
+        final String script = "function b() { return 2; }; function foo(a = b()) { return a; }";
+        assertIntEvaluates(32, script + "\nfoo(32)");
+        assertIntEvaluates(2, script + "\nfoo()");
+        assertIntEvaluates(2, script + "\nfoo(undefined)");
+    }
+
+    @Test
+    public void functionDefaultArgsBasicArrow() throws Exception {
+        final String script = "((a = 2, b) => { return a; })";
+        assertIntEvaluates(32, script + "(32, 12)");
+        assertIntEvaluates(12, script + "(12)");
+        assertIntEvaluates(2, script + "()");
+    }
+
+    @Test
+    public void functionDefaultArgsArrayArrow() throws Exception {
+        final String script = "(([a = 2, b = 1] = [1, 2]) => { return a + b; })";
+        assertIntEvaluates(3, script + "()");
+        assertIntEvaluates(5, script + "([4,])");
+        assertIntEvaluates(6, script + "([,4])");
+    }
+
+    @Test
+    public void functionDefaultArgsMulti() throws Exception {
+        final String script = "function foo(a = 2, b = 23) { return a + b; }";
+        assertIntEvaluates(55, script + "\nfoo(32)");
+        assertIntEvaluates(25, script + "\nfoo()");
+        assertIntEvaluates(34, script + "\nfoo(32, 2)");
+        assertIntEvaluates(25, script + "\nfoo(undefined, undefined)");
+    }
+
+    @Test
+    public void functionDefaultArgsUsage() throws Exception {
+        final String script = "function foo(a = 2, b = a * 2) { return a + b; }";
+        assertIntEvaluates(96, script + "\nfoo(32)");
+        assertIntEvaluates(6, script + "\nfoo()");
+        assertIntEvaluates(34, script + "\nfoo(32, 2)");
+    }
+
+    @Test
+    public void ObjIdInitSimpleStrictExpr() throws Exception {
+        final String script =
+                "(function () { \n " + "'use strict'; \n " + "(0, { eval = 0 } = {}) })()";
+        assertThrows("syntax error", script);
+    }
+
+    @Test
+    public void ObjIdInitSimpleStrictForOf() throws Exception {
+        final String script = "for ({ eval = 0 } of [{}]) ;";
+        assertThrows("syntax error", script);
+    }
+
+    @Test
+    public void CoverInitName() throws Exception {
+        final String script = "({ a = 1 });";
+        assertThrows("syntax error", script);
+    }
+
+    @Test
+    public void functionDefaultArgsObjectArrow() throws Exception {
+        final String script = "(({x = 1} = {x: 2}) => {\n  return x;\n})";
+
+        assertIntEvaluates(1, script + "({})");
+        assertIntEvaluates(2, script + "()");
+        assertIntEvaluates(3, script + "({x: 3})");
+    }
+
+    @Test
+    @Ignore("defaults-not-supported-in-let-destructuring")
+    public void letExprDestructuring() throws Exception {
+        // JavaScript
+        final String script =
+                "function a() {}; (function() { "
+                        + "            for (let {x = a()} = {}; ; ) { "
+                        + "                return 3; "
+                        + "            }"
+                        + "        })()";
+        assertIntEvaluates(3, script);
+    }
+
+    @Test
+    public void letExprUnresolvableRefDestructuring() throws Exception {
+        // JavaScript
+        final String script =
+                "  (function() { for (let [ x = unresolvableReference ] = []; ; ) {\n"
+                        + "    return 3;\n"
+                        + "  }})()";
+        assertThrows("ReferenceError: \"unresolvableReference\" is not defined.", script);
+    }
+
+    @Test
+    public void destructuringNestedArray() throws Exception {
+        // JavaScript
+        final String script = "let [[y], x] = [[4], 3]; x + y";
+        assertIntEvaluates(7, script);
+    }
+
+    @Test
+    public void letExprUnresolvableRefObjDestructuring() throws Exception {
+        // JavaScript
+        final String script = "var f = function({ x = unresolvableReference } = {}) {}; f()";
+        assertThrows("ReferenceError: \"unresolvableReference\" is not defined.", script);
+    }
+
+    @Test
+    public void getIntPropArg() throws Exception {
+        final String script =
+                "function foo([gen = function () { return 2; }, xGen = function* x() { yield 2; }] = []) {\n"
+                        + " return gen() + xGen().next().value; }";
+        assertIntEvaluates(4, script + "; foo()");
+    }
+
+    @Test
+    public void getIntErrPropArg() throws Exception {
+        final String script =
+                "var e = 0; var b = 'hello'; var { f: y = ++e } = { f: { get: function() {}}}; "
+                        + "Object.keys(y).includes('get') && Object.keys(y).length == 1";
+        assertEvaluates(true, script);
+    }
+
+    @Test
+    public void getIntPropArgParenExpr() throws Exception {
+        final String script =
+                "const [cover = (function () {}), xCover = (0, function() {})] = [];\n"
+                        + "cover.name == 'cover' && xCover.name == 'xCover' ? 4 : -1";
+        assertIntEvaluates(-1, script);
+    }
+
+    @Test
+    public void getIntProp() throws Exception {
+        final String script =
+                "const { gen = function () { return 2;}, xGen = function* () { yield 2;} } = {};\n"
+                        + "gen() + xGen().next().value";
+        assertIntEvaluates(4, script);
+    }
+
+    @Test
+    public void getIntPropExhausted() throws Exception {
+        final String script = "const [x = 23] = []; x";
+        assertIntEvaluates(23, script);
+    }
+
+    @Test
+    @Ignore("temporal-dead-zone")
+    public void functionDefaultArgsMultiFollowUsage() throws Exception {
+        final String script =
+                "function f(a = go()) {\n"
+                        + "  function go() {\n"
+                        + "    return \":P\";\n"
+                        + "  }\n"
+                        + " return a; "
+                        + "}\n"
+                        + "\n";
+        assertIntEvaluates(24, script + "\nf(24)");
+        assertThrows(
+                "ReferenceError: \"go\" is not defined.", "function f() { go() }; var f1 = f()");
+        assertThrows("ReferenceError: \"go\" is not defined.", script + "\nf()");
+    }
+
+    @Test
+    @Ignore("temporal-dead-zone")
+    public void functionDefaultArgsMultiReferEarlier() throws Exception {
+        final String script = "var f = function(a = b * 2, b = 3) { return a * b; }\n";
+        assertThrows("ReferenceError: \"b\" is not defined.", script + "\nf()");
+    }
+
+    @Test
+    public void functionConstructor() throws Exception {
+        final String script = "const f = new Function('a=2', 'b=a', 'return a + b');";
+        assertIntEvaluates(4, script + "f()");
+        assertIntEvaluates(6, script + "f(3)");
+        assertIntEvaluates(16, script + "f(3, 13)");
+    }
+
+    @Test
+    public void destructuringAssigmentDefaultArray() throws Exception {
+        final String script =
+                "function f([x = 1, y = 2] = [], [z = 1] = [4]) {\n"
+                        + "  return x + y + z;\n"
+                        + "}";
+
+        assertIntEvaluates(7, script + "f()");
+        assertIntEvaluates(7, script + "f([])");
+        assertIntEvaluates(4, script + "f([], [])");
+        assertIntEvaluates(8, script + "f([2])");
+        assertIntEvaluates(5, script + "f([2], [])");
+        assertIntEvaluates(8, script + "f([], [5])");
+        assertIntEvaluates(6, script + "f([2, 3], [])");
+        assertIntEvaluates(9, script + "f([2, 3], [4])");
+        assertIntEvaluates(7, script + "f([2], [3])");
+        assertIntEvaluates(9, script + "f([2, 3])");
+    }
+
+    @Test
+    @Ignore("needs-checking-for-iterator")
+    public void destructuringAssigmentInFunctionsWithObjectDefaults() throws Exception {
+        final String script = "function f([x = 1, y = 2] = {x: 3, y: 4}) {\n return x + y;\n }";
+
+        assertThrows("TypeError", script + "f()"); // TODO: returns 3
+        assertThrows("TypeError", script + "f(2)"); // TODO: returns 3, should be throwing TypeError
+    }
+
+    @Test
+    public void destructuringTest() throws Exception {
+        final String script = "function f([x]) { return x; }; f([1]);";
+        assertIntEvaluates(1, script);
+    }
+
+    @Test
+    public void destructuringAssignmentDefaultArray() throws Exception {
+        final String script = "var [a = 10] = []; a";
+        final String script2 = "var [a = 10] = [1]; a";
+        assertIntEvaluates(10, script);
+        assertIntEvaluates(1, script2);
+    }
+
+    @Test
+    public void destructuringAssignmentDefaultObject() throws Exception {
+        final String script1 = "var {a: b = 10} = {hello: 3}; b+a";
+        final String script3 = "var a = 20; var {a: b = 10} = {hello: 3}; b+a";
+        final String script4 = "var a = 30; var {a: b = 10} = {}; b+a";
+        assertThrows("ReferenceError", script1);
+        assertIntEvaluates(30, script3);
+        assertIntEvaluates(40, script4);
+    }
+
+    @Test
+    public void destructuringHookTest() throws Exception {
+        final String script = "function f([x]) { return x == undefined ? 2 : x; }; f([1]);";
+        assertIntEvaluates(1, script);
+    }
+
+    @Test
+    public void destructuringAssigmentRealRealBasicArray() throws Exception {
+        final String script = "function f([x] = [1]) {\n return x;\n }";
+        assertIntEvaluates(1, script + "f()");
+        assertIntEvaluates(2, script + "f([2])");
+        assertIntEvaluates(42, script + "f([]) == undefined ? 42 : 0");
+    }
+
+    @Test
+    public void destructuringAssigmentRealBasicArray() throws Exception {
+        final String script = "function f([x = 1]) {\n return x;\n }";
+        assertIntEvaluates(1, script + "f([])");
+        assertIntEvaluates(3, script + "f([3])");
+        assertThrows("TypeError", script + "f()");
+    }
+
+    @Test
+    public void destructuringAssigmentBasicArray() throws Exception {
+        final String script = "function f([x = 1] = [2]) {\n return x;\n }";
+        assertIntEvaluates(1, script + "f([])");
+        assertIntEvaluates(2, script + "f()");
+        assertIntEvaluates(3, script + "f([3])");
+    }
+
+    @Test
+    public void destructuringAssigmentBasicObject() throws Exception {
+        final String script = "function f({x = 1} = {x: 2}) {\n return x;\n }";
+
+        assertIntEvaluates(1, script + "f({})");
+        assertIntEvaluates(2, script + "f()");
+        assertIntEvaluates(3, script + "f({x: 3})");
+    }
+
+    @Test
+    public void destructuringAssigmentRealBasicObject() throws Exception {
+        final String script = "function f({x = 1}) {\n return x;\n }";
+
+        assertIntEvaluates(1, script + "f({})");
+        assertThrows("TypeError", script + "f()");
+        assertIntEvaluates(3, script + "f({x: 3})");
+    }
+
+    @Test
+    public void destructuringAssigmentDefaultObject() throws Exception {
+        final String script = "function f({ z = 3, x = 2 } = {}) {\n return z;\n}\n";
+        assertIntEvaluates(3, script + "f()");
+        assertIntEvaluates(3, script + "f({})");
+        assertIntEvaluates(2, script + "f({z: 2})");
+    }
+
+    @Test
+    public void destructuringAssigmentDefaultObjectWithDefaults() throws Exception {
+        final String script = "function f({ z = 3, x = 2 } = {z: 4, x: 5}) {\n return z;\n}\n";
+        assertIntEvaluates(4, script + "f()");
+        assertIntEvaluates(3, script + "f({})");
+        assertIntEvaluates(2, script + "f({z: 2})");
+    }
+
+    @Test
+    @Ignore("deeply-nested-literal-not-supported")
+    public void deeplyNestedObjectLiteral() throws Exception {
+        final String script =
+                "let { d: { b }, d, a} = { \n"
+                        + "                          a: \"world\",\n"
+                        + "                          d: {\n"
+                        + "                            b: \"hello\"\n"
+                        + "                          }\n"
+                        + "                        }\n"
+                        + "                        \n";
+        assertEvaluates("hello", script + "b");
+        assertEvaluates("world", script + "a");
+        assertEvaluates("hello", script + "d[b]");
+    }
+
+    @Test
+    public void defaultParametersWithArgumentsObject() throws Exception {
+        final String script =
+                "function f(a = 55) {\n"
+                        + "  arguments[0] = 99; // updating arguments[0] does not also update a\n"
+                        + "  return a;\n"
+                        + "}\n"
+                        + "\n"
+                        + "function g(a = 55) {\n"
+                        + "  a = 99; // updating a does not also update arguments[0]\n"
+                        + "  return arguments[0];\n"
+                        + "}\n"
+                        + "\n"
+                        + "// An untracked default parameter\n"
+                        + "function h(a = 55) {\n"
+                        + "  return arguments.length;\n"
+                        + "}\n";
+        assertIntEvaluates(10, script + "f(10)");
+        assertIntEvaluates(55, script + "f()");
+        assertIntEvaluates(10, script + "g(10)");
+        assertEvaluates(Undefined.instance, script + "g()");
+        assertIntEvaluates(0, script + "h()");
+        assertIntEvaluates(1, script + "h(10)");
+    }
+
+    @Test
+    public void functionDefaultArgsArray() throws Exception {
+        final String script =
+                "function append(value, array = []) {\n"
+                        + "  array.push(value);\n"
+                        + "  return array;\n"
+                        + "}\n"
+                        + "\n";
+        assertIntEvaluates(1, script + "append(1)[0]");
+        assertIntEvaluates(2, script + "append(2)[0]");
+    }
+
+    @Test
+    public void functionDefaultArgsObject() throws Exception {
+        final String script =
+                "function append(key, value, obj = {}) {\n"
+                        + "  obj[key]=value;\n"
+                        + "  return obj;\n"
+                        + "}\n"
+                        + "\n";
+        assertIntEvaluates(1, script + "append('a', 1)['a']");
+        assertIntEvaluates(2, script + "append('a', 2)['a']");
+    }
+
+    private static void assertThrows(final String expected, final String source) {
+        assertThrowsWithLanguageLevel(expected, source, Context.VERSION_ES6);
+    }
+
+    private static void assertThrowsWithLanguageLevel(
+            String expected, final String source, int languageLevel) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    int oldVersion = cx.getLanguageVersion();
+                    cx.setLanguageVersion(languageLevel);
+                    final Scriptable scope = cx.initStandardObjects();
+                    var error =
+                            Assert.assertThrows(
+                                    RhinoException.class,
+                                    () -> cx.evaluateString(scope, source, "test.js", 0, null));
+                    assertTrue(error.getMessage().startsWith(expected));
+                    return null;
+                });
+    }
+
+    private static void assertIntEvaluates(final Object expected, final String source) {
+        assertIntEvaluatesWithLanguageLevel(expected, source, Context.VERSION_ES6);
+    }
+
+    private static void assertEvaluates(final Object expected, final String source) {
+        assertIntEvaluatesWithLanguageLevel(expected, source, Context.VERSION_ES6);
+    }
+
+    @Test
+    public void parserThrowsOnLowerLanguageLevelBasic() throws Exception {
+        final String script = "function f(x = 1) {\n return x;\n }";
+        assertThrowsWithLanguageLevel(
+                "Default values are only supported in version >= 200",
+                script + "f()",
+                Context.VERSION_1_8);
+    }
+
+    @Test
+    public void parserThrowsOnLowerLanguageLevelObjLit() throws Exception {
+        final String script = "function f({ z = 3, x = 2 } = {}) {\n return z;\n}\n";
+        assertThrowsWithLanguageLevel(
+                "Default values are only supported in version >= 200",
+                script + "f()",
+                Context.VERSION_1_8);
+    }
+
+    @Test
+    public void parserThrowsOnLowerLanguageLevelArrowBasic() throws Exception {
+        final String script = "((x = 1) => {\n return x;\n })";
+        assertThrowsWithLanguageLevel(
+                "Default values are only supported in version >= 200",
+                script + "()",
+                Context.VERSION_1_8);
+    }
+
+    private static void assertIntEvaluatesWithLanguageLevel(
+            final Object expected, final String source, int languageLevel) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    int oldVersion = cx.getLanguageVersion();
+                    cx.setLanguageVersion(languageLevel);
+                    final Scriptable scope = cx.initStandardObjects();
+                    final Object rep = cx.evaluateString(scope, source, "test.js", 0, null);
+                    if (rep instanceof Double)
+                        assertEquals((int) expected, ((Double) rep).intValue());
+                    else assertEquals(expected, rep);
+                    return null;
+                });
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -103,7 +103,6 @@ public class Test262SuiteTest {
                             "class-fields-private",
                             "class-fields-public",
                             "default-arg",
-                            "default-parameters",
                             "new.target",
                             "object-rest",
                             "regexp-dotall",

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -769,7 +769,7 @@ built-ins/Error 6/41 (14.63%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 187/508 (36.81%)
+built-ins/Function 186/508 (36.61%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -863,7 +863,6 @@ built-ins/Function 187/508 (36.81%)
     prototype/toString/class-expression-explicit-ctor.js
     prototype/toString/class-expression-implicit-ctor.js
     prototype/toString/Function.js
-    prototype/toString/function-declaration-non-simple-parameter-list.js
     prototype/toString/generator-function-declaration.js
     prototype/toString/generator-function-expression.js
     prototype/toString/generator-method.js
@@ -975,7 +974,7 @@ built-ins/GeneratorPrototype 38/60 (63.33%)
 
 built-ins/Infinity 0/6 (0.0%)
 
-built-ins/JSON 36/144 (25.0%)
+built-ins/JSON 37/144 (25.69%)
     parse/builtin.js {unsupported: [Reflect.construct]}
     parse/duplicate-proto.js
     parse/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -1012,6 +1011,7 @@ built-ins/JSON 36/144 (25.0%)
     stringify/value-bigint-tojson-receiver.js
     stringify/value-object-proxy.js {unsupported: [Proxy]}
     stringify/value-object-proxy-revoked.js {unsupported: [Proxy]}
+    stringify/value-string-escape-unicode.js
 
 built-ins/Map 13/171 (7.6%)
     prototype/clear/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2198,7 +2198,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 128/1182 (10.83%)
+built-ins/String 140/1182 (11.84%)
     fromCharCode/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromCodePoint/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/charAt/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2218,8 +2218,7 @@ built-ins/String 128/1182 (10.83%)
     prototype/indexOf/searchstring-tostring-errors.js
     prototype/indexOf/searchstring-tostring-toprimitive.js
     prototype/indexOf/searchstring-tostring-wrapped-values.js
-    prototype/isWellFormed/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/isWellFormed/to-string-primitive.js
+    prototype/isWellFormed 8/8 (100.0%)
     prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/localeCompare/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/matchAll 20/20 (100.0%)
@@ -2285,8 +2284,7 @@ built-ins/String 128/1182 (10.83%)
     prototype/toString/non-generic-realm.js
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toUpperCase/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toWellFormed/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/toWellFormed/to-string-primitive.js
+    prototype/toWellFormed 8/8 (100.0%)
     prototype/trimEnd/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/trimEnd/this-value-object-toprimitive-call-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-err.js
@@ -3341,7 +3339,7 @@ built-ins/undefined 0/8 (0.0%)
 
 ~intl402
 
-language/arguments-object 190/263 (72.24%)
+language/arguments-object 189/263 (71.86%)
     mapped/mapped-arguments-nonconfigurable-3.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
@@ -3377,7 +3375,6 @@ language/arguments-object 190/263 (72.24%)
     mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict
     mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict
     mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
-    unmapped/via-params-dflt.js
     unmapped/via-params-dstr.js non-strict
     unmapped/via-params-rest.js non-strict
     10.6-11-b-1.js
@@ -3629,14 +3626,10 @@ language/computed-property-names 37/48 (77.08%)
     to-name-side-effects/class.js
     to-name-side-effects/numbers-class.js
 
-language/destructuring 12/18 (66.67%)
-    binding/syntax/array-elements-with-initializer.js
-    binding/syntax/array-elements-with-object-patterns.js
+language/destructuring 8/18 (44.44%)
     binding/syntax/array-rest-elements.js
     binding/syntax/destructuring-array-parameters-function-arguments-length.js
     binding/syntax/destructuring-object-parameters-function-arguments-length.js
-    binding/syntax/property-list-bindings-elements.js
-    binding/syntax/property-list-single-name-bindings.js
     binding/syntax/property-list-with-property-list.js
     binding/syntax/recursive-array-and-object-patterns.js
     binding/initialization-requires-object-coercible-null.js
@@ -3663,19 +3656,15 @@ language/directive-prologue 18/62 (29.03%)
     14.1-9-s.js {non-strict: [-1]}
     func-decl-inside-func-decl-parse.js non-strict
 
-language/eval-code 257/347 (74.06%)
+language/eval-code 253/347 (72.91%)
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
     direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
@@ -3978,29 +3967,23 @@ language/expressions/array 41/52 (78.85%)
     spread-sngl-literal.js
     spread-sngl-obj-ident.js
 
-language/expressions/arrow-function 213/343 (62.1%)
+language/expressions/arrow-function 167/343 (48.69%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -4023,99 +4006,72 @@ language/expressions/arrow-function 213/343 (62.1%)
     dstr/ary-ptrn-rest-id-iter-val-err.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
-    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-ary-init-iter-close.js
+    dstr/dflt-ary-init-iter-get-err.js
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/dflt-ary-init-iter-no-close.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-elem-obj-id.js
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/dflt-ary-ptrn-elision.js
+    dstr/dflt-ary-ptrn-elision-step-err.js
+    dstr/dflt-ary-ptrn-rest-ary-elem.js
+    dstr/dflt-ary-ptrn-rest-ary-elision.js
+    dstr/dflt-ary-ptrn-rest-ary-empty.js
+    dstr/dflt-ary-ptrn-rest-ary-rest.js
+    dstr/dflt-ary-ptrn-rest-id.js
+    dstr/dflt-ary-ptrn-rest-id-direct.js
+    dstr/dflt-ary-ptrn-rest-id-elision.js
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-rest-obj-id.js
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-obj-init-null.js
+    dstr/dflt-obj-init-undefined.js
+    dstr/dflt-obj-ptrn-id-get-value-err.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/dflt-obj-ptrn-id-init-skipped.js
+    dstr/dflt-obj-ptrn-id-init-throws.js
+    dstr/dflt-obj-ptrn-list-err.js
+    dstr/dflt-obj-ptrn-prop-ary.js
+    dstr/dflt-obj-ptrn-prop-ary-init.js
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/dflt-obj-ptrn-prop-eval-err.js
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/dflt-obj-ptrn-prop-obj.js
+    dstr/dflt-obj-ptrn-prop-obj-init.js
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -4131,11 +4087,8 @@ language/expressions/arrow-function 213/343 (62.1%)
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -4154,23 +4107,17 @@ language/expressions/arrow-function 213/343 (62.1%)
     syntax/arrowparameters-bindingidentifier-yield.js non-strict
     syntax/arrowparameters-cover-formalparameters-yield.js non-strict
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
-    syntax/arrowparameters-cover-initialize-1.js
     syntax/arrowparameters-cover-initialize-2.js
     syntax/arrowparameters-cover-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
     array-destructuring-param-strict-body.js
     ArrowFunction_restricted-properties.js
-    dflt-params-abrupt.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    dflt-params-duplicates.js {unsupported: [default-parameters]}
-    dflt-params-ref-later.js {unsupported: [default-parameters]}
-    dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    dflt-params-ref-self.js {unsupported: [default-parameters]}
-    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js non-strict
+    dflt-params-ref-later.js
+    dflt-params-ref-self.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
-    length-dflt.js {unsupported: [default-parameters]}
+    eval-var-scope-syntax-err.js non-strict
+    length-dflt.js
     lexical-new.target.js {unsupported: [new.target]}
     lexical-new.target-closure-returned.js {unsupported: [new.target]}
     lexical-super-call-from-within-constructor.js
@@ -4178,23 +4125,18 @@ language/expressions/arrow-function 213/343 (62.1%)
     lexical-super-property-from-within-constructor.js
     lexical-supercall-from-immediately-invoked-arrow.js
     object-destructuring-param-strict-body.js
-    param-dflt-yield-expr.js {unsupported: [default-parameters]}
-    param-dflt-yield-id-non-strict.js {unsupported: [default-parameters]}
-    param-dflt-yield-id-strict.js {unsupported: [default-parameters]}
+    param-dflt-yield-expr.js
+    param-dflt-yield-id-non-strict.js non-strict
     params-duplicate.js non-strict
     scope-body-lex-distinct.js non-strict
-    scope-param-elem-var-close.js non-strict
-    scope-param-elem-var-open.js non-strict
     scope-param-rest-elem-var-close.js non-strict
     scope-param-rest-elem-var-open.js non-strict
-    scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/assignment 207/480 (43.13%)
+language/expressions/assignment 193/480 (40.21%)
     destructuring 3/3 (100.0%)
-    dstr/array-elem-init-assignment.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
     dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
@@ -4205,7 +4147,6 @@ language/expressions/assignment 207/480 (43.13%)
     dstr/array-elem-init-let.js
     dstr/array-elem-init-order.js
     dstr/array-elem-init-simple-no-strict.js non-strict
-    dstr/array-elem-init-yield-expr.js
     dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
@@ -4314,10 +4255,6 @@ language/expressions/assignment 207/480 (43.13%)
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
     dstr/obj-id-identifier-yield-ident-valid.js non-strict
-    dstr/obj-id-init-assignment-missing.js
-    dstr/obj-id-init-assignment-null.js
-    dstr/obj-id-init-assignment-truthy.js
-    dstr/obj-id-init-assignment-undef.js
     dstr/obj-id-init-evaluation.js
     dstr/obj-id-init-fn-name-arrow.js
     dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
@@ -4328,15 +4265,9 @@ language/expressions/assignment 207/480 (43.13%)
     dstr/obj-id-init-let.js
     dstr/obj-id-init-order.js
     dstr/obj-id-init-simple-no-strict.js non-strict
-    dstr/obj-id-init-yield-expr.js
     dstr/obj-id-init-yield-ident-valid.js non-strict
     dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
-    dstr/obj-id-simple-strict.js strict
-    dstr/obj-prop-elem-init-assignment-missing.js
-    dstr/obj-prop-elem-init-assignment-null.js
-    dstr/obj-prop-elem-init-assignment-truthy.js
-    dstr/obj-prop-elem-init-assignment-undef.js
     dstr/obj-prop-elem-init-evaluation.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
@@ -4345,14 +4276,12 @@ language/expressions/assignment 207/480 (43.13%)
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-expr.js
     dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
     dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-expr.js
     dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
     dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
@@ -4399,7 +4328,7 @@ language/expressions/assignment 207/480 (43.13%)
     target-super-computed-reference-null.js
     target-super-identifier-reference-null.js
 
-language/expressions/async-arrow-function 44/60 (73.33%)
+language/expressions/async-arrow-function 42/60 (70.0%)
     forbidden-ext/b1 2/2 (100.0%)
     forbidden-ext/b2 3/3 (100.0%)
     arrow-returns-promise.js {unsupported: [async]}
@@ -4413,19 +4342,17 @@ language/expressions/async-arrow-function 44/60 (73.33%)
     await-as-param-nested-arrow-body-position.js {unsupported: [async-functions]}
     await-as-param-nested-arrow-parameter-position.js {unsupported: [async-functions]}
     await-as-param-rest-nested-arrow-parameter-position.js {unsupported: [async-functions]}
-    dflt-params-abrupt.js {unsupported: [default-parameters, async-functions, async]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-functions, async]}
-    dflt-params-arg-val-undefined.js {unsupported: [default-parameters, async-functions, async]}
-    dflt-params-duplicates.js {unsupported: [default-parameters]}
-    dflt-params-ref-later.js {unsupported: [default-parameters, async-functions, async]}
-    dflt-params-ref-prior.js {unsupported: [default-parameters, async-functions, async]}
-    dflt-params-ref-self.js {unsupported: [default-parameters, async-functions, async]}
-    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-abrupt.js {unsupported: [async-functions, async]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [async-functions, async]}
+    dflt-params-arg-val-undefined.js {unsupported: [async-functions, async]}
+    dflt-params-ref-later.js {unsupported: [async-functions, async]}
+    dflt-params-ref-prior.js {unsupported: [async-functions, async]}
+    dflt-params-ref-self.js {unsupported: [async-functions, async]}
     dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
     early-errors-arrow-duplicate-parameters.js {unsupported: [async-functions]}
     escaped-async.js {unsupported: [async-functions]}
     escaped-async-line-terminator.js {unsupported: [async-functions]}
-    eval-var-scope-syntax-err.js {unsupported: [default-parameters, async-functions, async]}
+    eval-var-scope-syntax-err.js {unsupported: [async-functions, async]}
     name.js
     params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
     params-trailing-comma-single.js {unsupported: [async-functions, async]}
@@ -4542,7 +4469,7 @@ language/expressions/coalesce 2/24 (8.33%)
 language/expressions/comma 1/6 (16.67%)
     tco-final.js {unsupported: [tail-call-optimization]}
 
-language/expressions/compound-assignment 137/454 (30.18%)
+language/expressions/compound-assignment 125/454 (27.53%)
     11.13.2-34-s.js strict
     11.13.2-35-s.js strict
     11.13.2-36-s.js strict
@@ -4554,11 +4481,8 @@ language/expressions/compound-assignment 137/454 (30.18%)
     11.13.2-42-s.js strict
     11.13.2-43-s.js strict
     11.13.2-44-s.js strict
-    11.13.2-6-1gs.js strict
     add-arguments-strict.js strict
-    add-eval-strict.js strict
     and-arguments-strict.js strict
-    and-eval-strict.js strict
     compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
     compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
     compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
@@ -4582,7 +4506,6 @@ language/expressions/compound-assignment 137/454 (30.18%)
     compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict
     compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
     div-arguments-strict.js strict
-    div-eval-strict.js strict
     left-hand-side-private-reference-accessor-property-add.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-bitand.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-bitor.js {unsupported: [class-fields-private]}
@@ -4632,13 +4555,9 @@ language/expressions/compound-assignment 137/454 (30.18%)
     left-hand-side-private-reference-readonly-accessor-property-srshift.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-sub.js {unsupported: [class-fields-private]}
     lshift-arguments-strict.js strict
-    lshift-eval-strict.js strict
     mod-arguments-strict.js strict
-    mod-eval-strict.js strict
     mult-arguments-strict.js strict
-    mult-eval-strict.js strict
     or-arguments-strict.js strict
-    or-eval-strict.js strict
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
     S11.13.2_A7.10_T4.js
@@ -4673,13 +4592,9 @@ language/expressions/compound-assignment 137/454 (30.18%)
     S11.13.2_A7.9_T2.js
     S11.13.2_A7.9_T4.js
     srshift-arguments-strict.js strict
-    srshift-eval-strict.js strict
     sub-arguments-strict.js strict
-    sub-eval-strict.js strict
     urshift-arguments-strict.js strict
-    urshift-eval-strict.js strict
     xor-arguments-strict.js strict
-    xor-eval-strict.js strict
 
 language/expressions/concatenation 0/5 (0.0%)
 
@@ -4716,29 +4631,23 @@ language/expressions/exponentiation 3/44 (6.82%)
     bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/function 214/264 (81.06%)
+language/expressions/function 168/264 (63.64%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -4761,99 +4670,72 @@ language/expressions/function 214/264 (81.06%)
     dstr/ary-ptrn-rest-id-iter-val-err.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
-    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-ary-init-iter-close.js
+    dstr/dflt-ary-init-iter-get-err.js
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/dflt-ary-init-iter-no-close.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-elem-obj-id.js
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/dflt-ary-ptrn-elision.js
+    dstr/dflt-ary-ptrn-elision-step-err.js
+    dstr/dflt-ary-ptrn-rest-ary-elem.js
+    dstr/dflt-ary-ptrn-rest-ary-elision.js
+    dstr/dflt-ary-ptrn-rest-ary-empty.js
+    dstr/dflt-ary-ptrn-rest-ary-rest.js
+    dstr/dflt-ary-ptrn-rest-id.js
+    dstr/dflt-ary-ptrn-rest-id-direct.js
+    dstr/dflt-ary-ptrn-rest-id-elision.js
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-rest-obj-id.js
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-obj-init-null.js
+    dstr/dflt-obj-init-undefined.js
+    dstr/dflt-obj-ptrn-id-get-value-err.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/dflt-obj-ptrn-id-init-skipped.js
+    dstr/dflt-obj-ptrn-id-init-throws.js
+    dstr/dflt-obj-ptrn-list-err.js
+    dstr/dflt-obj-ptrn-prop-ary.js
+    dstr/dflt-obj-ptrn-prop-ary-init.js
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/dflt-obj-ptrn-prop-eval-err.js
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/dflt-obj-ptrn-prop-obj.js
+    dstr/dflt-obj-ptrn-prop-obj-init.js
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -4863,17 +4745,13 @@ language/expressions/function 214/264 (81.06%)
     dstr/obj-ptrn-id-init-fn-name-gen.js
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -4886,19 +4764,14 @@ language/expressions/function 214/264 (81.06%)
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
-    dflt-params-abrupt.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    dflt-params-duplicates.js {unsupported: [default-parameters]}
-    dflt-params-ref-later.js {unsupported: [default-parameters]}
-    dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    dflt-params-ref-self.js {unsupported: [default-parameters]}
-    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js non-strict
+    dflt-params-ref-later.js
+    dflt-params-ref-self.js
+    dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
-    length-dflt.js {unsupported: [default-parameters]}
+    eval-var-scope-syntax-err.js non-strict
+    length-dflt.js
     name-arguments-strict-body.js non-strict
-    name-eval-strict-body.js non-strict
     named-no-strict-reassign-fn-name-in-body.js non-strict
     named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
     named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
@@ -4906,52 +4779,43 @@ language/expressions/function 214/264 (81.06%)
     named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
     named-strict-error-reassign-fn-name-in-body-in-eval.js strict
     object-destructuring-param-strict-body.js
-    param-dflt-yield-non-strict.js {unsupported: [default-parameters]}
-    param-dflt-yield-strict.js {unsupported: [default-parameters]}
+    param-dflt-yield-non-strict.js non-strict
+    param-dflt-yield-strict.js strict
     param-duplicated-strict-body-1.js non-strict
     param-duplicated-strict-body-2.js non-strict
     param-duplicated-strict-body-3.js non-strict
     param-eval-strict-body.js non-strict
-    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
-    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
+    params-dflt-ref-arguments.js
     rest-param-strict-body.js
     scope-body-lex-distinct.js non-strict
     scope-name-var-open-non-strict.js non-strict
     scope-name-var-open-strict.js strict
-    scope-param-elem-var-close.js non-strict
-    scope-param-elem-var-open.js non-strict
     scope-param-rest-elem-var-close.js non-strict
     scope-param-rest-elem-var-open.js non-strict
-    scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 232/290 (80.0%)
+language/expressions/generators 194/290 (66.9%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
     dstr/ary-ptrn-elem-ary-val-null.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -4977,99 +4841,78 @@ language/expressions/generators 232/290 (80.0%)
     dstr/ary-ptrn-rest-id-iter-val-err.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
-    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-ary-init-iter-close.js
+    dstr/dflt-ary-init-iter-get-err.js
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/dflt-ary-init-iter-no-close.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-elem-obj-id.js
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js
+    dstr/dflt-ary-ptrn-elision.js
+    dstr/dflt-ary-ptrn-elision-step-err.js
+    dstr/dflt-ary-ptrn-rest-ary-elem.js
+    dstr/dflt-ary-ptrn-rest-ary-elision.js
+    dstr/dflt-ary-ptrn-rest-ary-empty.js
+    dstr/dflt-ary-ptrn-rest-ary-rest.js
+    dstr/dflt-ary-ptrn-rest-id.js
+    dstr/dflt-ary-ptrn-rest-id-direct.js
+    dstr/dflt-ary-ptrn-rest-id-elision.js
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-rest-obj-id.js
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-obj-init-null.js
+    dstr/dflt-obj-init-undefined.js
+    dstr/dflt-obj-ptrn-id-get-value-err.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/dflt-obj-ptrn-id-init-skipped.js
+    dstr/dflt-obj-ptrn-id-init-throws.js
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js
+    dstr/dflt-obj-ptrn-list-err.js
+    dstr/dflt-obj-ptrn-prop-ary.js
+    dstr/dflt-obj-ptrn-prop-ary-init.js
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/dflt-obj-ptrn-prop-eval-err.js
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/dflt-obj-ptrn-prop-obj.js
+    dstr/dflt-obj-ptrn-prop-obj-init.js
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -5087,7 +4930,6 @@ language/expressions/generators 232/290 (80.0%)
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
@@ -5100,25 +4942,20 @@ language/expressions/generators 232/290 (80.0%)
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1 2/2 (100.0%)
     arguments-with-arguments-fn.js non-strict
-    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     default-proto.js
-    dflt-params-abrupt.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    dflt-params-duplicates.js {unsupported: [default-parameters]}
-    dflt-params-ref-later.js {unsupported: [default-parameters]}
-    dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    dflt-params-ref-self.js {unsupported: [default-parameters]}
-    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-abrupt.js
+    dflt-params-duplicates.js non-strict
+    dflt-params-ref-later.js
+    dflt-params-ref-self.js
+    dflt-params-rest.js
     dflt-params-trailing-comma.js
     eval-body-proto-realm.js
-    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
-    generator-created-after-decl-inst.js
+    eval-var-scope-syntax-err.js non-strict
     has-instance.js
     implicit-name.js
     invoke-as-constructor.js
-    length-dflt.js {unsupported: [default-parameters]}
+    length-dflt.js
     named-no-strict-reassign-fn-name-in-body.js non-strict
     named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
     named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
@@ -5131,9 +4968,6 @@ language/expressions/generators 232/290 (80.0%)
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
     object-destructuring-param-strict-body.js
-    param-dflt-yield.js {unsupported: [default-parameters]}
-    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
-    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js
@@ -5142,11 +4976,8 @@ language/expressions/generators 232/290 (80.0%)
     scope-name-var-close.js non-interpreted
     scope-name-var-open-non-strict.js non-strict
     scope-name-var-open-strict.js strict
-    scope-param-elem-var-close.js non-strict
-    scope-param-elem-var-open.js non-strict
     scope-param-rest-elem-var-close.js non-strict
     scope-param-rest-elem-var-open.js non-strict
-    scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
@@ -5220,7 +5051,7 @@ language/expressions/less-than-or-equal 2/47 (4.26%)
 language/expressions/logical-and 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/logical-assignment 55/78 (70.51%)
+language/expressions/logical-assignment 53/78 (67.95%)
     left-hand-side-private-reference-accessor-property-and.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-nullish.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-or.js {unsupported: [class-fields-private]}
@@ -5251,7 +5082,6 @@ language/expressions/logical-assignment 55/78 (70.51%)
     lgcl-and-assignment-operator-non-extensible.js strict
     lgcl-and-assignment-operator-non-simple-lhs.js
     lgcl-and-assignment-operator-non-writeable.js strict
-    lgcl-and-eval-strict.js strict
     lgcl-nullish-assignment-operator.js
     lgcl-nullish-assignment-operator-bigint.js
     lgcl-nullish-assignment-operator-lhs-before-rhs.js
@@ -5275,7 +5105,6 @@ language/expressions/logical-assignment 55/78 (70.51%)
     lgcl-or-assignment-operator-no-set-put.js strict
     lgcl-or-assignment-operator-non-simple-lhs.js
     lgcl-or-assignment-operator-non-writeable.js strict
-    lgcl-or-eval-strict.js strict
 
 language/expressions/logical-not 0/19 (0.0%)
 
@@ -5337,7 +5166,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 863/1169 (73.82%)
+language/expressions/object 809/1169 (69.2%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -5578,99 +5407,93 @@ language/expressions/object 863/1169 (73.82%)
     dstr/gen-meth-ary-ptrn-rest-id-iter-val-err.js
     dstr/gen-meth-ary-ptrn-rest-obj-id.js
     dstr/gen-meth-ary-ptrn-rest-obj-prop-id.js
-    dstr/gen-meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/gen-meth-dflt-ary-init-iter-close.js
+    dstr/gen-meth-dflt-ary-init-iter-get-err.js
+    dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/gen-meth-dflt-ary-init-iter-no-close.js
+    dstr/gen-meth-dflt-ary-name-iter-val.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-undef.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-done.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-null.js
+    dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js
+    dstr/gen-meth-dflt-ary-ptrn-elision.js
+    dstr/gen-meth-dflt-ary-ptrn-elision-exhausted.js
+    dstr/gen-meth-dflt-ary-ptrn-elision-step-err.js
+    dstr/gen-meth-dflt-ary-ptrn-empty.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-elem.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-elision.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-empty.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-ary-rest.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-direct.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-obj-id.js
+    dstr/gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/gen-meth-dflt-obj-init-null.js
+    dstr/gen-meth-dflt-obj-init-undefined.js
+    dstr/gen-meth-dflt-obj-ptrn-empty.js
+    dstr/gen-meth-dflt-obj-ptrn-id-get-value-err.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-skipped.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-throws.js
+    dstr/gen-meth-dflt-obj-ptrn-id-init-unresolvable.js
+    dstr/gen-meth-dflt-obj-ptrn-id-trailing-comma.js
+    dstr/gen-meth-dflt-obj-ptrn-list-err.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary-init.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-eval-err.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/gen-meth-obj-init-null.js
     dstr/gen-meth-obj-init-undefined.js
     dstr/gen-meth-obj-ptrn-empty.js
@@ -5710,22 +5533,16 @@ language/expressions/object 863/1169 (73.82%)
     dstr/meth-ary-ptrn-elem-ary-elem-init.js
     dstr/meth-ary-ptrn-elem-ary-elem-iter.js
     dstr/meth-ary-ptrn-elem-ary-elision-init.js
-    dstr/meth-ary-ptrn-elem-ary-elision-iter.js
     dstr/meth-ary-ptrn-elem-ary-empty-init.js
-    dstr/meth-ary-ptrn-elem-ary-empty-iter.js
     dstr/meth-ary-ptrn-elem-ary-rest-init.js
     dstr/meth-ary-ptrn-elem-ary-rest-iter.js
-    dstr/meth-ary-ptrn-elem-id-init-exhausted.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/meth-ary-ptrn-elem-id-init-hole.js
     dstr/meth-ary-ptrn-elem-id-init-skipped.js
     dstr/meth-ary-ptrn-elem-id-init-throws.js
-    dstr/meth-ary-ptrn-elem-id-init-undef.js
-    dstr/meth-ary-ptrn-elem-id-init-unresolvable.js
     dstr/meth-ary-ptrn-elem-id-iter-step-err.js
     dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/meth-ary-ptrn-elem-id-iter-val-err.js
@@ -5748,99 +5565,72 @@ language/expressions/object 863/1169 (73.82%)
     dstr/meth-ary-ptrn-rest-id-iter-val-err.js
     dstr/meth-ary-ptrn-rest-obj-id.js
     dstr/meth-ary-ptrn-rest-obj-prop-id.js
-    dstr/meth-dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/meth-dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/meth-dflt-ary-init-iter-close.js
+    dstr/meth-dflt-ary-init-iter-get-err.js
+    dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/meth-dflt-ary-init-iter-no-close.js
+    dstr/meth-dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/meth-dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/meth-dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/meth-dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/meth-dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/meth-dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/meth-dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/meth-dflt-ary-ptrn-elem-obj-id.js
+    dstr/meth-dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/meth-dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/meth-dflt-ary-ptrn-elision.js
+    dstr/meth-dflt-ary-ptrn-elision-step-err.js
+    dstr/meth-dflt-ary-ptrn-rest-ary-elem.js
+    dstr/meth-dflt-ary-ptrn-rest-ary-elision.js
+    dstr/meth-dflt-ary-ptrn-rest-ary-empty.js
+    dstr/meth-dflt-ary-ptrn-rest-ary-rest.js
+    dstr/meth-dflt-ary-ptrn-rest-id.js
+    dstr/meth-dflt-ary-ptrn-rest-id-direct.js
+    dstr/meth-dflt-ary-ptrn-rest-id-elision.js
+    dstr/meth-dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/meth-dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/meth-dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/meth-dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/meth-dflt-ary-ptrn-rest-obj-id.js
+    dstr/meth-dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/meth-dflt-obj-init-null.js
+    dstr/meth-dflt-obj-init-undefined.js
+    dstr/meth-dflt-obj-ptrn-id-get-value-err.js
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/meth-dflt-obj-ptrn-id-init-skipped.js
+    dstr/meth-dflt-obj-ptrn-id-init-throws.js
+    dstr/meth-dflt-obj-ptrn-list-err.js
+    dstr/meth-dflt-obj-ptrn-prop-ary.js
+    dstr/meth-dflt-obj-ptrn-prop-ary-init.js
+    dstr/meth-dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/meth-dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/meth-dflt-obj-ptrn-prop-eval-err.js
+    dstr/meth-dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/meth-dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/meth-dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/meth-dflt-obj-ptrn-prop-obj.js
+    dstr/meth-dflt-obj-ptrn-prop-obj-init.js
+    dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/meth-dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/meth-dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-obj-init-null.js
     dstr/meth-obj-init-undefined.js
     dstr/meth-obj-ptrn-id-init-fn-name-arrow.js
@@ -5850,17 +5640,13 @@ language/expressions/object 863/1169 (73.82%)
     dstr/meth-obj-ptrn-id-init-fn-name-gen.js
     dstr/meth-obj-ptrn-id-init-skipped.js
     dstr/meth-obj-ptrn-id-init-throws.js
-    dstr/meth-obj-ptrn-id-init-unresolvable.js
     dstr/meth-obj-ptrn-list-err.js
     dstr/meth-obj-ptrn-prop-ary.js
     dstr/meth-obj-ptrn-prop-ary-init.js
     dstr/meth-obj-ptrn-prop-ary-value-null.js
     dstr/meth-obj-ptrn-prop-eval-err.js
-    dstr/meth-obj-ptrn-prop-id-get-value-err.js
-    dstr/meth-obj-ptrn-prop-id-init.js
     dstr/meth-obj-ptrn-prop-id-init-skipped.js
     dstr/meth-obj-ptrn-prop-id-init-throws.js
-    dstr/meth-obj-ptrn-prop-id-init-unresolvable.js
     dstr/meth-obj-ptrn-prop-obj.js
     dstr/meth-obj-ptrn-prop-obj-init.js
     dstr/meth-obj-ptrn-prop-obj-value-null.js
@@ -5900,17 +5686,17 @@ language/expressions/object 863/1169 (73.82%)
     method-definition/async-gen-await-as-label-identifier.js {unsupported: [async-iteration]}
     method-definition/async-gen-await-as-label-identifier-escaped.js {unsupported: [async-iteration]}
     method-definition/async-gen-meth-array-destructuring-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-abrupt.js {unsupported: [default-parameters, async-iteration]}
-    method-definition/async-gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-iteration, async]}
-    method-definition/async-gen-meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters, async-iteration, async]}
-    method-definition/async-gen-meth-dflt-params-duplicates.js {unsupported: [default-parameters, async-iteration]}
-    method-definition/async-gen-meth-dflt-params-ref-later.js {unsupported: [default-parameters, async-iteration]}
-    method-definition/async-gen-meth-dflt-params-ref-prior.js {unsupported: [default-parameters, async-iteration, async]}
-    method-definition/async-gen-meth-dflt-params-ref-self.js {unsupported: [default-parameters, async-iteration]}
-    method-definition/async-gen-meth-dflt-params-rest.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-dflt-params-abrupt.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-arg-val-undefined.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-duplicates.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-ref-later.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-ref-prior.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-ref-self.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-rest.js {unsupported: [async-iteration]}
     method-definition/async-gen-meth-dflt-params-trailing-comma.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-meth-escaped-async.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-gen-meth-eval-var-scope-syntax-err.js {unsupported: [async-iteration]}
     method-definition/async-gen-meth-object-destructuring-param-strict-body.js {unsupported: [async-iteration]}
     method-definition/async-gen-meth-params-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-meth-params-trailing-comma-single.js {unsupported: [async-iteration, async]}
@@ -5992,17 +5778,17 @@ language/expressions/object 863/1169 (73.82%)
     method-definition/async-gen-yield-star-sync-return.js {unsupported: [async-iteration, async]}
     method-definition/async-gen-yield-star-sync-throw.js {unsupported: [async-iteration, async]}
     method-definition/async-meth-array-destructuring-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-meth-dflt-params-abrupt.js {unsupported: [default-parameters, async-functions, async]}
-    method-definition/async-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters, async-functions, async]}
-    method-definition/async-meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters, async-functions, async]}
-    method-definition/async-meth-dflt-params-duplicates.js {unsupported: [default-parameters, async-iteration]}
-    method-definition/async-meth-dflt-params-ref-later.js {unsupported: [default-parameters, async-functions, async]}
-    method-definition/async-meth-dflt-params-ref-prior.js {unsupported: [default-parameters, async-functions, async]}
-    method-definition/async-meth-dflt-params-ref-self.js {unsupported: [default-parameters, async-functions, async]}
-    method-definition/async-meth-dflt-params-rest.js {unsupported: [default-parameters, async-iteration]}
+    method-definition/async-meth-dflt-params-abrupt.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-arg-val-not-undefined.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-arg-val-undefined.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-duplicates.js {unsupported: [async-iteration]}
+    method-definition/async-meth-dflt-params-ref-later.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-ref-prior.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-ref-self.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-rest.js {unsupported: [async-iteration]}
     method-definition/async-meth-dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
     method-definition/async-meth-escaped-async.js {unsupported: [async-functions]}
-    method-definition/async-meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters, async-functions, async]}
+    method-definition/async-meth-eval-var-scope-syntax-err.js {unsupported: [async-functions, async]}
     method-definition/async-meth-object-destructuring-param-strict-body.js {unsupported: [async-iteration]}
     method-definition/async-meth-params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
     method-definition/async-meth-params-trailing-comma-single.js {unsupported: [async-functions, async]}
@@ -6033,16 +5819,14 @@ language/expressions/object 863/1169 (73.82%)
     method-definition/escaped-set-t.js
     method-definition/fn-name-fn.js
     method-definition/fn-name-gen.js
-    method-definition/gen-meth-dflt-params-abrupt.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-duplicates.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-ref-later.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-ref-self.js {unsupported: [default-parameters]}
-    method-definition/gen-meth-dflt-params-rest.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-dflt-params-abrupt.js
+    method-definition/gen-meth-dflt-params-arg-val-not-undefined.js
+    method-definition/gen-meth-dflt-params-arg-val-undefined.js
+    method-definition/gen-meth-dflt-params-ref-later.js
+    method-definition/gen-meth-dflt-params-ref-prior.js
+    method-definition/gen-meth-dflt-params-ref-self.js
     method-definition/gen-meth-dflt-params-trailing-comma.js
-    method-definition/gen-meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
+    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict
     method-definition/gen-meth-params-trailing-comma-multiple.js
     method-definition/gen-meth-params-trailing-comma-single.js
     method-definition/gen-yield-identifier-non-strict.js non-strict
@@ -6054,7 +5838,7 @@ language/expressions/object 863/1169 (73.82%)
     method-definition/generator-invoke-fn-no-strict.js non-strict
     method-definition/generator-invoke-fn-strict.js non-strict
     method-definition/generator-length.js
-    method-definition/generator-length-dflt.js {unsupported: [default-parameters]}
+    method-definition/generator-length-dflt.js
     method-definition/generator-name-prop-string.js
     method-definition/generator-name-prop-symbol.js
     method-definition/generator-no-yield.js
@@ -6067,23 +5851,19 @@ language/expressions/object 863/1169 (73.82%)
     method-definition/generator-prototype-prop.js
     method-definition/generator-return.js
     method-definition/generator-super-prop-body.js
-    method-definition/generator-super-prop-param.js {unsupported: [super, default-parameters]}
+    method-definition/generator-super-prop-param.js {unsupported: [super]}
     method-definition/meth-array-destructuring-param-strict-body.js
-    method-definition/meth-dflt-params-abrupt.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-duplicates.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-ref-later.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-ref-self.js {unsupported: [default-parameters]}
-    method-definition/meth-dflt-params-rest.js {unsupported: [default-parameters]}
+    method-definition/meth-dflt-params-duplicates.js non-strict
+    method-definition/meth-dflt-params-ref-later.js
+    method-definition/meth-dflt-params-ref-self.js
+    method-definition/meth-dflt-params-rest.js
     method-definition/meth-dflt-params-trailing-comma.js
-    method-definition/meth-eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
+    method-definition/meth-eval-var-scope-syntax-err.js non-strict
     method-definition/meth-object-destructuring-param-strict-body.js
     method-definition/meth-rest-param-strict-body.js
     method-definition/name-invoke-ctor.js
     method-definition/name-invoke-fn-strict.js non-strict
-    method-definition/name-length-dflt.js {unsupported: [default-parameters]}
+    method-definition/name-length-dflt.js
     method-definition/name-name-prop-string.js
     method-definition/name-name-prop-symbol.js
     method-definition/name-param-id-yield.js non-strict
@@ -6095,10 +5875,9 @@ language/expressions/object 863/1169 (73.82%)
     method-definition/name-super-prop-body.js {unsupported: [super]}
     method-definition/name-super-prop-param.js {unsupported: [super]}
     method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
-    method-definition/params-dflt-gen-meth-args-unmapped.js {unsupported: [default-parameters]}
-    method-definition/params-dflt-gen-meth-ref-arguments.js {unsupported: [default-parameters]}
-    method-definition/params-dflt-meth-args-unmapped.js {unsupported: [default-parameters]}
-    method-definition/params-dflt-meth-ref-arguments.js {unsupported: [default-parameters]}
+    method-definition/params-dflt-gen-meth-args-unmapped.js
+    method-definition/params-dflt-gen-meth-ref-arguments.js
+    method-definition/params-dflt-meth-ref-arguments.js
     method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
     method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
     method-definition/private-name-early-error-async-gen.js {unsupported: [async-iteration]}
@@ -6153,7 +5932,7 @@ language/expressions/object 863/1169 (73.82%)
     fn-name-gen.js
     getter-body-strict-inside.js non-strict
     getter-body-strict-outside.js strict
-    getter-param-dflt.js {unsupported: [default-parameters]}
+    getter-param-dflt.js
     getter-super-prop.js
     ident-name-prop-name-literal-await-static-init.js
     identifier-shorthand-await-strict-mode.js non-strict
@@ -6184,18 +5963,14 @@ language/expressions/object 863/1169 (73.82%)
     scope-gen-meth-paramsbody-var-open.js
     scope-getter-body-lex-distinc.js non-strict
     scope-meth-body-lex-distinct.js non-strict
-    scope-meth-param-elem-var-close.js non-strict
-    scope-meth-param-elem-var-open.js non-strict
     scope-meth-param-rest-elem-var-close.js non-strict
     scope-meth-param-rest-elem-var-open.js non-strict
-    scope-meth-paramsbody-var-close.js
     scope-meth-paramsbody-var-open.js
     scope-setter-body-lex-distinc.js non-strict
-    scope-setter-paramsbody-var-close.js
     scope-setter-paramsbody-var-open.js
     setter-body-strict-inside.js non-strict
     setter-body-strict-outside.js strict
-    setter-length-dflt.js {unsupported: [default-parameters]}
+    setter-length-dflt.js
     setter-param-arguments-strict-inside.js non-strict
     setter-param-eval-strict-inside.js non-strict
     setter-super-prop.js
@@ -6675,29 +6450,23 @@ language/statements/break 0/20 (0.0%)
 
 ~language/statements/class
 
-language/statements/const 108/136 (79.41%)
+language/statements/const 98/136 (72.06%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -6729,17 +6498,13 @@ language/statements/const 108/136 (79.41%)
     dstr/obj-ptrn-id-init-fn-name-gen.js
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -6805,7 +6570,7 @@ language/statements/empty 0/2 (0.0%)
 
 language/statements/expression 0/3 (0.0%)
 
-language/statements/for 264/385 (68.57%)
+language/statements/for 244/385 (63.38%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -6901,22 +6666,16 @@ language/statements/for 264/385 (68.57%)
     dstr/let-ary-ptrn-elem-ary-elem-init.js
     dstr/let-ary-ptrn-elem-ary-elem-iter.js
     dstr/let-ary-ptrn-elem-ary-elision-init.js
-    dstr/let-ary-ptrn-elem-ary-elision-iter.js
     dstr/let-ary-ptrn-elem-ary-empty-init.js
-    dstr/let-ary-ptrn-elem-ary-empty-iter.js
     dstr/let-ary-ptrn-elem-ary-rest-init.js
     dstr/let-ary-ptrn-elem-ary-rest-iter.js
-    dstr/let-ary-ptrn-elem-id-init-exhausted.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/let-ary-ptrn-elem-id-init-hole.js
     dstr/let-ary-ptrn-elem-id-init-skipped.js
     dstr/let-ary-ptrn-elem-id-init-throws.js
-    dstr/let-ary-ptrn-elem-id-init-undef.js
-    dstr/let-ary-ptrn-elem-id-init-unresolvable.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
     dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
@@ -6950,18 +6709,14 @@ language/statements/for 264/385 (68.57%)
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
     dstr/let-obj-ptrn-id-init-skipped.js
     dstr/let-obj-ptrn-id-init-throws.js
-    dstr/let-obj-ptrn-id-init-unresolvable.js
     dstr/let-obj-ptrn-list-err.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
     dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
-    dstr/let-obj-ptrn-prop-id-get-value-err.js
-    dstr/let-obj-ptrn-prop-id-init.js
     dstr/let-obj-ptrn-prop-id-init-skipped.js
     dstr/let-obj-ptrn-prop-id-init-throws.js
-    dstr/let-obj-ptrn-prop-id-init-unresolvable.js
     dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
@@ -6975,22 +6730,16 @@ language/statements/for 264/385 (68.57%)
     dstr/var-ary-ptrn-elem-ary-elem-init.js
     dstr/var-ary-ptrn-elem-ary-elem-iter.js
     dstr/var-ary-ptrn-elem-ary-elision-init.js
-    dstr/var-ary-ptrn-elem-ary-elision-iter.js
     dstr/var-ary-ptrn-elem-ary-empty-init.js
-    dstr/var-ary-ptrn-elem-ary-empty-iter.js
     dstr/var-ary-ptrn-elem-ary-rest-init.js
     dstr/var-ary-ptrn-elem-ary-rest-iter.js
-    dstr/var-ary-ptrn-elem-id-init-exhausted.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/var-ary-ptrn-elem-id-init-hole.js
     dstr/var-ary-ptrn-elem-id-init-skipped.js
     dstr/var-ary-ptrn-elem-id-init-throws.js
-    dstr/var-ary-ptrn-elem-id-init-undef.js
-    dstr/var-ary-ptrn-elem-id-init-unresolvable.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
     dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
@@ -7024,17 +6773,13 @@ language/statements/for 264/385 (68.57%)
     dstr/var-obj-ptrn-id-init-fn-name-gen.js
     dstr/var-obj-ptrn-id-init-skipped.js
     dstr/var-obj-ptrn-id-init-throws.js
-    dstr/var-obj-ptrn-id-init-unresolvable.js
     dstr/var-obj-ptrn-list-err.js
     dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-ary-init.js
     dstr/var-obj-ptrn-prop-ary-value-null.js
     dstr/var-obj-ptrn-prop-eval-err.js
-    dstr/var-obj-ptrn-prop-id-get-value-err.js
-    dstr/var-obj-ptrn-prop-id-init.js
     dstr/var-obj-ptrn-prop-id-init-skipped.js
     dstr/var-obj-ptrn-prop-id-init-throws.js
-    dstr/var-obj-ptrn-prop-id-init-unresolvable.js
     dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
@@ -7115,8 +6860,7 @@ language/statements/for-in 40/115 (34.78%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 482/741 (65.05%)
-    dstr/array-elem-init-assignment.js
+language/statements/for-of 453/741 (61.13%)
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
     dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
@@ -7127,7 +6871,6 @@ language/statements/for-of 482/741 (65.05%)
     dstr/array-elem-init-let.js
     dstr/array-elem-init-order.js
     dstr/array-elem-init-simple-no-strict.js non-strict
-    dstr/array-elem-init-yield-expr.js
     dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
@@ -7327,22 +7070,16 @@ language/statements/for-of 482/741 (65.05%)
     dstr/let-ary-ptrn-elem-ary-elem-init.js
     dstr/let-ary-ptrn-elem-ary-elem-iter.js
     dstr/let-ary-ptrn-elem-ary-elision-init.js
-    dstr/let-ary-ptrn-elem-ary-elision-iter.js
     dstr/let-ary-ptrn-elem-ary-empty-init.js
-    dstr/let-ary-ptrn-elem-ary-empty-iter.js
     dstr/let-ary-ptrn-elem-ary-rest-init.js
     dstr/let-ary-ptrn-elem-ary-rest-iter.js
-    dstr/let-ary-ptrn-elem-id-init-exhausted.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/let-ary-ptrn-elem-id-init-hole.js
     dstr/let-ary-ptrn-elem-id-init-skipped.js
     dstr/let-ary-ptrn-elem-id-init-throws.js
-    dstr/let-ary-ptrn-elem-id-init-undef.js
-    dstr/let-ary-ptrn-elem-id-init-unresolvable.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
     dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
@@ -7376,17 +7113,13 @@ language/statements/for-of 482/741 (65.05%)
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
     dstr/let-obj-ptrn-id-init-skipped.js
     dstr/let-obj-ptrn-id-init-throws.js
-    dstr/let-obj-ptrn-id-init-unresolvable.js
     dstr/let-obj-ptrn-list-err.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
-    dstr/let-obj-ptrn-prop-id-get-value-err.js
-    dstr/let-obj-ptrn-prop-id-init.js
     dstr/let-obj-ptrn-prop-id-init-skipped.js
     dstr/let-obj-ptrn-prop-id-init-throws.js
-    dstr/let-obj-ptrn-prop-id-init-unresolvable.js
     dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
@@ -7415,11 +7148,6 @@ language/statements/for-of 482/741 (65.05%)
     dstr/obj-id-init-yield-ident-valid.js non-strict
     dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
-    dstr/obj-id-simple-strict.js strict
-    dstr/obj-prop-elem-init-assignment-missing.js
-    dstr/obj-prop-elem-init-assignment-null.js
-    dstr/obj-prop-elem-init-assignment-truthy.js
-    dstr/obj-prop-elem-init-assignment-undef.js
     dstr/obj-prop-elem-init-evaluation.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
@@ -7428,14 +7156,12 @@ language/statements/for-of 482/741 (65.05%)
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-expr.js
     dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
     dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-expr.js
     dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
     dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
@@ -7472,22 +7198,16 @@ language/statements/for-of 482/741 (65.05%)
     dstr/var-ary-ptrn-elem-ary-elem-init.js
     dstr/var-ary-ptrn-elem-ary-elem-iter.js
     dstr/var-ary-ptrn-elem-ary-elision-init.js
-    dstr/var-ary-ptrn-elem-ary-elision-iter.js
     dstr/var-ary-ptrn-elem-ary-empty-init.js
-    dstr/var-ary-ptrn-elem-ary-empty-iter.js
     dstr/var-ary-ptrn-elem-ary-rest-init.js
     dstr/var-ary-ptrn-elem-ary-rest-iter.js
-    dstr/var-ary-ptrn-elem-id-init-exhausted.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/var-ary-ptrn-elem-id-init-hole.js
     dstr/var-ary-ptrn-elem-id-init-skipped.js
     dstr/var-ary-ptrn-elem-id-init-throws.js
-    dstr/var-ary-ptrn-elem-id-init-undef.js
-    dstr/var-ary-ptrn-elem-id-init-unresolvable.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
     dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
@@ -7521,17 +7241,13 @@ language/statements/for-of 482/741 (65.05%)
     dstr/var-obj-ptrn-id-init-fn-name-gen.js
     dstr/var-obj-ptrn-id-init-skipped.js
     dstr/var-obj-ptrn-id-init-throws.js
-    dstr/var-obj-ptrn-id-init-unresolvable.js
     dstr/var-obj-ptrn-list-err.js
     dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-ary-init.js
     dstr/var-obj-ptrn-prop-ary-value-null.js
     dstr/var-obj-ptrn-prop-eval-err.js
-    dstr/var-obj-ptrn-prop-id-get-value-err.js
-    dstr/var-obj-ptrn-prop-id-init.js
     dstr/var-obj-ptrn-prop-id-init-skipped.js
     dstr/var-obj-ptrn-prop-id-init-throws.js
-    dstr/var-obj-ptrn-prop-id-init-unresolvable.js
     dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
@@ -7599,29 +7315,23 @@ language/statements/for-of 482/741 (65.05%)
     typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
-language/statements/function 230/451 (51.0%)
+language/statements/function 183/451 (40.58%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -7644,99 +7354,72 @@ language/statements/function 230/451 (51.0%)
     dstr/ary-ptrn-rest-id-iter-val-err.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
-    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-ary-init-iter-close.js
+    dstr/dflt-ary-init-iter-get-err.js
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/dflt-ary-init-iter-no-close.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-elem-obj-id.js
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/dflt-ary-ptrn-elision.js
+    dstr/dflt-ary-ptrn-elision-step-err.js
+    dstr/dflt-ary-ptrn-rest-ary-elem.js
+    dstr/dflt-ary-ptrn-rest-ary-elision.js
+    dstr/dflt-ary-ptrn-rest-ary-empty.js
+    dstr/dflt-ary-ptrn-rest-ary-rest.js
+    dstr/dflt-ary-ptrn-rest-id.js
+    dstr/dflt-ary-ptrn-rest-id-direct.js
+    dstr/dflt-ary-ptrn-rest-id-elision.js
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-rest-obj-id.js
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-obj-init-null.js
+    dstr/dflt-obj-init-undefined.js
+    dstr/dflt-obj-ptrn-id-get-value-err.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/dflt-obj-ptrn-id-init-skipped.js
+    dstr/dflt-obj-ptrn-id-init-throws.js
+    dstr/dflt-obj-ptrn-list-err.js
+    dstr/dflt-obj-ptrn-prop-ary.js
+    dstr/dflt-obj-ptrn-prop-ary-init.js
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/dflt-obj-ptrn-prop-eval-err.js
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/dflt-obj-ptrn-prop-obj.js
+    dstr/dflt-obj-ptrn-prop-obj-init.js
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -7746,17 +7429,13 @@ language/statements/function 230/451 (51.0%)
     dstr/obj-ptrn-id-init-fn-name-gen.js
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -7791,66 +7470,51 @@ language/statements/function 230/451 (51.0%)
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
-    dflt-params-abrupt.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    dflt-params-duplicates.js {unsupported: [default-parameters]}
-    dflt-params-ref-later.js {unsupported: [default-parameters]}
-    dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    dflt-params-ref-self.js {unsupported: [default-parameters]}
-    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-duplicates.js non-strict
+    dflt-params-ref-later.js
+    dflt-params-ref-self.js
+    dflt-params-rest.js
     dflt-params-trailing-comma.js
-    enable-strict-via-body.js non-strict
-    enable-strict-via-outer-body.js non-strict
-    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
-    length-dflt.js {unsupported: [default-parameters]}
+    eval-var-scope-syntax-err.js non-strict
+    length-dflt.js
     name-arguments-strict-body.js non-strict
     name-eval-strict-body.js non-strict
     object-destructuring-param-strict-body.js
     param-arguments-strict-body.js non-strict
-    param-dflt-yield-non-strict.js {unsupported: [default-parameters]}
-    param-dflt-yield-strict.js {unsupported: [default-parameters]}
+    param-dflt-yield-non-strict.js non-strict
+    param-dflt-yield-strict.js strict
     param-duplicated-strict-body-1.js non-strict
     param-duplicated-strict-body-2.js non-strict
     param-duplicated-strict-body-3.js non-strict
     param-eval-strict-body.js non-strict
-    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
-    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
+    params-dflt-ref-arguments.js
     rest-param-strict-body.js
     scope-body-lex-distinct.js non-strict
-    scope-param-elem-var-close.js non-strict
-    scope-param-elem-var-open.js non-strict
     scope-param-rest-elem-var-close.js non-strict
     scope-param-rest-elem-var-open.js non-strict
-    scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     static-init-await-binding-valid.js
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 217/266 (81.58%)
+language/statements/generators 179/266 (67.29%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
     dstr/ary-ptrn-elem-ary-val-null.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
@@ -7876,99 +7540,78 @@ language/statements/generators 217/266 (81.58%)
     dstr/ary-ptrn-rest-id-iter-val-err.js
     dstr/ary-ptrn-rest-obj-id.js
     dstr/ary-ptrn-rest-obj-prop-id.js
-    dstr/dflt-ary-init-iter-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-init-iter-no-close.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-name-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-elision-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elem.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-ary-rest.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-direct.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-init-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-id.js {unsupported: [default-parameters]}
-    dstr/dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-init-undefined.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-empty.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-list-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-eval-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-init.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [default-parameters]}
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [default-parameters, object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [default-parameters, object-rest]}
+    dstr/dflt-ary-init-iter-close.js
+    dstr/dflt-ary-init-iter-get-err.js
+    dstr/dflt-ary-init-iter-get-err-array-prototype.js
+    dstr/dflt-ary-init-iter-no-close.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-init.js
+    dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-elision-init.js
+    dstr/dflt-ary-ptrn-elem-ary-empty-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-init.js
+    dstr/dflt-ary-ptrn-elem-ary-rest-iter.js
+    dstr/dflt-ary-ptrn-elem-ary-val-null.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+    dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+    dstr/dflt-ary-ptrn-elem-id-init-hole.js
+    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
+    dstr/dflt-ary-ptrn-elem-id-init-throws.js
+    dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js
+    dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
+    dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-elem-obj-id.js
+    dstr/dflt-ary-ptrn-elem-obj-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id.js
+    dstr/dflt-ary-ptrn-elem-obj-prop-id-init.js
+    dstr/dflt-ary-ptrn-elem-obj-val-null.js
+    dstr/dflt-ary-ptrn-elem-obj-val-undef.js
+    dstr/dflt-ary-ptrn-elision.js
+    dstr/dflt-ary-ptrn-elision-step-err.js
+    dstr/dflt-ary-ptrn-rest-ary-elem.js
+    dstr/dflt-ary-ptrn-rest-ary-elision.js
+    dstr/dflt-ary-ptrn-rest-ary-empty.js
+    dstr/dflt-ary-ptrn-rest-ary-rest.js
+    dstr/dflt-ary-ptrn-rest-id.js
+    dstr/dflt-ary-ptrn-rest-id-direct.js
+    dstr/dflt-ary-ptrn-rest-id-elision.js
+    dstr/dflt-ary-ptrn-rest-id-elision-next-err.js
+    dstr/dflt-ary-ptrn-rest-id-exhausted.js
+    dstr/dflt-ary-ptrn-rest-id-iter-step-err.js
+    dstr/dflt-ary-ptrn-rest-id-iter-val-err.js
+    dstr/dflt-ary-ptrn-rest-obj-id.js
+    dstr/dflt-ary-ptrn-rest-obj-prop-id.js
+    dstr/dflt-obj-init-null.js
+    dstr/dflt-obj-init-undefined.js
+    dstr/dflt-obj-ptrn-id-get-value-err.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+    dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+    dstr/dflt-obj-ptrn-id-init-skipped.js
+    dstr/dflt-obj-ptrn-id-init-throws.js
+    dstr/dflt-obj-ptrn-id-init-unresolvable.js
+    dstr/dflt-obj-ptrn-list-err.js
+    dstr/dflt-obj-ptrn-prop-ary.js
+    dstr/dflt-obj-ptrn-prop-ary-init.js
+    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/dflt-obj-ptrn-prop-ary-value-null.js
+    dstr/dflt-obj-ptrn-prop-eval-err.js
+    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
+    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
+    dstr/dflt-obj-ptrn-prop-id-init-throws.js
+    dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js
+    dstr/dflt-obj-ptrn-prop-obj.js
+    dstr/dflt-obj-ptrn-prop-obj-init.js
+    dstr/dflt-obj-ptrn-prop-obj-value-null.js
+    dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -7986,7 +7629,6 @@ language/statements/generators 217/266 (81.58%)
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
@@ -7999,39 +7641,28 @@ language/statements/generators 217/266 (81.58%)
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1 2/2 (100.0%)
     arguments-with-arguments-fn.js non-strict
-    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
     default-proto.js
-    dflt-params-abrupt.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [default-parameters]}
-    dflt-params-arg-val-undefined.js {unsupported: [default-parameters]}
-    dflt-params-duplicates.js {unsupported: [default-parameters]}
-    dflt-params-ref-later.js {unsupported: [default-parameters]}
-    dflt-params-ref-prior.js {unsupported: [default-parameters]}
-    dflt-params-ref-self.js {unsupported: [default-parameters]}
-    dflt-params-rest.js {unsupported: [default-parameters]}
+    dflt-params-abrupt.js
+    dflt-params-duplicates.js non-strict
+    dflt-params-ref-later.js
+    dflt-params-ref-self.js
+    dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js {unsupported: [default-parameters]}
-    generator-created-after-decl-inst.js
+    eval-var-scope-syntax-err.js non-strict
     has-instance.js
     invoke-as-constructor.js
-    length-dflt.js {unsupported: [default-parameters]}
+    length-dflt.js
     object-destructuring-param-strict-body.js
-    param-dflt-yield.js {unsupported: [default-parameters]}
-    params-dflt-args-unmapped.js {unsupported: [default-parameters]}
-    params-dflt-ref-arguments.js {unsupported: [default-parameters]}
     prototype-own-properties.js
     prototype-relation-to-function.js
     prototype-value.js
     rest-param-strict-body.js
     restricted-properties.js
     scope-body-lex-distinct.js non-strict
-    scope-param-elem-var-close.js non-strict
-    scope-param-elem-var-open.js non-strict
     scope-param-rest-elem-var-close.js non-strict
     scope-param-rest-elem-var-open.js non-strict
-    scope-paramsbody-var-close.js
     scope-paramsbody-var-open.js
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
@@ -8107,29 +7738,23 @@ language/statements/labeled 15/24 (62.5%)
     value-yield-non-strict.js non-strict
     value-yield-non-strict-escaped.js non-strict
 
-language/statements/let 101/145 (69.66%)
+language/statements/let 91/145 (62.76%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -8161,17 +7786,13 @@ language/statements/let 101/145 (69.66%)
     dstr/obj-ptrn-id-init-fn-name-gen.js
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -8394,29 +8015,23 @@ language/statements/try 113/201 (56.22%)
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable 95/178 (53.37%)
+language/statements/variable 85/178 (47.75%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
     dstr/ary-ptrn-elem-ary-elem-init.js
     dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
     dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
     dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -8450,17 +8065,13 @@ language/statements/variable 95/178 (53.37%)
     dstr/obj-ptrn-id-init-fn-name-gen.js
     dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
     dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js


### PR DESCRIPTION
Adds support for default values in function parameters and default values in destructuring assignment.

What's not implemented yet, that I plan to implement subsequently:

- Destructuring with defaults in for loops (eg: for (let {x = 2} = {}; ; ))
- Reading [Symbol.iterator] from default array/object
- Nested Literals

(Added ignored tests for these in DefaultParametersTest)

(same changes as https://github.com/mozilla/rhino/pull/1481, but squashed and on top of master)

