### PR TITLE
Fixed problems with hoisting

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -499,10 +499,26 @@ public final class IRFactory {
         }
         try {
             List<Node> kids = new ArrayList<>();
+            /*
+            Function declarations inside blocks (FUNCTION_EXPRESSION_STATEMENTS) should be
+            hoisted at the top of block so that they can be referred by statements above them
+             */
+            List<Node> functions = new ArrayList<>();
+
             for (Node kid : node) {
-                kids.add(transform((AstNode) kid));
+                if (kid instanceof FunctionNode
+                        && ((FunctionNode) kid).getFunctionType()
+                                == FunctionNode.FUNCTION_EXPRESSION_STATEMENT) {
+                    functions.add(transform((AstNode) kid));
+                } else {
+                    kids.add(transform((AstNode) kid));
+                }
             }
             node.removeChildren();
+
+            for (Node function : functions) {
+                node.addChildToBack(function);
+            }
             for (Node kid : kids) {
                 node.addChildToBack(kid);
             }

--- a/rhino/src/main/java/org/mozilla/javascript/ast/AstNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/AstNode.java
@@ -584,6 +584,8 @@ public abstract class AstNode extends Node implements Comparable<AstNode> {
                 buffer.append(" ").append(((Name) node).getIdentifier());
             } else if (tt == Token.STRING) {
                 buffer.append(" ").append(((StringLiteral) node).getValue(true));
+            } else if (tt == Token.FUNCTION) {
+                buffer.append(" functionType=").append(((FunctionNode) node).getFunctionType());
             }
             buffer.append("\n");
             return true; // process kids

--- a/rhino/src/test/java/org/mozilla/javascript/HoistingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/HoistingTest.java
@@ -1,0 +1,237 @@
+package org.mozilla.javascript;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mozilla.javascript.tests.Utils;
+
+public class HoistingTest {
+    @Test
+    public void hoistedFunctionCallTryCatchShouldNotThrowReferenceError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; \n"
+                        + "   try {\n"
+                        + "       r = _add(2, 3);\n"
+                        + "       function _add(a, b) { return a + b; }\n"
+                        + "   } catch(err) {\n"
+                        + "       throw err;\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    public void functionCallTryCatchExprStmt() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r = 1; \n"
+                        + "   if (r == 1) {\n"
+                        + "       function _add(a, b) { return a + b; };\n"
+                        + "       return _add(5, 4);\n"
+                        + "   }\n"
+                        + "   return _add(2, 3);\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(9, script);
+    }
+
+    @Test
+    public void hoistedFunctionShouldShadowFunctionWithTheSameName() {
+        String script =
+                ""
+                        + "function g() {\n"
+                        + "    result = '';\n"
+                        + "    result += f();\n"
+                        + "\n"
+                        + "    function f() {\n"
+                        + "        return 1;\n"
+                        + "    }\n"
+                        + "\n"
+                        + "    do {\n"
+                        + "        result += f();\n"
+                        + "\n"
+                        + "        function f() {\n"
+                        + "            return 0;\n"
+                        + "        }\n"
+                        + "    } while (0);\n"
+                        + "\n"
+                        + "    result += f();\n"
+                        + "    return result;\n"
+                        + "}\n"
+                        + "\n"
+                        + "g()";
+        Utils.assertWithAllModes_ES6("100", script);
+    }
+
+    @Test
+    public void hoistedFunctionCallDoWhileShouldNotThrowReferenceError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; \n"
+                        + "   do {\n"
+                        + "       r = _add(2, 3);\n"
+                        + "       function _add(a, b) { return a + b; }\n"
+                        + "   } while(0) {\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    public void hoistedFunctionCallBlockShouldNotThrowReferenceError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; \n"
+                        + "   {\n"
+                        + "       r = _add(2, 3);\n"
+                        + "       function _add(a, b) { return a + b; }\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    public void hoistedFunctionCallForLoopShouldNotThrowReferenceError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; \n"
+                        + "   for (var i = 0; i<1; i++) {\n"
+                        + "       r = _add(2, 3);\n"
+                        + "       function _add(a, b) { return a + b; }\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    public void hoistedFunctionCallIfShouldNotThrowReferenceError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; var i = 0; \n"
+                        + "   if (i<1) {\n"
+                        + "       r = _add(2, 3);\n"
+                        + "       function _add(a, b) { return a + b; }\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    @Ignore("switch-doesnt-open-a-block")
+    public void hoistedFunctionCallSwitchShouldNotThrowReferenceError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; var i = 0; \n"
+                        + "   switch(i) {\n"
+                        + "       case 0:"
+                        + "         r = _add(2, 3);\n"
+                        + "       default:\n"
+                        + "         function _add(a, b) { return a + b; }\n"
+                        + "         break;\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    public void hoistedFunctionCallShouldNotThrowUndefinedErrorNoNestedScope() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "  var r; \n"
+                        + "  r = _add(2, 3);\n"
+                        + "  function _add(a, b) { return a + b; }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertWithAllModes_ES6(5, script);
+    }
+
+    @Test
+    public void hoistedFunctionExpressionCallShouldThrowUndefinedError() {
+        String script =
+                ""
+                        + "var result = test();\n"
+                        + "function test() {\n"
+                        + "   var r; \n"
+                        + "   try {\n"
+                        + "       r = _add(2, 3);\n"
+                        + "       var _add = function(a, b) { return a + b; }\n"
+                        + "   } catch(err) {\n"
+                        + "       throw err;\n"
+                        + "   }\n"
+                        + "  return r;\n"
+                        + "}\n"
+                        + "result";
+        Utils.assertJavaScriptException_ES6(
+                "TypeError: _add is not a function, it is undefined. (test#8)", script);
+    }
+
+    @Test
+    public void hoistedReferenceShouldNotThrowReferenceError() {
+        Utils.runWithAllModes(
+                (cx) -> {
+                    int languageVersion = cx.getLanguageVersion();
+                    try {
+                        cx.setLanguageVersion(Context.VERSION_ES6);
+                        Scriptable scope = cx.initStandardObjects();
+                        String script =
+                                ""
+                                        + "var arr_obj = [];\n"
+                                        + "test();\n"
+                                        + "function test() {\n"
+                                        + "try {\n"
+                                        + "    arr_obj.push({test: \"a\", key: 6});\n"
+                                        + "    arr_obj.push({test: \"b\", key: 3});\n"
+                                        + "    arr_obj.push({test: \"c\", key: 5});\n"
+                                        + "    arr_obj.sort(_sortByKey);\n"
+                                        + "    function _sortByKey(a, b) {\n"
+                                        + "      return a.key - b.key;\n"
+                                        + "    }\n"
+                                        + "} catch(err) {\n"
+                                        + "    throw err;\n"
+                                        + "}\n"
+                                        + "}\n"
+                                        + "\n"
+                                        + "arr_obj";
+                        Object result = cx.evaluateString(scope, script, "hoistedRef", 1, null);
+                        Assert.assertTrue(result instanceof NativeArray);
+                        Assert.assertEquals(3, ((NativeArray) result).size());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        Assert.fail();
+                    } finally {
+                        cx.setLanguageVersion(languageVersion);
+                    }
+                    return null;
+                });
+    }
+}

