### PR TITLE
Performance optimizations in initSafeStandardObjects

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -107,13 +107,14 @@ public class NativeGlobal implements Serializable, IdFunctionCall {
                 continue;
             }
             String name = error.name();
-            ScriptableObject errorProto =
-                    (ScriptableObject)
-                            ScriptRuntime.newBuiltinObject(
-                                    cx, scope, TopLevel.Builtins.Error, ScriptRuntime.emptyArgs);
+            Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
+            IdFunctionObject ctor =
+                    (IdFunctionObject)
+                            TopLevel.getBuiltinCtor(cx, topLevelScope, TopLevel.Builtins.Error);
+            ScriptableObject errorProto = NativeError.makeProto(topLevelScope, ctor);
             errorProto.defineProperty("name", name, DONTENUM);
             errorProto.defineProperty("message", "", DONTENUM);
-            IdFunctionObject ctor;
+
             if (error == TopLevel.NativeErrors.AggregateError) {
                 ctor = new IdFunctionObject(obj, FTAG, Id_new_AggregateError, name, 2, scope);
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/RhinoException.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RhinoException.java
@@ -10,6 +10,7 @@ import java.io.CharArrayWriter;
 import java.io.FilenameFilter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -386,15 +387,20 @@ public abstract class RhinoException extends RuntimeException {
 
     // Allow us to override default stack style for debugging.
     static {
-        String style = System.getProperty("rhino.stack.style");
-        if (style != null) {
-            if ("Rhino".equalsIgnoreCase(style)) {
-                stackStyle = StackStyle.RHINO;
-            } else if ("Mozilla".equalsIgnoreCase(style)) {
-                stackStyle = StackStyle.MOZILLA;
-            } else if ("V8".equalsIgnoreCase(style)) {
-                stackStyle = StackStyle.V8;
+        try {
+            String style = System.getProperty("rhino.stack.style");
+            if (style != null) {
+                if ("Rhino".equalsIgnoreCase(style)) {
+                    stackStyle = StackStyle.RHINO;
+                } else if ("Mozilla".equalsIgnoreCase(style)) {
+                    stackStyle = StackStyle.MOZILLA;
+                } else if ("V8".equalsIgnoreCase(style)) {
+                    stackStyle = StackStyle.V8;
+                }
             }
+        } catch (AccessControlException ace) {
+            // ignore. We will land here, if SecurityManager is in place and error is lazily
+            // initialized
         }
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.WrappedException;
 
 /**
@@ -39,6 +40,12 @@ public class ErrorHandlingTest {
                 e -> {
                     Assert.assertEquals(JavaScriptException.class, e.getClass());
                     Assert.assertEquals("Error: foo (myScript.js#1)", e.getMessage());
+                });
+        testIt(
+                "throw new EvalError('foo')",
+                e -> {
+                    Assert.assertEquals(JavaScriptException.class, e.getClass());
+                    Assert.assertEquals("EvalError: foo (myScript.js#1)", e.getMessage());
                 });
         testIt(
                 "try { throw new Error('foo') } catch (e) { throw e }",
@@ -96,6 +103,14 @@ public class ErrorHandlingTest {
                     Assert.assertEquals(RuntimeException.class, e.getCause().getClass());
                     Assert.assertEquals("foo", e.getCause().getMessage());
                 });
+    }
+
+    @Test
+    public void stackProvider() {
+        Utils.assertWithAllOptimizationLevels(Undefined.instance, "Error.stack");
+        Utils.assertWithAllOptimizationLevels("\tat test.js:0\n", "new Error().stack");
+        Utils.assertWithAllOptimizationLevels(Undefined.instance, "EvalError.stack");
+        Utils.assertWithAllOptimizationLevels("\tat test.js:0\n", "new EvalError('foo').stack");
     }
 
     private void testIt(final String script, final Consumer<Throwable> exception) {


### PR DESCRIPTION
This PR optimizes the performance, especially in `initSafeStandardObjects`  by factor 2

The problem is that initSafeStandardObjects creates a dozen NativeError prototypes. Each prototype is initialized with an empty exception as default stackProvider.
This means, you construct ~10 exceptions (with stack trace etc.) on every initSafeStandardObjects.

This PR changes the initialization of prototypes in a way, that the stack is not generated for the prototypes (but still for new Error instances)

This speeds up the initialization about factor 2