### PR TITLE
Allow passing `Undefined.instance` to `ScriptRuntime.evalSpecial`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3044,7 +3044,11 @@ public class ScriptRuntime {
         Script script = cx.compileString(x.toString(), evaluator, reporter, sourceName, 1, null);
         evaluator.setEvalScriptFlag(script);
         Callable c = (Callable) script;
-        return c.call(cx, scope, (Scriptable) thisArg, ScriptRuntime.emptyArgs);
+        Scriptable thisObject =
+                thisArg == Undefined.instance
+                        ? Undefined.SCRIPTABLE_UNDEFINED
+                        : (Scriptable) thisArg;
+        return c.call(cx, scope, thisObject, ScriptRuntime.emptyArgs);
     }
 
     /** The typeof operator */

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
@@ -1,0 +1,35 @@
+package org.mozilla.javascript;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.mozilla.javascript.tests.Utils;
+
+public class ScriptRuntimeEvalSpecialTest {
+    @Test
+    public void worksWithAnObject() {
+        canUseEvalSpecialWithThisSetTo(new NativeObject());
+    }
+
+    @Test
+    public void worksWithNull() {
+        canUseEvalSpecialWithThisSetTo(null);
+    }
+
+    @Test
+    public void worksWithUndefined() {
+        canUseEvalSpecialWithThisSetTo(Undefined.instance);
+    }
+
+    private static void canUseEvalSpecialWithThisSetTo(Object thisArg) {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    ScriptableObject scope = cx.initStandardObjects();
+                    Object o =
+                            ScriptRuntime.evalSpecial(
+                                    cx, scope, thisArg, new Object[] {"true"}, "", 0);
+                    assertEquals(true, o);
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
The method `ScriptRuntime.evalSpecial` takes a generic `Object` for `thisArg`. However, it then casts it to `Scriptable`.
We have some (rare) code paths where we end up passing `Undefined.instance` to that method, where we get a `ClassCastException`.
This simple PR allows it and adds a test.