### PR TITLE
Optimize `extractSetMethod(...)` and `findFunction(...)`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -727,28 +727,24 @@ class JavaMembers {
         //       instance of the target arg to determine that.
         //
 
-        // Make two passes: one to find a method with direct type assignment,
-        // and one to find a widening conversion.
-        for (int pass = 1; pass <= 2; ++pass) {
-            for (MemberBox method : methods) {
-                if (!isStatic || method.isStatic()) {
-                    Class<?>[] params = method.argTypes;
-                    if (params.length == 1) {
-                        if (pass == 1) {
-                            if (params[0] == type) {
-                                return method;
-                            }
-                        } else {
-                            if (pass != 2) Kit.codeBug();
-                            if (params[0].isAssignableFrom(type)) {
-                                return method;
-                            }
-                        }
+        MemberBox acceptableMatch = null;
+        for (MemberBox method : methods) {
+            if (!isStatic || method.isStatic()) {
+                Class<?>[] params = method.argTypes;
+                if (params.length == 1) {
+                    if (params[0] == type) {
+                        // perfect match, no need to continue scanning
+                        return method;
+                    }
+                    if (acceptableMatch == null
+                        && params[0].isAssignableFrom(type)) {
+                        // do not return at this point, there can still be perfect match
+                        acceptableMatch = method;
                     }
                 }
             }
         }
-        return null;
+        return acceptableMatch;
     }
 
     private static MemberBox extractSetMethod(MemberBox[] methods, boolean isStatic) {

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -736,8 +736,7 @@ class JavaMembers {
                         // perfect match, no need to continue scanning
                         return method;
                     }
-                    if (acceptableMatch == null
-                        && params[0].isAssignableFrom(type)) {
+                    if (acceptableMatch == null && params[0].isAssignableFrom(type)) {
                         // do not return at this point, there can still be perfect match
                         acceptableMatch = method;
                     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -306,13 +306,9 @@ public class NativeJavaMethod extends BaseFunction {
             int worseCount = 0; // number of times best fits were preferred
             // over member
             for (int j = -1; j != extraBestFitsCount; ++j) {
-                int bestFitIndex = j < 0
-                    ? firstBestFit
-                    : extraBestFits[j];
+                int bestFitIndex = j < 0 ? firstBestFit : extraBestFits[j];
                 MemberBox bestFit = methodsOrCtors[bestFitIndex];
-                int[] bestFitWeights = j < 0
-                    ? firstBestFitWeights
-                    : extraBestFitWeights[j];
+                int[] bestFitWeights = j < 0 ? firstBestFitWeights : extraBestFitWeights[j];
                 if (cx.hasFeature(Context.FEATURE_ENHANCED_JAVA_ACCESS)
                         && bestFit.isPublic() != member.isPublic()) {
                     // When FEATURE_ENHANCED_JAVA_ACCESS gives us access
@@ -321,13 +317,8 @@ public class NativeJavaMethod extends BaseFunction {
                     if (!bestFit.isPublic()) ++betterCount;
                     else ++worseCount;
                 } else {
-                    int preference = preferSignature(
-                        args,
-                        member,
-                        weights,
-                        bestFit,
-                        bestFitWeights
-                    );
+                    int preference =
+                            preferSignature(args, member, weights, bestFit, bestFitWeights);
                     if (preference == PREFERENCE_AMBIGUOUS) {
                         break;
                     } else if (preference == PREFERENCE_FIRST_ARG) {
@@ -348,8 +339,7 @@ public class NativeJavaMethod extends BaseFunction {
                             // static methods of the class hierarchy, even if
                             // a derived class's parameters match exactly.
                             // We want to call the derived class's method.
-                            if (debug)
-                                printDebug("Substituting (overridden static)", member, args);
+                            if (debug) printDebug("Substituting (overridden static)", member, args);
                             if (j == -1) {
                                 firstBestFit = i;
                                 firstBestFitWeights = weights;
@@ -358,8 +348,7 @@ public class NativeJavaMethod extends BaseFunction {
                                 extraBestFitWeights[j] = weights;
                             }
                         } else {
-                            if (debug)
-                                printDebug("Ignoring same signature member ", member, args);
+                            if (debug) printDebug("Ignoring same signature member ", member, args);
                         }
                         continue search;
                     }
@@ -435,28 +424,25 @@ public class NativeJavaMethod extends BaseFunction {
     private static final int PREFERENCE_AMBIGUOUS = 3;
 
     /**
-     * Determine which of two signatures is the closer fit.
-     * Returns one of {@link #PREFERENCE_EQUAL}, {@link #PREFERENCE_FIRST_ARG},
-     * {@link #PREFERENCE_SECOND_ARG}, or {@link #PREFERENCE_AMBIGUOUS}.
+     * Determine which of two signatures is the closer fit. Returns one of {@link
+     * #PREFERENCE_EQUAL}, {@link #PREFERENCE_FIRST_ARG}, {@link #PREFERENCE_SECOND_ARG}, or {@link
+     * #PREFERENCE_AMBIGUOUS}.
      */
     private static int preferSignature(
-        Object[] args,
-        MemberBox member1,
-        int[] computedWeights1,
-        MemberBox member2,
-        int[] computedWeights2
-    ) {
+            Object[] args,
+            MemberBox member1,
+            int[] computedWeights1,
+            MemberBox member2,
+            int[] computedWeights2) {
         final var types1 = member1.argTypes;
         final var types2 = member2.argTypes;
 
         int totalPreference = 0;
         for (int j = 0; j < args.length; j++) {
-            final var type1 = member1.vararg && j >= types1.length
-                ? types1[types1.length - 1]
-                : types1[j];
-            final var type2 = member2.vararg && j >= types2.length
-                ? types2[types2.length - 1]
-                : types2[j];
+            final var type1 =
+                    member1.vararg && j >= types1.length ? types1[types1.length - 1] : types1[j];
+            final var type2 =
+                    member2.vararg && j >= types2.length ? types2[types2.length - 1] : types2[j];
             if (type1 == type2) {
                 continue;
             }
@@ -464,12 +450,14 @@ public class NativeJavaMethod extends BaseFunction {
 
             // Determine which of type1, type2 is easier to convert from arg.
 
-            final var rank1 = j < computedWeights1.length
-                ? computedWeights1[j]
-                : NativeJavaObject.getConversionWeight(arg, type1);
-            final var rank2 = j < computedWeights2.length
-                ? computedWeights2[j]
-                : NativeJavaObject.getConversionWeight(arg, type2);
+            final var rank1 =
+                    j < computedWeights1.length
+                            ? computedWeights1[j]
+                            : NativeJavaObject.getConversionWeight(arg, type1);
+            final var rank2 =
+                    j < computedWeights2.length
+                            ? computedWeights2[j]
+                            : NativeJavaObject.getConversionWeight(arg, type2);
 
             int preference;
             if (rank1 < rank2) {
@@ -502,11 +490,11 @@ public class NativeJavaMethod extends BaseFunction {
 
     /**
      * 1. {@code args} is too short for {@code member} calling -> return {@code null}
-     * <p>
-     * 2. at least one arg cannot be converted -> return {@code null}
-     * <p>
-     * 3. otherwise -> return an int array holding all computed conversion weights, whose length will be {@code args.length} for
-     * non-vararg member or {@code args.length-1} for vararg member
+     *
+     * <p>2. at least one arg cannot be converted -> return {@code null}
+     *
+     * <p>3. otherwise -> return an int array holding all computed conversion weights, whose length
+     * will be {@code args.length} for non-vararg member or {@code args.length-1} for vararg member
      *
      * @see NativeJavaObject#getConversionWeight(Object, Class)
      * @see NativeJavaObject#canConvert(Object, Class)

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -527,7 +527,7 @@ public class NativeJavaMethod extends BaseFunction {
         final var weights = new int[typeLen];
         for (int i = 0; i < typeLen; i++) {
             final var weight = NativeJavaObject.getConversionWeight(args[i], argTypes[i]);
-            if (weight < NativeJavaObject.CONVERSION_NONE) {
+            if (weight >= NativeJavaObject.CONVERSION_NONE) {
                 if (debug) {
                     printDebug("Rejecting (args can't convert) ", member, args);
                 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -38,7 +38,7 @@ public class NativeJavaMethodTest {
         }
 
         public void fN(String s1, String s2, String... sN) {
-            captured.add("N");
+            captured.add("N." + sN.length);
         }
     }
 
@@ -107,7 +107,16 @@ public class NativeJavaMethodTest {
 
     @Test
     void varArg() {
-        expect(Arrays.asList("N"), "d.fN('x', 'y', 'overflow');");
+        expect(
+                Arrays.asList("N.0", "N.3", "N.2"),
+                "d.fN('x', 'y');",
+                "d.fN('x', 'y', 'extra1', 'extra2', 'extra3');",
+                "d.fN('x', 'y', 'extra1', 'extra2');");
+    }
+
+    @Test
+    void argsTooShortForFixedArg() {
+        expectException(EvaluatorException.class, "Can't find method", "d.f2('x');");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -1,0 +1,84 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author ZZZank
+ */
+public class NativeJavaMethodTest {
+
+    public static class MethodDummy {
+        public final List<String> captured = new ArrayList<>();
+
+        public void f1(String s) {
+            captured.add("1");
+        }
+
+        public void f1(String s, int forOverload) {
+            captured.add("1.1");
+        }
+
+        public void f1(String s, String forOverload) {
+            captured.add("1.2");
+        }
+
+        public void f2(String s1, String s2) {
+            captured.add("2");
+        }
+
+        public void f2(String s1, String s2, String... sN) {
+            captured.add("2.N");
+        }
+
+        public void fN(String s1, String s2, String... sN) {
+            captured.add("N");
+        }
+    }
+
+    private static final String INIT = "const d = new Packages.org.mozilla.javascript.tests.NativeJavaMethodTest$MethodDummy();\n";
+
+    @Test
+    void fixedArg() {
+        Utils.assertWithAllModes_ES6(Arrays.asList("1", "2"), INIT
+            + "d.f1('xxx');"
+            + "d.f2('x', 'y');"
+            + "d.captured");
+    }
+
+    @Test
+    void overload() {
+        Utils.assertWithAllModes_ES6(Arrays.asList("1", "1.2", "1.1", "1.2"), INIT
+            + "d.f1('xxx');"
+            + "d.f1('x', 'y');"
+            + "d.f1('x', 3);"
+            + "d.f1('x', '3');"
+            + "d.captured");
+    }
+
+    @Test
+    void varArg() {
+        Utils.assertWithAllModes_ES6(Arrays.asList("N"), INIT
+            + "d.fN('x', 'y', 'overflow');"
+            + "d.captured");
+    }
+
+    @Test
+    void argsTooShortForVarArg() {
+        Utils.assertEvaluatorExceptionES6("Can't find method", INIT
+            + "d.fN('x');"
+            + "d.captured");
+    }
+
+    @Test
+    void varArgAndFixedArgPreference() {
+        // TODO: the second f2() should use the fixed arg variant
+        Utils.assertWithAllModes_ES6(Arrays.asList("2.N", "2"), INIT
+            + "d.f2('x', 'y', 'overflow');"
+            + "d.f2('x', 'y');"
+            + "d.captured");
+    }
+}


### PR DESCRIPTION

- setter extracting is rewritten to do setter scanning in 1 pass instead of 2 passes
- a helper method `failFastConversionWeights(...)` that can compute conversion weights in batch
- computed weights from `failFastConversionWeights(...)` will now be cached to prevent computing weight again in `preferSignature()`