### PR TITLE
Begin to use invokedynamic in the bytecode

### DIFF
--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -12,5 +12,6 @@ module org.mozilla.rhino {
     exports org.mozilla.javascript.xml;
 
     requires java.compiler;
+    requires jdk.dynalink;
     requires transitive java.desktop;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1367,15 +1367,15 @@ class BodyCodegen {
                 generateExpression(child.getNext(), node); // id
                 cfw.addALoad(contextLocal);
                 if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1) {
-                    addScriptRuntimeInvoke(
-                            "getObjectIndex",
+                    addDynamicInvoke(
+                            "PROP:GETINDEX",
                             "(Ljava/lang/Object;D"
                                     + "Lorg/mozilla/javascript/Context;"
                                     + ")Ljava/lang/Object;");
                 } else {
                     cfw.addALoad(variableObjectLocal);
-                    addScriptRuntimeInvoke(
-                            "getObjectElem",
+                    addDynamicInvoke(
+                            "PROP:GETELEMENT",
                             "(Ljava/lang/Object;"
                                     + "Ljava/lang/Object;"
                                     + "Lorg/mozilla/javascript/Context;"
@@ -1707,13 +1707,10 @@ class BodyCodegen {
             unnestedYieldCount++;
             cfw.addALoad(variableObjectLocal);
             cfw.add(ByteCode.SWAP);
-            cfw.addLoadConstant(nn);
-            cfw.add(ByteCode.SWAP);
             cfw.addALoad(contextLocal);
-
-            addScriptRuntimeInvoke(
-                    "setObjectProp",
-                    "(Lorg/mozilla/javascript/Scriptable;Ljava/lang/String;Ljava/lang/Object;"
+            addDynamicInvoke(
+                    "PROP:SET:" + nn,
+                    "(Lorg/mozilla/javascript/Scriptable;Ljava/lang/Object;"
                             + "Lorg/mozilla/javascript/Context;)Ljava/lang/Object;");
             cfw.add(ByteCode.POP);
 
@@ -3887,14 +3884,12 @@ class BodyCodegen {
         }
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        cfw.addPush(name);
-        addScriptRuntimeInvoke(
-                "setName",
+        addDynamicInvoke(
+                "NAME:SET:" + name,
                 "(Lorg/mozilla/javascript/Scriptable;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
-                        + "Ljava/lang/String;"
                         + ")Ljava/lang/Object;");
     }
 
@@ -3906,14 +3901,12 @@ class BodyCodegen {
         }
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        cfw.addPush(name);
-        addScriptRuntimeInvoke(
-                "strictSetName",
+        addDynamicInvoke(
+                "NAME:SETSTRICT:" + name,
                 "(Lorg/mozilla/javascript/Scriptable;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
-                        + "Ljava/lang/String;"
                         + ")Ljava/lang/Object;");
     }
 
@@ -3924,13 +3917,11 @@ class BodyCodegen {
             child = child.getNext();
         }
         cfw.addALoad(contextLocal);
-        cfw.addPush(name);
-        addScriptRuntimeInvoke(
-                "setConst",
+        addDynamicInvoke(
+                "NAME:SETCONST:" + name,
                 "(Lorg/mozilla/javascript/Scriptable;"
                         + "Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Ljava/lang/String;"
                         + ")Ljava/lang/Object;");
     }
 
@@ -4146,8 +4137,8 @@ class BodyCodegen {
                 cfw.add(ByteCode.DUP2_X1);
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectIndex",
+                addDynamicInvoke(
+                        "PROP:GETINDEX",
                         "(Ljava/lang/Object;D"
                                 + "Lorg/mozilla/javascript/Context;"
                                 + "Lorg/mozilla/javascript/Scriptable;"
@@ -4158,8 +4149,8 @@ class BodyCodegen {
                 cfw.add(ByteCode.DUP_X1);
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectElem",
+                addDynamicInvoke(
+                        "PROP:GETELEMENT",
                         "(Ljava/lang/Object;"
                                 + "Ljava/lang/Object;"
                                 + "Lorg/mozilla/javascript/Context;"
@@ -4171,8 +4162,8 @@ class BodyCodegen {
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
         if (indexIsNumber) {
-            addScriptRuntimeInvoke(
-                    "setObjectIndex",
+            addDynamicInvoke(
+                    "PROP:SETINDEX",
                     "(Ljava/lang/Object;"
                             + "D"
                             + "Ljava/lang/Object;"
@@ -4180,8 +4171,8 @@ class BodyCodegen {
                             + "Lorg/mozilla/javascript/Scriptable;"
                             + ")Ljava/lang/Object;");
         } else {
-            addScriptRuntimeInvoke(
-                    "setObjectElem",
+            addDynamicInvoke(
+                    "PROP:SETELEMENT",
                     "(Ljava/lang/Object;"
                             + "Ljava/lang/Object;"
                             + "Ljava/lang/Object;"

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -984,8 +984,8 @@ class BodyCodegen {
 
             case Token.NAME:
                 {
-                    cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
+                    cfw.addALoad(contextLocal);
                     addDynamicInvoke("NAME:GET:" + node.getString(), Signatures.NAME_GET);
                 }
                 break;
@@ -1473,8 +1473,8 @@ class BodyCodegen {
                         child = child.getNext();
                     }
                     // Generate code for "ScriptRuntime.bind(varObj, "s")"
-                    cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
+                    cfw.addALoad(contextLocal);
                     addDynamicInvoke("NAME:BIND:" + node.getString(), Signatures.NAME_BIND);
                 }
                 break;
@@ -2644,8 +2644,8 @@ class BodyCodegen {
             case Token.NAME:
                 {
                     String name = node.getString();
-                    cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
+                    cfw.addALoad(contextLocal);
                     addDynamicInvoke("NAME:GETWITHTHIS:" + name, Signatures.NAME_GET_THIS);
                     break;
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1664,14 +1664,11 @@ class BodyCodegen {
         if (unnestedYields.containsKey(node)) {
             // Yield was previously moved up via the "nestedYield" code below.
             if (exprContext) {
+                String name = unnestedYields.get(node);
                 cfw.addALoad(variableObjectLocal);
-                cfw.addLoadConstant(unnestedYields.get(node));
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "getObjectPropNoWarn",
-                        "(Ljava/lang/Object;Ljava/lang/String;Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;");
+                addDynamicInvoke("PROP:GETNOWARN:" + name, Signatures.PROP_GET_NOWARN);
             }
             return;
         }
@@ -1689,14 +1686,9 @@ class BodyCodegen {
             unnestedYieldCount++;
             cfw.addALoad(variableObjectLocal);
             cfw.add(ByteCode.SWAP);
-            cfw.addLoadConstant(nn);
-            cfw.add(ByteCode.SWAP);
             cfw.addALoad(contextLocal);
-
-            addScriptRuntimeInvoke(
-                    "setObjectProp",
-                    "(Lorg/mozilla/javascript/Scriptable;Ljava/lang/String;Ljava/lang/Object;"
-                            + "Lorg/mozilla/javascript/Context;)Ljava/lang/Object;");
+            cfw.addALoad(variableObjectLocal);
+            addDynamicInvoke("PROP:SET:" + nn, Signatures.PROP_SET);
             cfw.add(ByteCode.POP);
 
             unnestedYields.put(nestedYield, nn);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -61,34 +61,69 @@ public class Bootstrapper {
         if ("PROP".equals(namespaceName)) {
             switch (opName) {
                 case "GET":
+                    // Get an object property with a constant name
                     return StandardOperation.GET
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
                 case "GETNOWARN":
+                    // Same with no warning of strict mode
                     return RhinoOperation.GETNOWARN
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
                 case "GETWITHTHIS":
+                    // Same but also return "this" so that it is found by "lastStoredScriptable"
                     return RhinoOperation.GETWITHTHIS
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
+                case "GETELEMENT":
+                    // Get the value of an element from a property that is on the stack,\
+                    // as if using "[]" notation. Could be a String, number, or Symbol
+                    return RhinoOperation.GETELEMENT.withNamespace(StandardNamespace.PROPERTY);
+                case "GETINDEX":
+                    // Same but the value is definitely a numeric index
+                    return RhinoOperation.GETINDEX.withNamespace(StandardNamespace.PROPERTY);
                 case "SET":
+                    // Set an object property with a constant name
                     return StandardOperation.SET
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
+                case "SETELEMENT":
+                    // Set an object property as if by "[]", with a property on the stack
+                    return RhinoOperation.SETELEMENT.withNamespace(StandardNamespace.PROPERTY);
+                case "SETINDEX":
+                    // Same but the property name is definitely a number
+                    return RhinoOperation.SETINDEX.withNamespace(StandardNamespace.PROPERTY);
             }
         } else if ("NAME".equals(namespaceName)) {
             switch (opName) {
                 case "BIND":
+                    // Bind a new variable to the context with a constant name
                     return RhinoOperation.BIND
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
                 case "GET":
+                    // Get a variable from the context with a constant name
                     return StandardOperation.GET
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
                 case "GETWITHTHIS":
+                    // Same but also return "this" so that it is found by "lastStoredScriptable"
                     return RhinoOperation.GETWITHTHIS
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SET":
+                    // Set an object in the context with a constant name
+                    return StandardOperation.SET
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SETSTRICT":
+                    // Same but implement strict mode checks
+                    return RhinoOperation.SETSTRICT
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SETCONST":
+                    // Same but try to set a constant
+                    return RhinoOperation.SETCONST
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
             }
@@ -101,10 +136,9 @@ public class Bootstrapper {
 
     // Given a list of name segments and a position, return the interned name at the
     // specified position.
-    private static String getNameSegment(String[] segments, String name, int pos)
-            throws NoSuchMethodException {
+    private static String getNameSegment(String[] segments, String name, int pos) {
         if (pos >= segments.length) {
-            throw new NoSuchMethodException(name);
+            return "";
         }
         // Because segments of operation names, especially property names, are essentially
         // wired in to the bootstrapping result, interning works and has a big impact on

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -1,0 +1,114 @@
+package org.mozilla.javascript.optimizer;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.regex.Pattern;
+import jdk.dynalink.CallSiteDescriptor;
+import jdk.dynalink.DynamicLinker;
+import jdk.dynalink.DynamicLinkerFactory;
+import jdk.dynalink.Operation;
+import jdk.dynalink.StandardNamespace;
+import jdk.dynalink.StandardOperation;
+import jdk.dynalink.support.SimpleRelinkableCallSite;
+import org.mozilla.classfile.ByteCode;
+import org.mozilla.classfile.ClassFileWriter;
+
+/**
+ * The Bootstrapper contains the method that is called by invokedynamic instructions in the bytecode
+ * to map a call site to a method.
+ */
+public class Bootstrapper {
+    private static final Pattern SEPARATOR = Pattern.compile(":");
+
+    public static final ClassFileWriter.MHandle BOOTSTRAP_HANDLE =
+            new ClassFileWriter.MHandle(
+                    ByteCode.MH_INVOKESTATIC,
+                    "org.mozilla.javascript.optimizer.Bootstrapper",
+                    "bootstrap",
+                    "(Ljava/lang/invoke/MethodHandles$Lookup;"
+                            + "Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;");
+
+    private static final DynamicLinker linker;
+
+    static {
+        // Set up the linkers that will be invoked whenever a call site needs to be resolved.
+        DynamicLinkerFactory factory = new DynamicLinkerFactory();
+        factory.setPrioritizedLinkers(new DefaultLinker());
+        linker = factory.createLinker();
+    }
+
+    /** This is the method called by every call site in the bytecode to map it to a function. */
+    @SuppressWarnings("unused")
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType mType)
+            throws NoSuchMethodException, IllegalAccessException {
+        Operation op = parseOperation(name);
+        // For now, use a very simple call site.
+        // When we change to add more linkers, we will likely switch to ChainedCallSite.
+        return linker.link(new SimpleRelinkableCallSite(new CallSiteDescriptor(lookup, op, mType)));
+    }
+
+    /**
+     * Operation names in the bytecode are names like "PROP:GET:<NAME> and "NAME:BIND:<NAME>". This
+     * translates them the first time a call site is seen to an object that can be easily consumed
+     * by the various types of linkers.
+     */
+    private static Operation parseOperation(String name) throws NoSuchMethodException {
+        String[] tokens = SEPARATOR.split(name, -1);
+        String namespaceName = getNameSegment(tokens, name, 0);
+        String opName = getNameSegment(tokens, name, 1);
+
+        if ("PROP".equals(namespaceName)) {
+            switch (opName) {
+                case "GET":
+                    return StandardOperation.GET
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETNOWARN":
+                    return RhinoOperation.GETNOWARN
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETWITHTHIS":
+                    return RhinoOperation.GETWITHTHIS
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "SET":
+                    return StandardOperation.SET
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+            }
+        } else if ("NAME".equals(namespaceName)) {
+            switch (opName) {
+                case "BIND":
+                    return RhinoOperation.BIND
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GET":
+                    return StandardOperation.GET
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETWITHTHIS":
+                    return RhinoOperation.GETWITHTHIS
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+            }
+        }
+
+        // Fall through to no match. This should only happen if the name in the bytecode
+        // does not match the pattern that this method understands.
+        throw new NoSuchMethodException(name);
+    }
+
+    // Given a list of name segments and a position, return the interned name at the
+    // specified position.
+    private static String getNameSegment(String[] segments, String name, int pos)
+            throws NoSuchMethodException {
+        if (pos >= segments.length) {
+            throw new NoSuchMethodException(name);
+        }
+        // Because segments of operation names, especially property names, are essentially
+        // wired in to the bootstrapping result, interning works and has a big impact on
+        // performance.
+        return segments[pos].intern();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -16,8 +16,9 @@ import org.mozilla.classfile.ClassFileWriter;
 
 /**
  * The Bootstrapper contains the method that is called by invokedynamic instructions in the bytecode
- * to map a call site to a method.
+ * to map a call site to a method. We should never go down this entire code path on Android.
  */
+@SuppressWarnings("AndroidJdkLibsChecker")
 public class Bootstrapper {
     private static final Pattern SEPARATOR = Pattern.compile(":");
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -1,0 +1,160 @@
+package org.mozilla.javascript.optimizer;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import jdk.dynalink.NamedOperation;
+import jdk.dynalink.NamespaceOperation;
+import jdk.dynalink.Operation;
+import jdk.dynalink.StandardNamespace;
+import jdk.dynalink.StandardOperation;
+import jdk.dynalink.linker.GuardedInvocation;
+import jdk.dynalink.linker.GuardingDynamicLinker;
+import jdk.dynalink.linker.LinkRequest;
+import jdk.dynalink.linker.LinkerServices;
+import org.mozilla.javascript.ScriptRuntime;
+
+/**
+ * This linker is the last one in the chain, and as such it must be able to link every type of
+ * operation that we support. It links every operation to the corresponding ScriptRuntime or
+ * OptRuntime operation that was used in the bytecode before we introduced dynamic linking.
+ */
+class DefaultLinker implements GuardingDynamicLinker {
+    static final boolean DEBUG;
+
+    static {
+        String debugVal = System.getProperty("RHINO_DEBUG_LINKER");
+        if (debugVal == null) {
+            debugVal = System.getenv("RHINO_DEBUG_LINKER");
+        }
+        DEBUG = Boolean.parseBoolean(debugVal);
+    }
+
+    @Override
+    public GuardedInvocation getGuardedInvocation(LinkRequest req, LinkerServices svc)
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Operation rootOp = req.getCallSiteDescriptor().getOperation();
+        MethodType mType = req.getCallSiteDescriptor().getMethodType();
+
+        // So far, every operation in our application is a NamedOperation, but if
+        // we add non-named operations in the future, this will still work because
+        // "getName" will return an empty string and "Op" will return "rootOp".
+        String name = getName(rootOp);
+        Operation op = NamedOperation.getBaseOperation(rootOp);
+
+        // In our application, every operation has a namespace.
+        if (!(op instanceof NamespaceOperation)) {
+            throw new UnsupportedOperationException(op.toString());
+        }
+        NamespaceOperation nsOp = (NamespaceOperation) op;
+        op = NamespaceOperation.getBaseOperation(op);
+
+        GuardedInvocation invocation = getInvocation(lookup, mType, rootOp, nsOp, op, name);
+        if (DEBUG) {
+            System.out.println(rootOp + ": default link");
+        }
+        return invocation;
+    }
+
+    private GuardedInvocation getInvocation(
+            MethodHandles.Lookup lookup,
+            MethodType mType,
+            Operation rootOp,
+            NamespaceOperation nsOp,
+            Operation op,
+            String name)
+            throws NoSuchMethodException, IllegalAccessException {
+        if (nsOp.contains(StandardNamespace.PROPERTY)) {
+            return getPropertyInvocation(lookup, mType, rootOp, op, name);
+        } else if (nsOp.contains(RhinoNamespace.NAME)) {
+            return getNameInvocation(lookup, mType, rootOp, op, name);
+        }
+        throw new UnsupportedOperationException(rootOp.toString());
+    }
+
+    private GuardedInvocation getPropertyInvocation(
+            MethodHandles.Lookup lookup,
+            MethodType mType,
+            Operation rootOp,
+            Operation op,
+            String name)
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodType tt;
+        MethodHandle mh = null;
+
+        // The name of the property to look up is now not on the Java stack,
+        // but was passed as part of the operation name in the bytecode.
+        // Put the property name back in the right place in the parameter list
+        // so that we can invoke the operation normally.
+        if (StandardOperation.GET.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getObjectProp", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        } else if (RhinoOperation.GETNOWARN.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getObjectPropNoWarn", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        } else if (RhinoOperation.GETWITHTHIS.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getPropFunctionAndThis", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        } else if (StandardOperation.SET.equals(op)) {
+            tt = mType.insertParameterTypes(1, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "setObjectProp", tt);
+            mh = MethodHandles.insertArguments(mh, 1, name);
+        }
+
+        if (mh != null) {
+            return new GuardedInvocation(mh);
+        }
+        // We will only get here if a new operation was introduced
+        // without appropriate changes. This particular linker must never return null.
+        throw new UnsupportedOperationException(rootOp.toString());
+    }
+
+    private GuardedInvocation getNameInvocation(
+            MethodHandles.Lookup lookup,
+            MethodType mType,
+            Operation rootOp,
+            Operation op,
+            String name)
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodType tt;
+        MethodHandle mh = null;
+
+        // Like above for properties, the name to handle is not on the Java stack,
+        // but is something that we parsed from the name of the invokedynamic operation.
+        if (RhinoOperation.BIND.equals(op)) {
+            tt = mType.insertParameterTypes(2, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "bind", tt);
+            mh = MethodHandles.insertArguments(mh, 2, name);
+        } else if (StandardOperation.GET.equals(op)) {
+            tt = mType.insertParameterTypes(2, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "name", tt);
+            mh = MethodHandles.insertArguments(mh, 2, name);
+        } else if (RhinoOperation.GETWITHTHIS.equals(op)) {
+            tt = mType.insertParameterTypes(0, String.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getNameFunctionAndThis", tt);
+            mh = MethodHandles.insertArguments(mh, 0, name);
+        }
+
+        if (mh != null) {
+            return new GuardedInvocation(mh);
+        }
+        throw new UnsupportedOperationException(rootOp.toString());
+    }
+
+    // If the operation is a named operation, then return the name,
+    // or the empty string if it's not.
+    static String getName(Operation op) {
+        Object nameObj = NamedOperation.getName(op);
+        if (nameObj instanceof String) {
+            return (String) nameObj;
+        } else if (nameObj != null) {
+            throw new UnsupportedOperationException(op.toString());
+        } else {
+            return "";
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -19,6 +19,7 @@ import org.mozilla.javascript.ScriptRuntime;
  * operation that we support. It links every operation to the corresponding ScriptRuntime or
  * OptRuntime operation that was used in the bytecode before we introduced dynamic linking.
  */
+@SuppressWarnings("AndroidJdkLibsChecker")
 class DefaultLinker implements GuardingDynamicLinker {
     static final boolean DEBUG;
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoNamespace.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoNamespace.java
@@ -1,0 +1,11 @@
+package org.mozilla.javascript.optimizer;
+
+import jdk.dynalink.Namespace;
+
+/**
+ * A list of namespaces for operations that are specific to Rhino, on top of standard namespaces
+ * like "Property".
+ */
+public enum RhinoNamespace implements Namespace {
+    NAME,
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoNamespace.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoNamespace.java
@@ -6,6 +6,7 @@ import jdk.dynalink.Namespace;
  * A list of namespaces for operations that are specific to Rhino, on top of standard namespaces
  * like "Property".
  */
+@SuppressWarnings("AndroidJdkLibsChecker")
 public enum RhinoNamespace implements Namespace {
     NAME,
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -1,0 +1,14 @@
+package org.mozilla.javascript.optimizer;
+
+import jdk.dynalink.Operation;
+
+/**
+ * A list of operation types used that are specific to Rhino, in addition to standard operations
+ * like GET and SET...
+ */
+public enum RhinoOperation implements Operation {
+    BIND,
+    GETNOWARN,
+    GETWITHTHIS,
+    SETSTRICT,
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -10,5 +10,10 @@ public enum RhinoOperation implements Operation {
     BIND,
     GETNOWARN,
     GETWITHTHIS,
+    GETELEMENT,
+    GETINDEX,
     SETSTRICT,
+    SETCONST,
+    SETELEMENT,
+    SETINDEX,
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -6,6 +6,7 @@ import jdk.dynalink.Operation;
  * A list of operation types used that are specific to Rhino, in addition to standard operations
  * like GET and SET...
  */
+@SuppressWarnings("AndroidJdkLibsChecker")
 public enum RhinoOperation implements Operation {
     BIND,
     GETNOWARN,

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -1,0 +1,143 @@
+package org.mozilla.javascript.optimizer;
+
+/**
+ * This class defines the method signatures for the properties used by the invokedynamic
+ * instructions in the bytecode. This helps us identify what each bytecode operation means, and what
+ * the method signature should be.
+ */
+interface Signatures {
+    /**
+     * PROP:GET:{name}: Looks up the object property named "name". Falls back to
+     * ScriptRuntime.getObjectPropNoWarn.
+     */
+    String PROP_GET =
+            "(Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * PROP:GETNOWARN:{name}: Looks up the object property named "name" and does not warn if it does
+     * not exist. Falls back to ScriptRuntime.getObjectProp.
+     */
+    String PROP_GET_NOWARN =
+            "(Ljava/lang/Object;Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;";
+
+    /**
+     * PROP:GETWITHTHIS:{name}: Looks up an object property like PROP:GET, and sets "this" in the
+     * "last stored scriptable." Falls back to ScriptRuntime.getPropFunctionAndThis.
+     */
+    String PROP_GET_THIS =
+            "(Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Lorg/mozilla/javascript/Callable;";
+
+    /**
+     * PROP:GETINDEX: Get a property from an object based on a numeric index. Falls back to
+     * ScriptRuntime.getObjectIndex.
+     */
+    String PROP_GET_INDEX =
+            "(Ljava/lang/Object;D"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;";
+
+    /**
+     * PROP:GETELEMENT: Get a property from an object based on an element ID, which could be a
+     * string, number, or symbol. Falls back to ScriptRuntime.getObjectElem.
+     */
+    String PROP_GET_ELEMENT =
+            "(Ljava/lang/Object;"
+                    + "Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * PROP:SET:{name}: Sets the named property on an object. Falls back to
+     * ScriptRuntime.setObjectProp.
+     */
+    String PROP_SET =
+            "(Ljava/lang/Object;Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;";
+
+    /**
+     * PROP:SETINDEX: Set a property on an object based on a numeric index. Falls back to
+     * ScriptRuntime.setObjectIndex.
+     */
+    String PROP_SET_INDEX =
+            "(Ljava/lang/Object;"
+                    + "D"
+                    + "Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * PROP:SETELEMENT: Set a property on an object based on an identifier. Falls back to
+     * ScriptRuntime.setObjectElem.
+     */
+    String PROP_SET_ELEMENT =
+            "(Ljava/lang/Object;"
+                    + "Ljava/lang/Object;"
+                    + "Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * NAME:GET:{name}: Looks up a the named value from the scope. Falls back to ScriptRuntime.name.
+     */
+    String NAME_GET =
+            "(Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * NAME:GETWITHTHIS:{name}: Looks up a name in the scope like NAME:GET, and sets "this" in the
+     * "last stored scriptable." Falls back to ScriptRuntime.getNameFunctionAndThis.
+     */
+    String NAME_GET_THIS =
+            "(Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Lorg/mozilla/javascript/Callable;";
+
+    /** NAME:SET:{name}: Sets the named value in the scope. Falls back to ScriptRuntime.setName. */
+    String NAME_SET =
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * NAME:BIND:{name}: Bind the named value into the current scope. Falls back to
+     * ScriptRuntime.bind.
+     */
+    String NAME_BIND =
+            "(Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Lorg/mozilla/javascript/Scriptable;";
+
+    /**
+     * NAME:SETSTRICT:{name}: Sets the named value in the scope, and enforces strict mode. Falls
+     * back to ScriptRuntime.strictSetName.
+     */
+    String NAME_SET_STRICT =
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * NAME:SETCONST:{name}: Sets the named constant in the scope. Falls back to
+     * ScriptRuntime.setConst.
+     */
+    String NAME_SET_CONST =
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + ")Ljava/lang/Object;";
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -3,7 +3,9 @@ package org.mozilla.javascript.optimizer;
 /**
  * This class defines the method signatures for the properties used by the invokedynamic
  * instructions in the bytecode. This helps us identify what each bytecode operation means, and what
- * the method signature should be.
+ * the method signature should be. The method signatures here don't necessarily map 1:1 with
+ * ScriptRuntime operations -- the runtime will insert the value of the "name" part of the operation
+ * name before making the call.
  */
 interface Signatures {
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -5,7 +5,9 @@ package org.mozilla.javascript.optimizer;
  * instructions in the bytecode. This helps us identify what each bytecode operation means, and what
  * the method signature should be. The method signatures here don't necessarily map 1:1 with
  * ScriptRuntime operations -- the runtime will insert the value of the "name" part of the operation
- * name before making the call.
+ * name before making the call. Also, many of the "name" operations have a different signature than
+ * the ScriptRuntime equivalents because in these signatures we are trying to make the "target" of
+ * each operation the first argument to make future optimizations easier.
  */
 interface Signatures {
     /**
@@ -92,8 +94,8 @@ interface Signatures {
      * NAME:GET:{name}: Looks up a the named value from the scope. Falls back to ScriptRuntime.name.
      */
     String NAME_GET =
-            "(Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/Context;"
                     + ")Ljava/lang/Object;";
 
     /**
@@ -101,8 +103,8 @@ interface Signatures {
      * "last stored scriptable." Falls back to ScriptRuntime.getNameFunctionAndThis.
      */
     String NAME_GET_THIS =
-            "(Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/Context;"
                     + ")Lorg/mozilla/javascript/Callable;";
 
     /** NAME:SET:{name}: Sets the named value in the scope. Falls back to ScriptRuntime.setName. */
@@ -118,8 +120,8 @@ interface Signatures {
      * ScriptRuntime.bind.
      */
     String NAME_BIND =
-            "(Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/Context;"
                     + ")Lorg/mozilla/javascript/Scriptable;";
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -92,6 +92,9 @@ interface Signatures {
 
     /**
      * NAME:GET:{name}: Looks up a the named value from the scope. Falls back to ScriptRuntime.name.
+     * Compared to that function, this version of the signature puts the "scope" first in the
+     * argument list rather than second. This makes it easier for future linkers to work because
+     * they can always assume that the "receiver" of an operation is the first argument.
      */
     String NAME_GET =
             "(Lorg/mozilla/javascript/Scriptable;"
@@ -100,7 +103,8 @@ interface Signatures {
 
     /**
      * NAME:GETWITHTHIS:{name}: Looks up a name in the scope like NAME:GET, and sets "this" in the
-     * "last stored scriptable." Falls back to ScriptRuntime.getNameFunctionAndThis.
+     * "last stored scriptable." Falls back to ScriptRuntime.getNameFunctionAndThis. Also, this
+     * version of the signature makes the scope the first argument, as described above.
      */
     String NAME_GET_THIS =
             "(Lorg/mozilla/javascript/Scriptable;"
@@ -117,7 +121,9 @@ interface Signatures {
 
     /**
      * NAME:BIND:{name}: Bind the named value into the current scope. Falls back to
-     * ScriptRuntime.bind.
+     * ScriptRuntime.bind. Like some methods above, this version of the signature puts the scope
+     * first in the argument list so that future linkers can have a consistent place to find the
+     * "receiver".
      */
     String NAME_BIND =
             "(Lorg/mozilla/javascript/Scriptable;"


### PR DESCRIPTION
This begins to use invokedynamic instructions in Rhino's bytecode.

It replaces the operations that call the ScriptRuntime operations for
common property operations like setting and getting properties and
elements, and common context operations like setting and getting variables,
with invokedynamic instructions.

It also adds components that will wire up those invokedynamic instructions
to the appropriate ScriptRuntime operations using the Dynalink package.

The result should be that Rhino behaves exactly the same and performs the
same as well.

However, once this is implemented we can begin to create additional dynalink
"linkers" that do specific things to optimize performance based on what is
happening at runtime.