### PR TITLE
NativeRegExp: Fix character class parsing regression

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -1542,6 +1542,7 @@ public class NativeRegExp extends IdScriptableObject {
             case '[':
                 ClassContents classContents = parseClassContents(state, params);
                 if (classContents == null) {
+                    reportError("msg.unterm.class", "");
                     return false;
                 }
                 state.result = new RENode(REOP_CLASS);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -949,4 +949,9 @@ public class NativeRegExpTest {
                 "var regex = /\\x/;\n" + "var res = '' + regex.test('x');\n" + "res;";
         Utils.assertWithAllModes_ES6("true", script2);
     }
+
+    @Test
+    public void unterminatedCharacterClass() {
+        Utils.assertEcmaErrorES6("SyntaxError: Unterminated character class", "new RegExp('[')");
+    }
 }


### PR DESCRIPTION
The regression was introduced by 4e4b06b077edb0965e62e08426d636b9c2be7b03.