### PR TITLE
Initialize `arguments` lazily

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -104,6 +104,7 @@ class CodeGenerator extends Icode {
 
         itsData.itsFunctionType = theFunction.getFunctionType();
         itsData.itsNeedsActivation = theFunction.requiresActivation();
+        itsData.itsNeedsArguments = theFunction.needsArguments();
         if (theFunction.getFunctionName() != null) {
             itsData.itsName = theFunction.getName();
         }

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -104,7 +104,7 @@ class CodeGenerator extends Icode {
 
         itsData.itsFunctionType = theFunction.getFunctionType();
         itsData.itsNeedsActivation = theFunction.requiresActivation();
-        itsData.itsNeedsArguments = theFunction.needsArguments();
+        itsData.itsRequiresArgumentObject = theFunction.requiresArgumentObject();
         if (theFunction.getFunctionName() != null) {
             itsData.itsName = theFunction.getName();
         }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1422,7 +1422,7 @@ public final class IRFactory {
         if (functionCount != 0) {
             // Functions containing other functions require activation objects
             fnNode.setRequiresActivation();
-            propagateNeedsArgumentsFromNestedArrowFunctions(fnNode);
+            propagateRequiresArgumentObjectFromNestedArrowFunctions(fnNode);
         }
 
         if (functionType == FunctionNode.FUNCTION_EXPRESSION) {
@@ -1460,8 +1460,9 @@ public final class IRFactory {
         return result;
     }
 
-    private static void propagateNeedsArgumentsFromNestedArrowFunctions(FunctionNode fnNode) {
-        if (fnNode.needsArguments()) {
+    private static void propagateRequiresArgumentObjectFromNestedArrowFunctions(
+            FunctionNode fnNode) {
+        if (fnNode.requiresArgumentObject()) {
             return;
         }
 
@@ -1470,8 +1471,8 @@ public final class IRFactory {
         while (!toVisit.isEmpty()) {
             FunctionNode nestedFunction = toVisit.poll();
             if (nestedFunction.getFunctionType() == FunctionNode.ARROW_FUNCTION) {
-                if (nestedFunction.needsArguments()) {
-                    fnNode.setNeedsArguments();
+                if (nestedFunction.requiresArgumentObject()) {
+                    fnNode.setRequiresArgumentObject();
                     return;
                 }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -147,6 +147,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         args,
                                         fnOrScript.isStrict(),
                                         idata.argsHasRest,
+                                        idata.itsNeedsArguments,
                                         homeObject);
                     } else {
                         scope =
@@ -157,6 +158,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         args,
                                         fnOrScript.isStrict(),
                                         idata.argsHasRest,
+                                        idata.itsNeedsArguments,
                                         homeObject);
                     }
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -147,7 +147,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         args,
                                         fnOrScript.isStrict(),
                                         idata.argsHasRest,
-                                        idata.itsNeedsArguments,
+                                        idata.itsRequiresArgumentObject,
                                         homeObject);
                     } else {
                         scope =
@@ -158,7 +158,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         args,
                                         fnOrScript.isStrict(),
                                         idata.argsHasRest,
-                                        idata.itsNeedsArguments,
+                                        idata.itsRequiresArgumentObject,
                                         homeObject);
                     }
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -46,7 +46,7 @@ final class InterpreterData implements Serializable, DebuggableScript {
     String itsName;
     String itsSourceFile;
     boolean itsNeedsActivation;
-    boolean itsNeedsArguments;
+    boolean itsRequiresArgumentObject;
     int itsFunctionType;
 
     String[] itsStringTable;

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -46,6 +46,7 @@ final class InterpreterData implements Serializable, DebuggableScript {
     String itsName;
     String itsSourceFile;
     boolean itsNeedsActivation;
+    boolean itsNeedsArguments;
     int itsFunctionType;
 
     String[] itsStringTable;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
@@ -34,7 +34,7 @@ public final class NativeCall extends IdScriptableObject {
             boolean isArrow,
             boolean isStrict,
             boolean argsHasRest,
-            boolean needsArguments,
+            boolean requiresArgumentObject,
             Scriptable homeObject) {
         this.function = function;
         this.homeObject = homeObject;
@@ -77,7 +77,7 @@ public final class NativeCall extends IdScriptableObject {
             }
         }
 
-        if (needsArguments) {
+        if (requiresArgumentObject) {
             // initialize "arguments" property but only if it was not overridden by
             // the parameter with the same name
             if (!super.has("arguments", this) && !isArrow) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
@@ -34,6 +34,7 @@ public final class NativeCall extends IdScriptableObject {
             boolean isArrow,
             boolean isStrict,
             boolean argsHasRest,
+            boolean needsArguments,
             Scriptable homeObject) {
         this.function = function;
         this.homeObject = homeObject;
@@ -76,11 +77,13 @@ public final class NativeCall extends IdScriptableObject {
             }
         }
 
-        // initialize "arguments" property but only if it was not overridden by
-        // the parameter with the same name
-        if (!super.has("arguments", this) && !isArrow) {
-            arguments = new Arguments(this);
-            defineProperty("arguments", arguments, PERMANENT);
+        if (needsArguments) {
+            // initialize "arguments" property but only if it was not overridden by
+            // the parameter with the same name
+            if (!super.has("arguments", this) && !isArrow) {
+                arguments = new Arguments(this);
+                defineProperty("arguments", arguments, PERMANENT);
+            }
         }
 
         if (paramAndVarCount != 0) {

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4168,6 +4168,10 @@ public class Parser {
     }
 
     protected void checkActivationName(String name, int token) {
+        if ("arguments".equals(name) && currentScriptOrFn instanceof FunctionNode) {
+            ((FunctionNode) currentScriptOrFn).setNeedsArguments();
+        }
+
         if (!insideFunctionBody()) {
             return;
         }
@@ -4203,6 +4207,9 @@ public class Parser {
                 || (pn.getType() == Token.GETPROP
                         && "eval".equals(((PropertyGet) pn).getProperty().getIdentifier())))
             setRequiresActivation();
+        if (insideFunctionBody()) {
+            ((FunctionNode) currentScriptOrFn).setNeedsArguments();
+        }
     }
 
     protected void setIsGenerator() {

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4169,7 +4169,10 @@ public class Parser {
 
     protected void checkActivationName(String name, int token) {
         if ("arguments".equals(name) && currentScriptOrFn instanceof FunctionNode) {
-            ((FunctionNode) currentScriptOrFn).setNeedsArguments();
+            // If there is a usage of "arguments" we need to initialize it. However,
+            // we might not be in a function body, because we could be inside a function's
+            // default arguments. So, we do this check first, before the "insideFunctionBody"
+            ((FunctionNode) currentScriptOrFn).setRequiresArgumentObject();
         }
 
         if (!insideFunctionBody()) {
@@ -4205,16 +4208,21 @@ public class Parser {
     private void checkCallRequiresActivation(AstNode pn) {
         if ((pn.getType() == Token.NAME && "eval".equals(((Name) pn).getIdentifier()))
                 || (pn.getType() == Token.GETPROP
-                        && "eval".equals(((PropertyGet) pn).getProperty().getIdentifier())))
+                        && "eval".equals(((PropertyGet) pn).getProperty().getIdentifier()))) {
             setRequiresActivation();
-        if (insideFunctionBody()) {
-            ((FunctionNode) currentScriptOrFn).setNeedsArguments();
+            setRequiresArgumentObject();
         }
     }
 
     protected void setIsGenerator() {
         if (insideFunctionBody()) {
             ((FunctionNode) currentScriptOrFn).setIsGenerator();
+        }
+    }
+
+    private void setRequiresArgumentObject() {
+        if (insideFunctionBody()) {
+            ((FunctionNode) currentScriptOrFn).setRequiresArgumentObject();
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4571,10 +4571,18 @@ public class ScriptRuntime {
             Object[] args,
             boolean isStrict,
             boolean argsHasRest,
-            boolean needsArguments,
+            boolean requiresArgumentObject,
             Scriptable homeObject) {
         return new NativeCall(
-                funObj, cx, scope, args, false, isStrict, argsHasRest, needsArguments, homeObject);
+                funObj,
+                cx,
+                scope,
+                args,
+                false,
+                isStrict,
+                argsHasRest,
+                requiresArgumentObject,
+                homeObject);
     }
 
     /**
@@ -4620,10 +4628,18 @@ public class ScriptRuntime {
             Object[] args,
             boolean isStrict,
             boolean argsHasRest,
-            boolean needsArguments,
+            boolean requiresArgumentObject,
             Scriptable homeObject) {
         return new NativeCall(
-                funObj, cx, scope, args, true, isStrict, argsHasRest, needsArguments, homeObject);
+                funObj,
+                cx,
+                scope,
+                args,
+                true,
+                isStrict,
+                argsHasRest,
+                requiresArgumentObject,
+                homeObject);
     }
 
     public static void enterActivationFunction(Context cx, Scriptable scope) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4530,13 +4530,38 @@ public class ScriptRuntime {
 
     /**
      * @deprecated Use {@link #createFunctionActivation(NativeFunction, Context, Scriptable,
-     *     Object[], boolean, boolean, Scriptable)} instead
+     *     Object[], boolean, boolean, boolean, Scriptable)} instead
      */
     @Deprecated
     public static Scriptable createFunctionActivation(
             NativeFunction funObj, Scriptable scope, Object[] args, boolean isStrict) {
         return new NativeCall(
-                funObj, Context.getCurrentContext(), scope, args, false, isStrict, false, null);
+                funObj,
+                Context.getCurrentContext(),
+                scope,
+                args,
+                false,
+                isStrict,
+                false,
+                true,
+                null);
+    }
+
+    /**
+     * @deprecated Use {@link #createFunctionActivation(NativeFunction, Context, Scriptable,
+     *     Object[], boolean, boolean, boolean, Scriptable)} instead
+     */
+    @Deprecated
+    public static Scriptable createFunctionActivation(
+            NativeFunction funObj,
+            Context cx,
+            Scriptable scope,
+            Object[] args,
+            boolean isStrict,
+            boolean argsHasRest,
+            Scriptable homeObject) {
+        return new NativeCall(
+                funObj, cx, scope, args, false, isStrict, argsHasRest, true, homeObject);
     }
 
     public static Scriptable createFunctionActivation(
@@ -4546,19 +4571,46 @@ public class ScriptRuntime {
             Object[] args,
             boolean isStrict,
             boolean argsHasRest,
+            boolean needsArguments,
             Scriptable homeObject) {
-        return new NativeCall(funObj, cx, scope, args, false, isStrict, argsHasRest, homeObject);
+        return new NativeCall(
+                funObj, cx, scope, args, false, isStrict, argsHasRest, needsArguments, homeObject);
     }
 
     /**
      * @deprecated Use {@link #createArrowFunctionActivation(NativeFunction, Context, Scriptable,
-     *     Object[], boolean, boolean, Scriptable)} instead
+     *     Object[], boolean, boolean, boolean, Scriptable)} instead
      */
     @Deprecated
     public static Scriptable createArrowFunctionActivation(
             NativeFunction funObj, Scriptable scope, Object[] args, boolean isStrict) {
         return new NativeCall(
-                funObj, Context.getCurrentContext(), scope, args, true, isStrict, false, null);
+                funObj,
+                Context.getCurrentContext(),
+                scope,
+                args,
+                true,
+                isStrict,
+                false,
+                true,
+                null);
+    }
+
+    /**
+     * @deprecated Use {@link #createArrowFunctionActivation(NativeFunction, Context, Scriptable,
+     *     Object[], boolean, boolean, boolean, Scriptable)} instead
+     */
+    @Deprecated
+    public static Scriptable createArrowFunctionActivation(
+            NativeFunction funObj,
+            Context cx,
+            Scriptable scope,
+            Object[] args,
+            boolean isStrict,
+            boolean argsHasRest,
+            Scriptable homeObject) {
+        return new NativeCall(
+                funObj, cx, scope, args, true, isStrict, argsHasRest, true, homeObject);
     }
 
     public static Scriptable createArrowFunctionActivation(
@@ -4568,8 +4620,10 @@ public class ScriptRuntime {
             Object[] args,
             boolean isStrict,
             boolean argsHasRest,
+            boolean needsArguments,
             Scriptable homeObject) {
-        return new NativeCall(funObj, cx, scope, args, true, isStrict, argsHasRest, homeObject);
+        return new NativeCall(
+                funObj, cx, scope, args, true, isStrict, argsHasRest, needsArguments, homeObject);
     }
 
     public static void enterActivationFunction(Context cx, Scriptable scope) {

--- a/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
@@ -114,7 +114,7 @@ public class FunctionNode extends ScriptNode {
     // codegen variables
     private int functionType;
     private boolean needsActivation;
-    private boolean needsArguments;
+    private boolean requiresArgumentObject;
     private boolean isGenerator;
     private boolean isES6Generator;
     private List<Node> generatorResumePoints;
@@ -298,12 +298,12 @@ public class FunctionNode extends ScriptNode {
         needsActivation = true;
     }
 
-    public boolean needsArguments() {
-        return needsArguments;
+    public boolean requiresArgumentObject() {
+        return requiresArgumentObject;
     }
 
-    public void setNeedsArguments() {
-        this.needsArguments = true;
+    public void setRequiresArgumentObject() {
+        this.requiresArgumentObject = true;
     }
 
     public boolean isGenerator() {

--- a/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/FunctionNode.java
@@ -114,6 +114,7 @@ public class FunctionNode extends ScriptNode {
     // codegen variables
     private int functionType;
     private boolean needsActivation;
+    private boolean needsArguments;
     private boolean isGenerator;
     private boolean isES6Generator;
     private List<Node> generatorResumePoints;
@@ -295,6 +296,14 @@ public class FunctionNode extends ScriptNode {
 
     public void setRequiresActivation() {
         needsActivation = true;
+    }
+
+    public boolean needsArguments() {
+        return needsArguments;
+    }
+
+    public void setNeedsArguments() {
+        this.needsArguments = true;
     }
 
     public boolean isGenerator() {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -122,7 +122,7 @@ class BodyCodegen {
         cfw.addPush(scriptOrFn.hasRestParameter());
         cfw.addPush(
                 !(scriptOrFn instanceof FunctionNode)
-                        || ((FunctionNode) scriptOrFn).needsArguments());
+                        || ((FunctionNode) scriptOrFn).requiresArgumentObject());
         cfw.addLoadThis();
         cfw.addInvoke(
                 ByteCode.INVOKEVIRTUAL,
@@ -438,7 +438,7 @@ class BodyCodegen {
             cfw.addPush(scriptOrFn.hasRestParameter());
             cfw.addPush(
                     !(scriptOrFn instanceof FunctionNode)
-                            || ((FunctionNode) scriptOrFn).needsArguments());
+                            || ((FunctionNode) scriptOrFn).requiresArgumentObject());
 
             if (!isArrow) {
                 // Just pass the home object of the function

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -120,6 +120,9 @@ class BodyCodegen {
         cfw.addALoad(argsLocal);
         cfw.addPush(scriptOrFn.isInStrictMode());
         cfw.addPush(scriptOrFn.hasRestParameter());
+        cfw.addPush(
+                !(scriptOrFn instanceof FunctionNode)
+                        || ((FunctionNode) scriptOrFn).needsArguments());
         cfw.addLoadThis();
         cfw.addInvoke(
                 ByteCode.INVOKEVIRTUAL,
@@ -132,6 +135,7 @@ class BodyCodegen {
                         + "Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/Scriptable;"
                         + "[Ljava/lang/Object;"
+                        + "Z"
                         + "Z"
                         + "Z"
                         + "Lorg/mozilla/javascript/Scriptable;"
@@ -432,6 +436,9 @@ class BodyCodegen {
             cfw.addALoad(argsLocal);
             cfw.addPush(scriptOrFn.isInStrictMode());
             cfw.addPush(scriptOrFn.hasRestParameter());
+            cfw.addPush(
+                    !(scriptOrFn instanceof FunctionNode)
+                            || ((FunctionNode) scriptOrFn).needsArguments());
 
             if (!isArrow) {
                 // Just pass the home object of the function
@@ -473,6 +480,7 @@ class BodyCodegen {
                             + "Lorg/mozilla/javascript/Context;"
                             + "Lorg/mozilla/javascript/Scriptable;"
                             + "[Ljava/lang/Object;"
+                            + "Z"
                             + "Z"
                             + "Z"
                             + "Lorg/mozilla/javascript/Scriptable;"

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ArgumentsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ArgumentsTest.java
@@ -46,4 +46,28 @@ public class ArgumentsTest {
 
         Utils.assertWithAllModes_ES6("1235", code);
     }
+
+    @Test
+    public void argumentsNestedLambdas() {
+        String code =
+                "var foo = (function foo() {\n"
+                        + "    return () => arguments[0];\n"
+                        + "})(1);\n"
+                        + "foo()";
+
+        Utils.assertWithAllModes_ES6(1, code);
+    }
+
+    @Test
+    public void argumentsNestedNestedLambdas() {
+        String code =
+                "var foo = (function foo() {\n"
+                        + "   return () => {"
+                        + "       return () => arguments[0];\n"
+                        + "   }\n"
+                        + "})(1);\n"
+                        + "foo()()";
+
+        Utils.assertWithAllModes_ES6(1, code);
+    }
 }


### PR DESCRIPTION
From analyzing some of our benchmarks, we have seen that we spend a non trivial amount of time initializing `arguments` every time we have an activation (a `NativeCall`). However, we create activations quite often, in particular for any function that has a `try/catch` in it. Therefore, in this PR I have modified the code so that we can have an activation but no initialization of `arguments`.

It's a small improvement, but measurable in some benchmarks and neutral in many. For example, over 5% in this one:

```
After
Benchmark                  (interpreted)  Mode  Cnt      Score     Error  Units
V8Benchmark.earley                 false  avgt   20  10231.747 ± 389.858  us/op
V8Benchmark.earley                  true  avgt   20  16791.476 ± 116.138  us/op

Before
Benchmark                  (interpreted)  Mode  Cnt      Score     Error  Units
V8Benchmark.earley                 false  avgt   20  11293.621 ± 644.573  us/op
V8Benchmark.earley                  true  avgt   20  17703.935 ± 184.165  us/op
```

Also, running that benchmark with JFR recording memory allocations, we see a pretty big reduction.

<img width="2672" alt="Screenshot 2025-03-27 at 10 18 19" src="https://github.com/user-attachments/assets/51b5b597-2dd5-4352-9682-c6fd27dbdc6b" />
