### PR TITLE
Updated: Implement Symbol.prototype.description

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -35,7 +35,7 @@ public class LambdaConstructor extends LambdaFunction {
     public static final int CONSTRUCTOR_DEFAULT = CONSTRUCTOR_FUNCTION | CONSTRUCTOR_NEW;
 
     // Lambdas should not be serialized.
-    private final transient Constructable targetConstructor;
+    protected final transient Constructable targetConstructor;
     private final int flags;
 
     /**
@@ -125,6 +125,23 @@ public class LambdaConstructor extends LambdaFunction {
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
+        f.setStandardPropertyAttributes(propertyAttributes);
+        ScriptableObject proto = getPrototypeScriptable();
+        proto.defineProperty(name, f, attributes);
+    }
+
+    /**
+     * Define a function property on the prototype of the constructor using a LambdaFunction under
+     * the covers.
+     */
+    public void definePrototypeMethod(
+            Scriptable scope,
+            SymbolKey name,
+            int length,
+            Callable target,
+            int attributes,
+            int propertyAttributes) {
+        LambdaFunction f = new LambdaFunction(scope, "[" + name.getName() + "]", length, target);
         f.setStandardPropertyAttributes(propertyAttributes);
         ScriptableObject proto = getPrototypeScriptable();
         proto.defineProperty(name, f, attributes);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -87,7 +87,7 @@ public class LambdaConstructor extends LambdaFunction {
             throw ScriptRuntime.typeErrorById("msg.constructor.no.function", getFunctionName());
         }
         if (target == null) {
-            return targetConstructor.construct(cx, scope, args);
+            return fireConstructor(cx, scope, args);
         }
         return target.call(cx, scope, thisObj, args);
     }
@@ -97,6 +97,10 @@ public class LambdaConstructor extends LambdaFunction {
         if ((flags & CONSTRUCTOR_NEW) == 0) {
             throw ScriptRuntime.typeErrorById("msg.no.new", getFunctionName());
         }
+        return fireConstructor(cx, scope, args);
+    }
+
+    private Scriptable fireConstructor(Context cx, Scriptable scope, Object[] args) {
         Scriptable obj = targetConstructor.construct(cx, scope, args);
         obj.setPrototype(getClassPrototype());
         obj.setParentScope(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -41,7 +41,9 @@ public class LambdaConstructor extends LambdaFunction {
     /**
      * Create a new function that may be used as a constructor. The new object will have the
      * Function prototype and no parent. The caller is responsible for binding this object to the
-     * appropriate scope.
+     * appropriate scope. The new constructor function can be invoked using "new" or by calling it
+     * directly, and in either case will result in a new object being returned and wired to the
+     * correct prototype and scope.
      *
      * @param scope scope of the calling context
      * @param name name of the function
@@ -56,8 +58,18 @@ public class LambdaConstructor extends LambdaFunction {
     }
 
     /**
-     * Create a new function and control whether it may be invoked using new, as a function, or
-     * both.
+     * Create a new function that may be used as a constructor. The new object will have the
+     * Function prototype and no parent. The caller is responsible for binding this object to the
+     * appropriate scope. The "flags" argument controls whether the function may be invoked using
+     * "new," via a direct call, or both. If allowed by the flags, then the constructor will have
+     * the same effect either way. If not allowed by the flags, then a TypeError will be thrown.
+     *
+     * @param scope scope of the calling context
+     * @param name name of the function
+     * @param length the arity of the function
+     * @param flags which may be a combination of CONSTRUCTOR_NEW and CONSTRUCTOR_FUNCTION
+     * @param target an object that implements the function in Java. Since Constructable is a
+     *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaConstructor(
             Scriptable scope, String name, int length, int flags, Constructable target) {
@@ -67,8 +79,19 @@ public class LambdaConstructor extends LambdaFunction {
     }
 
     /**
-     * Create a new constructor that may be called using new or as a function, and exhibits
-     * different behavior for each.
+     * Create a new function that may be used as a constructor. The new object will have the
+     * Function prototype and no parent. The caller is responsible for binding this object to the
+     * appropriate scope. The new constructor function will have different behavior depending on
+     * whether it is invoked via "new" or via a direct call. In the case of "new", a new object with
+     * a prototype and scope chain be returned, but in the case of a direct call, the user must
+     * implement whatever they need. This is typically used in the case of functions like the native
+     * Date constructor, which has totally different behavior depending on how it's invoked.
+     *
+     * @param scope scope of the calling context
+     * @param name name of the function
+     * @param length the arity of the function
+     * @param target an object that implements the function in Java. Since Constructable is a
+     *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaConstructor(
             Scriptable scope,
@@ -162,15 +185,22 @@ public class LambdaConstructor extends LambdaFunction {
         proto.defineProperty(key, value, attributes);
     }
 
+    /**
+     * Define a property on the prototype using a function. The function will be wired to a
+     * JavaScript function, so the resulting property will look just like one that was defined using
+     * "Object.defineOwnProperty" with a property descriptor.
+     */
     public void definePrototypeProperty(
-            Context cx,
-            String name,
-            java.util.function.Function<Scriptable, Object> getter,
-            int attributes) {
+            Context cx, String name, Function<Scriptable, Object> getter, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
         proto.defineProperty(cx, name, getter, null, attributes);
     }
 
+    /**
+     * Define a property on the prototype using functions for getter and setter. The function will
+     * be wired to a JavaScript function, so the resulting property will look just like one that was
+     * defined using "Object.defineOwnProperty" with a property descriptor.
+     */
     public void definePrototypeProperty(
             Context cx,
             String name,

--- a/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
@@ -25,14 +25,27 @@ public class SymbolKey implements Symbol, Serializable {
     public static final SymbolKey SPLIT = new SymbolKey("Symbol.split");
     public static final SymbolKey UNSCOPABLES = new SymbolKey("Symbol.unscopables");
 
-    private String name;
+    // If passed a javascript undefined, this will be a (java) null
+    private final String name;
 
     public SymbolKey(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the symbol's name. Returns empty string for anonymous symbol (i.e. something created
+     * with <code>Symbol()</code>).
+     */
     public String getName() {
-        return name;
+        return name != null ? name : "";
+    }
+
+    /**
+     * Returns the symbol's description - will return {@link Undefined#instance} if we have an
+     * anonymous symbol (i.e. something created with <code>Symbol()</code>).
+     */
+    public Object getDescription() {
+        return name != null ? name : Undefined.instance;
     }
 
     @Override

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
@@ -91,6 +91,22 @@ public class LambdaFunctionTest {
     }
 
     @Test
+    public void constructLambdaClassWithFunction() {
+        TestClass.init(root);
+        eval(
+                "let tc = TestClass('foo');\n"
+                        + "assertEquals(tc.value, 'foo');\n"
+                        + "tc.value = 'bar';\n"
+                        + "assertEquals(tc.value, 'bar');\n"
+                        + "tc.anotherValue = 123;\n"
+                        + "assertEquals(tc.anotherValue, 123);\n"
+                        + "assertEquals(TestClass.name, 'TestClass');\n"
+                        + "assertEquals(TestClass.length, 1);\n"
+                        + "assertEquals(typeof TestClass, 'function');\n"
+                        + "assertTrue(tc instanceof TestClass);\n");
+    }
+
+    @Test
     public void nativePrototypeFunctions() {
         eval(
                 "function TestClass(v) { this.value = v; }\n"

--- a/tests/testsrc/jstests/es6/symbols.js
+++ b/tests/testsrc/jstests/es6/symbols.js
@@ -571,4 +571,19 @@ TestStringify('{}', symbol_wrapper);
 symbol_wrapper.a = 1;
 TestStringify('{"a":1}', symbol_wrapper);
 
+
+function TestDescription() {
+  assertEquals(Symbol("abc").description, "abc");
+  assertEquals(Symbol.iterator.description, "Symbol.iterator");
+  assertEquals(Symbol().description, undefined);
+
+  assertFalse(Symbol("abc").hasOwnProperty("description"));
+  assertTrue(Symbol.prototype.hasOwnProperty("description"));
+  assertTrue(Object.getOwnPropertyDescriptor(Symbol.prototype, "description").configurable);
+  assertFalse(Object.getOwnPropertyDescriptor(Symbol.prototype, "description").enumerable);
+  assertTrue(Object.getOwnPropertyDescriptor(Symbol.prototype, "description").get !== null);
+}
+TestDescription();
+
+
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2308,7 +2308,7 @@ built-ins/String 140/1182 (11.84%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 36/94 (38.3%)
+built-ins/Symbol 26/94 (27.66%)
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
     dispose/prop-desc.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2312,25 +2312,15 @@ built-ins/Symbol 36/94 (38.3%)
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
     dispose/prop-desc.js
-    for/cross-realm.js
-    for/description.js
     for/not-a-constructor.js {unsupported: [Reflect.construct]}
     hasInstance/cross-realm.js
     isConcatSpreadable/cross-realm.js
     iterator/cross-realm.js
     keyFor/arg-non-symbol.js
-    keyFor/cross-realm.js
     keyFor/not-a-constructor.js {unsupported: [Reflect.construct]}
     matchAll 2/2 (100.0%)
     match/cross-realm.js
-    prototype/description/description-symboldescriptivestring.js
-    prototype/description/descriptor.js
-    prototype/description/get.js
     prototype/description/this-val-non-symbol.js
-    prototype/description/this-val-symbol.js
-    prototype/description/wrapper.js
-    prototype/Symbol.toPrimitive/name.js
-    prototype/Symbol.toPrimitive/prop-desc.js
     prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js
     prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}


### PR DESCRIPTION
This includes the changes made by @andreabergia to:

* Add Symbol.prototype.description
* Move Symbol to use lambdas

Since so many things have changed in this area recently, and since the lambda
implementation wasn't totally ready for this, and since I wanted this to 
use Lambdas appropriately AND move forward, this PR includes @andreabergia's
original commits and a few more tweaks on top.

Closes #962 

