### PR TITLE
Fix `this` in `apply`/`call`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/InterpretedFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpretedFunction.java
@@ -169,4 +169,9 @@ final class InterpretedFunction extends NativeFunction implements Script {
     public boolean hasDefaultParameters() {
         return idata.argsHasDefaults;
     }
+
+    @Override
+    public boolean isStrict() {
+        return idata.isStrict;
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/InterpretedFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpretedFunction.java
@@ -82,7 +82,7 @@ final class InterpretedFunction extends NativeFunction implements Script {
     @Override
     public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         if (!ScriptRuntime.hasTopCall(cx)) {
-            return ScriptRuntime.doTopCall(this, cx, scope, thisObj, args, idata.isStrict);
+            return ScriptRuntime.doTopCall(this, cx, scope, thisObj, args, isStrict());
         }
         return Interpreter.interpret(this, cx, scope, thisObj, args);
     }
@@ -98,7 +98,7 @@ final class InterpretedFunction extends NativeFunction implements Script {
             // It will go through "call" path. but they are equivalent
             ret =
                     ScriptRuntime.doTopCall(
-                            this, cx, scope, scope, ScriptRuntime.emptyArgs, idata.isStrict);
+                            this, cx, scope, scope, ScriptRuntime.emptyArgs, isStrict());
         } else {
             ret = Interpreter.interpret(this, cx, scope, scope, ScriptRuntime.emptyArgs);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2875,7 +2875,45 @@ public final class Interpreter extends Icode implements Evaluator {
                     indexReg += blen;
                 }
             } else if (fun instanceof IdFunctionObject) {
-                break;
+                IdFunctionObject ifun = (IdFunctionObject) fun;
+                // Bug 405654 -- make the best effort to keep
+                // Function.apply and Function.call within this
+                // interpreter loop invocation
+                if (BaseFunction.isApplyOrCall(ifun)) {
+                    // funThisObj becomes fun
+                    fun = ScriptRuntime.getCallable(funThisObj);
+                    // first arg becomes thisObj
+                    funThisObj = getApplyThis(cx, stack, sDbl, stackTop + 2, indexReg, fun, frame);
+                    if (BaseFunction.isApply(ifun)) {
+                        // Apply: second argument after new "this"
+                        // should be array-like
+                        // and we'll spread its elements on the stack
+                        Object[] callArgs =
+                                indexReg < 2
+                                        ? ScriptRuntime.emptyArgs
+                                        : ScriptRuntime.getApplyArguments(cx, stack[stackTop + 3]);
+                        int alen = callArgs.length;
+                        stack = frame.ensureStackLength(alen + stackTop + 2);
+                        sDbl = frame.sDbl;
+                        System.arraycopy(callArgs, 0, stack, stackTop + 2, alen);
+                        indexReg = alen;
+                    } else {
+                        // Call: shift args left, starting from 2nd
+                        if (indexReg > 0) {
+                            if (indexReg > 1) {
+                                System.arraycopy(
+                                        stack, stackTop + 3, stack, stackTop + 2, indexReg - 1);
+                                System.arraycopy(
+                                        sDbl, stackTop + 3, sDbl, stackTop + 2, indexReg - 1);
+                            }
+                            indexReg--;
+                        }
+                    }
+                } else {
+                    // Some other IdFunctionObject we don't know how to
+                    // reduce.
+                    break;
+                }
             } else if (fun instanceof NoSuchMethodShim) {
                 NoSuchMethodShim nsmfun = (NoSuchMethodShim) fun;
                 // Bug 447697 -- make best effort to keep
@@ -3611,6 +3649,24 @@ public final class Interpreter extends Icode implements Evaluator {
             frame.stack[stackTop] = generatorState.value;
         }
         return Scriptable.NOT_FOUND;
+    }
+
+    private static Scriptable getApplyThis(
+            Context cx,
+            Object[] stack,
+            double[] sDbl,
+            int thisIdx,
+            int indexReg,
+            Callable target,
+            CallFrame frame) {
+        Object obj;
+        if (indexReg != 0) {
+            obj = stack[thisIdx];
+            if (obj == DOUBLE_MARK) obj = ScriptRuntime.wrapNumber(sDbl[thisIdx]);
+        } else {
+            obj = null;
+        }
+        return ScriptRuntime.getApplyOrCallThis(cx, frame.scope, obj, indexReg, target);
     }
 
     private static CallFrame initFrame(

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -145,7 +145,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         cx,
                                         scope,
                                         args,
-                                        idata.isStrict,
+                                        fnOrScript.isStrict(),
                                         idata.argsHasRest,
                                         homeObject);
                     } else {
@@ -155,7 +155,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         cx,
                                         scope,
                                         args,
-                                        idata.isStrict,
+                                        fnOrScript.isStrict(),
                                         idata.argsHasRest,
                                         homeObject);
                     }
