### PR TITLE
RegExp: Fix bug with quantified capture groups

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -2683,11 +2683,11 @@ public class NativeRegExp extends IdScriptableObject {
                                             startcp,
                                             state.continuationOp,
                                             state.continuationPc);
-                                    int parenCount = getIndex(program, pc);
-                                    int parenIndex = getIndex(program, pc + INDEX_LEN);
-                                    for (int k = 0; k < parenCount; k++) {
-                                        gData.setParens(parenIndex + k, -1, 0);
-                                    }
+                                }
+                                int parenCount = getIndex(program, pc);
+                                int parenIndex = getIndex(program, pc + INDEX_LEN);
+                                for (int k = 0; k < parenCount; k++) {
+                                    gData.setParens(parenIndex + k, -1, 0);
                                 }
                             } while (program[nextpc] == REOP_ENDCHILD);
 


### PR DESCRIPTION
Fixes an issue where capture groups in quantified expressions (min ≥ 2) were not cleared between iterations. For example, in `/(?:(\2)(\d)){2}/`, during the second iteration, `\2` incorrectly retained the first iteration's value instead of being reset.

Before:
```
js>  /(?:(\2)(\d)){2}/.exec("112")
112,1,2
```

After:
```
js>  /(?:(\2)(\d)){2}/.exec("112")
11,,1
```