### PR TITLE
fix `ClassCache#get(...)` and `ClassCache.CacheKey#hashCode()`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -46,7 +46,7 @@ public class ClassCache implements Serializable {
         public int hashCode() {
             int result = cls.hashCode();
             if (sec != null) {
-                result = sec.hashCode() * 31;
+                result = result * 31 + sec.hashCode();
             }
             return result;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -44,11 +44,10 @@ public class ClassCache implements Serializable {
 
         @Override
         public int hashCode() {
-            int result = cls.hashCode();
             if (sec != null) {
-                result = result * 31 + sec.hashCode();
+                return sec.hashCode() ^ cls.hashCode();
             }
-            return result;
+            return cls.hashCode();
         }
 
         @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -62,17 +62,30 @@ public class ClassCache implements Serializable {
     /**
      * Search for ClassCache object in the given scope. The method first calls {@link
      * ScriptableObject#getTopLevelScope(Scriptable scope)} to get the top most scope and then tries
-     * to locate associated ClassCache object in the prototype chain of the top scope.
+     * to locate associated ClassCache object in the prototype chain of the top scope. If none was
+     * found, it will try to associate a new ClassCache object to the top scope.
      *
      * @param scope scope to search for ClassCache object.
      * @return previously associated ClassCache object or a new instance of ClassCache if no
      *     ClassCache object was found.
      * @see #associate(ScriptableObject topScope)
+     * @throws IllegalArgumentException if the top scope of provided scope have no associated
+     *     ClassCache, and cannot have ClassCache associated due to the top scope not being a {@link
+     *     ScriptableObject}
      */
     public static ClassCache get(Scriptable scope) {
         ClassCache cache = (ClassCache) ScriptableObject.getTopScopeValue(scope, AKEY);
         if (cache == null) {
-            throw new RuntimeException("Can't find top level scope for " + "ClassCache.get");
+            // we expect this to not happen frequently, so computing top scope twice is acceptable
+            var topScope = ScriptableObject.getTopLevelScope(scope);
+            if (!(topScope instanceof ScriptableObject)) {
+                // Note: it's originally a RuntimeException, the super class of
+                // IllegalArgumentException, so this will not break error catching
+                throw new IllegalArgumentException(
+                        "top scope have no associated ClassCache and cannot have ClassCache associated due to not being a ScriptableObject");
+            }
+            cache = new ClassCache();
+            cache.associate(((ScriptableObject) topScope));
         }
         return cache;
     }


### PR DESCRIPTION
- The original hashing of `CacheKey` will completely ignore the `cls` field when `sec` is present, now it will combine hash code for both fields.
- `ClassCache.get(...)` will now try to associate a new ClassCache object when none was found, then return the new object, as described in `@return` javadoc of it.

Fixes #1884 