### PR TITLE
Fix: handle stack frames in the correct order

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -14,6 +14,7 @@ import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -951,7 +952,10 @@ public final class Interpreter extends Icode implements Evaluator {
                 --previousCount;
             }
             array = new CallFrame[previousCount + 1];
-            cx.previousInterpreterInvocations.toArray(array);
+
+            ArrayList<Object> tempList = new ArrayList<>(cx.previousInterpreterInvocations);
+            Collections.reverse(tempList);
+            tempList.toArray(array);
         }
         array[array.length - 1] = (CallFrame) cx.lastInterpreterFrame;
 


### PR DESCRIPTION
Commit f3c64ee29f9094bdc87a4fe3615c21f9c65fab51 removed `ObjArray` and replaced its usage with standard JDK classes. In `Interpreter`, in particular, an `ArrayDeque` is now used to store
`cx.previousInterpreterInvocations`, which is used to generate the stack frame information. However, there is one place where `toArray` is done, and the behavior for `ObjArray` and `ArrayDeque` are different (swapped).
Unfortunately no tests actually ends up exercising this difference due to the interpreter function peeling optimization done in https://github.com/mozilla/rhino/pull/1510.

We have discovered this problem because, in ServiceNow's fork, we currently need to disable the function peeling optimization.

I cannot figure out how to write an unit test for this problem, though. Any ideas?

---

To verify that the behavior are different, I've written this code:

```java
class ObjArrayTest {
	public static void main(String[] args) {
		var objArray = new ObjArray();
		objArray.push(1);
		objArray.push(2);
		objArray.push(3);
		System.out.println("objArray: " + Arrays.toString(objArray.toArray()));
	
		var deque = new ArrayDeque<Integer>();
		deque.push(1);
		deque.push(2);
		deque.push(3);
		System.out.println("ArrayDeque: " + Arrays.toString(deque.toArray()));
	}
}
```

It prints:

```
objArray: [1, 2, 3]
ArrayDeque: [3, 2, 1]
```