### PR TITLE
Deliberately set language, locale, and TZ in all build phases

### DIFF
--- a/buildSrc/src/main/groovy/rhino.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.java-conventions.gradle
@@ -31,7 +31,7 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
     options.release = 11
     options.compilerArgs = [
-            '-Xlint:deprecation,unchecked'
+        '-Xlint:deprecation,unchecked'
     ]
 }
 
@@ -44,6 +44,9 @@ tasks.withType(Test).configureEach {
         }
     }
 
+    // Explicitly set locale, timezone, and encoding for all build and test phases
+    // to ensure consistent test execution no matter where. This affects many
+    // time- and date-related tests, which will fail otherwise.
     systemProperty 'user.language', 'en'
     systemProperty 'user.country', 'US'
     systemProperty 'user.timezone', 'America/Los_Angeles'

--- a/buildSrc/src/main/groovy/rhino.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.java-conventions.gradle
@@ -27,15 +27,15 @@ dependencies {
     testImplementation "javax.xml.soap:javax.xml.soap-api:1.4.0"
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
     options.release = 11
     options.compilerArgs = [
-        '-Xlint:deprecation,unchecked'
+            '-Xlint:deprecation,unchecked'
     ]
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     if (testJavaVersion > 0) {
         // We get here if RHINO_TEST_JAVA_VERSION was set and if we did then
         // we try to run the tests with that version if Gradle will let us
@@ -43,6 +43,11 @@ tasks.withType(Test) {
             languageVersion = JavaLanguageVersion.of(testJavaVersion)
         }
     }
+
+    systemProperty 'user.language', 'en'
+    systemProperty 'user.country', 'US'
+    systemProperty 'user.timezone', 'America/Los_Angeles'
+    systemProperty 'file.encoding', 'UTF-8'
 }
 
 test {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -39,10 +39,6 @@ test {
     systemProperty 'java.awt.headless', 'true'
     systemProperty 'mozilla.js.tests', 'testsrc/tests'
     systemProperty 'mozilla.js.tests.timeout', 60000
-    systemProperty 'user.language', 'en'
-    systemProperty 'user.country', 'US'
-    systemProperty 'user.timezone', 'America/Los_Angeles'
-    systemProperty 'file.encoding', 'UTF-8'
 
     // Required for JWT GUI tests
     jvmArgs += ['--add-opens', 'java.desktop/javax.swing.table=ALL-UNNAMED']


### PR DESCRIPTION
This is (IMO) a more generic implementation of:
 
https://github.com/mozilla/rhino/pull/1819

This should result in hard-coding the language in every build phase regardless of the system where it's running.

I'd be interested to see from those of you affected if this fixes the problem that PR was trying to address.