### PR TITLE
Start to factor out slot map container

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
@@ -44,7 +44,7 @@ public class SlotMapBenchmark {
     public Object embeddedInsert1Key(EmbeddedState state) {
         Slot newSlot = null;
         for (int i = 0; i < 100; i++) {
-            newSlot = state.emptyMap.modify(state.randomKeys[i], 0, 0);
+            newSlot = state.emptyMap.modify(null, state.randomKeys[i], 0, 0);
         }
         if (newSlot == null) {
             throw new AssertionError();
@@ -109,7 +109,7 @@ public class SlotMapBenchmark {
     public Object hashInsert1Key(HashState state) {
         Slot newSlot = null;
         for (int i = 0; i < 100; i++) {
-            newSlot = state.emptyMap.modify(state.randomKeys[i], 0, 0);
+            newSlot = state.emptyMap.modify(null, state.randomKeys[i], 0, 0);
         }
         if (newSlot == null) {
             throw new AssertionError();
@@ -156,7 +156,7 @@ public class SlotMapBenchmark {
     /** Insert a random key and value into the map */
     private static String insertRandomEntry(SlotMap map) {
         String key = makeRandomString();
-        Slot slot = map.modify(key, 0, 0);
+        Slot slot = map.modify(null, key, 0, 0);
         slot.setValue(key, null, null);
         return key;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
@@ -30,6 +30,14 @@ public class HashSlotMap implements SlotMap {
         }
     }
 
+    public HashSlotMap(SlotMap oldMap, Slot newSlot) {
+        map = new LinkedHashMap<>(oldMap.dirtySize() + 1);
+        for (Slot n : oldMap) {
+            add(null, n.copySlot());
+        }
+        add(null, newSlot);
+    }
+
     @Override
     public int size() {
         return map.size();

--- a/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
@@ -26,7 +26,7 @@ public class HashSlotMap implements SlotMap {
     public HashSlotMap(SlotMap oldMap) {
         map = new LinkedHashMap<>(oldMap.size());
         for (Slot n : oldMap) {
-            add(n.copySlot());
+            add(null, n.copySlot());
         }
     }
 
@@ -47,21 +47,22 @@ public class HashSlotMap implements SlotMap {
     }
 
     @Override
-    public Slot modify(Object key, int index, int attributes) {
+    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
         Object name = makeKey(key, index);
         return map.computeIfAbsent(name, n -> new Slot(key, index, attributes));
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <S extends Slot> S compute(Object key, int index, SlotComputer<S> c) {
+    public <S extends Slot> S compute(
+            SlotMapOwner owner, Object key, int index, SlotComputer<S> c) {
         Object name = makeKey(key, index);
         Slot ret = map.compute(name, (n, existing) -> c.compute(key, index, existing));
         return (S) ret;
     }
 
     @Override
-    public void add(Slot newSlot) {
+    public void add(SlotMapOwner owner, Slot newSlot) {
         Object name = makeKey(newSlot);
         map.put(name, newSlot);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -51,7 +51,7 @@ import org.mozilla.javascript.debug.DebuggableObject;
  * @see org.mozilla.javascript.Scriptable
  * @author Norris Boyd
  */
-public abstract class ScriptableObject
+public abstract class ScriptableObject extends SlotMapOwner
         implements Scriptable, SymbolScriptable, Serializable, DebuggableObject, ConstProperties {
 
     private static final long serialVersionUID = 2829861078851942586L;
@@ -109,12 +109,6 @@ public abstract class ScriptableObject
     /** The parent scope of this object. */
     private Scriptable parentScopeObject;
 
-    /**
-     * This holds all the slots. It may or may not be thread-safe, and may expand itself to a
-     * different data structure depending on the size of the object.
-     */
-    private transient SlotMapContainer slotMap;
-
     // Where external array data is stored.
     private transient ExternalArrayData externalData;
 
@@ -157,24 +151,16 @@ public abstract class ScriptableObject
         }
     }
 
-    private static SlotMapContainer createSlotMap(int initialSize) {
-        Context cx = Context.getCurrentContext();
-        if ((cx != null) && cx.hasFeature(Context.FEATURE_THREAD_SAFE_OBJECTS)) {
-            return new ThreadSafeSlotMapContainer(initialSize);
-        }
-        return new SlotMapContainer(initialSize);
-    }
-
     public ScriptableObject() {
-        slotMap = createSlotMap(0);
+        super(0);
     }
 
     public ScriptableObject(Scriptable scope, Scriptable prototype) {
+        super(0);
         if (scope == null) throw new IllegalArgumentException();
 
         parentScopeObject = scope;
         prototypeObject = prototype;
-        slotMap = createSlotMap(0);
     }
 
     /**
@@ -205,7 +191,7 @@ public abstract class ScriptableObject
      */
     @Override
     public boolean has(String name, Scriptable start) {
-        return null != slotMap.query(name, 0);
+        return null != getMap().query(name, 0);
     }
 
     /**
@@ -220,13 +206,13 @@ public abstract class ScriptableObject
         if (externalData != null) {
             return (index < externalData.getArrayLength());
         }
-        return null != slotMap.query(null, index);
+        return null != getMap().query(null, index);
     }
 
     /** A version of "has" that supports symbols. */
     @Override
     public boolean has(Symbol key, Scriptable start) {
-        return null != slotMap.query(key, 0);
+        return null != getMap().query(key, 0);
     }
 
     /**
@@ -240,7 +226,7 @@ public abstract class ScriptableObject
      */
     @Override
     public Object get(String name, Scriptable start) {
-        Slot slot = slotMap.query(name, 0);
+        Slot slot = getMap().query(name, 0);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
         }
@@ -263,7 +249,7 @@ public abstract class ScriptableObject
             return Scriptable.NOT_FOUND;
         }
 
-        Slot slot = slotMap.query(null, index);
+        Slot slot = getMap().query(null, index);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
         }
@@ -273,7 +259,7 @@ public abstract class ScriptableObject
     /** Another version of Get that supports Symbol keyed properties. */
     @Override
     public Object get(Symbol key, Scriptable start) {
-        Slot slot = slotMap.query(key, 0);
+        Slot slot = getMap().query(key, 0);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
         }
@@ -384,7 +370,7 @@ public abstract class ScriptableObject
     @Override
     public void delete(String name) {
         checkNotSealed(name, 0);
-        slotMap.compute(name, 0, ScriptableObject::checkSlotRemoval);
+        getMap().compute(this, name, 0, ScriptableObject::checkSlotRemoval);
     }
 
     /**
@@ -397,14 +383,14 @@ public abstract class ScriptableObject
     @Override
     public void delete(int index) {
         checkNotSealed(null, index);
-        slotMap.compute(null, index, ScriptableObject::checkSlotRemoval);
+        getMap().compute(this, null, index, ScriptableObject::checkSlotRemoval);
     }
 
     /** Removes an object like the others, but using a Symbol as the key. */
     @Override
     public void delete(Symbol key) {
         checkNotSealed(key, 0);
-        slotMap.compute(key, 0, ScriptableObject::checkSlotRemoval);
+        getMap().compute(this, key, 0, ScriptableObject::checkSlotRemoval);
     }
 
     private static Slot checkSlotRemoval(Object key, int index, Slot slot) {
@@ -458,7 +444,7 @@ public abstract class ScriptableObject
      */
     @Override
     public boolean isConst(String name) {
-        Slot slot = slotMap.query(name, 0);
+        Slot slot = getMap().query(name, 0);
         if (slot == null) {
             return false;
         }
@@ -561,7 +547,7 @@ public abstract class ScriptableObject
      */
     public void setAttributes(String name, int attributes) {
         checkNotSealed(name, 0);
-        Slot attrSlot = slotMap.modify(name, 0, 0);
+        Slot attrSlot = getMap().modify(this, name, 0, 0);
         attrSlot.setAttributes(attributes);
     }
 
@@ -579,14 +565,14 @@ public abstract class ScriptableObject
      */
     public void setAttributes(int index, int attributes) {
         checkNotSealed(null, index);
-        Slot attrSlot = slotMap.modify(null, index, 0);
+        Slot attrSlot = getMap().modify(this, null, index, 0);
         attrSlot.setAttributes(attributes);
     }
 
     /** Set attributes of a Symbol-keyed property. */
     public void setAttributes(Symbol key, int attributes) {
         checkNotSealed(key, 0);
-        Slot attrSlot = slotMap.modify(key, 0, 0);
+        Slot attrSlot = getMap().modify(this, key, 0, 0);
         attrSlot.setAttributes(attributes);
     }
 
@@ -599,9 +585,9 @@ public abstract class ScriptableObject
         AccessorSlot aSlot;
         if (isExtensible()) {
             // Create a new AccessorSlot, or cast it if it's already set
-            aSlot = slotMap.compute(name, index, ScriptableObject::ensureAccessorSlot);
+            aSlot = getMap().compute(this, name, index, ScriptableObject::ensureAccessorSlot);
         } else {
-            Slot slot = slotMap.query(name, index);
+            Slot slot = getMap().query(name, index);
             if (slot instanceof AccessorSlot) {
                 aSlot = (AccessorSlot) slot;
             } else {
@@ -647,7 +633,7 @@ public abstract class ScriptableObject
      */
     public Object getGetterOrSetter(String name, int index, Scriptable scope, boolean isSetter) {
         if (name != null && index != 0) throw new IllegalArgumentException(name);
-        Slot slot = slotMap.query(name, index);
+        Slot slot = getMap().query(name, index);
         if (slot == null) return null;
         Function getterOrSetter =
                 isSetter
@@ -683,14 +669,14 @@ public abstract class ScriptableObject
      * @return whether the property is a getter or a setter
      */
     protected boolean isGetterOrSetter(String name, int index, boolean setter) {
-        Slot slot = slotMap.query(name, index);
+        Slot slot = getMap().query(name, index);
         return (slot != null && slot.isSetterSlot());
     }
 
     void addLazilyInitializedValue(String name, int index, LazilyLoadedCtor init, int attributes) {
         if (name != null && index != 0) throw new IllegalArgumentException(name);
         checkNotSealed(name, index);
-        LazyLoadSlot lslot = slotMap.compute(name, index, ScriptableObject::ensureLazySlot);
+        LazyLoadSlot lslot = getMap().compute(this, name, index, ScriptableObject::ensureLazySlot);
         lslot.setAttributes(attributes);
         lslot.value = init;
     }
@@ -1588,7 +1574,8 @@ public abstract class ScriptableObject
             }
         }
 
-        AccessorSlot aSlot = slotMap.compute(propertyName, 0, ScriptableObject::ensureAccessorSlot);
+        AccessorSlot aSlot =
+                getMap().compute(this, propertyName, 0, ScriptableObject::ensureAccessorSlot);
         aSlot.setAttributes(attributes);
         if (getterBox != null) {
             aSlot.getter = new AccessorSlot.MemberBoxGetter(getterBox);
@@ -1658,7 +1645,7 @@ public abstract class ScriptableObject
             }
         }
 
-        // this property lookup cannot happen from inside slotMap.compute lambda
+        // this property lookup cannot happen from inside getMap().compute lambda
         // as it risks causing a deadlock if ThreadSafeSlotMapContainer is used
         // and `this` is in prototype chain of `desc`
         Object enumerable = getProperty(desc, "enumerable");
@@ -1671,69 +1658,70 @@ public abstract class ScriptableObject
 
         // Do some complex stuff depending on whether or not the key
         // already exists in a single hash map operation
-        slotMap.compute(
-                key,
-                index,
-                (k, ix, existing) -> {
-                    if (checkValid) {
-                        checkPropertyChangeForSlot(id, existing, desc);
-                    }
+        getMap().compute(
+                        this,
+                        key,
+                        index,
+                        (k, ix, existing) -> {
+                            if (checkValid) {
+                                checkPropertyChangeForSlot(id, existing, desc);
+                            }
 
-                    Slot slot;
-                    int attributes;
+                            Slot slot;
+                            int attributes;
 
-                    if (existing == null) {
-                        slot = new Slot(k, ix, 0);
-                        attributes =
-                                applyDescriptorToAttributeBitset(
-                                        DONTENUM | READONLY | PERMANENT,
-                                        enumerable,
-                                        writable,
-                                        configurable);
-                    } else {
-                        slot = existing;
-                        attributes =
-                                applyDescriptorToAttributeBitset(
-                                        existing.getAttributes(),
-                                        enumerable,
-                                        writable,
-                                        configurable);
-                    }
+                            if (existing == null) {
+                                slot = new Slot(k, ix, 0);
+                                attributes =
+                                        applyDescriptorToAttributeBitset(
+                                                DONTENUM | READONLY | PERMANENT,
+                                                enumerable,
+                                                writable,
+                                                configurable);
+                            } else {
+                                slot = existing;
+                                attributes =
+                                        applyDescriptorToAttributeBitset(
+                                                existing.getAttributes(),
+                                                enumerable,
+                                                writable,
+                                                configurable);
+                            }
 
-                    if (accessorDescriptor) {
-                        AccessorSlot fslot;
-                        if (slot instanceof AccessorSlot) {
-                            fslot = (AccessorSlot) slot;
-                        } else {
-                            fslot = new AccessorSlot(slot);
-                            slot = fslot;
-                        }
-                        if (getter != NOT_FOUND) {
-                            fslot.getter = new AccessorSlot.FunctionGetter(getter);
-                        }
+                            if (accessorDescriptor) {
+                                AccessorSlot fslot;
+                                if (slot instanceof AccessorSlot) {
+                                    fslot = (AccessorSlot) slot;
+                                } else {
+                                    fslot = new AccessorSlot(slot);
+                                    slot = fslot;
+                                }
+                                if (getter != NOT_FOUND) {
+                                    fslot.getter = new AccessorSlot.FunctionGetter(getter);
+                                }
 
-                        if (setter != NOT_FOUND) {
-                            fslot.setter = new AccessorSlot.FunctionSetter(setter);
-                        }
-                        fslot.value = Undefined.instance;
-                    } else {
-                        if (!slot.isValueSlot() && isDataDescriptor(desc)) {
-                            // Replace a non-base slot with a regular slot
-                            slot = new Slot(slot);
-                        }
+                                if (setter != NOT_FOUND) {
+                                    fslot.setter = new AccessorSlot.FunctionSetter(setter);
+                                }
+                                fslot.value = Undefined.instance;
+                            } else {
+                                if (!slot.isValueSlot() && isDataDescriptor(desc)) {
+                                    // Replace a non-base slot with a regular slot
+                                    slot = new Slot(slot);
+                                }
 
-                        if (value != NOT_FOUND) {
-                            slot.value = value;
-                        } else if (existing == null) {
-                            // Ensure we don't get a zombie value if we have switched a lot
-                            slot.value = Undefined.instance;
-                        }
-                    }
+                                if (value != NOT_FOUND) {
+                                    slot.value = value;
+                                } else if (existing == null) {
+                                    // Ensure we don't get a zombie value if we have switched a lot
+                                    slot.value = Undefined.instance;
+                                }
+                            }
 
-                    // After all that, whatever we return now ends up in the map
-                    slot.setAttributes(attributes);
-                    return slot;
-                });
+                            // After all that, whatever we return now ends up in the map
+                            slot.setAttributes(attributes);
+                            return slot;
+                        });
         return true;
     }
 
@@ -1753,7 +1741,7 @@ public abstract class ScriptableObject
      */
     public void defineProperty(
             String name, Supplier<Object> getter, Consumer<Object> setter, int attributes) {
-        LambdaSlot slot = slotMap.compute(name, 0, ScriptableObject::ensureLambdaSlot);
+        LambdaSlot slot = getMap().compute(this, name, 0, ScriptableObject::ensureLambdaSlot);
         slot.setAttributes(attributes);
         slot.getter = getter;
         slot.setter = setter;
@@ -1789,19 +1777,20 @@ public abstract class ScriptableObject
         LambdaAccessorSlot newSlot = createLambdaAccessorSlot(name, 0, getter, setter, attributes);
         ScriptableObject newDesc = newSlot.buildPropertyDescriptor(cx);
         checkPropertyDefinition(newDesc);
-        slotMap.compute(
-                name,
-                0,
-                (id, index, existing) -> {
-                    if (existing != null) {
-                        // it's dangerous to use `this` as scope inside slotMap.compute.
-                        // It can cause deadlock when ThreadSafeSlotMapContainer is used
+        getMap().compute(
+                        this,
+                        name,
+                        0,
+                        (id, index, existing) -> {
+                            if (existing != null) {
+                                // it's dangerous to use `this` as scope inside slotMap.compute.
+                                // It can cause deadlock when ThreadSafeSlotMapContainer is used
 
-                        return replaceExistingLambdaSlot(cx, name, existing, newSlot);
-                    }
-                    checkPropertyChangeForSlot(name, null, newDesc);
-                    return newSlot;
-                });
+                                return replaceExistingLambdaSlot(cx, name, existing, newSlot);
+                            }
+                            checkPropertyChangeForSlot(name, null, newDesc);
+                            return newSlot;
+                        });
     }
 
     private LambdaAccessorSlot replaceExistingLambdaSlot(
@@ -2155,9 +2144,9 @@ public abstract class ScriptableObject
             }
             toInitialize.clear();
 
-            long stamp = slotMap.readLock();
+            long stamp = getMap().readLock();
             try {
-                for (Slot slot : slotMap) {
+                for (Slot slot : getMap()) {
                     Object value = slot.value;
                     if (value instanceof LazilyLoadedCtor) {
                         toInitialize.add(slot);
@@ -2167,7 +2156,7 @@ public abstract class ScriptableObject
                     isSealed = true;
                 }
             } finally {
-                slotMap.unlockRead(stamp);
+                getMap().unlockRead(stamp);
             }
         }
     }
@@ -2716,7 +2705,7 @@ public abstract class ScriptableObject
         // so we inline the extensible/sealed checks below.
         Slot slot;
         if (this != start) {
-            slot = slotMap.query(key, index);
+            slot = getMap().query(key, index);
             if (!isExtensible
                     && (slot == null
                             || (!(slot instanceof AccessorSlot)
@@ -2728,7 +2717,7 @@ public abstract class ScriptableObject
                 return false;
             }
         } else if (!isExtensible) {
-            slot = slotMap.query(key, index);
+            slot = getMap().query(key, index);
             if ((slot == null
                             || (!(slot instanceof AccessorSlot)
                                     && (slot.getAttributes() & READONLY) != 0))
@@ -2742,7 +2731,7 @@ public abstract class ScriptableObject
             if (isSealed) {
                 checkNotSealed(key, index);
             }
-            slot = slotMap.modify(key, index, 0);
+            slot = getMap().modify(this, key, index, 0);
         }
         return slot.setValue(value, this, start, isThrow);
     }
@@ -2768,19 +2757,19 @@ public abstract class ScriptableObject
         }
         Slot slot;
         if (this != start) {
-            slot = slotMap.query(name, index);
+            slot = getMap().query(name, index);
             if (slot == null) {
                 return false;
             }
         } else if (!isExtensible()) {
-            slot = slotMap.query(name, index);
+            slot = getMap().query(name, index);
             if (slot == null) {
                 return true;
             }
         } else {
             checkNotSealed(name, index);
             // either const hoisted declaration or initialization
-            slot = slotMap.modify(name, index, CONST);
+            slot = getMap().modify(this, name, index, CONST);
             int attr = slot.getAttributes();
             if ((attr & READONLY) == 0)
                 throw Context.reportRuntimeErrorById("msg.var.redecl", name);
@@ -2796,7 +2785,7 @@ public abstract class ScriptableObject
     }
 
     private Slot getAttributeSlot(String name, int index) {
-        Slot slot = slotMap.query(name, index);
+        Slot slot = getMap().query(name, index);
         if (slot == null) {
             String str = (name != null ? name : Integer.toString(index));
             throw Context.reportRuntimeErrorById("msg.prop.not.found", str);
@@ -2805,7 +2794,7 @@ public abstract class ScriptableObject
     }
 
     private Slot getAttributeSlot(Symbol key) {
-        Slot slot = slotMap.query(key, 0);
+        Slot slot = getMap().query(key, 0);
         if (slot == null) {
             throw Context.reportRuntimeErrorById("msg.prop.not.found", key);
         }
@@ -2824,20 +2813,20 @@ public abstract class ScriptableObject
                 a[i] = Integer.valueOf(i);
             }
         }
-        if (slotMap.isEmpty()) {
+        if (getMap().isEmpty()) {
             return a;
         }
 
         int c = externalLen;
-        final long stamp = slotMap.readLock();
+        final long stamp = getMap().readLock();
         try {
-            for (Slot slot : slotMap) {
+            for (Slot slot : getMap()) {
                 if ((getNonEnumerable || (slot.getAttributes() & DONTENUM) == 0)
                         && (getSymbols || !(slot.name instanceof Symbol))) {
                     if (c == externalLen) {
                         // Special handling to combine external array with additional properties
                         Object[] oldA = a;
-                        a = new Object[slotMap.dirtySize() + externalLen];
+                        a = new Object[getMap().dirtySize() + externalLen];
                         if (oldA != null) {
                             System.arraycopy(oldA, 0, a, 0, externalLen);
                         }
@@ -2846,7 +2835,7 @@ public abstract class ScriptableObject
                 }
             }
         } finally {
-            slotMap.unlockRead(stamp);
+            getMap().unlockRead(stamp);
         }
 
         Object[] result;
@@ -2901,19 +2890,19 @@ public abstract class ScriptableObject
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        final long stamp = slotMap.readLock();
+        final long stamp = getMap().readLock();
         try {
-            int objectsCount = slotMap.dirtySize();
+            int objectsCount = getMap().dirtySize();
             if (objectsCount == 0) {
                 out.writeInt(0);
             } else {
                 out.writeInt(objectsCount);
-                for (Slot slot : slotMap) {
+                for (Slot slot : getMap()) {
                     out.writeObject(slot);
                 }
             }
         } finally {
-            slotMap.unlockRead(stamp);
+            getMap().unlockRead(stamp);
         }
     }
 
@@ -2921,10 +2910,10 @@ public abstract class ScriptableObject
         in.defaultReadObject();
 
         int tableSize = in.readInt();
-        slotMap = createSlotMap(tableSize);
+        setMap(createSlotMap(tableSize));
         for (int i = 0; i < tableSize; i++) {
             Slot slot = (Slot) in.readObject();
-            slotMap.add(slot);
+            getMap().add(this, slot);
         }
     }
 
@@ -2936,24 +2925,24 @@ public abstract class ScriptableObject
 
     protected Slot querySlot(Context cx, Object id) {
         if (id instanceof Symbol) {
-            return slotMap.query(id, 0);
+            return getMap().query(id, 0);
         }
         StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(id);
         if (s.stringId == null) {
-            return slotMap.query(null, s.index);
+            return getMap().query(null, s.index);
         }
-        return slotMap.query(s.stringId, 0);
+        return getMap().query(s.stringId, 0);
     }
 
     // Partial implementation of java.util.Map. See NativeObject for
     // a subclass that implements java.util.Map.
 
     public int size() {
-        return slotMap.size();
+        return getMap().size();
     }
 
     public boolean isEmpty() {
-        return slotMap.isEmpty();
+        return getMap().isEmpty();
     }
 
     public Object get(Object key) {

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
@@ -39,7 +39,7 @@ public interface SlotMap extends Iterable<Slot> {
      *     slots will not be modified.
      * @return a Slot, which will be created anew if no such slot exists.
      */
-    Slot modify(Object key, int index, int attributes);
+    Slot modify(SlotMapOwner owner, Object key, int index, int attributes);
 
     /**
      * Retrieve the slot at EITHER key or index, or return null if the slot cannot be found.
@@ -58,11 +58,24 @@ public interface SlotMap extends Iterable<Slot> {
      * code and is more efficient than making multiple calls to this interface. In order to allow
      * use of multiple Slot subclasses, this function is templatized.
      */
-    <S extends Slot> S compute(Object key, int index, SlotComputer<S> compute);
+    <S extends Slot> S compute(SlotMapOwner owner, Object key, int index, SlotComputer<S> compute);
 
     /**
      * Insert a new slot to the map. Both "name" and "indexOrHash" must be populated. Note that
      * ScriptableObject generally adds slots via the "modify" method.
      */
-    void add(Slot newSlot);
+    void add(SlotMapOwner owner, Slot newSlot);
+
+    default long readLock() {
+        // No locking in the default implementation
+        return 0L;
+    }
+
+    default void unlockRead(long stamp) {
+        // No locking in the default implementation
+    }
+
+    default int dirtySize() {
+        return size();
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
@@ -69,7 +69,7 @@ class SlotMapContainer extends SlotMapOwner implements SlotMap {
         }
     }
 
-    static EmptySlotMap EMPTY_SLOT_MAP = new EmptySlotMap();
+    static SlotMap EMPTY_SLOT_MAP = new EmptySlotMap();
 
     SlotMapContainer() {
         this(DEFAULT_SIZE);

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapContainer.java
@@ -13,16 +13,16 @@ import java.util.Iterator;
  * This class holds the various SlotMaps of various types, and knows how to atomically switch
  * between them when we need to so that we use the right data structure at the right time.
  */
-class SlotMapContainer implements SlotMap {
+class SlotMapContainer extends SlotMapOwner implements SlotMap {
 
     /**
      * Once the object has this many properties in it, we will replace the EmbeddedSlotMap with
      * HashSlotMap. We can adjust this parameter to balance performance for typical objects versus
      * performance for huge objects with many collisions.
      */
-    private static final int LARGE_HASH_SIZE = 2000;
+    static final int LARGE_HASH_SIZE = 2000;
 
-    private static final int DEFAULT_SIZE = 10;
+    static final int DEFAULT_SIZE = 10;
 
     private static class EmptySlotMap implements SlotMap {
 
@@ -42,8 +42,10 @@ class SlotMapContainer implements SlotMap {
         }
 
         @Override
-        public Slot modify(Object key, int index, int attributes) {
-            return null;
+        public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+            var map = new EmbeddedSlotMap();
+            owner.setMap(map);
+            return map.modify(owner, key, index, attributes);
         }
 
         @Override
@@ -52,81 +54,89 @@ class SlotMapContainer implements SlotMap {
         }
 
         @Override
-        public void add(Slot newSlot) {
-            throw new IllegalStateException();
+        public void add(SlotMapOwner owner, Slot newSlot) {
+            var map = new EmbeddedSlotMap();
+            owner.setMap(map);
+            map.add(owner, newSlot);
         }
 
         @Override
-        public <S extends Slot> S compute(Object key, int index, SlotComputer<S> compute) {
-            throw new IllegalStateException();
+        public <S extends Slot> S compute(
+                SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
+            var map = new EmbeddedSlotMap();
+            owner.setMap(map);
+            return map.compute(owner, key, index, compute);
         }
     }
 
-    private static EmptySlotMap EMPTY_SLOT_MAP = new EmptySlotMap();
-
-    protected SlotMap map;
+    static EmptySlotMap EMPTY_SLOT_MAP = new EmptySlotMap();
 
     SlotMapContainer() {
         this(DEFAULT_SIZE);
     }
 
     SlotMapContainer(int initialSize) {
+        super(initialMap(initialSize));
+    }
+
+    private static SlotMap initialMap(int initialSize) {
         if (initialSize == 0) {
-            map = EMPTY_SLOT_MAP;
+            return EMPTY_SLOT_MAP;
         } else if (initialSize > LARGE_HASH_SIZE) {
-            map = new HashSlotMap();
+            return new HashSlotMap();
         } else {
-            map = new EmbeddedSlotMap();
+            return new EmbeddedSlotMap();
         }
     }
 
     @Override
     public int size() {
-        return map.size();
+        return getMap().size();
     }
 
+    @Override
     public int dirtySize() {
-        return map.size();
+        return getMap().size();
     }
 
     @Override
     public boolean isEmpty() {
-        return map.isEmpty();
+        return getMap().isEmpty();
     }
 
     @Override
-    public Slot modify(Object key, int index, int attributes) {
-        checkMapSize();
-        return map.modify(key, index, attributes);
+    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+        return getMap().modify(this, key, index, attributes);
     }
 
     @Override
-    public <S extends Slot> S compute(Object key, int index, SlotComputer<S> c) {
-        checkMapSize();
-        return map.compute(key, index, c);
+    public <S extends Slot> S compute(
+            SlotMapOwner owner, Object key, int index, SlotComputer<S> c) {
+        return getMap().compute(this, key, index, c);
     }
 
     @Override
     public Slot query(Object key, int index) {
-        return map.query(key, index);
+        return getMap().query(key, index);
     }
 
     @Override
-    public void add(Slot newSlot) {
-        checkMapSize();
-        map.add(newSlot);
+    public void add(SlotMapOwner owner, Slot newSlot) {
+        getMap().add(this, newSlot);
     }
 
     @Override
     public Iterator<Slot> iterator() {
-        return map.iterator();
+        return getMap().iterator();
     }
 
+    @Override
     public long readLock() {
         // No locking in the default implementation
         return 0L;
     }
 
+    @Override
     public void unlockRead(long stamp) {
         // No locking in the default implementation
     }
@@ -136,11 +146,12 @@ class SlotMapContainer implements SlotMap {
      * map to a HashMap that is more robust against large numbers of hash collisions.
      */
     protected void checkMapSize() {
+        var map = getMap();
         if (map == EMPTY_SLOT_MAP) {
-            map = new EmbeddedSlotMap();
+            setMap(new EmbeddedSlotMap());
         } else if ((map instanceof EmbeddedSlotMap) && map.size() >= LARGE_HASH_SIZE) {
             SlotMap newMap = new HashSlotMap(map);
-            map = newMap;
+            setMap(newMap);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -1,0 +1,39 @@
+package org.mozilla.javascript;
+
+public abstract class SlotMapOwner {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * This holds all the slots. It may or may not be thread-safe, and may expand itself to a
+     * different data structure depending on the size of the object.
+     */
+    private SlotMap slotMap;
+
+    protected SlotMapOwner() {
+        slotMap = createSlotMap(0);
+    }
+
+    protected SlotMapOwner(int capacity) {
+        slotMap = createSlotMap(capacity);
+    }
+
+    protected SlotMapOwner(SlotMap map) {
+        slotMap = map;
+    }
+
+    protected static SlotMap createSlotMap(int initialSize) {
+        Context cx = Context.getCurrentContext();
+        if ((cx != null) && cx.hasFeature(Context.FEATURE_THREAD_SAFE_OBJECTS)) {
+            return new ThreadSafeSlotMapContainer(initialSize);
+        }
+        return new SlotMapContainer(initialSize);
+    }
+
+    final SlotMap getMap() {
+        return slotMap;
+    }
+
+    final void setMap(SlotMap newMap) {
+        slotMap = newMap;
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -25,8 +25,13 @@ public abstract class SlotMapOwner {
         Context cx = Context.getCurrentContext();
         if ((cx != null) && cx.hasFeature(Context.FEATURE_THREAD_SAFE_OBJECTS)) {
             return new ThreadSafeSlotMapContainer(initialSize);
+        } else if (initialSize == 0) {
+            return SlotMapContainer.EMPTY_SLOT_MAP;
+        } else if (initialSize > SlotMapContainer.LARGE_HASH_SIZE) {
+            return new HashSlotMap();
+        } else {
+            return new EmbeddedSlotMap();
         }
-        return new SlotMapContainer(initialSize);
     }
 
     final SlotMap getMap() {


### PR DESCRIPTION
# Start to factor out slot map container

This is a stacked PR on top of 
* #1782 

This PR introduces an abstract super class of `ScriptableObject` and `SlotMapContainer` called `SlotMapOwner`. It is responsible for creating, getting, and setting the slot map owned by these objects. I originally experimented with this as an interface but was writing the almost exact same code for both classes and it was hard to limit the visibility of the API which should be entirely internal to Rhino. This also moves all slot promotion to the maps themselves. I did some minor refactoring in `EmbeddedSlotMap` to only check for promotion when would expand the backing array.

This changes the slot map structure in the single threaded case from

```mermaid
graph LR
Object["ScriptableObject"]
Container["SlotMapContainer"]
Map["SlotMap"]
Array["Slot[]"]
Slot1["Slot"]
Slot2["Slot"]
Slot3["Slot"]
Object1["ScriptableObject"]
Container1["SlotMapContainer"]
Map1["SlotMap"]
Array1["Slot[]"]
Slot4["Slot"]
Slot5["Slot"]
Slot6["Slot"]
Object --> Container --> Map --> Array
Array --> Slot1
Array --> Slot2
Array --> Slot3
Object1 --> Container1 --> Map1 --> Array1
Array1 --> Slot4
Array1 --> Slot5
Array1 --> Slot6
```
to:
```mermaid
graph LR
Object["ScriptableObject"]
Map["SlotMap"]
Array["Slot[]"]
Slot1["Slot"]
Slot2["Slot"]
Slot3["Slot"]
Object1["ScriptableObject"]
Map1["SlotMap"]
Array1["Slot[]"]
Slot4["Slot"]
Slot5["Slot"]
Slot6["Slot"]
Object --> Map --> Array
Array --> Slot1
Array --> Slot2
Array --> Slot3
Object1 --> Map1 --> Array1
Array1 --> Slot4
Array1 --> Slot5
Array1 --> Slot6
```

This saves 24 bytes per object.