### PR TITLE
Fixed ScriptRuntime.toPrimitive() and use it for toXXX() (taken from #1611 done by @tonygermano)

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -1947,10 +1947,9 @@ public class NativeArray extends IdScriptableObject implements List {
     */
     private static Boolean js_includes(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-        long len = ScriptRuntime.toLength(new Object[] {getProperty(thisObj, "length")}, 0);
+        long len = getLengthProperty(cx, o);
         if (len == 0) return Boolean.FALSE;
 
         long k;
@@ -1964,6 +1963,8 @@ public class NativeArray extends IdScriptableObject implements List {
             }
             if (k > len - 1) return Boolean.FALSE;
         }
+
+        Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
         if (o instanceof NativeArray) {
             NativeArray na = (NativeArray) o;
             if (na.denseOnly) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -436,15 +436,10 @@ public class ScriptRuntime {
             if (val instanceof String) return toNumber((String) val);
             if (val instanceof CharSequence) return toNumber(val.toString());
             if (val instanceof Boolean) return ((Boolean) val).booleanValue() ? 1 : +0.0;
-            if (val instanceof Symbol) throw typeErrorById("msg.not.a.number");
-            if (val instanceof Scriptable) {
-                val = ((Scriptable) val).getDefaultValue(NumberClass);
-                if ((val instanceof Scriptable) && !isSymbol(val))
-                    throw errorWithClassName("msg.primitive.expected", val);
-                continue;
-            }
-            warnAboutNonJSObject(val);
-            return NaN;
+            if (isSymbol(val)) throw typeErrorById("msg.not.a.number");
+            // Assert: val is an Object
+            val = toPrimitive(val, NumberClass);
+            // Assert: val is a primitive
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -1014,24 +1014,22 @@ public class ScriptRuntime {
                 return val.toString();
             }
             if (val instanceof BigInteger) {
-                return val.toString();
+                return ((BigInteger) val).toString(10);
             }
             if (val instanceof Number) {
                 // XXX should we just teach NativeNumber.stringValue()
                 // about Numbers?
                 return numberToString(((Number) val).doubleValue(), 10);
             }
-            if (val instanceof Symbol) {
+            if (val instanceof Boolean) {
+                return val.toString();
+            }
+            if (isSymbol(val)) {
                 throw typeErrorById("msg.not.a.string");
             }
-            if (val instanceof Scriptable) {
-                val = ((Scriptable) val).getDefaultValue(StringClass);
-                if ((val instanceof Scriptable) && !isSymbol(val)) {
-                    throw errorWithClassName("msg.primitive.expected", val);
-                }
-                continue;
-            }
-            return val.toString();
+            // Assert: val is an Object
+            val = toPrimitive(val, StringClass);
+            // Assert: val is a primitive
         }
     }
 
@@ -3581,7 +3579,7 @@ public class ScriptRuntime {
                 && !Undefined.isUndefined(exoticToPrim)) {
             throw notFunctionError(exoticToPrim);
         }
-        final Class<?> defaultValueHint = preferredType == null ? preferredType : NumberClass;
+        final Class<?> defaultValueHint = preferredType == null ? NumberClass : preferredType;
         final Object result = s.getDefaultValue(defaultValueHint);
         if ((result instanceof Scriptable) && !isSymbol(result))
             throw typeErrorById("msg.bad.default.value");

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3576,7 +3576,9 @@ public class ScriptRuntime {
             }
             return result;
         }
-        if (!Undefined.isUndefined(exoticToPrim) && exoticToPrim != Scriptable.NOT_FOUND) {
+        if (exoticToPrim != null
+                && exoticToPrim != Scriptable.NOT_FOUND
+                && !Undefined.isUndefined(exoticToPrim)) {
             throw notFunctionError(exoticToPrim);
         }
         final Class<?> defaultValueHint = preferredType == null ? preferredType : NumberClass;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -708,56 +708,47 @@ public class ScriptRuntime {
 
     /** Convert the value to a BigInt. */
     public static BigInteger toBigInt(Object val) {
-        for (; ; ) {
-            if (val instanceof BigInteger) {
-                return (BigInteger) val;
-            }
-            if (val instanceof BigDecimal) {
-                return ((BigDecimal) val).toBigInteger();
-            }
-            if (val instanceof Number) {
-                if (val instanceof Long) {
-                    return BigInteger.valueOf(((Long) val));
-                } else {
-                    double d = ((Number) val).doubleValue();
-                    if (Double.isNaN(d) || Double.isInfinite(d)) {
-                        throw rangeErrorById(
-                                "msg.cant.convert.to.bigint.isnt.integer", toString(val));
-                    }
-                    BigDecimal bd = new BigDecimal(d, MathContext.UNLIMITED);
-                    try {
-                        return bd.toBigIntegerExact();
-                    } catch (ArithmeticException e) {
-                        throw rangeErrorById(
-                                "msg.cant.convert.to.bigint.isnt.integer", toString(val));
-                    }
-                }
-            }
-            if (val == null || Undefined.isUndefined(val)) {
-                throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
-            }
-            if (val instanceof String) {
-                return toBigInt((String) val);
-            }
-            if (val instanceof CharSequence) {
-                return toBigInt(val.toString());
-            }
-            if (val instanceof Boolean) {
-                return ((Boolean) val).booleanValue() ? BigInteger.ONE : BigInteger.ZERO;
-            }
-            if (val instanceof Symbol) {
-                throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
-            }
-            if (val instanceof Scriptable) {
-                val = ((Scriptable) val).getDefaultValue(BigIntegerClass);
-                if ((val instanceof Scriptable) && !isSymbol(val)) {
-                    throw errorWithClassName("msg.primitive.expected", val);
-                }
-                continue;
-            }
-            warnAboutNonJSObject(val);
-            return BigInteger.ZERO;
+        val = toPrimitive(val, NumberClass);
+        if (val instanceof BigInteger) {
+            return (BigInteger) val;
         }
+        if (val instanceof BigDecimal) {
+            return ((BigDecimal) val).toBigInteger();
+        }
+        if (val instanceof Number) {
+            if (val instanceof Long) {
+                return BigInteger.valueOf(((Long) val));
+            } else {
+                double d = ((Number) val).doubleValue();
+                if (Double.isNaN(d) || Double.isInfinite(d)) {
+                    throw rangeErrorById(
+                            "msg.cant.convert.to.bigint.isnt.integer", toString(val));
+                }
+                BigDecimal bd = new BigDecimal(d, MathContext.UNLIMITED);
+                try {
+                    return bd.toBigIntegerExact();
+                } catch (ArithmeticException e) {
+                    throw rangeErrorById(
+                            "msg.cant.convert.to.bigint.isnt.integer", toString(val));
+                }
+            }
+        }
+        if (val == null || Undefined.isUndefined(val)) {
+            throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
+        }
+        if (val instanceof String) {
+            return toBigInt((String) val);
+        }
+        if (val instanceof CharSequence) {
+            return toBigInt(val.toString());
+        }
+        if (val instanceof Boolean) {
+            return ((Boolean) val).booleanValue() ? BigInteger.ONE : BigInteger.ZERO;
+        }
+        if (isSymbol(val)) {
+            throw typeErrorById("msg.cant.convert.to.bigint", toString(val));
+        }
+        throw errorWithClassName("msg.primitive.expected", val);
     }
 
     /** ToBigInt applied to the String type */

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -827,6 +827,7 @@ public class ScriptRuntime {
      * <p>See ECMA 7.1.3 (v11.0).
      */
     public static Number toNumeric(Object val) {
+        val = toPrimitive(val, NumberClass);
         if (val instanceof Number) {
             return (Number) val;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -721,15 +721,13 @@ public class ScriptRuntime {
             } else {
                 double d = ((Number) val).doubleValue();
                 if (Double.isNaN(d) || Double.isInfinite(d)) {
-                    throw rangeErrorById(
-                            "msg.cant.convert.to.bigint.isnt.integer", toString(val));
+                    throw rangeErrorById("msg.cant.convert.to.bigint.isnt.integer", toString(val));
                 }
                 BigDecimal bd = new BigDecimal(d, MathContext.UNLIMITED);
                 try {
                     return bd.toBigIntegerExact();
                 } catch (ArithmeticException e) {
-                    throw rangeErrorById(
-                            "msg.cant.convert.to.bigint.isnt.integer", toString(val));
+                    throw rangeErrorById("msg.cant.convert.to.bigint.isnt.integer", toString(val));
                 }
             }
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
@@ -288,6 +288,9 @@ public class IterableTest {
 
         @Override
         public Object get(Symbol key, Scriptable start) {
+            if (SymbolKey.TO_PRIMITIVE == key) {
+                return null;
+            }
             throw new UnsupportedOperationException(
                     "Not supported yet."); // To change body of generated methods, choose Tools |
             // Templates.

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray2Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray2Test.java
@@ -18,7 +18,9 @@ public class NativeArray2Test {
                         + " '' + e;\n"
                         + "};";
 
-        Utils.assertWithAllOptimizationLevelsES6("TypeError: Array length 9,007,199,254,740,992 exceeds supported capacity limit.", js);
+        Utils.assertWithAllOptimizationLevelsES6(
+                "TypeError: Array length 9,007,199,254,740,992 exceeds supported capacity limit.",
+                js);
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray2Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray2Test.java
@@ -1,31 +1,10 @@
 package org.mozilla.javascript.tests.es6;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.tests.Utils;
 
 /** Test for NativeArray. */
 public class NativeArray2Test {
-
-    private Context cx;
-    private ScriptableObject scope;
-
-    @Before
-    public void setUp() {
-        cx = Context.enter();
-        cx.setLanguageVersion(Context.VERSION_ES6);
-        scope = cx.initStandardObjects();
-    }
-
-    @After
-    public void tearDown() {
-        Context.exit();
-    }
 
     @Test
     public void concatLimitSpreadable() {
@@ -39,8 +18,7 @@ public class NativeArray2Test {
                         + " '' + e;\n"
                         + "};";
 
-        String result = (String) cx.evaluateString(scope, js, "test", 1, null);
-        assertTrue(result.endsWith("exceeds supported capacity limit."));
+        Utils.assertWithAllOptimizationLevelsES6("TypeError: Array length 9,007,199,254,740,992 exceeds supported capacity limit.", js);
     }
 
     @Test
@@ -59,7 +37,6 @@ public class NativeArray2Test {
                         + " '' + e;\n"
                         + "};";
 
-        String result = (String) cx.evaluateString(scope, js, "test", 1, null);
-        assertEquals(result, "Error: get failed", result);
+        Utils.assertWithAllOptimizationLevelsES6("Error: get failed", js);
     }
 }

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -382,17 +382,15 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 21/75 (28.0%)
+built-ins/BigInt 18/75 (24.0%)
     asIntN/bigint-tobigint-errors.js
     asIntN/bigint-tobigint-toprimitive.js
-    asIntN/bigint-tobigint-wrapped-values.js
     asIntN/bits-toindex-errors.js
     asIntN/bits-toindex-toprimitive.js
     asIntN/bits-toindex-wrapped-values.js
     asIntN/not-a-constructor.js {unsupported: [Reflect.construct]}
     asUintN/bigint-tobigint-errors.js
     asUintN/bigint-tobigint-toprimitive.js
-    asUintN/bigint-tobigint-wrapped-values.js
     asUintN/bits-toindex-errors.js
     asUintN/bits-toindex-toprimitive.js
     asUintN/bits-toindex-wrapped-values.js
@@ -401,7 +399,6 @@ built-ins/BigInt 21/75 (28.0%)
     prototype/toString/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toString/prototype-call.js Check IsInteger in ES2020, not IsSafeInteger, https://github.com/tc39/test262/commit/bf1b79d65a760a5f03df1198557da2d010f8f397#diff-3ecd6a0c50da5c8f8eff723afb6182a889b7315d99545b055559e22d302cc453
     prototype/valueOf/not-a-constructor.js {unsupported: [Reflect.construct]}
-    constructor-coercion.js
     is-a-constructor.js {unsupported: [Reflect.construct]}
     wrapper-object-ordinary-toprimitive.js
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -27,7 +27,7 @@ harness 23/115 (20.0%)
     isConstructor.js {unsupported: [Reflect.construct]}
     nativeFunctionMatcher.js
 
-built-ins/Array 383/3074 (12.46%)
+built-ins/Array 382/3074 (12.43%)
     fromAsync 94/94 (100.0%)
     from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -135,7 +135,6 @@ built-ins/Array 383/3074 (12.46%)
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/flatMap/array-like-objects-poisoned-length.js
     prototype/flatMap/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/flatMap/proxy-access-count.js
     prototype/flatMap/target-array-non-extensible.js
@@ -2192,7 +2191,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 128/1182 (10.83%)
+built-ins/String 126/1182 (10.66%)
     fromCharCode/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromCodePoint/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/charAt/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2204,7 +2203,6 @@ built-ins/String 128/1182 (10.83%)
     prototype/includes/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/indexOf/position-tointeger-bigint.js
     prototype/indexOf/position-tointeger-errors.js
     prototype/indexOf/position-tointeger-toprimitive.js
     prototype/indexOf/position-tointeger-wrapped-values.js
@@ -2259,7 +2257,6 @@ built-ins/String 128/1182 (10.83%)
     prototype/slice/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js
-    prototype/split/limit-touint32-error.js
     prototype/split/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/split/separator-regexp.js
     prototype/split/separator-tostring-error.js
@@ -2960,7 +2957,7 @@ built-ins/TypedArray 1091/1422 (76.72%)
     resizable-buffer-length-tracking-1.js {unsupported: [resizable-arraybuffer]}
     resizable-buffer-length-tracking-2.js {unsupported: [resizable-arraybuffer]}
 
-built-ins/TypedArrayConstructors 597/735 (81.22%)
+built-ins/TypedArrayConstructors 595/735 (80.95%)
     BigInt64Array/prototype 4/4 (100.0%)
     BigInt64Array 8/8 (100.0%)
     BigUint64Array/prototype 4/4 (100.0%)
@@ -3033,8 +3030,6 @@ built-ins/TypedArrayConstructors 597/735 (81.22%)
     ctors/object-arg/proto-from-ctor-realm.js {unsupported: [Reflect]}
     ctors/object-arg/returns.js
     ctors/object-arg/throws-from-property.js
-    ctors/object-arg/throws-setting-obj-to-primitive.js
-    ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
     ctors/object-arg/throws-setting-property.js
     ctors/object-arg/throws-setting-symbol-property.js
     ctors/object-arg/use-custom-proto-if-object.js {unsupported: [Reflect]}
@@ -3291,25 +3286,13 @@ built-ins/eval 3/10 (30.0%)
 
 built-ins/global 0/29 (0.0%)
 
-built-ins/isFinite 8/17 (47.06%)
+built-ins/isFinite 2/17 (11.76%)
     length.js
     not-a-constructor.js {unsupported: [Reflect.construct]}
-    toprimitive-call-abrupt.js
-    toprimitive-get-abrupt.js
-    toprimitive-not-callable-throws.js
-    toprimitive-result-is-object-throws.js
-    toprimitive-result-is-symbol-throws.js
-    toprimitive-valid-result.js
 
-built-ins/isNaN 8/17 (47.06%)
+built-ins/isNaN 2/17 (11.76%)
     length.js
     not-a-constructor.js {unsupported: [Reflect.construct]}
-    toprimitive-call-abrupt.js
-    toprimitive-get-abrupt.js
-    toprimitive-not-callable-throws.js
-    toprimitive-result-is-object-throws.js
-    toprimitive-result-is-symbol-throws.js
-    toprimitive-valid-result.js
 
 built-ins/parseFloat 3/59 (5.08%)
     not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -6065,8 +6048,7 @@ language/expressions/unary-minus 1/14 (7.14%)
 
 language/expressions/unary-plus 0/17 (0.0%)
 
-language/expressions/unsigned-right-shift 3/45 (6.67%)
-    bigint-non-primitive.js
+language/expressions/unsigned-right-shift 2/45 (4.44%)
     bigint-toprimitive.js
     order-of-evaluation.js
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4343,25 +4343,18 @@ language/expressions/async-arrow-function 42/60 (70.0%)
 
 ~language/expressions/await
 
-language/expressions/bitwise-and 4/30 (13.33%)
-    bigint-non-primitive.js
+language/expressions/bitwise-and 2/30 (6.67%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/bitwise-not 1/16 (6.25%)
-    bigint-non-primitive.js
+language/expressions/bitwise-not 0/16 (0.0%)
 
-language/expressions/bitwise-or 4/30 (13.33%)
-    bigint-non-primitive.js
+language/expressions/bitwise-or 2/30 (6.67%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/bitwise-xor 4/30 (13.33%)
-    bigint-non-primitive.js
+language/expressions/bitwise-xor 2/30 (6.67%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/call 60/92 (65.22%)
@@ -4575,9 +4568,8 @@ language/expressions/delete 5/67 (7.46%)
     super-property-method.js {unsupported: [class]}
     super-property-null-base.js {unsupported: [class]}
 
-language/expressions/division 3/45 (6.67%)
+language/expressions/division 2/45 (4.44%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/does-not-equals 0/38 (0.0%)
@@ -4586,9 +4578,8 @@ language/expressions/does-not-equals 0/38 (0.0%)
 
 language/expressions/equals 0/47 (0.0%)
 
-language/expressions/exponentiation 3/44 (6.82%)
+language/expressions/exponentiation 2/44 (4.55%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/function 168/264 (63.64%)
@@ -4992,10 +4983,8 @@ language/expressions/instanceof 7/43 (16.28%)
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift 4/45 (8.89%)
-    bigint-non-primitive.js
+language/expressions/left-shift 2/45 (4.44%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/less-than 0/45 (0.0%)
@@ -5065,14 +5054,12 @@ language/expressions/logical-not 0/19 (0.0%)
 language/expressions/logical-or 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/modulus 3/40 (7.5%)
+language/expressions/modulus 2/40 (5.0%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
-language/expressions/multiplication 3/40 (7.5%)
+language/expressions/multiplication 2/40 (5.0%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/new 41/59 (69.49%)
@@ -6008,19 +5995,16 @@ language/expressions/property-accessors 0/21 (0.0%)
 
 language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift 4/37 (10.81%)
-    bigint-non-primitive.js
+language/expressions/right-shift 2/37 (5.41%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 language/expressions/strict-does-not-equals 0/30 (0.0%)
 
 language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction 3/38 (7.89%)
+language/expressions/subtraction 2/38 (5.26%)
     bigint-toprimitive.js
-    bigint-wrapped-values.js
     order-of-evaluation.js
 
 ~language/expressions/super
@@ -6040,8 +6024,7 @@ language/expressions/typeof 2/16 (12.5%)
     built-in-ordinary-objects-no-call.js
     proxy.js {unsupported: [Proxy]}
 
-language/expressions/unary-minus 1/14 (7.14%)
-    bigint-non-primitive.js
+language/expressions/unary-minus 0/14 (0.0%)
 
 language/expressions/unary-plus 0/17 (0.0%)
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -382,17 +382,13 @@ built-ins/ArrayIteratorPrototype 1/27 (3.7%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 18/75 (24.0%)
+built-ins/BigInt 14/75 (18.67%)
     asIntN/bigint-tobigint-errors.js
-    asIntN/bigint-tobigint-toprimitive.js
     asIntN/bits-toindex-errors.js
-    asIntN/bits-toindex-toprimitive.js
     asIntN/bits-toindex-wrapped-values.js
     asIntN/not-a-constructor.js {unsupported: [Reflect.construct]}
     asUintN/bigint-tobigint-errors.js
-    asUintN/bigint-tobigint-toprimitive.js
     asUintN/bits-toindex-errors.js
-    asUintN/bits-toindex-toprimitive.js
     asUintN/bits-toindex-wrapped-values.js
     asUintN/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/toLocaleString/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2188,7 +2184,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 126/1182 (10.66%)
+built-ins/String 125/1182 (10.58%)
     fromCharCode/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromCodePoint/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/charAt/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2201,7 +2197,6 @@ built-ins/String 126/1182 (10.66%)
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/indexOf/position-tointeger-errors.js
-    prototype/indexOf/position-tointeger-toprimitive.js
     prototype/indexOf/position-tointeger-wrapped-values.js
     prototype/indexOf/searchstring-tostring-bigint.js
     prototype/indexOf/searchstring-tostring-errors.js
@@ -4343,18 +4338,15 @@ language/expressions/async-arrow-function 42/60 (70.0%)
 
 ~language/expressions/await
 
-language/expressions/bitwise-and 2/30 (6.67%)
-    bigint-toprimitive.js
+language/expressions/bitwise-and 1/30 (3.33%)
     order-of-evaluation.js
 
 language/expressions/bitwise-not 0/16 (0.0%)
 
-language/expressions/bitwise-or 2/30 (6.67%)
-    bigint-toprimitive.js
+language/expressions/bitwise-or 1/30 (3.33%)
     order-of-evaluation.js
 
-language/expressions/bitwise-xor 2/30 (6.67%)
-    bigint-toprimitive.js
+language/expressions/bitwise-xor 1/30 (3.33%)
     order-of-evaluation.js
 
 language/expressions/call 60/92 (65.22%)
@@ -4568,8 +4560,7 @@ language/expressions/delete 5/67 (7.46%)
     super-property-method.js {unsupported: [class]}
     super-property-null-base.js {unsupported: [class]}
 
-language/expressions/division 2/45 (4.44%)
-    bigint-toprimitive.js
+language/expressions/division 1/45 (2.22%)
     order-of-evaluation.js
 
 language/expressions/does-not-equals 0/38 (0.0%)
@@ -4578,8 +4569,7 @@ language/expressions/does-not-equals 0/38 (0.0%)
 
 language/expressions/equals 0/47 (0.0%)
 
-language/expressions/exponentiation 2/44 (4.55%)
-    bigint-toprimitive.js
+language/expressions/exponentiation 1/44 (2.27%)
     order-of-evaluation.js
 
 language/expressions/function 168/264 (63.64%)
@@ -4983,8 +4973,7 @@ language/expressions/instanceof 7/43 (16.28%)
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift 2/45 (4.44%)
-    bigint-toprimitive.js
+language/expressions/left-shift 1/45 (2.22%)
     order-of-evaluation.js
 
 language/expressions/less-than 0/45 (0.0%)
@@ -5054,12 +5043,10 @@ language/expressions/logical-not 0/19 (0.0%)
 language/expressions/logical-or 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/modulus 2/40 (5.0%)
-    bigint-toprimitive.js
+language/expressions/modulus 1/40 (2.5%)
     order-of-evaluation.js
 
-language/expressions/multiplication 2/40 (5.0%)
-    bigint-toprimitive.js
+language/expressions/multiplication 1/40 (2.5%)
     order-of-evaluation.js
 
 language/expressions/new 41/59 (69.49%)
@@ -5995,16 +5982,14 @@ language/expressions/property-accessors 0/21 (0.0%)
 
 language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift 2/37 (5.41%)
-    bigint-toprimitive.js
+language/expressions/right-shift 1/37 (2.7%)
     order-of-evaluation.js
 
 language/expressions/strict-does-not-equals 0/30 (0.0%)
 
 language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction 2/38 (5.26%)
-    bigint-toprimitive.js
+language/expressions/subtraction 1/38 (2.63%)
     order-of-evaluation.js
 
 ~language/expressions/super

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1063,11 +1063,9 @@ built-ins/Math 51/327 (15.6%)
 
 built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors 31/123 (25.2%)
+built-ins/NativeErrors 29/123 (23.58%)
     AggregateError/errors-iterabletolist-failures.js
     AggregateError/is-a-constructor.js {unsupported: [Reflect.construct]}
-    AggregateError/message-tostring-abrupt.js
-    AggregateError/message-tostring-abrupt-symbol.js
     AggregateError/newtarget-proto-custom.js {unsupported: [Reflect.construct]}
     AggregateError/newtarget-proto-fallback.js
     AggregateError/proto-from-ctor-realm.js {unsupported: [Reflect]}
@@ -1118,7 +1116,7 @@ built-ins/Number 24/335 (7.16%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 217/3408 (6.37%)
+built-ins/Object 216/3408 (6.34%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/not-a-constructor.js {unsupported: [Reflect.construct]}
     assign/source-own-prop-desc-missing.js {unsupported: [Proxy]}
@@ -1188,7 +1186,6 @@ built-ins/Object 217/3408 (6.37%)
     freeze/throws-when-false.js
     freeze/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     fromEntries/not-a-constructor.js {unsupported: [Reflect.construct]}
-    fromEntries/to-property-key.js
     fromEntries/uses-keys-not-iterator.js
     getOwnPropertyDescriptors/not-a-constructor.js {unsupported: [Reflect.construct]}
     getOwnPropertyDescriptors/observable-operations.js {unsupported: [Proxy]}
@@ -2184,7 +2181,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 125/1182 (10.58%)
+built-ins/String 116/1182 (9.81%)
     fromCharCode/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromCodePoint/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/charAt/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2198,9 +2195,6 @@ built-ins/String 125/1182 (10.58%)
     prototype/indexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/indexOf/position-tointeger-errors.js
     prototype/indexOf/position-tointeger-wrapped-values.js
-    prototype/indexOf/searchstring-tostring-bigint.js
-    prototype/indexOf/searchstring-tostring-errors.js
-    prototype/indexOf/searchstring-tostring-toprimitive.js
     prototype/indexOf/searchstring-tostring-wrapped-values.js
     prototype/isWellFormed/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/isWellFormed/to-string-primitive.js
@@ -2223,7 +2217,6 @@ built-ins/String 125/1182 (10.58%)
     prototype/replaceAll/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/replaceAll/replaceValue-call-each-match-position.js
     prototype/replaceAll/replaceValue-call-matching-empty.js
-    prototype/replaceAll/replaceValue-value-tostring.js
     prototype/replaceAll/searchValue-flags-no-g-throws.js
     prototype/replaceAll/searchValue-flags-null-undefined-throws.js
     prototype/replaceAll/searchValue-flags-toString-abrupt.js
@@ -2236,7 +2229,6 @@ built-ins/String 125/1182 (10.58%)
     prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
     prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
     prototype/replaceAll/searchValue-tostring-regexp.js
-    prototype/replaceAll/this-tostring.js
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
     prototype/replace/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2272,16 +2264,12 @@ built-ins/String 125/1182 (10.58%)
     prototype/toWellFormed/to-string-primitive.js
     prototype/trimEnd/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/trimEnd/this-value-object-toprimitive-call-err.js
-    prototype/trimEnd/this-value-object-toprimitive-meth-err.js
     prototype/trimEnd/this-value-object-toprimitive-meth-priority.js
-    prototype/trimEnd/this-value-object-toprimitive-returns-object-err.js
     prototype/trimEnd/this-value-object-tostring-meth-priority.js
     prototype/trimEnd/this-value-object-valueof-meth-priority.js
     prototype/trimStart/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/trimStart/this-value-object-toprimitive-call-err.js
-    prototype/trimStart/this-value-object-toprimitive-meth-err.js
     prototype/trimStart/this-value-object-toprimitive-meth-priority.js
-    prototype/trimStart/this-value-object-toprimitive-returns-object-err.js
     prototype/trimStart/this-value-object-tostring-meth-priority.js
     prototype/trimStart/this-value-object-valueof-meth-priority.js
     prototype/trim/not-a-constructor.js {unsupported: [Reflect.construct]}


### PR DESCRIPTION
This is another carve out from #1661.

It contains
* some major fixes for the toPrimitive() implementation itself and 
* the usage of toPrimitive() in ScriptRuntime#toString(), ScriptRuntime#toNumeric(), ScriptRuntime#toBigInt(), and ScriptRuntime#toNumber().

This fixes again a bunch of Test262 cases and should be still backward compatible.

I left the single steps as single commits to (hopefully) make the review simpler. But I think we should squash this on merge.

@gbrail @tonygermano @rPraml @p-bakker please have a look, it was a bit hard to do the backward compatibility in toPrimitive() - i'm only 99% sure that all this is correct...
