### PR TITLE
Console should always flush after writing a newline

### DIFF
--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
@@ -36,6 +36,8 @@ class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
                     console.println(element.toString());
                 }
             }
+
+            console.flush();
         } catch (IOException e) {
             throw Context.reportRuntimeError(e.getMessage());
         }


### PR DESCRIPTION
Not really sure this deserves a big description. 🙂 
We just want to ensure that any `console.log` actually ends up being printed immediately and not buffered.