### PR TITLE
Fixed computed property in object literal with negative integers

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4866,8 +4866,8 @@ public class ScriptRuntime {
                     Symbol sym = (Symbol) id;
                     SymbolScriptable so = (SymbolScriptable) object;
                     so.put(sym, object, value);
-                } else if (id instanceof Integer) {
-                    int index = ((Integer) id).intValue();
+                } else if (id instanceof Integer && ((Integer) id) >= 0) {
+                    int index = (Integer) id;
                     object.put(index, object, value);
                 } else {
                     StringIdOrIndex s = toStringIdOrIndex(id);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
@@ -49,10 +49,10 @@ public class ComputedPropertiesTest {
                         + "var o = {\n"
                         + "  a: 1,\n"
                         + "  0: 2,\n"
-                        + "  [1]: 3\n,"
+                        + "  [-1]: 3\n,"
                         + "  [f('b')]: 4\n"
                         + "};\n"
-                        + "o.a + o[0] + o['1'] + o.b";
+                        + "o.a + o[0] + o['-1'] + o.b";
 
         ScriptableObject scope = cx.initStandardObjects();
         Object value = cx.evaluateString(scope, script, "test", 1, null);


### PR DESCRIPTION
There is a code path, in compiled mode only (not in interpreted!), where something like `o = { [-1]: xxx }` would not work correctly.

The problem is a combination of factors:
- in the interpreter, we would treat `-1` as a `double`, not an `int`;
- but there are various places in `ScriptRuntime` where integer keys are allowed _only_ for positive or zero numbers, per the spec - otherwise they need to be treated as strings.

We have modified the existing test for computed properties and fixed the code.