### PR TITLE
Reduce indirection and memory overhead for slot maps.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeSlotMapContainer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeSlotMapContainer.java
@@ -77,6 +77,7 @@ class ThreadSafeSlotMapContainer extends SlotMapContainer {
     public <S extends Slot> S compute(Object key, int index, SlotComputer<S> c) {
         final long stamp = lock.writeLock();
         try {
+            checkMapSize();
             return map.compute(key, index, c);
         } finally {
             lock.unlockWrite(stamp);


### PR DESCRIPTION
# Reducing the property related memory overhead of JavaScript objects.

## Current slot map model

Currently JavaScript Objects in RHino store their properties in slot map, which is held by a slot map container. The map itself then either holds an array, or some other collection structure, which actually holds the slots. So the structure looks something like this:

```mermaid
graph LR
Object["ScriptableObject"]
Container["SlotMapContainer"]
Map["SlotMap"]
Array["Slot[]"]
Slot1["Slot"]
Slot2["Slot"]
Slot3["Slot"]
Object1["ScriptableObject"]
Container1["SlotMapContainer"]
Map1["SlotMap"]
Array1["Slot[]"]
Slot4["Slot"]
Slot5["Slot"]
Slot6["Slot"]
Object --> Container --> Map --> Array
Array --> Slot1
Array --> Slot2
Array --> Slot3
Object1 --> Container1 --> Map1 --> Array1
Array1 --> Slot4
Array1 --> Slot5
Array1 --> Slot6
```

And in any environment which relies on thread safe slot map handling there is an additional stamped lock object like this:

```mermaid
graph LR
Object["ScriptableObject"]
Container["SlotMapContainer"]
Lock["StampedLock"]
Map["SlotMap"]
Array["Slot[]"]
Slot1["Slot"]
Slot2["Slot"]
Slot3["Slot"]
Object --> Container --> Map --> Array
Container --> Lock
Array --> Slot1
Array --> Slot2
Array --> Slot3
Object1["ScriptableObject"]
Container1["SlotMapContainer"]
Lock1["StampedLock"]
Map1["SlotMap"]
Array1["Slot[]"]
Slot4["Slot"]
Slot5["Slot"]
Slot6["Slot"]
Object1 --> Container1 --> Map1 --> Array1
Container1 --> Lock1
Array1 --> Slot4
Array1 --> Slot5
Array1 --> Slot6
```

There is one optimisation here, in that the arrays for slots in an `EmbeddedSlotMap` are not created until slots are stored in the map, but all the other objects are created eagerly. If I look at a heap dump from one of our production systems and analyse the number of properties stored in slot maps then we see the following:

| No. of props | Count   | Cummulative count | Cummulative % |
|--------------|---------|-------------------|---------------|
| 0            | 113,538 | 113,538           | 76.6428827    |
| 1            | 28,013  | 141,551           | 95.5528254    |
| 2            | 1,243   | 142,794           | 96.3919022    |
| 3            | 1,965   | 144,759           | 97.7183591    |
| 4            | 426     | 145,185           | 98.0059269    |

The remaining objects are distributed over a fairly wide range.

The prevalence of zero size slot maps may be surprising, but is due to the large number of common objects that are implemented in Rhino itself as `IdScriptableObject`s with built in properties not held as real slots (functions, strings, arrays, wrapped native Java methods, etc.). This means we pay a significant memory overhead on the 75% of objects that will never have properties, and we aren't optimising for the remaining commons case of a single property. This type of property map size distribution appears consistent with my experience on TruffleRuby and other dynamic language implementations, so I would expect roughly similar distributions for other users.

In our particular case we have a small number of objects shared between threads, and so enable thread safety, so we pay for a lock with every one of these objects.

The memory overheads we incur are as follows (on a 64bit JVM with compact oops

| Object             | Size                       |
|--------------------|----------------------------|
| `SlotMapContainer` | 24                         |
| `StampedLocked`    | 48                         |
| `EmbeddedSlotMap`  | 32                         |
| `Slot[]`           | 16 + 4 * (size rounded up) |

Combined with the data on object sizes about this gives us total sizes as follows

| No. of props | Object size | Thread safe object size | Count  | Size * Count | Thread safe size * Count |
|--------------|-------------|-------------------------|--------|--------------|--------------------------|
|            0 |          56 |                     104 | 113538 |      6358128 |                 11807952 |
|            1 |          88 |                     136 |  28013 |      2465144 |                  3809768 |
|            2 |          88 |                     136 |   1243 |       109384 |                   169048 |
|            3 |          88 |                     136 |   1965 |       172920 |                   267240 |
|            4 |          88 |                     136 |    426 |        37488 |                    57936 |

## Reducing indirection

Ideally we would want the common cases to incur as little overhead as possible, and potential store a small number of properties within the `ScriptableObject` itself if that significantly reduced overhead. Short of that we can optimise for the common cases and change the existing slot map promotion chain of:

```mermaid
graph LR
EmbededdedSlotMap --> HashSlotMap
```

to something more like:

```mermaid
graph LR
EmptySlotMap --> SingleEntrySlotMap --> EmbededdedSlotMap --> HashSlotMap
```

I do not propose to embed slots in the `ScriptableObject`s themselves at this time, but instead exploit the fact that we can use a singular immutable empty slot map; refactor out the slot map container for single threaded use; introduce a single entry slot map to reduce overhead and indirection in the remaining common case; and finally remove the use of slot map containers in the multi-threaded case.

## PRs

I've split this into a number of stacked PRs detailed below
* #1782 (This PR)
* #1783
* #1784
* #1785

### Introduce a singleton `EMPTY_SLOT_MAP` (#1782)

This PR.

Introduces a singleton `EMPTY_SLOT_MAP` reducing the common empty case to
```mermaid
graph LR
Object["ScriptableObject"]
Container["SlotMapContainer"]
Map["EMPTY_SLOT_MAP"]
Object1["ScriptableObject"]
Container1["SlotMapContainer"]
Object --> Container --> Map
Object1 --> Container1 --> Map
```

This saves 32 bytes per object with an empty property map.

### Start to factor out slot map container (#1783)

Introduces the concept of a `SlotMapOwner` and refactors `ScritableObject` and `SlotMapContainer` to inherit from `SlotMapOwner`. The slot maps themselves are made responsible for promotions themselves via the `SlotMapOwner`. As well as reducing the amount of indirection needed to access the slots it also means we can avoid promotion checks except when we know the collection might overflow some internal limit (for example, when the array in `EmbeddedSlotMap` would be expanded). This changes the empty map case to:

```mermaid
graph LR
Object["ScriptableObject"]
Map["EMPTY_SLOT_MAP"]
Object1["ScriptableObject"]
Object --> Map
Object1 --> Map
```

and the occupied map case to

```mermaid
graph LR
Object["ScriptableObject"]
Map["SlotMap"]
Array["Slot[]"]
Slot1["Slot"]
Slot2["Slot"]
Slot3["Slot"]
Object1["ScriptableObject"]
Map1["SlotMap"]
Array1["Slot[]"]
Slot4["Slot"]
Slot5["Slot"]
Slot6["Slot"]
Object --> Map --> Array
Array --> Slot1
Array --> Slot2
Array --> Slot3
Object1 --> Map1 --> Array1
Array1 --> Slot4
Array1 --> Slot5
Array1 --> Slot6
```

### Single-entry slot maps (#1784)

Introduces an immutable single-entry slot map. It is immutable and *always* promotes to `EmbeddedSlotMap` to make its future use in multi-threaded cases easier, but also because it seems like a reasonable assumption that any single-entry slot map that is mutated is likely to continue being mutated.

This changes the single slot case to:

```mermaid
graph LR
Object["ScriptableObject"]
Map["SingleEntrySlotMap"]
Slot1["Slot"]
Object1["ScriptableObject"]
Map1["SingleEntrySlotMap"]
Slot2["Slot"]
Object --> Map --> Slot1
Object1 --> Map1 --> Slot2
```

### Introduce thread safe versions of slot maps (#1785)

Introduces an API on slot map owner to do a compare and swap of the current slot map to enable thread safe promotion of maps, and introduces thread safe versions of the slot map types which handle locking where necessary. We avoid the use of locks on empty and single entry maps as they are immutable, and introduce APIS and share locks between further promotions to avoid the overhead of an additional container.

## Benchmark comparison

Benchmark scores are roughly neutral, some are gains, some gain performance on the two full runs I performed, and some lost performance, but they all show a degree of instability on repeated runs.

| Benchmark                                                   | (interpreted) | Mode | Cnt |  Old Score | Old Error |  New Score |  New Error | Units |      % Gain |    % Error |
|-------------------------------------------------------------|---------------|------|-----|------------|-----------|------------|------------|-------|-------------|------------|
| BuiltinBenchmark.annotatedClassMethods                      | false         | avgt |   5 |     21.521 |     0.215 |     25.207 |      0.359 | us/op |  -17.127457 |  1.4242076 |
| BuiltinBenchmark.annotatedClassMethods                      | true          | avgt |   5 |    146.907 |    18.851 |    125.198 |      1.876 | us/op |   14.777376 |  1.4984265 |
| BuiltinBenchmark.dumbLambdaClassMethods                     | false         | avgt |   5 |     18.682 |     0.470 |     18.261 |      0.202 | us/op |   2.2535060 |  1.1061826 |
| BuiltinBenchmark.dumbLambdaClassMethods                     | true          | avgt |   5 |    149.805 |     4.646 |    123.110 |      1.675 | us/op |   17.819832 |  1.3605718 |
| BuiltinBenchmark.idClassMethods                             | false         | avgt |   5 |     25.316 |     1.140 |     22.394 |      2.280 | us/op |   11.542108 |  10.181299 |
| BuiltinBenchmark.idClassMethods                             | true          | avgt |   5 |    141.918 |     5.423 |    122.982 |      1.360 | us/op |   13.342916 |  1.1058529 |
| MathBenchmark.addConstantFloats                             | false         | avgt |   5 |      8.819 |     0.248 |      8.543 |      0.111 | ns/op |   3.1296065 |  1.2993094 |
| MathBenchmark.addConstantFloats                             | true          | avgt |   5 |    192.417 |     7.392 |    176.734 |      6.012 | ns/op |   8.1505272 |  3.4017224 |
| MathBenchmark.addConstantInts                               | false         | avgt |   5 |      8.258 |     0.146 |      8.469 |      0.126 | ns/op |  -2.5550981 |  1.4877790 |
| MathBenchmark.addConstantInts                               | true          | avgt |   5 |    182.400 |     0.414 |    186.263 |      1.745 | ns/op |  -2.1178728 | 0.93684736 |
| MathBenchmark.addIntAndConstant                             | false         | avgt |   5 |     11.183 |     0.680 |     11.310 |      0.142 | ns/op |  -1.1356523 |  1.2555261 |
| MathBenchmark.addIntAndConstant                             | true          | avgt |   5 |    274.836 |     3.912 |    276.018 |      8.103 | ns/op | -0.43007466 |  2.9356781 |
| MathBenchmark.addMixedStrings                               | false         | avgt |   5 |     36.016 |     0.971 |     36.450 |      0.619 | ns/op |  -1.2050200 |  1.6982167 |
| MathBenchmark.addMixedStrings                               | true          | avgt |   5 |    278.977 |     3.535 |    269.311 |      3.058 | ns/op |   3.4648018 |  1.1354902 |
| MathBenchmark.addStringsInLoop                              | false         | avgt |   5 |     84.544 |     7.452 |     84.872 |      2.305 | ns/op | -0.38796366 |  2.7158545 |
| MathBenchmark.addStringsInLoop                              | true          | avgt |   5 |    843.004 |    13.554 |    909.288 |     46.029 | ns/op |  -7.8628334 |  5.0620925 |
| MathBenchmark.addTwoFloats                                  | false         | avgt |   5 |     24.307 |    49.848 |     14.623 |      5.111 | ns/op |   39.840375 |  34.951788 |
| MathBenchmark.addTwoFloats                                  | true          | avgt |   5 |    355.543 |     7.334 |    370.175 |     24.142 | ns/op |  -4.1153953 |  6.5217802 |
| MathBenchmark.addTwoInts                                    | false         | avgt |   5 |     14.168 |     0.225 |     15.857 |      0.199 | ns/op |  -11.921231 |  1.2549663 |
| MathBenchmark.addTwoInts                                    | true          | avgt |   5 |    367.576 |    11.698 |    349.172 |      3.876 | ns/op |   5.0068557 |  1.1100546 |
| MathBenchmark.bitwiseAnd                                    | false         | avgt |   5 |     14.792 |     1.144 |     14.448 |      0.263 | ns/op |   2.3255814 |  1.8203212 |
| MathBenchmark.bitwiseAnd                                    | true          | avgt |   5 |    359.100 |     3.495 |    353.973 |      2.887 | ns/op |   1.4277360 | 0.81559893 |
| MathBenchmark.bitwiseLsh                                    | false         | avgt |   5 |     14.166 |     0.181 |     15.366 |      0.185 | ns/op |  -8.4709869 |  1.2039568 |
| MathBenchmark.bitwiseLsh                                    | true          | avgt |   5 |    340.105 |     9.303 |    307.955 |     17.735 | ns/op |   9.4529631 |  5.7589583 |
| MathBenchmark.bitwiseOr                                     | false         | avgt |   5 |     14.521 |     0.117 |     15.786 |      4.163 | ns/op |  -8.7115212 |  26.371468 |
| MathBenchmark.bitwiseOr                                     | true          | avgt |   5 |    365.443 |     3.158 |    349.798 |      1.803 | ns/op |   4.2811054 | 0.51544034 |
| MathBenchmark.bitwiseRsh                                    | false         | avgt |   5 |     13.753 |     0.148 |     14.356 |      0.162 | ns/op |  -4.3844979 |  1.1284480 |
| MathBenchmark.bitwiseRsh                                    | true          | avgt |   5 |    328.926 |     3.579 |    311.810 |      4.052 | ns/op |   5.2036020 |  1.2995093 |
| MathBenchmark.bitwiseSignedRsh                              | false         | avgt |   5 |     13.575 |     0.261 |     14.134 |      0.158 | ns/op |  -4.1178637 |  1.1178718 |
| MathBenchmark.bitwiseSignedRsh                              | true          | avgt |   5 |    360.686 |     6.364 |    347.190 |      2.527 | ns/op |   3.7417588 | 0.72784354 |
| MathBenchmark.subtractFloats                                | false         | avgt |   5 |     11.270 |     0.119 |     11.309 |      0.114 | ns/op | -0.34605146 |  1.0080467 |
| MathBenchmark.subtractFloats                                | true          | avgt |   5 |    280.508 |     9.309 |    271.140 |      2.755 | ns/op |   3.3396552 |  1.0160803 |
| MathBenchmark.subtractInts                                  | false         | avgt |   5 |     11.780 |     0.558 |     11.865 |      0.131 | ns/op | -0.72156197 |  1.1040877 |
| MathBenchmark.subtractInts                                  | true          | avgt |   5 |    274.109 |    16.658 |    272.634 |      2.526 | ns/op |  0.53810710 | 0.92651687 |
| MathBenchmark.subtractTwoFloats                             | false         | avgt |   5 |     14.159 |     0.572 |     14.389 |      0.107 | ns/op |  -1.6244085 | 0.74362360 |
| MathBenchmark.subtractTwoFloats                             | true          | avgt |   5 |    350.104 |     9.883 |    346.064 |      4.471 | ns/op |   1.1539428 |  1.2919576 |
| ObjectBenchmark.accessFields                                | false         | avgt |   5 |      0.062 |     0.001 |      0.073 |      0.005 | us/op |  -17.741935 |  6.8493151 |
| ObjectBenchmark.accessFields                                | true          | avgt |   5 |      0.507 |     0.020 |      0.557 |      0.005 | us/op |  -9.8619329 | 0.89766607 |
| ObjectBenchmark.createFields                                | false         | avgt |   5 |     46.803 |     0.878 |     47.669 |      0.320 | us/op |  -1.8503087 | 0.67129581 |
| ObjectBenchmark.createFields                                | true          | avgt |   5 |    318.915 |     4.921 |    348.613 |      5.578 | us/op |  -9.3121992 |  1.6000551 |
| ObjectBenchmark.deleteFields                                | false         | avgt |   5 |      0.066 |     0.001 |      0.073 |      0.001 | us/op |  -10.606061 |  1.3698630 |
| ObjectBenchmark.deleteFields                                | true          | avgt |   5 |      0.475 |     0.005 |      0.523 |      0.014 | us/op |  -10.105263 |  2.6768642 |
| ObjectBenchmark.iterateFields                               | false         | avgt |   5 |     82.580 |     1.017 |     83.256 |      4.002 | us/op | -0.81860015 |  4.8068608 |
| ObjectBenchmark.iterateFields                               | true          | avgt |   5 |    227.787 |    28.930 |    230.405 |      2.585 | us/op |  -1.1493193 |  1.1219375 |
| ObjectBenchmark.ownKeysFields                               | false         | avgt |   5 |     79.724 |     0.650 |     78.692 |      0.928 | us/op |   1.2944659 |  1.1792812 |
| ObjectBenchmark.ownKeysFields                               | true          | avgt |   5 |     81.579 |     7.778 |     79.953 |      1.003 | us/op |   1.9931600 |  1.2544870 |
| PropertyBenchmark.addTwoProperties                          | false         | avgt |   5 |      8.999 |     0.129 |      8.763 |      0.137 | ns/op |   2.6225136 |  1.5633915 |
| PropertyBenchmark.addTwoProperties                          | true          | avgt |   5 |    101.038 |     1.496 |    106.104 |      1.081 | ns/op |  -5.0139551 |  1.0188117 |
| PropertyBenchmark.createObject                              | false         | avgt |   5 |    169.871 |     2.012 |     96.735 |      1.937 | ns/op |   43.053847 |  2.0023776 |
| PropertyBenchmark.createObject                              | true          | avgt |   5 |    240.923 |     3.740 |    206.758 |      1.446 | ns/op |   14.180879 | 0.69936834 |
| PropertyBenchmark.createObjectFieldByField                  | false         | avgt |   5 |    169.260 |     4.393 |     85.181 |      1.198 | ns/op |   49.674465 |  1.4064169 |
| PropertyBenchmark.createObjectFieldByField                  | true          | avgt |   5 |    324.056 |     5.682 |    377.576 |      6.570 | ns/op |  -16.515664 |  1.7400470 |
| PropertyBenchmark.getOneProperty                            | false         | avgt |   5 |      7.139 |     0.073 |      7.306 |      0.096 | ns/op |  -2.3392632 |  1.3139885 |
| PropertyBenchmark.getOneProperty                            | true          | avgt |   5 |     34.944 |     0.642 |     35.038 |      0.605 | ns/op | -0.26900183 |  1.7266967 |
| SlotMapBenchmark.embeddedInsert1Key                         | N/A           | avgt |   5 |      1.047 |     0.020 |      1.061 |      0.013 | ns/op |  -1.3371538 |  1.2252592 |
| SlotMapBenchmark.embeddedQueryKey100Entries                 | N/A           | avgt |   5 |      0.805 |     0.057 |      0.804 |      0.008 | ns/op |  0.12422360 | 0.99502488 |
| SlotMapBenchmark.embeddedQueryKey10Entries                  | N/A           | avgt |   5 |      0.664 |     0.006 |      0.673 |      0.008 | ns/op |  -1.3554217 |  1.1887073 |
| SlotMapBenchmark.hashInsert1Key                             | N/A           | avgt |   5 |      5.426 |     0.724 |      5.608 |      0.107 | ns/op |  -3.3542204 |  1.9079886 |
| SlotMapBenchmark.hashQueryKey100Entries                     | N/A           | avgt |   5 |      1.254 |     0.018 |      1.256 |      0.012 | ns/op | -0.15948963 | 0.95541401 |
| SlotMapBenchmark.hashQueryKey10Entries                      | N/A           | avgt |   5 |      1.131 |     0.011 |      1.172 |      0.017 | ns/op |  -3.6251105 |  1.4505119 |
| StartupBenchmark.startUpRhino                               | N/A           | avgt |   5 |     14.145 |     0.254 |     13.478 |      0.878 | us/op |   4.7154472 |  6.5143196 |
| SunSpiderBenchmark.AccessBinaryTreesState.accessBinaryTrees | false         | avgt |   5 |   4215.743 |    79.865 |   3792.279 |    261.463 | us/op |   10.044825 |  6.8946140 |
| SunSpiderBenchmark.AccessBinaryTreesState.accessBinaryTrees | true          | avgt |   5 |  33492.688 |   368.416 |  35512.264 |  18864.755 | us/op |  -6.0299012 |  53.121803 |
| SunSpiderBenchmark.AccessFannAccessNsieveState.accessNsieve | false         | avgt |   5 |   2870.759 |   205.348 |   2219.509 |     79.610 | us/op |   22.685638 |  3.5868293 |
| SunSpiderBenchmark.AccessFannAccessNsieveState.accessNsieve | true          | avgt |   5 | 102711.650 |  2874.606 | 112870.312 |   3339.730 | us/op |  -9.8904671 |  2.9589092 |
| SunSpiderBenchmark.AccessFannkuchState.accessFannkuch       | false         | avgt |   5 |   6615.882 |   191.768 |   6363.320 |    102.694 | us/op |   3.8175107 |  1.6138431 |
| SunSpiderBenchmark.AccessFannkuchState.accessFannkuch       | true          | avgt |   5 | 193440.347 |  4971.624 | 199674.221 |   4812.636 | us/op |  -3.2226338 |  2.4102440 |
| SunSpiderBenchmark.AccessNBodyState.accessNBody             | false         | avgt |   5 |   7902.119 |  1583.218 |  10779.537 |    628.571 | us/op |  -36.413246 |  5.8311503 |
| SunSpiderBenchmark.AccessNBodyState.accessNBody             | true          | avgt |   5 |  89853.993 |  1003.660 |  99411.506 |    856.333 | us/op |  -10.636715 | 0.86140230 |
| SunSpiderBenchmark.Bitops3BitState.bitops3BitBitsInByte     | false         | avgt |   5 |    864.472 |    27.466 |    880.893 |     28.433 | us/op |  -1.8995410 |  3.2277473 |
| SunSpiderBenchmark.Bitops3BitState.bitops3BitBitsInByte     | true          | avgt |   5 |  73874.685 |  1188.332 |  76124.145 |    709.665 | us/op |  -3.0449673 | 0.93224692 |
| SunSpiderBenchmark.BitopsAndState.bitopsBitwiseAnd          | false         | avgt |   5 |  29084.840 |  3475.464 |  14485.668 |   2191.559 | us/op |   50.195126 |  15.129154 |
| SunSpiderBenchmark.BitopsAndState.bitopsBitwiseAnd          | true          | avgt |   5 |  70984.414 |   641.453 |  73832.491 |    761.945 | us/op |  -4.0122568 |  1.0319915 |
| SunSpiderBenchmark.BitopsBitsState.bitopsBitsInByte         | false         | avgt |   5 |    973.839 |    98.603 |   1022.713 |     49.686 | us/op |  -5.0186941 |  4.8582545 |
| SunSpiderBenchmark.BitopsBitsState.bitopsBitsInByte         | true          | avgt |   5 |  98937.234 |  1332.956 | 100312.942 |   1340.841 | us/op |  -1.3904856 |  1.3366580 |
| SunSpiderBenchmark.BitopsNsieveState.bitopsNsieveBits       | false         | avgt |   5 |   4287.363 |   112.761 |   3542.270 |     36.620 | us/op |   17.378818 |  1.0338004 |
| SunSpiderBenchmark.BitopsNsieveState.bitopsNsieveBits       | true          | avgt |   5 |  84830.381 |  2141.095 |  89398.150 |   3367.636 | us/op |  -5.3845909 |  3.7670086 |
| SunSpiderBenchmark.CryptoAesState.cryptoAes                 | false         | avgt |   5 |   5212.191 |    80.142 |   4985.114 |     71.585 | us/op |   4.3566516 |  1.4359752 |
| SunSpiderBenchmark.CryptoAesState.cryptoAes                 | true          | avgt |   5 |  53519.802 |   841.627 |  55419.398 |    599.505 | us/op |  -3.5493330 |  1.0817602 |
| SunSpiderBenchmark.CryptoMd5State.cryptoMd5                 | false         | avgt |   5 |   4477.072 |    74.629 |   4299.079 |     43.832 | us/op |   3.9756564 |  1.0195672 |
| SunSpiderBenchmark.CryptoMd5State.cryptoMd5                 | true          | avgt |   5 |  41742.866 |   831.995 |  42974.484 |    463.523 | us/op |  -2.9504874 |  1.0786005 |
| SunSpiderBenchmark.CryptoShaState.cryptoSha1                | false         | avgt |   5 |   3084.482 |    88.514 |   2570.779 |     21.558 | us/op |   16.654433 | 0.83857850 |
| SunSpiderBenchmark.CryptoShaState.cryptoSha1                | true          | avgt |   5 |  47429.860 |  1369.206 |  47267.275 |   4464.666 | us/op |  0.34279039 |  9.4455752 |
| SunSpiderBenchmark.DateFormatToFteState.dateFormatToFte     | false         | avgt |   5 |   7751.395 |   427.961 |   7953.029 |    236.523 | us/op |  -2.6012608 |  2.9739990 |
| SunSpiderBenchmark.DateFormatToFteState.dateFormatToFte     | true          | avgt |   5 |  34734.364 |   867.207 |  36405.110 |    478.431 | us/op |  -4.8100665 |  1.3141864 |
| SunSpiderBenchmark.DateFormatXparbState.dateFormatXparb     | false         | avgt |   5 |  15948.911 |   675.946 |  14625.379 |    252.648 | us/op |   8.2985729 |  1.7274629 |
| SunSpiderBenchmark.DateFormatXparbState.dateFormatXparb     | true          | avgt |   5 |  23119.470 |   227.553 |  23493.920 |    282.401 | us/op |  -1.6196306 |  1.2020174 |
| SunSpiderBenchmark.MathCordicState.mathCordic               | false         | avgt |   5 |   4405.314 |    53.462 |   4547.668 |     55.890 | us/op |  -3.2314155 |  1.2289815 |
| SunSpiderBenchmark.MathCordicState.mathCordic               | true          | avgt |   5 | 141308.798 |  7728.749 | 126202.312 |   1208.821 | us/op |   10.690407 | 0.95784378 |
| SunSpiderBenchmark.MathPartialState.mathPartialSums         | false         | avgt |   5 |  12464.984 |   471.334 |  13806.067 |    212.468 | us/op |  -10.758802 |  1.5389466 |
| SunSpiderBenchmark.MathPartialState.mathPartialSums         | true          | avgt |   5 |  60192.493 |   889.795 |  58942.605 |    561.784 | us/op |   2.0764849 | 0.95310345 |
| SunSpiderBenchmark.MathSpectralNormState.mathSpectralNorm   | false         | avgt |   5 |    630.957 |     9.622 |    752.299 |     10.758 | us/op |  -19.231421 |  1.4300165 |
| SunSpiderBenchmark.MathSpectralNormState.mathSpectralNorm   | true          | avgt |   5 |  45405.061 |   892.770 |  45383.445 |    528.752 | us/op | 0.047607028 |  1.1650768 |
| SunSpiderBenchmark.RecursiveState.controlflowRecursive      | false         | avgt |   5 |   1527.656 |    23.848 |   1580.938 |     88.109 | us/op |  -3.4878271 |  5.5732103 |
| SunSpiderBenchmark.RecursiveState.controlflowRecursive      | true          | avgt |   5 |  45491.450 |  2522.202 |  44252.907 |    299.934 | us/op |   2.7225841 | 0.67777242 |
| SunSpiderBenchmark.RegexpState.regexpDna                    | false         | avgt |   5 |  45726.300 |   858.063 |  45577.969 |   4585.112 | us/op |  0.32438881 |  10.059930 |
| SunSpiderBenchmark.RegexpState.regexpDna                    | true          | avgt |   5 |  45387.522 |   896.888 |  45677.837 |    450.440 | us/op | -0.63963615 | 0.98612375 |
| SunSpiderBenchmark.StringBase64State.stringBase64           | false         | avgt |   5 |   7323.512 |   168.637 |   7850.049 |     58.964 | us/op |  -7.1896789 | 0.75112907 |
| SunSpiderBenchmark.StringBase64State.stringBase64           | true          | avgt |   5 |  43562.706 |   711.527 |  48341.457 |    971.829 | us/op |  -10.969821 |  2.0103428 |
| SunSpiderBenchmark.StringFastaState.stringFasta             | false         | avgt |   5 |  11490.173 |   124.971 |  12057.432 |    133.057 | us/op |  -4.9369056 |  1.1035269 |
| SunSpiderBenchmark.StringFastaState.stringFasta             | true          | avgt |   5 |  70060.273 |  1162.633 |  66996.399 |    371.257 | us/op |   4.3731973 | 0.55414471 |
| SunSpiderBenchmark.StringTagcloudState.stringTagcloud       | false         | avgt |   5 |  16212.874 |   266.513 |  16595.346 |    401.539 | us/op |  -2.3590635 |  2.4195880 |
| SunSpiderBenchmark.StringTagcloudState.stringTagcloud       | true          | avgt |   5 |  38023.062 |   652.512 |  37029.902 |   1521.375 | us/op |   2.6119937 |  4.1085040 |
| SunSpiderBenchmark.StringUnpackState.stringUnpackCode       | false         | avgt |   5 |  13583.510 |   375.019 |  13936.242 |    197.378 | us/op |  -2.5967662 |  1.4162929 |
| SunSpiderBenchmark.StringUnpackState.stringUnpackCode       | true          | avgt |   5 |  29042.402 |   394.761 |  32275.857 |    110.125 | us/op |  -11.133566 | 0.34119931 |
| SunSpiderBenchmark.StringValidateState.stringValidateInput  | false         | avgt |   5 |   6712.011 |   445.466 |   6848.257 |    121.288 | us/op |  -2.0298834 |  1.7710784 |
| SunSpiderBenchmark.StringValidateState.stringValidateInput  | true          | avgt |   5 |  37554.862 |   523.600 |  35878.264 |    526.572 | us/op |   4.4643966 |  1.4676630 |
| SunSpiderBenchmark.ThreeDCubeState.threeDCube               | false         | avgt |   5 |   3843.477 |    50.124 |   3821.218 |     58.373 | us/op |  0.57913707 |  1.5276019 |
| SunSpiderBenchmark.ThreeDCubeState.threeDCube               | true          | avgt |   5 |  81855.773 |  1156.971 |  82086.928 |   1273.475 | us/op | -0.28239303 |  1.5513737 |
| SunSpiderBenchmark.ThreeDMorphState.threeDMorph             | false         | avgt |   5 |   6118.231 |    89.437 |   5176.360 |    184.973 | us/op |   15.394499 |  3.5734184 |
| SunSpiderBenchmark.ThreeDMorphState.threeDMorph             | true          | avgt |   5 |  99530.914 | 10876.330 | 105509.979 |    867.381 | us/op |  -6.0072441 | 0.82208433 |
| SunSpiderBenchmark.ThreeDRayState.threeDRayTrace            | false         | avgt |   5 |   5194.259 |   134.927 |   4992.991 |     97.742 | us/op |   3.8748164 |  1.9575841 |
| SunSpiderBenchmark.ThreeDRayState.threeDRayTrace            | true          | avgt |   5 |  66232.530 |   721.436 |  62805.470 |    539.075 | us/op |   5.1742852 | 0.85832492 |
| V8Benchmark.boyer                                           | false         | avgt |   5 |  41470.547 |   702.090 |  37794.096 |    465.216 | us/op |   8.8652098 |  1.2309224 |
| V8Benchmark.boyer                                           | true          | avgt |   5 | 256933.199 |  3583.252 | 245761.334 |   3474.153 | us/op |   4.3481594 |  1.4136288 |
| V8Benchmark.cryptoDecrypt                                   | false         | avgt |   5 |  35013.038 |   591.379 |  38285.726 |    557.370 | us/op |  -9.3470552 |  1.4558167 |
| V8Benchmark.cryptoDecrypt                                   | true          | avgt |   5 | 680021.678 | 23241.467 | 694427.887 | 127854.307 | us/op |  -2.1184926 |  18.411459 |
| V8Benchmark.cryptoEncrpyt                                   | false         | avgt |   5 |   2109.576 |    49.195 |   2388.464 |    153.436 | us/op |  -13.220097 |  6.4240449 |
| V8Benchmark.cryptoEncrpyt                                   | true          | avgt |   5 |  35262.902 |  1498.064 |  35567.578 |   5629.968 | us/op | -0.86401284 |  15.828933 |
| V8Benchmark.deltaBlue                                       | false         | avgt |   5 |   2739.431 |    38.602 |   2983.660 |    738.029 | us/op |  -8.9153185 |  24.735694 |
| V8Benchmark.deltaBlue                                       | true          | avgt |   5 |  18041.310 |   243.068 |  23405.338 |    341.166 | us/op |  -29.731921 |  1.4576418 |
| V8Benchmark.earley                                          | false         | avgt |   5 |   9913.887 |    97.453 |  10065.755 |    163.166 | us/op |  -1.5318714 |  1.6210011 |
| V8Benchmark.earley                                          | true          | avgt |   5 |  19281.331 |   367.104 |  19301.104 |    209.699 | us/op | -0.10254997 |  1.0864612 |
| V8Benchmark.rayTrace                                        | false         | avgt |   5 |  24030.710 |   251.571 |  22165.706 |   1328.762 | us/op |   7.7609193 |  5.9946748 |
| V8Benchmark.rayTrace                                        | true          | avgt |   5 |  93965.848 |  1193.860 |  88427.095 |   1228.630 | us/op |   5.8944320 |  1.3894271 |
| V8Benchmark.richards                                        | false         | avgt |   5 |   1657.980 |    34.761 |   1710.126 |     31.242 | us/op |  -3.1451525 |  1.8268829 |
| V8Benchmark.richards                                        | true          | avgt |   5 |   9381.922 |   129.274 |   9284.463 |    127.235 | us/op |   1.0387957 |  1.3704077 |
| V8Benchmark.splay                                           | false         | avgt |   5 |   1149.642 |   209.171 |   1078.130 |    135.130 | us/op |   6.2203712 |  12.533739 |
| V8Benchmark.splay                                           | true          | avgt |   5 |   4931.381 |   890.335 |   4727.164 |    716.615 | us/op |   4.1411726 |  15.159512 |
