### PR TITLE
Convert `NativeObject` from `IdScriptableObject` to lambda constructor.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -505,9 +505,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
             sb.append(getFunctionName());
             sb.append("() {\n\t");
         }
-        sb.append("[native code, arity=");
-        sb.append(getArity());
-        sb.append("]\n");
+        sb.append("[native code]\n");
         if (!justbody) {
             sb.append("}\n");
         }

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -391,7 +391,8 @@ public class BaseFunction extends IdScriptableObject implements Function {
                                 ((NativeFunction) ((BoundFunction) thisObj).getTargetFunction())
                                         .getPrototypeProperty();
                     else protoProp = ScriptableObject.getProperty(thisObj, "prototype");
-                    if (protoProp instanceof IdScriptableObject) {
+                    if (protoProp instanceof NativeObject
+                            || protoProp instanceof IdScriptableObject) {
                         return ScriptRuntime.jsDelegatesTo(obj, (Scriptable) protoProp);
                     }
                     throw ScriptRuntime.typeErrorById(

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
@@ -42,8 +42,7 @@ public abstract class ES6Iterator extends IdScriptableObject {
         this.tag = tag;
         Scriptable top = ScriptableObject.getTopLevelScope(scope);
         this.setParentScope(top);
-        IdScriptableObject prototype =
-                (IdScriptableObject) ScriptableObject.getTopScopeValue(top, tag);
+        ScriptableObject prototype = (ScriptableObject) ScriptableObject.getTopScopeValue(top, tag);
         setPrototype(prototype);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -26,6 +26,7 @@ public class EmbeddedSlotMap implements SlotMap {
     private Slot lastAdded;
 
     private int count;
+    private boolean hasIndex = false;
 
     // initial slot array size, must be a power of 2
     private static final int INITIAL_SLOT_SIZE = 4;
@@ -79,7 +80,7 @@ public class EmbeddedSlotMap implements SlotMap {
     /** Locate the slot with the given name or index. */
     @Override
     public Slot query(Object key, int index) {
-        if (slots == null) {
+        if (slots == null || (key == null && !hasIndex)) {
             return null;
         }
 
@@ -231,6 +232,7 @@ public class EmbeddedSlotMap implements SlotMap {
             firstAdded = newSlot;
         }
         lastAdded = newSlot;
+        if (newSlot.name == null) hasIndex = true;
         addKnownAbsentSlot(slots, newSlot);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -8,8 +8,6 @@
 
 package org.mozilla.javascript;
 
-import java.util.EnumSet;
-
 public class IdFunctionObject extends BaseFunction {
     private static final long serialVersionUID = -5332312783643935019L;
 
@@ -95,28 +93,6 @@ public class IdFunctionObject extends BaseFunction {
         // To follow current (2003-05-01) SpiderMonkey behavior, change it to:
         // return super.createObject(cx, scope);
         throw ScriptRuntime.typeErrorById("msg.not.ctor", functionName);
-    }
-
-    @Override
-    String decompile(int indent, EnumSet<DecompilerFlag> flags) {
-        StringBuilder sb = new StringBuilder();
-        boolean justbody = flags.contains(DecompilerFlag.ONLY_BODY);
-        if (!justbody) {
-            sb.append("function ");
-            sb.append(getFunctionName());
-            sb.append("() { ");
-        }
-        sb.append("[native code for ");
-        if (idcall instanceof Scriptable) {
-            Scriptable sobj = (Scriptable) idcall;
-            sb.append(sobj.getClassName());
-            sb.append('.');
-        }
-        sb.append(getFunctionName());
-        sb.append(", arity=");
-        sb.append(getArity());
-        sb.append(justbody ? "]\n" : "] }\n");
-        return sb.toString();
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -181,6 +181,24 @@ public class LambdaConstructor extends LambdaFunction {
         proto.defineProperty(name, f, attributes);
     }
 
+    /**
+     * Define a function property on the prototype of the constructor using a LambdaFunction under
+     * the covers.
+     */
+    public void definePrototypeMethod(
+            Scriptable scope,
+            String name,
+            int length,
+            Object prototype,
+            SerializableCallable target,
+            int attributes,
+            int propertyAttributes) {
+        LambdaFunction f = new LambdaFunction(scope, name, length, prototype, target);
+        f.setStandardPropertyAttributes(propertyAttributes);
+        ScriptableObject proto = getPrototypeScriptable();
+        proto.defineProperty(name, f, attributes);
+    }
+
     /** Define a property that may be of any type on the prototype of this constructor. */
     public void definePrototypeProperty(String name, Object value, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
@@ -302,6 +320,24 @@ public class LambdaConstructor extends LambdaFunction {
             int attributes,
             int propertyAttributes) {
         LambdaFunction f = new LambdaFunction(scope, name, length, target);
+        f.setStandardPropertyAttributes(propertyAttributes);
+        defineProperty(name, f, attributes);
+    }
+
+    /**
+     * Define a function property directly on the constructor that is implemented under the covers
+     * by a LambdaFunction, and override the properties of its "name", "length", "arity", and
+     * "protoyupe" properties.
+     */
+    public void defineConstructorMethod(
+            Scriptable scope,
+            String name,
+            int length,
+            Object prototype,
+            SerializableCallable target,
+            int attributes,
+            int propertyAttributes) {
+        LambdaFunction f = new LambdaFunction(scope, name, length, prototype, target);
         f.setStandardPropertyAttributes(propertyAttributes);
         defineProperty(name, f, attributes);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
@@ -38,6 +38,30 @@ public class LambdaFunction extends BaseFunction {
         setupDefaultPrototype();
     }
 
+    /**
+     * Create a new function. The new object will have the Function prototype and no parent. The
+     * caller is responsible for binding this object to the appropriate scope.
+     *
+     * @param scope scope of the calling context
+     * @param name name of the function
+     * @param length the arity of the function
+     * @param prototype prototype to set for this function
+     * @param target an object that implements the function in Java. Since Callable is a
+     *     single-function interface this will typically be implemented as a lambda.
+     */
+    public LambdaFunction(
+            Scriptable scope,
+            String name,
+            int length,
+            Object prototype,
+            SerializableCallable target) {
+        this.target = target;
+        this.name = name;
+        this.length = length;
+        ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
+        setPrototypeProperty(prototype);
+    }
+
     /** Create a new built-in function, with no name, and no default prototype. */
     public LambdaFunction(Scriptable scope, int length, SerializableCallable target) {
         this.target = target;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -24,14 +24,256 @@ import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
  *
  * @author Norris Boyd
  */
-public class NativeObject extends IdScriptableObject implements Map {
+public class NativeObject extends ScriptableObject implements Map {
     private static final long serialVersionUID = -6345305608474346996L;
 
     private static final Object OBJECT_TAG = "Object";
+    private static final String CLASS_NAME = "Object";
 
     static void init(Scriptable scope, boolean sealed) {
-        NativeObject obj = new NativeObject();
-        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+        LambdaConstructor constructor =
+                new LambdaConstructor(
+                        scope,
+                        CLASS_NAME,
+                        1,
+                        NativeObject::js_constructorCall,
+                        NativeObject::js_constructor) {
+                    @Override
+                    public Scriptable construct(Context cx, Scriptable scope, Object[] args) {
+                        return js_constructor(cx, scope, args);
+                    }
+                };
+        constructor.defineConstructorMethod(
+                scope,
+                "getPrototypeOf",
+                1,
+                null,
+                NativeObject::js_getPrototypeOf,
+                DONTENUM,
+                DONTENUM | READONLY);
+        if (Context.getCurrentContext().version >= Context.VERSION_ES6) {
+            constructor.defineConstructorMethod(
+                    scope,
+                    "setPrototypeOf",
+                    2,
+                    null,
+                    NativeObject::js_setPrototypeOf,
+                    DONTENUM,
+                    DONTENUM | READONLY);
+            constructor.defineConstructorMethod(
+                    scope,
+                    "entries",
+                    1,
+                    null,
+                    NativeObject::js_entries,
+                    DONTENUM,
+                    DONTENUM | READONLY);
+            constructor.defineConstructorMethod(
+                    scope,
+                    "fromEntries",
+                    1,
+                    null,
+                    NativeObject::js_fromEntries,
+                    DONTENUM,
+                    DONTENUM | READONLY);
+            constructor.defineConstructorMethod(
+                    scope,
+                    "values",
+                    1,
+                    null,
+                    NativeObject::js_values,
+                    DONTENUM,
+                    DONTENUM | READONLY);
+            constructor.defineConstructorMethod(
+                    scope,
+                    "hasOwn",
+                    1,
+                    null,
+                    NativeObject::js_hasOwn,
+                    DONTENUM,
+                    DONTENUM | READONLY);
+        }
+        constructor.defineConstructorMethod(
+                scope, "keys", 1, null, NativeObject::js_keys, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "getOwnPropertyNames",
+                1,
+                null,
+                NativeObject::js_getOwnPropertyNames,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "getOwnPropertySymbols",
+                1,
+                null,
+                NativeObject::js_getOwnPropertySymbols,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "getOwnPropertyDescriptor",
+                2,
+                null,
+                NativeObject::js_getOwnPropertyDescriptor,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "getOwnPropertyDescriptors",
+                1,
+                null,
+                NativeObject::js_getOwnPropertyDescriptors,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "defineProperty",
+                3,
+                null,
+                NativeObject::js_defineProperty,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "isExtensible",
+                1,
+                null,
+                NativeObject::js_isExtensible,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "preventExtensions",
+                1,
+                null,
+                NativeObject::js_preventExtensions,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "defineProperties",
+                2,
+                null,
+                NativeObject::js_defineProperties,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "create", 2, null, NativeObject::js_create, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "isSealed",
+                1,
+                null,
+                NativeObject::js_isSealed,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope,
+                "isFrozen",
+                1,
+                null,
+                NativeObject::js_isFrozen,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "seal", 1, null, NativeObject::js_seal, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "freeze", 1, null, NativeObject::js_freeze, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "assign", 2, null, NativeObject::js_assign, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "is", 2, null, NativeObject::js_is, DONTENUM, DONTENUM | READONLY);
+        constructor.defineConstructorMethod(
+                scope, "groupBy", 2, null, NativeObject::js_groupBy, DONTENUM, DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "toString",
+                0,
+                null,
+                NativeObject::js_toString,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "toLocaleString",
+                0,
+                null,
+                NativeObject::js_toLocaleString,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "__lookupGetter__",
+                1,
+                null,
+                NativeObject::js_lookupGetter,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "__lookupSetter__",
+                1,
+                null,
+                NativeObject::js_lookupSetter,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "__defineGetter__",
+                2,
+                null,
+                NativeObject::js_defineGetter,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "__defineSetter__",
+                2,
+                null,
+                NativeObject::js_defineSetter,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "hasOwnProperty",
+                1,
+                null,
+                NativeObject::js_hasOwnProperty,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "propertyIsEnumerable",
+                1,
+                null,
+                NativeObject::js_propertyIsEnumerable,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope, "valueOf", 0, null, NativeObject::js_valueOf, DONTENUM, DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "isPrototypeOf",
+                1,
+                null,
+                NativeObject::js_isPrototypeOf,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.definePrototypeMethod(
+                scope,
+                "toSource",
+                0,
+                null,
+                ScriptRuntime::defaultObjectToSource,
+                DONTENUM,
+                DONTENUM | READONLY);
+        constructor.setPrototypePropertyAttributes(PERMANENT | READONLY | DONTENUM);
+        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
+        if (sealed) {
+            constructor.sealObject();
+        }
     }
 
     @Override
@@ -44,200 +286,19 @@ public class NativeObject extends IdScriptableObject implements Map {
         return ScriptRuntime.defaultObjectToString(this);
     }
 
-    @SuppressWarnings("resource")
-    @Override
-    protected void fillConstructorProperties(IdFunctionObject ctor) {
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_getPrototypeOf, "getPrototypeOf", 1);
-        if (Context.getCurrentContext().version >= Context.VERSION_ES6) {
-            addIdFunctionProperty(
-                    ctor, OBJECT_TAG, ConstructorId_setPrototypeOf, "setPrototypeOf", 2);
-            addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_entries, "entries", 1);
-            addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_fromEntries, "fromEntries", 1);
-            addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_values, "values", 1);
-            addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_hasOwn, "hasOwn", 1);
+    private static Scriptable js_constructorCall(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (args.length == 0 || args[0] == null || Undefined.isUndefined(args[0])) {
+            return cx.newObject(scope);
         }
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_keys, "keys", 1);
-        addIdFunctionProperty(
-                ctor, OBJECT_TAG, ConstructorId_getOwnPropertyNames, "getOwnPropertyNames", 1);
-        addIdFunctionProperty(
-                ctor, OBJECT_TAG, ConstructorId_getOwnPropertySymbols, "getOwnPropertySymbols", 1);
-        addIdFunctionProperty(
-                ctor,
-                OBJECT_TAG,
-                ConstructorId_getOwnPropertyDescriptor,
-                "getOwnPropertyDescriptor",
-                2);
-        addIdFunctionProperty(
-                ctor,
-                OBJECT_TAG,
-                ConstructorId_getOwnPropertyDescriptors,
-                "getOwnPropertyDescriptors",
-                1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_defineProperty, "defineProperty", 3);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isExtensible, "isExtensible", 1);
-        addIdFunctionProperty(
-                ctor, OBJECT_TAG, ConstructorId_preventExtensions, "preventExtensions", 1);
-        addIdFunctionProperty(
-                ctor, OBJECT_TAG, ConstructorId_defineProperties, "defineProperties", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_create, "create", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isSealed, "isSealed", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_isFrozen, "isFrozen", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_seal, "seal", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_freeze, "freeze", 1);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_assign, "assign", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_is, "is", 2);
-        addIdFunctionProperty(ctor, OBJECT_TAG, ConstructorId_groupBy, "groupBy", 2);
-        super.fillConstructorProperties(ctor);
+        return ScriptRuntime.toObject(cx, scope, args[0]);
     }
 
-    @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        switch (id) {
-            case Id_constructor:
-                arity = 1;
-                s = "constructor";
-                break;
-            case Id_toString:
-                arity = 0;
-                s = "toString";
-                break;
-            case Id_toLocaleString:
-                arity = 0;
-                s = "toLocaleString";
-                break;
-            case Id_valueOf:
-                arity = 0;
-                s = "valueOf";
-                break;
-            case Id_hasOwnProperty:
-                arity = 1;
-                s = "hasOwnProperty";
-                break;
-            case Id_propertyIsEnumerable:
-                arity = 1;
-                s = "propertyIsEnumerable";
-                break;
-            case Id_isPrototypeOf:
-                arity = 1;
-                s = "isPrototypeOf";
-                break;
-            case Id_toSource:
-                arity = 0;
-                s = "toSource";
-                break;
-            case Id___defineGetter__:
-                arity = 2;
-                s = "__defineGetter__";
-                break;
-            case Id___defineSetter__:
-                arity = 2;
-                s = "__defineSetter__";
-                break;
-            case Id___lookupGetter__:
-                arity = 1;
-                s = "__lookupGetter__";
-                break;
-            case Id___lookupSetter__:
-                arity = 1;
-                s = "__lookupSetter__";
-                break;
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
+    private static Scriptable js_constructor(Context cx, Scriptable scope, Object[] args) {
+        if (args.length == 0 || args[0] == null || Undefined.isUndefined(args[0])) {
+            return cx.newObject(scope);
         }
-        initPrototypeMethod(OBJECT_TAG, id, s, arity);
-    }
-
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(OBJECT_TAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
-        }
-        int id = f.methodId();
-        switch (id) {
-            case Id_constructor:
-                {
-                    if (thisObj != null) {
-                        // BaseFunction.construct will set up parent, proto
-                        return f.construct(cx, scope, args);
-                    }
-                    if (args.length == 0 || args[0] == null || Undefined.isUndefined(args[0])) {
-                        return cx.newObject(scope);
-                    }
-                    return ScriptRuntime.toObject(cx, scope, args[0]);
-                }
-
-            case Id_toLocaleString:
-                return js_toLocaleString(cx, scope, thisObj, args);
-            case Id_toString:
-                return js_toString(cx, scope, thisObj, args);
-            case Id_valueOf:
-                return js_valueOf(cx, scope, thisObj, args);
-            case Id_hasOwnProperty:
-                return js_hasOwnProperty(cx, scope, thisObj, args);
-            case Id_propertyIsEnumerable:
-                return js_propertyIsEnumerable(cx, scope, thisObj, args);
-            case Id_isPrototypeOf:
-                return js_isPrototypeOf(cx, scope, thisObj, args);
-            case Id_toSource:
-                return ScriptRuntime.defaultObjectToSource(cx, scope, thisObj, args);
-            case Id___defineGetter__:
-            case Id___defineSetter__:
-                return js_defineGetterOrSetter(cx, scope, id == Id___defineSetter__, thisObj, args);
-            case Id___lookupGetter__:
-            case Id___lookupSetter__:
-                return js_lookupGetterOrSetter(cx, scope, id == Id___lookupSetter__, thisObj, args);
-            case ConstructorId_getPrototypeOf:
-                return js_getPrototypeOf(cx, scope, thisObj, args);
-            case ConstructorId_setPrototypeOf:
-                return js_setPrototypeOf(cx, scope, thisObj, args);
-            case ConstructorId_keys:
-                return js_keys(cx, scope, thisObj, args);
-            case ConstructorId_entries:
-                return js_entries(cx, scope, thisObj, args);
-            case ConstructorId_fromEntries:
-                return js_fromEntries(cx, scope, thisObj, args);
-            case ConstructorId_values:
-                return js_values(cx, scope, thisObj, args);
-            case ConstructorId_hasOwn:
-                return js_hasOwn(cx, scope, thisObj, args);
-            case ConstructorId_getOwnPropertyNames:
-                return js_getOwnPropertyNames(cx, scope, thisObj, args);
-            case ConstructorId_getOwnPropertySymbols:
-                return js_getOwnPropertySymbols(cx, scope, thisObj, args);
-            case ConstructorId_getOwnPropertyDescriptor:
-                return js_getOwnPropertyDescriptor(cx, scope, thisObj, args);
-            case ConstructorId_getOwnPropertyDescriptors:
-                return js_getOwnPropertyDescriptors(cx, scope, thisObj, args);
-            case ConstructorId_defineProperty:
-                return js_defineProperty(cx, scope, thisObj, args);
-            case ConstructorId_isExtensible:
-                return js_isExtensible(cx, scope, thisObj, args);
-            case ConstructorId_preventExtensions:
-                return js_preventExtensions(cx, scope, thisObj, args);
-            case ConstructorId_defineProperties:
-                return js_defineProperties(cx, scope, thisObj, args);
-            case ConstructorId_create:
-                return js_create(cx, scope, thisObj, args);
-            case ConstructorId_isSealed:
-                return js_isSealed(cx, scope, thisObj, args);
-            case ConstructorId_isFrozen:
-                return js_isFrozen(cx, scope, thisObj, args);
-            case ConstructorId_seal:
-                return js_seal(cx, scope, thisObj, args);
-            case ConstructorId_freeze:
-                return js_freeze(cx, scope, thisObj, args);
-            case ConstructorId_assign:
-                return js_assign(cx, scope, thisObj, args);
-            case ConstructorId_is:
-                return js_is(cx, scope, thisObj, args);
-            case ConstructorId_groupBy:
-                return js_groupBy(cx, scope, thisObj, args);
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
+        return ScriptRuntime.toObject(cx, scope, args[0]);
     }
 
     private static Object js_toLocaleString(
@@ -359,6 +420,16 @@ public class NativeObject extends IdScriptableObject implements Map {
         return ScriptRuntime.wrapBoolean(result);
     }
 
+    private static Object js_defineGetter(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        return js_defineGetterOrSetter(cx, scope, false, thisObj, args);
+    }
+
+    private static Object js_defineSetter(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        return js_defineGetterOrSetter(cx, scope, true, thisObj, args);
+    }
+
     private static Object js_defineGetterOrSetter(
             Context cx, Scriptable scope, boolean isSetter, Scriptable thisObj, Object[] args) {
         if (args.length < 2 || !(args[1] instanceof Callable)) {
@@ -379,6 +450,16 @@ public class NativeObject extends IdScriptableObject implements Map {
         if (so instanceof NativeArray) ((NativeArray) so).setDenseOnly(false);
 
         return Undefined.instance;
+    }
+
+    private static Object js_lookupGetter(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        return js_lookupGetterOrSetter(cx, scope, false, thisObj, args);
+    }
+
+    private static Object js_lookupSetter(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        return js_lookupGetterOrSetter(cx, scope, true, thisObj, args);
     }
 
     private static Object js_lookupGetterOrSetter(
@@ -1070,53 +1151,6 @@ public class NativeObject extends IdScriptableObject implements Map {
         public int size() {
             return NativeObject.this.size();
         }
-    }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        int id;
-        switch (s) {
-            case "constructor":
-                id = Id_constructor;
-                break;
-            case "toString":
-                id = Id_toString;
-                break;
-            case "toLocaleString":
-                id = Id_toLocaleString;
-                break;
-            case "valueOf":
-                id = Id_valueOf;
-                break;
-            case "hasOwnProperty":
-                id = Id_hasOwnProperty;
-                break;
-            case "propertyIsEnumerable":
-                id = Id_propertyIsEnumerable;
-                break;
-            case "isPrototypeOf":
-                id = Id_isPrototypeOf;
-                break;
-            case "toSource":
-                id = Id_toSource;
-                break;
-            case "__defineGetter__":
-                id = Id___defineGetter__;
-                break;
-            case "__defineSetter__":
-                id = Id___defineSetter__;
-                break;
-            case "__lookupGetter__":
-                id = Id___lookupGetter__;
-                break;
-            case "__lookupSetter__":
-                id = Id___lookupSetter__;
-                break;
-            default:
-                id = 0;
-                break;
-        }
-        return id;
     }
 
     private static final int ConstructorId_getPrototypeOf = -1,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -273,6 +273,7 @@ public class NativeObject extends ScriptableObject implements Map {
         ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
+            ((NativeObject) constructor.getPrototypeProperty()).sealObject();
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -30,10 +30,10 @@ public class NativeObject extends ScriptableObject implements Map {
     private static final Object OBJECT_TAG = "Object";
     private static final String CLASS_NAME = "Object";
 
-    static void init(Scriptable scope, boolean sealed) {
-        LambdaConstructor constructor =
+    static void init(Scriptable s, boolean sealed) {
+        LambdaConstructor ctor =
                 new LambdaConstructor(
-                        scope,
+                        s,
                         CLASS_NAME,
                         1,
                         NativeObject::js_constructorCall,
@@ -43,238 +43,71 @@ public class NativeObject extends ScriptableObject implements Map {
                         return js_constructor(cx, scope, args);
                     }
                 };
-        constructor.defineConstructorMethod(
-                scope,
-                "getPrototypeOf",
-                1,
-                null,
-                NativeObject::js_getPrototypeOf,
-                DONTENUM,
-                DONTENUM | READONLY);
+
+        defOnCtor(ctor, s, "getPrototypeOf", 1, NativeObject::js_getPrototypeOf);
         if (Context.getCurrentContext().version >= Context.VERSION_ES6) {
-            constructor.defineConstructorMethod(
-                    scope,
-                    "setPrototypeOf",
-                    2,
-                    null,
-                    NativeObject::js_setPrototypeOf,
-                    DONTENUM,
-                    DONTENUM | READONLY);
-            constructor.defineConstructorMethod(
-                    scope,
-                    "entries",
-                    1,
-                    null,
-                    NativeObject::js_entries,
-                    DONTENUM,
-                    DONTENUM | READONLY);
-            constructor.defineConstructorMethod(
-                    scope,
-                    "fromEntries",
-                    1,
-                    null,
-                    NativeObject::js_fromEntries,
-                    DONTENUM,
-                    DONTENUM | READONLY);
-            constructor.defineConstructorMethod(
-                    scope,
-                    "values",
-                    1,
-                    null,
-                    NativeObject::js_values,
-                    DONTENUM,
-                    DONTENUM | READONLY);
-            constructor.defineConstructorMethod(
-                    scope,
-                    "hasOwn",
-                    1,
-                    null,
-                    NativeObject::js_hasOwn,
-                    DONTENUM,
-                    DONTENUM | READONLY);
+            defOnCtor(ctor, s, "setPrototypeOf", 2, NativeObject::js_setPrototypeOf);
+            defOnCtor(ctor, s, "entries", 1, NativeObject::js_entries);
+            defOnCtor(ctor, s, "fromEntries", 1, NativeObject::js_fromEntries);
+            defOnCtor(ctor, s, "values", 1, NativeObject::js_values);
+            defOnCtor(ctor, s, "hasOwn", 1, NativeObject::js_hasOwn);
         }
-        constructor.defineConstructorMethod(
-                scope, "keys", 1, null, NativeObject::js_keys, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "getOwnPropertyNames",
-                1,
-                null,
-                NativeObject::js_getOwnPropertyNames,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "getOwnPropertySymbols",
-                1,
-                null,
-                NativeObject::js_getOwnPropertySymbols,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "getOwnPropertyDescriptor",
-                2,
-                null,
-                NativeObject::js_getOwnPropertyDescriptor,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "getOwnPropertyDescriptors",
-                1,
-                null,
-                NativeObject::js_getOwnPropertyDescriptors,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "defineProperty",
-                3,
-                null,
-                NativeObject::js_defineProperty,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "isExtensible",
-                1,
-                null,
-                NativeObject::js_isExtensible,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "preventExtensions",
-                1,
-                null,
-                NativeObject::js_preventExtensions,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "defineProperties",
-                2,
-                null,
-                NativeObject::js_defineProperties,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "create", 2, null, NativeObject::js_create, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "isSealed",
-                1,
-                null,
-                NativeObject::js_isSealed,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "isFrozen",
-                1,
-                null,
-                NativeObject::js_isFrozen,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "seal", 1, null, NativeObject::js_seal, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "freeze", 1, null, NativeObject::js_freeze, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "assign", 2, null, NativeObject::js_assign, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "is", 2, null, NativeObject::js_is, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "groupBy", 2, null, NativeObject::js_groupBy, DONTENUM, DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "toString",
-                0,
-                null,
-                NativeObject::js_toString,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "toLocaleString",
-                0,
-                null,
-                NativeObject::js_toLocaleString,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "__lookupGetter__",
-                1,
-                null,
-                NativeObject::js_lookupGetter,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "__lookupSetter__",
-                1,
-                null,
-                NativeObject::js_lookupSetter,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "__defineGetter__",
-                2,
-                null,
-                NativeObject::js_defineGetter,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "__defineSetter__",
-                2,
-                null,
-                NativeObject::js_defineSetter,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "hasOwnProperty",
-                1,
-                null,
-                NativeObject::js_hasOwnProperty,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "propertyIsEnumerable",
-                1,
-                null,
-                NativeObject::js_propertyIsEnumerable,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope, "valueOf", 0, null, NativeObject::js_valueOf, DONTENUM, DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "isPrototypeOf",
-                1,
-                null,
-                NativeObject::js_isPrototypeOf,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.definePrototypeMethod(
-                scope,
-                "toSource",
-                0,
-                null,
-                ScriptRuntime::defaultObjectToSource,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.setPrototypePropertyAttributes(PERMANENT | READONLY | DONTENUM);
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
+        defOnCtor(ctor, s, "keys", 1, NativeObject::js_keys);
+        defOnCtor(ctor, s, "getOwnPropertyNames", 1, NativeObject::js_getOwnPropertyNames);
+        defOnCtor(ctor, s, "getOwnPropertySymbols", 1, NativeObject::js_getOwnPropertySymbols);
+        defOnCtor(ctor, s, "getOwnPropertyDescriptor", 2, NativeObject::js_getOwnPropDesc);
+        defOnCtor(ctor, s, "getOwnPropertyDescriptors", 1, NativeObject::js_getOwnPropDescs);
+        defOnCtor(ctor, s, "defineProperty", 3, NativeObject::js_defineProperty);
+        defOnCtor(ctor, s, "isExtensible", 1, NativeObject::js_isExtensible);
+        defOnCtor(ctor, s, "preventExtensions", 1, NativeObject::js_preventExtensions);
+        defOnCtor(ctor, s, "defineProperties", 2, NativeObject::js_defineProperties);
+        defOnCtor(ctor, s, "create", 2, NativeObject::js_create);
+        defOnCtor(ctor, s, "isSealed", 1, NativeObject::js_isSealed);
+        defOnCtor(ctor, s, "isFrozen", 1, NativeObject::js_isFrozen);
+        defOnCtor(ctor, s, "seal", 1, NativeObject::js_seal);
+        defOnCtor(ctor, s, "freeze", 1, NativeObject::js_freeze);
+        defOnCtor(ctor, s, "assign", 2, NativeObject::js_assign);
+        defOnCtor(ctor, s, "is", 2, NativeObject::js_is);
+        defOnCtor(ctor, s, "groupBy", 2, NativeObject::js_groupBy);
+
+        defOnProto(ctor, s, "toString", 0, NativeObject::js_toString);
+        defOnProto(ctor, s, "toLocaleString", 0, NativeObject::js_toLocaleString);
+        defOnProto(ctor, s, "__lookupGetter__", 1, NativeObject::js_lookupGetter);
+        defOnProto(ctor, s, "__lookupSetter__", 1, NativeObject::js_lookupSetter);
+        defOnProto(ctor, s, "__defineGetter__", 2, NativeObject::js_defineGetter);
+        defOnProto(ctor, s, "__defineSetter__", 2, NativeObject::js_defineSetter);
+        defOnProto(ctor, s, "hasOwnProperty", 1, NativeObject::js_hasOwnProperty);
+        defOnProto(ctor, s, "propertyIsEnumerable", 1, NativeObject::js_propertyIsEnumerable);
+        defOnProto(ctor, s, "valueOf", 0, NativeObject::js_valueOf);
+        defOnProto(ctor, s, "isPrototypeOf", 1, NativeObject::js_isPrototypeOf);
+        defOnProto(ctor, s, "toSource", 0, ScriptRuntime::defaultObjectToSource);
+
+        ctor.setPrototypePropertyAttributes(PERMANENT | READONLY | DONTENUM);
+        ScriptableObject.defineProperty(s, CLASS_NAME, ctor, DONTENUM);
         if (sealed) {
-            constructor.sealObject();
-            ((NativeObject) constructor.getPrototypeProperty()).sealObject();
+            ctor.sealObject();
+            ((NativeObject) ctor.getPrototypeProperty()).sealObject();
         }
+    }
+
+    private static void defOnCtor(
+            LambdaConstructor constructor,
+            Scriptable scope,
+            String name,
+            int length,
+            SerializableCallable target) {
+        constructor.defineConstructorMethod(
+                scope, name, length, null, target, DONTENUM, DONTENUM | READONLY);
+    }
+
+    private static void defOnProto(
+            LambdaConstructor constructor,
+            Scriptable scope,
+            String name,
+            int length,
+            SerializableCallable target) {
+        constructor.definePrototypeMethod(
+                scope, name, length, null, target, DONTENUM, DONTENUM | READONLY);
     }
 
     @Override
@@ -659,7 +492,7 @@ public class NativeObject extends ScriptableObject implements Map {
         return cx.newArray(scope, syms.toArray());
     }
 
-    private static Object js_getOwnPropertyDescriptor(
+    private static Object js_getOwnPropDesc(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         // TODO(norris): There's a deeper issue here if
@@ -672,7 +505,7 @@ public class NativeObject extends ScriptableObject implements Map {
         return desc == null ? Undefined.instance : desc;
     }
 
-    private static Object js_getOwnPropertyDescriptors(
+    private static Object js_getOwnPropDescs(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s = getCompatibleObject(cx, scope, arg);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -45,9 +45,7 @@ public class LookupSetterTest {
 
     @Test
     public void lookedUpGetter_toString() throws Exception {
-        test(
-                "function s() {\n\t[native code, arity=0]\n}\n",
-                "new Foo().__lookupGetter__('s').toString()");
+        test("function s() {\n\t[native code]\n}\n", "new Foo().__lookupGetter__('s').toString()");
     }
 
     @Test
@@ -86,9 +84,7 @@ public class LookupSetterTest {
 
     @Test
     public void lookedUpSetter_toString() throws Exception {
-        test(
-                "function s() {\n\t[native code, arity=0]\n}\n",
-                "new Foo().__lookupSetter__('s').toString()");
+        test("function s() {\n\t[native code]\n}\n", "new Foo().__lookupSetter__('s').toString()");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -8,7 +8,7 @@ public class NativeProxyTest {
     @Test
     public void testToString() {
         Utils.assertWithAllModes_ES6(
-                "function Proxy() {\n\t[native code, arity=2]\n}\n", "Proxy.toString()");
+                "function Proxy() {\n\t[native code]\n}\n", "Proxy.toString()");
 
         Utils.assertWithAllModes_ES6(
                 "[object Object]", "Object.prototype.toString.call(new Proxy({}, {}))");

--- a/tests/testsrc/doctests/array.every.doctest
+++ b/tests/testsrc/doctests/array.every.doctest
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> Array.every;
-function every() { [native code for Array.every, arity=1] }
+function every() {
+	[native code]
+}
 
 js> function isSmall(n) { return n < 10; };
 

--- a/tests/testsrc/doctests/array.filter.doctest
+++ b/tests/testsrc/doctests/array.filter.doctest
@@ -5,13 +5,17 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [1, 13, 4, 16, 42].filter;
-function filter() { [native code for Array.filter, arity=1] }
+function filter() {
+	[native code]
+}
 
 js> "" + [1, 13, 4, 16, 42].filter(isSmall);
 1,4
 
 js> Array.filter;
-function filter() { [native code for Array.filter, arity=1] }
+function filter() {
+	[native code]
+}
 
 js> "" + Array.filter([1, 13, 4, 16, 42], isSmall);
 1,4

--- a/tests/testsrc/doctests/array.find.doctest
+++ b/tests/testsrc/doctests/array.find.doctest
@@ -5,13 +5,17 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [13, 4, 17].find;
-function find() { [native code for Array.find, arity=1] }
+function find() {
+	[native code]
+}
 
 js> [13, 4, 17].find(isSmall);
 4
 
 js> Array.find;
-function find() { [native code for Array.find, arity=1] }
+function find() {
+	[native code]
+}
 
 js> res = '';
 js> Array.find([13, 4, 17], isSmall);

--- a/tests/testsrc/doctests/array.findIndex.doctest
+++ b/tests/testsrc/doctests/array.findIndex.doctest
@@ -5,13 +5,17 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [13, 4, 17].findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
+function findIndex() {
+	[native code]
+}
 
 js> [13, 4, 17].findIndex(isSmall);
 1
 
 js> Array.findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
+function findIndex() {
+	[native code]
+}
 
 js> Array.findIndex([13, 4, 17], isSmall);
 1

--- a/tests/testsrc/doctests/array.forEach.doctest
+++ b/tests/testsrc/doctests/array.forEach.doctest
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> [1, 13, 4].forEach;
-function forEach() { [native code for Array.forEach, arity=1] }
+function forEach() {
+	[native code]
+}
 
 js> res = '';
 js> [1, 13, 4].forEach(function(elem) { res += elem });
@@ -11,7 +13,9 @@ js> res
 1134
 
 js> Array.forEach;
-function forEach() { [native code for Array.forEach, arity=1] }
+function forEach() {
+	[native code]
+}
 
 js> res = '';
 js> Array.forEach([1, 13, 4], function(elem) { res += elem });

--- a/tests/testsrc/doctests/array.isarray.doctest
+++ b/tests/testsrc/doctests/array.isarray.doctest
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> Array.isArray;
-function isArray() { [native code for Array.isArray, arity=1] }
+function isArray() {
+	[native code]
+}
 
 js> Array.isArray()
 false

--- a/tests/testsrc/doctests/array.map.doctest
+++ b/tests/testsrc/doctests/array.map.doctest
@@ -3,13 +3,17 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> [9, 16, 25].map;
-function map() { [native code for Array.map, arity=1] }
+function map() {
+	[native code]
+}
 
 js> "" + [9, 16, 25].map(Math.sqrt);
 3,4,5
 
 js> Array.map;
-function map() { [native code for Array.map, arity=1] }
+function map() {
+	[native code]
+}
 
 js> "" + Array.map([9, 16, 25], Math.sqrt);
 3,4,5

--- a/tests/testsrc/doctests/array.reduce.doctest
+++ b/tests/testsrc/doctests/array.reduce.doctest
@@ -5,13 +5,17 @@
 js> function sum(acc, val) { return acc + val; };
 
 js> [1, 4, 9, 16].reduce;
-function reduce() { [native code for Array.reduce, arity=1] }
+function reduce() {
+	[native code]
+}
 
 js> [1, 4, 9, 16].reduce(sum);
 30
 
 js> Array.reduce;
-function reduce() { [native code for Array.reduce, arity=1] }
+function reduce() {
+	[native code]
+}
 
 js> Array.reduce([1, 4, 9, 16], sum);
 30

--- a/tests/testsrc/doctests/array.reduceRight.doctest
+++ b/tests/testsrc/doctests/array.reduceRight.doctest
@@ -5,13 +5,17 @@
 js> function diff(acc, val) { return acc - val; };
 
 js> [1, 4, 9, 16].reduceRight;
-function reduceRight() { [native code for Array.reduceRight, arity=1] }
+function reduceRight() {
+	[native code]
+}
 
 js> [1, 4, 9, 16].reduceRight(diff);
 2
 
 js> Array.reduceRight;
-function reduceRight() { [native code for Array.reduceRight, arity=1] }
+function reduceRight() {
+	[native code]
+}
 
 js> Array.reduceRight([1, 4, 9, 16], diff);
 2

--- a/tests/testsrc/doctests/array.some.doctest
+++ b/tests/testsrc/doctests/array.some.doctest
@@ -5,7 +5,9 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [1, 4, 9, 16].some;
-function some() { [native code for Array.some, arity=1] }
+function some() {
+	[native code]
+}
 
 js> [1, 4, 9, 16].some(isSmall);
 true
@@ -14,7 +16,9 @@ js> [19, 42].some(isSmall);
 false
 
 js> Array.some;
-function some() { [native code for Array.some, arity=1] }
+function some() {
+	[native code]
+}
 
 js> Array.some([1, 4, 9, 16], isSmall);
 true

--- a/tests/testsrc/doctests/date.toisostring.doctest
+++ b/tests/testsrc/doctests/date.toisostring.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Date.prototype.toISOString;
-function toISOString() { [native code for Date.toISOString, arity=0] }
+function toISOString() {
+	[native code]
+}
 
 js> expectError(function() { 
   >   new Date(Infinity).toISOString() 

--- a/tests/testsrc/doctests/date.tojson.doctest
+++ b/tests/testsrc/doctests/date.tojson.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Date.prototype.toJSON;
-function toJSON() { [native code for Date.toJSON, arity=1] }
+function toJSON() {
+	[native code]
+}
 
 js> Date.prototype.toJSON.call({
   >   valueOf: function() { return Infinity; }

--- a/tests/testsrc/doctests/function.bind.doctest
+++ b/tests/testsrc/doctests/function.bind.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Function.prototype.bind
-function bind() { [native code for Function.bind, arity=1] }
+function bind() {
+	[native code]
+}
 
 js> expectTypeError(function() {
   >   Function.prototype.bind.call({})

--- a/tests/testsrc/doctests/object.create.doctest
+++ b/tests/testsrc/doctests/object.create.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.create;
-function create() { [native code for Object.create, arity=2] }
+function create() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.create() });
 js> [undefined, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.defineproperties.doctest
+++ b/tests/testsrc/doctests/object.defineproperties.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.defineProperties
-function defineProperties() { [native code for Object.defineProperties, arity=2] }
+function defineProperties() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.defineProperties() });
 js> expectTypeError(function() { Object.defineProperties({}) });

--- a/tests/testsrc/doctests/object.defineproperty.doctest
+++ b/tests/testsrc/doctests/object.defineproperty.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.defineProperty
-function defineProperty() { [native code for Object.defineProperty, arity=3] }
+function defineProperty() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.defineProperty() });
 js> expectTypeError(function() { Object.defineProperty({}) });

--- a/tests/testsrc/doctests/object.extensible.doctest
+++ b/tests/testsrc/doctests/object.extensible.doctest
@@ -5,14 +5,18 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isExtensible;
-function isExtensible() { [native code for Object.isExtensible, arity=1] }
+function isExtensible() {
+	[native code]
+}
 js> expectTypeError(function() { Object.isExtensible() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.isExtensible(value) }) 
   > })
 
 js> Object.preventExtensions;
-function preventExtensions() { [native code for Object.preventExtensions, arity=1] }
+function preventExtensions() {
+	[native code]
+}
 js> expectTypeError(function() { Object.preventExtensions() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.preventExtensions(value) }) 

--- a/tests/testsrc/doctests/object.freeze.doctest
+++ b/tests/testsrc/doctests/object.freeze.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.freeze;
-function freeze() { [native code for Object.freeze, arity=1] }
+function freeze() {
+	[native code]
+}
 
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.freeze(value) }) 

--- a/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
+++ b/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getOwnPropertyDescriptor;
-function getOwnPropertyDescriptor() { [native code for Object.getOwnPropertyDescriptor, arity=2] }
+function getOwnPropertyDescriptor() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.getOwnPropertyDescriptor() })
 

--- a/tests/testsrc/doctests/object.getownpropertynames.doctest
+++ b/tests/testsrc/doctests/object.getownpropertynames.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getOwnPropertyNames;
-function getOwnPropertyNames() { [native code for Object.getOwnPropertyNames, arity=1] }
+function getOwnPropertyNames() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.getOwnPropertyNames() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.getprototypeof.doctest
+++ b/tests/testsrc/doctests/object.getprototypeof.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getPrototypeOf;
-function getPrototypeOf() { [native code for Object.getPrototypeOf, arity=1] }
+function getPrototypeOf() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.getPrototypeOf() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.isfrozen.doctest
+++ b/tests/testsrc/doctests/object.isfrozen.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isFrozen
-function isFrozen() { [native code for Object.isFrozen, arity=1] }
+function isFrozen() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.isFrozen() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.issealed.doctest
+++ b/tests/testsrc/doctests/object.issealed.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isSealed
-function isSealed() { [native code for Object.isSealed, arity=1] }
+function isSealed() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.isSealed() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.keys.doctest
+++ b/tests/testsrc/doctests/object.keys.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.keys;
-function keys() { [native code for Object.keys, arity=1] }
+function keys() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.keys() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.seal.doctest
+++ b/tests/testsrc/doctests/object.seal.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.seal;
-function seal() { [native code for Object.seal, arity=1] }
+function seal() {
+	[native code]
+}
 
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.seal(value) }) 

--- a/tests/testsrc/doctests/parseint.doctest
+++ b/tests/testsrc/doctests/parseint.doctest
@@ -4,7 +4,7 @@
 
 js> parseInt
 function parseInt() {
-	[native code, arity=2]
+	[native code]
 }
 js> parseInt("0");
 0

--- a/tests/testsrc/doctests/string.trim.doctest
+++ b/tests/testsrc/doctests/string.trim.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> String.prototype.trim;
-function trim() { [native code for String.trim, arity=0] }
+function trim() {
+	[native code]
+}
 
 js> String.prototype.trim.call({toString: function() { return "a" }});
 a

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -915,9 +915,8 @@ built-ins/Number 8/335 (2.39%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 177/3408 (5.19%)
+built-ins/Object 149/3408 (4.37%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
-    assign/not-a-constructor.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order.js
     assign/strings-and-symbol-order-proxy.js
@@ -929,7 +928,6 @@ built-ins/Object 177/3408 (5.19%)
     assign/target-is-sealed-existing-accessor-property.js
     assign/target-is-sealed-existing-data-property.js
     assign/target-is-sealed-property-creation-throws.js
-    create/not-a-constructor.js
     defineProperties/15.2.3.7-6-a-112.js non-strict
     defineProperties/15.2.3.7-6-a-113.js non-strict
     defineProperties/15.2.3.7-6-a-118.js
@@ -946,7 +944,6 @@ built-ins/Object 177/3408 (5.19%)
     defineProperties/15.2.3.7-6-a-184.js
     defineProperties/15.2.3.7-6-a-185.js
     defineProperties/15.2.3.7-6-a-282.js
-    defineProperties/not-a-constructor.js
     defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js
     defineProperties/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
@@ -970,18 +967,13 @@ built-ins/Object 177/3408 (5.19%)
     defineProperty/15.2.3.6-4-336.js
     defineProperty/coerced-P-grow.js {unsupported: [resizable-arraybuffer]}
     defineProperty/coerced-P-shrink.js {unsupported: [resizable-arraybuffer]}
-    defineProperty/not-a-constructor.js
     defineProperty/property-description-must-be-an-object-not-symbol.js
     defineProperty/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    entries/not-a-constructor.js
     entries/observable-operations.js
     entries/order-after-define-property-with-function.js
-    freeze/not-a-constructor.js
     freeze/proxy-no-ownkeys-returned-keys-order.js
     freeze/proxy-with-defineProperty-handler.js
     freeze/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    fromEntries/not-a-constructor.js
-    getOwnPropertyDescriptors/not-a-constructor.js
     getOwnPropertyDescriptors/order-after-define-property.js
     getOwnPropertyDescriptors/proxy-no-ownkeys-returned-keys-order.js
     getOwnPropertyDescriptors/proxy-undefined-descriptor.js
@@ -990,28 +982,17 @@ built-ins/Object 177/3408 (5.19%)
     getOwnPropertyDescriptor/15.2.3.3-4-214.js
     getOwnPropertyDescriptor/15.2.3.3-4-215.js
     getOwnPropertyDescriptor/15.2.3.3-4-250.js
-    getOwnPropertyDescriptor/not-a-constructor.js
-    getOwnPropertyNames/not-a-constructor.js
     getOwnPropertyNames/order-after-define-property.js
-    getOwnPropertySymbols/not-a-constructor.js
-    getPrototypeOf/not-a-constructor.js
     hasOwn/length.js
-    hasOwn/not-a-constructor.js
     hasOwn/symbol_property_toPrimitive.js
     hasOwn/symbol_property_toString.js
     hasOwn/symbol_property_valueOf.js
     internals/DefineOwnProperty/consistent-value-regexp-dollar1.js
-    isExtensible/not-a-constructor.js
-    isFrozen/not-a-constructor.js
     isFrozen/proxy-no-ownkeys-returned-keys-order.js
-    isSealed/not-a-constructor.js
     isSealed/proxy-no-ownkeys-returned-keys-order.js
-    is/not-a-constructor.js
-    keys/not-a-constructor.js
     keys/order-after-define-property-with-function.js
     keys/property-traps-order-with-proxied-array.js
     keys/proxy-keys.js
-    preventExtensions/not-a-constructor.js
     prototype/__defineGetter__/define-abrupt.js
     prototype/__defineGetter__/define-existing.js
     prototype/__defineGetter__/define-non-configurable.js
@@ -1042,22 +1023,17 @@ built-ins/Object 177/3408 (5.19%)
     prototype/__proto__/set-non-obj-coercible.js
     prototype/__proto__/set-non-object.js
     prototype/__proto__/set-ordinary-obj.js
-    prototype/hasOwnProperty/not-a-constructor.js
     prototype/hasOwnProperty/symbol_property_toPrimitive.js
     prototype/hasOwnProperty/symbol_property_toString.js
     prototype/hasOwnProperty/symbol_property_valueOf.js
     prototype/hasOwnProperty/topropertykey_before_toobject.js
-    prototype/isPrototypeOf/not-a-constructor.js
     prototype/isPrototypeOf/null-this-and-primitive-arg-returns-false.js
     prototype/isPrototypeOf/undefined-this-and-primitive-arg-returns-false.js
-    prototype/propertyIsEnumerable/not-a-constructor.js
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    prototype/toLocaleString/not-a-constructor.js
     prototype/toLocaleString/primitive_this_value.js strict
     prototype/toLocaleString/primitive_this_value_getter.js strict
-    prototype/toString/not-a-constructor.js
     prototype/toString/proxy-function.js {unsupported: [async-functions]}
     prototype/toString/proxy-function-async.js {unsupported: [async-functions]}
     prototype/toString/proxy-revoked-during-get-call.js
@@ -1072,10 +1048,8 @@ built-ins/Object 177/3408 (5.19%)
     prototype/toString/symbol-tag-string-builtin.js
     prototype/toString/symbol-tag-weakmap-builtin.js
     prototype/toString/symbol-tag-weakset-builtin.js
-    prototype/valueOf/not-a-constructor.js
     prototype/valueOf/S15.2.4.4_A14.js
     prototype/valueOf/S15.2.4.4_A15.js
-    seal/not-a-constructor.js
     seal/proxy-no-ownkeys-returned-keys-order.js
     seal/proxy-with-defineProperty-handler.js
     seal/seal-asyncarrowfunction.js
@@ -1087,8 +1061,6 @@ built-ins/Object 177/3408 (5.19%)
     seal/seal-generatorfunction.js
     seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     seal/seal-weakref.js
-    setPrototypeOf/not-a-constructor.js
-    values/not-a-constructor.js
     values/observable-operations.js
     property-order.js
     proto-from-ctor-realm.js


### PR DESCRIPTION
@gbrail I'm creating this as a draft PR for now. There are 24 test failures from doc tests due to small changes in the `toString` results for various functions on object, and I'm not sure if we should work to reduce those differences or if we're fine with changing the tests.

I'll update this PR with benchmark comparisons when I've had time to run the full suite.