### PR TITLE
Add __exception__ property only in enhanced java access

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4376,7 +4376,7 @@ public class ScriptRuntime {
             catchScopeObject.defineProperty(exceptionName, obj, ScriptableObject.PERMANENT);
         }
 
-        if (isVisible(cx, t)) {
+        if (cx.hasFeature(Context.FEATURE_ENHANCED_JAVA_ACCESS) && isVisible(cx, t)) {
             // Add special Rhino object __exception__ defined in the catch
             // scope that can be used to retrieve the Java exception associated
             // with the JavaScript exception (to get stack trace info, etc.)


### PR DESCRIPTION
I noticed that Rhino stores the current exception in a `__exception__` variable.
This is not really standard and in my opinion it only makes sense when using LiveConnect (and even there I see no reason to enable this by default).

My suggestion is to enable this feature only via flag (FEATURE_ENHANCED_JAVA_ACCESS should fit) or remove it completely.

It was introduced with https://github.com/mozilla/rhino/commit/d0c1400b1618f6d84a35c59682dc63c4890693b9 but no test or use case was described. And I also found only this post: https://groups.google.com/g/mozilla.dev.tech.js-engine.rhino/c/qNttXExynw4?pli=1

Instead of putting something in the current scope, you can use this more object oriented code to access the underlying exception
```javascript
try {
   ... 
} catch (e) {
   e.rhinoException.printStackTrace();
   // or if it is a real java exception:
   e.javaException.printStackTrace();
}
```

So maybe anyone can tell a use case for this feature, if this is still needed?