### PR TITLE
Modularize some tests and fix module specifications

### DIFF
--- a/buildSrc/src/main/groovy/rhino.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.java-conventions.gradle
@@ -23,8 +23,10 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    testImplementation "org.hamcrest:hamcrest:3.0"
     testImplementation "org.yaml:snakeyaml:1.33"
     testImplementation "javax.xml.soap:javax.xml.soap-api:1.4.0"
+    testImplementation "javax.activation:javax.activation-api:1.2.0"
 }
 
 tasks.withType(JavaCompile) {

--- a/rhino-engine/build.gradle
+++ b/rhino-engine/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':rhino')
+    testImplementation project(':testutils')
 }
 
 publishing {

--- a/rhino-engine/src/main/java/module-info.java
+++ b/rhino-engine/src/main/java/module-info.java
@@ -1,6 +1,9 @@
 module org.mozilla.rhino.engine {
     exports org.mozilla.javascript.engine;
 
+    provides javax.script.ScriptEngineFactory with
+            org.mozilla.javascript.engine.RhinoScriptEngineFactory;
+
     requires transitive org.mozilla.rhino;
     requires transitive java.scripting;
 }

--- a/rhino-engine/src/test/java/module-info.java
+++ b/rhino-engine/src/test/java/module-info.java
@@ -1,0 +1,10 @@
+module org.mozilla.rhino.engine.test {
+    exports org.mozilla.javascript.tests.scriptengine;
+
+    requires org.mozilla.rhino.engine;
+    requires org.mozilla.rhino;
+    requires org.mozilla.rhino.testutils;
+    requires junit;
+    requires org.junit.jupiter.api;
+    requires org.junit.jupiter.params;
+}

--- a/rhino-kotlin/src/main/java/module-info.java
+++ b/rhino-kotlin/src/main/java/module-info.java
@@ -6,6 +6,8 @@ module org.mozilla.rhino.kotlin {
     requires kotlin.stdlib;
     requires org.mozilla.rhino;
 
+    exports org.mozilla.kotlin;
+
     provides NullabilityDetector with
             KotlinNullabilityDetector;
 }

--- a/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/JavaClass.java
+++ b/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/JavaClass.java
@@ -1,4 +1,4 @@
-package org.mozilla.kotlin;
+package org.mozilla.kotlin.tests;
 
 public class JavaClass {
     private final String property1;

--- a/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinClass.kt
+++ b/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinClass.kt
@@ -1,4 +1,4 @@
-package org.mozilla.kotlin
+package org.mozilla.kotlin.tests
 
 class KotlinClass(
     val nonNullProperty: String,

--- a/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinClassWithOverloadedFunction.kt
+++ b/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinClassWithOverloadedFunction.kt
@@ -1,4 +1,4 @@
-package org.mozilla.kotlin
+package org.mozilla.kotlin.tests
 
 class KotlinClassWithOverloadedFunction {
     fun function(nullableParam: Int?, nonNullParam: Int, anotherNullableParam: KotlinClass?) {

--- a/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinNullabilityDetectorTest.java
+++ b/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinNullabilityDetectorTest.java
@@ -1,4 +1,4 @@
-package org.mozilla.kotlin;
+package org.mozilla.kotlin.tests;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.mozilla.kotlin.KotlinNullabilityDetector;
 
 public class KotlinNullabilityDetectorTest {
     private final KotlinNullabilityDetector detector = new KotlinNullabilityDetector();

--- a/rhino-tools/build.gradle
+++ b/rhino-tools/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':rhino')
+    testImplementation project(':testutils')
 }
 
 publishing {

--- a/rhino-tools/src/test/java/module-info.java
+++ b/rhino-tools/src/test/java/module-info.java
@@ -1,14 +1,10 @@
-module org.mozilla.rhino.tests {
+module org.mozilla.rhino.tools.test {
     requires org.mozilla.rhino;
     requires org.mozilla.rhino.testutils;
     requires org.mozilla.rhino.tools;
-    requires org.mozilla.javascript.xml;
     requires junit;
     requires org.junit.jupiter.api;
     requires org.junit.jupiter.params;
 
-    requires java.desktop;
-    requires java.naming;
-    requires java.sql;
-    requires java.xml;
+    exports org.mozilla.javascript.tools.tests;
 }

--- a/rhino-tools/src/test/java/org/mozilla/javascript/tools/tests/SanityTest.java
+++ b/rhino-tools/src/test/java/org/mozilla/javascript/tools/tests/SanityTest.java
@@ -1,0 +1,38 @@
+package org.mozilla.javascript.tools.tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.testutils.Utils;
+import org.mozilla.javascript.tools.shell.Global;
+
+public class SanityTest {
+    /** Make sure that we can load and execute Global in a module environment. */
+    @Test
+    public void sanityCheckGlobal() {
+        Utils.runWithAllModes(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    var g = new Global(cx);
+                    var result =
+                            cx.evaluateString(
+                                    g,
+                                    "const v = version();\n"
+                                            + "if (typeof v !== 'number') throw 'version() returned ' + v;"
+                                            + "v",
+                                    "test.js",
+                                    1,
+                                    null);
+                    assertInstanceOf(Number.class, result);
+                    assertEquals(Context.VERSION_ES6, ((Number) result).intValue());
+                    return null;
+                });
+    }
+
+    /** Verify that the compiler class can at least be instantiated. */
+    @Test
+    public void sanityCheckCompiler() {
+        new org.mozilla.javascript.tools.jsc.Main();
+    }
+}

--- a/rhino-xml/build.gradle
+++ b/rhino-xml/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':rhino')
+    testImplementation project(':testutils')
 }
 
 publishing {

--- a/rhino-xml/src/test/java/module-info.java
+++ b/rhino-xml/src/test/java/module-info.java
@@ -1,0 +1,10 @@
+module org.mozilla.javascript.xml.test {
+    exports org.mozilla.javascript.tests;
+    exports org.mozilla.javascript.xmlimpl.tests;
+
+    requires org.mozilla.javascript.xml;
+    requires org.mozilla.rhino.testutils;
+    requires junit;
+    requires org.junit.jupiter.api;
+    requires org.junit.jupiter.params;
+}

--- a/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/NonResettableDocumentBuilder.java
+++ b/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/NonResettableDocumentBuilder.java
@@ -1,4 +1,4 @@
-package org.mozilla.javascript.xmlimpl;
+package org.mozilla.javascript.xmlimpl.tests;
 
 import java.io.IOException;
 import javax.xml.parsers.DocumentBuilder;

--- a/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/NonResettableDocumentBuilderFactory.java
+++ b/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/NonResettableDocumentBuilderFactory.java
@@ -1,4 +1,4 @@
-package org.mozilla.javascript.xmlimpl;
+package org.mozilla.javascript.xmlimpl.tests;
 
 import java.util.Properties;
 import javax.xml.parsers.DocumentBuilder;

--- a/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/XmlNonResettableDocumentBuilderTest.java
+++ b/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/XmlNonResettableDocumentBuilderTest.java
@@ -1,4 +1,4 @@
-package org.mozilla.javascript.xmlimpl;
+package org.mozilla.javascript.xmlimpl.tests;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -2,7 +2,7 @@ package org.mozilla.javascript;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class FunctionPrototypeSymbolHasInstanceTest {
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/HoistingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/HoistingTest.java
@@ -3,7 +3,7 @@ package org.mozilla.javascript;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class HoistingTest {
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/NullableArgumentsConversionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullableArgumentsConversionTest.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 @RunWith(Parameterized.class)
 public class NullableArgumentsConversionTest {

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
@@ -3,7 +3,7 @@ package org.mozilla.javascript;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ScriptRuntimeEvalSpecialTest {
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 class SuperTest {
     @Nested

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ApplyOnPrimitiveNumberTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ApplyOnPrimitiveNumberTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Primitive numbers are not wrapped before calling apply. Test for bug <a

--- a/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 public class AssignSubclassTest {
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
@@ -8,6 +8,7 @@ import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.testutils.Utils;
 
 /** This is a set of tests for parsing and using BigInts. */
 public class BigIntTest {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug409702Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug409702Test.java
@@ -6,6 +6,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=409702

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug412433Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug412433Test.java
@@ -6,6 +6,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=412433

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug419940Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug419940Test.java
@@ -5,6 +5,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=419940

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug421071Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug421071Test.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 public class Bug421071Test {
     private ContextFactory factory;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug637811Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug637811Test.java
@@ -7,6 +7,7 @@ package org.mozilla.javascript.tests;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author André Bargull

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
@@ -6,7 +6,7 @@ package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.mozilla.javascript.tests.Utils.runWithAllModes;
+import static org.mozilla.javascript.testutils.Utils.runWithAllModes;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CodegenTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CodegenTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.mozilla.javascript.NativeFunction;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Test for falling back to the interpreter if generated code is too large.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DecompileTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DecompileTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Script;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Test for {@link Context#decompileScript(Script, int)}.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DeletePropertyTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DeletePropertyTest.java
@@ -6,6 +6,7 @@ package org.mozilla.javascript.tests;
 
 import org.junit.Test;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Test for delete that should apply for properties defined in prototype chain. See

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.WrappedException;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Unit tests to check error handling. Especially, we expect to get a correct cause, when an error

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ErrorPropertiesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ErrorPropertiesTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Unit tests for <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=549604">bug 549604</a>. This

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ForEachForOfTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ForEachForOfTest.java
@@ -14,6 +14,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Unit tests to check forEach loops.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/FunctionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/FunctionTest.java
@@ -6,6 +6,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Unit tests for Function.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/GlobalParseXTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/GlobalParseXTest.java
@@ -6,6 +6,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Tests for global functions parseFloat and parseInt.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/InterfaceAdapterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/InterfaceAdapterTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Wrapper;
+import org.mozilla.javascript.testutils.Utils;
 
 /*
  * This testcase tests the support of converting javascript functions to

--- a/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.SymbolScriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Tests for host objects implementing the iterable protocol.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 public class LookupSetterTest {
     private final String defineSetterAndGetterX =

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeRegExpTest {
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author Marc Guillemot

--- a/rhino/src/test/java/org/mozilla/javascript/tests/OverloadTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/OverloadTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 public class OverloadTest {
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/PrimitiveTypeScopeResolutionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/PrimitiveTypeScopeResolutionTest.java
@@ -7,6 +7,7 @@ package org.mozilla.javascript.tests;
 import org.junit.Test;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Unit tests for <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=374918">Bug 374918 - String

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeEquivalentValuesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeEquivalentValuesTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.*;
 import org.mozilla.javascript.annotations.JSConstructor;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Test cases for the {@link ScriptRuntime} support for ScriptableObject#equivalentValues(Object)

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ToNumberConversionsTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ToNumberConversionsTest.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Test cases for ToNumber conversion applied to a String type.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/TypeOfTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/TypeOfTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Takes care that it's possible to customize the result of the typeof operator. See

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -44,6 +44,8 @@ test {
     systemProperty 'user.timezone', 'America/Los_Angeles'
     systemProperty 'file.encoding', 'UTF-8'
 
+    // Required for Junit tests
+    jvmArgs += ['--add-opens', 'org.hamcrest']
     // Required for JWT GUI tests
     jvmArgs += ['--add-opens', 'java.desktop/javax.swing.table=ALL-UNNAMED']
     // Required for some reflection tests

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -27,7 +27,6 @@ tasks.withType(JavaCompile) {
 }
 
 test {
-    testLogging.showStandardStreams = true
     maxHeapSize = "1g"
     // Many tests do not clean up contexts properly. This makes the tests much
     // more resilient at the expense of performance.
@@ -44,8 +43,6 @@ test {
     systemProperty 'user.timezone', 'America/Los_Angeles'
     systemProperty 'file.encoding', 'UTF-8'
 
-    // Required for Junit tests
-    jvmArgs += ['--add-opens', 'org.hamcrest']
     // Required for JWT GUI tests
     jvmArgs += ['--add-opens', 'java.desktop/javax.swing.table=ALL-UNNAMED']
     // Required for some reflection tests

--- a/tests/src/test/java/module-info.java
+++ b/tests/src/test/java/module-info.java
@@ -1,0 +1,14 @@
+module org.mozilla.rhino.tests {
+    requires org.mozilla.rhino;
+    requires org.mozilla.rhino.testutils;
+    requires org.mozilla.rhino.tools;
+    requires org.mozilla.javascript.xml;
+    requires junit;
+    requires org.junit.jupiter.api;
+    requires org.junit.jupiter.params;
+
+    requires java.desktop;
+    requires java.naming;
+    requires java.sql;
+    requires java.xml;
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComputedPropertiesTest.java
@@ -5,6 +5,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ComputedPropertiesTest {
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/CovariantReturnTypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/CovariantReturnTypeTest.java
@@ -5,6 +5,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**

--- a/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DefaultParametersTest.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript.tests;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mozilla.javascript.*;
+import org.mozilla.javascript.testutils.Utils;
 
 /*
    Many of these are taken from examples at developer.mozilla.org

--- a/tests/src/test/java/org/mozilla/javascript/tests/ForTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ForTest.java
@@ -6,6 +6,7 @@ package org.mozilla.javascript.tests;
 
 import org.junit.Test;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ForTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/ImportClassTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ImportClassTest.java
@@ -21,6 +21,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.UniqueTag;
 import org.mozilla.javascript.drivers.TestUtils;
+import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.ShellContextFactory;
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
 
 public class LambdaAccessorSlotTest {
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.testutils.Utils;
 
 public class LambdaFunctionTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author ZZZank

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeObjectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeObjectTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeObjectTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/NullishCoalescingOpTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NullishCoalescingOpTest.java
@@ -1,6 +1,7 @@
 package org.mozilla.javascript.tests;
 
 import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NullishCoalescingOpTest {
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
@@ -14,6 +14,7 @@ import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author Norris Boyd

--- a/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
@@ -2,6 +2,7 @@ package org.mozilla.javascript.tests;
 
 import org.junit.Test;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
 
 public class OptionalChainingOperatorTest {
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -133,12 +133,8 @@ public class SealedSharedScopeTest {
     public void importClassWithScope() throws Exception {
         Object o;
         evaluateString(scope1, "importClass(javax.naming.Name);");
-        evaluateString(scope2, "importClass(javax.xml.soap.Name);");
         o = evaluateString(scope1, "Name");
         assertEquals(javax.naming.Name.class, o);
-
-        o = evaluateString(scope2, "Name");
-        assertEquals(javax.xml.soap.Name.class, o);
 
         o = evaluateString(sharedScope, "typeof Name"); // JavaScript "Statement"
         // function
@@ -149,12 +145,8 @@ public class SealedSharedScopeTest {
     public void importPackageWithScope() throws Exception {
         Object o;
         evaluateString(scope1, "importPackage(javax.naming);");
-        evaluateString(scope2, "importPackage(javax.xml.soap);");
         o = evaluateString(scope1, "Name");
         assertEquals(javax.naming.Name.class, o);
-
-        o = evaluateString(scope2, "Name");
-        assertEquals(javax.xml.soap.Name.class, o);
 
         o = evaluateString(sharedScope, "typeof Name"); // JavaScript "Statement"
         // function

--- a/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -133,8 +133,12 @@ public class SealedSharedScopeTest {
     public void importClassWithScope() throws Exception {
         Object o;
         evaluateString(scope1, "importClass(javax.naming.Name);");
+        evaluateString(scope2, "importClass(javax.xml.soap.Name);");
         o = evaluateString(scope1, "Name");
         assertEquals(javax.naming.Name.class, o);
+
+        o = evaluateString(scope2, "Name");
+        assertEquals(javax.xml.soap.Name.class, o);
 
         o = evaluateString(sharedScope, "typeof Name"); // JavaScript "Statement"
         // function
@@ -145,8 +149,12 @@ public class SealedSharedScopeTest {
     public void importPackageWithScope() throws Exception {
         Object o;
         evaluateString(scope1, "importPackage(javax.naming);");
+        evaluateString(scope2, "importPackage(javax.xml.soap);");
         o = evaluateString(scope1, "Name");
         assertEquals(javax.naming.Name.class, o);
+
+        o = evaluateString(scope2, "Name");
+        assertEquals(javax.xml.soap.Name.class, o);
 
         o = evaluateString(sharedScope, "typeof Name"); // JavaScript "Statement"
         // function

--- a/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
@@ -13,7 +13,6 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.security.URIParameter;
 import java.util.Enumeration;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -21,6 +20,7 @@ import org.mozilla.javascript.ClassShutter;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.SecurityController;
+import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.JavaPolicySecurity;
 
@@ -38,10 +38,9 @@ public class SecurityControllerTest {
     /** Setup the security */
     @BeforeClass
     public static void setup() throws Exception {
-        Assume.assumeThat(
+        Assume.assumeFalse(
                 "Skipping test for Java 21",
-                Utils.isJavaVersionAtLeast(21),
-                CoreMatchers.is(false));
+                Utils.isJavaVersionAtLeast(21));
         URL url = SecurityControllerTest.class.getResource("grant-all-java.policy");
         if (url != null) {
             System.setProperty("java.security.policy", url.toString());
@@ -76,10 +75,9 @@ public class SecurityControllerTest {
     @Test
     public void barAccess() {
         // Security managers are out in Java 21, so skip.
-        Assume.assumeThat(
+        Assume.assumeFalse(
                 "Skipping test for Java 21",
-                Utils.isJavaVersionAtLeast(21),
-                CoreMatchers.is(false));
+                Utils.isJavaVersionAtLeast(21));
 
         // f.create produces "SomeClass extends ArrayList<String> implements
         // SomeInterface"

--- a/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
@@ -38,9 +38,7 @@ public class SecurityControllerTest {
     /** Setup the security */
     @BeforeClass
     public static void setup() throws Exception {
-        Assume.assumeFalse(
-                "Skipping test for Java 21",
-                Utils.isJavaVersionAtLeast(21));
+        Assume.assumeFalse("Skipping test for Java 21", Utils.isJavaVersionAtLeast(21));
         URL url = SecurityControllerTest.class.getResource("grant-all-java.policy");
         if (url != null) {
             System.setProperty("java.security.policy", url.toString());
@@ -75,9 +73,7 @@ public class SecurityControllerTest {
     @Test
     public void barAccess() {
         // Security managers are out in Java 21, so skip.
-        Assume.assumeFalse(
-                "Skipping test for Java 21",
-                Utils.isJavaVersionAtLeast(21));
+        Assume.assumeFalse("Skipping test for Java 21", Utils.isJavaVersionAtLeast(21));
 
         // f.create produces "SomeClass extends ArrayList<String> implements
         // SomeInterface"

--- a/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
@@ -13,6 +13,7 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.security.URIParameter;
 import java.util.Enumeration;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,7 +39,10 @@ public class SecurityControllerTest {
     /** Setup the security */
     @BeforeClass
     public static void setup() throws Exception {
-        Assume.assumeFalse("Skipping test for Java 21", Utils.isJavaVersionAtLeast(21));
+        Assume.assumeThat(
+                "Skipping test for Java 21",
+                Utils.isJavaVersionAtLeast(21),
+                CoreMatchers.is(false));
         URL url = SecurityControllerTest.class.getResource("grant-all-java.policy");
         if (url != null) {
             System.setProperty("java.security.policy", url.toString());
@@ -73,7 +77,10 @@ public class SecurityControllerTest {
     @Test
     public void barAccess() {
         // Security managers are out in Java 21, so skip.
-        Assume.assumeFalse("Skipping test for Java 21", Utils.isJavaVersionAtLeast(21));
+        Assume.assumeThat(
+                "Skipping test for Java 21",
+                Utils.isJavaVersionAtLeast(21),
+                CoreMatchers.is(false));
 
         // f.create produces "SomeClass extends ArrayList<String> implements
         // SomeInterface"

--- a/tests/src/test/java/org/mozilla/javascript/tests/ShellTimerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ShellTimerTest.java
@@ -13,6 +13,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.Timers;
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.StackStyle;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author Marc Guillemot

--- a/tests/src/test/java/org/mozilla/javascript/tests/StrictModeApiTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StrictModeApiTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import java.lang.reflect.Method;
 import org.junit.Test;
 import org.mozilla.javascript.*;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Test of strict mode APIs.

--- a/tests/src/test/java/org/mozilla/javascript/tests/backwardcompat/BackwardParseInt.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/backwardcompat/BackwardParseInt.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.backwardcompat;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class BackwardParseInt {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/backwardcompat/BackwardUseStrict.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/backwardcompat/BackwardUseStrict.java
@@ -11,7 +11,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class BackwardUseStrict {

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 @RunWith(Parameterized.class)
 public class ComplianceTest {

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -19,7 +19,7 @@ import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author Attila Szegedi

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2022/NativeObjectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2022/NativeObjectTest.java
@@ -6,7 +6,7 @@
 package org.mozilla.javascript.tests.es2022;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeObjectTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/FunctionApplyArrayLikeArguments.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/FunctionApplyArrayLikeArguments.java
@@ -9,7 +9,7 @@ package org.mozilla.javascript.tests.es5;
 
 import org.junit.Test;
 import org.mozilla.javascript.Undefined;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class FunctionApplyArrayLikeArguments {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/GeneratorToStringTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/GeneratorToStringTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es5;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class GeneratorToStringTest {
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/NativeArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/NativeArrayTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es5;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @see <a

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/ObjectIsPrototypeOfTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/ObjectIsPrototypeOfTest.java
@@ -8,7 +8,7 @@
 package org.mozilla.javascript.tests.es5;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ObjectIsPrototypeOfTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/StrictTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/StrictTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es5;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @see <a

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ArgumentsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ArgumentsTest.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Tests for Arguments support. */
 public class ArgumentsTest {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ArrayDestructuringTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ArrayDestructuringTest.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ArrayDestructuringTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/BoundFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/BoundFunctionTest.java
@@ -8,7 +8,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class BoundFunctionTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ES6IteratorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ES6IteratorTest.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ES6IteratorTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
@@ -9,7 +9,7 @@ import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Checks if setting "functionName = null" is propagated to thisObject.

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionsRestParametersTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionsRestParametersTest.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * Tests for Functions Rest Parameters.

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/Issue1297FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/Issue1297FunctionNameTest.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Test that we can redefine a function's name. */
 public class Issue1297FunctionNameTest {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray2Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray2Test.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Test for NativeArray. */
 public class NativeArray2Test {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray3Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArray3Test.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Tests for NativeArray support. */
 public class NativeArray3Test {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -13,7 +13,7 @@ import java.util.TimeZone;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Test for NativeDate. */
 public class NativeDateTest {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeFunctionTest.java
@@ -8,7 +8,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.annotations.JSConstructor;
 import org.mozilla.javascript.annotations.JSFunction;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeFunctionTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeNumberPropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeNumberPropertyTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeNumberPropertyTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeObjectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeObjectTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Test for NativeObject. */
 public class NativeObjectTest {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeProxyTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeReflectTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeRegExpTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeRegExpTest.java
@@ -5,7 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author Ronald Brill

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeString2Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeString2Test.java
@@ -9,7 +9,7 @@ package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Test for handling const variables. */
 public class NativeString2Test {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NumericSeparatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NumericSeparatorTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NumericSeparatorTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ObjectSealFreezeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ObjectSealFreezeTest.java
@@ -8,7 +8,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class ObjectSealFreezeTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PromiseTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PromiseTest.java
@@ -8,7 +8,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class PromiseTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 public class PropertyTest {
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/Symbol3Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/Symbol3Test.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Tests for Symbol support. */
 public class Symbol3Test {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/TypedArrayJavaTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/TypedArrayJavaTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /** Test for TypedArrays. */
 public class TypedArrayJavaTest {

--- a/tests/src/test/java/org/mozilla/javascript/tests/intl402/NativeStringTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/intl402/NativeStringTest.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.tests.Utils;
+import org.mozilla.javascript.testutils.Utils;
 
 /**
  * @author Ronald Brill

--- a/testutils/src/main/java/module-info.java
+++ b/testutils/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module org.mozilla.rhino.testutils {
+    exports org.mozilla.javascript.testutils;
+
+    requires org.mozilla.rhino;
+    requires junit;
+}

--- a/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
+++ b/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.javascript.tests;
+package org.mozilla.javascript.testutils;
 
 import static org.junit.Assert.*;
 
@@ -40,7 +40,7 @@ public class Utils {
      *
      * @param script the script code
      */
-    static void executeScript(String script, boolean interpreted) {
+    public static void executeScript(String script, boolean interpreted) {
         Utils.runWithMode(
                 cx -> {
                     final Scriptable scope = cx.initStandardObjects();


### PR DESCRIPTION
Some of our module specifications haven't been right, and these weren't caught in tests because the tests weren't themselves modularized. This PR addresses some of the problems by modularizing the tests for rhino-engine, rhino-tools, and rhino-xml. Here's the status of the rest:

* A bunch of tests in the main "rhino" module live in the org.mozilla.rhino package, which is already exported by the main package. We can't modularize the tests unless we move those tests to a different package, and that means making more classes "public", or re-packaging in some other creative way
* I failed to modularize rhino-kotlin -- in module mode, the tests couldn't find their associated Kotlin classes. I don't know why not.
* I failed to modularize "tests" -- the various "getResourceAsStream" methods work differently once modules are introduced, and despite lots of experiments and research I couldn't figure it out. This might even be a bug in Gradle, but regardless it was difficult.

This, at least, will ensure that we will catch most of the problems with module specifications for the main modules.