### PR TITLE
Add double null check pattern when initializing cache values

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -139,9 +139,7 @@ public class ClassCache implements Serializable {
         if (classTable == null) {
             synchronized (this) {
                 if (classTable == null) {
-                    // Use 1 as concurrency level here and for other concurrent hash maps
-                    // as we don't expect high levels of sustained concurrent writes.
-                    classTable = new ConcurrentHashMap<>(16, 0.75f, 1);
+                    classTable = new ConcurrentHashMap<>();
                 }
             }
         }
@@ -152,7 +150,7 @@ public class ClassCache implements Serializable {
         if (classAdapterCache == null) {
             synchronized (this) {
                 if (classAdapterCache == null) {
-                    classAdapterCache = new ConcurrentHashMap<>(16, 0.75f, 1);
+                    classAdapterCache = new ConcurrentHashMap<>();
                 }
             }
         }
@@ -194,7 +192,7 @@ public class ClassCache implements Serializable {
             if (interfaceAdapterCache == null) {
                 synchronized (this) {
                     if (interfaceAdapterCache == null) {
-                        interfaceAdapterCache = new ConcurrentHashMap<>(16, 0.75f, 1);
+                        interfaceAdapterCache = new ConcurrentHashMap<>();
                     }
                 }
             }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -22,9 +22,9 @@ public class ClassCache implements Serializable {
     private static final long serialVersionUID = -8866246036237312215L;
     private static final Object AKEY = "ClassCache";
     private volatile boolean cachingIsEnabled = true;
-    private transient Map<CacheKey, JavaMembers> classTable;
-    private transient Map<JavaAdapter.JavaAdapterSignature, Class<?>> classAdapterCache;
-    private transient Map<Class<?>, Object> interfaceAdapterCache;
+    private transient volatile Map<CacheKey, JavaMembers> classTable;
+    private transient volatile Map<JavaAdapter.JavaAdapterSignature, Class<?>> classAdapterCache;
+    private transient volatile Map<Class<?>, Object> interfaceAdapterCache;
     private int generatedClassSerial;
     private Scriptable associatedScope;
 
@@ -137,16 +137,24 @@ public class ClassCache implements Serializable {
      */
     Map<CacheKey, JavaMembers> getClassCacheMap() {
         if (classTable == null) {
-            // Use 1 as concurrency level here and for other concurrent hash maps
-            // as we don't expect high levels of sustained concurrent writes.
-            classTable = new ConcurrentHashMap<>(16, 0.75f, 1);
+            synchronized (this) {
+                if (classTable == null) {
+                    // Use 1 as concurrency level here and for other concurrent hash maps
+                    // as we don't expect high levels of sustained concurrent writes.
+                    classTable = new ConcurrentHashMap<>(16, 0.75f, 1);
+                }
+            }
         }
         return classTable;
     }
 
     Map<JavaAdapter.JavaAdapterSignature, Class<?>> getInterfaceAdapterCacheMap() {
         if (classAdapterCache == null) {
-            classAdapterCache = new ConcurrentHashMap<>(16, 0.75f, 1);
+            synchronized (this) {
+                if (classAdapterCache == null) {
+                    classAdapterCache = new ConcurrentHashMap<>(16, 0.75f, 1);
+                }
+            }
         }
         return classAdapterCache;
     }
@@ -184,7 +192,11 @@ public class ClassCache implements Serializable {
     synchronized void cacheInterfaceAdapter(Class<?> cl, Object iadapter) {
         if (cachingIsEnabled) {
             if (interfaceAdapterCache == null) {
-                interfaceAdapterCache = new ConcurrentHashMap<>(16, 0.75f, 1);
+                synchronized (this) {
+                    if (interfaceAdapterCache == null) {
+                        interfaceAdapterCache = new ConcurrentHashMap<>(16, 0.75f, 1);
+                    }
+                }
             }
             interfaceAdapterCache.put(cl, iadapter);
         }


### PR DESCRIPTION
I found some places in ClassCache, where maps are initialized lazy.

These places may not be 100% thread safe.
This would probably not be a problem, because in most cases it is not accessed concurrently
But I would still like to fix this.

@gbrail I've used here the `infamous "double-checked locking" pattern` hopefully in the right way (with volatile type)

Do you see here also problems, that this could fail?
I'm also open to do an eager initialization of the three maps (constructing three ConcurrentHashMaps should not be too expensive)