### PR TITLE
Use JVM default file encoding as fallback

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.List;
 
@@ -167,11 +168,8 @@ public class UrlModuleSourceProvider extends ModuleSourceProviderBase {
         if (encoding != null) {
             return encoding;
         }
-        final String contentType = pct.getContentType();
-        if (contentType != null && contentType.startsWith("text/")) {
-            return "8859_1";
-        }
-        return "utf-8";
+
+        return Charset.defaultCharset().name();
     }
 
     private Object getSecurityDomain(URLConnection urlConnection) {


### PR DESCRIPTION
When the Shell is run with a file with `.js` extension, the content-type is determined to be `text/javascript`, which leads to the 8859_1 encoding to be used. AFAICT this is obsolete now. Change it to use the JVM default encoding.