### PR TITLE
Implement optional chaining for function call

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -602,10 +602,12 @@ class CodeGenerator extends Icode {
             case Token.CALL:
             case Token.NEW:
                 {
+                    boolean isOptionalChainingCall =
+                            node.getIntProp(Node.OPTIONAL_CHAINING, 0) == 1;
                     if (type == Token.NEW) {
                         visitExpression(child, 0);
                     } else {
-                        generateCallFunAndThis(child);
+                        generateCallFunAndThis(child, isOptionalChainingCall);
                     }
                     int argCount = 0;
                     while ((child = child.getNext()) != null) {
@@ -615,7 +617,11 @@ class CodeGenerator extends Icode {
                     int callType = node.getIntProp(Node.SPECIALCALL_PROP, Node.NON_SPECIALCALL);
                     if (type != Token.REF_CALL && callType != Node.NON_SPECIALCALL) {
                         // embed line number and source filename
-                        addIndexOp(Icode_CALLSPECIAL, argCount);
+                        addIndexOp(
+                                isOptionalChainingCall
+                                        ? Icode_CALLSPECIAL_OPTIONAL
+                                        : Icode_CALLSPECIAL,
+                                argCount);
                         addUint8(callType);
                         addUint8(type == Token.NEW ? 1 : 0);
                         addUint16(lineNumber & 0xFFFF);
@@ -629,7 +635,11 @@ class CodeGenerator extends Icode {
                                 && !itsInTryFlag) {
                             type = Icode_TAIL_CALL;
                         }
-                        addIndexOp(type, argCount);
+                        addIndexOp(
+                                type == Token.CALL && isOptionalChainingCall
+                                        ? Icode_CALL_OPTIONAL
+                                        : type,
+                                argCount);
                     }
                     // adjust stack
                     if (type == Token.NEW) {
@@ -1148,7 +1158,7 @@ class CodeGenerator extends Icode {
         stackChange(-1);
     }
 
-    private void generateCallFunAndThis(Node left) {
+    private void generateCallFunAndThis(Node left, boolean isOptionalChainingCall) {
         // Generate code to place on stack function and thisObj
         int type = left.getType();
         switch (type) {
@@ -1156,7 +1166,11 @@ class CodeGenerator extends Icode {
                 {
                     String name = left.getString();
                     // stack: ... -> ... function thisObj
-                    addStringOp(Icode_NAME_AND_THIS, name);
+                    addStringOp(
+                            isOptionalChainingCall
+                                    ? Icode_NAME_AND_THIS_OPTIONAL
+                                    : Icode_NAME_AND_THIS,
+                            name);
                     stackChange(2);
                     break;
                 }
@@ -1169,12 +1183,19 @@ class CodeGenerator extends Icode {
                     if (type == Token.GETPROP) {
                         String property = id.getString();
                         // stack: ... target -> ... function thisObj
-                        addStringOp(Icode_PROP_AND_THIS, property);
+                        addStringOp(
+                                isOptionalChainingCall
+                                        ? Icode_PROP_AND_THIS_OPTIONAL
+                                        : Icode_PROP_AND_THIS,
+                                property);
                         stackChange(1);
                     } else {
                         visitExpression(id, 0);
                         // stack: ... target id -> ... function thisObj
-                        addIcode(Icode_ELEM_AND_THIS);
+                        addIcode(
+                                isOptionalChainingCall
+                                        ? Icode_ELEM_AND_THIS_OPTIONAL
+                                        : Icode_ELEM_AND_THIS);
                     }
                     break;
                 }
@@ -1182,7 +1203,10 @@ class CodeGenerator extends Icode {
                 // Including Token.GETVAR
                 visitExpression(left, 0);
                 // stack: ... value -> ... function thisObj
-                addIcode(Icode_VALUE_AND_THIS);
+                addIcode(
+                        isOptionalChainingCall
+                                ? Icode_VALUE_AND_THIS_OPTIONAL
+                                : Icode_VALUE_AND_THIS);
                 stackChange(1);
                 break;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -604,10 +604,15 @@ class CodeGenerator extends Icode {
                 {
                     boolean isOptionalChainingCall =
                             node.getIntProp(Node.OPTIONAL_CHAINING, 0) == 1;
+                    CompleteOptionalCallJump completeOptionalCallJump = null;
                     if (type == Token.NEW) {
                         visitExpression(child, 0);
                     } else {
-                        generateCallFunAndThis(child, isOptionalChainingCall);
+                        completeOptionalCallJump =
+                                generateCallFunAndThis(child, isOptionalChainingCall);
+                        if (completeOptionalCallJump != null) {
+                            resolveForwardGoto(completeOptionalCallJump.putArgsAndDoCallLabel);
+                        }
                     }
                     int argCount = 0;
                     while ((child = child.getNext()) != null) {
@@ -617,11 +622,7 @@ class CodeGenerator extends Icode {
                     int callType = node.getIntProp(Node.SPECIALCALL_PROP, Node.NON_SPECIALCALL);
                     if (type != Token.REF_CALL && callType != Node.NON_SPECIALCALL) {
                         // embed line number and source filename
-                        addIndexOp(
-                                isOptionalChainingCall
-                                        ? Icode_CALLSPECIAL_OPTIONAL
-                                        : Icode_CALLSPECIAL,
-                                argCount);
+                        addIndexOp(Icode_CALLSPECIAL, argCount);
                         addUint8(callType);
                         addUint8(type == Token.NEW ? 1 : 0);
                         addUint16(lineNumber & 0xFFFF);
@@ -635,11 +636,7 @@ class CodeGenerator extends Icode {
                                 && !itsInTryFlag) {
                             type = Icode_TAIL_CALL;
                         }
-                        addIndexOp(
-                                type == Token.CALL && isOptionalChainingCall
-                                        ? Icode_CALL_OPTIONAL
-                                        : type,
-                                argCount);
+                        addIndexOp(type, argCount);
                     }
                     // adjust stack
                     if (type == Token.NEW) {
@@ -652,6 +649,10 @@ class CodeGenerator extends Icode {
                     }
                     if (argCount > itsData.itsMaxCalleeArgs) {
                         itsData.itsMaxCalleeArgs = argCount;
+                    }
+
+                    if (completeOptionalCallJump != null) {
+                        resolveForwardGoto(completeOptionalCallJump.afterLabel);
                     }
                 }
                 break;
@@ -1158,7 +1159,8 @@ class CodeGenerator extends Icode {
         stackChange(-1);
     }
 
-    private void generateCallFunAndThis(Node left, boolean isOptionalChainingCall) {
+    private CompleteOptionalCallJump generateCallFunAndThis(
+            Node left, boolean isOptionalChainingCall) {
         // Generate code to place on stack function and thisObj
         int type = left.getType();
         switch (type) {
@@ -1166,12 +1168,14 @@ class CodeGenerator extends Icode {
                 {
                     String name = left.getString();
                     // stack: ... -> ... function thisObj
-                    addStringOp(
-                            isOptionalChainingCall
-                                    ? Icode_NAME_AND_THIS_OPTIONAL
-                                    : Icode_NAME_AND_THIS,
-                            name);
-                    stackChange(2);
+                    if (isOptionalChainingCall) {
+                        addStringOp(Icode_NAME_AND_THIS_OPTIONAL, name);
+                        stackChange(2);
+                        return completeOptionalCallJump();
+                    } else {
+                        addStringOp(Icode_NAME_AND_THIS, name);
+                        stackChange(2);
+                    }
                     break;
                 }
             case Token.GETPROP:
@@ -1183,19 +1187,23 @@ class CodeGenerator extends Icode {
                     if (type == Token.GETPROP) {
                         String property = id.getString();
                         // stack: ... target -> ... function thisObj
-                        addStringOp(
-                                isOptionalChainingCall
-                                        ? Icode_PROP_AND_THIS_OPTIONAL
-                                        : Icode_PROP_AND_THIS,
-                                property);
-                        stackChange(1);
+                        if (isOptionalChainingCall) {
+                            addStringOp(Icode_PROP_AND_THIS_OPTIONAL, property);
+                            stackChange(1);
+                            return completeOptionalCallJump();
+                        } else {
+                            addStringOp(Icode_PROP_AND_THIS, property);
+                            stackChange(1);
+                        }
                     } else {
                         visitExpression(id, 0);
                         // stack: ... target id -> ... function thisObj
-                        addIcode(
-                                isOptionalChainingCall
-                                        ? Icode_ELEM_AND_THIS_OPTIONAL
-                                        : Icode_ELEM_AND_THIS);
+                        if (isOptionalChainingCall) {
+                            addIcode(Icode_ELEM_AND_THIS_OPTIONAL);
+                            return completeOptionalCallJump();
+                        } else {
+                            addIcode(Icode_ELEM_AND_THIS);
+                        }
                     }
                     break;
                 }
@@ -1203,13 +1211,35 @@ class CodeGenerator extends Icode {
                 // Including Token.GETVAR
                 visitExpression(left, 0);
                 // stack: ... value -> ... function thisObj
-                addIcode(
-                        isOptionalChainingCall
-                                ? Icode_VALUE_AND_THIS_OPTIONAL
-                                : Icode_VALUE_AND_THIS);
-                stackChange(1);
+                if (isOptionalChainingCall) {
+                    addIcode(Icode_VALUE_AND_THIS_OPTIONAL);
+                    stackChange(1);
+                    return completeOptionalCallJump();
+                } else {
+                    addIcode(Icode_VALUE_AND_THIS);
+                    stackChange(1);
+                }
                 break;
         }
+        return null;
+    }
+
+    private CompleteOptionalCallJump completeOptionalCallJump() {
+        // If it's null or undefined, pop undefined and skip the arguments and call
+        addIcode(Icode_DUP);
+        stackChange(1);
+        int putArgsAndDoCallLabel = iCodeTop;
+        addGotoOp(Icode.Icode_IF_NOT_NULL_UNDEF);
+        stackChange(-1);
+
+        // Put undefined
+        addIcode(Icode_POP);
+        addIcode(Icode_POP);
+        addStringOp(Token.NAME, "undefined");
+        int afterLabel = iCodeTop;
+        addGotoOp(Token.GOTO);
+
+        return new CompleteOptionalCallJump(putArgsAndDoCallLabel, afterLabel);
     }
 
     private void visitIncDec(Node node, Node child) {
@@ -1718,5 +1748,15 @@ class CodeGenerator extends Icode {
     private void releaseLocal(int localSlot) {
         --localTop;
         if (localSlot != localTop) Kit.codeBug();
+    }
+
+    private static final class CompleteOptionalCallJump {
+        private final int putArgsAndDoCallLabel;
+        private final int afterLabel;
+
+        public CompleteOptionalCallJump(int putArgsAndDoCallLabel, int afterLabel) {
+            this.putArgsAndDoCallLabel = putArgsAndDoCallLabel;
+            this.afterLabel = afterLabel;
+        }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -661,6 +661,9 @@ public final class IRFactory {
             AstNode arg = args.get(i);
             call.addChildToBack(transform(arg));
         }
+        if (node.isOptionalCall()) {
+            call.putIntProp(Node.OPTIONAL_CHAINING, 1);
+        }
         return call;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Icode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Icode.java
@@ -46,16 +46,22 @@ abstract class Icode {
             Icode_PROP_AND_THIS = Icode_NAME_AND_THIS - 1,
             Icode_ELEM_AND_THIS = Icode_PROP_AND_THIS - 1,
             Icode_VALUE_AND_THIS = Icode_ELEM_AND_THIS - 1,
+            Icode_NAME_AND_THIS_OPTIONAL = Icode_VALUE_AND_THIS - 1,
+            Icode_PROP_AND_THIS_OPTIONAL = Icode_NAME_AND_THIS_OPTIONAL - 1,
+            Icode_ELEM_AND_THIS_OPTIONAL = Icode_PROP_AND_THIS_OPTIONAL - 1,
+            Icode_VALUE_AND_THIS_OPTIONAL = Icode_ELEM_AND_THIS_OPTIONAL - 1,
+            Icode_CALL_OPTIONAL = Icode_VALUE_AND_THIS_OPTIONAL - 1,
 
             // Create closure object for nested functions
-            Icode_CLOSURE_EXPR = Icode_VALUE_AND_THIS - 1,
+            Icode_CLOSURE_EXPR = Icode_CALL_OPTIONAL - 1,
             Icode_CLOSURE_STMT = Icode_CLOSURE_EXPR - 1,
 
             // Special calls
             Icode_CALLSPECIAL = Icode_CLOSURE_STMT - 1,
+            Icode_CALLSPECIAL_OPTIONAL = Icode_CALLSPECIAL - 1,
 
             // To return undefined value
-            Icode_RETUNDEF = Icode_CALLSPECIAL - 1,
+            Icode_RETUNDEF = Icode_CALLSPECIAL_OPTIONAL - 1,
 
             // Exception handling implementation
             Icode_GOSUB = Icode_RETUNDEF - 1,
@@ -163,6 +169,8 @@ abstract class Icode {
         }
 
         switch (bytecode) {
+            case Icode_DELNAME:
+                return "DELNAME";
             case Icode_DUP:
                 return "DUP";
             case Icode_DUP2:
@@ -197,12 +205,24 @@ abstract class Icode {
                 return "ELEM_AND_THIS";
             case Icode_VALUE_AND_THIS:
                 return "VALUE_AND_THIS";
+            case Icode_NAME_AND_THIS_OPTIONAL:
+                return "NAME_AND_THIS_OPTIONAL";
+            case Icode_PROP_AND_THIS_OPTIONAL:
+                return "PROP_AND_THIS_OPTIONAL";
+            case Icode_ELEM_AND_THIS_OPTIONAL:
+                return "ELEM_AND_THIS_OPTIONAL";
+            case Icode_VALUE_AND_THIS_OPTIONAL:
+                return "VALUE_AND_THIS_OPTIONAL";
+            case Icode_CALL_OPTIONAL:
+                return "CALL_OPTIONAL";
             case Icode_CLOSURE_EXPR:
                 return "CLOSURE_EXPR";
             case Icode_CLOSURE_STMT:
                 return "CLOSURE_STMT";
             case Icode_CALLSPECIAL:
                 return "CALLSPECIAL";
+            case Icode_CALLSPECIAL_OPTIONAL:
+                return "CALLSPECIAL_OPTIONAL";
             case Icode_RETUNDEF:
                 return "RETUNDEF";
             case Icode_GOSUB:

--- a/rhino/src/main/java/org/mozilla/javascript/Icode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Icode.java
@@ -50,10 +50,9 @@ abstract class Icode {
             Icode_PROP_AND_THIS_OPTIONAL = Icode_NAME_AND_THIS_OPTIONAL - 1,
             Icode_ELEM_AND_THIS_OPTIONAL = Icode_PROP_AND_THIS_OPTIONAL - 1,
             Icode_VALUE_AND_THIS_OPTIONAL = Icode_ELEM_AND_THIS_OPTIONAL - 1,
-            Icode_CALL_OPTIONAL = Icode_VALUE_AND_THIS_OPTIONAL - 1,
 
             // Create closure object for nested functions
-            Icode_CLOSURE_EXPR = Icode_CALL_OPTIONAL - 1,
+            Icode_CLOSURE_EXPR = Icode_VALUE_AND_THIS_OPTIONAL - 1,
             Icode_CLOSURE_STMT = Icode_CLOSURE_EXPR - 1,
 
             // Special calls
@@ -213,8 +212,6 @@ abstract class Icode {
                 return "ELEM_AND_THIS_OPTIONAL";
             case Icode_VALUE_AND_THIS_OPTIONAL:
                 return "VALUE_AND_THIS_OPTIONAL";
-            case Icode_CALL_OPTIONAL:
-                return "CALL_OPTIONAL";
             case Icode_CLOSURE_EXPR:
                 return "CLOSURE_EXPR";
             case Icode_CLOSURE_STMT:

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -609,7 +609,6 @@ public final class Interpreter extends Icode implements Evaluator {
                     out.println(tname + " " + idata.itsNestedFunctions[indexReg]);
                     break;
                 case Token.CALL:
-                case Icode_CALL_OPTIONAL:
                 case Icode_TAIL_CALL:
                 case Token.REF_CALL:
                 case Token.NEW:
@@ -1854,7 +1853,6 @@ public final class Interpreter extends Icode implements Evaluator {
                                     continue Loop;
                                 }
                             case Token.CALL:
-                            case Icode_CALL_OPTIONAL:
                             case Icode_TAIL_CALL:
                             case Token.REF_CALL:
                                 {
@@ -2006,10 +2004,6 @@ public final class Interpreter extends Icode implements Evaluator {
                                                     cx.newArray(calleeScope, elements);
                                             indexReg = 2;
                                         } else if (fun == null) {
-                                            if (op == Icode_CALL_OPTIONAL) {
-                                                stack[stackTop] = Undefined.instance;
-                                                continue Loop;
-                                            }
                                             throw ScriptRuntime.notFunctionError(null, null);
                                         } else {
                                             // Current function is something that we can't reduce
@@ -3582,7 +3576,7 @@ public final class Interpreter extends Icode implements Evaluator {
     }
 
     private static void setCallResult(CallFrame frame, Object callResult, double callResultDbl) {
-        if (frame.savedCallOp == Token.CALL || frame.savedCallOp == Icode_CALL_OPTIONAL) {
+        if (frame.savedCallOp == Token.CALL) {
             frame.stack[frame.savedStackTop] = callResult;
             frame.sDbl[frame.savedStackTop] = callResultDbl;
         } else if (frame.savedCallOp == Token.NEW) {
@@ -3621,7 +3615,7 @@ public final class Interpreter extends Icode implements Evaluator {
                 x.stack[i] = null;
                 x.stackAttributes[i] = ScriptableObject.EMPTY;
             }
-            if (x.savedCallOp == Token.CALL || x.savedCallOp == Icode_CALL_OPTIONAL) {
+            if (x.savedCallOp == Token.CALL) {
                 // the call will always overwrite the stack top with the result
                 x.stack[x.savedStackTop] = null;
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -2729,6 +2729,10 @@ public class ScriptRuntime {
             Scriptable thisObj,
             boolean isOptionalChainingCall) {
         if (thisObj == null) {
+            if (isOptionalChainingCall) {
+                storeScriptable(cx, null);
+                return null;
+            }
             throw undefCallError(obj, property);
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -2044,7 +2044,7 @@ public class ScriptRuntime {
             return result;
         }
 
-        return nameOrFunction(cx, scope, parent, name, false);
+        return nameOrFunction(cx, scope, parent, name, false, false);
     }
 
     private static Object nameOrFunction(
@@ -2052,7 +2052,8 @@ public class ScriptRuntime {
             Scriptable scope,
             Scriptable parentScope,
             String name,
-            boolean asFunctionCall) {
+            boolean asFunctionCall,
+            boolean isOptionalChainingCall) {
         Object result;
         Scriptable thisObj = scope; // It is used only if asFunctionCall==true.
 
@@ -2122,6 +2123,13 @@ public class ScriptRuntime {
 
         if (asFunctionCall) {
             if (!(result instanceof Callable)) {
+                if (isOptionalChainingCall
+                        && (result == Scriptable.NOT_FOUND
+                                || result == null
+                                || Undefined.isUndefined(result))) {
+                    storeScriptable(cx, null);
+                    return null;
+                }
                 throw notFunctionError(result, name);
             }
             storeScriptable(cx, thisObj);
@@ -2568,10 +2576,28 @@ public class ScriptRuntime {
      * caller must call ScriptRuntime.lastStoredScriptable() immediately after calling this method.
      */
     public static Callable getNameFunctionAndThis(String name, Context cx, Scriptable scope) {
+        return getNameFunctionAndThisInner(name, cx, scope, false);
+    }
+
+    public static Callable getNameFunctionAndThisOptional(
+            String name, Context cx, Scriptable scope) {
+        return getNameFunctionAndThisInner(name, cx, scope, true);
+    }
+
+    private static Callable getNameFunctionAndThisInner(
+            String name, Context cx, Scriptable scope, boolean isOptionalChainingCall) {
         Scriptable parent = scope.getParentScope();
         if (parent == null) {
             Object result = topScopeName(cx, scope, name);
             if (!(result instanceof Callable)) {
+                if (isOptionalChainingCall
+                        && (result == Scriptable.NOT_FOUND
+                                || result == null
+                                || Undefined.isUndefined(result))) {
+                    storeScriptable(cx, null);
+                    return null;
+                }
+
                 if (result == Scriptable.NOT_FOUND) {
                     throw notFoundError(scope, name);
                 }
@@ -2583,7 +2609,7 @@ public class ScriptRuntime {
         }
 
         // name will call storeScriptable(cx, thisObj);
-        return (Callable) nameOrFunction(cx, scope, parent, name, true);
+        return (Callable) nameOrFunction(cx, scope, parent, name, true, isOptionalChainingCall);
     }
 
     /**
@@ -2607,6 +2633,16 @@ public class ScriptRuntime {
      */
     public static Callable getElemFunctionAndThis(
             Object obj, Object elem, Context cx, Scriptable scope) {
+        return getElemFunctionAndThisInner(obj, elem, cx, scope, false);
+    }
+
+    public static Callable getElemFunctionAndThisOptional(
+            Object obj, Object elem, Context cx, Scriptable scope) {
+        return getElemFunctionAndThisInner(obj, elem, cx, scope, true);
+    }
+
+    private static Callable getElemFunctionAndThisInner(
+            Object obj, Object elem, Context cx, Scriptable scope, boolean isOptionalChainingCall) {
         Scriptable thisObj;
         Object value;
 
@@ -2632,6 +2668,13 @@ public class ScriptRuntime {
         }
 
         if (!(value instanceof Callable)) {
+            if (isOptionalChainingCall
+                    && (value == Scriptable.NOT_FOUND
+                            || value == null
+                            || Undefined.isUndefined(value))) {
+                storeScriptable(cx, null);
+                return null;
+            }
             throw notFunctionError(value, elem);
         }
 
@@ -2661,12 +2704,30 @@ public class ScriptRuntime {
      */
     public static Callable getPropFunctionAndThis(
             Object obj, String property, Context cx, Scriptable scope) {
+        return getPropFunctionAndThisInner(obj, property, cx, scope, false);
+    }
+
+    public static Callable getPropFunctionAndThisOptional(
+            Object obj, String property, Context cx, Scriptable scope) {
+        return getPropFunctionAndThisInner(obj, property, cx, scope, true);
+    }
+
+    private static Callable getPropFunctionAndThisInner(
+            Object obj,
+            String property,
+            Context cx,
+            Scriptable scope,
+            boolean isOptionalChainingCall) {
         Scriptable thisObj = toObjectOrNull(cx, obj, scope);
-        return getPropFunctionAndThisHelper(obj, property, cx, thisObj);
+        return getPropFunctionAndThisHelper(obj, property, cx, thisObj, isOptionalChainingCall);
     }
 
     private static Callable getPropFunctionAndThisHelper(
-            Object obj, String property, Context cx, Scriptable thisObj) {
+            Object obj,
+            String property,
+            Context cx,
+            Scriptable thisObj,
+            boolean isOptionalChainingCall) {
         if (thisObj == null) {
             throw undefCallError(obj, property);
         }
@@ -2679,6 +2740,13 @@ public class ScriptRuntime {
         }
 
         if (!(value instanceof Callable)) {
+            if (isOptionalChainingCall
+                    && (value == Scriptable.NOT_FOUND
+                            || value == null
+                            || Undefined.isUndefined(value))) {
+                storeScriptable(cx, null);
+                return null;
+            }
             throw notFunctionError(thisObj, value, property);
         }
 
@@ -2693,7 +2761,23 @@ public class ScriptRuntime {
      * ScriptRuntime.lastStoredScriptable() immediately after calling this method.
      */
     public static Callable getValueFunctionAndThis(Object value, Context cx) {
+        return getValueFunctionAndThisInner(value, cx, false);
+    }
+
+    public static Callable getValueFunctionAndThisOptional(Object value, Context cx) {
+        return getValueFunctionAndThisInner(value, cx, true);
+    }
+
+    private static Callable getValueFunctionAndThisInner(
+            Object value, Context cx, boolean isOptionalChainingCall) {
         if (!(value instanceof Callable)) {
+            if (isOptionalChainingCall
+                    && (value == Scriptable.NOT_FOUND
+                            || value == null
+                            || Undefined.isUndefined(value))) {
+                storeScriptable(cx, null);
+                return null;
+            }
             throw notFunctionError(value);
         }
 
@@ -2785,7 +2869,12 @@ public class ScriptRuntime {
             Scriptable callerThis,
             int callType,
             String filename,
-            int lineNumber) {
+            int lineNumber,
+            boolean isOptionalChainingCall) {
+        if (fun == null && isOptionalChainingCall) {
+            return Undefined.instance;
+        }
+
         if (callType == Node.SPECIALCALL_EVAL) {
             if (thisObj.getParentScope() == null && NativeGlobal.isEvalFunction(fun)) {
                 return evalSpecial(cx, scope, callerThis, args, filename, lineNumber);

--- a/rhino/src/main/java/org/mozilla/javascript/ast/FunctionCall.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/FunctionCall.java
@@ -20,6 +20,7 @@ public class FunctionCall extends AstNode {
     protected List<AstNode> arguments;
     protected int lp = -1;
     protected int rp = -1;
+    protected boolean optionalCall = false;
 
     {
         type = Token.CALL;
@@ -123,11 +124,24 @@ public class FunctionCall extends AstNode {
         this.rp = rp;
     }
 
+    /** Marks that the call is preceded by the optional chaining operator ?. */
+    public void markIsOptionalCall() {
+        this.optionalCall = true;
+    }
+
+    /** Returns whether the call is preceded by the optional chaining operator ?. */
+    public boolean isOptionalCall() {
+        return optionalCall;
+    }
+
     @Override
     public String toSource(int depth) {
         StringBuilder sb = new StringBuilder();
         sb.append(makeIndent(depth));
         sb.append(target.toSource(0));
+        if (optionalCall) {
+            sb.append("?.");
+        }
         sb.append("(");
         if (arguments != null) {
             printList(arguments, sb);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -75,6 +75,11 @@ public class Bootstrapper {
                     return RhinoOperation.GETWITHTHIS
                             .withNamespace(StandardNamespace.PROPERTY)
                             .named(getNameSegment(tokens, name, 2));
+                case "GETWITHTHISOPTIONAL":
+                    // Similar to the above, but won't complain if prop is not found
+                    return RhinoOperation.GETWITHTHISOPTIONAL
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
                 case "GETELEMENT":
                     // Get the value of an element from a property that is on the stack,\
                     // as if using "[]" notation. Could be a String, number, or Symbol
@@ -109,6 +114,11 @@ public class Bootstrapper {
                 case "GETWITHTHIS":
                     // Same but also return "this" so that it is found by "lastStoredScriptable"
                     return RhinoOperation.GETWITHTHIS
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "GETWITHTHISOPTIONAL":
+                    // Similar to the above, but won't complain if prop is not found
+                    return RhinoOperation.GETWITHTHISOPTIONAL
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
                 case "SET":

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -101,6 +101,15 @@ class DefaultLinker implements GuardingDynamicLinker {
             mh =
                     bindStringParameter(
                             lookup, mType, ScriptRuntime.class, "getPropFunctionAndThis", 1, name);
+        } else if (RhinoOperation.GETWITHTHISOPTIONAL.equals(op)) {
+            mh =
+                    bindStringParameter(
+                            lookup,
+                            mType,
+                            ScriptRuntime.class,
+                            "getPropFunctionAndThisOptional",
+                            1,
+                            name);
         } else if (StandardOperation.SET.equals(op)) {
             mh = bindStringParameter(lookup, mType, ScriptRuntime.class, "setObjectProp", 1, name);
         } else if (RhinoOperation.GETELEMENT.equals(op)) {
@@ -150,6 +159,13 @@ class DefaultLinker implements GuardingDynamicLinker {
                     MethodType.methodType(
                             Callable.class, String.class, Context.class, Scriptable.class);
             mh = lookup.findStatic(ScriptRuntime.class, "getNameFunctionAndThis", tt);
+            mh = MethodHandles.insertArguments(mh, 0, name);
+            mh = MethodHandles.permuteArguments(mh, mType, 1, 0);
+        } else if (RhinoOperation.GETWITHTHISOPTIONAL.equals(op)) {
+            tt =
+                    MethodType.methodType(
+                            Callable.class, String.class, Context.class, Scriptable.class);
+            mh = lookup.findStatic(ScriptRuntime.class, "getNameFunctionAndThisOptional", tt);
             mh = MethodHandles.insertArguments(mh, 0, name);
             mh = MethodHandles.permuteArguments(mh, mType, 1, 0);
         } else if (StandardOperation.SET.equals(op)) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -29,10 +29,26 @@ public final class OptRuntime extends ScriptRuntime {
         return fun.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
+    public static Object call0Optional(
+            Callable fun, Scriptable thisObj, Context cx, Scriptable scope) {
+        if (fun == null) {
+            return Undefined.instance;
+        }
+        return call0(fun, thisObj, cx, scope);
+    }
+
     /** Implement ....(arg) call shrinking optimizer code. */
     public static Object call1(
             Callable fun, Scriptable thisObj, Object arg0, Context cx, Scriptable scope) {
         return fun.call(cx, scope, thisObj, new Object[] {arg0});
+    }
+
+    public static Object call1Optional(
+            Callable fun, Scriptable thisObj, Object arg0, Context cx, Scriptable scope) {
+        if (fun == null) {
+            return Undefined.instance;
+        }
+        return call1(fun, thisObj, arg0, cx, scope);
     }
 
     /** Implement ....(arg0, arg1) call shrinking optimizer code. */
@@ -46,15 +62,46 @@ public final class OptRuntime extends ScriptRuntime {
         return fun.call(cx, scope, thisObj, new Object[] {arg0, arg1});
     }
 
+    public static Object call2Optional(
+            Callable fun,
+            Scriptable thisObj,
+            Object arg0,
+            Object arg1,
+            Context cx,
+            Scriptable scope) {
+        if (fun == null) {
+            return Undefined.instance;
+        }
+        return call2(fun, thisObj, arg0, arg1, cx, scope);
+    }
+
     /** Implement ....(arg0, arg1, ...) call shrinking optimizer code. */
     public static Object callN(
             Callable fun, Scriptable thisObj, Object[] args, Context cx, Scriptable scope) {
         return fun.call(cx, scope, thisObj, args);
     }
 
+    public static Object callNOptional(
+            Callable fun, Scriptable thisObj, Object[] args, Context cx, Scriptable scope) {
+        if (fun == null) {
+            return Undefined.instance;
+        }
+        return callN(fun, thisObj, args, cx, scope);
+    }
+
     /** Implement name(args) call shrinking optimizer code. */
     public static Object callName(Object[] args, String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
+        Scriptable thisObj = lastStoredScriptable(cx);
+        return f.call(cx, scope, thisObj, args);
+    }
+
+    public static Object callNameOptional(
+            Object[] args, String name, Context cx, Scriptable scope) {
+        Callable f = getNameFunctionAndThisOptional(name, cx, scope);
+        if (f == null) {
+            return Undefined.instance;
+        }
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, args);
     }
@@ -66,9 +113,28 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
+    public static Object callName0Optional(String name, Context cx, Scriptable scope) {
+        Callable f = getNameFunctionAndThisOptional(name, cx, scope);
+        if (f == null) {
+            return Undefined.instance;
+        }
+        Scriptable thisObj = lastStoredScriptable(cx);
+        return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
+    }
+
     /** Implement x.property() call shrinking optimizer code. */
     public static Object callProp0(Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
+        Scriptable thisObj = lastStoredScriptable(cx);
+        return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
+    }
+
+    public static Object callProp0Optional(
+            Object value, String property, Context cx, Scriptable scope) {
+        Callable f = getPropFunctionAndThisOptional(value, property, cx, scope);
+        if (f == null) {
+            return Undefined.instance;
+        }
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
@@ -131,9 +197,19 @@ public final class OptRuntime extends ScriptRuntime {
             Scriptable callerThis,
             int callType,
             String fileName,
-            int lineNumber) {
+            int lineNumber,
+            boolean isOptionalChainingCall) {
         return ScriptRuntime.callSpecial(
-                cx, fun, thisObj, args, scope, callerThis, callType, fileName, lineNumber);
+                cx,
+                fun,
+                thisObj,
+                args,
+                scope,
+                callerThis,
+                callType,
+                fileName,
+                lineNumber,
+                isOptionalChainingCall);
     }
 
     public static Object newObjectSpecial(

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -43,14 +43,6 @@ public final class OptRuntime extends ScriptRuntime {
         return fun.call(cx, scope, thisObj, new Object[] {arg0});
     }
 
-    public static Object call1Optional(
-            Callable fun, Scriptable thisObj, Object arg0, Context cx, Scriptable scope) {
-        if (fun == null) {
-            return Undefined.instance;
-        }
-        return call1(fun, thisObj, arg0, cx, scope);
-    }
-
     /** Implement ....(arg0, arg1) call shrinking optimizer code. */
     public static Object call2(
             Callable fun,
@@ -62,46 +54,15 @@ public final class OptRuntime extends ScriptRuntime {
         return fun.call(cx, scope, thisObj, new Object[] {arg0, arg1});
     }
 
-    public static Object call2Optional(
-            Callable fun,
-            Scriptable thisObj,
-            Object arg0,
-            Object arg1,
-            Context cx,
-            Scriptable scope) {
-        if (fun == null) {
-            return Undefined.instance;
-        }
-        return call2(fun, thisObj, arg0, arg1, cx, scope);
-    }
-
     /** Implement ....(arg0, arg1, ...) call shrinking optimizer code. */
     public static Object callN(
             Callable fun, Scriptable thisObj, Object[] args, Context cx, Scriptable scope) {
         return fun.call(cx, scope, thisObj, args);
     }
 
-    public static Object callNOptional(
-            Callable fun, Scriptable thisObj, Object[] args, Context cx, Scriptable scope) {
-        if (fun == null) {
-            return Undefined.instance;
-        }
-        return callN(fun, thisObj, args, cx, scope);
-    }
-
     /** Implement name(args) call shrinking optimizer code. */
     public static Object callName(Object[] args, String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
-        Scriptable thisObj = lastStoredScriptable(cx);
-        return f.call(cx, scope, thisObj, args);
-    }
-
-    public static Object callNameOptional(
-            Object[] args, String name, Context cx, Scriptable scope) {
-        Callable f = getNameFunctionAndThisOptional(name, cx, scope);
-        if (f == null) {
-            return Undefined.instance;
-        }
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, args);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -11,6 +11,7 @@ public enum RhinoOperation implements Operation {
     BIND,
     GETNOWARN,
     GETWITHTHIS,
+    GETWITHTHISOPTIONAL,
     GETELEMENT,
     GETINDEX,
     SETSTRICT,

--- a/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
@@ -194,6 +194,12 @@ public class OptionalChainingOperatorTest {
     }
 
     @Test
+    public void shortCircuitsFunctionCalls() {
+        Utils.assertWithAllOptimizationLevelsES6(Undefined.instance, "a = undefined; a?.b()");
+        Utils.assertWithAllOptimizationLevelsES6(Undefined.instance, "a = {}; a.b?.c().d()");
+    }
+
+    @Test
     public void toStringOfOptionalChaining() {
         Utils.assertWithAllOptimizationLevelsES6(
                 "function f() { a?.b }", "function f() { a?.b } f.toString()");

--- a/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
@@ -200,6 +200,31 @@ public class OptionalChainingOperatorTest {
     }
 
     @Test
+    public void shortCircuitArgumentEvaluation() {
+        Utils.assertWithAllOptimizationLevelsES6(1, "c = 0; f = function(x){}; f?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; f = undefined; f?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; f = null; f?.(c++); c");
+
+        Utils.assertWithAllOptimizationLevelsES6(1, "c = 0; a = {f: function() {}}; a.f?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = {f: undefined}; a.f?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = {f: null}; a.f?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = {}; a.f?.(c++); c");
+
+        Utils.assertWithAllOptimizationLevelsES6(1, "c = 0; a = [function() {}]; a[0]?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = [undefined]; a[0]?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = [null]; a[0]?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = []; a[0]?.(c++); c");
+
+        Utils.assertWithAllOptimizationLevelsES6(
+                1, "c = 0; a = {__parent__: function() {}}; a.__parent__?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(
+                0, "c = 0; a = {__parent__: undefined}; a.__parent__?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(
+                0, "c = 0; a = {__parent__: null}; a.__parent__?.(c++); c");
+        Utils.assertWithAllOptimizationLevelsES6(0, "c = 0; a = {}; a.__parent__.f?.(c++); c");
+    }
+
+    @Test
     public void toStringOfOptionalChaining() {
         Utils.assertWithAllOptimizationLevelsES6(
                 "function f() { a?.b }", "function f() { a?.b } f.toString()");

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -5794,7 +5794,7 @@ language/expressions/object 790/1169 (67.58%)
     yield-non-strict-access.js non-strict
     yield-non-strict-syntax.js non-strict
 
-language/expressions/optional-chaining 21/38 (55.26%)
+language/expressions/optional-chaining 18/38 (47.37%)
     call-expression.js
     early-errors-tail-position-null-optchain-template-string.js
     early-errors-tail-position-null-optchain-template-string-esi.js
@@ -5809,12 +5809,9 @@ language/expressions/optional-chaining 21/38 (55.26%)
     member-expression-async-literal.js {unsupported: [async]}
     member-expression-async-this.js {unsupported: [async]}
     new-target-optional-call.js
-    optional-call-preserves-this.js
-    optional-chain.js
     optional-chain-async-optional-chain-square-brackets.js {unsupported: [async]}
     optional-chain-async-square-brackets.js {unsupported: [async]}
     optional-chain-prod-arguments.js
-    short-circuiting.js
     super-property-optional-call.js
 
 language/expressions/postfix-decrement 9/37 (24.32%)


### PR DESCRIPTION
PR stacked on top of https://github.com/mozilla/rhino/pull/1694

It implements the optional chaining operator for function call, i.e. `f?.()` and similar.

There is a lot of complexity in this PR caused by the fact that rhino has many different ways of calling a function:

- `f()` is a `NAME_AND_THIS` followed by a `CALL`
- `a.b()` is a `PROP_AND_THIS` followed by a `CALL`
- `a[b]()` is an `ELEM_AND_THIS` followed by a `CALL`
- there are even other cases, such as `a.__parent__()` or `eval`.

The approach I've used is similar to the one used for optional property access, i.e. for `f?.(x)` it will do something like:

```
lookup f
put this
if isNullOrUndefined {
  pop
  put undefined on the stack
} else {
  evaluate x
  call function
}
```

This is necessary to do the proper short-circuiting required by the spec (there's a lot of unit test cases to verify them).

There is a little bit of duplication in the code, but I think it makes for much easier reading. Also, the bytecode and runtime code generated for the "normal" function call (non-optional) is exactly the same as before; there are no new branches added.

We pass a lot of test262 cases; the ones we do not are for the following reasons:

- `call-expression.js`, `super-property-optional-call.js`: use `class`
- `early-errors-tail-position-null-optchain-template-string.js`, `early-errors-tail-position-null-optchain-template-string-esi.js`, `early-errors-tail-position-optchain-template-string.js`, `early-errors-tail-position-optchain-template-string-esi.js`, `punctuator-decimal-lookahead.js`: these use things like `fn``x``?.a` which we do not support because we also do not support the non-optional access, i.e. `fn``x`.a` already does not work. Tracked by https://github.com/mozilla/rhino/issues/1703
- `eval-optional-call.js`: `eval.?` has a special semantic that I did _not_ implement. Tracked by https://github.com/mozilla/rhino/issues/1704
- `optional-chain-prod-arguments.js`: there are some existing problems with the spread syntax, tracked by https://github.com/mozilla/rhino/issues/1217
- `new-target-optional-call.js`: uses `new.target` which is unsupported, but the test is not marked as requiring it. Probably needs a fix in test262.
- `member-expression.js`: uses `async`, `class`, and `new.target`
- `iteration-statement-for-in.js`, `iteration-statement-for-of-type-error.js`: uses `for (const key of xxx)`, which does not work. Tracked by https://github.com/mozilla/rhino/issues/939
