### PR TITLE
NativeRegExp: Implement named capture groups

### DIFF
--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -256,6 +256,15 @@ msg.arg.not.object =\
 msg.str.match.all.no.global.flag =\
     String.prototype.matchAll called with a non-global RegExp argument
 
+msg.invalid.group.name =\
+    Invalid capture group name
+
+msg.duplicate.group.name =\
+    Duplicate capture group name "{0}"
+
+msg.invalid.named.backref =\
+    Invalid named capture referenced
+
 # NativeDate
 msg.invalid.date =\
     Date is invalid.

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -732,4 +732,103 @@ public class NativeRegExpTest {
         Utils.assertWithAllModes_ES6("non-greedy-{2}", true, test.apply("{2}?", "123"));
         Utils.assertWithAllModes_ES6("non-greedy-{2,3}", true, test.apply("{2,}?", "123"));
     }
+
+    @Test
+    public void namedBackrefWithoutNamedCapture() {
+        final String script =
+                "var regex = /\\k<name>/;\n" + "var res = '' + regex.test('k<name>');\n" + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+    }
+
+    @Test
+    public void invalidNamedBackrefWithoutNamedCapture() {
+        final String script =
+                "var regex = /\\k<nam/;\n" + "var res = '' + regex.test('k<nam');\n" + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+    }
+
+    @Test
+    public void invalidNamedBackrefWithNamedCapture() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Invalid named capture referenced", "/\\k<nam(?<foo>)/.compile()");
+    }
+
+    @Test
+    public void duplicateNamedCapture() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Duplicate capture group name", "/(?<foo>)(?<foo>)/.compile()");
+    }
+
+    @Test
+    public void namedBackrefNotFound() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Invalid named capture referenced", "/(?<foo>)\\k<bar>/.compile()");
+    }
+
+    @Test
+    public void namedBackref() {
+        final String script =
+                "var regex = /(?<foo>\\d)\\k<foo>/m;\n"
+                        + "var res = '' + regex.test('11');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+    }
+
+    @Test
+    public void duplicateNamedCapturesInDisjunction() {
+        final String script =
+                "var regex = /(?:(?<x>a)|(?<x>b))\\k<x>/;\n"
+                        + "var res = '' + regex.test('bb');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+    }
+
+    @Test
+    public void duplicateNamedCaptures() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Duplicate capture group name \"x\"", "/(?<x>a)(?<x>b)/.compile()");
+
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Duplicate capture group name \"x\"",
+                "/(?<x>a)(?:b|(?<x>c))/.compile()");
+    }
+
+    @Test
+    public void namedCaptureInDisjunction() {
+        final String script =
+                "var regex = /a|(?<x>b)/;\n"
+                        + "var result = regex.exec('b');\n"
+                        + "var res = '' + result.groups.x;\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("b", script);
+    }
+
+    @Test
+    public void duplicateNamedCaptureInDisjunction() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Duplicate capture group name \"a\"",
+                "/(?<a>a)(?:(?<a>b)|(?<a>c))/.compile()");
+    }
+
+    @Test
+    public void execNamedCapture() {
+        final String script =
+                "var regex = /(?<foo>\\d)(?<bar>\\d)/;\n"
+                        + "var result = regex.exec('12');\n"
+                        + "var res = '' + result.groups.foo;\n"
+                        + "res = res + '-' + result.groups.bar;\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("1-2", script);
+    }
+
+    @Test
+    public void execNamedCaptureBackref() {
+        final String script =
+                "var regex = /(?<foo>\\d)(?<bar>\\d)\\1\\2/;\n"
+                        + "var result = regex.exec('1212');\n"
+                        + "var res = '' + result[1];\n"
+                        + "res = res + '-' + result[2];\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("1-2", script);
+    }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -831,4 +831,57 @@ public class NativeRegExpTest {
                         + "res;";
         Utils.assertWithAllModes_ES6("1-2", script);
     }
