### PR TITLE
Make built-in function source spec compliant.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -505,9 +505,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
             sb.append(getFunctionName());
             sb.append("() {\n\t");
         }
-        sb.append("[native code, arity=");
-        sb.append(getArity());
-        sb.append("]\n");
+        sb.append("[native code]\n");
         if (!justbody) {
             sb.append("}\n");
         }

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -8,8 +8,6 @@
 
 package org.mozilla.javascript;
 
-import java.util.EnumSet;
-
 public class IdFunctionObject extends BaseFunction {
     private static final long serialVersionUID = -5332312783643935019L;
 
@@ -95,28 +93,6 @@ public class IdFunctionObject extends BaseFunction {
         // To follow current (2003-05-01) SpiderMonkey behavior, change it to:
         // return super.createObject(cx, scope);
         throw ScriptRuntime.typeErrorById("msg.not.ctor", functionName);
-    }
-
-    @Override
-    String decompile(int indent, EnumSet<DecompilerFlag> flags) {
-        StringBuilder sb = new StringBuilder();
-        boolean justbody = flags.contains(DecompilerFlag.ONLY_BODY);
-        if (!justbody) {
-            sb.append("function ");
-            sb.append(getFunctionName());
-            sb.append("() { ");
-        }
-        sb.append("[native code for ");
-        if (idcall instanceof Scriptable) {
-            Scriptable sobj = (Scriptable) idcall;
-            sb.append(sobj.getClassName());
-            sb.append('.');
-        }
-        sb.append(getFunctionName());
-        sb.append(", arity=");
-        sb.append(getArity());
-        sb.append(justbody ? "]\n" : "] }\n");
-        return sb.toString();
     }
 
     @Override

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -45,9 +45,7 @@ public class LookupSetterTest {
 
     @Test
     public void lookedUpGetter_toString() throws Exception {
-        test(
-                "function s() {\n\t[native code, arity=0]\n}\n",
-                "new Foo().__lookupGetter__('s').toString()");
+        test("function s() {\n\t[native code]\n}\n", "new Foo().__lookupGetter__('s').toString()");
     }
 
     @Test
@@ -86,9 +84,7 @@ public class LookupSetterTest {
 
     @Test
     public void lookedUpSetter_toString() throws Exception {
-        test(
-                "function s() {\n\t[native code, arity=0]\n}\n",
-                "new Foo().__lookupSetter__('s').toString()");
+        test("function s() {\n\t[native code]\n}\n", "new Foo().__lookupSetter__('s').toString()");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -8,7 +8,7 @@ public class NativeProxyTest {
     @Test
     public void testToString() {
         Utils.assertWithAllModes_ES6(
-                "function Proxy() {\n\t[native code, arity=2]\n}\n", "Proxy.toString()");
+                "function Proxy() {\n\t[native code]\n}\n", "Proxy.toString()");
 
         Utils.assertWithAllModes_ES6(
                 "[object Object]", "Object.prototype.toString.call(new Proxy({}, {}))");

--- a/tests/testsrc/doctests/array.every.doctest
+++ b/tests/testsrc/doctests/array.every.doctest
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> Array.every;
-function every() { [native code for Array.every, arity=1] }
+function every() {
+	[native code]
+}
 
 js> function isSmall(n) { return n < 10; };
 

--- a/tests/testsrc/doctests/array.filter.doctest
+++ b/tests/testsrc/doctests/array.filter.doctest
@@ -5,13 +5,17 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [1, 13, 4, 16, 42].filter;
-function filter() { [native code for Array.filter, arity=1] }
+function filter() {
+	[native code]
+}
 
 js> "" + [1, 13, 4, 16, 42].filter(isSmall);
 1,4
 
 js> Array.filter;
-function filter() { [native code for Array.filter, arity=1] }
+function filter() {
+	[native code]
+}
 
 js> "" + Array.filter([1, 13, 4, 16, 42], isSmall);
 1,4

--- a/tests/testsrc/doctests/array.find.doctest
+++ b/tests/testsrc/doctests/array.find.doctest
@@ -5,13 +5,17 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [13, 4, 17].find;
-function find() { [native code for Array.find, arity=1] }
+function find() {
+	[native code]
+}
 
 js> [13, 4, 17].find(isSmall);
 4
 
 js> Array.find;
-function find() { [native code for Array.find, arity=1] }
+function find() {
+	[native code]
+}
 
 js> res = '';
 js> Array.find([13, 4, 17], isSmall);

--- a/tests/testsrc/doctests/array.findIndex.doctest
+++ b/tests/testsrc/doctests/array.findIndex.doctest
@@ -5,13 +5,17 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [13, 4, 17].findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
+function findIndex() {
+	[native code]
+}
 
 js> [13, 4, 17].findIndex(isSmall);
 1
 
 js> Array.findIndex;
-function findIndex() { [native code for Array.findIndex, arity=1] }
+function findIndex() {
+	[native code]
+}
 
 js> Array.findIndex([13, 4, 17], isSmall);
 1

--- a/tests/testsrc/doctests/array.forEach.doctest
+++ b/tests/testsrc/doctests/array.forEach.doctest
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> [1, 13, 4].forEach;
-function forEach() { [native code for Array.forEach, arity=1] }
+function forEach() {
+	[native code]
+}
 
 js> res = '';
 js> [1, 13, 4].forEach(function(elem) { res += elem });
@@ -11,7 +13,9 @@ js> res
 1134
 
 js> Array.forEach;
-function forEach() { [native code for Array.forEach, arity=1] }
+function forEach() {
+	[native code]
+}
 
 js> res = '';
 js> Array.forEach([1, 13, 4], function(elem) { res += elem });

--- a/tests/testsrc/doctests/array.isarray.doctest
+++ b/tests/testsrc/doctests/array.isarray.doctest
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> Array.isArray;
-function isArray() { [native code for Array.isArray, arity=1] }
+function isArray() {
+	[native code]
+}
 
 js> Array.isArray()
 false

--- a/tests/testsrc/doctests/array.map.doctest
+++ b/tests/testsrc/doctests/array.map.doctest
@@ -3,13 +3,17 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 js> [9, 16, 25].map;
-function map() { [native code for Array.map, arity=1] }
+function map() {
+	[native code]
+}
 
 js> "" + [9, 16, 25].map(Math.sqrt);
 3,4,5
 
 js> Array.map;
-function map() { [native code for Array.map, arity=1] }
+function map() {
+	[native code]
+}
 
 js> "" + Array.map([9, 16, 25], Math.sqrt);
 3,4,5

--- a/tests/testsrc/doctests/array.reduce.doctest
+++ b/tests/testsrc/doctests/array.reduce.doctest
@@ -5,13 +5,17 @@
 js> function sum(acc, val) { return acc + val; };
 
 js> [1, 4, 9, 16].reduce;
-function reduce() { [native code for Array.reduce, arity=1] }
+function reduce() {
+	[native code]
+}
 
 js> [1, 4, 9, 16].reduce(sum);
 30
 
 js> Array.reduce;
-function reduce() { [native code for Array.reduce, arity=1] }
+function reduce() {
+	[native code]
+}
 
 js> Array.reduce([1, 4, 9, 16], sum);
 30

--- a/tests/testsrc/doctests/array.reduceRight.doctest
+++ b/tests/testsrc/doctests/array.reduceRight.doctest
@@ -5,13 +5,17 @@
 js> function diff(acc, val) { return acc - val; };
 
 js> [1, 4, 9, 16].reduceRight;
-function reduceRight() { [native code for Array.reduceRight, arity=1] }
+function reduceRight() {
+	[native code]
+}
 
 js> [1, 4, 9, 16].reduceRight(diff);
 2
 
 js> Array.reduceRight;
-function reduceRight() { [native code for Array.reduceRight, arity=1] }
+function reduceRight() {
+	[native code]
+}
 
 js> Array.reduceRight([1, 4, 9, 16], diff);
 2

--- a/tests/testsrc/doctests/array.some.doctest
+++ b/tests/testsrc/doctests/array.some.doctest
@@ -5,7 +5,9 @@
 js> function isSmall(n) { return n < 10; };
 
 js> [1, 4, 9, 16].some;
-function some() { [native code for Array.some, arity=1] }
+function some() {
+	[native code]
+}
 
 js> [1, 4, 9, 16].some(isSmall);
 true
@@ -14,7 +16,9 @@ js> [19, 42].some(isSmall);
 false
 
 js> Array.some;
-function some() { [native code for Array.some, arity=1] }
+function some() {
+	[native code]
+}
 
 js> Array.some([1, 4, 9, 16], isSmall);
 true

--- a/tests/testsrc/doctests/date.toisostring.doctest
+++ b/tests/testsrc/doctests/date.toisostring.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Date.prototype.toISOString;
-function toISOString() { [native code for Date.toISOString, arity=0] }
+function toISOString() {
+	[native code]
+}
 
 js> expectError(function() { 
   >   new Date(Infinity).toISOString() 

--- a/tests/testsrc/doctests/date.tojson.doctest
+++ b/tests/testsrc/doctests/date.tojson.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Date.prototype.toJSON;
-function toJSON() { [native code for Date.toJSON, arity=1] }
+function toJSON() {
+	[native code]
+}
 
 js> Date.prototype.toJSON.call({
   >   valueOf: function() { return Infinity; }

--- a/tests/testsrc/doctests/function.bind.doctest
+++ b/tests/testsrc/doctests/function.bind.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Function.prototype.bind
-function bind() { [native code for Function.bind, arity=1] }
+function bind() {
+	[native code]
+}
 
 js> expectTypeError(function() {
   >   Function.prototype.bind.call({})

--- a/tests/testsrc/doctests/object.create.doctest
+++ b/tests/testsrc/doctests/object.create.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.create;
-function create() { [native code for Object.create, arity=2] }
+function create() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.create() });
 js> [undefined, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.defineproperties.doctest
+++ b/tests/testsrc/doctests/object.defineproperties.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.defineProperties
-function defineProperties() { [native code for Object.defineProperties, arity=2] }
+function defineProperties() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.defineProperties() });
 js> expectTypeError(function() { Object.defineProperties({}) });

--- a/tests/testsrc/doctests/object.defineproperty.doctest
+++ b/tests/testsrc/doctests/object.defineproperty.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.defineProperty
-function defineProperty() { [native code for Object.defineProperty, arity=3] }
+function defineProperty() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.defineProperty() });
 js> expectTypeError(function() { Object.defineProperty({}) });

--- a/tests/testsrc/doctests/object.extensible.doctest
+++ b/tests/testsrc/doctests/object.extensible.doctest
@@ -5,14 +5,18 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isExtensible;
-function isExtensible() { [native code for Object.isExtensible, arity=1] }
+function isExtensible() {
+	[native code]
+}
 js> expectTypeError(function() { Object.isExtensible() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.isExtensible(value) }) 
   > })
 
 js> Object.preventExtensions;
-function preventExtensions() { [native code for Object.preventExtensions, arity=1] }
+function preventExtensions() {
+	[native code]
+}
 js> expectTypeError(function() { Object.preventExtensions() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.preventExtensions(value) }) 

--- a/tests/testsrc/doctests/object.freeze.doctest
+++ b/tests/testsrc/doctests/object.freeze.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.freeze;
-function freeze() { [native code for Object.freeze, arity=1] }
+function freeze() {
+	[native code]
+}
 
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.freeze(value) }) 

--- a/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
+++ b/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getOwnPropertyDescriptor;
-function getOwnPropertyDescriptor() { [native code for Object.getOwnPropertyDescriptor, arity=2] }
+function getOwnPropertyDescriptor() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.getOwnPropertyDescriptor() })
 

