### PR TITLE
The $262 object does not use LiveConnect any more

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1346,7 +1346,7 @@ public abstract class ScriptableObject
     }
 
     /** Utility method to add lambda properties to arbitrary Scriptable object. */
-    protected void defineProperty(
+    public void defineProperty(
             Scriptable scope,
             String name,
             int length,

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1345,7 +1345,18 @@ public abstract class ScriptableObject
         so.defineProperty(propertyName, value, attributes);
     }
 
-    /** Utility method to add lambda properties to arbitrary Scriptable object. */
+    /**
+     * Utility method to add lambda properties to arbitrary Scriptable object.
+     *
+     * @param scope ScriptableObject to define the property on
+     * @param name the name of the property to define.
+     * @param length the arity of the function
+     * @param target an object that implements the function in Java. Since Callable is a
+     *     single-function interface this will typically be implemented as a lambda.
+     * @param attributes the attributes of the JavaScript property
+     * @param propertyAttributes Sets the attributes of the "name", "length", and "arity" properties
+     *     of the internal LambdaFunction, which differ for many * native objects.
+     */
     public void defineProperty(
             Scriptable scope,
             String name,

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -448,17 +448,15 @@ public class Test262SuiteTest {
             proto.setPrototype(getObjectPrototype(scope));
             proto.setParentScope(scope);
 
-            proto.defineProperty("toSource", "Math", DONTENUM | READONLY | PERMANENT);
-
-            proto.defineProperty(scope, "gc", 1, $262::gc, DONTENUM, DONTENUM | READONLY);
+            proto.defineProperty(scope, "gc", 0, $262::gc, DONTENUM, DONTENUM | READONLY);
             proto.defineProperty(
-                    scope, "createRealm", 1, $262::createRealm, DONTENUM, DONTENUM | READONLY);
+                    scope, "createRealm", 0, $262::createRealm, DONTENUM, DONTENUM | READONLY);
             proto.defineProperty(
                     scope, "evalScript", 1, $262::evalScript, DONTENUM, DONTENUM | READONLY);
             proto.defineProperty(
                     scope,
                     "detachArrayBuffer",
-                    1,
+                    0,
                     $262::detachArrayBuffer,
                     DONTENUM,
                     DONTENUM | READONLY);


### PR DESCRIPTION
I noticed, that the $262 object, which defines the [host functions](https://github.com/tc39/test262/blob/main/INTERPRETING.md#host-defined-functions) was wrapped into a NativeJavaObject.

In other words, the `@JsMethod` annotations were useless, instead, the methods were exposed by LiveConnect.

In this PR, I've changed the $262 to a subclass of ScriptableObject, so that the annotations take place and we do not longer depend on LC when running the 262 tests.