--- a/testutils/src/main/java/org/mozilla/javascript/tests/Utils.java
+++ b/testutils/src/main/java/org/mozilla/javascript/tests/Utils.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
@@ -279,6 +280,46 @@ public class Utils {
      */
     public static void assertEcmaError_1_8(final String expectedMessage, final String script) {
         assertException(Context.VERSION_1_8, EcmaError.class, expectedMessage, script);
+    }
+
+    /**
+     * Execute the provided script and assert an {@link org.mozilla.javascript.JavaScriptException}.
+     * The error message of the {@link org.mozilla.javascript.JavaScriptException} has to start with
+     * the provided expectedMessage.
+     *
+     * @param expectedMessage the expected result
+     * @param script the javascript script to execute
+     */
+    public static void assertJavaScriptException(
+            final String expectedMessage, final String script) {
+        assertException(-1, JavaScriptException.class, expectedMessage, script);
+    }
+
+    /**
+     * Execute the provided script and assert an {@link JavaScriptException}. The error message of
+     * the {@link JavaScriptException} has to start with the provided expectedMessage. Before the
+     * execution the language version is set to {@link Context#VERSION_1_8}.
+     *
+     * @param expectedMessage the expected result
+     * @param script the javascript script to execute
+     */
+    public static void assertJavaScriptException_1_8(
+            final String expectedMessage, final String script) {
+        assertException(Context.VERSION_1_8, JavaScriptException.class, expectedMessage, script);
+    }
+
+    /**
+     * Execute the provided script and assert an {@link org.mozilla.javascript.JavaScriptException}.
+     * The error message of the {@link org.mozilla.javascript.JavaScriptException} has to start with
+     * the provided expectedMessage. Before the execution the language version is set to {@link
+     * Context#VERSION_1_8}.
+     *
+     * @param expectedMessage the expected result
+     * @param script the javascript script to execute
+     */
+    public static void assertJavaScriptException_ES6(
+            final String expectedMessage, final String script) {
+        assertException(Context.VERSION_ES6, JavaScriptException.class, expectedMessage, script);
     }
 
     /**


### PR DESCRIPTION
This PR fixes some problems with function hoisting in nested scopes. Consider this:

```js
function outer() {
  inner();

  function inner() {}
  do {
    inBlock();
    function inBlock() {} 
  } while (false);

  var expr = function() {}
}
```

The hoisting rules say that this is sorta equivalent to:

```js
function outer() {
  // Hoisting declaraitons
  var inner;
  var inBlock;
  var expr;
  inner = function inner() {}

  inner();

  do {
    // Hoisting
    inBlock = function inBlock() {} 

    inBlock();
  } while (false);

  expr = function() {}
}
```

Rhino correctly handles hoisting at the top level of the function (i.e. for `inner`), but it does not handle it correctly for nested blocks (i.e. for `inBlock`). So in the example above, the following exception gets thrown:

```
TypeError: inBlock is not a function, it is undefined
```

This PR fixes the problem. The trick is that, whenever the IR for a block is generated, nested functions are hoisted on top of it.