### PR TITLE
Load more classes lazily

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Initializable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Initializable.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+
+/**
+ * A single-function interface so that we can use lambda functions to lazily initialize native
+ * classes.
+ */
+public interface Initializable extends Serializable {
+    /** Initialize the class in question, returning the new constructor. */
+    Object initialize(Context cx, Scriptable scope, boolean sealed);
+}

--- a/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
@@ -22,34 +22,73 @@ public final class LazilyLoadedCtor implements Serializable {
     private static final int STATE_INITIALIZING = 1;
     private static final int STATE_WITH_VALUE = 2;
 
-    private final ScriptableObject scope;
+    private final Scriptable scope;
+    private final Initializable initializer;
     private final String propertyName;
-    private final String className;
     private final boolean sealed;
     private final boolean privileged;
     private Object initializedValue;
     private int state;
 
+    /**
+     * Create a constructor using a lambda function. The lambda should initialize the new value
+     * however it needs and then return the value.
+     */
+    public LazilyLoadedCtor(
+            ScriptableObject scope,
+            String propertyName,
+            boolean sealed,
+            boolean privileged,
+            Initializable initializer) {
+        this.scope = scope;
+        this.propertyName = propertyName;
+        this.sealed = sealed;
+        this.privileged = privileged;
+        this.state = STATE_BEFORE_INIT;
+        this.initializer = initializer;
+
+        scope.addLazilyInitializedValue(propertyName, 0, this, ScriptableObject.DONTENUM);
+    }
+
+    /**
+     * Create a constructor using a lambda function. The lambda should initialize the new value
+     * however it needs and then return the value.
+     */
+    public LazilyLoadedCtor(
+            ScriptableObject scope,
+            String propertyName,
+            boolean sealed,
+            Initializable initializer,
+            boolean privileged) {
+        this(scope, propertyName, sealed, privileged, initializer);
+    }
+
+    /**
+     * Create a constructor that loads via reflection, looking for an "init" method on the class.
+     * This is a legacy mechanism.
+     */
     public LazilyLoadedCtor(
             ScriptableObject scope, String propertyName, String className, boolean sealed) {
         this(scope, propertyName, className, sealed, false);
     }
 
+    /**
+     * Create a constructor that loads via reflection, looking for an "init" method on the class.
+     * This is a legacy mechanism.
+     */
     public LazilyLoadedCtor(
             ScriptableObject scope,
             String propertyName,
             String className,
             boolean sealed,
             boolean privileged) {
-
-        this.scope = scope;
-        this.propertyName = propertyName;
-        this.className = className;
-        this.sealed = sealed;
-        this.privileged = privileged;
-        this.state = STATE_BEFORE_INIT;
-
-        scope.addLazilyInitializedValue(propertyName, 0, this, ScriptableObject.DONTENUM);
+        this(
+                scope,
+                propertyName,
+                sealed,
+                privileged,
+                (Context lcx, Scriptable lscope, boolean lsealed) ->
+                        buildUsingReflection(lscope, className, propertyName, lsealed));
     }
 
     void init() {
@@ -77,19 +116,16 @@ public final class LazilyLoadedCtor implements Serializable {
     }
 
     private Object buildValue() {
+        Context cx = Context.getCurrentContext();
         if (privileged) {
             return AccessController.doPrivileged(
-                    new PrivilegedAction<Object>() {
-                        @Override
-                        public Object run() {
-                            return buildValue0();
-                        }
-                    });
+                    (PrivilegedAction<Object>) () -> initializer.initialize(cx, scope, sealed));
         }
-        return buildValue0();
+        return initializer.initialize(cx, scope, sealed);
     }
 
-    private Object buildValue0() {
+    private static Object buildUsingReflection(
+            Scriptable scope, String className, String propertyName, boolean sealed) {
         Class<? extends Scriptable> cl = cast(Kit.classOrNull(className));
         if (cl != null) {
             try {
@@ -106,10 +142,11 @@ public final class LazilyLoadedCtor implements Serializable {
                 if (target instanceof RuntimeException) {
                     throw (RuntimeException) target;
                 }
-            } catch (RhinoException ex) {
-            } catch (InstantiationException ex) {
-            } catch (IllegalAccessException ex) {
-            } catch (SecurityException ex) {
+            } catch (RhinoException
+                    | InstantiationException
+                    | IllegalAccessException
+                    | SecurityException ex) {
+                // Ignore, which is the legacy behavior
             }
         }
         return Scriptable.NOT_FOUND;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -17,7 +17,7 @@ final class NativeBigInt extends ScriptableObject {
 
     private final BigInteger bigIntValue;
 
-    static void init(Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -64,11 +64,10 @@ final class NativeBigInt extends ScriptableObject {
                 DONTENUM | READONLY);
         constructor.definePrototypeProperty(
                 SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     NativeBigInt(BigInteger bigInt) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
@@ -30,7 +30,7 @@ public final class NativeJSON extends ScriptableObject {
 
     private static final int MAX_STRINGIFY_GAP_LENGTH = 10;
 
-    static void init(Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         NativeJSON json = new NativeJSON();
         json.setPrototype(getObjectPrototype(scope));
         json.setParentScope(scope);
@@ -42,11 +42,10 @@ public final class NativeJSON extends ScriptableObject {
         json.defineProperty("toSource", "JSON", DONTENUM | READONLY | PERMANENT);
 
         json.defineProperty(SymbolKey.TO_STRING_TAG, JSON_TAG, DONTENUM | READONLY);
-
-        ScriptableObject.defineProperty(scope, JSON_TAG, json, DONTENUM);
         if (sealed) {
             json.sealObject();
         }
+        return json;
     }
 
     private NativeJSON() {}

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -18,7 +18,7 @@ public class NativeMap extends ScriptableObject {
 
     private boolean instanceOfMap = false;
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -135,11 +135,10 @@ public class NativeMap extends ScriptableObject {
                 SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, ScriptableObject.DONTENUM);
-
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
@@ -18,7 +18,7 @@ final class NativeMath extends ScriptableObject {
     private static final double LOG2E = 1.4426950408889634;
     private static final Double Double32 = Double.valueOf(32d);
 
-    static void init(Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         NativeMath math = new NativeMath();
         math.setPrototype(getObjectPrototype(scope));
         math.setParentScope(scope);
@@ -71,11 +71,10 @@ final class NativeMath extends ScriptableObject {
         math.defineProperty("SQRT2", 1.4142135623730951, DONTENUM | READONLY | PERMANENT);
 
         math.defineProperty(SymbolKey.TO_STRING_TAG, MATH_TAG, DONTENUM | READONLY);
-
-        ScriptableObject.defineProperty(scope, MATH_TAG, math, DONTENUM);
         if (sealed) {
             math.sealObject();
         }
+        return math;
     }
 
     private NativeMath() {}

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -27,7 +27,7 @@ public class NativePromise extends ScriptableObject {
     private ArrayList<Reaction> fulfillReactions = new ArrayList<>();
     private ArrayList<Reaction> rejectReactions = new ArrayList<>();
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -76,11 +76,10 @@ public class NativePromise extends ScriptableObject {
 
         constructor.definePrototypeProperty(
                 SymbolKey.TO_STRING_TAG, "Promise", DONTENUM | READONLY);
-
-        ScriptableObject.defineProperty(scope, "Promise", constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     private static Scriptable constructor(Context cx, Scriptable scope, Object[] args) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -57,7 +57,7 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
         }
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -80,11 +80,10 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
 
         constructor.defineConstructorMethod(
                 scope, "revocable", 2, NativeProxy::revocable, DONTENUM, DONTENUM | READONLY);
-
-        ScriptableObject.defineProperty(scope, PROXY_TAG, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     private NativeProxy(ScriptableObject target, Scriptable handler) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -19,7 +19,7 @@ final class NativeReflect extends ScriptableObject {
 
     private static final String REFLECT_TAG = "Reflect";
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         NativeReflect reflect = new NativeReflect();
         reflect.setPrototype(getObjectPrototype(scope));
         reflect.setParentScope(scope);
@@ -84,11 +84,10 @@ final class NativeReflect extends ScriptableObject {
                 DONTENUM | READONLY);
 
         reflect.defineProperty(SymbolKey.TO_STRING_TAG, REFLECT_TAG, DONTENUM | READONLY);
-
-        ScriptableObject.defineProperty(scope, REFLECT_TAG, reflect, DONTENUM);
         if (sealed) {
             reflect.sealObject();
         }
+        return reflect;
     }
 
     private NativeReflect() {}

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -17,7 +17,7 @@ public class NativeSet extends ScriptableObject {
 
     private boolean instanceOfSet = false;
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -116,11 +116,10 @@ public class NativeSet extends ScriptableObject {
                 SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, ScriptableObject.DONTENUM);
-
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
@@ -29,7 +29,7 @@ public class NativeWeakMap extends ScriptableObject {
 
     private static final Object NULL_VALUE = new Object();
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -79,11 +79,10 @@ public class NativeWeakMap extends ScriptableObject {
                 SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, ScriptableObject.DONTENUM);
-
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
@@ -25,7 +25,7 @@ public class NativeWeakSet extends ScriptableObject {
 
     private transient WeakHashMap<Scriptable, Boolean> map = new WeakHashMap<>();
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -64,11 +64,10 @@ public class NativeWeakSet extends ScriptableObject {
                 SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, ScriptableObject.DONTENUM);
-
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -242,15 +242,15 @@ public class ScriptRuntime {
             NativeSymbol.init(cx, scope, sealed);
             NativeCollectionIterator.init(scope, NativeSet.ITERATOR_TAG, sealed);
             NativeCollectionIterator.init(scope, NativeMap.ITERATOR_TAG, sealed);
-            NativeMap.init(cx, scope, sealed);
-            NativePromise.init(cx, scope, sealed);
-            NativeSet.init(cx, scope, sealed);
-            NativeWeakMap.init(cx, scope, sealed);
-            NativeWeakSet.init(cx, scope, sealed);
+            new LazilyLoadedCtor(scope, "Map", sealed, true, NativeMap::init);
+            new LazilyLoadedCtor(scope, "Promise", sealed, true, NativePromise::init);
+            new LazilyLoadedCtor(scope, "Set", sealed, true, NativeSet::init);
+            new LazilyLoadedCtor(scope, "WeakMap", sealed, true, NativeWeakMap::init);
+            new LazilyLoadedCtor(scope, "WeakSet", sealed, true, NativeWeakSet::init);
+            // Will convert when this is converted to lambdas
             NativeBigInt.init(scope, sealed);
-
-            NativeProxy.init(cx, scope, sealed);
-            NativeReflect.init(cx, scope, sealed);
+            new LazilyLoadedCtor(scope, "Proxy", sealed, true, NativeProxy::init);
+            new LazilyLoadedCtor(scope, "Reflect", sealed, true, NativeReflect::init);
         }
 
         if (scope instanceof TopLevel) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -22,6 +22,17 @@ import java.util.ServiceLoader;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
+import org.mozilla.javascript.typedarrays.NativeDataView;
+import org.mozilla.javascript.typedarrays.NativeFloat32Array;
+import org.mozilla.javascript.typedarrays.NativeFloat64Array;
+import org.mozilla.javascript.typedarrays.NativeInt16Array;
+import org.mozilla.javascript.typedarrays.NativeInt32Array;
+import org.mozilla.javascript.typedarrays.NativeInt8Array;
+import org.mozilla.javascript.typedarrays.NativeUint16Array;
+import org.mozilla.javascript.typedarrays.NativeUint32Array;
+import org.mozilla.javascript.typedarrays.NativeUint8Array;
+import org.mozilla.javascript.typedarrays.NativeUint8ClampedArray;
 import org.mozilla.javascript.v8dtoa.DoubleConversion;
 import org.mozilla.javascript.v8dtoa.FastDtoa;
 import org.mozilla.javascript.xml.XMLLib;
@@ -198,6 +209,8 @@ public class ScriptRuntime {
         NativeJavaMap.init(scope, sealed);
 
         // define lazy-loaded properties using their class name
+        // Depends on the old reflection-based lazy loading mechanism
+        // to property initialize the prototype.
         new LazilyLoadedCtor(
                 scope, "Continuation", "org.mozilla.javascript.NativeContinuation", sealed, true);
 
@@ -211,72 +224,18 @@ public class ScriptRuntime {
         if (((cx.getLanguageVersion() >= Context.VERSION_1_8)
                         && cx.hasFeature(Context.FEATURE_V8_EXTENSIONS))
                 || (cx.getLanguageVersion() >= Context.VERSION_ES6)) {
+            new LazilyLoadedCtor(scope, "ArrayBuffer", sealed, true, NativeArrayBuffer::init);
+            new LazilyLoadedCtor(scope, "Int8Array", sealed, true, NativeInt8Array::init);
+            new LazilyLoadedCtor(scope, "Uint8Array", sealed, true, NativeUint8Array::init);
             new LazilyLoadedCtor(
-                    scope,
-                    "ArrayBuffer",
-                    "org.mozilla.javascript.typedarrays.NativeArrayBuffer",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Int8Array",
-                    "org.mozilla.javascript.typedarrays.NativeInt8Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Uint8Array",
-                    "org.mozilla.javascript.typedarrays.NativeUint8Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Uint8ClampedArray",
-                    "org.mozilla.javascript.typedarrays.NativeUint8ClampedArray",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Int16Array",
-                    "org.mozilla.javascript.typedarrays.NativeInt16Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Uint16Array",
-                    "org.mozilla.javascript.typedarrays.NativeUint16Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Int32Array",
-                    "org.mozilla.javascript.typedarrays.NativeInt32Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Uint32Array",
-                    "org.mozilla.javascript.typedarrays.NativeUint32Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Float32Array",
-                    "org.mozilla.javascript.typedarrays.NativeFloat32Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "Float64Array",
-                    "org.mozilla.javascript.typedarrays.NativeFloat64Array",
-                    sealed,
-                    true);
-            new LazilyLoadedCtor(
-                    scope,
-                    "DataView",
-                    "org.mozilla.javascript.typedarrays.NativeDataView",
-                    sealed,
-                    true);
+                    scope, "Uint8ClampedArray", sealed, true, NativeUint8ClampedArray::init);
+            new LazilyLoadedCtor(scope, "Int16Array", sealed, true, NativeInt16Array::init);
+            new LazilyLoadedCtor(scope, "Uint16Array", sealed, true, NativeUint16Array::init);
+            new LazilyLoadedCtor(scope, "Int32Array", sealed, true, NativeInt32Array::init);
+            new LazilyLoadedCtor(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
+            new LazilyLoadedCtor(scope, "Float32Array", sealed, true, NativeFloat32Array::init);
+            new LazilyLoadedCtor(scope, "Float64Array", sealed, true, NativeFloat64Array::init);
+            new LazilyLoadedCtor(scope, "DataView", sealed, true, NativeDataView::init);
         }
 
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
@@ -312,6 +271,7 @@ public class ScriptRuntime {
             Context cx, ScriptableObject scope, boolean sealed) {
         ScriptableObject s = initSafeStandardObjects(cx, scope, sealed);
 
+        // These depend on the legacy initialization behavior of the lazy loading mechanism
         new LazilyLoadedCtor(
                 s, "Packages", "org.mozilla.javascript.NativeJavaTopPackage", sealed, true);
         new LazilyLoadedCtor(

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -192,8 +192,8 @@ public class ScriptRuntime {
         NativeBoolean.init(scope, sealed);
         NativeNumber.init(scope, sealed);
         NativeDate.init(scope, sealed);
-        NativeMath.init(scope, sealed);
-        NativeJSON.init(scope, sealed);
+        new LazilyLoadedCtor(scope, "Math", sealed, true, NativeMath::init);
+        new LazilyLoadedCtor(scope, "JSON", sealed, true, NativeJSON::init);
 
         NativeWith.init(scope, sealed);
         NativeCall.init(scope, sealed);
@@ -247,8 +247,7 @@ public class ScriptRuntime {
             new LazilyLoadedCtor(scope, "Set", sealed, true, NativeSet::init);
             new LazilyLoadedCtor(scope, "WeakMap", sealed, true, NativeWeakMap::init);
             new LazilyLoadedCtor(scope, "WeakSet", sealed, true, NativeWeakSet::init);
-            // Will convert when this is converted to lambdas
-            NativeBigInt.init(scope, sealed);
+            new LazilyLoadedCtor(scope, "BigInt", sealed, true, NativeBigInt::init);
             new LazilyLoadedCtor(scope, "Proxy", sealed, true, NativeProxy::init);
             new LazilyLoadedCtor(scope, "Reflect", sealed, true, NativeReflect::init);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -33,7 +33,7 @@ public class NativeArrayBuffer extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -56,10 +56,10 @@ public class NativeArrayBuffer extends ScriptableObject {
         constructor.definePrototypeProperty(
                 cx, "byteLength", NativeArrayBuffer::js_byteLength, DONTENUM | READONLY);
 
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     /** Create an empty buffer. */

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -37,7 +36,7 @@ public class NativeDataView extends NativeArrayBufferView {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -208,10 +207,10 @@ public class NativeDataView extends NativeArrayBufferView {
                 DONTENUM,
                 DONTENUM | READONLY);
 
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     private static int determinePos(Object[] args) {

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
@@ -11,7 +11,6 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -39,7 +38,7 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -61,11 +60,10 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
                 "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
@@ -11,7 +11,6 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -39,7 +38,7 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -61,11 +60,10 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
                 "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -38,7 +37,7 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -60,11 +59,10 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
                 "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
@@ -11,7 +11,6 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -39,7 +38,7 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -61,11 +60,10 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
                 "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -37,7 +36,7 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -54,11 +53,10 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
                 "BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -38,7 +37,7 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -60,11 +59,10 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
                 "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -38,7 +37,7 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -60,11 +59,10 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
                 "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -37,7 +36,7 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -54,11 +53,10 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
                 "BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -39,7 +38,7 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -56,11 +55,10 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
                 "BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
         }
+        return constructor;
     }
 
     @Override


### PR DESCRIPTION
With the switch to LambdaConstructor-based native classes, initialization time for Rhino goes up because those classes create so many properties. This PR updates our lazy loading mechanism so that there's a less-complicated way to do it without using reflection, and loads many more classes this way.