### PR TITLE
Make lambda-based classes serializable

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
@@ -1,8 +1,5 @@
 package org.mozilla.javascript;
 
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-
 /**
  * A specialized property accessor using lambda functions, similar to {@link LambdaSlot}, but allows
  * defining properties with getter and setter lambdas that require access to the owner object
@@ -15,8 +12,8 @@ import java.util.function.Function;
  * native functionality without the need for reflection.
  */
 public class LambdaAccessorSlot extends Slot {
-    private transient Function<Scriptable, Object> getter;
-    private transient BiConsumer<Scriptable, Object> setter;
+    private ScriptableObject.LambdaGetterFunction getter;
+    private ScriptableObject.LambdaSetterFunction setter;
     private LambdaFunction getterFunction;
     private LambdaFunction setterFunction;
 
@@ -123,7 +120,7 @@ public class LambdaAccessorSlot extends Slot {
         return super.getValue(owner);
     }
 
-    public void setGetter(Scriptable scope, Function<Scriptable, Object> getter) {
+    public void setGetter(Scriptable scope, ScriptableObject.LambdaGetterFunction getter) {
         this.getter = getter;
         if (getter != null) {
             this.getterFunction =
@@ -135,7 +132,7 @@ public class LambdaAccessorSlot extends Slot {
         }
     }
 
-    public void setSetter(Scriptable scope, BiConsumer<Scriptable, Object> setter) {
+    public void setSetter(Scriptable scope, ScriptableObject.LambdaSetterFunction setter) {
         this.setter = setter;
         if (setter != null) {
             this.setterFunction =

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -6,9 +6,6 @@
 
 package org.mozilla.javascript;
 
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-
 /**
  * This class implements a JavaScript function that may be used as a constructor by delegating to an
  * interface that can be easily implemented as a lambda. The LambdaFunction class may be used to add
@@ -35,7 +32,7 @@ public class LambdaConstructor extends LambdaFunction {
     public static final int CONSTRUCTOR_DEFAULT = CONSTRUCTOR_FUNCTION | CONSTRUCTOR_NEW;
 
     // Lambdas should not be serialized.
-    protected final transient Constructable targetConstructor;
+    protected final SerializableConstructable targetConstructor;
     private final int flags;
 
     /**
@@ -51,7 +48,8 @@ public class LambdaConstructor extends LambdaFunction {
      * @param target an object that implements the function in Java. Since Constructable is a
      *     single-function interface this will typically be implemented as a lambda.
      */
-    public LambdaConstructor(Scriptable scope, String name, int length, Constructable target) {
+    public LambdaConstructor(
+            Scriptable scope, String name, int length, SerializableConstructable target) {
         super(scope, name, length, null);
         this.targetConstructor = target;
         this.flags = CONSTRUCTOR_DEFAULT;
@@ -72,7 +70,11 @@ public class LambdaConstructor extends LambdaFunction {
      *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaConstructor(
-            Scriptable scope, String name, int length, int flags, Constructable target) {
+            Scriptable scope,
+            String name,
+            int length,
+            int flags,
+            SerializableConstructable target) {
         super(scope, name, length, null);
         this.targetConstructor = target;
         this.flags = flags;
@@ -97,8 +99,8 @@ public class LambdaConstructor extends LambdaFunction {
             Scriptable scope,
             String name,
             int length,
-            Callable target,
-            Constructable targetConstructor) {
+            SerializableCallable target,
+            SerializableConstructable targetConstructor) {
         super(scope, name, length, target);
         this.targetConstructor = targetConstructor;
         this.flags = CONSTRUCTOR_DEFAULT;
@@ -138,7 +140,8 @@ public class LambdaConstructor extends LambdaFunction {
      * Define a function property on the prototype of the constructor using a LambdaFunction under
      * the covers.
      */
-    public void definePrototypeMethod(Scriptable scope, String name, int length, Callable target) {
+    public void definePrototypeMethod(
+            Scriptable scope, String name, int length, SerializableCallable target) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
         ScriptableObject proto = getPrototypeScriptable();
         proto.defineProperty(name, f, 0);
@@ -152,7 +155,7 @@ public class LambdaConstructor extends LambdaFunction {
             Scriptable scope,
             String name,
             int length,
-            Callable target,
+            SerializableCallable target,
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
@@ -169,7 +172,7 @@ public class LambdaConstructor extends LambdaFunction {
             Scriptable scope,
             SymbolKey name,
             int length,
-            Callable target,
+            SerializableCallable target,
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, "[" + name.getName() + "]", length, target);
@@ -195,7 +198,7 @@ public class LambdaConstructor extends LambdaFunction {
      * "Object.defineOwnProperty" with a property descriptor.
      */
     public void definePrototypeProperty(
-            Context cx, String name, Function<Scriptable, Object> getter, int attributes) {
+            Context cx, String name, ScriptableObject.LambdaGetterFunction getter, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
         proto.defineProperty(cx, name, getter, null, attributes);
     }
@@ -208,8 +211,8 @@ public class LambdaConstructor extends LambdaFunction {
     public void definePrototypeProperty(
             Context cx,
             String name,
-            Function<Scriptable, Object> getter,
-            BiConsumer<Scriptable, Object> setter,
+            ScriptableObject.LambdaGetterFunction getter,
+            ScriptableObject.LambdaSetterFunction setter,
             int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
         proto.defineProperty(cx, name, getter, setter, attributes);
@@ -226,7 +229,11 @@ public class LambdaConstructor extends LambdaFunction {
      * @param attributes the attributes to set on the new property
      */
     public void defineConstructorMethod(
-            Scriptable scope, String name, int length, Callable target, int attributes) {
+            Scriptable scope,
+            String name,
+            int length,
+            SerializableCallable target,
+            int attributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
         defineProperty(name, f, attributes);
     }
@@ -246,7 +253,7 @@ public class LambdaConstructor extends LambdaFunction {
             Symbol key,
             String name,
             int length,
-            Callable target,
+            SerializableCallable target,
             int attributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
         defineProperty(key, f, attributes);
@@ -261,7 +268,7 @@ public class LambdaConstructor extends LambdaFunction {
             Scriptable scope,
             String name,
             int length,
-            Callable target,
+            SerializableCallable target,
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
@@ -16,7 +16,7 @@ public class LambdaFunction extends BaseFunction {
     private static final long serialVersionUID = -8388132362854748293L;
 
     // The target is expected to be a lambda -- lambdas should not be serialized.
-    protected final transient Callable target;
+    protected final SerializableCallable target;
     private final String name;
     private final int length;
 
@@ -30,7 +30,7 @@ public class LambdaFunction extends BaseFunction {
      * @param target an object that implements the function in Java. Since Callable is a
      *     single-function interface this will typically be implemented as a lambda.
      */
-    public LambdaFunction(Scriptable scope, String name, int length, Callable target) {
+    public LambdaFunction(Scriptable scope, String name, int length, SerializableCallable target) {
         this.target = target;
         this.name = name;
         this.length = length;
@@ -39,7 +39,7 @@ public class LambdaFunction extends BaseFunction {
     }
 
     /** Create a new built-in function, with no name, and no default prototype. */
-    public LambdaFunction(Scriptable scope, int length, Callable target) {
+    public LambdaFunction(Scriptable scope, int length, SerializableCallable target) {
         this.target = target;
         this.length = length;
         this.name = "";

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -39,7 +39,7 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
     private Scriptable handlerObj;
     private final String typeOf;
 
-    private static final class Revoker implements Callable {
+    private static final class Revoker implements SerializableCallable {
         private NativeProxy revocableProxy = null;
 
         public Revoker(NativeProxy proxy) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1746,10 +1746,18 @@ public abstract class ScriptableObject extends SlotMapOwner
         slot.setter = setter;
     }
 
+    /**
+     * This is a single method interface suitable to be implemented as a lambda. It's used in the
+     * "defineProperty" method.
+     */
     public interface LambdaGetterFunction extends Serializable {
         Object apply(Scriptable scope);
     }
 
+    /**
+     * This is a single method interface suitable to be implemented as a lambda. It's used in the
+     * "defineProperty" method.
+     */
     public interface LambdaSetterFunction extends Serializable {
         void accept(Scriptable scope, Object value);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
@@ -1386,7 +1385,7 @@ public abstract class ScriptableObject extends SlotMapOwner
             Scriptable scope,
             String name,
             int length,
-            Callable target,
+            SerializableCallable target,
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
@@ -1747,6 +1746,14 @@ public abstract class ScriptableObject extends SlotMapOwner
         slot.setter = setter;
     }
 
+    public interface LambdaGetterFunction extends Serializable {
+        Object apply(Scriptable scope);
+    }
+
+    public interface LambdaSetterFunction extends Serializable {
+        void accept(Scriptable scope, Object value);
+    }
+
     /**
      * Define a property on this object that is implemented using lambda functions accepting
      * Scriptable `this` object as first parameter. Unlike with `defineProperty(String name,
@@ -1768,8 +1775,8 @@ public abstract class ScriptableObject extends SlotMapOwner
     public void defineProperty(
             Context cx,
             String name,
-            java.util.function.Function<Scriptable, Object> getter,
-            BiConsumer<Scriptable, Object> setter,
+            LambdaGetterFunction getter,
+            LambdaSetterFunction setter,
             int attributes) {
         if (getter == null && setter == null)
             throw ScriptRuntime.typeError("at least one of {getter, setter} is required");
@@ -1812,8 +1819,8 @@ public abstract class ScriptableObject extends SlotMapOwner
     private LambdaAccessorSlot createLambdaAccessorSlot(
             Object name,
             int index,
-            java.util.function.Function<Scriptable, Object> getter,
-            BiConsumer<Scriptable, Object> setter,
+            LambdaGetterFunction getter,
+            LambdaSetterFunction setter,
             int attributes) {
         LambdaAccessorSlot slot = new LambdaAccessorSlot(name, index);
         slot.setGetter(this, getter);

--- a/rhino/src/main/java/org/mozilla/javascript/SerializableCallable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SerializableCallable.java
@@ -2,4 +2,10 @@ package org.mozilla.javascript;
 
 import java.io.Serializable;
 
+/**
+ * This interface makes it possible to pass a lambda function to the various methods in
+ * LambdaConstructor and LambdaFunction that require a Callable that is also Serializable. Code that
+ * works with lambdas will largely "not notice" this interface, but it will make it possible for
+ * lambda-based classes to work with serialization like older Rhino native classes.
+ */
 public interface SerializableCallable extends Callable, Serializable {}

--- a/rhino/src/main/java/org/mozilla/javascript/SerializableCallable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SerializableCallable.java
@@ -1,0 +1,5 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+
+public interface SerializableCallable extends Callable, Serializable {}

--- a/rhino/src/main/java/org/mozilla/javascript/SerializableConstructable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SerializableConstructable.java
@@ -1,0 +1,5 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+
+public interface SerializableConstructable extends Constructable, Serializable {}

--- a/rhino/src/main/java/org/mozilla/javascript/SerializableConstructable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SerializableConstructable.java
@@ -2,4 +2,8 @@ package org.mozilla.javascript;
 
 import java.io.Serializable;
 
+/**
+ * This interface makes it possible to pass a lambda function to the various methods in
+ * LambdaConstructor and LambdaFunction that require a Constructable that is also Serializable.
+ */
 public interface SerializableConstructable extends Constructable, Serializable {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,6 +12,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.serialize.ScriptableInputStream;
+import org.mozilla.javascript.serialize.ScriptableOutputStream;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class NativeSerializationTest {
@@ -23,7 +23,7 @@ public class NativeSerializationTest {
     @BeforeEach
     public void init() {
         cx = Context.enter();
-        cx.setInterpretedMode(true);
+        //cx.setInterpretedMode(true);
         scope = new Global(cx);
     }
 
@@ -34,12 +34,32 @@ public class NativeSerializationTest {
 
     private static Object[][] getTestCases() {
         return new Object[][]{
+                /*{
+                        "String",
+                        "TESTOBJ = 'testing';",
+                        "assertEquals('testing', TESTOBJ);"
+                },
                 {
+                        "Number",
+                        "TESTOBJ = Number(123);",
+                        "assertEquals(123, TESTOBJ);"
+                },
+                {
+                        "Boolean",
+                        "TESTOBJ = Boolean(true);",
+                        "assertEquals(true, TESTOBJ);"
+                },*/
+                {
+                        "Symbol",
+                        "TESTOBJ = Symbol('test');",
+                        "assertEquals('Symbol(test)', TESTOBJ.toString());"
+                },
+                /*{
                         "Symbol Registry",
                         "TESTOBJ = Symbol.for('test');",
                         "assertEquals(Symbol.for('test'), TESTOBJ);"
                 },
-                {
+                /*{
                         "Object",
                         "TESTOBJ = {a: 1, b: 'two', c: {a: 3}}",
                         "assertEquals(1, TESTOBJ.a);\nassertEquals('two', TESTOBJ.b);\nassertEquals(3, TESTOBJ.c.a);"
@@ -53,7 +73,7 @@ public class NativeSerializationTest {
                         "Set",
                         "TESTOBJ = new Set();\nTESTOBJ.add('testing');",
                         "assertTrue(TESTOBJ.has('testing'));"
-                }
+                }*/
         };
     }
 
@@ -81,11 +101,11 @@ public class NativeSerializationTest {
 
     private Object serializeLoop(Object obj) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
-        ObjectOutputStream out = new ObjectOutputStream(outBuf);
+        ScriptableOutputStream out = new ScriptableOutputStream(outBuf, scope);
         out.writeObject(obj);
         out.close();
         ByteArrayInputStream inBuf = new ByteArrayInputStream(outBuf.toByteArray());
-        ObjectInputStream in = new ObjectInputStream(inBuf);
+        ScriptableInputStream in = new ScriptableInputStream(inBuf, scope);
         return in.readObject();
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
@@ -1,0 +1,76 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.tools.shell.Global;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class NativeSerializationTest {
+    private Context cx;
+    private Scriptable scope;
+
+    @BeforeEach
+    public void init() {
+        cx = Context.enter();
+        cx.setInterpretedMode(true);
+        scope = new Global(cx);
+    }
+
+    @AfterEach
+    public void close() {
+        Context.exit();
+    }
+
+    @ParameterizedTest(name = "Serialize {0}")
+    @MethodSource("getTestCases")
+    public void testWithoutSerialization(String name, String createScript, String testScript) {
+        cx.evaluateString(scope, "load('testsrc/assert.js');", "init.js", 1, null);
+        cx.evaluateString(scope, createScript, "create.js", 1, null);
+        cx.evaluateString(scope, testScript, "test.js", 1, null);
+    }
+
+    @ParameterizedTest(name = "Serialize {0}")
+    @MethodSource("getTestCases")
+    public void testSerialization(String name, String createScript, String testScript) throws IOException, ClassNotFoundException {
+        cx.evaluateString(scope, "load('testsrc/assert.js');", "init.js", 1, null);
+        cx.evaluateString(scope, createScript, "create.js", 1, null);
+        cx.evaluateString(scope, testScript, "test.js", 1, null);
+        Object testObj = ScriptableObject.getProperty(scope, "TESTOBJ");
+        assertNotNull(testObj);
+        Object newTestObj = serializeLoop(testObj);
+        ScriptableObject.putProperty(scope, "TESTOBJ", newTestObj);
+        cx.evaluateString(scope, testScript, "test.js", 1, null);
+    }
+
+    private static Object[][] getTestCases() {
+        return new Object[][] {
+                {"Map",
+                "TESTOBJ = new Map();\n" +
+                        "TESTOBJ.set('testing', '123');",
+                "assertNotNull(TESTOBJ.get('testing'));\n" +
+                        "assertEquals('123', TESTOBJ.get('testing'));"}
+        };
+    }
+
+    private Object serializeLoop(Object obj) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(outBuf);
+        out.writeObject(obj);
+        out.close();
+        ByteArrayInputStream inBuf = new ByteArrayInputStream(outBuf.toByteArray());
+        ObjectInputStream in = new ObjectInputStream(inBuf);
+        return in.readObject();
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
@@ -23,7 +23,7 @@ public class NativeSerializationTest {
     @BeforeEach
     public void init() {
         cx = Context.enter();
-        //cx.setInterpretedMode(true);
+        // cx.setInterpretedMode(true);
         scope = new Global(cx);
     }
 
@@ -33,47 +33,35 @@ public class NativeSerializationTest {
     }
 
     private static Object[][] getTestCases() {
-        return new Object[][]{
-                /*{
-                        "String",
-                        "TESTOBJ = 'testing';",
-                        "assertEquals('testing', TESTOBJ);"
-                },
-                {
-                        "Number",
-                        "TESTOBJ = Number(123);",
-                        "assertEquals(123, TESTOBJ);"
-                },
-                {
-                        "Boolean",
-                        "TESTOBJ = Boolean(true);",
-                        "assertEquals(true, TESTOBJ);"
-                },*/
-                {
-                        "Symbol",
-                        "TESTOBJ = Symbol('test');",
-                        "assertEquals('Symbol(test)', TESTOBJ.toString());"
-                },
-                /*{
-                        "Symbol Registry",
-                        "TESTOBJ = Symbol.for('test');",
-                        "assertEquals(Symbol.for('test'), TESTOBJ);"
-                },
-                /*{
-                        "Object",
-                        "TESTOBJ = {a: 1, b: 'two', c: {a: 3}}",
-                        "assertEquals(1, TESTOBJ.a);\nassertEquals('two', TESTOBJ.b);\nassertEquals(3, TESTOBJ.c.a);"
-                },
-                {
-                        "Map",
-                        "TESTOBJ = new Map();\nTESTOBJ.set('testing', '123');",
-                        "assertEquals('123', TESTOBJ.get('testing'));"
-                },
-                {
-                        "Set",
-                        "TESTOBJ = new Set();\nTESTOBJ.add('testing');",
-                        "assertTrue(TESTOBJ.has('testing'));"
-                }*/
+        return new Object[][] {
+            {"String", "TESTOBJ = 'testing';", "assertEquals('testing', TESTOBJ);"},
+            {"Number", "TESTOBJ = Number(123);", "assertEquals(123, TESTOBJ);"},
+            {"Boolean", "TESTOBJ = Boolean(true);", "assertEquals(true, TESTOBJ);"},
+            {
+                "Symbol",
+                "TESTOBJ = Symbol('test');",
+                "assertEquals('Symbol(test)', TESTOBJ.toString());"
+            },
+            /*{
+                    "Symbol Registry",
+                    "TESTOBJ = Symbol.for('test');",
+                    "assertEquals(Symbol.for('test'), TESTOBJ);"
+            },*/
+            {
+                "Object",
+                "TESTOBJ = {a: 1, b: 'two', c: {a: 3}};",
+                "assertEquals(1, TESTOBJ.a);\nassertEquals('two', TESTOBJ.b);\nassertEquals(3, TESTOBJ.c.a);"
+            },
+            {
+                "Map",
+                "TESTOBJ = new Map();\nTESTOBJ.set('testing', '123');",
+                "assertEquals('123', TESTOBJ.get('testing'));"
+            },
+            {
+                "Set",
+                "TESTOBJ = new Set();\nTESTOBJ.add('testing');",
+                "assertTrue(TESTOBJ.has('testing'));"
+            }
         };
     }
 


### PR DESCRIPTION
Create new interfaces and change existing ones so that native classes based on LambdaConstructor and LambdaFunction can be serialized. Even though serialization is an old and complex part of Java that should not be used in modern apps, many existing code relies on it, as does Rhino's continuation mechanism, which means that if we want to rebuild many of the native classes using lambdas, we need serialization to work.

This adds some new interfaces to make this possible, and fortunately does not require major changes other than that. It also adds a set of tests so that we can ensure that key native classes are serializable as we continue to make changes.