### PR TITLE
Function.prototype[Symbol.hasInstance] fix

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -405,8 +405,7 @@ public class BaseFunction extends IdScriptableObject implements Function {
                                 ((NativeFunction) ((BoundFunction) thisObj).getTargetFunction())
                                         .getPrototypeProperty();
                     else protoProp = ScriptableObject.getProperty(thisObj, "prototype");
-                    if (protoProp instanceof NativeObject
-                            || protoProp instanceof IdScriptableObject) {
+                    if (ScriptRuntime.isObject(protoProp)) {
                         return ScriptRuntime.jsDelegatesTo(obj, (Scriptable) protoProp);
                     }
                     throw ScriptRuntime.typeErrorById(

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -681,7 +681,7 @@ msg.instanceof.not.object = \
     Can''t use ''instanceof'' on a non-object.
 
 msg.instanceof.bad.prototype = \
-    ''prototype'' property of {0} is not an object.
+    ''prototype'' property of ''{0}'' is not an object.
 
 msg.in.not.object = \
     Can''t use ''in'' on a non-object.

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -149,4 +149,54 @@ public class FunctionPrototypeSymbolHasInstanceTest {
         Utils.assertEcmaErrorES6(
                 "TypeError: 'prototype' property of  is not an object. (test#3)", script);
     }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceStringProto() {
+        String script =
+                "var f = function() {}; \n"
+                        + "f.prototype = new String(); \n"
+                        + "f[Symbol.hasInstance]({})";
+
+        Utils.assertWithAllModes(false, script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceBooleanProto() {
+        String script =
+                "var f = function() {}; \n"
+                        + "f.prototype = new Boolean(); \n"
+                        + "f[Symbol.hasInstance]({})";
+
+        Utils.assertWithAllModes(false, script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceArrayProto() {
+        String script =
+                "var f = function() {}; \n"
+                        + "f.prototype = new Array(); \n"
+                        + "f[Symbol.hasInstance]({})";
+
+        Utils.assertWithAllModes(false, script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceNumberProto() {
+        String script =
+                "var f = function() {}; \n"
+                        + "f.prototype = new Number(); \n"
+                        + "f[Symbol.hasInstance]({})";
+
+        Utils.assertWithAllModes(false, script);
+    }
+
+    @Test
+    public void testFunctionPrototypeSymbolHasInstanceFunctionProto() {
+        String script =
+                "var f = function() {}; \n"
+                        + "f.prototype = function() {}\n"
+                        + "f[Symbol.hasInstance]({})";
+
+        Utils.assertWithAllModes(false, script);
+    }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -145,7 +145,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "f.prototype = Symbol(); \n"
                         + "f[Symbol.hasInstance]({})";
         Utils.assertEcmaErrorES6(
-                "TypeError: 'prototype' property of  is not an object. (test#3)", script);
+                "TypeError: 'prototype' property of '' is not an object. (test#3)", script);
     }
 
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -1,6 +1,5 @@
 package org.mozilla.javascript;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -58,7 +57,6 @@ public class FunctionPrototypeSymbolHasInstanceTest {
     }
 
     @Test
-    @Ignore("name-length-params-prototype-set-incorrectly")
     public void testFunctionPrototypeSymbolHasInstanceHasProperties() {
         String script =
                 "var a = Object.getOwnPropertyDescriptor(Function.prototype[Symbol.hasInstance], 'length');\n"


### PR DESCRIPTION
I found that `String[Symbol.hasInstance]({})` threw a type error, when it should be simply return `false`. This likely was a result of switching NativeString to the lambda constructor pattern.

According to the [spec](https://tc39.es/ecma262/#sec-ordinaryhasinstance), if the `prototype` property of `this`  is not an object, it must be an error. In our implementation, the "isObject" check only included `NativeObject`s and `IdScriptableObject`s (to exclude Symbols, essentially). Fix it to simply use `ScriptRuntime.isObject()`, which should do the right thing for symbols as well.