### PR TITLE
Fix: `strict` flag is not set correctly at compile time

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -335,7 +335,21 @@ public class BaseFunction extends IdScriptableObject implements Function {
         int id = f.methodId();
         switch (id) {
             case Id_constructor:
-                return jsConstructor(cx, scope, args);
+                if (cx.isStrictMode()) {
+                    // Disable strict mode forcefully, and restore it after the call
+                    NativeCall activation = cx.currentActivationCall;
+                    boolean strictMode = cx.isTopLevelStrict;
+                    try {
+                        cx.currentActivationCall = null;
+                        cx.isTopLevelStrict = false;
+                        return jsConstructor(cx, scope, args);
+                    } finally {
+                        cx.isTopLevelStrict = strictMode;
+                        cx.currentActivationCall = activation;
+                    }
+                } else {
+                    return jsConstructor(cx, scope, args);
+                }
 
             case Id_toString:
                 {

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -697,7 +697,6 @@ public class Parser {
         // that begins with a Directive Prologue that contains a Use Strict Directive.
         boolean inDirectivePrologue = true;
         boolean savedStrictMode = inUseStrictDirective;
-        inUseStrictDirective = false;
 
         pn.setLineColumnNumber(lineNumber(), columnNumber());
         try {

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -554,13 +554,9 @@ built-ins/Error 5/41 (12.2%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 149/508 (29.33%)
+built-ins/Function 136/508 (26.77%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
-    length/S15.3.5.1_A1_T3.js strict
-    length/S15.3.5.1_A2_T3.js strict
-    length/S15.3.5.1_A3_T3.js strict
-    length/S15.3.5.1_A4_T3.js strict
     prototype/apply/15.3.4.3-1-s.js strict
     prototype/apply/15.3.4.3-2-s.js strict
     prototype/apply/15.3.4.3-3-s.js strict
@@ -654,18 +650,9 @@ built-ins/Function 149/508 (29.33%)
     prototype/restricted-property-caller.js
     prototype/S15.3.4_A5.js
     15.3.2.1-10-6gs.js non-strict
-    15.3.2.1-11-1.js strict
     15.3.2.1-11-1-s.js non-strict
-    15.3.2.1-11-2-s.js strict
-    15.3.2.1-11-3.js strict
     15.3.2.1-11-3-s.js non-strict
-    15.3.2.1-11-4-s.js strict
-    15.3.2.1-11-5.js strict
     15.3.2.1-11-5-s.js non-strict
-    15.3.2.1-11-6-s.js strict
-    15.3.2.1-11-7-s.js strict
-    15.3.2.1-11-8-s.js strict
-    15.3.2.1-11-9-s.js strict
     15.3.5-1gs.js strict
     15.3.5-2gs.js strict
     15.3.5.4_2-11gs.js strict
@@ -3149,10 +3136,9 @@ language/destructuring 8/18 (44.44%)
     binding/initialization-requires-object-coercible-undefined.js
     binding/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
 
-language/directive-prologue 3/62 (4.84%)
+language/directive-prologue 2/62 (3.23%)
     14.1-4-s.js non-strict
     14.1-5-s.js non-strict
-    func-decl-inside-func-decl-parse.js non-strict
 
 language/eval-code 241/347 (69.45%)
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
@@ -4554,7 +4540,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 717/1169 (61.33%)
+language/expressions/object 715/1169 (61.16%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -5233,7 +5219,6 @@ language/expressions/object 717/1169 (61.33%)
     fn-name-fn.js
     fn-name-gen.js
     getter-body-strict-inside.js non-strict
-    getter-body-strict-outside.js strict
     getter-param-dflt.js
     ident-name-prop-name-literal-await-static-init.js
     identifier-shorthand-await-strict-mode.js non-strict
@@ -5266,7 +5251,6 @@ language/expressions/object 717/1169 (61.33%)
     scope-setter-body-lex-distinc.js non-strict
     scope-setter-paramsbody-var-open.js
     setter-body-strict-inside.js non-strict
-    setter-body-strict-outside.js strict
     setter-length-dflt.js
     setter-param-arguments-strict-inside.js non-strict
     setter-param-eval-strict-inside.js non-strict
@@ -6551,7 +6535,7 @@ language/statements/for-of 433/741 (58.43%)
     typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
-language/statements/function 164/451 (36.36%)
+language/statements/function 162/451 (35.92%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6662,10 +6646,8 @@ language/statements/function 164/451 (36.36%)
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
     forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    13.0-12-s.js strict
     13.0-13-s.js non-strict
     13.0-14-s.js non-strict
-    13.0_4-17gs.js strict
     13.1-22-s.js non-strict
     13.2-10-s.js
     13.2-13-s.js
@@ -7216,7 +7198,7 @@ language/statements/try 113/201 (56.22%)
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable 78/178 (43.82%)
+language/statements/variable 66/178 (37.08%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7274,21 +7256,9 @@ language/statements/variable 78/178 (43.82%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     12.2.1-10-s.js strict
-    12.2.1-17-s.js strict
     12.2.1-20-s.js strict
     12.2.1-21-s.js strict
-    12.2.1-3-s.js strict
-    12.2.1-6-s.js strict
     12.2.1-9-s.js strict
-    arguments-fn-strict-list-final.js strict
-    arguments-fn-strict-list-final-init.js strict
-    arguments-fn-strict-list-first.js strict
-    arguments-fn-strict-list-first-init.js strict
-    arguments-fn-strict-list-middle.js strict
-    arguments-fn-strict-list-middle-init.js strict
-    arguments-fn-strict-list-repeated.js strict
-    arguments-fn-strict-single.js strict
-    arguments-fn-strict-single-init.js strict
     fn-name-arrow.js
     fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
@@ -7311,8 +7281,7 @@ language/statements/while 13/38 (34.21%)
     let-identifier-with-newline.js non-strict
     tco-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/with 26/175 (14.86%)
-    12.10.1-8-s.js non-strict
+language/statements/with 22/175 (12.57%)
     binding-blocked-by-unscopables.js non-strict
     cptn-abrupt-empty.js non-strict
     cptn-nrml.js non-strict
@@ -7332,9 +7301,6 @@ language/statements/with 26/175 (14.86%)
     set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
     set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js non-strict
     set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js non-strict
-    strict-fn-decl-nested-1.js non-strict
-    strict-fn-expr.js strict
-    strict-fn-method.js strict
     unscopables-get-err.js non-strict
     unscopables-inc-dec.js non-strict
     unscopables-prop-get-err.js non-strict


### PR DESCRIPTION
If a function does not have the directive `use strict`, but it is contained in a scope which is strict, we should propagate the strict flag. However, the parser was incorrectly resetting it.

Fixes various test262 cases.

Unfortunately, fixing this broke the `Function` constructor (which is akin to `eval`). I've done a bit of a hacky fix - it works, but I'm not particularly proud of it.