### PR TITLE
Literal object creation rework

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1332,7 +1332,7 @@ class CodeGenerator extends Icode {
                 // Will be a node of type Token.COMPUTED_PROPERTY wrapping the actual expression
                 Node computedPropertyNode = (Node) propertyId;
                 visitExpression(computedPropertyNode.first, 0);
-                addIndexOp(Icode_LITERAL_KEY_SET, i);
+                addIcode(Icode_LITERAL_KEY_SET);
                 stackChange(-1);
             }
 

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1319,9 +1319,8 @@ class CodeGenerator extends Icode {
         int nextLiteralIndex = literalIds.size();
         literalIds.add(propertyIds);
 
-        addIndexOp(Icode_LITERAL_KEYS, nextLiteralIndex);
+        addIndexOp(Icode_LITERAL_NEW_OBJECT, nextLiteralIndex);
         addUint8(hasAnyComputedProperty ? 1 : 0);
-        addIndexOp(Icode_LITERAL_NEW, count);
         stackChange(3);
 
         int i = 0;
@@ -1352,7 +1351,7 @@ class CodeGenerator extends Icode {
         for (Node n = child; n != null; n = n.getNext()) {
             ++count;
         }
-        addIndexOp(Icode_LITERAL_NEW, count);
+        addIndexOp(Icode_LITERAL_NEW_ARRAY, count);
         stackChange(2);
         while (child != null) {
             visitLiteralValue(child);

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1321,7 +1321,7 @@ class CodeGenerator extends Icode {
 
         addIndexOp(Icode_LITERAL_NEW_OBJECT, nextLiteralIndex);
         addUint8(hasAnyComputedProperty ? 1 : 0);
-        stackChange(3);
+        stackChange(4);
 
         int i = 0;
         while (child != null) {
@@ -1343,7 +1343,7 @@ class CodeGenerator extends Icode {
 
         addToken(Token.OBJECTLIT);
 
-        stackChange(-2);
+        stackChange(-3);
     }
 
     private void visitArrayLiteral(Node node, Node child) {

--- a/rhino/src/main/java/org/mozilla/javascript/Icode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Icode.java
@@ -75,8 +75,9 @@ abstract class Icode {
             Icode_INTNUMBER = Icode_SHORTNUMBER - 1,
 
             // To create and populate array to hold values for [] and {} literals
-            Icode_LITERAL_NEW = Icode_INTNUMBER - 1,
-            Icode_LITERAL_SET = Icode_LITERAL_NEW - 1,
+            Icode_LITERAL_NEW_OBJECT = Icode_INTNUMBER - 1,
+            Icode_LITERAL_NEW_ARRAY = Icode_LITERAL_NEW_OBJECT - 1,
+            Icode_LITERAL_SET = Icode_LITERAL_NEW_ARRAY - 1,
 
             // Array literal with skipped index like [1,,2]
             Icode_SPARE_ARRAYLIT = Icode_LITERAL_SET - 1,
@@ -145,8 +146,7 @@ abstract class Icode {
 
             // Call to GetTemplateLiteralCallSite
             Icode_TEMPLATE_LITERAL_CALLSITE = Icode_REG_BIGINT4 - 1,
-            Icode_LITERAL_KEYS = Icode_TEMPLATE_LITERAL_CALLSITE - 1,
-            Icode_LITERAL_KEY_SET = Icode_LITERAL_KEYS - 1,
+            Icode_LITERAL_KEY_SET = Icode_TEMPLATE_LITERAL_CALLSITE - 1,
 
             // Jump if stack head is null or undefined
             Icode_IF_NULL_UNDEF = Icode_LITERAL_KEY_SET - 1,
@@ -234,8 +234,10 @@ abstract class Icode {
                 return "SHORTNUMBER";
             case Icode_INTNUMBER:
                 return "INTNUMBER";
-            case Icode_LITERAL_NEW:
-                return "LITERAL_NEW";
+            case Icode_LITERAL_NEW_OBJECT:
+                return "LITERAL_NEW_OBJECT";
+            case Icode_LITERAL_NEW_ARRAY:
+                return "LITERAL_NEW_ARRAY";
             case Icode_LITERAL_SET:
                 return "LITERAL_SET";
             case Icode_SPARE_ARRAYLIT:
@@ -326,8 +328,6 @@ abstract class Icode {
                 return "LOAD_BIGINT4";
             case Icode_TEMPLATE_LITERAL_CALLSITE:
                 return "TEMPLATE_LITERAL_CALLSITE";
-            case Icode_LITERAL_KEYS:
-                return "LITERAL_KEYS";
             case Icode_LITERAL_KEY_SET:
                 return "LITERAL_KEY_SET";
             case Icode_IF_NULL_UNDEF:

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2490,7 +2490,8 @@ public final class Interpreter extends Icode implements Evaluator {
                                         key = ScriptRuntime.wrapNumber(sDbl[stackTop]);
                                     --stackTop;
                                     Object[] ids = (Object[]) stack[stackTop - 2];
-                                    ids[indexReg] = key;
+                                    int i = (int) sDbl[stackTop];
+                                    ids[i] = key;
                                     continue Loop;
                                 }
                             case Token.OBJECTLIT:

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2437,6 +2437,8 @@ public final class Interpreter extends Icode implements Evaluator {
                                     boolean copyArray = iCode[frame.pc] != 0;
                                     ++frame.pc;
                                     ++stackTop;
+                                    stack[stackTop] = cx.newObject(frame.scope);
+                                    ++stackTop;
                                     stack[stackTop] =
                                             copyArray ? Arrays.copyOf(ids, ids.length) : ids;
                                     ++stackTop;
@@ -2499,15 +2501,15 @@ public final class Interpreter extends Icode implements Evaluator {
                                 }
                             case Token.OBJECTLIT:
                                 {
-                                    Object[] data = (Object[]) stack[stackTop];
+                                    Object[] values = (Object[]) stack[stackTop];
                                     --stackTop;
                                     int[] getterSetters = (int[]) stack[stackTop];
                                     --stackTop;
-                                    Object[] ids = (Object[]) stack[stackTop];
-                                    Object val =
-                                            ScriptRuntime.newObjectLiteral(
-                                                    ids, data, getterSetters, cx, frame.scope);
-                                    stack[stackTop] = val;
+                                    Object[] keys = (Object[]) stack[stackTop];
+                                    --stackTop;
+                                    Scriptable object = (Scriptable) stack[stackTop];
+                                    ScriptRuntime.fillObjectLiteral(
+                                            object, keys, values, getterSetters, cx, frame.scope);
                                     continue Loop;
                                 }
                             case Token.ARRAYLIT:

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4815,16 +4815,26 @@ public class ScriptRuntime {
      * object literal is compiled. The next instance will be the version called from new code.
      * <strong>This method only present for compatibility.</strong>
      *
-     * @deprecated Use {@link #newObjectLiteral(Object[], Object[], int[], Context, Scriptable)}
-     *     instead
+     * @deprecated Use {@link #fillObjectLiteral(Scriptable, Object[], Object[], int[], Context,
+     *     Scriptable)} instead
      */
     @Deprecated
     public static Scriptable newObjectLiteral(
             Object[] propertyIds, Object[] propertyValues, Context cx, Scriptable scope) {
         // Passing null for getterSetters means no getters or setters
-        return newObjectLiteral(propertyIds, propertyValues, null, cx, scope);
+        Scriptable object = cx.newObject(scope);
+        fillObjectLiteral(object, propertyIds, propertyValues, null, cx, scope);
+        return object;
     }
 
+    /**
+     * This method is here for backward compat with existing compiled code. <strong>This method only
+     * present for compatibility.</strong>
+     *
+     * @deprecated Use {@link #fillObjectLiteral(Scriptable, Object[], Object[], int[], Context,
+     *     Scriptable)}
+     */
+    @Deprecated
     public static Scriptable newObjectLiteral(
             Object[] propertyIds,
             Object[] propertyValues,
@@ -4832,6 +4842,17 @@ public class ScriptRuntime {
             Context cx,
             Scriptable scope) {
         Scriptable object = cx.newObject(scope);
+        fillObjectLiteral(object, propertyIds, propertyValues, getterSetters, cx, scope);
+        return object;
+    }
+
+    public static void fillObjectLiteral(
+            Scriptable object,
+            Object[] propertyIds,
+            Object[] propertyValues,
+            int[] getterSetters,
+            Context cx,
+            Scriptable scope) {
         int end = propertyIds == null ? 0 : propertyIds.length;
         for (int i = 0; i != end; ++i) {
             Object id = propertyIds[i];
@@ -4868,7 +4889,6 @@ public class ScriptRuntime {
                 so.setGetterOrSetter(key, index == null ? 0 : index, getterOrSetter, isSetter);
             }
         }
-        return object;
     }
 
     public static boolean isArrayObject(Object obj) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -2266,6 +2266,15 @@ class BodyCodegen {
             return;
         }
 
+        cfw.addALoad(contextLocal);
+        cfw.addALoad(variableObjectLocal);
+        cfw.addInvoke(
+                ByteCode.INVOKEVIRTUAL,
+                "org/mozilla/javascript/Context",
+                "newObject",
+                "(Lorg/mozilla/javascript/Scriptable;)Lorg/mozilla/javascript/Scriptable;");
+        cfw.add(ByteCode.DUP);
+
         addLoadProperty(node, child, properties, count);
 
         // check if object literal actually has any getters or setters
@@ -2305,13 +2314,15 @@ class BodyCodegen {
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
         addScriptRuntimeInvoke(
-                "newObjectLiteral",
-                "([Ljava/lang/Object;"
+                "fillObjectLiteral",
+                "("
+                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "[Ljava/lang/Object;"
                         + "[Ljava/lang/Object;"
                         + "[I"
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
-                        + ")Lorg/mozilla/javascript/Scriptable;");
+                        + ")V");
     }
 
     private void visitSpecialCall(Node node, int type, int specialType, Node child) {


### PR DESCRIPTION
This PR changes a bit the interpreter bytecode when creating a literal object - rhino now generates and uses a slightly more compact bytecode. Furthermore, there is a preliminary change for implementing `super` discussed below.

Before this change, this JS fragment:

```js
var o = {
  a: 1,
  [b]: 42,
}
```

would generate the following interpreter bytecode:

```
 [5] REG_IND_C0
 [6] LITERAL_KEYS [a, 136] true
 [8] REG_IND_C2
 [9] LITERAL_NEW
 [10] ONE
 [11] LITERAL_SET
 [12] REG_STR_C1 "b"
 [13] NAME
 [14] REG_IND_C1
 [15] LITERAL_KEY_SET
 [16] SHORTNUMBER 42
 [19] LITERAL_SET
 [20] OBJECTLIT
```

After this PR, it will generate the following:

```
 [5] REG_IND_C0
 [6] LITERAL_NEW_OBJECT [a, 142] true
 [8] ONE
 [9] LITERAL_SET
 [10] REG_STR_C1 "b"
 [11] NAME
 [12] LITERAL_KEY_SET
 [13] SHORTNUMBER 42
 [16] LITERAL_SET
 [17] OBJECTLIT
```

The changes are:
- `LITERAL_KEY_SET` uses the same indexing algorithm as `LITERAL_SET`, therefore does not require the `REG_IND_xxx` instruction before it
- renamed old `LITERAL_NEW` into `LITERAL_NEW_ARRAY`
- unified `LITERAL_KEYS` and the old behavior of `LITERAL_NEW` for objects into a new opcode called `LITERAL_NEW_OBJECT`
- modified `LITERAL_NEW_OBJECTS` so that it puts the object on the stack and then calls `ScriptRuntime.fillObjectLiteral`, instead of calling `ScriptRuntime.newObjectLiteral`. So, previously the stack would contain `[keys, flags, values]`; now it contains `[object, keys, flags, values]`. This is a preliminary step for implementing `super` (see https://github.com/mozilla/rhino/pull/1735).

Implemented with @0xe 