### PR TITLE
Shell: improve handling of unhandled promise rejection

### DIFF
--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Main.java
@@ -96,7 +96,7 @@ public class Main {
             }
             if (type == PROCESS_FILES) {
                 processFiles(cx, args);
-                printPromiseWarnings(cx);
+                printPromiseWarnings(cx, true);
             } else if (type == EVAL_INLINE_SCRIPT) {
                 evalInlineScript(cx, scriptText);
             } else {
@@ -493,7 +493,7 @@ public class Main {
                         NativeArray h = global.history;
                         h.put((int) h.getLength(), h, source);
                     }
-                    printPromiseWarnings(cx);
+                    printPromiseWarnings(cx, false);
                 } catch (RhinoException rex) {
                     ToolErrorReporter.reportException(cx.getErrorReporter(), rex);
                     exitCode = EXITCODE_RUNTIME_ERROR;
@@ -642,21 +642,22 @@ public class Main {
         }
     }
 
-    private static void printPromiseWarnings(Context cx) {
+    private static void printPromiseWarnings(Context cx, boolean exitOnRejections) {
         List<Object> unhandled = cx.getUnhandledPromiseTracker().enumerate();
         if (!unhandled.isEmpty()) {
-            Object result = unhandled.get(0);
-            String msg = "Unhandled rejected promise: " + Context.toString(result);
-            if (result instanceof Scriptable) {
-                Object stack = ScriptableObject.getProperty((Scriptable) result, "stack");
-                if (stack != null && stack != Scriptable.NOT_FOUND) {
-                    msg += '\n' + Context.toString(stack);
+            for (Object rejection : unhandled) {
+                String msg = "Unhandled rejected promise: " + Context.toString(rejection);
+                if (rejection instanceof Scriptable) {
+                    Object stack = ScriptableObject.getProperty((Scriptable) rejection, "stack");
+                    if (stack != null && stack != Scriptable.NOT_FOUND) {
+                        msg += '\n' + Context.toString(stack);
+                    }
                 }
+                System.out.println(msg);
             }
-            System.out.println(msg);
-            if (unhandled.size() > 1) {
-                System.out.println(
-                        "  and " + (unhandled.size() - 1) + " other unhandled rejected promises");
+
+            if (exitOnRejections) {
+                exitCode = EXITCODE_RUNTIME_ERROR;
             }
         }
     }


### PR DESCRIPTION
We have changed the logging to log _all_ the exceptions, rather than just the first one. Also, we quit the process with non-zero status if we are evaluating a file (i.e. not in REPL mode) and there are any unhandled promise rejections.


Example: create a file named `promise.js`:

```js
Promise.reject('some error');
Promise.reject('another error');
```

If you launch this in both node and rhino, you will see that node exits with status 1, while rhino (before this PR) with status 0. With this change, rhino too exits with a non-zero status.