### PR TITLE
Fix: add file name in stack traces for compiled classes

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -250,11 +250,7 @@ public class Codegen implements Evaluator {
         boolean hasFunctions = (scriptOrFnNodes.length > 1 || !hasScript);
         boolean isStrictMode = scriptOrFnNodes[0].isInStrictMode();
 
-        String sourceFile = null;
-        if (compilerEnv.isGenerateDebugInfo()) {
-            sourceFile = scriptOrFnNodes[0].getSourceName();
-        }
-
+        String sourceFile = scriptOrFnNodes[0].getSourceName();
         ClassFileWriter cfw = new ClassFileWriter(mainClassName, SUPER_CLASS_NAME, sourceFile);
         cfw.addField(ID_FIELD_NAME, "I", ACC_PRIVATE);
 

--- a/tests/src/test/resources/org/mozilla/javascript/tests/commonjs/module/throw-one.js
+++ b/tests/src/test/resources/org/mozilla/javascript/tests/commonjs/module/throw-one.js
@@ -1,0 +1,2 @@
+const two = require('throw-two');
+two();

--- a/tests/src/test/resources/org/mozilla/javascript/tests/commonjs/module/throw-two.js
+++ b/tests/src/test/resources/org/mozilla/javascript/tests/commonjs/module/throw-two.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	throw new Error('hey')
+}


### PR DESCRIPTION
In interpreter mode, we always put the file name, but in compiled mode we do it only in case of `compilerEnv.isGenerateDebugInfo()`. I think that the interpreter's behavior is much more useful, so I changed the compiler to always include the file name.

For an example of the difference, create two files:

<b>`one.js`</b>

```js
const two = require('./two');
two();
```

and <b>`two.js`</b>:

```js
module.exports = function() {
	throw new Error('hey')
}
```

Then launch the shell passing `-version 200 -opt -1 -require one.js` to get the following, useful stack trace:

```
js: "file:/Users/andrea.bergia/src/rhino/two.js", line 2: exception from uncaught JavaScript throw: Error: hey
	at file:/Users/andrea.bergia/src/rhino/two.js:2
	at file:/Users/andrea.bergia/src/rhino/one.js:2
```

But with `-opt 0` we get:

```
js: "file:/Users/andrea.bergia/src/rhino/two.js", line 2: exception from uncaught JavaScript throw: Error: hey
	at (unknown):2 (anonymous)
	at (unknown):2
```

which isn't as useful.