### PR TITLE
Add missing copy to fix ArrayIndexOutOfBoundException when invoke captureContinuation

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -233,6 +233,7 @@ public final class Interpreter extends Icode implements Evaluator {
             if (length > stack.length) {
                 stack = Arrays.copyOf(stack, length);
                 sDbl = Arrays.copyOf(sDbl, length);
+                stackAttributes = Arrays.copyOf(stackAttributes, length);
                 // TODO: adjust idata idata.itsMaxFrameArray & idata.itsMaxStack so they start with
                 // larger stacks next time? Not clear this is always a good idea.
             }


### PR DESCRIPTION
In the `captureContinuation` method, `stack` and `stackAttribute` are considered to be the same length. The `ensureStackLength` method does not copy `stackAttributes` with the new length, so calling `captureContinuation` after this will throw an ArrayIndexOutOfBoundException. I updated my project to use v1.8.0 and found this issue so I fixed it and create this pr.