### PR TITLE
fix endless loop in ScriptRuntimem toString() and toNumber() and add tests to ensure backward comatibility

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -437,9 +437,15 @@ public class ScriptRuntime {
             if (val instanceof CharSequence) return toNumber(val.toString());
             if (val instanceof Boolean) return ((Boolean) val).booleanValue() ? 1 : +0.0;
             if (isSymbol(val)) throw typeErrorById("msg.not.a.number");
-            // Assert: val is an Object
-            val = toPrimitive(val, NumberClass);
-            // Assert: val is a primitive
+
+            if (val instanceof Scriptable) {
+                // Assert: val is an Object
+                val = toPrimitive(val, NumberClass);
+                // Assert: val is a primitive
+            } else {
+                warnAboutNonJSObject(val);
+                return Double.NaN;
+            }
         }
     }
 
@@ -1025,9 +1031,14 @@ public class ScriptRuntime {
             if (isSymbol(val)) {
                 throw typeErrorById("msg.not.a.string");
             }
-            // Assert: val is an Object
-            val = toPrimitive(val, StringClass);
-            // Assert: val is a primitive
+            if (val instanceof Scriptable) {
+                // Assert: val is an Object
+                val = toPrimitive(val, StringClass);
+                // Assert: val is a primitive
+            } else {
+                warnAboutNonJSObject(val);
+                return val.toString();
+            }
         }
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeTest.java
@@ -1,0 +1,45 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Test cases for the {@link org.mozilla.javascript.ScriptRuntime}.
+ *
+ * @author Ronald Brill
+ */
+public class ScriptRuntimeTest {
+
+    /**
+     * Test toNumber(Object) to work with non Scriptable objects that are not supported by the
+     * Rhino. There was a bug that in this case the impl stucks in an endless loop.
+     */
+    @Test
+    public void toNumberNotScriptable() {
+        assertEquals(Double.NaN, ScriptRuntime.toNumber(Scriptable.NOT_FOUND), 0.00001);
+        assertEquals(Double.NaN, ScriptRuntime.toNumber(new Object()), 0.00001);
+        assertEquals(Double.NaN, ScriptRuntime.toNumber(new NullPointerException("NPE")), 0.00001);
+    }
+
+    /**
+     * Test toString(Object) to work with non Scriptable objects that are not supported by the
+     * Rhino. There was a bug that in this case the impl stucks in an endless loop.
+     */
+    @Test
+    public void toStringNotScriptable() {
+        assertTrue(
+                ScriptRuntime.toString(Scriptable.NOT_FOUND)
+                        .startsWith("org.mozilla.javascript.UniqueTag@"));
+        assertTrue(ScriptRuntime.toString(Scriptable.NOT_FOUND).endsWith("NOT_FOUND"));
+
+        assertTrue(ScriptRuntime.toString(new Object()).startsWith("java.lang.Object@"));
+
+        assertEquals(
+                "java.lang.NullPointerException: NPE",
+                ScriptRuntime.toString(new NullPointerException("NPE")));
+    }
+}


### PR DESCRIPTION
while integrating the latest changes into htmlunit core-js i noticed that i have introduced a no longer backward compatible behaviour. Sorry - and in fact this introduces an endless loop for some calls.

This fixes that...