### PR TITLE
Support generator methods in object literals, e.g. `o = {*g() {...}}`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -33,6 +33,7 @@ import org.mozilla.javascript.ast.FunctionCall;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.GeneratorExpression;
 import org.mozilla.javascript.ast.GeneratorExpressionLoop;
+import org.mozilla.javascript.ast.GeneratorMethodDefinition;
 import org.mozilla.javascript.ast.IfStatement;
 import org.mozilla.javascript.ast.InfixExpression;
 import org.mozilla.javascript.ast.Jump;
@@ -266,6 +267,9 @@ public final class IRFactory {
                 }
                 if (node instanceof XmlLiteral) {
                     return transformXmlLiteral((XmlLiteral) node);
+                }
+                if (node instanceof GeneratorMethodDefinition) {
+                    return transformGeneratorMethodDefinition((GeneratorMethodDefinition) node);
                 }
                 throw new IllegalArgumentException("Can't transform: " + node);
         }
@@ -1320,6 +1324,11 @@ public final class IRFactory {
     private Node transformDefaultXmlNamespace(UnaryExpression node) {
         Node child = transform(node.getOperand());
         return createUnary(Token.DEFAULTNAMESPACE, child);
+    }
+
+    private Node transformGeneratorMethodDefinition(GeneratorMethodDefinition node) {
+        // Unwrap the "temporary" AST node
+        return transform(node.getMethodName());
     }
 
     /** If caseExpression argument is null it indicates a default label. */

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -41,6 +41,7 @@ import org.mozilla.javascript.ast.FunctionCall;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.GeneratorExpression;
 import org.mozilla.javascript.ast.GeneratorExpressionLoop;
+import org.mozilla.javascript.ast.GeneratorMethodDefinition;
 import org.mozilla.javascript.ast.IdeErrorReporter;
 import org.mozilla.javascript.ast.IfStatement;
 import org.mozilla.javascript.ast.InfixExpression;
@@ -3794,6 +3795,11 @@ public class Parser {
                 if (pname instanceof Name || pname instanceof StringLiteral) {
                     // For complicated reasons, parsing a name does not advance the token
                     pname.setLineColumnNumber(lineNumber(), columnNumber());
+                } else if (pname instanceof GeneratorMethodDefinition) {
+                    // Same as above
+                    ((GeneratorMethodDefinition) pname)
+                            .getMethodName()
+                            .setLineColumnNumber(lineNumber(), columnNumber());
                 }
 
                 // This code path needs to handle both destructuring object
@@ -3840,13 +3846,21 @@ public class Parser {
                     } else {
                         propertyName = ts.getString();
                         // short-hand method definition
-                        ObjectProperty objectProp = methodDefinition(ppos, pname, entryKind);
+                        ObjectProperty objectProp =
+                                methodDefinition(
+                                        ppos,
+                                        pname,
+                                        entryKind,
+                                        pname instanceof GeneratorMethodDefinition);
                         pname.setJsDocNode(jsdocNode);
                         elems.add(objectProp);
                     }
                 } else {
                     pname.setJsDocNode(jsdocNode);
                     elems.add(plainProperty(pname, tt));
+                }
+                if (pname instanceof GeneratorMethodDefinition && entryKind != METHOD_ENTRY) {
+                    reportError("msg.bad.prop");
                 }
             }
 
@@ -3939,6 +3953,22 @@ public class Parser {
                 }
                 break;
 
