### PR TITLE
Make all service loading static

### DIFF
--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -16,8 +16,8 @@ module org.mozilla.rhino {
     uses org.mozilla.javascript.RegExpProxy;
     uses org.mozilla.javascript.xml.XMLLoader;
 
-    provides org.mozilla.javascript.RegExpProxy with
-            org.mozilla.javascript.regexp.RegExpImpl;
+    provides org.mozilla.javascript.RegExpLoader with
+            org.mozilla.javascript.regexp.RegExpLoaderImpl;
 
     requires java.compiler;
     requires jdk.dynalink;

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -35,7 +35,6 @@ import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.debug.DebuggableScript;
 import org.mozilla.javascript.debug.Debugger;
 import org.mozilla.javascript.xml.XMLLib;
-import org.mozilla.javascript.xml.XMLLoader;
 
 /**
  * This class represents the runtime context of an executing script.
@@ -387,6 +386,9 @@ public class Context implements Closeable {
 
     public static final String languageVersionProperty = "language version";
     public static final String errorReporterProperty = "error reporter";
+
+    private static final RegExpLoader regExpLoader =
+            ScriptRuntime.loadOneServiceImplementation(RegExpLoader.class);
 
     /**
      * Convenient value to use as zero-length array of objects.
@@ -2327,9 +2329,8 @@ public class Context implements Closeable {
      */
     @Deprecated
     public XMLLib.Factory getE4xImplementationFactory() {
-        XMLLoader loader = ScriptRuntime.loadOneServiceImplementation(XMLLoader.class);
-        if (loader != null) {
-            return loader.getFactory();
+        if (ScriptRuntime.xmlLoaderImpl != null) {
+            return ScriptRuntime.xmlLoaderImpl.getFactory();
         }
         return null;
     }
@@ -2690,8 +2691,8 @@ public class Context implements Closeable {
     }
 
     RegExpProxy getRegExpProxy() {
-        if (regExpProxy == null) {
-            regExpProxy = ScriptRuntime.loadOneServiceImplementation(RegExpProxy.class);
+        if (regExpProxy == null && regExpLoader != null) {
+            regExpProxy = regExpLoader.newProxy();
         }
         return regExpProxy;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -34,6 +34,9 @@ final class MemberBox implements Serializable {
     transient Function asSetterFunction;
     transient Object delegateTo;
 
+    private static final NullabilityDetector nullDetector =
+            ScriptRuntime.loadOneServiceImplementation(NullabilityDetector.class);
+
     MemberBox(Method method) {
         init(method);
     }
@@ -45,24 +48,20 @@ final class MemberBox implements Serializable {
     private void init(Method method) {
         this.memberObject = method;
         this.argTypes = method.getParameterTypes();
-        NullabilityDetector detector =
-                ScriptRuntime.loadOneServiceImplementation(NullabilityDetector.class);
         this.argNullability =
-                detector == null
+                nullDetector == null
                         ? new boolean[method.getParameters().length]
-                        : detector.getParameterNullability(method);
+                        : nullDetector.getParameterNullability(method);
         this.vararg = method.isVarArgs();
     }
 
     private void init(Constructor<?> constructor) {
         this.memberObject = constructor;
         this.argTypes = constructor.getParameterTypes();
-        NullabilityDetector detector =
-                ScriptRuntime.loadOneServiceImplementation(NullabilityDetector.class);
         this.argNullability =
-                detector == null
+                nullDetector == null
                         ? new boolean[constructor.getParameters().length]
-                        : detector.getParameterNullability(constructor);
+                        : nullDetector.getParameterNullability(constructor);
         this.vararg = constructor.isVarArgs();
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpLoader.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpLoader.java
@@ -1,0 +1,7 @@
+package org.mozilla.javascript;
+
+/** This interface is used to load the RegExp implementation from the classpath. */
+public interface RegExpLoader {
+    // Create a new instance of a RegExpProxy
+    RegExpProxy newProxy();
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -202,9 +202,8 @@ public class ScriptRuntime {
                 scope, "Continuation", "org.mozilla.javascript.NativeContinuation", sealed, true);
 
         if (cx.hasFeature(Context.FEATURE_E4X)) {
-            XMLLoader loader = loadOneServiceImplementation(XMLLoader.class);
-            if (loader != null) {
-                loader.load(scope, sealed);
+            if (xmlLoaderImpl != null) {
+                xmlLoaderImpl.load(scope, sealed);
             }
         }
 
@@ -5658,4 +5657,7 @@ public class ScriptRuntime {
 
     public static final Object[] emptyArgs = new Object[0];
     public static final String[] emptyStrings = new String[0];
+
+    static final XMLLoader xmlLoaderImpl =
+            ScriptRuntime.loadOneServiceImplementation(XMLLoader.class);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpLoaderImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpLoaderImpl.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript.regexp;
+
+import org.mozilla.javascript.RegExpLoader;
+import org.mozilla.javascript.RegExpProxy;
+
+/** This class loads the default RegExp implementation. */
+public class RegExpLoaderImpl implements RegExpLoader {
+    @Override
+    public RegExpProxy newProxy() {
+        return new RegExpImpl();
+    }
+}

--- a/rhino/src/main/resources/META-INF/services/org.mozilla.javascript.RegExpLoader
+++ b/rhino/src/main/resources/META-INF/services/org.mozilla.javascript.RegExpLoader
@@ -1,0 +1,1 @@
+org.mozilla.javascript.regexp.RegExpLoaderImpl

--- a/rhino/src/main/resources/META-INF/services/org.mozilla.javascript.RegExpProxy
+++ b/rhino/src/main/resources/META-INF/services/org.mozilla.javascript.RegExpProxy
@@ -1,1 +1,0 @@
-org.mozilla.javascript.regexp.RegExpImpl


### PR DESCRIPTION
This prevents the large performance regression of loading these classes from the classpath every time they are needed, and should cover existing use cases since all these features are designed to be configured statically by deciding which Rhino modules to use.

@rbri I didn't see a big regression in standard benchmarks like the V8 benchmarks but I could imagine that in a use case with a lot of reflection that things could be much worse. This should fix it, please take a look!