### PR TITLE
Fix flaky ShellTimerTest

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/ShellTimerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ShellTimerTest.java
@@ -125,9 +125,14 @@ public class ShellTimerTest {
         runTest(
                 "load('testsrc/assert.js');\n"
                         + "let count = 0;\n"
-                        + "setTimeout(() => { assertEquals(0, count++);\n"
-                        + "  setTimeout(() => { assertEquals(2, count++); TestsComplete = true; }, 5);\n"
-                        + "  setTimeout(() => { assertEquals(1, count++); }, 2);\n"
+                        + "setTimeout(() => {\n"
+                        + "  setTimeout(() => {\n"
+                        + "    setTimeout(() => {\n"
+                        + "      assertEquals(2, count++); TestsComplete = true;\n"
+                        + "    });"
+                        + "    assertEquals(1, count++);\n"
+                        + "  }, 2);\n"
+                        + "  assertEquals(0, count++);\n"
                         + "});");
     }
 


### PR DESCRIPTION
The nested timer test was depending on how long it took for the tests to run, which is never a good thing for a timer-related test.