### PR TITLE
FEAT: Implement Symbol.hasInstance for Function.prototype

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -770,6 +770,14 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         return function;
     }
 
+    public final IdFunctionObject initPrototypeMethod(
+            Object tag, int id, Symbol key, String functionName, int arity, int attributes) {
+        Scriptable scope = ScriptableObject.getTopLevelScope(this);
+        IdFunctionObject function = newIdFunction(tag, id, functionName, arity, scope);
+        prototypeValues.initValue(id, key, function, attributes);
+        return function;
+    }
+
     public final void initPrototypeConstructor(IdFunctionObject f) {
         int id = prototypeValues.constructorId;
         if (id == 0) throw new IllegalStateException();

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -201,7 +201,13 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                 Context cx = Context.getContext();
                 if (cx.isStrictMode()) {
                     int nameSlot = (id - 1) * SLOT_SPAN + NAME_SLOT;
-                    String name = (String) valueArray[nameSlot];
+
+                    String name = null;
+                    if (valueArray[nameSlot] instanceof String)
+                        name = (String) valueArray[nameSlot];
+                    else if (valueArray[nameSlot] instanceof Symbol) {
+                        name = valueArray[nameSlot].toString();
+                    }
                     throw ScriptRuntime.typeErrorById(
                             "msg.delete.property.with.configurable.false", name);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/Node.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Node.java
@@ -1181,7 +1181,7 @@ public class Node implements Iterable<Node> {
                             Object[] a = (Object[]) x.objectValue;
                             sb.append("[");
                             for (int i = 0; i < a.length; i++) {
-                                sb.append(a[i].toString());
+                                if (a[i] != null) sb.append(a[i].toString());
                                 if (i + 1 < a.length) sb.append(", ");
                             }
                             sb.append("]");

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -46,15 +46,4 @@ public class ScriptRuntimeES6 {
         ScriptableObject.putProperty(unScopablesDescriptor, "writable", false);
         constructor.defineOwnProperty(cx, SymbolKey.UNSCOPABLES, unScopablesDescriptor, false);
     }
-
-    /** Registers the symbol <code>[Symbol.hasInstance]</code> on the given constructor function. */
-    public static void addSymbolHasInstance(
-            Context cx, Scriptable scope, IdScriptableObject constructor) {
-        ScriptableObject hasInstanceDescriptor = (ScriptableObject) cx.newObject(scope);
-        ScriptableObject.putProperty(hasInstanceDescriptor, "value", ScriptableObject.EMPTY);
-        ScriptableObject.putProperty(hasInstanceDescriptor, "enumerable", false);
-        ScriptableObject.putProperty(hasInstanceDescriptor, "configurable", false);
-        ScriptableObject.putProperty(hasInstanceDescriptor, "writable", false);
-        constructor.defineOwnProperty(cx, SymbolKey.HAS_INSTANCE, hasInstanceDescriptor, false);
-    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -46,4 +46,15 @@ public class ScriptRuntimeES6 {
         ScriptableObject.putProperty(unScopablesDescriptor, "writable", false);
         constructor.defineOwnProperty(cx, SymbolKey.UNSCOPABLES, unScopablesDescriptor, false);
     }
+
+    /** Registers the symbol <code>[Symbol.hasInstance]</code> on the given constructor function. */
+    public static void addSymbolHasInstance(
+            Context cx, Scriptable scope, IdScriptableObject constructor) {
+        ScriptableObject hasInstanceDescriptor = (ScriptableObject) cx.newObject(scope);
+        ScriptableObject.putProperty(hasInstanceDescriptor, "value", ScriptableObject.EMPTY);
+        ScriptableObject.putProperty(hasInstanceDescriptor, "enumerable", false);
+        ScriptableObject.putProperty(hasInstanceDescriptor, "configurable", false);
+        ScriptableObject.putProperty(hasInstanceDescriptor, "writable", false);
+        constructor.defineOwnProperty(cx, SymbolKey.HAS_INSTANCE, hasInstanceDescriptor, false);
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -864,6 +864,12 @@ public abstract class ScriptableObject
         // chasing. This will be overridden in NativeFunction and non-JS
         // objects.
 
+        Context cx = Context.getCurrentContext();
+        Object hasInstance = ScriptRuntime.getObjectElem(this, SymbolKey.HAS_INSTANCE, cx);
+        if (hasInstance instanceof Callable) {
+            return (boolean)
+                    ((Callable) hasInstance).call(cx, getParentScope(), this, new Object[] {this});
+        }
         return ScriptRuntime.jsDelegatesTo(instance, this);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -867,8 +867,8 @@ public abstract class ScriptableObject
         Context cx = Context.getCurrentContext();
         Object hasInstance = ScriptRuntime.getObjectElem(this, SymbolKey.HAS_INSTANCE, cx);
         if (hasInstance instanceof Callable) {
-            return (boolean)
-                    ((Callable) hasInstance).call(cx, getParentScope(), this, new Object[] {this});
+            return ScriptRuntime.toBoolean(
+                    ((Callable) hasInstance).call(cx, getParentScope(), this, new Object[] {this}));
         }
         return ScriptRuntime.jsDelegatesTo(instance, this);
     }

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -1,6 +1,5 @@
 package org.mozilla.javascript;
 
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mozilla.javascript.tests.Utils;
@@ -16,7 +15,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "};\n"
                         + "var g = {};\n"
                         + "`${f.hasOwnProperty(Symbol.hasInstance)}:${g.hasOwnProperty(Symbol.hasInstance)}`";
-        Utils.assertWithAllOptimizationLevelsES6("true:false", script);
+        Utils.assertWithAllModes("true:false", script);
     }
 
     @Test
@@ -29,7 +28,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "   }"
                         + "};\n"
                         + "f[Symbol.hasInstance]() == 42";
-        Utils.assertWithAllOptimizationLevelsES6(true, script);
+        Utils.assertWithAllModes(true, script);
     }
 
     // See: https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%
@@ -38,7 +37,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
         String script =
                 "var a = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.hasInstance);\n"
                         + "a.writable + ':' + a.configurable + ':' + a.enumerable";
-        Utils.assertWithAllOptimizationLevelsES6("false:false:false", script);
+        Utils.assertWithAllModes("false:false:false", script);
     }
 
     // See: https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%
@@ -55,7 +54,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "    typeErrorThrown = true \n"
                         + "}\n"
                         + "Object.prototype.hasOwnProperty.call(Function.prototype, Symbol.hasInstance) + ':' + typeErrorThrown + ':' + t + ':' + a.writable + ':' + a.configurable + ':' + a.enumerable; \n";
-        Utils.assertWithAllOptimizationLevelsES6("true:true:function:false:false:false", script);
+        Utils.assertWithAllModes("true:true:function:false:false:false", script);
     }
 
     @Test
