### PR TITLE
Implement `String.prototype.matchAll` and related

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -820,18 +820,22 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
      * @return obj casted to the target type
      * @throws EcmaError if the cast failed.
      */
-    @SuppressWarnings("unchecked")
     protected static <T> T ensureType(Object obj, Class<T> clazz, IdFunctionObject f) {
+        return ensureType(obj, clazz, f.getFunctionName());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static <T> T ensureType(Object obj, Class<T> clazz, String functionName) {
         if (clazz.isInstance(obj)) {
             return (T) obj;
         }
         if (obj == null) {
             throw ScriptRuntime.typeErrorById(
-                    "msg.incompat.call.details", f.getFunctionName(), "null", clazz.getName());
+                    "msg.incompat.call.details", functionName, "null", clazz.getName());
         }
         throw ScriptRuntime.typeErrorById(
                 "msg.incompat.call.details",
-                f.getFunctionName(),
+                functionName,
                 obj.getClass().getName(),
                 clazz.getName());
     }

--- a/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
@@ -35,7 +35,7 @@ public final class LazilyLoadedCtor implements Serializable {
         this(scope, propertyName, className, sealed, false);
     }
 
-    LazilyLoadedCtor(
+    public LazilyLoadedCtor(
             ScriptableObject scope,
             String propertyName,
             String className,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -72,6 +72,7 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
         createStandardSymbol(cx, scope, ctor, "isRegExp", SymbolKey.IS_REGEXP);
         createStandardSymbol(cx, scope, ctor, "toPrimitive", SymbolKey.TO_PRIMITIVE);
         createStandardSymbol(cx, scope, ctor, "match", SymbolKey.MATCH);
+        createStandardSymbol(cx, scope, ctor, "matchAll", SymbolKey.MATCH_ALL);
         createStandardSymbol(cx, scope, ctor, "replace", SymbolKey.REPLACE);
         createStandardSymbol(cx, scope, ctor, "search", SymbolKey.SEARCH);
         createStandardSymbol(cx, scope, ctor, "split", SymbolKey.SPLIT);

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
@@ -18,6 +18,8 @@ public interface RegExpProxy {
     public static final int RA_REPLACE_ALL = 3;
     public static final int RA_SEARCH = 4;
 
+    public void register(ScriptableObject scope, boolean sealed);
+
     public boolean isRegExp(Scriptable obj);
 
     public Object compileRegExp(Context cx, String source, String flags);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -188,7 +188,7 @@ public class ScriptRuntime {
 
         NativeArrayIterator.init(scope, sealed);
         NativeStringIterator.init(scope, sealed);
-        getRegExpProxy(cx).register(scope, sealed);
+        registerRegExp(cx, scope, sealed);
 
         NativeJavaObject.init(scope, sealed);
         NativeJavaMap.init(scope, sealed);
@@ -296,6 +296,13 @@ public class ScriptRuntime {
         }
 
         return scope;
+    }
+
+    private static void registerRegExp(Context cx, ScriptableObject scope, boolean sealed) {
+        RegExpProxy regExpProxy = getRegExpProxy(cx);
+        if (regExpProxy != null) {
+            regExpProxy.register(scope, sealed);
+        }
     }
 
     public static ScriptableObject initStandardObjects(

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -188,6 +188,7 @@ public class ScriptRuntime {
 
         NativeArrayIterator.init(scope, sealed);
         NativeStringIterator.init(scope, sealed);
+        getRegExpProxy(cx).register(scope, sealed);
 
         NativeJavaObject.init(scope, sealed);
         NativeJavaMap.init(scope, sealed);
@@ -196,8 +197,6 @@ public class ScriptRuntime {
                 cx.hasFeature(Context.FEATURE_E4X) && cx.getE4xImplementationFactory() != null;
 
         // define lazy-loaded properties using their class name
-        new LazilyLoadedCtor(
-                scope, "RegExp", "org.mozilla.javascript.regexp.NativeRegExp", sealed, true);
         new LazilyLoadedCtor(
                 scope, "Continuation", "org.mozilla.javascript.NativeContinuation", sealed, true);
 
@@ -1388,6 +1387,14 @@ public class ScriptRuntime {
         return (long) Math.min(len, NativeNumber.MAX_SAFE_INTEGER);
     }
 
+    public static long toLength(Object value) {
+        double len = toInteger(value);
+        if (len <= 0.0) {
+            return 0;
+        }
+        return (long) Math.min(len, NativeNumber.MAX_SAFE_INTEGER);
+    }
+
     /** See ECMA 9.5. */
     public static int toInt32(Object val) {
         // short circuit for common integer values
@@ -1442,6 +1449,20 @@ public class ScriptRuntime {
             return Optional.of(num);
         }
         return Optional.empty();
+    }
+
+    /** Implements the abstract operation AdvanceStringIndex. See ECMAScript spec 22.2.7.3 */
+    public static long advanceStringIndex(String string, long index, boolean unicode) {
+        if (index >= NativeNumber.MAX_SAFE_INTEGER) Kit.codeBug();
+        if (!unicode) {
+            return index + 1;
+        }
+        int length = string.length();
+        if (index + 1 > length) {
+            return index + 1;
+        }
+        int cp = string.codePointAt((int) index);
+        return index + Character.charCount(cp);
     }
 
     // XXX: this is until setDefaultNamespace will learn how to store NS

--- a/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
@@ -20,6 +20,7 @@ public class SymbolKey implements Symbol, Serializable {
     public static final SymbolKey IS_REGEXP = new SymbolKey("Symbol.isRegExp");
     public static final SymbolKey TO_PRIMITIVE = new SymbolKey("Symbol.toPrimitive");
     public static final SymbolKey MATCH = new SymbolKey("Symbol.match");
+    public static final SymbolKey MATCH_ALL = new SymbolKey("Symbol.matchAll");
     public static final SymbolKey REPLACE = new SymbolKey("Symbol.replace");
     public static final SymbolKey SEARCH = new SymbolKey("Symbol.search");
     public static final SymbolKey SPLIT = new SymbolKey("Symbol.split");

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -19,6 +19,13 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     private static final long serialVersionUID = 1L;
     private static final String ITERATOR_TAG = "RegExpStringIterator";
 
+    private Scriptable regexp;
+    private String string;
+    private boolean global;
+    private boolean fullUnicode;
+    private boolean nextDone;
+    private Object next = null;
+
     public static void init(ScriptableObject scope, boolean sealed) {
         ES6Iterator.init(scope, sealed, new NativeRegExpStringIterator(), ITERATOR_TAG);
     }
@@ -101,11 +108,4 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     protected String getTag() {
         return ITERATOR_TAG;
     }
-
-    private Scriptable regexp;
-    private String string;
-    private boolean global;
-    private boolean fullUnicode;
-    private boolean nextDone;
-    private Object next = null;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -1,0 +1,111 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.regexp;
+
+import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ES6Iterator;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.Undefined;
+
+// See ECMAScript spec 22.2.9.1
+public final class NativeRegExpStringIterator extends ES6Iterator {
+    private static final long serialVersionUID = 1L;
+    private static final String ITERATOR_TAG = "RegExpStringIterator";
+
+    public static void init(ScriptableObject scope, boolean sealed) {
+        ES6Iterator.init(scope, sealed, new NativeRegExpStringIterator(), ITERATOR_TAG);
+    }
+
+    /** Only for constructing the prototype object. */
+    private NativeRegExpStringIterator() {
+        super();
+    }
+
+    public NativeRegExpStringIterator(
+            Scriptable scope,
+            Scriptable regexp,
+            String string,
+            boolean global,
+            boolean fullUnicode) {
+        super(scope, ITERATOR_TAG);
+
+        this.regexp = regexp;
+        this.string = string;
+        this.global = global;
+        this.fullUnicode = fullUnicode;
+        this.nextDone = false;
+    }
+
+    @Override
+    public String getClassName() {
+        return "RegExp String Iterator";
+    }
+
+    @Override
+    protected boolean isDone(Context cx, Scriptable scope) {
+        // The base class calls _first_ isDone and _then_ nextValue, so we'll just compute the next
+        // value here and return it form "nextValue".
+        // Also, for non-global regexp, we need to return the first match and then "done" on the
+        // next iteration.
+
+        if (nextDone) {
+            return true;
+        }
+
+        next = regExpExec(cx, scope);
+        if (next == null) {
+            // Done! Point ii of the spec
+            next = Undefined.instance;
+            nextDone = true;
+            return true;
+        } else if (!global) {
+            // Return false at this iteration, but true at the next. Point iii of the spec
+            nextDone = true;
+            return false;
+        }
+
+        // Increment index if matched empty string, as per the spec, point v.
+        String matchStr = ScriptRuntime.toString(ScriptRuntime.getObjectIndex(next, 0, cx, scope));
+        if (matchStr.isEmpty()) {
+            long thisIndex =
+                    ScriptRuntime.toLength(ScriptRuntime.getObjectProp(regexp, "lastIndex", cx));
+            long nextIndex = ScriptRuntime.advanceStringIndex(string, thisIndex, fullUnicode);
+            ScriptRuntime.setObjectProp(regexp, "lastIndex", nextIndex, cx);
+        }
+
+        return false;
+    }
+
+    @Override
+    protected Object nextValue(Context cx, Scriptable scope) {
+        return next;
+    }
+
+    private Object regExpExec(Context cx, Scriptable scope) {
+        // See ECMAScript spec 22.2.7.1
+        Object execMethod = ScriptRuntime.getObjectProp(regexp, "exec", cx);
+        if (execMethod instanceof Callable) {
+            return ((Callable) execMethod).call(cx, scope, regexp, new Object[] {string});
+        }
+        return NativeRegExp.js_exec(cx, scope, regexp, new Object[] {string});
+    }
+
+    @Override
+    protected String getTag() {
+        return ITERATOR_TAG;
+    }
+
+    private Scriptable regexp;
+    private String string;
+    private boolean global;
+    private boolean fullUnicode;
+    private boolean nextDone;
+    private Object next = null;
+}

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -9,6 +9,7 @@ package org.mozilla.javascript.regexp;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Kit;
+import org.mozilla.javascript.LazilyLoadedCtor;
 import org.mozilla.javascript.RegExpProxy;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
@@ -17,6 +18,13 @@ import org.mozilla.javascript.Undefined;
 
 /** */
 public class RegExpImpl implements RegExpProxy {
+
+    @Override
+    public void register(ScriptableObject scope, boolean sealed) {
+        NativeRegExpStringIterator.init(scope, sealed);
+        new LazilyLoadedCtor(
+                scope, "RegExp", "org.mozilla.javascript.regexp.NativeRegExp", sealed, true);
+    }
 
     @Override
     public boolean isRegExp(Scriptable obj) {

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -253,6 +253,9 @@ msg.bad.regexp.compile =\
 msg.arg.not.object =\
     Expected argument of type object, but instead had type {0}
 
+msg.str.match.all.no.global.flag =\
+    String.prototype.matchAll called with a non-global RegExp argument
+
 # NativeDate
 msg.invalid.date =\
     Date is invalid.

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeAdvanceStringIndexTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeAdvanceStringIndexTest.java
@@ -1,0 +1,27 @@
+package org.mozilla.javascript;
+
+import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.Test;
+
+public class ScriptRuntimeAdvanceStringIndexTest {
+    @Test
+    void nonUnicode() {
+        assertEquals(2, ScriptRuntime.advanceStringIndex("abc", 1, false));
+    }
+
+    @Test
+    void unicodeNormalCodePoint() {
+        assertEquals(1, ScriptRuntime.advanceStringIndex("abc", 0, true));
+    }
+
+    @Test
+    void unicodeCodePointSurrogatePair() {
+        assertEquals(2, ScriptRuntime.advanceStringIndex("\uD81B\uDF777a", 0, true));
+    }
+
+    @Test
+    void unicodeAfterEnd() {
+        assertEquals(4, ScriptRuntime.advanceStringIndex("abc", 3, true));
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -112,8 +112,6 @@ public class Test262SuiteTest {
                             "regexp-unicode-property-escapes",
                             "resizable-arraybuffer",
                             "super",
-                            "String.prototype.matchAll",
-                            "Symbol.matchAll",
                             "tail-call-optimization",
                             "u180e"));
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2020/StringMatchAllTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2020/StringMatchAllTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests.es2020;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es2020/string-match-all.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class StringMatchAllTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/es2020/string-match-all.js
+++ b/tests/testsrc/jstests/es2020/string-match-all.js
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+load("testsrc/assert.js");
+
+function assertIteratorIsDone(iterator) {
+	const next = iterator.next();
+	assertTrue(next.done);
+	assertEquals(undefined, next.value);
+}
+
+(function happyPath() {
+	const s = "aabbc";
+	const re = /([a-z])\1/g;
+	const matches = s.matchAll(re);
+
+	var match = matches.next();
+	assertFalse(match.done);
+	assertEquals("aa", match.value[0]);
+	assertEquals(0, match.value.index);
+	assertEquals(s, match.value.input);
+
+	match = matches.next();
+	assertFalse(match.done);
+	assertEquals("bb", match.value[0]);
+	assertEquals(2, match.value.index);
+	assertEquals(s, match.value.input);
+
+	assertIteratorIsDone(matches);
+})();
+
+(function matchingEmptyStringDoesNotResultInInfiniteLoop() {
+	const s = "abc";
+	const re = /(?=[a-b])/g;
+	const matches = s.matchAll(re);
+
+	var match = matches.next();
+	assertFalse(match.done);
+	assertEquals("", match.value[0]);
+	assertEquals(0, match.value.index);
+	assertEquals(s, match.value.input);
+
+	match = matches.next();
+	assertFalse(match.done);
+	assertEquals("", match.value[0]);
+	assertEquals(1, match.value.index);
+	assertEquals(s, match.value.input);
+
+	assertIteratorIsDone(matches);
+})();
+
+(function stringMatchAllCalledWithNonGlobalRegExp() {
+	const s = "aabbc";
+	const re = /([a-z])\1/;
+	try {
+		s.matchAll(re);
+		throw new Error('Expected a TypeError because regex is not global');
+	} catch (err) {
+		assertEquals('TypeError', err.name);
+		assertEquals('String.prototype.matchAll called with a non-global RegExp argument', err.message);
+	}
+})();
+
+(function regexpSymbolMatchAllGlobal() {
+	const s = "aabbc";
+	const re = /([a-z])\1/g;
+	const matches = re[Symbol.matchAll](s);
+
+	var match = matches.next();
+	assertFalse(match.done);
+	assertEquals("aa", match.value[0]);
+	assertEquals(0, match.value.index);
+	assertEquals(s, match.value.input);
+
+	match = matches.next();
+	assertFalse(match.done);
+	assertEquals("bb", match.value[0]);
+	assertEquals(2, match.value.index);
+	assertEquals(s, match.value.input);
+
+	assertIteratorIsDone(matches);
+})();
+
+(function regexpSymbolMatchAllNonGlobal() {
+	const s = "aabbc";
+	const re = /([a-z])\1/;
+	const matches = re[Symbol.matchAll](s);
+
+	var match = matches.next();
+	assertFalse(match.done);
+	assertEquals("aa", match.value[0]);
+	assertEquals(0, match.value.index);
+	assertEquals(s, match.value.input);
+
+	// No second match, already done	
+	assertIteratorIsDone(matches);
+})();
+
+(function symbolMatchAllIsNotCallable() {
+	const s = "aabbc";
+	const re = {
+		[Symbol.matchAll]: 42
+	};
+	try {
+		s.matchAll(re);
+		throw new Error('Expected a TypeError because the value of Symbol.matchAll is not a function');
+	} catch (err) {
+		assertEquals('TypeError', err.name);
+		assertEquals('Cannot call property Symbol.matchAll in object [object Object]. It is not a function, it is "number".', err.message);
+	}
+})();
+
+(function customSymbolMatchAllImplementation() {
+	const s = "2016-01-02|2019-03-07";
+
+	const numbers = {
+		[Symbol.matchAll]: function*(str) {
+			for (var n of str.matchAll(/[0-9]+/g)) {
+				yield n[0];
+			}
+		},
+	};
+
+	const results = Array.from(s.matchAll(numbers));
+	assertEquals(6, results.length);
+	assertEquals("2016", results[0]);
+	assertEquals("01", results[1]);
+	assertEquals("02", results[2]);
+	assertEquals("2019", results[3]);
+	assertEquals("03", results[4]);
+	assertEquals("07", results[5]);
+})();
+
+(function nullRegExpShouldMatchLiteralNullString() {
+	const s = "to null or not to null";
+	const results = Array.from(s.matchAll(null));
+	assertEquals(2, results.length);
+	assertEquals("null", results[0][0]);
+	assertEquals(3, results[0].index);
+	assertEquals("null", results[1][0]);
+	assertEquals(18, results[1].index);
+})();
+
+'success';

--- a/tests/testsrc/jstests/es6/symbols.js
+++ b/tests/testsrc/jstests/es6/symbols.js
@@ -443,10 +443,19 @@ TestGetOwnPropertySymbolsWithProto()
 
 function TestWellKnown() {
   var symbols = [
+    "iterator",
+    "species",
+    "toStringTag",
     "hasInstance",
-    // TODO(rossberg): reactivate once implemented.
-    // "isConcatSpreadable", "isRegExp",
-    "iterator", /* "toStringTag", */ "unscopables"
+    "isConcatSpreadable",
+    "isRegExp",
+    "toPrimitive",
+    "match",
+    "matchAll",
+    "replace",
+    "search",
+    "split",
+    "unscopables",
   ]
 
   for (var i in symbols) {

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1679,7 +1679,7 @@ built-ins/Promise 406/631 (64.34%)
 
 ~built-ins/Reflect
 
-built-ins/RegExp 1169/1854 (63.05%)
+built-ins/RegExp 1152/1854 (62.14%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1758,7 +1758,15 @@ built-ins/RegExp 1169/1854 (63.05%)
     prototype/sticky/name.js
     prototype/sticky/prop-desc.js
     prototype/sticky/this-val-regexp-prototype.js
-    prototype/Symbol.matchAll 26/26 (100.0%)
+    prototype/Symbol.matchAll/isregexp-called-once.js
+    prototype/Symbol.matchAll/isregexp-this-throws.js
+    prototype/Symbol.matchAll/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/Symbol.matchAll/species-constructor.js
+    prototype/Symbol.matchAll/species-constructor-get-species-throws.js
+    prototype/Symbol.matchAll/this-get-flags.js
+    prototype/Symbol.matchAll/this-not-object-throws.js
+    prototype/Symbol.matchAll/this-tostring-flags.js
+    prototype/Symbol.matchAll/this-tostring-flags-throws.js
     prototype/Symbol.match/builtin-infer-unicode.js
     prototype/Symbol.match/builtin-success-g-set-lastindex.js
     prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
@@ -1953,7 +1961,7 @@ built-ins/RegExp 1169/1854 (63.05%)
     unicode_identity_escape.js
     valid-flags-y.js
 
-built-ins/RegExpStringIteratorPrototype 17/17 (100.0%)
+built-ins/RegExpStringIteratorPrototype 0/17 (0.0%)
 
 built-ins/Set 167/381 (43.83%)
     prototype/add/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2128,7 +2136,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 116/1182 (9.81%)
+built-ins/String 101/1182 (8.54%)
     fromCharCode/not-a-constructor.js {unsupported: [Reflect.construct]}
     fromCodePoint/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/charAt/not-a-constructor.js {unsupported: [Reflect.construct]}
@@ -2147,7 +2155,11 @@ built-ins/String 116/1182 (9.81%)
     prototype/isWellFormed/to-string-primitive.js
     prototype/lastIndexOf/not-a-constructor.js {unsupported: [Reflect.construct]}
     prototype/localeCompare/not-a-constructor.js {unsupported: [Reflect.construct]}
-    prototype/matchAll 20/20 (100.0%)
+    prototype/matchAll/flags-nonglobal-throws.js
+    prototype/matchAll/flags-undefined-throws.js
+    prototype/matchAll/not-a-constructor.js {unsupported: [Reflect.construct]}
+    prototype/matchAll/regexp-matchAll-invocation.js
+    prototype/matchAll/regexp-prototype-matchAll-invocation.js
     prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/duplicate-named-groups-properties.js
@@ -2229,7 +2241,7 @@ built-ins/String 116/1182 (9.81%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol 26/94 (27.66%)
+built-ins/Symbol 25/94 (26.6%)
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
     dispose/prop-desc.js
@@ -2239,7 +2251,7 @@ built-ins/Symbol 26/94 (27.66%)
     iterator/cross-realm.js
     keyFor/arg-non-symbol.js
     keyFor/not-a-constructor.js {unsupported: [Reflect.construct]}
-    matchAll 2/2 (100.0%)
+    matchAll/cross-realm.js
     match/cross-realm.js
     prototype/description/this-val-non-symbol.js
     prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js


### PR DESCRIPTION
This PR implements:
- [`Symbol.matchAll`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll)
- [`String.prototype.matchAll`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll)
- [`RegExp.prototype[Symbol.matchAll]`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.matchAll)

All test262 cases pass; those that do not, fail for pre-existing reasons unrelated to these changes:

  - unicode flag 'u' not supported - looks similar to https://github.com/mozilla/rhino/issues/959 but I'm not 100% sure
    - RegExp/prototype/Symbol.matchAll/species-constructor.js
    - String/prototype/matchAll/flags-undefined-throws.js
  - flag property on regexp is not modifiable - tracked by https://github.com/mozilla/rhino/issues/1730
    - String/prototype/matchAll/flags-nonglobal-throws.js
    - RegExp/prototype/Symbol.matchAll/this-get-flags.js
    - RegExp/prototype/Symbol.matchAll/this-tostring-flags.js
    - RegExp/prototype/Symbol.matchAll/this-tostring-flags-throws.js
  - pre-existing problem with computed property on getter/setter and symbol keys - tracked by https://github.com/mozilla/rhino/issues/1729
    - Regexp/prototype/Symbol.matchAll/isregexp-this-throws.js
    - Regexp/prototype/Symbol.matchAll/isregexp-called-once.js
    - Regexp/prototype/Symbol.matchAll/species-constructor-get-species-throws.js
  - we autobox the `this` object, so we get a `NativeString` instead of the raw string literal and the last assertion fails
    - String/prototype/matchAll/regexp-matchAll-invocation.js
    - String/prototype/matchAll/regexp-prototype-matchAll-invocation.js
  - we autobox arguments to function calls, so `f.call(true)` receivedes a `NativeBoolean` which is an object
    - Regexp/prototype/Symbol.matchAll/this-not-object-throws.js

Please squash if accepted!