### PR TITLE
Refactor the interpreter loop to avoid performance degradation.

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/BuiltinBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/BuiltinBenchmark.java
@@ -19,9 +19,13 @@ public class BuiltinBenchmark {
     @State(Scope.Thread)
     public static class AbstractClassState {
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public void init()
                 throws IllegalAccessException, InvocationTargetException, InstantiationException {
             cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
             cx.setLanguageVersion(Context.VERSION_ES6);
 
             scope = cx.initStandardObjects();

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/MathBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/MathBenchmark.java
@@ -33,9 +33,13 @@ public class MathBenchmark {
         Function bitwiseRsh;
         Function bitwiseSignedRsh;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setup() throws IOException {
             cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
             cx.setLanguageVersion(Context.VERSION_ES6);
             scope = cx.initStandardObjects();
 

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
@@ -33,10 +33,14 @@ public class ObjectBenchmark {
         Scriptable strings;
         Scriptable ints;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         @SuppressWarnings("unused")
         public void create() throws IOException {
             cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
             cx.setLanguageVersion(Context.VERSION_ES6);
 
             scope = new Global(cx);

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/PropertyBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/PropertyBenchmark.java
@@ -24,9 +24,13 @@ public class PropertyBenchmark {
 
         Object object;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setup() throws IOException {
             cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
             cx.setLanguageVersion(Context.VERSION_ES6);
             scope = cx.initStandardObjects();
 

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SunSpiderBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SunSpiderBenchmark.java
@@ -22,9 +22,12 @@ public class SunSpiderBenchmark {
             this.fileName = TEST_BASE + fileName;
         }
 
+        protected abstract boolean isInterpreted();
+
         @Setup(Level.Trial)
         public void setUp() {
             cx = Context.enter();
+            cx.setInterpretedMode(isInterpreted());
             cx.setLanguageVersion(Context.VERSION_ES6);
             scope = cx.initStandardObjects();
 
@@ -47,8 +50,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class ThreeDCubeState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public ThreeDCubeState() {
             super("3d-cube.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -59,8 +70,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class ThreeDMorphState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public ThreeDMorphState() {
             super("3d-morph.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -71,8 +90,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class ThreeDRayState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public ThreeDRayState() {
             super("3d-raytrace.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -83,8 +110,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class AccessBinaryTreesState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public AccessBinaryTreesState() {
             super("access-binary-trees.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -95,8 +130,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class AccessFannkuchState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public AccessFannkuchState() {
             super("access-fannkuch.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -107,8 +150,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class AccessNBodyState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public AccessNBodyState() {
             super("access-nbody.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -119,8 +170,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class AccessFannAccessNsieveState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public AccessFannAccessNsieveState() {
             super("access-nsieve.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -131,8 +190,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class Bitops3BitState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public Bitops3BitState() {
             super("bitops-3bit-bits-in-byte.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -143,8 +210,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class BitopsBitsState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public BitopsBitsState() {
             super("bitops-bits-in-byte.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -155,8 +230,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class BitopsAndState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public BitopsAndState() {
             super("bitops-bitwise-and.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -167,8 +250,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class BitopsNsieveState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public BitopsNsieveState() {
             super("bitops-nsieve-bits.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -179,8 +270,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class RecursiveState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public RecursiveState() {
             super("controlflow-recursive.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -191,8 +290,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class CryptoAesState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public CryptoAesState() {
             super("crypto-aes.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -203,8 +310,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class CryptoMd5State extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public CryptoMd5State() {
             super("crypto-md5.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -215,8 +330,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class CryptoShaState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public CryptoShaState() {
             super("crypto-sha1.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -227,8 +350,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class DateFormatToFteState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public DateFormatToFteState() {
             super("date-format-tofte.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -239,8 +370,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class DateFormatXparbState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public DateFormatXparbState() {
             super("date-format-xparb.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -251,8 +390,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class MathCordicState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public MathCordicState() {
             super("math-cordic.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -263,8 +410,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class MathPartialState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public MathPartialState() {
             super("math-partial-sums.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -275,8 +430,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class MathSpectralNormState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public MathSpectralNormState() {
             super("math-spectral-norm.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -287,8 +450,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class RegexpState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public RegexpState() {
             super("regexp-dna.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -299,8 +470,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class StringBase64State extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public StringBase64State() {
             super("string-base64.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -311,8 +490,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class StringFastaState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public StringFastaState() {
             super("string-fasta.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -323,8 +510,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class StringTagcloudState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public StringTagcloudState() {
             super("string-tagcloud.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -335,8 +530,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class StringUnpackState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public StringUnpackState() {
             super("string-unpack-code.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark
@@ -347,8 +550,16 @@ public class SunSpiderBenchmark {
 
     @State(Scope.Thread)
     public static class StringValidateState extends AbstractState {
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         public StringValidateState() {
             super("string-validate-input.js");
+        }
+
+        @Override
+        protected boolean isInterpreted() {
+            return interpreted;
         }
 
         @Benchmark

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/V8Benchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/V8Benchmark.java
@@ -38,8 +38,9 @@ public class V8Benchmark {
             }
         }
 
-        void initialize() {
+        void initialize(boolean interpreted) {
             cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
             cx.setLanguageVersion(Context.VERSION_ES6);
             scope = cx.initStandardObjects();
             evaluateSource(cx, scope, "testsrc/benchmarks/framework.js");
@@ -64,9 +65,12 @@ public class V8Benchmark {
     public static class SplayState extends AbstractState {
         Callable splay;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setUp() {
-            initialize();
+            initialize(interpreted);
             evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/splay.js");
             runSetup();
             splay = getRunFunc("Splay");
@@ -89,9 +93,12 @@ public class V8Benchmark {
         Callable encrypt;
         Callable decrypt;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setUp() {
-            initialize();
+            initialize(interpreted);
             evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/crypto.js");
             runSetup();
             encrypt = getRunFunc("Encrypt");
@@ -121,9 +128,12 @@ public class V8Benchmark {
     public static class DeltaBlueState extends AbstractState {
         Callable db;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setUp() {
-            initialize();
+            initialize(interpreted);
             evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/deltablue.js");
             runSetup();
             db = getRunFunc("DeltaBlue");
@@ -145,9 +155,12 @@ public class V8Benchmark {
     public static class RayTraceState extends AbstractState {
         Callable rt;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setUp() {
-            initialize();
+            initialize(interpreted);
             evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/raytrace.js");
             runSetup();
             rt = getRunFunc("RayTrace");
@@ -195,9 +208,12 @@ public class V8Benchmark {
     public static class RichardsState extends AbstractState {
         Callable r;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setUp() {
-            initialize();
+            initialize(interpreted);
             evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/richards.js");
             runSetup();
             r = getRunFunc("Richards");
@@ -220,9 +236,12 @@ public class V8Benchmark {
         Callable earley;
         Callable boyer;
 
+        @Param({"false", "true"})
+        public boolean interpreted;
+
         @Setup(Level.Trial)
         public void setUp() {
-            initialize();
+            initialize(interpreted);
             evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/earley-boyer.js");
             runSetup();
             earley = getRunFunc("Earley");


### PR DESCRIPTION
# Extract function calls handling to a separate method to reduce the overall `interpretLoop` size.

While doing some benchmarking I noticed that the recent change to introduce `super` had caused a significant performance regression in the interpreter, which appears to be a result of the `interpretLoop` just getting too big for the JIT to do much with. This PR introduces paramterization to the benchmarks so that we test interpreted mode as well as compiled, and refactors the interpreter loop to extract the function call handling code.

This change appears to restore performance and get some small gains in the interpreter acrosss all benchmarks compared to a8696c7 (the commit immediately preceding the `super` implementation.

Merry Christmas everyone!