@@ -68,9 +67,8 @@ public class FunctionPrototypeSymbolHasInstanceTest {
         String script2 =
                 "var a = Object.getOwnPropertyDescriptor(Function.prototype[Symbol.hasInstance], 'name');\n"
                         + "a.value + ':' + a.writable + ':' + a.configurable + ':' + a.enumerable";
-        Utils.assertWithAllOptimizationLevelsES6("1:false:true:false", script);
-        Utils.assertWithAllOptimizationLevelsES6(
-                "Symbol(Symbol.hasInstance):false:true:false", script2);
+        Utils.assertWithAllModes("1:false:true:false", script);
+        Utils.assertWithAllModes("Symbol(Symbol.hasInstance):false:true:false", script2);
     }
 
     @Test
@@ -78,7 +76,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
         String script =
                 "(Function.prototype[Symbol.hasInstance] instanceof Function) + ':' + "
                         + "Function.prototype[Symbol.hasInstance].call(Function, Object)\n";
-        Utils.assertWithAllOptimizationLevelsES6("true:true", script);
+        Utils.assertWithAllModes("true:true", script);
     }
 
     @Test
@@ -89,7 +87,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "var o2 = Object.create(o);\n"
                         + "(f[Symbol.hasInstance](o)) + ':' + "
                         + "(f[Symbol.hasInstance](o2));\n";
-        Utils.assertWithAllOptimizationLevelsES6("true:true", script);
+        Utils.assertWithAllModes("true:true", script);
     }
 
     @Test
@@ -99,7 +97,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "var bc = new BC();\n"
                         + "var bound = BC.bind();\n"
                         + "bound[Symbol.hasInstance](bc);\n";
-        Utils.assertWithAllOptimizationLevelsES6(true, script);
+        Utils.assertWithAllModes(true, script);
     }
 
     @Test
@@ -112,7 +110,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "(null instanceof f) + ':' +\n"
                         + "(void 0 instanceof f)\n"
                         + "a";
-        Utils.assertWithAllOptimizationLevelsES6("false:false:false:false", script);
+        Utils.assertWithAllModes("false:false:false:false", script);
     }
 
     @Test
@@ -120,7 +118,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
         String script =
                 "Function.prototype[Symbol.hasInstance].call() + ':' +"
                         + "Function.prototype[Symbol.hasInstance].call({});";
-        Utils.assertWithAllOptimizationLevelsES6("false:false", script);
+        Utils.assertWithAllModes("false:false", script);
     }
 
     @Test
