### PR TITLE
NativeRegExp: Fix handling of \x and \u

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1208,15 +1208,21 @@ public class NativeRegExp extends IdScriptableObject {
                 {
                     int n = 0;
                     int i;
-                    for (i = 0; (i < nDigits) && (state.cp < state.cpend); i++) {
-                        c = src[state.cp++];
-                        n = Kit.xDigitToInt(c, n);
-                        if (n < 0) {
-                            // Back off to accepting the original
-                            // 'u' or 'x' as a literal
-                            state.cp -= (i + 2);
-                            n = src[state.cp++];
-                            break;
+                    if ((state.cp >= state.cpend)) {
+                        // Back off to accepting the original
+                        // 'u' or 'x' as a literal
+                        n = src[state.cp - 1];
+                    } else {
+                        for (i = 0; (i < nDigits); i++) {
+                            c = src[state.cp++];
+                            n = Kit.xDigitToInt(c, n);
+                            if (n < 0) {
+                                // Back off to accepting the original
+                                // 'u' or 'x' as a literal
+                                state.cp -= (i + 2);
+                                n = src[state.cp++];
+                                break;
+                            }
                         }
                     }
                     c = (char) n;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -939,4 +939,14 @@ public class NativeRegExpTest {
                         + "res;";
         Utils.assertWithAllModes_ES6("true-true-true-false", script);
     }
+
+    @Test
+    public void unicodeEscapeFallback() {
+        final String script = "var regex = /\\u/;\n" + "var res = '' + regex.test('u');\n" + "res;";
+        Utils.assertWithAllModes_ES6("true", script);
+
+        final String script2 =
+                "var regex = /\\x/;\n" + "var res = '' + regex.test('x');\n" + "res;";
+        Utils.assertWithAllModes_ES6("true", script2);
+    }
 }


### PR DESCRIPTION
Handle \x and \u properly when they appear at the very end of a regexp. They should be treated as literals in this case.