### PR TITLE
SlotMap.compute can lead to deadlock in ThreadSafeSlotMapContainer

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -113,10 +113,34 @@ public class AccessorSlot extends Slot {
         return getter.asGetterFunction(name, scope);
     }
 
+    @Override
+    boolean isSameGetterFunction(Object function) {
+        if (function == Scriptable.NOT_FOUND) {
+            return true;
+        } else if (getter == null) {
+            return ScriptRuntime.shallowEq(Undefined.instance, function);
+        } else {
+            return getter.isSameGetterFunction(function);
+        }
+    }
+
+    @Override
+    boolean isSameSetterFunction(Object function) {
+        if (function == Scriptable.NOT_FOUND) {
+            return true;
+        } else if (setter == null) {
+            return ScriptRuntime.shallowEq(Undefined.instance, function);
+        } else {
+            return setter.isSameSetterFunction(function);
+        }
+    }
+
     interface Getter {
         Object getValue(Scriptable start);
 
         Function asGetterFunction(final String name, final Scriptable scope);
+
+        boolean isSameGetterFunction(Object getter);
     }
 
     /** This is a Getter that delegates to a Java function via a MemberBox. */
@@ -138,6 +162,11 @@ public class AccessorSlot extends Slot {
         @Override
         public Function asGetterFunction(String name, Scriptable scope) {
             return member.asGetterFunction(name, scope);
+        }
+
+        @Override
+        public boolean isSameGetterFunction(Object function) {
+            return member.isSameGetterFunction(function);
         }
     }
 
@@ -164,12 +193,20 @@ public class AccessorSlot extends Slot {
         public Function asGetterFunction(String name, Scriptable scope) {
             return target instanceof Function ? (Function) target : null;
         }
+
+        @Override
+        public boolean isSameGetterFunction(Object function) {
+            return ScriptRuntime.shallowEq(
+                    target instanceof Function ? (Function) target : Undefined.instance, function);
+        }
     }
 
     interface Setter {
         boolean setValue(Object value, Scriptable owner, Scriptable start);
 
         Function asSetterFunction(final String name, final Scriptable scope);
+
+        boolean isSameSetterFunction(Object getter);
     }
 
     /** Invoke the setter on this slot via reflection using MemberBox. */