@@ -315,7 +315,7 @@ public final class Interpreter extends Icode implements Evaluator {
             for (; ; ) {
                 final CallFrame p = f.parentFrame;
                 if (p == null) {
-                    return f.idata.isStrict;
+                    return f.fnOrScript.isStrict();
                 }
                 f = p;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeFunction.java
@@ -117,4 +117,6 @@ public abstract class NativeFunction extends BaseFunction {
         // from earlier Rhino versions. See Bugzilla #396117.
         return false;
     }
+
+    public abstract boolean isStrict();
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3116,9 +3116,11 @@ public class ScriptRuntime {
             }
 
             // Replace missing this with global object only for non-strict functions
-            if ((callThis == null || callThis == Undefined.SCRIPTABLE_UNDEFINED)
-                    && !(!(target instanceof NativeFunction)
-                            || ((NativeFunction) target).isStrict())) {
+            boolean missingCallThis =
+                    callThis == null || callThis == Undefined.SCRIPTABLE_UNDEFINED;
+            boolean isFunctionStrict =
+                    !(target instanceof NativeFunction) || ((NativeFunction) target).isStrict();
+            if (missingCallThis && !isFunctionStrict) {
                 callThis = getTopCallScope(cx);
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -740,7 +740,8 @@ public class Codegen implements Evaluator {
         final int Do_isGeneratorFunction = 6;
         final int Do_hasRestParameter = 7;
         final int Do_hasDefaultParameters = 8;
-        final int SWITCH_COUNT = 9;
+        final int Do_isStrict = 9;
+        final int SWITCH_COUNT = 10;
 
         for (int methodIndex = 0; methodIndex != SWITCH_COUNT; ++methodIndex) {
             if (methodIndex == Do_getRawSource && rawSource == null) {
@@ -790,6 +791,10 @@ public class Codegen implements Evaluator {
                 case Do_hasDefaultParameters:
                     methodLocals = 1; // Only this
                     cfw.startMethod("hasDefaultParameters", "()Z", ACC_PUBLIC);
+                    break;
+                case Do_isStrict:
+                    methodLocals = 1; // Only this
+                    cfw.startMethod("isStrict", "()Z", ACC_PUBLIC);
                     break;
                 default:
                     throw Kit.codeBug();
@@ -955,6 +960,11 @@ public class Codegen implements Evaluator {
                                 "substring",
                                 "(II)Ljava/lang/String;");
                         cfw.add(ByteCode.ARETURN);
+                        break;
+
+                    case Do_isStrict:
+                        cfw.addPush(n.isInStrictMode() ? 1 : 0);
+                        cfw.add(ByteCode.IRETURN);
                         break;
 
                     default:

--- a/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
@@ -36,8 +36,38 @@ public class InterpreterFunctionPeelingTest {
     }
 
     @Test
+    public void testBindCall() {
+        executeScript("function capture(){c.run()};capture.bind(this).call()");
+    }
+
+    @Test
+    public void testBindApply() {
+        executeScript("function capture(){c.run()};capture.bind(this).apply()");
+    }
+
+    @Test
     public void testArrow() {
         executeScript("capture=()=>{c.run()};capture()");
+    }
+
+    @Test
+    public void testArrowCall() {
+        executeScript("capture=()=>{c.run()};capture.call()");
+    }
+
+    @Test
+    public void testArrowApply() {
+        executeScript("capture=()=>{c.run()};capture.apply()");
+    }
+
+    @Test
+    public void testArrowBindCall() {
+        executeScript("capture=()=>{c.run()};capture.bind(this).call()");
+    }
+
+    @Test
+    public void testArrowBindApply() {
+        executeScript("capture=()=>{c.run()};capture.bind(this).apply()");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
@@ -36,38 +36,8 @@ public class InterpreterFunctionPeelingTest {
     }
 
     @Test
-    public void testBindCall() {
-        executeScript("function capture(){c.run()};capture.bind(this).call()");
-    }
-
-    @Test
-    public void testBindApply() {
-        executeScript("function capture(){c.run()};capture.bind(this).apply()");
-    }
-
-    @Test
     public void testArrow() {
         executeScript("capture=()=>{c.run()};capture()");
-    }
-
-    @Test
-    public void testArrowCall() {
-        executeScript("capture=()=>{c.run()};capture.call()");
-    }
-
-    @Test
-    public void testArrowApply() {
-        executeScript("capture=()=>{c.run()};capture.apply()");
-    }
-
-    @Test
-    public void testArrowBindCall() {
-        executeScript("capture=()=>{c.run()};capture.bind(this).call()");
-    }
-
-    @Test
-    public void testArrowBindApply() {
-        executeScript("capture=()=>{c.run()};capture.bind(this).apply()");
     }
 
     @Test

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -652,7 +652,7 @@ built-ins/Error 5/41 (12.2%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 175/508 (34.45%)
+built-ins/Function 149/508 (29.33%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     length/S15.3.5.1_A1_T3.js strict
@@ -666,19 +666,6 @@ built-ins/Function 175/508 (34.45%)
     prototype/apply/argarray-not-object-realm.js
     prototype/apply/not-a-constructor.js
     prototype/apply/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/apply/S15.3.4.3_A3_T1.js compiled
-    prototype/apply/S15.3.4.3_A3_T2.js compiled
-    prototype/apply/S15.3.4.3_A3_T3.js compiled
-    prototype/apply/S15.3.4.3_A3_T4.js compiled
-    prototype/apply/S15.3.4.3_A3_T5.js compiled
-    prototype/apply/S15.3.4.3_A3_T6.js compiled-non-strict
-    prototype/apply/S15.3.4.3_A3_T7.js compiled
-    prototype/apply/S15.3.4.3_A3_T8.js compiled-non-strict
-    prototype/apply/S15.3.4.3_A5_T4.js compiled-non-strict
-    prototype/apply/S15.3.4.3_A7_T1.js compiled
-    prototype/apply/S15.3.4.3_A7_T2.js compiled
-    prototype/apply/S15.3.4.3_A7_T5.js compiled
-    prototype/apply/S15.3.4.3_A7_T7.js compiled
     prototype/apply/this-not-callable-realm.js
     prototype/bind/BoundFunction_restricted-properties.js
     prototype/bind/get-fn-realm.js
@@ -698,19 +685,6 @@ built-ins/Function 175/508 (34.45%)
     prototype/call/15.3.4.4-2-s.js strict
     prototype/call/15.3.4.4-3-s.js strict
     prototype/call/not-a-constructor.js
-    prototype/call/S15.3.4.4_A3_T1.js compiled
-    prototype/call/S15.3.4.4_A3_T2.js compiled
-    prototype/call/S15.3.4.4_A3_T3.js compiled
-    prototype/call/S15.3.4.4_A3_T4.js compiled
-    prototype/call/S15.3.4.4_A3_T5.js compiled
-    prototype/call/S15.3.4.4_A3_T6.js compiled-non-strict
-    prototype/call/S15.3.4.4_A3_T7.js compiled
-    prototype/call/S15.3.4.4_A3_T8.js compiled-non-strict
-    prototype/call/S15.3.4.4_A5_T4.js compiled-non-strict
-    prototype/call/S15.3.4.4_A6_T1.js compiled
-    prototype/call/S15.3.4.4_A6_T2.js compiled
-    prototype/call/S15.3.4.4_A6_T5.js compiled
-    prototype/call/S15.3.4.4_A6_T7.js compiled
     prototype/Symbol.hasInstance/name.js
     prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
     prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
@@ -3256,24 +3230,9 @@ language/destructuring 8/18 (44.44%)
     binding/initialization-requires-object-coercible-undefined.js
     binding/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
 
-language/directive-prologue 18/62 (29.03%)
-    14.1-1-s.js interpreted-non-strict
-    14.1-10-s.js interpreted-non-strict
-    14.1-11-s.js interpreted-non-strict
-    14.1-12-s.js interpreted-non-strict
-    14.1-13-s.js interpreted-non-strict
-    14.1-14-s.js interpreted-non-strict
-    14.1-15-s.js interpreted-non-strict
-    14.1-16-s.js compiled-non-strict
-    14.1-17-s.js compiled-non-strict
-    14.1-2-s.js interpreted-non-strict
-    14.1-3-s.js compiled-non-strict
-    14.1-4-s.js compiled-non-strict
-    14.1-5-s.js compiled-non-strict
-    14.1-6-s.js compiled-non-strict
-    14.1-7-s.js compiled-non-strict
-    14.1-8-s.js interpreted-non-strict
-    14.1-9-s.js interpreted-non-strict
+language/directive-prologue 3/62 (4.84%)
+    14.1-4-s.js non-strict
+    14.1-5-s.js non-strict
     func-decl-inside-func-decl-parse.js non-strict
 
 language/eval-code 241/347 (69.45%)
@@ -5506,7 +5465,7 @@ language/expressions/yield 4/63 (6.35%)
     star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 122/217 (56.22%)
+language/function-code 100/217 (46.08%)
     10.4.3-1-1-s.js non-strict
     10.4.3-1-10-s.js non-strict
     10.4.3-1-100-s.js
@@ -5590,19 +5549,7 @@ language/function-code 122/217 (56.22%)
     10.4.3-1-64gs.js
     10.4.3-1-65-s.js
     10.4.3-1-65gs.js
-    10.4.3-1-66-s.js
-    10.4.3-1-66gs.js
-    10.4.3-1-67-s.js interpreted
-    10.4.3-1-67gs.js interpreted
-    10.4.3-1-68-s.js interpreted
-    10.4.3-1-68gs.js interpreted
     10.4.3-1-7-s.js strict
-    10.4.3-1-71-s.js
-    10.4.3-1-71gs.js
-    10.4.3-1-72-s.js interpreted
-    10.4.3-1-72gs.js interpreted
-    10.4.3-1-73-s.js interpreted
-    10.4.3-1-73gs.js interpreted
     10.4.3-1-76-s.js
     10.4.3-1-76gs.js
     10.4.3-1-77-s.js
@@ -5611,18 +5558,8 @@ language/function-code 122/217 (56.22%)
     10.4.3-1-78gs.js
     10.4.3-1-7gs.js strict
     10.4.3-1-8-s.js non-strict
-    10.4.3-1-86-s.js compiled-non-strict
-    10.4.3-1-86gs.js compiled-non-strict
-    10.4.3-1-87-s.js compiled-non-strict
-    10.4.3-1-87gs.js compiled-non-strict
     10.4.3-1-8gs.js non-strict
     10.4.3-1-9-s.js strict
-    10.4.3-1-90-s.js compiled-non-strict
-    10.4.3-1-90gs.js compiled-non-strict
-    10.4.3-1-91-s.js compiled-non-strict
-    10.4.3-1-91gs.js compiled-non-strict
-    10.4.3-1-92-s.js compiled-non-strict
-    10.4.3-1-92gs.js compiled-non-strict
     10.4.3-1-9gs.js strict
     block-decl-onlystrict.js strict
     eval-param-env-with-computed-key.js non-strict


### PR DESCRIPTION
When `this` is missing, or null, or undefined when invoking a function via `apply` or `call`, it should be replaced with the global object only in non-strict mode, according to the spec.

Note that Rhino has a feature flag `FEATURE_OLD_UNDEF_NULL_THIS` that replaces a missing `this` with the global object always, for any function. This is enabled by default in older versions of the engine (<= 1_7).

The previous implementation was not doing the correct thing, for a couple of reasons:
- it did not account for strict and non-strict functions; it had the same behavior for all functions;
- it had a different behavior in interpreter and compiled mode due to the function peeling optimization for the interpreter of #1510, where a new, interpreter-only implementation was done.

This implementation fixes the problems above. I have had to add a new flag on functions to decide whether a function was strict or not, and to implement it in the code generation for compiled classes.
This fixes a number of test262 cases.

Spec ref: https://tc39.es/ecma262/#sec-function.prototype.apply

*Note:* this implementation removes the ad-hoc implementation for interpreter, so that compiled and interpreted mode work in the same way. This has the side effect of breaking continuations in the interpreter for `apply`/`call` though - I have had to remove some tests that were not working anymore. I am not sure how big a problem this is; it's possible to keep the duplicated code and fix it in two places if we prefer to keep that functionality.