### PR TITLE
Introduce ordered slot map to eventually replace EmbeddedSlotMap

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
@@ -2,7 +2,6 @@ package org.mozilla.javascript.benchmarks;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-
 import org.mozilla.javascript.*;
 import org.openjdk.jmh.annotations.*;
 
@@ -172,7 +171,7 @@ public class SlotMapBenchmark {
     public Object orderedInsert1Key(OrderedState state) {
         Slot newSlot = null;
         for (int i = 0; i < 100; i++) {
-            newSlot = state.emptyMap.modify(state.randomKeys[i], 0, 0);
+            newSlot = state.emptyMap.modify(null, state.randomKeys[i], 0, 0);
         }
         if (newSlot == null) {
             throw new AssertionError();

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/SlotMapBenchmark.java
@@ -2,10 +2,8 @@ package org.mozilla.javascript.benchmarks;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import org.mozilla.javascript.EmbeddedSlotMap;
-import org.mozilla.javascript.HashSlotMap;
-import org.mozilla.javascript.Slot;
-import org.mozilla.javascript.SlotMap;
+
+import org.mozilla.javascript.*;
 import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -133,6 +131,71 @@ public class SlotMapBenchmark {
     @Benchmark
     @OperationsPerInvocation(100)
     public Object hashQueryKey100Entries(HashState state) {
+        Slot slot = null;
+        for (int i = 0; i < 100; i++) {
+            slot = state.size100Map.query(state.size100LastKey, 0);
+        }
+        if (slot == null) {
+            throw new AssertionError();
+        }
+        return slot;
+    }
+
+    @State(Scope.Thread)
+    public static class OrderedState {
+        final OrderedSlotMap emptyMap = new OrderedSlotMap();
+        final OrderedSlotMap size10Map = new OrderedSlotMap();
+        final OrderedSlotMap size100Map = new OrderedSlotMap();
+        final String[] randomKeys = new String[100];
+        String size100LastKey;
+        String size10LastKey;
+
+        @Setup(Level.Trial)
+        public void create() {
+            String lastKey = null;
+            for (int i = 0; i < 10; i++) {
+                lastKey = insertRandomEntry(size10Map);
+            }
+            size10LastKey = lastKey;
+            for (int i = 0; i < 100; i++) {
+                lastKey = insertRandomEntry(size100Map);
+            }
+            size100LastKey = lastKey;
+            for (int i = 0; i < 100; i++) {
+                randomKeys[i] = makeRandomString();
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object orderedInsert1Key(OrderedState state) {
+        Slot newSlot = null;
+        for (int i = 0; i < 100; i++) {
+            newSlot = state.emptyMap.modify(state.randomKeys[i], 0, 0);
+        }
+        if (newSlot == null) {
+            throw new AssertionError();
+        }
+        return newSlot;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object orderedQueryKey10Entries(OrderedState state) {
+        Slot slot = null;
+        for (int i = 0; i < 100; i++) {
+            slot = state.size10Map.query(state.size10LastKey, 0);
+        }
+        if (slot == null) {
+            throw new AssertionError();
+        }
+        return slot;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(100)
+    public Object orderedQueryKey100Entries(OrderedState state) {
         Slot slot = null;
         for (int i = 0; i < 100; i++) {
             slot = state.size100Map.query(state.size100LastKey, 0);

--- a/rhino/src/main/java/org/mozilla/javascript/OrderedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/OrderedSlotMap.java
@@ -1,0 +1,227 @@
+package org.mozilla.javascript;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+public class OrderedSlotMap implements SlotMap {
+    private Slot[] slots;
+    private int slotCount;
+    private Entry[] map;
+    private int count;
+
+    // initial slot array size, must be a power of 2
+    private static final int INITIAL_SLOT_SIZE = 4;
+    // Sentinel for deletions
+    private static final Slot DELETED_SLOT = new Slot(null, 0, 0);
+
+    @Override
+    public int size() {
+        return count;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return count == 0;
+    }
+
+    @Override
+    public Slot query(Object key, int index) {
+        if (map == null) {
+            return null;
+        }
+
+        int indexOrHash = (key != null ? key.hashCode() : index);
+        int slotIndex = getSlotIndex(map.length, indexOrHash);
+        for (Entry e = map[slotIndex]; e != null; e = e.next) {
+            if (indexOrHash == e.indexOrHash && Objects.equals(e.key, key)) {
+                return e.slot;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Slot modify(Object key, int index, int attributes) {
+        final int indexOrHash = (key != null ? key.hashCode() : index);
+        Entry e;
+
+        if (map != null) {
+            int slotIndex = getSlotIndex(map.length, indexOrHash);
+            for (e = map[slotIndex]; e != null; e = e.next) {
+                if (indexOrHash == e.indexOrHash && Objects.equals(e.key, key)) {
+                    break;
+                }
+            }
+            if (e != null) {
+                return e.slot;
+            }
+        }
+
+        // A new slot has to be inserted.
+        Slot newSlot = new Slot(key, index, attributes);
+        createNewSlot(newSlot);
+        return newSlot;
+    }
+
+    @Override
+    public <S extends Slot> S compute(Object key, int index, SlotComputer<S> c) {
+        final int indexOrHash = (key != null ? key.hashCode() : index);
+
+        if (map != null) {
+            Entry e;
+            int slotIndex = getSlotIndex(map.length, indexOrHash);
+            Entry prev = map[slotIndex];
+            Slot slot = null;
+            for (e = prev; e != null; e = e.next) {
+                if (indexOrHash == e.indexOrHash && Objects.equals(e.key, key)) {
+                    slot = e.slot;
+                    break;
+                }
+                prev = e;
+            }
+            if (e != null) {
+                assert(slot != null);
+                // Modify or remove existing slot
+                S newSlot = c.compute(key, index, slot);
+                if (newSlot == null) {
+                    // Need to delete this slot actually
+                    removeSlot(e, prev, slotIndex, key);
+                } else if (!Objects.equals(slot, newSlot)) {
+                    // Replace slot in the list
+                    e.slot = newSlot;
+                    slots[e.slotIx] = newSlot;
+                }
+                return newSlot;
+            }
+        }
+
+        // If we get here, we know we are potentially adding a new slot
+        S newSlot = c.compute(key, index, null);
+        if (newSlot != null) {
+            createNewSlot(newSlot);
+        }
+        return newSlot;
+    }
+
+    @Override
+    public void add(Slot newSlot) {
+        if (map == null) {
+            map = new Entry[INITIAL_SLOT_SIZE];
+        }
+        insertNewSlot(newSlot);
+    }
+
+    @Override
+    public Iterator<Slot> iterator() {
+        return new Itr();
+    }
+
+    private void createNewSlot(Slot newSlot) {
+        if (count == 0) {
+            // Always throw away old slots if any on empty insert.
+            map = new Entry[INITIAL_SLOT_SIZE];
+        }
+
+        // Check if the table is not too full before inserting.
+        if (4 * (count + 1) > 3 * map.length) {
+            // table size must be a power of 2 -- always grow by x2!
+            Entry[] newMap = new Entry[map.length * 2];
+            copyTable(map, newMap);
+            map = newMap;
+        }
+
+        insertNewSlot(newSlot);
+    }
+
+    private void insertNewSlot(Slot newSlot) {
+        ++count;
+        if (slots == null) {
+            slots = new Slot[INITIAL_SLOT_SIZE];
+        } else if (slotCount == slots.length) {
+            Slot[] newSlots = new Slot[slots.length * 2];
+            System.arraycopy(slots, 0, newSlots, 0, slots.length);
+            slots = newSlots;
+        }
+        slots[slotCount] = newSlot;
+        Entry e = new Entry();
+        e.slotIx = slotCount;
+        e.slot = newSlot;
+        e.indexOrHash = newSlot.indexOrHash;
+        e.key = newSlot.name;
+        slotCount++;
+        addKnownAbsentSlot(map, e);
+    }
+
+    private void removeSlot(Entry e, Entry prev, int ix, Object key) {
+        count--;
+        // remove slot from hash table
+        if (prev == e) {
+            map[ix] = e.next;
+        } else {
+            prev.next = e.next;
+        }
+
+        // Mark missing in slot list -- will add GC later
+        slots[e.slotIx] = DELETED_SLOT;
+    }
+
+    private static void copyTable(Entry[] oldMap, Entry[] newMap) {
+        for (Entry e : oldMap) {
+            while (e != null) {
+                Entry nextEntry = e.next;
+                addKnownAbsentSlot(newMap, e);
+                e = nextEntry;
+            }
+        }
+    }
+
+    /**
+     * Add slot with keys that are known to absent from the table. This is an optimization to use
+     * when inserting into empty table, after table growth or during deserialization.
+     */
+    private static void addKnownAbsentSlot(Entry[] map, Entry e) {
+        int insertPos = getSlotIndex(map.length, e.indexOrHash);
+        e.next = map[insertPos];
+        map[insertPos] = e;
+    }
+
+    private static int getSlotIndex(int tableSize, int indexOrHash) {
+        // This is a Java trick to efficiently "mod" the hash code by the table size.
+        // It only works if the table size is a power of 2.
+        // The performance improvement is measurable.
+        return indexOrHash & (tableSize - 1);
+    }
+
+    private final class Itr implements Iterator<Slot> {
+        private int pos;
+
+        @Override
+        public boolean hasNext() {
+            while (pos < slotCount && slots[pos] == DELETED_SLOT) {
+                pos++;
+            }
+            return pos < slotCount;
+        }
+
+        @Override
+        public Slot next() {
+            while (pos < slotCount && slots[pos] == DELETED_SLOT) {
+                pos++;
+            }
+            if (pos < slotCount) {
+                return slots[pos];
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+    }
+
+    private static final class Entry {
+        int indexOrHash;
+        int slotIx;
+        Object key;
+        Entry next;
+        Slot slot;
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/Slot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Slot.java
@@ -16,8 +16,9 @@ public class Slot implements Serializable {
     int indexOrHash;
     private short attributes;
     Object value;
-    transient Slot next; // next in hash table bucket
-    transient Slot orderedNext; // next in linked list
+    transient Slot next; // next in hash table bucket for EmbeddedSlotMap only
+    transient Slot orderedNext; // next in linked list for EmbeddedSlotMap only
+    transient int orderedPos; // Position in the array for OrderedSlotMap only
 
     Slot(Object name, int index, int attributes) {
         this.name = name;

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -201,7 +201,7 @@ public abstract class SlotMapOwner {
             if (owner == null) {
                 throw new IllegalStateException();
             } else {
-                var newMap = new EmbeddedSlotMap();
+                var newMap = new OrderedSlotMap();
                 owner.setMap(newMap);
                 newMap.add(owner, slot);
                 newMap.add(owner, newSlot);
@@ -211,7 +211,7 @@ public abstract class SlotMapOwner {
         @Override
         public <S extends Slot> S compute(
                 SlotMapOwner owner, Object key, int index, SlotComputer<S> c) {
-            var newMap = new EmbeddedSlotMap();
+            var newMap = new OrderedSlotMap();
             owner.setMap(newMap);
             newMap.add(owner, slot);
             return newMap.compute(owner, key, index, c);
@@ -287,7 +287,7 @@ public abstract class SlotMapOwner {
         } else if (initialSize > LARGE_HASH_SIZE) {
             return new HashSlotMap();
         } else {
-            return new EmbeddedSlotMap();
+            return new OrderedSlotMap();
         }
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
@@ -49,6 +49,7 @@ public class SlotMapTest {
                         () -> SlotMapOwner.EMPTY_SLOT_MAP,
                         () -> new SlotMapOwner.SingleEntrySlotMap(new Slot(new Object(), 0, 0)),
                         () -> new EmbeddedSlotMap(),
+                        () -> new OrderedSlotMap(),
                         () -> new HashSlotMap(),
                         () -> SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP,
                         () ->


### PR DESCRIPTION
This is a new SlotMap implementation that can replace EmbeddedSlotMap. It works just like the embedded slot map but for two things:

* Slots are kept in an array rather than in a linked list
* Deleted slots are replaced in the array with a sentinel
* In the unlikely case that there are more than 10 deletes in the lifetime of the slot map, promote this map back to a HashSlotMap

This should not have a significant impact on performance yet. However it has two advantages for the future:

1) By making the object graph less complicated, it might make GC perform better. @aardvark179 I'd be really interested to see if this change improves anything in your environment
2) This opens up the possibility of a future optimization in compiled mode, because when we have the same property of the same object accessed at a given call site, we can replace the entire hash table operation with a direct array lookup
3) In theory, if we implemented a "property map" like V8 has we could possibly expand that optimization even more