### PR TITLE
Fix the setting of `length` on array instances, and ensure that property definitions still work correctly

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
@@ -112,7 +112,24 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
     @Override
     @SuppressWarnings("unchecked")
     public boolean setValue(Object value, Scriptable owner, Scriptable start, boolean isThrow) {
-        return setter.apply(((T) this.value), value, owner, start, isThrow);
+        if ((getAttributes() & ScriptableObject.READONLY) != 0) {
+            if (isThrow) {
+                throw ScriptRuntime.typeErrorById("msg.modify.readonly", name);
+            }
+            return true;
+        }
+        if (owner == start) {
+            return setter.apply(((T) this.value), value, owner, start, isThrow);
+        }
+        return false;
+    }
+
+    /* When setting a property descriptor we need to set the property
+    _without_ the normal checks on readonly and similar. */
+    @SuppressWarnings("unchecked")
+    public void setValueFromDescriptor(
+            Object value, Scriptable owner, Scriptable start, boolean isThrow) {
+        setter.apply(((T) this.value), value, owner, start, isThrow);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1740,7 +1740,8 @@ public abstract class ScriptableObject extends SlotMapOwner
                                 fslot.value = Undefined.instance;
                             } else if (slot instanceof BuiltInSlot) {
                                 if (value != NOT_FOUND) {
-                                    slot.setValue(value, owner, owner, true);
+                                    ((BuiltInSlot<?>) slot)
+                                            .setValueFromDescriptor(value, owner, owner, true);
                                 }
                             } else {
                                 if (!slot.isValueSlot() && isDataDescriptor(desc)) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/ArrayAsPrototypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ArrayAsPrototypeTest.java
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/array-as-prototype.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class ArrayAsPrototypeTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/array-as-prototype.js
+++ b/tests/testsrc/jstests/array-as-prototype.js
@@ -1,0 +1,19 @@
+// Check that the `length` property of an array, which is special in
+// various ways is handled correctly on when array is the prototype of
+// something else with a length.
+
+load("testsrc/assert.js");
+
+var WithArrayPrototype = function(array) {
+    this.length = array.length;
+    return this;
+}
+
+var wap = WithArrayPrototype.prototype = [];
+
+var test = new WithArrayPrototype(['abc']);
+
+assertEquals(0, wap.length);
+assertEquals(1, test.length);
+
+'success';


### PR DESCRIPTION
This resolves #1887 and without breaking the various test262 cases around setting array length via redefining the property. descriptor.