### PR TITLE
Fixed a problem with `super` and nested lambdas

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2331,6 +2331,10 @@ public final class Interpreter extends Icode implements Evaluator {
                                                 cx, frame.scope, frame.fnOrScript, indexReg);
                                 if (fn.idata.itsFunctionType == FunctionNode.ARROW_FUNCTION) {
                                     Scriptable homeObject = getCurrentFrameHomeObject(frame);
+                                    if (fn.idata.itsNeedsActivation) {
+                                        fn.setHomeObject(homeObject);
+                                    }
+
                                     stack[++stackTop] =
                                             new ArrowFunction(
                                                     cx, frame.scope, fn, frame.thisObj, homeObject);

--- a/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
@@ -1141,6 +1141,38 @@ class SuperTest {
 
             Utils.assertWithAllModes_ES6("object", script);
         }
+
+        @Test
+        void mixedCompileInterpret() {
+            String script =
+                    ""
+                            + "var proto = {\n"
+                            + "  x: 'proto',\n"
+                            + "  f() {\n"
+                            + "    return this.x;\n"
+                            + "  }\n"
+                            + "};\n"
+                            + "var object = {\n"
+                            + "   x: 'object',\n"
+                            + "   f() {\n"
+                            + "    return () => { return super.f(); };\n"
+                            + "  }\n"
+                            + "};\n"
+                            + "Object.setPrototypeOf(object, proto);\n";
+            String script2 = "object.f()();";
+
+            try (Context cx = Context.enter()) {
+                cx.setLanguageVersion(Context.VERSION_ES6);
+                ScriptableObject scope = cx.initStandardObjects();
+
+                cx.setInterpretedMode(true);
+                cx.evaluateString(scope, script, "test", 1, null);
+
+                cx.setInterpretedMode(false);
+                Object res = cx.evaluateString(scope, script2, "test", 1, null);
+                assertEquals("object", res);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
We discovered this problem in our fork, where we disable the "function peeling optimization", but we have managed to reproduce it with a unit test that mixes compiled and interpreted functions.

The problem is that nested lambda does not have the `homeObject` set correctly. In the interpreter we pick it up from the containing `NativeCall` (the activation), but in some situations, like without function peeling or when going from a compiled function to an interpreted one, it might not be set.

The fix we came up with is just to propagate the home object on the nested closure function, that gets wrapped in the `ArrowFunction`. It's not particularly elegant, but it seems to fix the problem, does not cause any regression, and it's pretty cheap at runtime.