### PR TITLE
FIX: Transform default values correctly in destructuring

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -613,8 +613,10 @@ public final class IRFactory {
             if (dfns != null) {
                 for (var i : dfns) {
                     Node a = i[0];
-                    AstNode b = (AstNode) i[1];
-                    a.replaceChild(b, transform(b));
+                    if (i[1] instanceof AstNode) {
+                        AstNode b = (AstNode) i[1];
+                        a.replaceChild(b, transform(b));
+                    }
                 }
             }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Node.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Node.java
@@ -293,6 +293,7 @@ public class Node implements Iterable<Node> {
     }
 
     public void replaceChild(Node child, Node newChild) {
+        if (child == newChild) return;
         newChild.next = child.next;
         if (child == first) {
             first = newChild;

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -766,7 +766,7 @@ public class Parser {
         // Would prefer not to call createDestructuringAssignment until codegen,
         // but the symbol definitions have to happen now, before body is parsed.
         Map<String, Node> destructuring = null;
-        Map<String, Node> destructuringDefault = null;
+        Map<String, AstNode> destructuringDefault = null;
 
         Set<String> paramNames = new HashSet<>();
         do {
@@ -878,7 +878,7 @@ public class Parser {
             Node destructuringNode = new Node(Token.COMMA);
             // Add assignment helper for each destructuring parameter
             for (Map.Entry<String, Node> param : destructuring.entrySet()) {
-                Node defaultValue = null;
+                AstNode defaultValue = null;
                 if (destructuringDefault != null) {
                     defaultValue = destructuringDefault.get(param.getKey());
                 }
@@ -1024,7 +1024,7 @@ public class Parser {
         // Would prefer not to call createDestructuringAssignment until codegen,
         // but the symbol definitions have to happen now, before body is parsed.
         Map<String, Node> destructuring = new HashMap<>();
-        Map<String, Node> destructuringDefault = new HashMap<>();
+        Map<String, AstNode> destructuringDefault = new HashMap<>();
         Set<String> paramNames = new HashSet<>();
 
         PerFunctionVariables savedVars = new PerFunctionVariables(fnNode);
@@ -1047,7 +1047,7 @@ public class Parser {
                 Node destructuringNode = new Node(Token.COMMA);
                 // Add assignment helper for each destructuring parameter
                 for (Map.Entry<String, Node> param : destructuring.entrySet()) {
-                    Node defaultValue = null;
+                    AstNode defaultValue = null;
                     if (destructuringDefault != null) {
                         defaultValue = destructuringDefault.get(param.getKey());
                     }
@@ -1087,7 +1087,7 @@ public class Parser {
             FunctionNode fnNode,
             AstNode params,
             Map<String, Node> destructuring,
-            Map<String, Node> destructuringDefault,
+            Map<String, AstNode> destructuringDefault,
             Set<String> paramNames)
             throws IOException {
         if (params instanceof ArrayLiteral || params instanceof ObjectLiteral) {
@@ -4194,7 +4194,7 @@ public class Parser {
      * @return expression that performs a series of assignments to the variables defined in left
      */
     Node createDestructuringAssignment(
-            int type, Node left, Node right, Node defaultValue, Transformer transformer) {
+            int type, Node left, Node right, AstNode defaultValue, Transformer transformer) {
         String tempName = currentScriptOrFn.getNextTempName();
         Node result =
                 destructuringAssignmentHelper(
@@ -4208,7 +4208,7 @@ public class Parser {
         return createDestructuringAssignment(type, left, right, null, transformer);
     }
 
-    Node createDestructuringAssignment(int type, Node left, Node right, Node defaultValue) {
+    Node createDestructuringAssignment(int type, Node left, Node right, AstNode defaultValue) {
         return createDestructuringAssignment(type, left, right, defaultValue, null);
     }
 
@@ -4217,7 +4217,7 @@ public class Parser {
             Node left,
             Node right,
             String tempName,
-            Node defaultValue,
+            AstNode defaultValue,
             Transformer transformer) {
         Scope result = createScopeNode(Token.LETEXPR, left.getLineno());
         result.addChildToFront(new Node(Token.LET, createName(Token.NAME, tempName, right)));
@@ -4276,7 +4276,7 @@ public class Parser {
             String tempName,
             Node parent,
             List<String> destructuringNames,
-            Node defaultValue, /* defaultValue to use in function param decls */
+            AstNode defaultValue, /* defaultValue to use in function param decls */
             Transformer transformer) {
         boolean empty = true;
         int setOp = variableType == Token.CONST ? Token.SETCONST : Token.SETNAME;
@@ -4347,14 +4347,7 @@ public class Parser {
             //              : $1[0])
             //          : x
 
-            if ((n.getRight() instanceof FunctionNode
-                            || n.getRight() instanceof UpdateExpression
-                            || n.getRight() instanceof ParenthesizedExpression)
-                    && transformer != null) {
-                right = transformer.transform(n.getRight());
-            } else {
-                right = n.getRight();
-            }
+            right = (transformer != null) ? transformer.transform(n.getRight()) : n.getRight();
 
             Node cond_inner =
                     new Node(
@@ -4363,21 +4356,18 @@ public class Parser {
                             right,
                             rightElem);
 
-            // if right is a function/update expression, it should be processed later
-            // store it in the node to be processed
-            if ((right instanceof FunctionNode
-                            || right instanceof UpdateExpression
-                            || right instanceof ParenthesizedExpression)
-                    && transformer == null) {
-                currentScriptOrFn.putDestructuringRvalues(cond_inner, right);
-            }
-
             Node cond =
                     new Node(
                             Token.HOOK,
                             new Node(Token.SHEQ, createName("undefined"), createName(name)),
                             cond_inner,
                             left);
+
+            // store it to be transformed later
+            if (transformer == null) {
+                currentScriptOrFn.putDestructuringRvalues(cond_inner, right);
+            }
+
             parent.addChildToBack(new Node(setOp, createName(Token.BINDNAME, name, null), cond));
             if (variableType != -1) {
                 defineSymbol(variableType, name, true);
@@ -4406,43 +4396,17 @@ public class Parser {
     }
 
     private void setupDefaultValues(
-            String tempName, Node parent, Node defaultValue, int setOp, Transformer transformer) {
+            String tempName,
+            Node parent,
+            AstNode defaultValue,
+            int setOp,
+            Transformer transformer) {
         if (defaultValue != null) {
             // if there's defaultValue it can be substituted for tempName if that's undefined
             // i.e. $1 = ($1 == undefined) ? defaultValue : $1
-            Node defaultRvalue = new Node(defaultValue.getType());
 
-            if (defaultValue instanceof ArrayLiteral) {
-                for (AstNode child : ((ArrayLiteral) defaultValue).getElements())
-                    defaultRvalue.addChildToBack(child);
-            } else if (defaultValue instanceof ObjectLiteral) {
-                // TODO: check if "Symbol.iterator" is defined
-                //                Node error_call = new Node(Token.NEW, createName("Error"));
-                //                error_call.addChildToBack(Node.newString("value is not
-                // iterable"));
-                //
-                //                Node check_iterator = new Node(
-                //                        Token.HOOK,
-                //                        new Node(Token.SHEQ,
-                //                                new Node(Token.GETPROP,
-                //                                        defaultValue,
-                //                                        createName("Symbol.iterator")),
-                //                                createName("undefined")),
-                //                        error_call,
-                //                        new Node(Token.TRUE));
-                //                parent.addChildToBack(check_iterator);
-
-                List<ObjectProperty> elems = ((ObjectLiteral) defaultValue).getElements();
-                Object[] props = new Object[elems.size()];
-                int i = 0;
-                for (ObjectProperty child : elems) {
-                    Object key = getPropKey(child.getLeft());
-                    Node right = child.getRight();
-                    props[i++] = key;
-                    defaultRvalue.addChildToBack(right);
-                }
-                defaultRvalue.putProp(Node.OBJECT_IDS_PROP, props);
-            }
+            Node defaultRvalue =
+                    transformer != null ? transformer.transform(defaultValue) : defaultValue;
 
             Node cond_default =
                     new Node(
@@ -4450,6 +4414,10 @@ public class Parser {
                             new Node(Token.SHEQ, createName(tempName), createName("undefined")),
                             defaultRvalue,
                             createName(tempName));
+
+            if (transformer == null) {
+                currentScriptOrFn.putDestructuringRvalues(cond_default, defaultRvalue);
+            }
 
             Node set_default =
                     new Node(setOp, createName(Token.BINDNAME, tempName, null), cond_default);
@@ -4463,7 +4431,7 @@ public class Parser {
             String tempName,
             Node parent,
             List<String> destructuringNames,
-            Node defaultValue, /* defaultValue to use in function param decls */
+            AstNode defaultValue, /* defaultValue to use in function param decls */
             Transformer transformer) {
         boolean empty = true;
         int setOp = variableType == Token.CONST ? Token.SETCONST : Token.SETNAME;

--- a/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
@@ -86,16 +86,82 @@ public class DefaultParametersTest {
     }
 
     @Test
-    @Ignore("defaults-not-supported-in-let-destructuring")
+    @Ignore("destructuring-not-supported-in-for-let-expressions")
     public void letExprDestructuring() throws Exception {
         // JavaScript
         final String script =
-                "function a() {}; (function() { "
-                        + "            for (let {x = a()} = {}; ; ) { "
-                        + "                return 3; "
+                "var a = 12; (function() { "
+                        + "            for (let {x = a} = {}; ; ) { "
+                        + "                return x; "
                         + "            }"
                         + "        })()";
-        Utils.assertWithAllOptimizationLevelsES6(3, script);
+        Utils.assertWithAllOptimizationLevelsES6(12, script);
+    }
+
+    @Test
+    public void normObjectLiteralDestructuringFunCall() throws Exception {
+        // JavaScript
+        final String script = "function a() { return 2;};  let {x = a()} = {x: 12}; x";
+
+        final String script2 = "function a() { return 2;};  let {x = 12} = {x: a()}; x";
+        Utils.assertWithAllOptimizationLevelsES6(12, script);
+        Utils.assertWithAllOptimizationLevelsES6(2, script2);
+    }
+
+    @Test
+    public void normDefaultParametersObjectDestructuringFunCall() throws Exception {
+        // JavaScript
+        final String script =
+                "function a() { return 12;};  function b({x = a()} = {x: 1}) { return x }; b()";
+        final String script2 =
+                "function a() { return 12;};  function b({x = a()} = {}) { return x }; b()";
+        final String script3 =
+                "var a = { p1: { p2: 121}}; function b({x = a.p1.p2} = {}) { return x }; b()";
+        final String script4 =
+                "function a() { return 12;};  function b({x = 1} = {x: a()}) { return x }; b()\n";
+
+        Utils.assertWithAllOptimizationLevelsES6(1, script);
+        Utils.assertWithAllOptimizationLevelsES6(12, script2);
+        Utils.assertWithAllOptimizationLevelsES6(121, script3);
+        Utils.assertWithAllOptimizationLevelsES6(12, script4);
+    }
+
+    @Test
+    public void normDefaultParametersArrayDestructuringFunCall() throws Exception {
+        // JavaScript
+        final String script =
+                "function a() { return 12;};  function b([x = a()] = [1]) { return x }; b()";
+        final String script2 =
+                "function a() { return 12;};  function b([x = a()] = []) { return x }; b()";
+        final String script3 =
+                "var a = { p1: { p2: 121}}; function b([x = a.p1.p2] = []) { return x }; b()";
+        final String script4 =
+                "function a() { return 12;};  function b([x = 1] = [a()]) { return x }; b()\n";
+
+        Utils.assertWithAllOptimizationLevelsES6(1, script);
+        Utils.assertWithAllOptimizationLevelsES6(12, script2);
+        Utils.assertWithAllOptimizationLevelsES6(121, script3);
+        Utils.assertWithAllOptimizationLevelsES6(12, script4);
+    }
+
+    @Test
+    public void normDefaultParametersFunCall() throws Exception {
+        // JavaScript
+        final String script = "function a() { return 12;};  function b(x = a()) { return x }; b()";
+        Utils.assertWithAllOptimizationLevelsES6(12, script);
+    }
+
+    @Test
+    @Ignore("destructuring-not-supported-in-for-let-expressions")
+    public void letExprDestructuringFunCall() throws Exception {
+        // JavaScript
+        final String script =
+                "function a() { return 4; }; (function() { "
+                        + "            for (let {x = a()} = {}; ; ) { "
+                        + "                return x; "
+                        + "            }"
+                        + "        })()";
+        Utils.assertWithAllOptimizationLevelsES6(4, script);
     }
 
     @Test

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -3887,7 +3887,7 @@ language/expressions/array 41/52 (78.85%)
     spread-sngl-literal.js
     spread-sngl-obj-ident.js
 
-language/expressions/arrow-function 167/343 (48.69%)
+language/expressions/arrow-function 151/343 (44.02%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3902,8 +3902,6 @@ language/expressions/arrow-function 167/343 (48.69%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -3929,7 +3927,6 @@ language/expressions/arrow-function 167/343 (48.69%)
     dstr/dflt-ary-init-iter-close.js
     dstr/dflt-ary-init-iter-get-err.js
     dstr/dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/dflt-ary-init-iter-no-close.js
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/dflt-ary-ptrn-elem-ary-elision-init.js
@@ -3941,9 +3938,6 @@ language/expressions/arrow-function 167/343 (48.69%)
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
     dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
@@ -3968,23 +3962,15 @@ language/expressions/arrow-function 167/343 (48.69%)
     dstr/dflt-ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-obj-init-null.js
     dstr/dflt-obj-init-undefined.js
-    dstr/dflt-obj-ptrn-id-get-value-err.js
     dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
     dstr/dflt-obj-ptrn-id-init-fn-name-class.js
     dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/dflt-obj-ptrn-id-init-skipped.js
-    dstr/dflt-obj-ptrn-id-init-throws.js
-    dstr/dflt-obj-ptrn-list-err.js
     dstr/dflt-obj-ptrn-prop-ary.js
     dstr/dflt-obj-ptrn-prop-ary-init.js
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/dflt-obj-ptrn-prop-ary-value-null.js
     dstr/dflt-obj-ptrn-prop-eval-err.js
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js
     dstr/dflt-obj-ptrn-prop-obj.js
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
@@ -4007,8 +3993,6 @@ language/expressions/arrow-function 167/343 (48.69%)
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -4055,7 +4039,7 @@ language/expressions/arrow-function 167/343 (48.69%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/assignment 193/480 (40.21%)
+language/expressions/assignment 186/480 (38.75%)
     destructuring 3/3 (100.0%)
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -4063,9 +4047,7 @@ language/expressions/assignment 193/480 (40.21%)
     dstr/array-elem-init-fn-name-cover.js
     dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
-    dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-order.js
     dstr/array-elem-init-simple-no-strict.js non-strict
     dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
@@ -4175,26 +4157,21 @@ language/expressions/assignment 193/480 (40.21%)
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
     dstr/obj-id-identifier-yield-ident-valid.js non-strict
-    dstr/obj-id-init-evaluation.js
     dstr/obj-id-init-fn-name-arrow.js
     dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
-    dstr/obj-id-init-in.js
     dstr/obj-id-init-let.js
-    dstr/obj-id-init-order.js
     dstr/obj-id-init-simple-no-strict.js non-strict
     dstr/obj-id-init-yield-ident-valid.js non-strict
     dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
-    dstr/obj-prop-elem-init-evaluation.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
-    dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
     dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
@@ -4531,7 +4508,7 @@ language/expressions/equals 0/47 (0.0%)
 language/expressions/exponentiation 1/44 (2.27%)
     order-of-evaluation.js
 
-language/expressions/function 168/264 (63.64%)
+language/expressions/function 149/264 (56.44%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4546,8 +4523,6 @@ language/expressions/function 168/264 (63.64%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -4573,7 +4548,6 @@ language/expressions/function 168/264 (63.64%)
     dstr/dflt-ary-init-iter-close.js
     dstr/dflt-ary-init-iter-get-err.js
     dstr/dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/dflt-ary-init-iter-no-close.js
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/dflt-ary-ptrn-elem-ary-elision-init.js
@@ -4585,9 +4559,6 @@ language/expressions/function 168/264 (63.64%)
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
     dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
@@ -4612,23 +4583,15 @@ language/expressions/function 168/264 (63.64%)
     dstr/dflt-ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-obj-init-null.js
     dstr/dflt-obj-init-undefined.js
-    dstr/dflt-obj-ptrn-id-get-value-err.js
     dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
     dstr/dflt-obj-ptrn-id-init-fn-name-class.js
     dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/dflt-obj-ptrn-id-init-skipped.js
-    dstr/dflt-obj-ptrn-id-init-throws.js
-    dstr/dflt-obj-ptrn-list-err.js
     dstr/dflt-obj-ptrn-prop-ary.js
     dstr/dflt-obj-ptrn-prop-ary-init.js
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/dflt-obj-ptrn-prop-ary-value-null.js
     dstr/dflt-obj-ptrn-prop-eval-err.js
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js
     dstr/dflt-obj-ptrn-prop-obj.js
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
@@ -4643,15 +4606,10 @@ language/expressions/function 168/264 (63.64%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
-    dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -4698,7 +4656,7 @@ language/expressions/function 168/264 (63.64%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 194/290 (66.9%)
+language/expressions/generators 185/290 (63.79%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4714,7 +4672,6 @@ language/expressions/generators 194/290 (66.9%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
@@ -4744,7 +4701,6 @@ language/expressions/generators 194/290 (66.9%)
     dstr/dflt-ary-init-iter-close.js
     dstr/dflt-ary-init-iter-get-err.js
     dstr/dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/dflt-ary-init-iter-no-close.js
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/dflt-ary-ptrn-elem-ary-elision-init.js
@@ -4757,8 +4713,6 @@ language/expressions/generators 194/290 (66.9%)
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
     dstr/dflt-ary-ptrn-elem-id-init-throws.js
     dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
@@ -4793,17 +4747,14 @@ language/expressions/generators 194/290 (66.9%)
     dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/dflt-obj-ptrn-id-init-skipped.js
     dstr/dflt-obj-ptrn-id-init-throws.js
     dstr/dflt-obj-ptrn-id-init-unresolvable.js
     dstr/dflt-obj-ptrn-list-err.js
     dstr/dflt-obj-ptrn-prop-ary.js
     dstr/dflt-obj-ptrn-prop-ary-init.js
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/dflt-obj-ptrn-prop-ary-value-null.js
     dstr/dflt-obj-ptrn-prop-eval-err.js
     dstr/dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
     dstr/dflt-obj-ptrn-prop-id-init-throws.js
     dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js
     dstr/dflt-obj-ptrn-prop-obj.js
@@ -4821,7 +4772,6 @@ language/expressions/generators 194/290 (66.9%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
@@ -4830,7 +4780,6 @@ language/expressions/generators 194/290 (66.9%)
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
@@ -5053,7 +5002,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 809/1169 (69.2%)
+language/expressions/object 790/1169 (67.58%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -5428,8 +5377,6 @@ language/expressions/object 809/1169 (69.2%)
     dstr/meth-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/meth-ary-ptrn-elem-id-init-skipped.js
-    dstr/meth-ary-ptrn-elem-id-init-throws.js
     dstr/meth-ary-ptrn-elem-id-iter-step-err.js
     dstr/meth-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/meth-ary-ptrn-elem-id-iter-val-err.js
@@ -5455,7 +5402,6 @@ language/expressions/object 809/1169 (69.2%)
     dstr/meth-dflt-ary-init-iter-close.js
     dstr/meth-dflt-ary-init-iter-get-err.js
     dstr/meth-dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/meth-dflt-ary-init-iter-no-close.js
     dstr/meth-dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/meth-dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/meth-dflt-ary-ptrn-elem-ary-elision-init.js
@@ -5467,9 +5413,6 @@ language/expressions/object 809/1169 (69.2%)
     dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/meth-dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/meth-dflt-ary-ptrn-elem-id-init-skipped.js
-    dstr/meth-dflt-ary-ptrn-elem-id-init-throws.js
     dstr/meth-dflt-ary-ptrn-elem-id-iter-step-err.js
     dstr/meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/meth-dflt-ary-ptrn-elem-id-iter-val-err.js
@@ -5494,23 +5437,15 @@ language/expressions/object 809/1169 (69.2%)
     dstr/meth-dflt-ary-ptrn-rest-obj-prop-id.js
     dstr/meth-dflt-obj-init-null.js
     dstr/meth-dflt-obj-init-undefined.js
-    dstr/meth-dflt-obj-ptrn-id-get-value-err.js
     dstr/meth-dflt-obj-ptrn-id-init-fn-name-arrow.js
     dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
     dstr/meth-dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/meth-dflt-obj-ptrn-id-init-skipped.js
-    dstr/meth-dflt-obj-ptrn-id-init-throws.js
-    dstr/meth-dflt-obj-ptrn-list-err.js
     dstr/meth-dflt-obj-ptrn-prop-ary.js
     dstr/meth-dflt-obj-ptrn-prop-ary-init.js
-    dstr/meth-dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/meth-dflt-obj-ptrn-prop-ary-value-null.js
     dstr/meth-dflt-obj-ptrn-prop-eval-err.js
-    dstr/meth-dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/meth-dflt-obj-ptrn-prop-id-init-skipped.js
-    dstr/meth-dflt-obj-ptrn-prop-id-init-throws.js
     dstr/meth-dflt-obj-ptrn-prop-obj.js
     dstr/meth-dflt-obj-ptrn-prop-obj-init.js
     dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js
@@ -5525,15 +5460,10 @@ language/expressions/object 809/1169 (69.2%)
     dstr/meth-obj-ptrn-id-init-fn-name-cover.js
     dstr/meth-obj-ptrn-id-init-fn-name-fn.js
     dstr/meth-obj-ptrn-id-init-fn-name-gen.js
-    dstr/meth-obj-ptrn-id-init-skipped.js
-    dstr/meth-obj-ptrn-id-init-throws.js
-    dstr/meth-obj-ptrn-list-err.js
     dstr/meth-obj-ptrn-prop-ary.js
     dstr/meth-obj-ptrn-prop-ary-init.js
     dstr/meth-obj-ptrn-prop-ary-value-null.js
     dstr/meth-obj-ptrn-prop-eval-err.js
-    dstr/meth-obj-ptrn-prop-id-init-skipped.js
-    dstr/meth-obj-ptrn-prop-id-init-throws.js
     dstr/meth-obj-ptrn-prop-obj.js
     dstr/meth-obj-ptrn-prop-obj-init.js
     dstr/meth-obj-ptrn-prop-obj-value-null.js
@@ -5984,7 +5914,7 @@ language/expressions/yield 4/63 (6.35%)
     star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 123/217 (56.68%)
+language/function-code 122/217 (56.22%)
     10.4.3-1-1-s.js non-strict
     10.4.3-1-10-s.js non-strict
     10.4.3-1-100-s.js
@@ -6104,7 +6034,6 @@ language/function-code 123/217 (56.68%)
     10.4.3-1-9gs.js strict
     block-decl-onlystrict.js strict
     eval-param-env-with-computed-key.js non-strict
-    eval-param-env-with-prop-initializer.js non-strict
     S10.4.3_A1.js strict
     switch-case-decl-onlystrict.js strict
     switch-dflt-decl-onlystrict.js strict
@@ -6355,7 +6284,7 @@ language/statements/break 0/20 (0.0%)
 
 ~language/statements/class
 
-language/statements/const 98/136 (72.06%)
+language/statements/const 91/136 (66.91%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6370,8 +6299,6 @@ language/statements/const 98/136 (72.06%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -6401,15 +6328,10 @@ language/statements/const 98/136 (72.06%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
-    dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -6475,7 +6397,7 @@ language/statements/empty 0/2 (0.0%)
 
 language/statements/expression 0/3 (0.0%)
 
-language/statements/for 244/385 (63.38%)
+language/statements/for 230/385 (59.74%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -6579,8 +6501,6 @@ language/statements/for 244/385 (63.38%)
     dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/let-ary-ptrn-elem-id-init-skipped.js
-    dstr/let-ary-ptrn-elem-id-init-throws.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
     dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
@@ -6612,16 +6532,11 @@ language/statements/for 244/385 (63.38%)
     dstr/let-obj-ptrn-id-init-fn-name-cover.js
     dstr/let-obj-ptrn-id-init-fn-name-fn.js
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
-    dstr/let-obj-ptrn-id-init-skipped.js
-    dstr/let-obj-ptrn-id-init-throws.js
-    dstr/let-obj-ptrn-list-err.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
     dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
-    dstr/let-obj-ptrn-prop-id-init-skipped.js
-    dstr/let-obj-ptrn-prop-id-init-throws.js
     dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
@@ -6643,8 +6558,6 @@ language/statements/for 244/385 (63.38%)
     dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/var-ary-ptrn-elem-id-init-skipped.js
-    dstr/var-ary-ptrn-elem-id-init-throws.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
     dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
@@ -6676,15 +6589,10 @@ language/statements/for 244/385 (63.38%)
     dstr/var-obj-ptrn-id-init-fn-name-cover.js
     dstr/var-obj-ptrn-id-init-fn-name-fn.js
     dstr/var-obj-ptrn-id-init-fn-name-gen.js
-    dstr/var-obj-ptrn-id-init-skipped.js
-    dstr/var-obj-ptrn-id-init-throws.js
-    dstr/var-obj-ptrn-list-err.js
     dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-ary-init.js
     dstr/var-obj-ptrn-prop-ary-value-null.js
     dstr/var-obj-ptrn-prop-eval-err.js
-    dstr/var-obj-ptrn-prop-id-init-skipped.js
-    dstr/var-obj-ptrn-prop-id-init-throws.js
     dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
@@ -6765,7 +6673,7 @@ language/statements/for-in 40/115 (34.78%)
     scope-head-lex-open.js
     scope-head-var-none.js non-strict
 
-language/statements/for-of 453/741 (61.13%)
+language/statements/for-of 434/741 (58.57%)
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
     dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
@@ -6774,7 +6682,6 @@ language/statements/for-of 453/741 (61.13%)
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-order.js
     dstr/array-elem-init-simple-no-strict.js non-strict
     dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
@@ -6983,8 +6890,6 @@ language/statements/for-of 453/741 (61.13%)
     dstr/let-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/let-ary-ptrn-elem-id-init-skipped.js
-    dstr/let-ary-ptrn-elem-id-init-throws.js
     dstr/let-ary-ptrn-elem-id-iter-step-err.js
     dstr/let-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/let-ary-ptrn-elem-id-iter-val-err.js
@@ -7016,15 +6921,10 @@ language/statements/for-of 453/741 (61.13%)
     dstr/let-obj-ptrn-id-init-fn-name-cover.js
     dstr/let-obj-ptrn-id-init-fn-name-fn.js
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
-    dstr/let-obj-ptrn-id-init-skipped.js
-    dstr/let-obj-ptrn-id-init-throws.js
-    dstr/let-obj-ptrn-list-err.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
-    dstr/let-obj-ptrn-prop-id-init-skipped.js
-    dstr/let-obj-ptrn-prop-id-init-throws.js
     dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
@@ -7053,7 +6953,6 @@ language/statements/for-of 453/741 (61.13%)
     dstr/obj-id-init-yield-ident-valid.js non-strict
     dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
-    dstr/obj-prop-elem-init-evaluation.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
@@ -7111,8 +7010,6 @@ language/statements/for-of 453/741 (61.13%)
     dstr/var-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/var-ary-ptrn-elem-id-init-skipped.js
-    dstr/var-ary-ptrn-elem-id-init-throws.js
     dstr/var-ary-ptrn-elem-id-iter-step-err.js
     dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/var-ary-ptrn-elem-id-iter-val-err.js
@@ -7144,15 +7041,10 @@ language/statements/for-of 453/741 (61.13%)
     dstr/var-obj-ptrn-id-init-fn-name-cover.js
     dstr/var-obj-ptrn-id-init-fn-name-fn.js
     dstr/var-obj-ptrn-id-init-fn-name-gen.js
-    dstr/var-obj-ptrn-id-init-skipped.js
-    dstr/var-obj-ptrn-id-init-throws.js
-    dstr/var-obj-ptrn-list-err.js
     dstr/var-obj-ptrn-prop-ary.js
     dstr/var-obj-ptrn-prop-ary-init.js
     dstr/var-obj-ptrn-prop-ary-value-null.js
     dstr/var-obj-ptrn-prop-eval-err.js
-    dstr/var-obj-ptrn-prop-id-init-skipped.js
-    dstr/var-obj-ptrn-prop-id-init-throws.js
     dstr/var-obj-ptrn-prop-obj.js
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
@@ -7208,19 +7100,16 @@ language/statements/for-of 453/741 (61.13%)
     let-block-with-newline.js non-strict
     let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
-    scope-body-lex-close.js
     scope-body-lex-open.js
-    scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js non-strict
     typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-grow-before-end.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
-language/statements/function 183/451 (40.58%)
+language/statements/function 164/451 (36.36%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7235,8 +7124,6 @@ language/statements/function 183/451 (40.58%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -7262,7 +7149,6 @@ language/statements/function 183/451 (40.58%)
     dstr/dflt-ary-init-iter-close.js
     dstr/dflt-ary-init-iter-get-err.js
     dstr/dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/dflt-ary-init-iter-no-close.js
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/dflt-ary-ptrn-elem-ary-elision-init.js
@@ -7274,9 +7160,6 @@ language/statements/function 183/451 (40.58%)
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
-    dstr/dflt-ary-ptrn-elem-id-init-throws.js
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
     dstr/dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/dflt-ary-ptrn-elem-id-iter-val-err.js
@@ -7301,23 +7184,15 @@ language/statements/function 183/451 (40.58%)
     dstr/dflt-ary-ptrn-rest-obj-prop-id.js
     dstr/dflt-obj-init-null.js
     dstr/dflt-obj-init-undefined.js
-    dstr/dflt-obj-ptrn-id-get-value-err.js
     dstr/dflt-obj-ptrn-id-init-fn-name-arrow.js
     dstr/dflt-obj-ptrn-id-init-fn-name-class.js
     dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/dflt-obj-ptrn-id-init-skipped.js
-    dstr/dflt-obj-ptrn-id-init-throws.js
-    dstr/dflt-obj-ptrn-list-err.js
     dstr/dflt-obj-ptrn-prop-ary.js
     dstr/dflt-obj-ptrn-prop-ary-init.js
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/dflt-obj-ptrn-prop-ary-value-null.js
     dstr/dflt-obj-ptrn-prop-eval-err.js
-    dstr/dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
-    dstr/dflt-obj-ptrn-prop-id-init-throws.js
     dstr/dflt-obj-ptrn-prop-obj.js
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
@@ -7332,15 +7207,10 @@ language/statements/function 183/451 (40.58%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
-    dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -7402,7 +7272,7 @@ language/statements/function 183/451 (40.58%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 179/266 (67.29%)
+language/statements/generators 170/266 (63.91%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7418,7 +7288,6 @@ language/statements/generators 179/266 (67.29%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
     dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-init-unresolvable.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
@@ -7448,7 +7317,6 @@ language/statements/generators 179/266 (67.29%)
     dstr/dflt-ary-init-iter-close.js
     dstr/dflt-ary-init-iter-get-err.js
     dstr/dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/dflt-ary-init-iter-no-close.js
     dstr/dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/dflt-ary-ptrn-elem-ary-elision-init.js
@@ -7461,8 +7329,6 @@ language/statements/generators 179/266 (67.29%)
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/dflt-ary-ptrn-elem-id-init-skipped.js
     dstr/dflt-ary-ptrn-elem-id-init-throws.js
     dstr/dflt-ary-ptrn-elem-id-init-unresolvable.js
     dstr/dflt-ary-ptrn-elem-id-iter-step-err.js
@@ -7497,17 +7363,14 @@ language/statements/generators 179/266 (67.29%)
     dstr/dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/dflt-obj-ptrn-id-init-skipped.js
     dstr/dflt-obj-ptrn-id-init-throws.js
     dstr/dflt-obj-ptrn-id-init-unresolvable.js
     dstr/dflt-obj-ptrn-list-err.js
     dstr/dflt-obj-ptrn-prop-ary.js
     dstr/dflt-obj-ptrn-prop-ary-init.js
-    dstr/dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/dflt-obj-ptrn-prop-ary-value-null.js
     dstr/dflt-obj-ptrn-prop-eval-err.js
     dstr/dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/dflt-obj-ptrn-prop-id-init-skipped.js
     dstr/dflt-obj-ptrn-prop-id-init-throws.js
     dstr/dflt-obj-ptrn-prop-id-init-unresolvable.js
     dstr/dflt-obj-ptrn-prop-obj.js
@@ -7525,7 +7388,6 @@ language/statements/generators 179/266 (67.29%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
     dstr/obj-ptrn-id-init-throws.js
     dstr/obj-ptrn-id-init-unresolvable.js
     dstr/obj-ptrn-list-err.js
@@ -7534,7 +7396,6 @@ language/statements/generators 179/266 (67.29%)
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
     dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
     dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-id-init-unresolvable.js
     dstr/obj-ptrn-prop-obj.js
@@ -7643,7 +7504,7 @@ language/statements/labeled 15/24 (62.5%)
     value-yield-non-strict.js non-strict
     value-yield-non-strict-escaped.js non-strict
 
-language/statements/let 91/145 (62.76%)
+language/statements/let 84/145 (57.93%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7658,8 +7519,6 @@ language/statements/let 91/145 (62.76%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -7689,15 +7548,10 @@ language/statements/let 91/145 (62.76%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
-    dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
@@ -7920,7 +7774,7 @@ language/statements/try 113/201 (56.22%)
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable 85/178 (47.75%)
+language/statements/variable 78/178 (43.82%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7935,8 +7789,6 @@ language/statements/variable 85/178 (47.75%)
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
@@ -7968,15 +7820,10 @@ language/statements/variable 85/178 (47.75%)
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
-    dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-list-err.js
     dstr/obj-ptrn-prop-ary.js
     dstr/obj-ptrn-prop-ary-init.js
     dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
     dstr/obj-ptrn-prop-obj.js
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js


### PR DESCRIPTION
Default values for destructuring assignments weren't transformed correctly. Partially addresses #1641.

For example, all of these expressions with default values were not being evaluated correctly:

```javascript
function a() { return 12;};  function b([x = a()] = []) { return x }; b()
function a() { return 12;};  function b([x = a()] = [1]) { return x }; b()
function a() { return 12;};  function b([x = 1] = [a()]) { return x }; b()
var a = { p1: { p2: 121}}; function b([x = a.p1.p2] = []) { return x }; b()
```

```javascript
function a() { return 12;};  function b({x = a()} = {}) { return x }; b()
function a() { return 12;};  function b({x = a()} = {x: 1}) { return x }; b()
var a = { p1: { p2: 121}}; function b({x = a.p1.p2} = {}) { return x }; b()
function a() { return 12;};  function b({x = 1} = {x: a()}) { return x }; b()
```