### PR TITLE
NativeRegExp: Fix the behaviour of sticky flag

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1885,7 +1885,11 @@ public class NativeRegExp extends IdScriptableObject {
             boolean anchor = false;
             while (gData.cp <= end) {
                 int match = simpleMatch(gData, input, op, program, pc, end, true);
-                if (match >= 0) {
+                if (match < 0) {
+                    if ((gData.regexp.flags & JSREG_STICKY) != 0) {
+                        return false;
+                    }
+                } else {
                     anchor = true;
                     pc = match; /* accept skip to next opcode */
                     op = program[pc++];

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -419,6 +419,30 @@ public class NativeRegExpTest {
         Utils.assertWithAllModes_ES6("3-a-a-a", script);
     }
 
+    @Test
+    public void execStickySymbol() throws Exception {
+        final String script =
+                "var regex = /[abc]/y;\n"
+                        + "var res = regex.exec('ab-c') + '-' + regex.lastIndex + '-'\n"
+                        + "res += regex.exec('ab-c') + '-' + regex.lastIndex + '-'\n"
+                        + "res += regex.exec('ab-c') + '-' + regex.lastIndex\n"
+                        + "res;";
+
+        Utils.assertWithAllModes_ES6("a-1-b-2-null-0", script);
+    }
+
+    @Test
+    public void exeGlobalStickySymbol() throws Exception {
+        final String script =
+                "var regex = /[abc]/gy;\n"
+                        + "var res = regex.exec('ab-c') + '-' + regex.lastIndex + '-'\n"
+                        + "res += regex.exec('ab-c') + '-' + regex.lastIndex + '-'\n"
+                        + "res += regex.exec('ab-c') + '-' + regex.lastIndex\n"
+                        + "res;";
+
+        Utils.assertWithAllModes_ES6("a-1-b-2-null-0", script);
+    }
+
     /**
      * @throws Exception if an error occurs
      */


### PR DESCRIPTION
The behaviour of NativeRegExp's exec with the sticky flag on was broken in cases where the regular expression does not start with a literal.

This fix doesn't fix any previously failing test262 tests. It seems that this test [test/built-ins/RegExp/prototype/exec/y-fail-lastindex.js](https://github.com/tc39/test262/blob/main/test/built-ins/RegExp/prototype/exec/y-fail-lastindex.js) is the one expected to cover the feature. However this test has always passed since the behaviour of sticky in these "simple" cases are handled as special case.