### PR TITLE
Enable assigning a Number to java.lang.Character

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -534,7 +534,8 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                     return coerceToNumber(
                             jsTypeCode == JSTYPE_BIGINT ? BigInteger.class : Double.TYPE, value);
                 } else if ((type.isPrimitive() && type != Boolean.TYPE)
-                        || ScriptRuntime.NumberClass.isAssignableFrom(type)) {
+                        || ScriptRuntime.NumberClass.isAssignableFrom(type)
+                        || ScriptRuntime.CharacterClass.isAssignableFrom(type)) {
                     return coerceToNumber(type, value);
                 } else {
                     reportConversionError(value, type);

--- a/tests/src/test/java/org/mozilla/javascript/tests/CharacterAssignmentTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/CharacterAssignmentTest.java
@@ -1,0 +1,48 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.tools.shell.Global;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Jakob Silbereisen, Foconis Analytics GmbH
+ */
+public class CharacterAssignmentTest {
+
+	public static class X {
+		public Character bigCharacter;
+		public char primitiveCharacter;
+		public X() {}
+		public X(char c) {
+			bigCharacter = c;
+			primitiveCharacter = c;
+		}
+	}
+
+	@Test
+	public void assignCharacterTypesFromNumbers() {
+		Utils.runWithAllModes(
+				cx -> {
+					final Global scope = new Global();
+					scope.init(cx);
+					X x1 = new X(), x2 = new X();
+					scope.put("x1", scope, x1);
+					scope.put("x2", scope, x2);
+					scope.put("src", scope, new X('X'));
+					Object ret =
+							cx.evaluateString(
+									scope,
+									"x1.bigCharacter = 65;"
+									+ "x1.primitiveCharacter = 65;"
+									+ "x2.bigCharacter = src.primitiveCharacter;",
+									"myScript.js",
+									1,
+									null);
+					assertEquals('A', x1.bigCharacter);
+					assertEquals('A', x1.primitiveCharacter);
+					assertEquals('X', x2.bigCharacter);
+					return null;
+				});
+	}
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/CharacterAssignmentTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/CharacterAssignmentTest.java
@@ -1,48 +1,50 @@
 package org.mozilla.javascript.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.Test;
 import org.mozilla.javascript.tools.shell.Global;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Jakob Silbereisen, Foconis Analytics GmbH
  */
 public class CharacterAssignmentTest {
 
-	public static class X {
-		public Character bigCharacter;
-		public char primitiveCharacter;
-		public X() {}
-		public X(char c) {
-			bigCharacter = c;
-			primitiveCharacter = c;
-		}
-	}
+    public static class X {
+        public Character bigCharacter;
+        public char primitiveCharacter;
 
-	@Test
-	public void assignCharacterTypesFromNumbers() {
-		Utils.runWithAllModes(
-				cx -> {
-					final Global scope = new Global();
-					scope.init(cx);
-					X x1 = new X(), x2 = new X();
-					scope.put("x1", scope, x1);
-					scope.put("x2", scope, x2);
-					scope.put("src", scope, new X('X'));
-					Object ret =
-							cx.evaluateString(
-									scope,
-									"x1.bigCharacter = 65;"
-									+ "x1.primitiveCharacter = 65;"
-									+ "x2.bigCharacter = src.primitiveCharacter;",
-									"myScript.js",
-									1,
-									null);
-					assertEquals('A', x1.bigCharacter);
-					assertEquals('A', x1.primitiveCharacter);
-					assertEquals('X', x2.bigCharacter);
-					return null;
-				});
-	}
+        public X() {}
+
+        public X(char c) {
+            bigCharacter = c;
+            primitiveCharacter = c;
+        }
+    }
+
+    @Test
+    public void assignCharacterTypesFromNumbers() {
+        Utils.runWithAllModes(
+                cx -> {
+                    final Global scope = new Global();
+                    scope.init(cx);
+                    X x1 = new X(), x2 = new X();
+                    scope.put("x1", scope, x1);
+                    scope.put("x2", scope, x2);
+                    scope.put("src", scope, new X('X'));
+                    Object ret =
+                            cx.evaluateString(
+                                    scope,
+                                    "x1.bigCharacter = 65;"
+                                            + "x1.primitiveCharacter = 65;"
+                                            + "x2.bigCharacter = src.primitiveCharacter;",
+                                    "myScript.js",
+                                    1,
+                                    null);
+                    assertEquals('A', x1.bigCharacter);
+                    assertEquals('A', x1.primitiveCharacter);
+                    assertEquals('X', x2.bigCharacter);
+                    return null;
+                });
+    }
 }


### PR DESCRIPTION
Currently, assigning a JS number to a primitive Java `char` is possible, but assigning it to a `java.lang.Character` results in an `EvaluatorException`, which is rather unintuitive.

To me it seemed like there might just be a case missing in the `coerceType` implementation, handling the `java.lang.Character` similar to the primitive one.

Let me know what you think.