@@ -138,7 +136,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "Object.setPrototypeOf(g, f);\n"
                         + "g instanceof f;"
                         + "globalSet == 1";
-        Utils.assertWithAllOptimizationLevelsES6(true, script);
+        Utils.assertWithAllModes(true, script);
     }
 
     @Test
@@ -148,25 +146,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "var f = function() {}; \n"
                         + "f.prototype = Symbol(); \n"
                         + "f[Symbol.hasInstance]({})";
-
-        Utils.runWithAllOptimizationLevels(
-                (cx) -> {
-                    cx.setLanguageVersion(Context.VERSION_ES6);
-                    final Scriptable scope = cx.initStandardObjects();
-                    var error =
-                            Assert.assertThrows(
-                                    EcmaError.class,
-                                    () ->
-                                            cx.evaluateString(
-                                                    scope,
-                                                    script,
-                                                    "testSymbolHasInstance",
-                                                    0,
-                                                    null));
-                    Assert.assertTrue(
-                            error.toString()
-                                    .contains("'prototype' property of  is not an object."));
-                    return null;
-                });
+        Utils.assertEcmaErrorES6(
+                "TypeError: 'prototype' property of  is not an object. (test#3)", script);
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -1,0 +1,172 @@
+package org.mozilla.javascript;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mozilla.javascript.tests.Utils;
+
+public class FunctionPrototypeSymbolHasInstanceTest {
+    @Test
+    public void testSymbolHasInstanceIsPresent() {
+        String script =
+                ""
+                        + "var f = {\n"
+                        + "   [Symbol.hasInstance](value) { "
+                        + "   }"
+                        + "};\n"
+                        + "var g = {};\n"
+                        + "`${f.hasOwnProperty(Symbol.hasInstance)}:${g.hasOwnProperty(Symbol.hasInstance)}`";
+        Utils.assertWithAllOptimizationLevelsES6("true:false", script);
+    }
+
+    @Test
+    public void testSymbolHasInstanceCanBeCalledLikeAnotherMethod() {
+        String script =
+                ""
+                        + "var f = {\n"
+                        + "   [Symbol.hasInstance](value) { "
+                        + "       return 42;"
+                        + "   }"
+                        + "};\n"
+                        + "f[Symbol.hasInstance]() == 42";
+        Utils.assertWithAllOptimizationLevelsES6(true, script);
+    }
+
+    // See: https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceHasAttributes() {
+        String script =
+                "var a = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.hasInstance);\n"
+                        + "a.writable + ':' + a.configurable + ':' + a.enumerable";
+        Utils.assertWithAllOptimizationLevelsES6("false:false:false", script);
+    }
+
+    // See: https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceHasAttributesStrictMode() {
+        String script =
+                "'use strict';\n"
+                        + "var t = typeof Function.prototype[Symbol.hasInstance];\n"
+                        + "var a = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.hasInstance);\n"
+                        + "var typeErrorThrown = false;\n"
+                        + "try { \n"
+                        + "    delete Function.prototype[Symbol.hasInstance] \n"
+                        + "} catch (e) { \n"
+                        + "    typeErrorThrown = true \n"
+                        + "}\n"
+                        + "Object.prototype.hasOwnProperty.call(Function.prototype, Symbol.hasInstance) + ':' + typeErrorThrown + ':' + t + ':' + a.writable + ':' + a.configurable + ':' + a.enumerable; \n";
+        Utils.assertWithAllOptimizationLevelsES6("true:true:function:false:false:false", script);
+    }
+
+    @Test
+    @Ignore("name-length-params-prototype-set-incorrectly")
+    public void testFunctionPrototypeSymbolHasInstanceHasProperties() {
+        String script =
+                "var a = Object.getOwnPropertyDescriptor(Function.prototype[Symbol.hasInstance], 'length');\n"
+                        + "a.value + ':' + a.writable + ':' + a.configurable + ':' + a.enumerable";
+
+        String script2 =
+                "var a = Object.getOwnPropertyDescriptor(Function.prototype[Symbol.hasInstance], 'name');\n"
+                        + "a.value + ':' + a.writable + ':' + a.configurable + ':' + a.enumerable";
+        Utils.assertWithAllOptimizationLevelsES6("1:false:true:false", script);
+        Utils.assertWithAllOptimizationLevelsES6(
+                "Symbol(Symbol.hasInstance):false:true:false", script2);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstance() {
+        String script =
+                "(Function.prototype[Symbol.hasInstance] instanceof Function) + ':' + "
+                        + "Function.prototype[Symbol.hasInstance].call(Function, Object)\n";
+        Utils.assertWithAllOptimizationLevelsES6("true:true", script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceOnObjectReturnsTrue() {
+        String script =
+                "var f = function() {};\n"
+                        + "var o = new f();\n"
+                        + "var o2 = Object.create(o);\n"
+                        + "(f[Symbol.hasInstance](o)) + ':' + "
+                        + "(f[Symbol.hasInstance](o2));\n";
+        Utils.assertWithAllOptimizationLevelsES6("true:true", script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceOnBoundTargetReturnsTrue() {
+        String script =
+                "var BC = function() {};\n"
+                        + "var bc = new BC();\n"
+                        + "var bound = BC.bind();\n"
+                        + "bound[Symbol.hasInstance](bc);\n";
+        Utils.assertWithAllOptimizationLevelsES6(true, script);
+    }
+
+    @Test
+    public void testFunctionInstanceNullVoidEtc() {
+        String script =
+                "var f = function() {};\n"
+                        + "var x;\n"
+                        + "a = (undefined instanceof f) + ':' +\n"
+                        + "(x instanceof f) + ':' +\n"
+                        + "(null instanceof f) + ':' +\n"
+                        + "(void 0 instanceof f)\n"
+                        + "a";
+        Utils.assertWithAllOptimizationLevelsES6("false:false:false:false", script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceReturnsFalseOnUndefinedOrProtoypeNotFound() {
+        String script =
+                "Function.prototype[Symbol.hasInstance].call() + ':' +"
+                        + "Function.prototype[Symbol.hasInstance].call({});";
+        Utils.assertWithAllOptimizationLevelsES6("false:false", script);
+    }
+
+    @Test
+    public void testSymbolHasInstanceIsInvokedInInstanceOf() {
+        String script =
+                ""
+                        + "var globalSet = 0;"
+                        + "var f = {\n"
+                        + "   [Symbol.hasInstance](value) { "
+                        + "       globalSet = 1;"
+                        + "       return true;"
+                        + "   }"
+                        + "}\n"
+                        + "var g = {}\n"
+                        + "Object.setPrototypeOf(g, f);\n"
+                        + "g instanceof f;"
+                        + "globalSet == 1";
+        Utils.assertWithAllOptimizationLevelsES6(true, script);
+    }
+
+    @Test
+    public void testThrowTypeErrorOnNonObjectIncludingSymbol() {
+        String script =
+                ""
+                        + "var f = function() {}; \n"
+                        + "f.prototype = Symbol(); \n"
+                        + "f[Symbol.hasInstance]({})";
+
+        Utils.runWithAllOptimizationLevels(
+                (cx) -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    final Scriptable scope = cx.initStandardObjects();
+                    var error =
+                            Assert.assertThrows(
+                                    EcmaError.class,
+                                    () ->
+                                            cx.evaluateString(
+                                                    scope,
+                                                    script,
+                                                    "testSymbolHasInstance",
+                                                    0,
+                                                    null));
+                    Assert.assertTrue(
+                            error.toString()
+                                    .contains("'prototype' property of  is not an object."));
+                    return null;
+                });
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -721,14 +721,7 @@ built-ins/Function 184/508 (36.22%)
     prototype/call/S15.3.4.4_A6_T7.js compiled
     prototype/Symbol.hasInstance/length.js
     prototype/Symbol.hasInstance/name.js
-    prototype/Symbol.hasInstance/prop-desc.js
-    prototype/Symbol.hasInstance/this-val-bound-target.js
-    prototype/Symbol.hasInstance/this-val-not-callable.js
-    prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
-    prototype/Symbol.hasInstance/value-get-prototype-of-err.js
-    prototype/Symbol.hasInstance/value-negative.js
-    prototype/Symbol.hasInstance/value-non-obj.js
-    prototype/Symbol.hasInstance/value-positive.js
+    prototype/Symbol.hasInstance/value-get-prototype-of-err.js {unsupported: [Proxy]}
     prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
     prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
     prototype/toString/async-function-expression.js {unsupported: [async-functions]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -660,7 +660,7 @@ built-ins/Error 5/41 (12.2%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 184/508 (36.22%)
+built-ins/Function 175/508 (34.45%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -719,9 +719,7 @@ built-ins/Function 184/508 (36.22%)
     prototype/call/S15.3.4.4_A6_T2.js compiled
     prototype/call/S15.3.4.4_A6_T5.js compiled
     prototype/call/S15.3.4.4_A6_T7.js compiled
-    prototype/Symbol.hasInstance/length.js
     prototype/Symbol.hasInstance/name.js
-    prototype/Symbol.hasInstance/value-get-prototype-of-err.js {unsupported: [Proxy]}
     prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
     prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
     prototype/toString/async-function-expression.js {unsupported: [async-functions]}


### PR DESCRIPTION
Adds support for `Function.prototype[Symbol.hasInstance]`.