### PR TITLE
Pass correct parameters in splitScope

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ast/Scope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/Scope.java
@@ -115,7 +115,7 @@ public class Scope extends Jump {
      * a scope chain.
      */
     public static Scope splitScope(Scope scope) {
-        Scope result = new Scope(scope.getType());
+        Scope result = new Scope(scope.getPosition(), scope.getLength());
         result.symbolTable = scope.symbolTable;
         scope.symbolTable = null;
         result.parent = scope.parent;


### PR DESCRIPTION
When I tried to replace Tokens by Enum (#1639) I noticed, that the constructor `Scope(int position)` was invoked with the tokenType.
I would suggest, invoke the correct ctor here (but maybe someone with more experience should take a look at this)
I suspect it has no impact, but it is wrong in my opinion even if no tests fail.