### PR TITLE
Add INDY operations for calling functions

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -212,16 +212,6 @@ public class Bootstrapper {
                             .named(getNameSegment(tokens, name, 2));
             }
 
-        } else if ("METHOD".equals(namespaceName)) {
-            switch (opName) {
-                case "CALL":
-                    return StandardOperation.CALL.withNamespace(StandardNamespace.METHOD);
-                case "CALL_0":
-                    return RhinoOperation.CALL_0.withNamespace(StandardNamespace.METHOD);
-                case "CALL_0_OPT":
-                    return RhinoOperation.CALL_0_OPTIONAL.withNamespace(StandardNamespace.METHOD);
-            }
-
         } else if ("MATH".equals(namespaceName)) {
             switch (opName) {
                 case "ADD":

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Bootstrapper.java
@@ -152,6 +152,16 @@ public class Bootstrapper {
                 case "SETINDEX":
                     // Same but the property name is definitely a number
                     return RhinoOperation.SETINDEX.withNamespace(StandardNamespace.PROPERTY);
+                case "CALL_0":
+                    // Call a function with no arguments
+                    return RhinoOperation.CALL_0
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
+                case "CALL_0_OPT":
+                    // Call a function with no arguments
+                    return RhinoOperation.CALL_0_OPTIONAL
+                            .withNamespace(StandardNamespace.PROPERTY)
+                            .named(getNameSegment(tokens, name, 2));
             }
         } else if ("NAME".equals(namespaceName)) {
             switch (opName) {
@@ -190,6 +200,26 @@ public class Bootstrapper {
                     return RhinoOperation.SETCONST
                             .withNamespace(RhinoNamespace.NAME)
                             .named(getNameSegment(tokens, name, 2));
+                case "CALL_0":
+                    // Call a function with no arguments
+                    return RhinoOperation.CALL_0
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+                case "CALL_0_OPT":
+                    // Call a function with no arguments
+                    return RhinoOperation.CALL_0_OPTIONAL
+                            .withNamespace(RhinoNamespace.NAME)
+                            .named(getNameSegment(tokens, name, 2));
+            }
+
+        } else if ("METHOD".equals(namespaceName)) {
+            switch (opName) {
+                case "CALL":
+                    return StandardOperation.CALL.withNamespace(StandardNamespace.METHOD);
+                case "CALL_0":
+                    return RhinoOperation.CALL_0.withNamespace(StandardNamespace.METHOD);
+                case "CALL_0_OPT":
+                    return RhinoOperation.CALL_0_OPTIONAL.withNamespace(StandardNamespace.METHOD);
             }
 
         } else if ("MATH".equals(namespaceName)) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -14,7 +14,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Token;
-import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.config.RhinoConfig;
 
 /**
@@ -55,8 +54,6 @@ class DefaultLinker implements GuardingDynamicLinker {
             return getPropertyInvocation(lookup, mType, op);
         } else if (op.isNamespace(RhinoNamespace.NAME)) {
             return getNameInvocation(lookup, mType, op);
-        } else if (op.isNamespace(StandardNamespace.METHOD)) {
-            return getMethodInvocation(lookup, mType, op);
         } else if (op.isNamespace(RhinoNamespace.MATH)) {
             return getMathInvocation(lookup, mType, op);
         }
@@ -194,44 +191,6 @@ class DefaultLinker implements GuardingDynamicLinker {
             mh = lookup.findStatic(OptRuntime.class, "callName0Optional", tt);
             mh = MethodHandles.insertArguments(mh, 0, name);
             mh = MethodHandles.permuteArguments(mh, mType, 1, 0);
-        }
-
-        if (mh != null) {
-            return new GuardedInvocation(mh);
-        }
-        throw new UnsupportedOperationException(op.toString());
-    }
-
-    private GuardedInvocation getMethodInvocation(
-            MethodHandles.Lookup lookup, MethodType mType, ParsedOperation op)
-            throws NoSuchMethodException, IllegalAccessException {
-        MethodHandle mh = null;
-
-        // Bind this method to the virtual "call" operation without
-        // introducing a special "wrapper" function
-        if (op.isOperation(StandardOperation.CALL)) {
-            // Bind to the virtual "call" method with the same signature
-            MethodType mt = mType.dropParameterTypes(0, 1);
-            mh = lookup.findVirtual(Callable.class, "call", mt);
-        } else if (op.isOperation(RhinoOperation.CALL_0)) {
-            // Bind to the virtual "call" method and add in empty args
-            MethodType mt = mType.appendParameterTypes(Object[].class);
-            mt = mt.dropParameterTypes(0, 1);
-            mh = lookup.findVirtual(Callable.class, "call", mt);
-            mh = MethodHandles.insertArguments(mh, 4, OptRuntime.emptyArgsForVarargs());
-        } else if (op.isOperation(RhinoOperation.CALL_0_OPTIONAL)) {
-            // The target method calls "call" virtually with empty arguments
-            MethodType mt = mType.appendParameterTypes(Object[].class);
-            mt = mt.dropParameterTypes(0, 1);
-            MethodHandle target = lookup.findVirtual(Callable.class, "call", mt);
-            target = MethodHandles.insertArguments(target, 4, OptRuntime.emptyArgsForVarargs());
-            // The fallback method just returns undefined
-            MethodHandle fallback = MethodHandles.constant(Object.class, Undefined.instance);
-            fallback = MethodHandles.dropArguments(fallback, 0, target.type().parameterList());
-            // The guard method tests for null
-            MethodType tt = mType.changeReturnType(Boolean.TYPE);
-            MethodHandle guard = lookup.findStatic(DefaultLinker.class, "isNotNullCallable", tt);
-            mh = MethodHandles.guardWithTest(guard, target, fallback);
         }
 
         if (mh != null) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -24,6 +24,13 @@ public final class OptRuntime extends ScriptRuntime {
     public static final Integer oneObj = Integer.valueOf(1);
     public static final Integer minusOneObj = Integer.valueOf(-1);
 
+    private static final Object[] argsForVarargs = new Object[] {ScriptRuntime.emptyArgs};
+
+    /** A way to pass an empty array to a varargs function like MethodHandles.insertArguments. */
+    public static Object[] emptyArgsForVarargs() {
+        return argsForVarargs;
+    }
+
     /** Implement ....() call shrinking optimizer code. */
     public static Object call0(Callable fun, Scriptable thisObj, Context cx, Scriptable scope) {
         return fun.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
@@ -84,6 +91,13 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     /** Implement x.property() call shrinking optimizer code. */
+    public static Object callProp(
+            Object value, String property, Context cx, Scriptable scope, Object[] args) {
+        Callable f = getPropFunctionAndThis(value, property, cx, scope);
+        Scriptable thisObj = lastStoredScriptable(cx);
+        return f.call(cx, scope, thisObj, args);
+    }
+
     public static Object callProp0(Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/RhinoOperation.java
@@ -34,4 +34,6 @@ public enum RhinoOperation implements Operation {
     TOUINT32,
     TONUMBER,
     TONUMERIC,
+    CALL_0,
+    CALL_0_OPTIONAL,
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -143,6 +143,16 @@ interface Signatures {
                     + ")Ljava/lang/Object;";
 
     /**
+     * PROP:CALL_0:{name} and PROP:CALL_0_OPT:{name}: Calls the named property with no arguments.
+     * Falls back to OptRuntime.callProp0 or callProp0Optional.
+     */
+    String PROP_CALL_0 =
+            "(Ljava/lang/Object;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /**
      * NAME:GET:{name}: Looks up a the named value from the scope. Falls back to ScriptRuntime.name.
      * Compared to that function, this version of the signature puts the "scope" first in the
      * argument list rather than second. This makes it easier for future linkers to work because
@@ -203,6 +213,35 @@ interface Signatures {
             "(Lorg/mozilla/javascript/Scriptable;"
                     + "Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * NAME:CALL_0:{name}, and NAME:CALL_0_OPT:{name}: Calls the named function with no arguments.
+     * Falls back to ScriptRuntime.callName0 or callName0Optional.
+     */
+    String NAME_CALL_0 =
+            "(Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + ")Ljava/lang/Object;";
+
+    /**
+     * METHOD:CALL_0, METHOD:CALL_0_OPT: Call the method with no arguments. Falls back to
+     * OptRuntime.call0.
+     */
+    String METHOD_CALL_0 =
+            "(Lorg/mozilla/javascript/Callable;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + ")Ljava/lang/Object;";
+
+    /** METHOD:CALL: Call the method with an array of arguments. Falls back to OptRuntime.callN. */
+    String METHOD_CALL =
+            "(Lorg/mozilla/javascript/Callable;"
+                    + "Lorg/mozilla/javascript/Context;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "[Ljava/lang/Object;"
                     + ")Ljava/lang/Object;";
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -225,26 +225,6 @@ interface Signatures {
                     + ")Ljava/lang/Object;";
 
     /**
-     * METHOD:CALL_0, METHOD:CALL_0_OPT: Call the method with no arguments. Falls back to
-     * OptRuntime.call0.
-     */
-    String METHOD_CALL_0 =
-            "(Lorg/mozilla/javascript/Callable;"
-                    + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
-                    + ")Ljava/lang/Object;";
-
-    /** METHOD:CALL: Call the method with an array of arguments. Falls back to OptRuntime.callN. */
-    String METHOD_CALL =
-            "(Lorg/mozilla/javascript/Callable;"
-                    + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
-                    + "[Ljava/lang/Object;"
-                    + ")Ljava/lang/Object;";
-
-    /**
      * MATH:ADD: Add the first two arguments on the stack, which could be numbers, strings, or
      * really just about anything.
      */

--- a/tests/src/test/java/org/mozilla/javascript/tests/UndefinedFunctionsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/UndefinedFunctionsTest.java
@@ -1,0 +1,7 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest(value = "testsrc/jstests/undefined-functions.js")
+public class UndefinedFunctionsTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/undefined-functions.js
+++ b/tests/testsrc/jstests/undefined-functions.js
@@ -1,0 +1,53 @@
+load("testsrc/assert.js");
+
+var functionCalled = false;
+
+function testFunction() {
+    functionCalled = true;
+}
+function callTestFunction() {
+   testFunction();
+}
+function callCallTestFunction() {
+  callTestFunction();
+}
+
+// Sanity tests
+functionCalled = false;
+callTestFunction();
+assertTrue(functionCalled);
+functionCalled = false;
+callTestFunction(10);
+assertTrue(functionCalled);
+functionCalled = false;
+callCallTestFunction();
+assertTrue(functionCalled);
+functionCalled = false;
+
+// Undefined function should not parse arguments first
+assertThrows(() => {
+  notFound(testFunction());
+});
+assertFalse(functionCalled);
+
+// Shouldn't matter if there are arguments
+assertThrows(() => {
+  notFound(testFunction(1, 2, 3));
+});
+assertFalse(functionCalled);
+
+// Same thing should happen in a chain
+assertThrows(() => {
+  notFound(callTestFunction(testFunction()));
+});
+assertFalse(functionCalled);
+
+
+// Calling a non-function should not parse arguments first
+let notFunction = 'Hello, World!';
+assertThrows(() => {
+  notFunction(testFunction());
+});
+assertFalse(functionCalled);
+
+'success';


### PR DESCRIPTION
Add invokedynamic instructions for function calling in the bytecode. Do this when simply calling a Callable on the stack, or performing a lookup and a call in one step.

Replace intermediate "call", "call0", "call1", etc code for calling methods with direct invocations of the Callable interface using MethodHandle invocations.

Replace "call1", "call2" optimization code with just building the argument array in the bytecode inline like the Java compiler does.

Only dispatch and call in one operation using "callName0" and "callProp0" when there are no arguments, to prevent resolving arguments before the status of the target is known.

This fixes https://github.com/mozilla/rhino/issues/1876

Some of these changes undo optimizations introduced to the bytecode over the years, but I'm having trouble seeing what they optimize, except making the bytecode smaller, which I believe was important in the earlier days of Java. One of those optimization introduced the aforementioned bug.

I have benchmarked it and it seems performance-neutral, or at least within the bounds of compiler variation, which seems to be the biggest differentiator in performance tests right now.

Switching to the "METHOD:CALL" family of instructions here, we are directly dispatching to the Callable interface rather than going through an intermediate "call" method in OptRuntime like we used to. This doesn't seem to affect performance. A side affect is that stack traces should be easier to read, except that they now include a bunch of MethodHandle operations instead!