### PR TITLE
make sure, equivalentValues(Object) is used if available

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3737,7 +3737,15 @@ public class ScriptRuntime {
             if (isSymbol(y) && isObject(x)) {
                 return eq(toPrimitive(x), y);
             }
-            if (y instanceof Scriptable) {
+            if (y == null || Undefined.isUndefined(y)) {
+                if (x instanceof ScriptableObject) {
+                    Object test = ((ScriptableObject) x).equivalentValues(y);
+                    if (test != Scriptable.NOT_FOUND) {
+                        return ((Boolean) test).booleanValue();
+                    }
+                }
+                return false;
+            } else if (y instanceof Scriptable) {
                 if (x instanceof ScriptableObject) {
                     Object test = ((ScriptableObject) x).equivalentValues(y);
                     if (test != Scriptable.NOT_FOUND) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeEquivalentValuesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeEquivalentValuesTest.java
@@ -1,0 +1,86 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.annotations.JSConstructor;
+
+/**
+ * Test cases for the {@link ScriptRuntime} support for ScriptableObject#equivalentValues(Object)
+ * method.
+ *
+ * @author Ronald Brill
+ */
+public class ScriptRuntimeEquivalentValuesTest {
+
+    @Test
+    public void equivalentValuesUndefined() throws Exception {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    try {
+                        ScriptableObject.defineClass(scope, EquivalentTesterObject.class);
+                    } catch (Exception e) {
+                    }
+
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "var o = new EquivalentTesterObject();"
+                                            + "'' + (o == undefined) + ' ' + (undefined == o)",
+                                    "test",
+                                    1,
+                                    null);
+                    assertEquals("" + cx.getOptimizationLevel(), "true true", result);
+
+                    return null;
+                });
+    }
+
+    @Test
+    public void equivalentValuesNull() throws Exception {
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    try {
+                        ScriptableObject.defineClass(scope, EquivalentTesterObject.class);
+                    } catch (Exception e) {
+                    }
+
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "var o = new EquivalentTesterObject();"
+                                            + "'' + (o == null) + ' ' + (null == o)",
+                                    "test",
+                                    1,
+                                    null);
+                    assertEquals("" + cx.getOptimizationLevel(), "true true", result);
+
+                    return null;
+                });
+    }
+
+    public static class EquivalentTesterObject extends ScriptableObject {
+
+        public EquivalentTesterObject() {}
+
+        @Override
+        public String getClassName() {
+            return "EquivalentTesterObject";
+        }
+
+        @JSConstructor
+        public void jsConstructorMethod() {}
+
+        @Override
+        protected Object equivalentValues(final Object value) {
+            if (value == null || Undefined.isUndefined(value)) {
+                return Boolean.TRUE;
+            }
+
+            return super.equivalentValues(value);
+        }
+    }
+}


### PR DESCRIPTION
The HTMLAllCollection implements some strange behavior - https://developer.mozilla.org/en-US/docs/Web/API/HTMLAllCollection#special_type_conversion_behavior. Of course we have to support this in HtmlUnit - see https://github.com/HtmlUnit/htmlunit/issues/896

Luckily Rhino supports this kind of customized equals behavior by overriding the ScriptableObject#equivalentValues() method.

But there are two bugs
* the equivalentValues() method is called if the lhs is null or undefined but NOT if the rhs is null or undefined (interpreter).
* the optimized version works correct if the lhs is undefined or rhs is undefined but does not call the equivalentValues() method in case lhs/rhs is null

This PR fixes both cases and also adds test cases.

