### PR TITLE
Reimplement `String.prototype.search`, `replace`, `replaceAll`, `split`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -505,4 +505,24 @@ public class AbstractEcmaObjectOperations {
 
         return argument instanceof Constructable;
     }
+
+    /**
+     * IsRegExp(argument)
+     *
+     * <p>https://tc39.es/ecma262/multipage/abstract-operations.html#sec-isregexp
+     */
+    static boolean isRegExp(Context cx, Scriptable scope, Object argument) {
+        if (!ScriptRuntime.isObject(argument)) {
+            return false;
+        }
+        Object matcher = ScriptRuntime.getObjectElem(argument, SymbolKey.MATCH, cx, scope);
+        if (!Undefined.isUndefined(matcher)) {
+            return ScriptRuntime.toBoolean(matcher);
+        }
+        RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
+        if (argument instanceof Scriptable && regExpProxy.isRegExp((Scriptable) argument)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
@@ -67,9 +67,7 @@ public class AbstractEcmaStringOperations {
                                 int digitCount = 1;
                                 if (templateRemainder.length() > 2) {
                                     char c2 = templateRemainder.charAt(2);
-                                    if (c2 == '0' || c2 == '1' || c2 == '2' || c2 == '3'
-                                            || c2 == '4' || c2 == '5' || c2 == '6' || c2 == '7'
-                                            || c2 == '8' || c2 == '9') {
+                                    if (isAsciiDigit(c2)) {
                                         digitCount = 2;
                                     }
                                 }
@@ -129,5 +127,24 @@ public class AbstractEcmaStringOperations {
             result.append(refReplacement);
         }
         return result.toString();
+    }
+
+    private static boolean isAsciiDigit(char c) {
+        switch (c) {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return true;
+
+            default:
+                return false;
+        }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
@@ -1,0 +1,133 @@
+package org.mozilla.javascript;
+
+/** Abstract operations for string manipulation as defined by EcmaScript */
+public class AbstractEcmaStringOperations {
+    /**
+     * GetSubstitution(matched, str, position, captures, namedCaptures, replacementTemplate)
+     *
+     * <p>https://tc39.es/ecma262/multipage/text-processing.html#sec-getsubstitution
+     */
+    public static String getSubstitution(
+            Context cx,
+            Scriptable scope,
+            String matched,
+            String str,
+            int position,
+            NativeArray capturesArray,
+            Object namedCaptures,
+            String replacementTemplate) {
+        // See ECMAScript spec 22.1.3.19.1
+        int stringLength = str.length();
+        if (position > stringLength) Kit.codeBug();
+        StringBuilder result = new StringBuilder();
+        String templateRemainder = replacementTemplate;
+        while (!templateRemainder.isEmpty()) {
+            String ref = templateRemainder.substring(0, 1);
+            String refReplacement = ref;
+
+            if (templateRemainder.charAt(0) == '$') {
+                if (templateRemainder.length() > 1) {
+                    char c = templateRemainder.charAt(1);
+                    switch (c) {
+                        case '$':
+                            ref = "$$";
+                            refReplacement = "$";
+                            break;
+
+                        case '`':
+                            ref = "$`";
+                            refReplacement = str.substring(0, position);
+                            break;
+
+                        case '&':
+                            ref = "$&";
+                            refReplacement = matched;
+                            break;
+
+                        case '\'':
+                            {
+                                ref = "$'";
+                                int matchLength = matched.length();
+                                int tailPos = position + matchLength;
+                                refReplacement = str.substring(Math.min(tailPos, stringLength));
+                                break;
+                            }
+
+                        case '0':
+                        case '1':
+                        case '2':
+                        case '3':
+                        case '4':
+                        case '5':
+                        case '6':
+                        case '7':
+                        case '8':
+                        case '9':
+                            {
+                                int digitCount = 1;
+                                if (templateRemainder.length() > 2) {
+                                    char c2 = templateRemainder.charAt(2);
+                                    if (c2 == '0' || c2 == '1' || c2 == '2' || c2 == '3'
+                                            || c2 == '4' || c2 == '5' || c2 == '6' || c2 == '7'
+                                            || c2 == '8' || c2 == '9') {
+                                        digitCount = 2;
+                                    }
+                                }
+                                String digits = templateRemainder.substring(1, 1 + digitCount);
+
+                                // No need for ScriptRuntime version; we know the string is one or
+                                // two characters and
+                                // contains only [0-9]
+                                int index = Integer.parseInt(digits);
+                                long captureLen = capturesArray.getLength();
+                                if (index > captureLen && digitCount == 2) {
+                                    digitCount = 1;
+                                    digits = digits.substring(0, 1);
+                                    index = Integer.parseInt(digits);
+                                }
+                                ref = templateRemainder.substring(0, 1 + digitCount);
+                                if (1 <= index && index <= captureLen) {
+                                    Object capture = capturesArray.get(index - 1);
+                                    if (capture
+                                            == null) { // Undefined or missing are returned as null
+                                        refReplacement = "";
+                                    } else {
+                                        refReplacement = ScriptRuntime.toString(capture);
+                                    }
+                                } else {
+                                    refReplacement = ref;
+                                }
+                                break;
+                            }
+
+                        case '<':
+                            {
+                                int gtPos = templateRemainder.indexOf('>');
+                                if (gtPos == -1 || Undefined.isUndefined(namedCaptures)) {
+                                    ref = "$<";
+                                    refReplacement = ref;
+                                } else {
+                                    ref = templateRemainder.substring(0, gtPos + 1);
+                                    String groupName = templateRemainder.substring(2, gtPos);
+                                    Object capture =
+                                            ScriptRuntime.getObjectProp(
+                                                    namedCaptures, groupName, cx, scope);
+                                    if (Undefined.isUndefined(capture)) {
+                                        refReplacement = "";
+                                    } else {
+                                        refReplacement = ScriptRuntime.toString(capture);
+                                    }
+                                }
+                            }
+                            break;
+                    }
+                }
+            }
+
+            int refLength = ref.length();
+            templateRemainder = templateRemainder.substring(refLength);
+            result.append(refReplacement);
+        }
+        return result.toString();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -423,16 +423,8 @@ final class NativeString extends ScriptableObject {
         int separatorLength = r.length();
         if (separatorLength == 0) {
             int strLen = s.length();
-            long outLen;
-            if (lim < 0) {
-                outLen = 0;
-            } else if (lim > strLen) {
-                outLen = strLen;
-            } else {
-                outLen = lim;
-            }
-
-            String head = s.substring(0, (int) outLen);
+            int outLen = ScriptRuntime.clamp((int) lim, 0, strLen);
+            String head = s.substring(0, outLen);
 
             List<Object> codeUnits = new ArrayList<>();
             for (int i = 0; i < head.length(); ) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -996,10 +996,8 @@ final class NativeString extends ScriptableObject {
         // See ECMAScript spec 22.1.3.14
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "matchAll");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
-        RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
         if (regexp != null && !Undefined.isUndefined(regexp)) {
-            boolean isRegExp =
-                    regexp instanceof Scriptable && regExpProxy.isRegExp((Scriptable) regexp);
+            boolean isRegExp = AbstractEcmaObjectOperations.isRegExp(cx, scope, regexp);
             if (isRegExp) {
                 Object flags = ScriptRuntime.getObjectProp(regexp, "flags", cx, scope);
                 requireObjectCoercible(cx, flags, CLASS_NAME, "matchAll");
@@ -1023,6 +1021,7 @@ final class NativeString extends ScriptableObject {
 
         String s = ScriptRuntime.toString(o);
         String regexpToString = Undefined.isUndefined(regexp) ? "" : ScriptRuntime.toString(regexp);
+        RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
         Object compiledRegExp = regExpProxy.compileRegExp(cx, regexpToString, "g");
         Scriptable rx = regExpProxy.wrapRegExp(cx, scope, compiledRegExp);
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -1422,7 +1422,7 @@ public class ScriptRuntime {
 
     /** Implements the abstract operation AdvanceStringIndex. See ECMAScript spec 22.2.7.3 */
     public static long advanceStringIndex(String string, long index, boolean unicode) {
-        if (index >= NativeNumber.MAX_SAFE_INTEGER) Kit.codeBug();
+        if (index > NativeNumber.MAX_SAFE_INTEGER) Kit.codeBug();
         if (!unicode) {
             return index + 1;
         }
@@ -3090,7 +3090,7 @@ public class ScriptRuntime {
         return function.call(cx, scope, callThis, callArgs);
     }
 
-    static Scriptable getApplyOrCallThis(
+    public static Scriptable getApplyOrCallThis(
             Context cx, Scriptable scope, Object arg0, int l, Callable target) {
         Scriptable callThis;
         if (cx.hasFeature(Context.FEATURE_OLD_UNDEF_NULL_THIS)) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -5703,6 +5703,21 @@ public class ScriptRuntime {
         return null;
     }
 
+    /**
+     * Clamps value between min and max, inclusive.
+     *
+     * @return value if it is between min and max, otherwise min or max
+     */
+    public static int clamp(int value, int min, int max) {
+        if (value < min) {
+            return min;
+        } else if (value > max) {
+            return max;
+        } else {
+            return value;
+        }
+    }
+
     public static final Object[] emptyArgs = new Object[0];
     public static final String[] emptyStrings = new String[0];
 

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -3613,14 +3613,7 @@ public class NativeRegExp extends IdScriptableObject {
             double positionDbl =
                     ScriptRuntime.toInteger(
                             ScriptRuntime.getObjectProp(result, "index", cx, scope));
-            int position;
-            if (positionDbl < 0) {
-                position = 0;
-            } else if (positionDbl > lengthS) {
-                position = lengthS;
-            } else {
-                position = (int) positionDbl;
-            }
+            int position = ScriptRuntime.clamp((int) positionDbl, 0, lengthS);
 
             List<Object> captures = new ArrayList<>();
             int n = 1;

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -89,8 +89,7 @@ public class RegExpImpl implements RegExpProxy {
                         re = createRegExp(cx, scope, args, 2, true);
                         if (RA_REPLACE_ALL == actionType
                                 && (re.getFlags() & NativeRegExp.JSREG_GLOB) == 0) {
-                            throw ScriptRuntime.typeError(
-                                    "replaceAll must be called with a global RegExp");
+                            throw ScriptRuntime.typeErrorById("msg.str.replace.all.no.global.flag");
                         }
                     } else {
                         Object arg0 = args.length < 1 ? Undefined.instance : args[0];

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -256,6 +256,9 @@ msg.arg.not.object =\
 msg.str.match.all.no.global.flag =\
     String.prototype.matchAll called with a non-global RegExp argument
 
+msg.str.replace.all.no.global.flag =\
+    replaceAll must be called with a global RegExp
+
 msg.invalid.group.name =\
     Invalid capture group name
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeTest.java
@@ -42,4 +42,13 @@ public class ScriptRuntimeTest {
                 "java.lang.NullPointerException: NPE",
                 ScriptRuntime.toString(new NullPointerException("NPE")));
     }
+
+    @Test
+    public void testClamp() {
+        assertEquals(5, ScriptRuntime.clamp(5, 0, 10));
+        assertEquals(10, ScriptRuntime.clamp(10, 0, 10));
+        assertEquals(10, ScriptRuntime.clamp(20, 0, 10));
+        assertEquals(0, ScriptRuntime.clamp(0, 0, 10));
+        assertEquals(0, ScriptRuntime.clamp(-10, 0, 10));
+    }
 }

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1408,7 +1408,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1038/1854 (55.99%)
+built-ins/RegExp 1036/1854 (55.88%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1426,7 +1426,6 @@ built-ins/RegExp 1038/1854 (55.99%)
     match-indices/indices-groups-properties.js
     match-indices/indices-property.js
     named-groups/duplicate-names-match-indices.js
-    named-groups/duplicate-names-replace.js
     named-groups/duplicate-names-replaceall.js
     named-groups/duplicate-names-split.js
     named-groups/functional-replace-global.js
@@ -1434,7 +1433,6 @@ built-ins/RegExp 1038/1854 (55.99%)
     named-groups/groups-object.js
     named-groups/groups-object-subclass.js
     named-groups/groups-object-subclass-sans.js
-    named-groups/groups-object-unmatched.js
     named-groups/groups-properties.js
     named-groups/lookbehind.js
     named-groups/non-unicode-property-names.js
@@ -1793,7 +1791,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 49/1182 (4.15%)
+built-ins/String 46/1182 (3.89%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -1823,9 +1821,6 @@ built-ins/String 49/1182 (4.15%)
     prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
     prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
     prototype/replaceAll/searchValue-tostring-regexp.js
-    prototype/replace/cstm-replace-get-err.js
-    prototype/replace/cstm-replace-invocation.js
-    prototype/replace/S15.5.4.11_A12.js non-strict
     prototype/search/cstm-search-invocation.js
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js
@@ -5299,13 +5294,11 @@ language/expressions/yield 4/63 (6.35%)
     star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 100/217 (46.08%)
+language/function-code 98/217 (45.16%)
     10.4.3-1-1-s.js non-strict
     10.4.3-1-10-s.js non-strict
-    10.4.3-1-100-s.js
-    10.4.3-1-100gs.js
-    10.4.3-1-102-s.js
-    10.4.3-1-102gs.js
+    10.4.3-1-102-s.js compiled
+    10.4.3-1-102gs.js compiled
     10.4.3-1-104.js strict
     10.4.3-1-106.js strict
     10.4.3-1-10gs.js non-strict

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1408,7 +1408,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 997/1854 (53.78%)
+built-ins/RegExp 996/1854 (53.72%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1426,7 +1426,6 @@ built-ins/RegExp 997/1854 (53.78%)
     match-indices/indices-groups-properties.js
     match-indices/indices-property.js
     named-groups/duplicate-names-match-indices.js
-    named-groups/duplicate-names-split.js
     named-groups/functional-replace-global.js
     named-groups/functional-replace-non-global.js
     named-groups/groups-object.js
@@ -1752,7 +1751,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 35/1182 (2.96%)
+built-ins/String 30/1182 (2.54%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -1772,11 +1771,6 @@ built-ins/String 35/1182 (2.96%)
     prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
     prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
     prototype/search/cstm-search-invocation.js
-    prototype/split/cstm-split-get-err.js
-    prototype/split/cstm-split-invocation.js
-    prototype/split/separator-regexp.js
-    prototype/split/separator-tostring-error.js
-    prototype/split/this-value-tostring-error.js
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/substring/S15.5.4.15_A1_T5.js
     prototype/toLocaleLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1409,7 +1409,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1103/1854 (59.49%)
+built-ins/RegExp 1097/1854 (59.17%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1595,18 +1595,12 @@ built-ins/RegExp 1103/1854 (59.49%)
     prototype/Symbol.replace/y-fail-return.js
     prototype/Symbol.replace/y-init-lastindex.js
     prototype/Symbol.replace/y-set-lastindex.js
-    prototype/Symbol.search/cstm-exec-return-index.js
-    prototype/Symbol.search/get-lastindex-err.js
-    prototype/Symbol.search/lastindex-no-restore.js
-    prototype/Symbol.search/match-err.js
+    prototype/Symbol.search/cstm-exec-return-invalid.js
     prototype/Symbol.search/not-a-constructor.js
-    prototype/Symbol.search/set-lastindex-init.js
     prototype/Symbol.search/set-lastindex-init-err.js
     prototype/Symbol.search/set-lastindex-init-samevalue.js
-    prototype/Symbol.search/set-lastindex-restore.js
     prototype/Symbol.search/set-lastindex-restore-err.js
     prototype/Symbol.search/set-lastindex-restore-samevalue.js
-    prototype/Symbol.search/success-get-index-err.js
     prototype/Symbol.search/u-lastindex-advance.js
     prototype/Symbol.split/coerce-flags.js
     prototype/Symbol.split/coerce-flags-err.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1320,7 +1320,7 @@ built-ins/Promise 392/631 (62.12%)
     resolve-thenable-deferred.js {unsupported: [async]}
     resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy 73/311 (23.47%)
+built-ins/Proxy 72/311 (23.15%)
     construct/arguments-realm.js
     construct/call-parameters.js
     construct/call-parameters-new-target.js
@@ -1359,7 +1359,6 @@ built-ins/Proxy 73/311 (23.47%)
     has/return-false-target-prop-exists-using-with.js non-strict
     has/return-false-targetdesc-not-configurable-using-with.js non-strict
     has/return-is-abrupt-with.js non-strict
-    has/trap-is-missing-target-is-proxy.js
     has/trap-is-not-callable-using-with.js non-strict
     ownKeys/trap-is-undefined-target-is-proxy.js
     preventExtensions/trap-is-undefined-target-is-proxy.js {unsupported: [module]}
@@ -1409,7 +1408,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1097/1854 (59.17%)
+built-ins/RegExp 1038/1854 (55.99%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1528,73 +1527,14 @@ built-ins/RegExp 1097/1854 (59.17%)
     prototype/Symbol.match/get-unicode-error.js
     prototype/Symbol.match/not-a-constructor.js
     prototype/Symbol.match/u-advance-after-empty.js
-    prototype/Symbol.replace/arg-1-coerce.js
-    prototype/Symbol.replace/arg-1-coerce-err.js
-    prototype/Symbol.replace/arg-2-coerce.js
-    prototype/Symbol.replace/arg-2-coerce-err.js
     prototype/Symbol.replace/coerce-global.js
-    prototype/Symbol.replace/coerce-lastindex.js
-    prototype/Symbol.replace/coerce-lastindex-err.js
     prototype/Symbol.replace/coerce-unicode.js
-    prototype/Symbol.replace/exec-err.js
-    prototype/Symbol.replace/exec-invocation.js
-    prototype/Symbol.replace/flags-tostring-error.js
-    prototype/Symbol.replace/fn-coerce-replacement.js
-    prototype/Symbol.replace/fn-coerce-replacement-err.js
-    prototype/Symbol.replace/fn-err.js
-    prototype/Symbol.replace/fn-invoke-args.js
-    prototype/Symbol.replace/fn-invoke-args-empty-result.js
-    prototype/Symbol.replace/fn-invoke-this-no-strict.js non-strict
-    prototype/Symbol.replace/fn-invoke-this-strict.js strict
-    prototype/Symbol.replace/g-init-lastindex.js
-    prototype/Symbol.replace/g-init-lastindex-err.js
-    prototype/Symbol.replace/g-pos-decrement.js
-    prototype/Symbol.replace/g-pos-increment.js
-    prototype/Symbol.replace/get-exec-err.js
-    prototype/Symbol.replace/get-flags-err.js
+    prototype/Symbol.replace/fn-invoke-this-strict.js compiled-strict
     prototype/Symbol.replace/get-global-err.js
     prototype/Symbol.replace/get-unicode-error.js
-    prototype/Symbol.replace/length.js
-    prototype/Symbol.replace/match-failure.js
-    prototype/Symbol.replace/name.js
     prototype/Symbol.replace/named-groups.js
-    prototype/Symbol.replace/named-groups-fn.js
     prototype/Symbol.replace/not-a-constructor.js
-    prototype/Symbol.replace/poisoned-stdlib.js
-    prototype/Symbol.replace/prop-desc.js
-    prototype/Symbol.replace/replace-with-trailing.js
-    prototype/Symbol.replace/replace-without-trailing.js
-    prototype/Symbol.replace/result-coerce-capture.js
-    prototype/Symbol.replace/result-coerce-capture-err.js
-    prototype/Symbol.replace/result-coerce-groups.js
-    prototype/Symbol.replace/result-coerce-groups-prop.js
-    prototype/Symbol.replace/result-coerce-groups-prop-err.js
-    prototype/Symbol.replace/result-coerce-index.js
-    prototype/Symbol.replace/result-coerce-index-err.js
-    prototype/Symbol.replace/result-coerce-index-undefined.js
-    prototype/Symbol.replace/result-coerce-length.js
-    prototype/Symbol.replace/result-coerce-length-err.js
-    prototype/Symbol.replace/result-coerce-matched.js
-    prototype/Symbol.replace/result-coerce-matched-err.js
-    prototype/Symbol.replace/result-coerce-matched-global.js
-    prototype/Symbol.replace/result-get-capture-err.js
-    prototype/Symbol.replace/result-get-groups-err.js
-    prototype/Symbol.replace/result-get-groups-prop-err.js
-    prototype/Symbol.replace/result-get-index-err.js
-    prototype/Symbol.replace/result-get-length-err.js
-    prototype/Symbol.replace/result-get-matched-err.js
-    prototype/Symbol.replace/subst-after.js
-    prototype/Symbol.replace/subst-before.js
-    prototype/Symbol.replace/subst-capture-idx-1.js
-    prototype/Symbol.replace/subst-capture-idx-2.js
-    prototype/Symbol.replace/subst-dollar.js
-    prototype/Symbol.replace/subst-matched.js
     prototype/Symbol.replace/u-advance-after-empty.js
-    prototype/Symbol.replace/y-fail-global-return.js
-    prototype/Symbol.replace/y-fail-lastindex.js
-    prototype/Symbol.replace/y-fail-return.js
-    prototype/Symbol.replace/y-init-lastindex.js
-    prototype/Symbol.replace/y-set-lastindex.js
     prototype/Symbol.search/cstm-exec-return-invalid.js
     prototype/Symbol.search/not-a-constructor.js
     prototype/Symbol.search/set-lastindex-init-err.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1408,7 +1408,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1036/1854 (55.88%)
+built-ins/RegExp 1035/1854 (55.83%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1426,7 +1426,6 @@ built-ins/RegExp 1036/1854 (55.88%)
     match-indices/indices-groups-properties.js
     match-indices/indices-property.js
     named-groups/duplicate-names-match-indices.js
-    named-groups/duplicate-names-replaceall.js
     named-groups/duplicate-names-split.js
     named-groups/functional-replace-global.js
     named-groups/functional-replace-non-global.js
@@ -1791,7 +1790,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 46/1182 (3.89%)
+built-ins/String 35/1182 (2.96%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -1804,23 +1803,12 @@ built-ins/String 46/1182 (3.89%)
     prototype/matchAll/regexp-prototype-matchAll-invocation.js
     prototype/match/cstm-matcher-invocation.js
     prototype/match/duplicate-named-indices-groups-properties.js
-    prototype/replaceAll/getSubstitution-0x0024-0x003C.js
-    prototype/replaceAll/getSubstitution-0x0024N.js
-    prototype/replaceAll/getSubstitution-0x0024NN.js
     prototype/replaceAll/replaceValue-call-each-match-position.js
     prototype/replaceAll/replaceValue-call-matching-empty.js
     prototype/replaceAll/searchValue-flags-no-g-throws.js
-    prototype/replaceAll/searchValue-flags-null-undefined-throws.js
-    prototype/replaceAll/searchValue-flags-toString-abrupt.js
-    prototype/replaceAll/searchValue-get-flags-abrupt.js
-    prototype/replaceAll/searchValue-isRegExp-abrupt.js
-    prototype/replaceAll/searchValue-replacer-before-tostring.js
-    prototype/replaceAll/searchValue-replacer-call.js
-    prototype/replaceAll/searchValue-replacer-call-abrupt.js
     prototype/replaceAll/searchValue-replacer-method-abrupt.js
     prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
     prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
-    prototype/replaceAll/searchValue-tostring-regexp.js
     prototype/search/cstm-search-invocation.js
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1408,7 +1408,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1035/1854 (55.83%)
+built-ins/RegExp 997/1854 (53.78%)
     CharacterClassEscapes 24/24 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1539,47 +1539,9 @@ built-ins/RegExp 1035/1854 (55.83%)
     prototype/Symbol.search/set-lastindex-restore-err.js
     prototype/Symbol.search/set-lastindex-restore-samevalue.js
     prototype/Symbol.search/u-lastindex-advance.js
-    prototype/Symbol.split/coerce-flags.js
-    prototype/Symbol.split/coerce-flags-err.js
-    prototype/Symbol.split/coerce-limit.js
-    prototype/Symbol.split/coerce-limit-err.js
-    prototype/Symbol.split/coerce-string.js
-    prototype/Symbol.split/coerce-string-err.js
-    prototype/Symbol.split/get-flags-err.js
-    prototype/Symbol.split/last-index-exceeds-str-size.js
-    prototype/Symbol.split/length.js
-    prototype/Symbol.split/limit-0-bail.js
-    prototype/Symbol.split/name.js
     prototype/Symbol.split/not-a-constructor.js
-    prototype/Symbol.split/prop-desc.js
-    prototype/Symbol.split/species-ctor.js
-    prototype/Symbol.split/species-ctor-ctor-get-err.js
-    prototype/Symbol.split/species-ctor-ctor-non-obj.js
-    prototype/Symbol.split/species-ctor-ctor-undef.js
-    prototype/Symbol.split/species-ctor-err.js
-    prototype/Symbol.split/species-ctor-species-get-err.js
-    prototype/Symbol.split/species-ctor-species-non-ctor.js
-    prototype/Symbol.split/species-ctor-species-undef.js
-    prototype/Symbol.split/species-ctor-y.js
     prototype/Symbol.split/splitter-proto-from-ctor-realm.js
-    prototype/Symbol.split/str-adv-thru-empty-match.js
-    prototype/Symbol.split/str-coerce-lastindex.js
-    prototype/Symbol.split/str-coerce-lastindex-err.js
-    prototype/Symbol.split/str-empty-match.js
-    prototype/Symbol.split/str-empty-match-err.js
-    prototype/Symbol.split/str-empty-no-match.js
-    prototype/Symbol.split/str-get-lastindex-err.js
-    prototype/Symbol.split/str-limit.js
-    prototype/Symbol.split/str-limit-capturing.js
-    prototype/Symbol.split/str-match-err.js
-    prototype/Symbol.split/str-result-coerce-length.js
-    prototype/Symbol.split/str-result-coerce-length-err.js
-    prototype/Symbol.split/str-result-get-capture-err.js
-    prototype/Symbol.split/str-result-get-length-err.js
-    prototype/Symbol.split/str-set-lastindex-err.js
-    prototype/Symbol.split/str-set-lastindex-match.js
-    prototype/Symbol.split/str-set-lastindex-no-match.js
-    prototype/Symbol.split/str-trailing-chars.js
+    prototype/Symbol.split/this-val-non-obj.js
     prototype/Symbol.split/u-lastindex-adv-thru-failure.js
     prototype/Symbol.split/u-lastindex-adv-thru-match.js
     prototype/test/not-a-constructor.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1853,7 +1853,7 @@ built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 52/1182 (4.4%)
+built-ins/String 49/1182 (4.15%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -1886,10 +1886,7 @@ built-ins/String 52/1182 (4.4%)
     prototype/replace/cstm-replace-get-err.js
     prototype/replace/cstm-replace-invocation.js
     prototype/replace/S15.5.4.11_A12.js non-strict
-    prototype/search/cstm-search-get-err.js
     prototype/search/cstm-search-invocation.js
-    prototype/search/invoke-builtin-search.js
-    prototype/search/invoke-builtin-search-searcher-undef.js
     prototype/split/cstm-split-get-err.js
     prototype/split/cstm-split-invocation.js
     prototype/split/separator-regexp.js


### PR DESCRIPTION
This PR adds implementation for:

- `RegExp.prototype[Symbol.search]`
- `RegExp.prototype[Symbol.replace]`
- `RegExp.prototype[Symbol.split]`

and rewrites the implementation of:

- `String.prototype.search`
- `String.prototype.replace`
- `String.prototype.replaceAll`
- `String.prototype.split`

following the spec, in order to rely on the `RegExp` implementation when the spec says so.

A little more than a hundred test262 cases now pass. The few apparent regressions are related to things that are known to be broken and were already failing for other tests, such as rhino doing too much auto-boxing or the `RegExp.prototype.flags` implementation not being correct according to the spec. I am happy to discuss any such case in more details.

I have a couple of style decisions that I would like some feedback on:

- There is a generic algorithm in the spec named [`GetSubstitution`](https://tc39.es/ecma262/multipage/text-processing.html#sec-getsubstitution) that is used by both `String` and `RegExp`. I have placed it in a new class named `AbstractEcmaStringOperations` but maybe it would be better in the existing `AbstractEcmaObjectOperations.java`?
- I have removed some dead code from `RegExpImpl`, though I cannot remove it all or some old test cases in `MozillaSuiteTest` would break. However, this was part of the public API of rhino, so I am uncertain if removing it is the best choice. I don't really imagine anyone would be using this... but who knows. Any opinion?

I've made an effort to keep the git history very clean, so it's ok to not squash this.