+            case Token.MUL:
+                if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
+                    int pos = ts.tokenBeg;
+                    nextToken();
+                    int lineno = lineNumber();
+                    int column = columnNumber();
+                    pname = objliteralProperty();
+
+                    pname = new GeneratorMethodDefinition(pos, ts.tokenEnd - pos, pname);
+                    pname.setLineColumnNumber(lineno, column);
+                } else {
+                    reportError("msg.bad.prop");
+                    return null;
+                }
+                break;
+
             default:
                 if (compilerEnv.isReservedKeywordAsIdentifier()
                         && TokenStream.isKeyword(
@@ -3987,8 +4017,8 @@ public class Parser {
         return pn;
     }
 
-    private ObjectProperty methodDefinition(int pos, AstNode propName, int entryKind)
-            throws IOException {
+    private ObjectProperty methodDefinition(
+            int pos, AstNode propName, int entryKind, boolean isGenerator) throws IOException {
         FunctionNode fn = function(FunctionNode.FUNCTION_EXPRESSION, true);
         // We've already parsed the function name, so fn should be anonymous.
         Name name = fn.getFunctionName();
@@ -4008,6 +4038,9 @@ public class Parser {
             case METHOD_ENTRY:
                 pn.setIsNormalMethod();
                 fn.setFunctionIsNormalMethod();
+                if (isGenerator) {
+                    fn.setIsES6Generator();
+                }
                 break;
         }
         int end = getNodeEnd(fn);
@@ -4522,6 +4555,8 @@ public class Parser {
         } else if (id instanceof NumberLiteral) {
             double n = ((NumberLiteral) id).getNumber();
             key = ScriptRuntime.getIndexObject(n);
+        } else if (id instanceof GeneratorMethodDefinition) {
+            key = getPropKey(((GeneratorMethodDefinition) id).getMethodName());
         } else {
             key = null; // Filled later
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ast/GeneratorMethodDefinition.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/GeneratorMethodDefinition.java
@@ -1,0 +1,47 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import org.mozilla.javascript.Token;
+
+/**
+ * AST node for a generator method definition in an object literal, i.e. `*key() {}` in an object
+ * literal.
+ */
+public class GeneratorMethodDefinition extends AstNode {
+
+    private AstNode methodName;
+
+    public GeneratorMethodDefinition(int pos, int len, AstNode methodName) {
+        super(pos, len);
+        setType(Token.MUL);
+        setMethodName(methodName);
+    }
+
+    public AstNode getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(AstNode methodName) {
+        assertNotNull(methodName);
+        this.methodName = methodName;
+        methodName.setParent(this);
+    }
+
+    @Override
+    public String toSource(int depth) {
+        return makeIndent(depth) + '*' + methodName.toSource(depth);
+    }
+
+    /** Visits this node, then the name. */
+    @Override
+    public void visit(NodeVisitor v) {
+        if (v.visit(this)) {
+            methodName.visit(v);
+        }
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -33,6 +33,7 @@ import org.mozilla.javascript.ast.ExpressionStatement;
 import org.mozilla.javascript.ast.ForLoop;
 import org.mozilla.javascript.ast.FunctionCall;
 import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.ast.GeneratorMethodDefinition;
 import org.mozilla.javascript.ast.IfStatement;
 import org.mozilla.javascript.ast.InfixExpression;
 import org.mozilla.javascript.ast.LabeledStatement;
@@ -1442,6 +1443,27 @@ public class ParserTest {
         assertEquals("g", f.getName());
         assertTrue(f.isGenerator());
         assertTrue(f.isES6Generator());
+    }
+
+    @Test
+    public void memberFunctionGenerator() {
+        environment.setLanguageVersion(Context.VERSION_ES6);
+        AstNode root = parse("o = { *g() { return true; } }");
+        ExpressionStatement expr = (ExpressionStatement) root.getFirstChild();
+        assertTrue(expr.getExpression() instanceof Assignment);
+        assertTrue(((Assignment) expr.getExpression()).getRight() instanceof ObjectLiteral);
+        ObjectLiteral obj = (ObjectLiteral) ((Assignment) expr.getExpression()).getRight();
+        assertEquals(1, obj.getElements().size());
+        ObjectProperty g = obj.getElements().get(0);
+
+        assertTrue(g.getLeft() instanceof GeneratorMethodDefinition);
+        assertLineColumnAre(0, 7, g.getLeft());
+        AstNode genMethodName = ((GeneratorMethodDefinition) g.getLeft()).getMethodName();
+        assertTrue(genMethodName instanceof Name);
+        assertLineColumnAre(0, 8, genMethodName);
+
+        assertTrue(g.getRight() instanceof FunctionNode);
+        assertTrue(((FunctionNode) g.getRight()).isES6Generator());
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/GeneratorMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/GeneratorMethodTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests.es6;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/es6/generator-method.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class GeneratorMethodTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/es6/generator-method.js
+++ b/tests/testsrc/jstests/es6/generator-method.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+load("testsrc/assert.js");
+
+(function generatorAsShortHandMethod() {
+	const o = {
+		h() {},
+		*g() {
+			yield 1;
+			yield 2;
+		}
+	};
+
+	const iter = o.g();
+
+	let next = iter.next();
+	assertEquals(1, next.value);
+	assertEquals(false, next.done);
+
+	next = iter.next();
+	assertEquals(2, next.value);
+	assertEquals(false, next.done);
+
+	next = iter.next();
+	assertEquals(undefined, next.value);
+	assertEquals(true, next.done);
+})();
+
+"success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -3238,7 +3238,7 @@ built-ins/undefined 0/8 (0.0%)
 
 ~intl402
 
-language/arguments-object 189/263 (71.86%)
+language/arguments-object 185/263 (70.34%)
     mapped/mapped-arguments-nonconfigurable-3.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
     mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
@@ -3422,11 +3422,7 @@ language/arguments-object 189/263 (71.86%)
     func-expr-args-trailing-comma-spread-operator.js
     gen-func-decl-args-trailing-comma-spread-operator.js
     gen-func-expr-args-trailing-comma-spread-operator.js
-    gen-meth-args-trailing-comma-multiple.js
-    gen-meth-args-trailing-comma-null.js
-    gen-meth-args-trailing-comma-single-args.js
     gen-meth-args-trailing-comma-spread-operator.js
-    gen-meth-args-trailing-comma-undefined.js
     meth-args-trailing-comma-spread-operator.js
 
 language/asi 0/102 (0.0%)
@@ -3512,13 +3508,12 @@ language/comments 9/52 (17.31%)
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
 
-language/computed-property-names 34/48 (70.83%)
+language/computed-property-names 33/48 (68.75%)
     class/accessor 4/4 (100.0%)
     class/method 11/11 (100.0%)
     class/static 14/14 (100.0%)
     object/accessor/getter.js
     object/accessor/setter.js
-    object/method/generator.js
     to-name-side-effects/class.js
     to-name-side-effects/numbers-class.js
 
@@ -4952,7 +4947,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 784/1169 (67.07%)
+language/expressions/object 719/1169 (61.51%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -5142,32 +5137,21 @@ language/expressions/object 784/1169 (67.07%)
     dstr/gen-meth-ary-init-iter-close.js
     dstr/gen-meth-ary-init-iter-get-err.js
     dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
-    dstr/gen-meth-ary-init-iter-no-close.js
-    dstr/gen-meth-ary-name-iter-val.js
     dstr/gen-meth-ary-ptrn-elem-ary-elem-init.js
     dstr/gen-meth-ary-ptrn-elem-ary-elem-iter.js
     dstr/gen-meth-ary-ptrn-elem-ary-elision-init.js
-    dstr/gen-meth-ary-ptrn-elem-ary-elision-iter.js
     dstr/gen-meth-ary-ptrn-elem-ary-empty-init.js
-    dstr/gen-meth-ary-ptrn-elem-ary-empty-iter.js
     dstr/gen-meth-ary-ptrn-elem-ary-rest-init.js
     dstr/gen-meth-ary-ptrn-elem-ary-rest-iter.js
     dstr/gen-meth-ary-ptrn-elem-ary-val-null.js
-    dstr/gen-meth-ary-ptrn-elem-id-init-exhausted.js
     dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/gen-meth-ary-ptrn-elem-id-init-hole.js
-    dstr/gen-meth-ary-ptrn-elem-id-init-skipped.js
     dstr/gen-meth-ary-ptrn-elem-id-init-throws.js
-    dstr/gen-meth-ary-ptrn-elem-id-init-undef.js
     dstr/gen-meth-ary-ptrn-elem-id-init-unresolvable.js
-    dstr/gen-meth-ary-ptrn-elem-id-iter-complete.js
-    dstr/gen-meth-ary-ptrn-elem-id-iter-done.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-step-err.js
-    dstr/gen-meth-ary-ptrn-elem-id-iter-val.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/gen-meth-ary-ptrn-elem-id-iter-val-err.js
     dstr/gen-meth-ary-ptrn-elem-obj-id.js
@@ -5177,9 +5161,7 @@ language/expressions/object 784/1169 (67.07%)
     dstr/gen-meth-ary-ptrn-elem-obj-val-null.js
     dstr/gen-meth-ary-ptrn-elem-obj-val-undef.js
     dstr/gen-meth-ary-ptrn-elision.js
-    dstr/gen-meth-ary-ptrn-elision-exhausted.js
     dstr/gen-meth-ary-ptrn-elision-step-err.js
-    dstr/gen-meth-ary-ptrn-empty.js
     dstr/gen-meth-ary-ptrn-rest-ary-elem.js
     dstr/gen-meth-ary-ptrn-rest-ary-elision.js
     dstr/gen-meth-ary-ptrn-rest-ary-empty.js
@@ -5196,32 +5178,21 @@ language/expressions/object 784/1169 (67.07%)
     dstr/gen-meth-dflt-ary-init-iter-close.js
     dstr/gen-meth-dflt-ary-init-iter-get-err.js
     dstr/gen-meth-dflt-ary-init-iter-get-err-array-prototype.js
-    dstr/gen-meth-dflt-ary-init-iter-no-close.js
-    dstr/gen-meth-dflt-ary-name-iter-val.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js
     dstr/gen-meth-dflt-ary-ptrn-elem-ary-val-null.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-hole.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-throws.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-init-undef.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-done.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js
-    dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-id.js
@@ -5231,9 +5202,7 @@ language/expressions/object 784/1169 (67.07%)
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-null.js
     dstr/gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js
     dstr/gen-meth-dflt-ary-ptrn-elision.js
-    dstr/gen-meth-dflt-ary-ptrn-elision-exhausted.js
     dstr/gen-meth-dflt-ary-ptrn-elision-step-err.js
-    dstr/gen-meth-dflt-ary-ptrn-empty.js
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-elem.js
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-elision.js
     dstr/gen-meth-dflt-ary-ptrn-rest-ary-empty.js
@@ -5249,30 +5218,22 @@ language/expressions/object 784/1169 (67.07%)
     dstr/gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js
     dstr/gen-meth-dflt-obj-init-null.js
     dstr/gen-meth-dflt-obj-init-undefined.js
-    dstr/gen-meth-dflt-obj-ptrn-empty.js
     dstr/gen-meth-dflt-obj-ptrn-id-get-value-err.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
-    dstr/gen-meth-dflt-obj-ptrn-id-init-skipped.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-throws.js
     dstr/gen-meth-dflt-obj-ptrn-id-init-unresolvable.js
-    dstr/gen-meth-dflt-obj-ptrn-id-trailing-comma.js
     dstr/gen-meth-dflt-obj-ptrn-list-err.js
     dstr/gen-meth-dflt-obj-ptrn-prop-ary.js
     dstr/gen-meth-dflt-obj-ptrn-prop-ary-init.js
-    dstr/gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js
     dstr/gen-meth-dflt-obj-ptrn-prop-ary-value-null.js
     dstr/gen-meth-dflt-obj-ptrn-prop-eval-err.js
-    dstr/gen-meth-dflt-obj-ptrn-prop-id.js
     dstr/gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init.js
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js
     dstr/gen-meth-dflt-obj-ptrn-prop-id-init-throws.js
     dstr/gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js
@@ -5282,30 +5243,22 @@ language/expressions/object 784/1169 (67.07%)
     dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/gen-meth-obj-init-null.js
     dstr/gen-meth-obj-init-undefined.js
-    dstr/gen-meth-obj-ptrn-empty.js
     dstr/gen-meth-obj-ptrn-id-get-value-err.js
     dstr/gen-meth-obj-ptrn-id-init-fn-name-arrow.js
     dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
     dstr/gen-meth-obj-ptrn-id-init-fn-name-cover.js
     dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
     dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
-    dstr/gen-meth-obj-ptrn-id-init-skipped.js
     dstr/gen-meth-obj-ptrn-id-init-throws.js
     dstr/gen-meth-obj-ptrn-id-init-unresolvable.js
-    dstr/gen-meth-obj-ptrn-id-trailing-comma.js
     dstr/gen-meth-obj-ptrn-list-err.js
     dstr/gen-meth-obj-ptrn-prop-ary.js
     dstr/gen-meth-obj-ptrn-prop-ary-init.js
-    dstr/gen-meth-obj-ptrn-prop-ary-trailing-comma.js
     dstr/gen-meth-obj-ptrn-prop-ary-value-null.js
     dstr/gen-meth-obj-ptrn-prop-eval-err.js
-    dstr/gen-meth-obj-ptrn-prop-id.js
     dstr/gen-meth-obj-ptrn-prop-id-get-value-err.js
-    dstr/gen-meth-obj-ptrn-prop-id-init.js
-    dstr/gen-meth-obj-ptrn-prop-id-init-skipped.js
     dstr/gen-meth-obj-ptrn-prop-id-init-throws.js
     dstr/gen-meth-obj-ptrn-prop-id-init-unresolvable.js
-    dstr/gen-meth-obj-ptrn-prop-id-trailing-comma.js
     dstr/gen-meth-obj-ptrn-prop-obj.js
     dstr/gen-meth-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
@@ -5437,9 +5390,6 @@ language/expressions/object 784/1169 (67.07%)
     method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-functions, async]}
     method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-functions, async]}
     method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b2/gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js non-strict
-    method-definition/forbidden-ext/b2/gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js non-strict
-    method-definition/forbidden-ext/b2/gen-meth-forbidden-ext-indirect-access-prop-caller.js non-strict
     method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
     method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
     method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
@@ -5586,39 +5536,31 @@ language/expressions/object 784/1169 (67.07%)
     method-definition/escaped-set-t.js
     method-definition/fn-name-fn.js
     method-definition/fn-name-gen.js
+    method-definition/gen-meth-array-destructuring-param-strict-body.js
     method-definition/gen-meth-dflt-params-abrupt.js
-    method-definition/gen-meth-dflt-params-arg-val-not-undefined.js
-    method-definition/gen-meth-dflt-params-arg-val-undefined.js
+    method-definition/gen-meth-dflt-params-duplicates.js non-strict
     method-definition/gen-meth-dflt-params-ref-later.js
-    method-definition/gen-meth-dflt-params-ref-prior.js
     method-definition/gen-meth-dflt-params-ref-self.js
+    method-definition/gen-meth-dflt-params-rest.js
     method-definition/gen-meth-dflt-params-trailing-comma.js
     method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict
-    method-definition/gen-meth-params-trailing-comma-multiple.js
-    method-definition/gen-meth-params-trailing-comma-single.js
+    method-definition/gen-meth-object-destructuring-param-strict-body.js
+    method-definition/gen-meth-rest-param-strict-body.js
     method-definition/gen-yield-identifier-non-strict.js non-strict
     method-definition/gen-yield-identifier-spread-non-strict.js non-strict
     method-definition/gen-yield-spread-arr-multiple.js
     method-definition/gen-yield-spread-arr-single.js
     method-definition/gen-yield-spread-obj.js
     method-definition/generator-invoke-ctor.js
-    method-definition/generator-invoke-fn-no-strict.js non-strict
     method-definition/generator-invoke-fn-strict.js non-strict
-    method-definition/generator-length.js
     method-definition/generator-length-dflt.js
     method-definition/generator-name-prop-string.js
     method-definition/generator-name-prop-symbol.js
-    method-definition/generator-no-yield.js
-    method-definition/generator-params.js
-    method-definition/generator-prop-name-eval-error.js
+    method-definition/generator-param-init-yield.js non-strict
+    method-definition/generator-param-redecl-let.js
     method-definition/generator-prop-name-yield-expr.js non-strict
     method-definition/generator-prop-name-yield-id.js non-strict
-    method-definition/generator-property-desc.js
-    method-definition/generator-prototype.js
     method-definition/generator-prototype-prop.js
-    method-definition/generator-return.js
-    method-definition/generator-super-prop-body.js
-    method-definition/generator-super-prop-param.js
     method-definition/meth-array-destructuring-param-strict-body.js
     method-definition/meth-dflt-params-duplicates.js non-strict
     method-definition/meth-dflt-params-ref-later.js
@@ -5640,8 +5582,6 @@ language/expressions/object 784/1169 (67.07%)
     method-definition/name-prop-name-yield-id.js non-strict
     method-definition/name-prototype-prop.js
     method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
-    method-definition/params-dflt-gen-meth-args-unmapped.js
-    method-definition/params-dflt-gen-meth-ref-arguments.js
     method-definition/params-dflt-meth-ref-arguments.js
     method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
     method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
@@ -5660,14 +5600,8 @@ language/expressions/object 784/1169 (67.07%)
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
     method-definition/yield-as-function-expression-binding-identifier.js non-strict
-    method-definition/yield-as-generator-method-binding-identifier.js
     method-definition/yield-as-identifier-in-nested-function.js non-strict
-    method-definition/yield-as-literal-property-name.js
-    method-definition/yield-as-property-name.js
-    method-definition/yield-as-statement.js
-    method-definition/yield-as-yield-operand.js
-    method-definition/yield-newline.js
-    method-definition/yield-return.js
+    method-definition/yield-star-after-newline.js
     method-definition/yield-star-before-newline.js
     11.1.5-2gs.js strict
     11.1.5_4-4-a-3.js strict
@@ -5683,7 +5617,6 @@ language/expressions/object 784/1169 (67.07%)
     accessor-name-literal-numeric-hex.js {strict: [-1], non-strict: [-1]}
     accessor-name-literal-numeric-octal.js {strict: [-1], non-strict: [-1]}
     computed-__proto__.js
-    concise-generator.js
     cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
     cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
     cpn-obj-lit-computed-property-name-from-yield-expression.js
@@ -5717,11 +5650,8 @@ language/expressions/object 784/1169 (67.07%)
     prop-dup-set-get-set.js strict
     prop-dup-set-set.js strict
     scope-gen-meth-body-lex-distinct.js non-strict
-    scope-gen-meth-param-elem-var-close.js non-strict
-    scope-gen-meth-param-elem-var-open.js non-strict
     scope-gen-meth-param-rest-elem-var-close.js non-strict
     scope-gen-meth-param-rest-elem-var-open.js non-strict
-    scope-gen-meth-paramsbody-var-close.js
     scope-gen-meth-paramsbody-var-open.js
     scope-getter-body-lex-distinc.js non-strict
     scope-meth-body-lex-distinct.js non-strict


### PR DESCRIPTION
This makes quite a few test262 cases pass.

There's a few tests that were passing and apparently are broken now, but that is a false positive. The reason is that, _before_ this PR, Rhino would not support the syntax altogether and thus would complain with a SyntaxError, whereas now we accept the method definition, and also accept some syntax that we shouldn't have inside the method body. For example one of the test cases, `method-definition/generator-param-redecl-let.js` has this body:

```js
var obj = {
    *foo(a) {
        let a = 3;
    }
};
```

Previously rhino would have thrown an error because `*foo` was not supported. After this PR, the method declaration is allowed and the test is passing, but rhino should throw a SyntaxError on `let a = 3`. However, the same test exists for non-generator methods, named `method-definition/name-param-redecl-let.js`, which was already failing because of the same underlying reason.
I've checked that this is true for all the test262 cases where there is a regression.