--- a/tests/testsrc/doctests/object.getownpropertynames.doctest
+++ b/tests/testsrc/doctests/object.getownpropertynames.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getOwnPropertyNames;
-function getOwnPropertyNames() { [native code for Object.getOwnPropertyNames, arity=1] }
+function getOwnPropertyNames() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.getOwnPropertyNames() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.getprototypeof.doctest
+++ b/tests/testsrc/doctests/object.getprototypeof.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.getPrototypeOf;
-function getPrototypeOf() { [native code for Object.getPrototypeOf, arity=1] }
+function getPrototypeOf() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.getPrototypeOf() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.isfrozen.doctest
+++ b/tests/testsrc/doctests/object.isfrozen.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isFrozen
-function isFrozen() { [native code for Object.isFrozen, arity=1] }
+function isFrozen() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.isFrozen() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.issealed.doctest
+++ b/tests/testsrc/doctests/object.issealed.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.isSealed
-function isSealed() { [native code for Object.isSealed, arity=1] }
+function isSealed() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.isSealed() });
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.keys.doctest
+++ b/tests/testsrc/doctests/object.keys.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.keys;
-function keys() { [native code for Object.keys, arity=1] }
+function keys() {
+	[native code]
+}
 
 js> expectTypeError(function() { Object.keys() })
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 

