### PR TITLE
NativeRegExp: Fix bugs in character class parsing

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1284,7 +1284,10 @@ public class NativeRegExp extends IdScriptableObject {
 
         if (state.cp >= state.cpend) return null;
 
-        if (src[state.cp] == ']') return contents;
+        if (src[state.cp] == ']') {
+            state.cp++;
+            return contents;
+        }
 
         if (src[state.cp] == '^') {
             state.cp++;

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1299,7 +1299,7 @@ public class NativeRegExp extends IdScriptableObject {
                 state.cp++;
                 if (state.cp < state.cpend && src[state.cp] == 'b') {
                     state.cp++;
-                    contents.chars.add((char) 0x8);
+                    thisChar = (char) 0x08;
                 } else {
                     if (!parseCharacterAndCharacterClassEscape(state, params)) {
                         if (src[state.cp] == 'c') { // when lookahead=c, parse the \\ as a literal
@@ -1317,6 +1317,8 @@ public class NativeRegExp extends IdScriptableObject {
                                 contents.chars.add('-');
                                 inRange = false;
                             }
+                            // multi-character character escapes don't need range handling
+                            continue;
                         }
                     }
                 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -884,4 +884,39 @@ public class NativeRegExpTest {
         Utils.assertEcmaErrorES6(
                 "SyntaxError: Invalid range in character class", "/[z-a]/.compile()");
     }
+
+    @Test
+    public void matchEmptyCharacterClass() {
+        Utils.assertWithAllModes_ES6(null, "''.match(/[]/)");
+        Utils.assertWithAllModes_ES6(null, "'abc'.match(/[]/)");
+
+        Utils.assertWithAllModes_ES6("", "''.match(/[]*/)[0]");
+        Utils.assertWithAllModes_ES6(1, "''.match(/[]*/).length");
+
+        Utils.assertWithAllModes_ES6("", "'abc'.match(/[]*/)[0]");
+        Utils.assertWithAllModes_ES6(1, "'abc'.match(/[]*/).length");
+    }
+
+    @Test
+    public void replaceEmptyCharacterClass() {
+        Utils.assertWithAllModes_ES6("", "''.replace(/[]/, 'x')");
+        Utils.assertWithAllModes_ES6("abc", "'abc'.replace(/[]/, 'x')");
+
+        Utils.assertWithAllModes_ES6("x", "''.replace(/[]*/, 'x')");
+        Utils.assertWithAllModes_ES6("xabc", "'abc'.replace(/[]*/, 'x')");
+
+        Utils.assertWithAllModes_ES6("x", "''.replace(/[]*/g, 'x')");
+        Utils.assertWithAllModes_ES6("xaxbxcx", "'abc'.replace(/[]*/g, 'x')");
+
+        Utils.assertWithAllModes_ES6("xaxbxxcx*xdx", "'ab]c*d'.replace(/[]*]*/g, 'x')");
+    }
+
+    @Test
+    public void testEmptyCharacterClass() {
+        Utils.assertWithAllModes_ES6(false, "/[]/.test('')");
+        Utils.assertWithAllModes_ES6(false, "/[]/.test('abc')");
+
+        Utils.assertWithAllModes_ES6(true, "/[]*/.test('')");
+        Utils.assertWithAllModes_ES6(true, "/[]*/.test('abc')");
+    }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -919,4 +919,24 @@ public class NativeRegExpTest {
         Utils.assertWithAllModes_ES6(true, "/[]*/.test('')");
         Utils.assertWithAllModes_ES6(true, "/[]*/.test('abc')");
     }
+
+    @Test
+    public void characterClassRangeWithSingleItemCharacterClasses() {
+        final String script =
+                "var regex = /[\\b-\\x10]/;\n"
+                        + "var res = '' + regex.test('\\x09') + '-' + regex.test('\\x07') + '-' + regex.test('\\x11');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("true-false-false", script);
+    }
+
+    @Test
+    public void characterClassWithMultiCharacterEscape() {
+        // [\d-A] should be parsed as a union of 3 character sets - digits,  '-', and 'A'.
+        // Therefore it shouldn't match something in between '9' and 'A', say ';'
+        final String script =
+                "var regex = /[\\d-A]/;\n"
+                        + "var res = '' + regex.test('5') + '-' + regex.test('A') + '-' + regex.test('-') + '-' + regex.test(';');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("true-true-true-false", script);
+    }
 }


### PR DESCRIPTION
This fixes two regressions introduced by #1847.

- Empty character class parsing (Thanks to @rbri for identifying the bug and providing test cases)
- Handling character class escapes in character classes