### PR TITLE
Fix RegExp.prototype[Symbol.match] and String.prototype.match

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -6,7 +6,6 @@
 
 package org.mozilla.javascript.regexp;
 
-import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ES6Iterator;
 import org.mozilla.javascript.ScriptRuntime;
@@ -66,7 +65,7 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
             return true;
         }
 
-        next = regExpExec(cx, scope);
+        next = NativeRegExp.regExpExec(regexp, string, cx, scope);
         if (next == null) {
             // Done! Point ii of the spec
             next = Undefined.instance;
@@ -93,15 +92,6 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     @Override
     protected Object nextValue(Context cx, Scriptable scope) {
         return next;
-    }
-
-    private Object regExpExec(Context cx, Scriptable scope) {
-        // See ECMAScript spec 22.2.7.1
-        Object execMethod = ScriptRuntime.getObjectProp(regexp, "exec", cx);
-        if (execMethod instanceof Callable) {
-            return ((Callable) execMethod).call(cx, scope, regexp, new Object[] {string});
-        }
-        return NativeRegExp.js_exec(cx, scope, regexp, new Object[] {string});
     }
 
     @Override

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -408,7 +408,7 @@ public class NativeRegExpTest {
     /**
      * @throws Exception if an error occurs
      */
-    // TODO @Test
+    @Test
     public void matchGlobalSymbol() throws Exception {
         final String script =
                 "var result = /a/g[Symbol.match]('aaba');\n"
@@ -500,7 +500,7 @@ public class NativeRegExpTest {
     /**
      * @throws Exception if an error occurs
      */
-    // TODO @Test
+    @Test
     public void matchStickyAndGlobalSymbol() throws Exception {
         final String script =
                 "var result = /a/yg[Symbol.match]('aaba');\n"

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1578,7 +1578,7 @@ built-ins/Reflect 13/153 (8.5%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1150/1854 (62.03%)
+built-ins/RegExp 1134/1854 (61.17%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1667,30 +1667,14 @@ built-ins/RegExp 1150/1854 (62.03%)
     prototype/Symbol.matchAll/this-tostring-flags-throws.js
     prototype/Symbol.match/builtin-infer-unicode.js
     prototype/Symbol.match/builtin-success-g-set-lastindex.js
-    prototype/Symbol.match/builtin-success-g-set-lastindex-err.js
     prototype/Symbol.match/builtin-success-u-return-val-groups.js
     prototype/Symbol.match/coerce-global.js
-    prototype/Symbol.match/exec-err.js
-    prototype/Symbol.match/exec-invocation.js
     prototype/Symbol.match/exec-return-type-invalid.js
-    prototype/Symbol.match/exec-return-type-valid.js
-    prototype/Symbol.match/flags-tostring-error.js
-    prototype/Symbol.match/g-coerce-result-err.js
     prototype/Symbol.match/g-get-exec-err.js
-    prototype/Symbol.match/g-get-result-err.js
-    prototype/Symbol.match/g-init-lastindex.js
-    prototype/Symbol.match/g-match-empty-advance-lastindex.js
-    prototype/Symbol.match/g-match-empty-coerce-lastindex-err.js
-    prototype/Symbol.match/g-match-empty-set-lastindex-err.js
-    prototype/Symbol.match/g-success-return-val.js
-    prototype/Symbol.match/get-exec-err.js
-    prototype/Symbol.match/get-flags-err.js
     prototype/Symbol.match/get-global-err.js
     prototype/Symbol.match/get-unicode-error.js
     prototype/Symbol.match/not-a-constructor.js
-    prototype/Symbol.match/this-val-non-regexp.js
     prototype/Symbol.match/u-advance-after-empty.js
-    prototype/Symbol.match/y-fail-global-return.js
     prototype/Symbol.replace/arg-1-coerce.js
     prototype/Symbol.replace/arg-1-coerce-err.js
     prototype/Symbol.replace/arg-2-coerce.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2008,7 +2008,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 92/1182 (7.78%)
+built-ins/String 90/1182 (7.61%)
     fromCharCode/not-a-constructor.js
     fromCodePoint/not-a-constructor.js
     prototype/charAt/not-a-constructor.js
@@ -2032,11 +2032,9 @@ built-ins/String 92/1182 (7.78%)
     prototype/matchAll/not-a-constructor.js
     prototype/matchAll/regexp-matchAll-invocation.js
     prototype/matchAll/regexp-prototype-matchAll-invocation.js
-    prototype/match/cstm-matcher-get-err.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/duplicate-named-groups-properties.js
     prototype/match/duplicate-named-indices-groups-properties.js
-    prototype/match/invoke-builtin-match.js
     prototype/match/not-a-constructor.js
     prototype/normalize/not-a-constructor.js
     prototype/padEnd/not-a-constructor.js


### PR DESCRIPTION
This PR includes two fixes based on the spec:

1. `RegExp.prototype[Symbol.match]`: The spec requires that this method invoke the `exec` method of the regular expression in a loop.
2. `String.prototype.match`: The spec mandates that this method call `RegExp.prototype[Symbol.match]`.

As a result, a few new test262 tests now pass. The remaining failing tests in `built-ins/RegExp/prototype/Symbol.match` and `built-ins/String/prototype/match` are unrelated to this fix.