### PR TITLE
Test: add a missing `@Test` annotation in `NativeProxyTest`

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -80,6 +80,7 @@ public class NativeProxyTest {
                 "try { Proxy() } catch(e) { '' + e }");
     }
 
+    @Test
     public void construct() {
         String js =
                 "var _target, _handler, _args, _P;\n"


### PR DESCRIPTION
Just adding a missing `@Test` annotation on a method of `NativeProxyTest` that I spotted while trying to understand how everything works. 🙂 

(@rbri - great job by the way!)