+
+    // just a \k without a name is invalid when there is a named capture group
+    @Test
+    public void invalidNamedBackref() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Invalid named capture referenced", "/(?<a>.)\\k/.compile()");
+    }
+
+    @Test
+    public void slashKInCharClass() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: invalid Unicode escape sequence", "/(?<a>.)[\\k]/.compile()");
+    }
+
+    // test that \0000 is octal escape for 0 (only supported by Rhino, inherited from SpiderMonkey)
+    @Test
+    public void octalEscapeSpiderMonkey() {
+        final String script =
+                "var regex = /\\0000101/;\n" + "var res = '' + regex.test('A');\n" + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+    }
+
+    // test that \0000 in character class is two chars \000 and 0
+    @Test
+    public void octalEscapeInCharacterClass() {
+        final String script =
+                "var regex = /[\\0000]/;\n"
+                        + "var res = '' + regex.test('\\0') + '-' + regex.test('0');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("true-true", script);
+    }
+
+    @Test
+    public void controlEscapeInCharacterClass() {
+        final String script =
+                "var regex = /[\\c]/;\n" + "var res = '' + regex.test('\\\\');\n" + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+    }
+
+    @Test
+    public void unterminatedBackslash() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Trailing \\ in regular expression", "new RegExp('[\\\\')");
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Trailing \\ in regular expression", "new RegExp('\\\\')");
+    }
+
+    // test z-a is invalid character range
+    @Test
+    public void invalidCharacterRange() {
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Invalid range in character class", "/[z-a]/.compile()");
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -100,7 +100,6 @@ public class Test262SuiteTest {
                             "new.target",
                             "object-rest",
                             "regexp-dotall",
-                            "regexp-named-groups",
                             "regexp-unicode-property-escapes",
                             "resizable-arraybuffer",
                             "tail-call-optimization",

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1549,29 +1549,52 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1117/1854 (60.25%)
+built-ins/RegExp 1103/1854 (59.49%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
     match-indices/indices-array.js
     match-indices/indices-array-element.js
     match-indices/indices-array-matched.js
-    match-indices/indices-array-non-unicode-match.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-array-non-unicode-match.js
     match-indices/indices-array-properties.js
-    match-indices/indices-array-unicode-match.js {unsupported: [regexp-named-groups]}
-    match-indices/indices-array-unicode-property-names.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-array-unicode-match.js
+    match-indices/indices-array-unicode-property-names.js
     match-indices/indices-array-unmatched.js
-    match-indices/indices-groups-object.js {unsupported: [regexp-named-groups]}
-    match-indices/indices-groups-object-undefined.js {unsupported: [regexp-named-groups]}
-    match-indices/indices-groups-object-unmatched.js {unsupported: [regexp-named-groups]}
-    match-indices/indices-groups-properties.js {unsupported: [regexp-named-groups]}
+    match-indices/indices-groups-object.js
+    match-indices/indices-groups-object-undefined.js
+    match-indices/indices-groups-object-unmatched.js
+    match-indices/indices-groups-properties.js
     match-indices/indices-property.js
-    named-groups 36/36 (100.0%)
+    named-groups/duplicate-names-match-indices.js
+    named-groups/duplicate-names-replace.js
+    named-groups/duplicate-names-replaceall.js
+    named-groups/duplicate-names-split.js
+    named-groups/functional-replace-global.js
+    named-groups/functional-replace-non-global.js
+    named-groups/groups-object.js
+    named-groups/groups-object-subclass.js
+    named-groups/groups-object-subclass-sans.js
+    named-groups/groups-object-unmatched.js
+    named-groups/groups-properties.js
+    named-groups/lookbehind.js
+    named-groups/non-unicode-property-names.js
+    named-groups/non-unicode-property-names-valid.js
+    named-groups/string-replace-escaped.js
+    named-groups/string-replace-get.js
+    named-groups/string-replace-missing.js
+    named-groups/string-replace-nocaptures.js
+    named-groups/string-replace-numbered.js
+    named-groups/string-replace-unclosed.js
+    named-groups/string-replace-undefined.js
+    named-groups/unicode-match.js
+    named-groups/unicode-property-names.js
+    named-groups/unicode-property-names-valid.js
+    named-groups/unicode-references.js
     property-escapes/generated/strings 28/28 (100.0%)
     property-escapes/generated 417/417 (100.0%)
     property-escapes 143/143 (100.0%)
     prototype/dotAll 8/8 (100.0%)
-    prototype/exec/duplicate-named-groups-properties.js
     prototype/exec/duplicate-named-indices-groups-properties.js
     prototype/exec/failure-lastindex-access.js
     prototype/exec/not-a-constructor.js
@@ -1674,19 +1697,18 @@ built-ins/RegExp 1117/1854 (60.25%)
     prototype/Symbol.replace/length.js
     prototype/Symbol.replace/match-failure.js
     prototype/Symbol.replace/name.js
-    prototype/Symbol.replace/named-groups.js {unsupported: [regexp-named-groups]}
-    prototype/Symbol.replace/named-groups-fn.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/named-groups.js
+    prototype/Symbol.replace/named-groups-fn.js
     prototype/Symbol.replace/not-a-constructor.js
-    prototype/Symbol.replace/poisoned-stdlib.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/poisoned-stdlib.js
     prototype/Symbol.replace/prop-desc.js
     prototype/Symbol.replace/replace-with-trailing.js
     prototype/Symbol.replace/replace-without-trailing.js
     prototype/Symbol.replace/result-coerce-capture.js
     prototype/Symbol.replace/result-coerce-capture-err.js
-    prototype/Symbol.replace/result-coerce-groups.js {unsupported: [regexp-named-groups]}
-    prototype/Symbol.replace/result-coerce-groups-err.js {unsupported: [regexp-named-groups]}
-    prototype/Symbol.replace/result-coerce-groups-prop.js {unsupported: [regexp-named-groups]}
-    prototype/Symbol.replace/result-coerce-groups-prop-err.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/result-coerce-groups.js
+    prototype/Symbol.replace/result-coerce-groups-prop.js
+    prototype/Symbol.replace/result-coerce-groups-prop-err.js
     prototype/Symbol.replace/result-coerce-index.js
     prototype/Symbol.replace/result-coerce-index-err.js
     prototype/Symbol.replace/result-coerce-index-undefined.js
@@ -1696,8 +1718,8 @@ built-ins/RegExp 1117/1854 (60.25%)
     prototype/Symbol.replace/result-coerce-matched-err.js
     prototype/Symbol.replace/result-coerce-matched-global.js
     prototype/Symbol.replace/result-get-capture-err.js
-    prototype/Symbol.replace/result-get-groups-err.js {unsupported: [regexp-named-groups]}
-    prototype/Symbol.replace/result-get-groups-prop-err.js {unsupported: [regexp-named-groups]}
+    prototype/Symbol.replace/result-get-groups-err.js
+    prototype/Symbol.replace/result-get-groups-prop-err.js
     prototype/Symbol.replace/result-get-index-err.js
     prototype/Symbol.replace/result-get-length-err.js
     prototype/Symbol.replace/result-get-matched-err.js
@@ -1793,7 +1815,6 @@ built-ins/RegExp 1117/1854 (60.25%)
     call_with_regexp_not_same_constructor.js
     character-class-escape-non-whitespace-u180e.js {unsupported: [u180e]}
     duplicate-flags.js {unsupported: [regexp-dotall]}
-    duplicate-named-capturing-groups-syntax.js
     from-regexp-like.js
     from-regexp-like-flag-override.js
     from-regexp-like-get-ctor-err.js
@@ -1978,7 +1999,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 53/1182 (4.48%)
+built-ins/String 52/1182 (4.4%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -1990,7 +2011,6 @@ built-ins/String 53/1182 (4.48%)
     prototype/matchAll/regexp-matchAll-invocation.js
     prototype/matchAll/regexp-prototype-matchAll-invocation.js
     prototype/match/cstm-matcher-invocation.js
-    prototype/match/duplicate-named-groups-properties.js
     prototype/match/duplicate-named-indices-groups-properties.js
     prototype/replaceAll/getSubstitution-0x0024-0x003C.js
     prototype/replaceAll/getSubstitution-0x0024N.js
@@ -5761,7 +5781,7 @@ language/keywords 0/25 (0.0%)
 
 language/line-terminators 0/41 (0.0%)
 
-language/literals 108/534 (20.22%)
+language/literals 52/534 (9.74%)
     bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
     bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     bigint/legacy-octal-like-invalid-00n.js non-strict
@@ -5777,7 +5797,6 @@ language/literals 108/534 (20.22%)
     numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
     numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     numeric/numeric-followed-by-ident.js
-    regexp/named-groups 56/56 (100.0%)
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
     regexp/invalid-braced-quantifier-range.js


### PR DESCRIPTION
**Note: This PR also includes commits from the lookbehind [PR](https://github.com/mozilla/rhino/pull/1843).**

This adds partial support for named capture groups in NativeRegExp. This also adds support for [duplicate-named-capturing-groups](https://github.com/tc39/proposal-duplicate-named-capturing-groups).

What is not implemented yet:
- capture group names that consist of unicode escape sequences.
- String.prototype.{replace, replaceAll}
 
Many new test262 test cases pass and there are no regressions. The ones that are failing are due to
- 'u' regexp flag not supported
- objects will null prototype do not work correctly with respect to accessing `__proto__` (a fix is being worked on)
- existing bugs in String.prototype.{replace, replaceAll, split}
- no support for classes 
