### PR TITLE
Single entry slot map

### DIFF
--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
@@ -121,7 +121,7 @@ public class SlotMapTest {
         assertEquals(newSlot.value, "bar");
         slot = obj.getMap().query("one", 0);
         assertEquals(slot.value, "bar");
-        assertEquals(obj.getMap().size(), 1);
+        assertEquals(1, obj.getMap().size());
     }
 
     @Test
@@ -145,7 +145,7 @@ public class SlotMapTest {
         Slot slot = obj.getMap().query("one", 0);
         assertNotNull(slot);
         assertEquals(slot.value, "bar");
-        assertEquals(obj.getMap().size(), 1);
+        assertEquals(1, obj.getMap().size());
     }
 
     @Test
@@ -168,7 +168,7 @@ public class SlotMapTest {
         assertNull(newSlot);
         slot = obj.getMap().query("one", 0);
         assertNull(slot);
-        assertEquals(obj.getMap().size(), 0);
+        assertEquals(0, obj.getMap().size());
     }
 
     private static final int NUM_INDICES = 67;


### PR DESCRIPTION
# Single entry slot map

This is a stacked PR on top of

* #1782
* #1783

This introduces a single-entry slot map to take the common case of a single property from:
```mermaid
graph LR
Object["ScriptableObject"]
Map["SlotMap"]
Array["Slot[]"]
Slot1["Slot"]
Object1["ScriptableObject"]
Map1["SlotMap"]
Array1["Slot[]"]
Slot2["Slot"]
Object --> Map --> Array
Array --> Slot1
Object1 --> Map1 --> Array1
Array1 --> Slot2
```
to:
```mermaid
graph LR
Object["ScriptableObject"]
Map["SingleEntrySlotMap"]
Slot1["Slot"]
Object1["ScriptableObject"]
Map1["SingleEntrySlotMap"]
Slot2["Slot"]
Object --> Map --> Slot1
Object1 --> Map1 --> Slot2
```

This saves 48 bytes on any object with a single slot.