### PR TITLE
Ensure `next` and `orderedNext` are null for slots in `HashSlotMap`.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -16,6 +16,17 @@ public class AccessorSlot extends Slot {
         super(oldSlot);
     }
 
+    @Override
+    AccessorSlot copySlot() {
+        var newSlot = new AccessorSlot(this);
+        newSlot.value = value;
+        newSlot.getter = getter;
+        newSlot.setter = setter;
+        newSlot.next = null;
+        newSlot.orderedNext = null;
+        return newSlot;
+    }
+
     // The Getter and Setter may each be of a different type (JavaScript function, Java
     // function, or neither). So, use an abstraction to distinguish them.
     transient Getter getter;

--- a/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
@@ -17,7 +17,18 @@ import java.util.LinkedHashMap;
  */
 public class HashSlotMap implements SlotMap {
 
-    private final LinkedHashMap<Object, Slot> map = new LinkedHashMap<>();
+    private final LinkedHashMap<Object, Slot> map;
+
+    public HashSlotMap() {
+        map = new LinkedHashMap<>();
+    }
+
+    public HashSlotMap(SlotMap oldMap) {
+        map = new LinkedHashMap<>(oldMap.size());
+        for (Slot n : oldMap) {
+            add(n.copySlot());
+        }
+    }
 
     @Override
     public int size() {

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
@@ -29,6 +29,19 @@ public class LambdaAccessorSlot extends Slot {
     }
 
     @Override
+    LambdaAccessorSlot copySlot() {
+        var newSlot = new LambdaAccessorSlot(this);
+        newSlot.value = value;
+        newSlot.getter = getter;
+        newSlot.setter = setter;
+        newSlot.getterFunction = getterFunction;
+        newSlot.setterFunction = setterFunction;
+        newSlot.next = null;
+        newSlot.orderedNext = null;
+        return newSlot;
+    }
+
+    @Override
     boolean isValueSlot() {
         return false;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
@@ -22,6 +22,17 @@ public class LambdaSlot extends Slot {
         super(oldSlot);
     }
 
+    @Override
+    LambdaSlot copySlot() {
+        var newSlot = new LambdaSlot(this);
+        newSlot.value = value;
+        newSlot.getter = getter;
+        newSlot.setter = setter;
+        newSlot.next = null;
+        newSlot.orderedNext = null;
+        return newSlot;
+    }
+
     transient Supplier<Object> getter;
     transient Consumer<Object> setter;
 

--- a/rhino/src/main/java/org/mozilla/javascript/LazyLoadSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazyLoadSlot.java
@@ -14,6 +14,15 @@ public class LazyLoadSlot extends Slot {
     }
 
     @Override
+    LazyLoadSlot copySlot() {
+        var newSlot = new LazyLoadSlot(this);
+        newSlot.value = value;
+        newSlot.next = null;
+        newSlot.orderedNext = null;
+        return newSlot;
+    }
+
+    @Override
     public Object getValue(Scriptable start) {
         Object val = this.value;
         if (val instanceof LazilyLoadedCtor) {

--- a/rhino/src/main/java/org/mozilla/javascript/Slot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Slot.java
@@ -25,6 +25,13 @@ public class Slot implements Serializable {
         this.attributes = (short) attributes;
     }
 
+    Slot copySlot() {
+        var newSlot = new Slot(this);
+        newSlot.next = null;
+        newSlot.orderedNext = null;
+        return newSlot;
+    }
+
     /**
      * Return true if this is a base-class "Slot". Sadly too much code breaks if we try to do this
      * any other way.

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
@@ -93,10 +93,7 @@ class SlotMapContainer implements SlotMap {
      */
     protected void checkMapSize() {
         if ((map instanceof EmbeddedSlotMap) && map.size() >= LARGE_HASH_SIZE) {
-            SlotMap newMap = new HashSlotMap();
-            for (Slot s : map) {
-                newMap.add(s);
-            }
+            SlotMap newMap = new HashSlotMap(map);
             map = newMap;
         }
     }


### PR DESCRIPTION
# Slot `next` and `orderedNext` in `HashSlotMap`

When an embedded slot map is promoted to being a `HashSlotMap` the slots are placed in the new map, but there `next` and `orderedNext` fields are not nulled, and nothing in the `HashSlotMap` code touches those fields. This can lead to slots holding on to an unexpected set of resources via the `orderedNext` chain which was built by `EmbeddedSlotMap`.

This PR copies the slots rather than reusing them, and sets the `next` and `orderedNext` fields to null on the copies, and sizes the linked hash map to match the number of slots being inserted on promotion to avoid unnecessary internal reallocations during this process.