@@ -202,6 +239,11 @@ public class AccessorSlot extends Slot {
         public Function asSetterFunction(String name, Scriptable scope) {
             return member.asSetterFunction(name, scope);
         }
+
+        @Override
+        public boolean isSameSetterFunction(Object function) {
+            return member.isSameSetterFunction(function);
+        }
     }
 
     /**
@@ -227,6 +269,12 @@ public class AccessorSlot extends Slot {
         @Override
         public Function asSetterFunction(String name, Scriptable scope) {
             return target instanceof Function ? (Function) target : null;
+        }
+
+        @Override
+        public boolean isSameSetterFunction(Object function) {
+            return ScriptRuntime.shallowEq(
+                    target instanceof Function ? (Function) target : Undefined.instance, function);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -117,22 +117,22 @@ public class AccessorSlot extends Slot {
     boolean isSameGetterFunction(Object function) {
         if (function == Scriptable.NOT_FOUND) {
             return true;
-        } else if (getter == null) {
-            return ScriptRuntime.shallowEq(Undefined.instance, function);
-        } else {
-            return getter.isSameGetterFunction(function);
         }
+        if (getter == null) {
+            return ScriptRuntime.shallowEq(Undefined.instance, function);
+        }
+        return getter.isSameGetterFunction(function);
     }
 
     @Override
     boolean isSameSetterFunction(Object function) {
         if (function == Scriptable.NOT_FOUND) {
             return true;
-        } else if (setter == null) {
-            return ScriptRuntime.shallowEq(Undefined.instance, function);
-        } else {
-            return setter.isSameSetterFunction(function);
         }
+        if (setter == null) {
+            return ScriptRuntime.shallowEq(Undefined.instance, function);
+        }
+        return setter.isSameSetterFunction(function);
     }
 
     interface Getter {

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -922,15 +922,15 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         ScriptableObject desc = super.getOwnPropertyDescriptor(cx, id);
         if (desc == null) {
             if (id instanceof String) {
-                return getBuiltInDescriptor((String) id);
+                return getBuiltInDataDescriptor((String) id);
             }
 
             if (ScriptRuntime.isSymbol(id)) {
                 if (id instanceof SymbolKey) {
-                    return getBuiltInDescriptor((SymbolKey) id);
+                    return getBuiltInDataDescriptor((SymbolKey) id);
                 }
 
-                return getBuiltInDescriptor(((NativeSymbol) id).getKey());
+                return getBuiltInDataDescriptor(((NativeSymbol) id).getKey());
             }
         }
         return desc;
@@ -954,7 +954,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         return slot;
     }
 
-    private ScriptableObject getBuiltInDescriptor(String name) {
+    private ScriptableObject getBuiltInDataDescriptor(String name) {
         Scriptable scope = getParentScope();
         if (scope == null) {
             scope = this;
@@ -990,7 +990,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         return null;
     }
 
-    private ScriptableObject getBuiltInDescriptor(Symbol key) {
+    private ScriptableObject getBuiltInDataDescriptor(Symbol key) {
         Scriptable scope = getParentScope();
         if (scope == null) {
             scope = this;

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -877,7 +877,12 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                             setInstanceIdValue(id, value);
                         }
                     }
-                    attr = applyDescriptorToAttributeBitset(attr, desc);
+                    attr =
+                            applyDescriptorToAttributeBitset(
+                                    attr,
+                                    getProperty(desc, "enumerable"),
+                                    getProperty(desc, "writable"),
+                                    getProperty(desc, "configurable"));
                     setAttributes(name, attr);
                     return;
                 }
@@ -900,7 +905,12 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                             }
                         }
                         prototypeValues.setAttributes(
-                                id, applyDescriptorToAttributeBitset(attr, desc));
+                                id,
+                                applyDescriptorToAttributeBitset(
+                                        attr,
+                                        getProperty(desc, "enumerable"),
+                                        getProperty(desc, "writable"),
+                                        getProperty(desc, "configurable")));
 
                         // Handle the regular slot that was created if this property was previously
                         // replaced

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
@@ -40,7 +40,17 @@ public class LambdaAccessorSlot extends Slot {
 
     @Override
     ScriptableObject getPropertyDescriptor(Context cx, Scriptable scope) {
-        ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
+        return buildPropertyDescriptor(cx);
+    }
+
+    /**
+     * The method exists avoid changing the getPropertyDescriptor signature and at the same time to
+     * make it explicit that we don't use Scriptable scope parameter of getPropertyDescriptor, since
+     * it can be problematic when called from inside ThreadSafeSlotMapContainer::compute lambda
+     * which can lead to deadlocks.
+     */
+    public ScriptableObject buildPropertyDescriptor(Context cx) {
+        ScriptableObject desc = new NativeObject();
 
         int attr = getAttributes();
         boolean es6 = cx.getLanguageVersion() >= Context.VERSION_ES6;
@@ -125,5 +135,13 @@ public class LambdaAccessorSlot extends Slot {
                                 return Undefined.instance;
                             });
         }
+    }
+
+    public void replaceWith(LambdaAccessorSlot slot) {
+        this.getterFunction = slot.getterFunction;
+        this.getter = slot.getter;
+        this.setterFunction = slot.setterFunction;
+        this.setter = slot.setter;
+        setAttributes(slot.getAttributes());
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -114,6 +114,16 @@ final class MemberBox implements Serializable {
         return memberObject.toString();
     }
 
+    boolean isSameGetterFunction(Object function) {
+        var f = asGetterFunction == null ? Undefined.instance : asGetterFunction;
+        return ScriptRuntime.shallowEq(function, f);
+    }
+
+    boolean isSameSetterFunction(Object function) {
+        var f = asSetterFunction == null ? Undefined.instance : asSetterFunction;
+        return ScriptRuntime.shallowEq(function, f);
+    }
+
     /** Function returned by calls to __lookupGetter__ */
     Function asGetterFunction(final String name, final Scriptable scope) {
         // Note: scope is the scriptable this function is related to; therefore this function

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1771,51 +1771,6 @@ public abstract class ScriptableObject
         }
     }
 