--- a/tests/testsrc/doctests/object.seal.doctest
+++ b/tests/testsrc/doctests/object.seal.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> Object.seal;
-function seal() { [native code for Object.seal, arity=1] }
+function seal() {
+	[native code]
+}
 
 js> [undefined, null, true, 1, 'hello'].forEach(function(value) { 
   >   expectTypeError(function() { Object.seal(value) }) 

--- a/tests/testsrc/doctests/parseint.doctest
+++ b/tests/testsrc/doctests/parseint.doctest
@@ -4,7 +4,7 @@
 
 js> parseInt
 function parseInt() {
-	[native code, arity=2]
+	[native code]
 }
 js> parseInt("0");
 0

--- a/tests/testsrc/doctests/string.trim.doctest
+++ b/tests/testsrc/doctests/string.trim.doctest
@@ -5,7 +5,9 @@
 js> load('testsrc/doctests/util.js');
 
 js> String.prototype.trim;
-function trim() { [native code for String.trim, arity=0] }
+function trim() {
+	[native code]
+}
 
 js> String.prototype.trim.call({toString: function() { return "a" }});
 a


### PR DESCRIPTION
This addresses some of the issues in #1300 by removing the override of `decompile` on `IdFunctionObject` so all built in functions print as
```
function name() {
    [native code]
}
```
and updating all the doc tests to match this behaviour.