### PR TITLE
When dumping icode, include string constants

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -671,6 +671,30 @@ public final class Interpreter extends Icode implements Evaluator {
                         pc += 4;
                         break;
                     }
+                case Icode_REG_STR_C0:
+                    {
+                        String str = strings[0];
+                        out.println(tname + " \"" + str + '"');
+                        break;
+                    }
+                case Icode_REG_STR_C1:
+                    {
+                        String str = strings[1];
+                        out.println(tname + " \"" + str + '"');
+                        break;
+                    }
+                case Icode_REG_STR_C2:
+                    {
+                        String str = strings[2];
+                        out.println(tname + " \"" + str + '"');
+                        break;
+                    }
+                case Icode_REG_STR_C3:
+                    {
+                        String str = strings[3];
+                        out.println(tname + " \"" + str + '"');
+                        break;
+                    }
                 case Icode_REG_IND_C0:
                     indexReg = 0;
                     out.println(tname);


### PR DESCRIPTION
When `Token.printICode` is set to true (generally only for debugging purposes), Rhino prints all the interpreter bytecode it generated. For the `Icode_REG_STRxx` instructions Rhino will also print inline the string value, but it does not do it for the (far more common) `Icode_REG_STR_Cxx` instructions.

This tiny PR just extends the same behavior to the `Icode_REG_STR_Cxx`. Therfore, for this js code:

```js
a + b
```

it will now print this:

```
ICode dump, for null, length = 10
MaxStack = 2
 [0] LINE : 2
 [3] REG_STR_C0 "a"
 [4] NAME
 [5] REG_STR_C1 "b"
 [6] NAME
 [7] ADD
 [8] POP_RESULT
 [9] RETURN_RESULT
```

whereas the old version would have just printed something like:

```
 [3] REG_STR_C0
```

There are no unit tests for all this stuff, but it's currently being used only for debugging purposes... so I didn't really think that it was worth creating a whole test suite from scratch for this change.