-    protected void checkPropertyChange(Object id, ScriptableObject current, ScriptableObject desc) {
-        if (current == null) { // new property
-            if (!isExtensible()) throw ScriptRuntime.typeErrorById("msg.not.extensible");
-        } else {
-            if (isFalse(current.get("configurable", current))) {
-                if (isTrue(getProperty(desc, "configurable")))
-                    throw ScriptRuntime.typeErrorById("msg.change.configurable.false.to.true", id);
-                if (isTrue(current.get("enumerable", current))
-                        != isTrue(getProperty(desc, "enumerable")))
-                    throw ScriptRuntime.typeErrorById(
-                            "msg.change.enumerable.with.configurable.false", id);
-                boolean isData = isDataDescriptor(desc);
-                boolean isAccessor = isAccessorDescriptor(desc);
-                if (!isData && !isAccessor) {
-                    // no further validation required for generic descriptor
-                } else if (isData && isDataDescriptor(current)) {
-                    if (isFalse(current.get("writable", current))) {
-                        if (isTrue(getProperty(desc, "writable")))
-                            throw ScriptRuntime.typeErrorById(
-                                    "msg.change.writable.false.to.true.with.configurable.false",
-                                    id);
-
-                        if (!sameValue(getProperty(desc, "value"), current.get("value", current)))
-                            throw ScriptRuntime.typeErrorById(
-                                    "msg.change.value.with.writable.false", id);
-                    }
-                } else if (isAccessor && isAccessorDescriptor(current)) {
-                    if (!sameValue(getProperty(desc, "set"), current.get("set", current)))
-                        throw ScriptRuntime.typeErrorById(
-                                "msg.change.setter.with.configurable.false", id);
-
-                    if (!sameValue(getProperty(desc, "get"), current.get("get", current)))
-                        throw ScriptRuntime.typeErrorById(
-                                "msg.change.getter.with.configurable.false", id);
-                } else {
-                    if (isDataDescriptor(current))
-                        throw ScriptRuntime.typeErrorById(
-                                "msg.change.property.data.to.accessor.with.configurable.false", id);
-                    throw ScriptRuntime.typeErrorById(
-                            "msg.change.property.accessor.to.data.with.configurable.false", id);
-                }
-            }
-        }
-    }
-
     protected void checkPropertyChangeForSlot(Object id, Slot current, ScriptableObject desc) {
         if (current == null) { // new property
             if (!isExtensible()) throw ScriptRuntime.typeErrorById("msg.not.extensible");

--- a/rhino/src/main/java/org/mozilla/javascript/Slot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Slot.java
@@ -120,4 +120,19 @@ public class Slot implements Serializable {
     Function getGetterFunction(String name, Scriptable scope) {
         return null;
     }
+
+    /**
+     * Compare the JavaScript function that represents the "setter" to the provided Object. We do
+     * this to avoid generating a new function object when it might not be required. Specifically,
+     * if we have a cached funciion object that has not yet been generated then we don't have to
+     * generate it because it cannot be the same as the provided function.
+     */
+    boolean isSameSetterFunction(Object function) {
+        return false;
+    }
+
+    /** Same for the "getter" function. */
+    boolean isSameGetterFunction(Object function) {
+        return false;
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/DeadlockReproTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/DeadlockReproTest.java
@@ -1,12 +1,12 @@
 package org.mozilla.javascript.tests.es6;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.ScriptableObject;
-
-import static org.junit.Assert.assertEquals;
 
 public class DeadlockReproTest {
     @Test
@@ -27,17 +27,14 @@ public class DeadlockReproTest {
             ScriptableObject scope = cx.initStandardObjects();
 
             scope.put("o", scope, new NativeObject());
-            final String script = "Object.defineProperty(o, 'test', {value: '1', configurable: !0});" +
-                            "Object.defineProperty(o, 'test', {value: 2});" +
-                    "o.test";
+            final String script =
+                    "Object.defineProperty(o, 'test', {value: '1', configurable: !0});"
+                            + "Object.defineProperty(o, 'test', {value: 2});"
+                            + "o.test";
 
-
-
-            var result =
-                     cx.evaluateString(scope, script, "myScript", 1, null);
+            var result = cx.evaluateString(scope, script, "myScript", 1, null);
 
             assertEquals(2, result);
         }
     }
-
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/DeadlockReproTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/DeadlockReproTest.java
@@ -1,0 +1,43 @@
+package org.mozilla.javascript.tests.es6;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.ScriptableObject;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeadlockReproTest {
+    @Test
+    public void redefinePropertyWithThreadSafeSlotMap() {
+        final ContextFactory factory =
+                new ContextFactory() {
+                    @Override
+                    protected boolean hasFeature(Context cx, int featureIndex) {
+                        if (featureIndex == Context.FEATURE_THREAD_SAFE_OBJECTS) {
+                            return true;
+                        }
+                        return super.hasFeature(cx, featureIndex);
+                    }
+                };
+
+        try (Context cx = factory.enterContext()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            ScriptableObject scope = cx.initStandardObjects();
+
+            scope.put("o", scope, new NativeObject());
+            final String script = "Object.defineProperty(o, 'test', {value: '1', configurable: !0});" +
+                            "Object.defineProperty(o, 'test', {value: 2});" +
+                    "o.test";
+
+
+
+            var result =
+                     cx.evaluateString(scope, script, "myScript", 1, null);
+
+            assertEquals(2, result);
+        }
+    }
+
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
@@ -1,19 +1,13 @@
 package org.mozilla.javascript.tests.es6;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.mozilla.javascript.tests.Utils.DEFAULT_OPT_LEVELS;
 
-import java.io.FileReader;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.tests.Utils;
-import org.mozilla.javascript.tools.shell.Global;
 
 public class PropertyTest {
 
@@ -125,9 +119,6 @@ public class PropertyTest {
 
                     return null;
                 });
-
-
-
     }
 
     @Test
@@ -163,19 +154,15 @@ public class PropertyTest {
                 // define custom getter method
                 final Method getter = MyHostObject.class.getMethod("getFoo");
                 final Method setter = MyHostObject.class.getMethod("setFoo", String.class);
-                myHostObject.defineProperty(
-                        "foo", null, getter, setter, ScriptableObject.EMPTY);
+                myHostObject.defineProperty("foo", null, getter, setter, ScriptableObject.EMPTY);
                 scope.put("MyHostObject", scope, myHostObject);
             } catch (Exception e) {
             }
 
-            final String result =
-                    (String) cx.evaluateString(scope, script, "myScript", 1, null);
+            final String result = (String) cx.evaluateString(scope, script, "myScript", 1, null);
 
             assertEquals(expected, result);
-
         }
-
     }
 
     public static class MyHostObject extends ScriptableObject {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
@@ -137,12 +137,10 @@ public class PropertyTest {
                 new ContextFactory() {
                     @Override
                     protected boolean hasFeature(Context cx, int featureIndex) {
-                        switch (featureIndex) {
-                            case Context.FEATURE_THREAD_SAFE_OBJECTS:
-                                return true;
-                            default:
-                                return super.hasFeature(cx, featureIndex);
+                        if (featureIndex == Context.FEATURE_THREAD_SAFE_OBJECTS) {
+                            return true;
                         }
+                        return super.hasFeature(cx, featureIndex);
                     }
                 };
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
@@ -1,12 +1,19 @@
 package org.mozilla.javascript.tests.es6;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mozilla.javascript.tests.Utils.DEFAULT_OPT_LEVELS;
 
+import java.io.FileReader;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.tools.shell.Global;
 
 public class PropertyTest {
 
@@ -118,6 +125,59 @@ public class PropertyTest {
 
                     return null;
                 });
+
+
+
+    }
+
+    @Test
+    public void redefinePropertyWithThreadSafeSlotMap() {
+
+        final ContextFactory factory =
+                new ContextFactory() {
+                    @Override
+                    protected boolean hasFeature(Context cx, int featureIndex) {
+                        switch (featureIndex) {
+                            case Context.FEATURE_THREAD_SAFE_OBJECTS:
+                                return true;
+                            default:
+                                return super.hasFeature(cx, featureIndex);
+                        }
+                    }
+                };
+
+        try (Context cx = factory.enterContext()) {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            ScriptableObject scope = cx.initStandardObjects();
+
+            final String expected = "undefined - true - true | function - function";
+
+            final String script =
+                    "Object.defineProperty(MyHostObject, 'foo', { enumerable: !0, configurable: !0, set: function() { return !0 }});\n"
+                            + "var desc = Object.getOwnPropertyDescriptor(MyHostObject, 'foo');"
+                            + "var result = '' + desc.writable + ' - ' + desc.configurable + ' - ' + desc.enumerable;"
+                            + "result = result + ' | ' + typeof desc.get + ' - ' + typeof desc.set;"
+                            + "result;";
+
+            try {
+                final MyHostObject myHostObject = new MyHostObject();
+
+                // define custom getter method
+                final Method getter = MyHostObject.class.getMethod("getFoo");
+                final Method setter = MyHostObject.class.getMethod("setFoo", String.class);
+                myHostObject.defineProperty(
+                        "foo", null, getter, setter, ScriptableObject.EMPTY);
+                scope.put("MyHostObject", scope, myHostObject);
+            } catch (Exception e) {
+            }
+
+            final String result =
+                    (String) cx.evaluateString(scope, script, "myScript", 1, null);
+
+            assertEquals(expected, result);
+
+        }
+
     }
 
     public static class MyHostObject extends ScriptableObject {


### PR DESCRIPTION
New SlotMap compute method introduced in [b7ece52](https://github.com/mozilla/rhino/commit/b7ece52d83a0d558b28b5962c63e8eea31f0ecd8) can lead to a Deadlock during re-definition of existing object properties when used in combination with `ThreadSafeSlotMapContainer`. 

The problem occurs, because `ThreadSafeSlotMapContainer` obtains and holds a [write lock](https://github.com/mozilla/rhino/blob/70509232ad0dc5b30db8cf31c259980e0f411d65/rhino/src/main/java/org/mozilla/javascript/ThreadSafeSlotMapContainer.java#L78) for the entire duration of method execution, including `SlotComputer` lambda logic and in certain conditions (details below) `ScriptableObject.defineOwnProperty` call to `getPropertyDescriptor` will attempt to obtain a read lock on the same slotMap instance from inside `SlotComputer` lambda body, as marked on below code snippet : 

```java
public abstract class ScriptableObject
... 
    protected void defineOwnProperty(
            Context cx, Object id, ScriptableObject desc, boolean checkValid) {

        Object key = null;
        int index = 0;
...
slotMap.compute(                            <<< WRITE LOCK AQUIRED 
        key,
        index,
        (k, ix, existing) -> {
            if (checkValid) {
                ScriptableObject current =
                        existing == null ? null : 
                               existing.getPropertyDescriptor(cx, this);  <<< READ LOCK  NEEDED
                checkPropertyChange(id, current, desc);
            }
... 
 });                                         <<< WRITE LOCK RELEASED  
...


```

Conditions necessary for this problem to occur: 
 - use of `ThreadSafeSlotMapContainer`, controlled by `Context.FEATURE_THREAD_SAFE_OBJECTS` which is not ON by default
 - property re-definition, since we only call `existing.getPropertyDescriptor` if existing != null. 
 - finally, the object in question (target of property definition) doesn't have the correct parent scope defined. This is likely to occur if it's created in Java, like in provided tests. Deadlock occurs when:
      - `existing.getPropertyDescriptor(cx, this)` is called during property redefinition, it will be used as the "global scope" when Property Descriptor object is initialised. 
      - This means that same `this` object is passed to `ScriptRuntime.getBuiltinPrototype` as scope
      - and eventually an attempt is made to [read a property](https://github.com/mozilla/rhino/blob/ed9af7ee9776accfe11a5c43737e46a61f65e407/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java#L2004) on `this` object
       - which requires read lock on the same instance of `ThreadSafeSlotMapContainer` that `slotMap.compute` is already locking.


This PR adds 2 test cases reproducing the same issue, both with `Context.FEATURE_THREAD_SAFE_OBJECTS` switched ON to force use of `ThreadSafeSlotMapContainer`:
 - new `DeadlockReproTest`, the most minimal repro we could come up with
 - new test case in PropertyTest, with identical code to existing `redefineGetterProperty`  test, showing that just changing SlotMapContainer causes the deadlock to occur. 

