### PR TITLE
Fix a mistake in implementing static service loading

### DIFF
--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -14,7 +14,7 @@ module org.mozilla.rhino {
     exports org.mozilla.javascript.xml;
     exports org.mozilla.javascript.config;
 
-    uses org.mozilla.javascript.RegExpProxy;
+    uses org.mozilla.javascript.RegExpLoader;
     uses org.mozilla.javascript.xml.XMLLoader;
     uses org.mozilla.javascript.config.RhinoPropertiesLoader;
 


### PR DESCRIPTION
A previous pull request introduced "RegExpLoader" as a new service that implements regular expressions. However, we neglec ted to update the module-info file for the "rhino" module, leading to a module configuration that cannot load.

https://github.com/mozilla/rhino/pull/1816