### PR TITLE
Allow usage of `require` in the debugger and use ES6

### DIFF
--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
@@ -6,13 +6,17 @@
 
 package org.mozilla.javascript.tools.debugger;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.net.URI;
+import java.util.List;
 import javax.swing.JFrame;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.commonjs.module.ModuleScope;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
@@ -163,20 +167,29 @@ public class Main {
         System.setOut(main.getOut());
         System.setErr(main.getErr());
 
-        Global global = org.mozilla.javascript.tools.shell.Main.getGlobal();
-        global.setIn(main.getIn());
-        global.setOut(main.getOut());
-        global.setErr(main.getErr());
-
         main.attachTo(org.mozilla.javascript.tools.shell.Main.shellContextFactory);
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
 
-        main.setScope(global);
+            Global global = org.mozilla.javascript.tools.shell.Main.getGlobal();
+            global.init(cx);
+            global.setIn(main.getIn());
+            global.setOut(main.getOut());
+            global.setErr(main.getErr());
 
-        main.pack();
-        main.setSize(600, 460);
-        main.setVisible(true);
+            global.installRequire(cx, List.of(), false);
 
-        org.mozilla.javascript.tools.shell.Main.exec(args);
+            URI uri = new File(System.getProperty("user.dir")).toURI();
+            ModuleScope scope = new ModuleScope(global, uri, null);
+
+            main.setScope(scope);
+
+            main.pack();
+            main.setSize(600, 460);
+            main.setVisible(true);
+
+            org.mozilla.javascript.tools.shell.Main.exec(args);
+        }
     }
 
     /**


### PR DESCRIPTION
Simple PR to allow using `require` in the debugger and to default to ES6 mode.