### PR TITLE
Fixed cleanup in unit test `DynamicScopeTest`

### DIFF
--- a/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import org.junit.After;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
@@ -46,6 +47,13 @@ public class DynamicScopeTest {
     private static class FreshContext extends Context {
         public FreshContext(ContextFactory contextFactory) {
             super(contextFactory);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        while (Context.getCurrentContext() != null) {
+            Context.exit();
         }
     }
 


### PR DESCRIPTION
The test is creating a couple of context but not closing them properly.