### PR TITLE
NativeRegExp: Fix regression introduced in hex and unicode hex parsing

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1208,12 +1208,12 @@ public class NativeRegExp extends IdScriptableObject {
                 {
                     int n = 0;
                     int i;
-                    if ((state.cp >= state.cpend)) {
+                    if (state.cp >= state.cpend) {
                         // Back off to accepting the original
                         // 'u' or 'x' as a literal
                         n = src[state.cp - 1];
                     } else {
-                        for (i = 0; (i < nDigits); i++) {
+                        for (i = 0; (i < nDigits) && (state.cp < state.cpend); i++) {
                             c = src[state.cp++];
                             n = Kit.xDigitToInt(c, n);
                             if (n < 0) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -940,13 +940,16 @@ public class NativeRegExpTest {
         Utils.assertWithAllModes_ES6("true-true-true-false", script);
     }
 
+    // The spec says that \\u and \\x should be followed by exactly 4 and 2 hex digits respectively
+    // for them to be valid unicode escapes. Rhino allows them to be followed by less than 4 or 2
     @Test
     public void unicodeEscapeFallback() {
-        final String script = "var regex = /\\u/;\n" + "var res = '' + regex.test('u');\n" + "res;";
-        Utils.assertWithAllModes_ES6("true", script);
-
-        final String script2 =
-                "var regex = /\\x/;\n" + "var res = '' + regex.test('x');\n" + "res;";
-        Utils.assertWithAllModes_ES6("true", script2);
+        final String script =
+                "var res = '' + /\\u/.test('u') + '-';\n"
+                        + "res += '' + /\\x/.test('x') + '-';\n"
+                        + "res += '' + /\\x1/.test('\\x01') + '-';\n"
+                        + "res += '' + /\\u61/.test('a');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("true-true-true-true", script);
     }
 }


### PR DESCRIPTION
This is a fix for a regression introduced by #1869.

@gbrail I'm sorry, I was too eager to remove code and ended up introducing a regression - at least we are adding new test cases :)