### PR TITLE
fix tokenEnd and cursor for string, template, xml literals and comments when using multibyte characters

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
@@ -1127,6 +1127,8 @@ class TokenStream implements Parser.CurrentPositionReporter {
 
                 String str = getStringFromBuffer();
                 this.string = internString(str);
+                cursor = sourceCursor;
+                tokenEnd = cursor;
                 return Token.STRING;
             }
 
@@ -1330,6 +1332,7 @@ class TokenStream implements Parser.CurrentPositionReporter {
                                 lookForSlash = true;
                             } else if (c == '/') {
                                 if (lookForSlash) {
+                                	cursor = sourceCursor;
                                     tokenEnd = cursor;
                                     return Token.COMMENT;
                                 }
@@ -1653,6 +1656,8 @@ class TokenStream implements Parser.CurrentPositionReporter {
                 case '`':
                     rawString.setLength(rawString.length() - 1); // don't include "`"
                     this.string = hasInvalidEscapeSequences ? null : getStringFromBuffer();
+                    cursor = sourceCursor;
+                    tokenEnd = cursor;
                     return Token.TEMPLATE_LITERAL;
                 case '$':
                     if (matchTemplateLiteralChar('{')) {
@@ -1907,6 +1912,8 @@ class TokenStream implements Parser.CurrentPositionReporter {
 
                 if (!xmlIsTagContent && xmlOpenTagsCount == 0) {
                     this.string = getStringFromBuffer();
+                    cursor = sourceCursor;
+                    tokenEnd = cursor;
                     return Token.XMLEND;
                 }
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
@@ -1332,7 +1332,7 @@ class TokenStream implements Parser.CurrentPositionReporter {
                                 lookForSlash = true;
                             } else if (c == '/') {
                                 if (lookForSlash) {
-                                	cursor = sourceCursor;
+                                    cursor = sourceCursor;
                                     tokenEnd = cursor;
                                     return Token.COMMENT;
                                 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -1212,34 +1212,37 @@ public class ParserTest {
         AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("𠮷", first.getString());
     }
-    
+
     @Test
     public void parseMultibyteCharacter_StringLiteral() {
         AstRoot root = parse("'\uD83C\uDF1F'");
-        StringLiteral first = (StringLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
+        StringLiteral first =
+                (StringLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals(4, first.getLength());
         assertEquals("'🌟'", first.getValue(true));
     }
-    
+
     @Test
     public void parseMultibyteCharacter_TemplateLiteral() {
         AstRoot root = parse("`\uD83C\uDF1F`");
-        TemplateLiteral first = (TemplateLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
+        TemplateLiteral first =
+                (TemplateLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         TemplateCharacters templateCharacter = (TemplateCharacters) first.getElement(0);
         assertEquals(2, templateCharacter.getLength());
         assertEquals("🌟", templateCharacter.getValue());
         assertEquals(4, first.getLength());
     }
-    
+
     @Test
     public void parseMultibyteCharacter_XMLLiteral() {
         AstRoot root = parse("<xml>\uD83C\uDF1F</xml>");
-        XmlLiteral first = (XmlLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
+        XmlLiteral first =
+                (XmlLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         XmlFragment fragment = first.getFragments().get(0);
         assertEquals(13, fragment.getLength());
         assertEquals("<xml>🌟</xml>", fragment.toSource());
     }
-    
+
     @Test
     public void parseMultibyteCharacter_Comment() {
         AstRoot root = parse("/*\uD83C\uDF1F*/");

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -1227,8 +1227,8 @@ public class ParserTest {
         TemplateLiteral first = (TemplateLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         TemplateCharacters templateCharacter = (TemplateCharacters) first.getElement(0);
         assertEquals(2, templateCharacter.getLength());
-		assertEquals("🌟", templateCharacter.getValue());
-		assertEquals(4, first.getLength());
+        assertEquals("🌟", templateCharacter.getValue());
+        assertEquals(4, first.getLength());
     }
     
     @Test
@@ -1245,7 +1245,7 @@ public class ParserTest {
         AstRoot root = parse("/*\uD83C\uDF1F*/");
         Comment comment = root.getComments().first();
         assertEquals(6, comment.getLength());
-		assertEquals("/*🌟*/", comment.getValue());
+        assertEquals("/*🌟*/", comment.getValue());
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -1207,14 +1207,14 @@ public class ParserTest {
     }
 
     @Test
-    public void testParseUnicodeMultibyteCharacter() {
+    public void parseUnicodeMultibyteCharacter() {
         AstRoot root = parse("\uD842\uDFB7");
         AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("𠮷", first.getString());
     }
     
     @Test
-    public void testParseMultibyteCharacter_StringLiteral() {
+    public void parseMultibyteCharacter_StringLiteral() {
         AstRoot root = parse("'\uD83C\uDF1F'");
         StringLiteral first = (StringLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals(4, first.getLength());
@@ -1222,7 +1222,7 @@ public class ParserTest {
     }
     
     @Test
-    public void testParseMultibyteCharacter_TemplateLiteral() {
+    public void parseMultibyteCharacter_TemplateLiteral() {
         AstRoot root = parse("`\uD83C\uDF1F`");
         TemplateLiteral first = (TemplateLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         TemplateCharacters templateCharacter = (TemplateCharacters) first.getElement(0);
@@ -1232,7 +1232,7 @@ public class ParserTest {
     }
     
     @Test
-    public void testParseMultibyteCharacter_XMLLiteral() {
+    public void parseMultibyteCharacter_XMLLiteral() {
         AstRoot root = parse("<xml>\uD83C\uDF1F</xml>");
         XmlLiteral first = (XmlLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
         XmlFragment fragment = first.getFragments().get(0);
@@ -1241,7 +1241,7 @@ public class ParserTest {
     }
     
     @Test
-    public void testParseMultibyteCharacter_Comment() {
+    public void parseMultibyteCharacter_Comment() {
         AstRoot root = parse("/*\uD83C\uDF1F*/");
         Comment comment = root.getComments().first();
         assertEquals(6, comment.getLength());
@@ -1249,7 +1249,7 @@ public class ParserTest {
     }
 
     @Test
-    public void testParseUnicodeIdentifierPartWhichIsNotJavaIdentifierPart() {
+    public void parseUnicodeIdentifierPartWhichIsNotJavaIdentifierPart() {
         // On the JDK 11 I'm using, Character.isUnicodeIdentifierPart(U+9FEB) returns true
         // but Character.isJavaIdentifierPart(U+9FEB) returns false. On a JDK 17 results
         // seem to vary, but I think it's enough to verify that TokenStream uses

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -48,11 +48,15 @@ import org.mozilla.javascript.ast.Scope;
 import org.mozilla.javascript.ast.StringLiteral;
 import org.mozilla.javascript.ast.SwitchCase;
 import org.mozilla.javascript.ast.SwitchStatement;
+import org.mozilla.javascript.ast.TemplateCharacters;
+import org.mozilla.javascript.ast.TemplateLiteral;
 import org.mozilla.javascript.ast.TryStatement;
 import org.mozilla.javascript.ast.UpdateExpression;
 import org.mozilla.javascript.ast.VariableDeclaration;
 import org.mozilla.javascript.ast.VariableInitializer;
 import org.mozilla.javascript.ast.WithStatement;
+import org.mozilla.javascript.ast.XmlFragment;
+import org.mozilla.javascript.ast.XmlLiteral;
 import org.mozilla.javascript.testing.TestErrorReporter;
 
 public class ParserTest {
@@ -1207,6 +1211,41 @@ public class ParserTest {
         AstRoot root = parse("\uD842\uDFB7");
         AstNode first = ((ExpressionStatement) root.getFirstChild()).getExpression();
         assertEquals("𠮷", first.getString());
+    }
+    
+    @Test
+    public void testParseMultibyteCharacter_StringLiteral() {
+        AstRoot root = parse("'\uD83C\uDF1F'");
+        StringLiteral first = (StringLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
+        assertEquals(4, first.getLength());
+        assertEquals("'🌟'", first.getValue(true));
+    }
+    
+    @Test
+    public void testParseMultibyteCharacter_TemplateLiteral() {
+        AstRoot root = parse("`\uD83C\uDF1F`");
+        TemplateLiteral first = (TemplateLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
+        TemplateCharacters templateCharacter = (TemplateCharacters) first.getElement(0);
+        assertEquals(2, templateCharacter.getLength());
+		assertEquals("🌟", templateCharacter.getValue());
+		assertEquals(4, first.getLength());
+    }
+    
+    @Test
+    public void testParseMultibyteCharacter_XMLLiteral() {
+        AstRoot root = parse("<xml>\uD83C\uDF1F</xml>");
+        XmlLiteral first = (XmlLiteral) ((ExpressionStatement) root.getFirstChild()).getExpression();
+        XmlFragment fragment = first.getFragments().get(0);
+        assertEquals(13, fragment.getLength());
+        assertEquals("<xml>🌟</xml>", fragment.toSource());
+    }
+    
+    @Test
+    public void testParseMultibyteCharacter_Comment() {
+        AstRoot root = parse("/*\uD83C\uDF1F*/");
+        Comment comment = root.getComments().first();
+        assertEquals(6, comment.getLength());
+		assertEquals("/*🌟*/", comment.getValue());
     }
 
     @Test


### PR DESCRIPTION
When using multibyte characters, the tokenEnd and cursor need to be adjusted otherwise the length of string, template, xml literals and comments is not correct. 