### PR TITLE
minor test suite improvements

### DIFF
--- a/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -107,10 +107,11 @@ public class ErrorHandlingTest {
 
     @Test
     public void stackProvider() {
+        String nl = System.lineSeparator();
         Utils.assertWithAllOptimizationLevels(Undefined.instance, "Error.stack");
-        Utils.assertWithAllOptimizationLevels("\tat test.js:0\n", "new Error().stack");
+        Utils.assertWithAllOptimizationLevels("\tat test.js:0" + nl, "new Error().stack");
         Utils.assertWithAllOptimizationLevels(Undefined.instance, "EvalError.stack");
-        Utils.assertWithAllOptimizationLevels("\tat test.js:0\n", "new EvalError('foo').stack");
+        Utils.assertWithAllOptimizationLevels("\tat test.js:0" + nl, "new EvalError('foo').stack");
     }
 
     private void testIt(final String script, final Consumer<Throwable> exception) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
@@ -110,8 +110,8 @@ public class IterableTest {
                                 null);
 
                     } catch (Throwable t) {
-                        assertEquals(t.getClass(), EcmaError.class);
-                        assertEquals(t.getMessage(), "TypeError: [object Object] is not iterable");
+                        assertEquals(EcmaError.class, t.getClass());
+                        assertEquals("TypeError: [object Object] is not iterable", t.getMessage());
                     }
 
                     return null;
@@ -143,8 +143,8 @@ public class IterableTest {
                                 0,
                                 null);
                     } catch (Throwable t) {
-                        assertEquals(t.getClass(), EcmaError.class);
-                        assertEquals(t.getMessage(), "TypeError: [object Object] is not iterable");
+                        assertEquals(EcmaError.class, t.getClass());
+                        assertEquals("TypeError: [object Object] is not iterable", t.getMessage());
                     }
 
                     return null;


### PR DESCRIPTION
* use System.lineSeparator() to make the tests passing on win
* fix the parameter order for assertEquals calls