### PR TITLE
Support more spec-compliant ScriptableObject extensions

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -221,7 +221,7 @@ public class AbstractEcmaObjectOperations {
         if (base == null) base = o;
 
         if (base instanceof ScriptableObject) {
-            if (((ScriptableObject) base).putImpl(p, 0, o, v, isThrow)) return;
+            if (((ScriptableObject) base).putOwnProperty(p, o, v, isThrow)) return;
 
             o.put(p, o, v);
         } else {
@@ -239,7 +239,7 @@ public class AbstractEcmaObjectOperations {
         if (base == null) base = o;
 
         if (base instanceof ScriptableObject) {
-            if (((ScriptableObject) base).putImpl(null, p, o, v, isThrow)) return;
+            if (((ScriptableObject) base).putOwnProperty(p, o, v, isThrow)) return;
 
             o.put(p, o, v);
         } else {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -674,16 +674,14 @@ public class NativeObject extends IdScriptableObject implements Map {
                                 if (sourceObj.has(intId, sourceObj)
                                         && isEnumerable(intId, sourceObj)) {
                                     Object val = sourceObj.get(intId, sourceObj);
-                                    AbstractEcmaObjectOperations.put(
-                                            cx, targetObj, intId, val, true);
+                                    ScriptableObject.putPropertyStrict(targetObj, intId, val);
                                 }
                             } else {
                                 String stringId = ScriptRuntime.toString(key);
                                 if (sourceObj.has(stringId, sourceObj)
                                         && isEnumerable(stringId, sourceObj)) {
                                     Object val = sourceObj.get(stringId, sourceObj);
-                                    AbstractEcmaObjectOperations.put(
-                                            cx, targetObj, stringId, val, true);
+                                    ScriptableObject.putPropertyStrict(targetObj, stringId, val);
                                 }
                             }
                         }
@@ -737,8 +735,14 @@ public class NativeObject extends IdScriptableObject implements Map {
     private boolean isEnumerable(int index, Object obj) {
         if (obj instanceof ScriptableObject) {
             ScriptableObject so = (ScriptableObject) obj;
-            int attrs = so.getAttributes(index);
-            return (attrs & ScriptableObject.DONTENUM) == 0;
+            try {
+                int attrs = so.getAttributes(index);
+                return (attrs & ScriptableObject.DONTENUM) == 0;
+            } catch (RhinoException re) {
+                // Not all ScriptableObject implementations implement
+                // "getAttributes" for all properties
+                return true;
+            }
         } else {
             return true;
         }
@@ -747,8 +751,12 @@ public class NativeObject extends IdScriptableObject implements Map {
     private boolean isEnumerable(String key, Object obj) {
         if (obj instanceof ScriptableObject) {
             ScriptableObject so = (ScriptableObject) obj;
-            int attrs = so.getAttributes(key);
-            return (attrs & ScriptableObject.DONTENUM) == 0;
+            try {
+                int attrs = so.getAttributes(key);
+                return (attrs & ScriptableObject.DONTENUM) == 0;
+            } catch (RhinoException re) {
+                return true;
+            }
         } else {
             return true;
         }
@@ -757,8 +765,12 @@ public class NativeObject extends IdScriptableObject implements Map {
     private boolean isEnumerable(Symbol sym, Object obj) {
         if (obj instanceof ScriptableObject) {
             ScriptableObject so = (ScriptableObject) obj;
-            int attrs = so.getAttributes(sym);
-            return (attrs & ScriptableObject.DONTENUM) == 0;
+            try {
+                int attrs = so.getAttributes(sym);
+                return (attrs & ScriptableObject.DONTENUM) == 0;
+            } catch (RhinoException re) {
+                return true;
+            }
         } else {
             return true;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -674,14 +674,16 @@ public class NativeObject extends IdScriptableObject implements Map {
                                 if (sourceObj.has(intId, sourceObj)
                                         && isEnumerable(intId, sourceObj)) {
                                     Object val = sourceObj.get(intId, sourceObj);
-                                    ScriptableObject.putPropertyStrict(targetObj, intId, val);
+                                    AbstractEcmaObjectOperations.put(
+                                            cx, targetObj, intId, val, true);
                                 }
                             } else {
                                 String stringId = ScriptRuntime.toString(key);
                                 if (sourceObj.has(stringId, sourceObj)
                                         && isEnumerable(stringId, sourceObj)) {
                                     Object val = sourceObj.get(stringId, sourceObj);
-                                    ScriptableObject.putPropertyStrict(targetObj, stringId, val);
+                                    AbstractEcmaObjectOperations.put(
+                                            cx, targetObj, stringId, val, true);
                                 }
                             }
                         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
@@ -1,67 +1,78 @@
 package org.mozilla.javascript.tests;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 public class AssignSubclassTest {
     @Test
     public void basicOperations() {
-        Utils.runWithAllOptimizationLevels(cx -> {
-            Scriptable scope = cx.initStandardObjects();
-            try {
-                ScriptableObject.defineClass(scope, MySubclass.class);
-            } catch (Exception e) {
-                fail(e);
-            }
-            Object result = cx.evaluateString(scope,
-                    "let o = new MySubclass();" +
-                    "o.foo = 'bar';\n" +
-                    "o.something = 'else';\n" +
-                    "o[0] = 'baz';\n" +
-                    "o[1] = 'frooby';\n" +
-                    "o;\n",
-                    "test", 1, null);
-            assertInstanceOf(Scriptable.class, result);
-            Scriptable o = (Scriptable) result;
-            assertEquals("bar", o.get("foo", o));
-            assertEquals("else", o.get("something", o));
-            assertEquals("baz", o.get(0, o));
-            assertEquals("frooby", o.get(1, o));
-            return null;
-        });
+        Utils.runWithAllModes(
+                cx -> {
+                    Scriptable scope = cx.initStandardObjects();
+                    try {
+                        ScriptableObject.defineClass(scope, MySubclass.class);
+                    } catch (Exception e) {
+                        fail(e);
+                    }
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "let o = new MySubclass();"
+                                            + "o.foo = 'bar';\n"
+                                            + "o.something = 'else';\n"
+                                            + "o[0] = 'baz';\n"
+                                            + "o[1] = 'frooby';\n"
+                                            + "o;\n",
+                                    "test",
+                                    1,
+                                    null);
+                    assertInstanceOf(Scriptable.class, result);
+                    Scriptable o = (Scriptable) result;
+                    assertEquals("bar", o.get("foo", o));
+                    assertEquals("else", o.get("something", o));
+                    assertEquals("baz", o.get(0, o));
+                    assertEquals("frooby", o.get(1, o));
+                    return null;
+                });
     }
 
     @Test
     public void assign() {
-        Utils.runWithAllOptimizationLevels(cx -> {
-            Scriptable scope = cx.initStandardObjects();
-            try {
-                ScriptableObject.defineClass(scope, MySubclass.class);
-            } catch (Exception e) {
-                fail(e);
-            }
-            Object result =cx.evaluateString(scope, "\n" +
-                            "let s = {foo: 'bar', something: 'else', 0: 'baz', 1: 'frooby'};\n" +
-                            "let o = new MySubclass();" +
-                            "o.foo = 'x';\n" +
-                            "o.something = 'y';\n" +
-                            "o[0] = 'z';\n" +
-                            "o[1] = false;\n" +
-                            "Object.assign(o, s);\n" +
-                            "o;\n",
-                    "test", 1, null);
-            assertInstanceOf(Scriptable.class, result);
-            Scriptable o = (Scriptable) result;
-            assertEquals("bar", o.get("foo", o));
-            assertEquals("else", o.get("something", o));
-            assertEquals("baz", o.get(0, o));
-            assertEquals("frooby", o.get(1, o));
-            return null;
-        });
+        Utils.runWithAllModes(
+                cx -> {
+                    Scriptable scope = cx.initStandardObjects();
+                    try {
+                        ScriptableObject.defineClass(scope, MySubclass.class);
+                    } catch (Exception e) {
+                        fail(e);
+                    }
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "\n"
+                                            + "let s = {foo: 'bar', something: 'else', 0: 'baz', 1: 'frooby'};\n"
+                                            + "let o = new MySubclass();"
+                                            + "o.foo = 'x';\n"
+                                            + "o.something = 'y';\n"
+                                            + "o[0] = 'z';\n"
+                                            + "o[1] = false;\n"
+                                            + "Object.assign(o, s);\n"
+                                            + "o;\n",
+                                    "test",
+                                    1,
+                                    null);
+                    assertInstanceOf(Scriptable.class, result);
+                    Scriptable o = (Scriptable) result;
+                    assertEquals("bar", o.get("foo", o));
+                    assertEquals("else", o.get("something", o));
+                    assertEquals("baz", o.get(0, o));
+                    assertEquals("frooby", o.get(1, o));
+                    return null;
+                });
     }
 
     public static class MySubclass extends ScriptableObject {
@@ -89,12 +100,13 @@ public class AssignSubclassTest {
         }
 
         @Override
-        public void put(String name, Scriptable start, Object value) {
+        public boolean putOwnProperty(
+                String name, Scriptable start, Object value, boolean isThrow) {
             if ("foo".equals(name)) {
                 foo = ScriptRuntime.toString(value);
-            } else {
-                super.put(name, start, value);
+                return true;
             }
+            return super.putOwnProperty(name, start, value, isThrow);
         }
 
         @Override
@@ -111,12 +123,12 @@ public class AssignSubclassTest {
         }
 
         @Override
-        public void put(int ix, Scriptable start, Object value) {
+        public boolean putOwnProperty(int ix, Scriptable start, Object value, boolean isThrow) {
             if (ix == 0) {
                 bar = ScriptRuntime.toString(value);
-            } else {
-                super.put(ix, start, value);
+                return true;
             }
+            return super.putOwnProperty(ix, start, value, isThrow);
         }
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
@@ -1,0 +1,122 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AssignSubclassTest {
+    @Test
+    public void basicOperations() {
+        Utils.runWithAllOptimizationLevels(cx -> {
+            Scriptable scope = cx.initStandardObjects();
+            try {
+                ScriptableObject.defineClass(scope, MySubclass.class);
+            } catch (Exception e) {
+                fail(e);
+            }
+            Object result = cx.evaluateString(scope,
+                    "let o = new MySubclass();" +
+                    "o.foo = 'bar';\n" +
+                    "o.something = 'else';\n" +
+                    "o[0] = 'baz';\n" +
+                    "o[1] = 'frooby';\n" +
+                    "o;\n",
+                    "test", 1, null);
+            assertInstanceOf(Scriptable.class, result);
+            Scriptable o = (Scriptable) result;
+            assertEquals("bar", o.get("foo", o));
+            assertEquals("else", o.get("something", o));
+            assertEquals("baz", o.get(0, o));
+            assertEquals("frooby", o.get(1, o));
+            return null;
+        });
+    }
+
+    @Test
+    public void assign() {
+        Utils.runWithAllOptimizationLevels(cx -> {
+            Scriptable scope = cx.initStandardObjects();
+            try {
+                ScriptableObject.defineClass(scope, MySubclass.class);
+            } catch (Exception e) {
+                fail(e);
+            }
+            Object result =cx.evaluateString(scope, "\n" +
+                            "let s = {foo: 'bar', something: 'else', 0: 'baz', 1: 'frooby'};\n" +
+                            "let o = new MySubclass();" +
+                            "o.foo = 'x';\n" +
+                            "o.something = 'y';\n" +
+                            "o[0] = 'z';\n" +
+                            "o[1] = false;\n" +
+                            "Object.assign(o, s);\n" +
+                            "o;\n",
+                    "test", 1, null);
+            assertInstanceOf(Scriptable.class, result);
+            Scriptable o = (Scriptable) result;
+            assertEquals("bar", o.get("foo", o));
+            assertEquals("else", o.get("something", o));
+            assertEquals("baz", o.get(0, o));
+            assertEquals("frooby", o.get(1, o));
+            return null;
+        });
+    }
+
+    public static class MySubclass extends ScriptableObject {
+        private String foo;
+        private String bar;
+
+        public MySubclass() {}
+
+        @Override
+        public String getClassName() {
+            return "MySubclass";
+        }
+
+        @Override
+        public Object get(String name, Scriptable start) {
+            if ("foo".equals(name)) {
+                return foo;
+            }
+            return super.get(name, start);
+        }
+
+        @Override
+        public boolean has(String name, Scriptable start) {
+            return "foo".equals(name) || super.has(name, start);
+        }
+
+        @Override
+        public void put(String name, Scriptable start, Object value) {
+            if ("foo".equals(name)) {
+                foo = ScriptRuntime.toString(value);
+            } else {
+                super.put(name, start, value);
+            }
+        }
+
+        @Override
+        public Object get(int ix, Scriptable start) {
+            if (ix == 0) {
+                return bar;
+            }
+            return super.get(ix, start);
+        }
+
+        @Override
+        public boolean has(int ix, Scriptable start) {
+            return ix == 0 || super.has(ix, start);
+        }
+
+        @Override
+        public void put(int ix, Scriptable start, Object value) {
+            if (ix == 0) {
+                bar = ScriptRuntime.toString(value);
+            } else {
+                super.put(ix, start, value);
+            }
+        }
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1132,7 +1132,6 @@ built-ins/Object 178/3408 (5.22%)
     setPrototypeOf/not-a-constructor.js
     values/not-a-constructor.js
     values/observable-operations.js
-    values/order-after-define-property.js
     property-order.js
     proto-from-ctor-realm.js
     subclass-object-arg.js {unsupported: [class]}
@@ -1560,10 +1559,7 @@ built-ins/Proxy 76/311 (24.44%)
     getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable.js
     getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-configurable.js
     getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-undefined.js
-    getOwnPropertyDescriptor/trap-is-missing-target-is-proxy.js
     getOwnPropertyDescriptor/trap-is-null-target-is-proxy.js
-    getOwnPropertyDescriptor/trap-is-undefined.js
-    getOwnPropertyDescriptor/trap-is-undefined-target-is-proxy.js
     get/accessor-get-is-undefined-throws.js
     get/trap-is-undefined-receiver.js
     has/call-in-prototype.js
@@ -3188,7 +3184,6 @@ language/arguments-object 185/263 (70.34%)
     mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
     unmapped/via-params-dstr.js non-strict
     unmapped/via-params-rest.js non-strict
-    10.6-11-b-1.js
     arguments-caller.js
     async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
     async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}


### PR DESCRIPTION
This fixes a problem in which ScriptableObject subclasses couldn't support some of the newer code, like Object.assign, because it depends on internal implementation details of ScriptableObject. This changes two things:

* Adds new overridable methods to ScriptableObject called "putOwnProperty".
* Call those in internal places instead of calling "putImpl" directly.
* Catch exceptions in Object.assign if "getAttributes" throws an exception, as the default implementation does.

This makes it possible to address the problem identified in https://github.com/mozilla/rhino/issues/1558.

To be fully compatible, a ScriptableObject subclass that wants to add its own properties should override "putOwnProperty" INSTEAD of overriding "put" and delegate to the superclass for any unknown properties.

Added a new test that demonstrates this technique.

I'd be interested in feedback here -- this is not a fix to all spec-compliance problems but it's not the ugliest fix in the world either.
