### PR TITLE
Using 'decycle' to detect package cycles

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,4 +9,5 @@ repositories {
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:7.1.0'
     implementation 'net.ltgt.gradle:gradle-errorprone-plugin:4.0.0'
+    implementation 'de.obqo.decycle:de.obqo.decycle.gradle.plugin:1.2.3'
 }

--- a/buildSrc/src/main/groovy/rhino.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.library-conventions.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'signing'
     id 'jacoco'
     id 'net.ltgt.errorprone'
+    id 'de.obqo.decycle'
 }
 
 dependencies {

--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -42,3 +42,22 @@ publishing {
         }
     }
 }
+decycle {
+    // package o.m.j.json contains only one class. Maybe move it to o.m.j
+    ignoring from: "org.mozilla.javascript.json.JsonParser", to: "org.mozilla.javascript.**"
+    // o.m.j.commonjs is strongly coupled to o.m.j
+    ignoring from: "org.mozilla.javascript.commonjs.**", to: "org.mozilla.javascript.**"
+    // o.m.j.debug is strongly coupled to o.m.j
+    ignoring from: "org.mozilla.javascript.debug.**", to: "org.mozilla.javascript.**"
+    // o.m.j.xml is strongly coupled to o.m.j (xmlimpl already in separate module)
+    ignoring from: "org.mozilla.javascript.xml.**", to: "org.mozilla.javascript.**"
+
+    // TODO: easy to remove
+    ignoring from: "org.mozilla.classfile.**", to: "org.mozilla.javascript.Kit"
+
+    // TODO: Should be possible to remove cycle between o.m.j.ast and o.m.j
+    ignoring from: "org.mozilla.javascript.ast.**", to: "org.mozilla.javascript.**"
+
+    // TODO: o.m.j.typedarrays can be decoupled with serviceLoader pattern
+    ignoring from: "org.mozilla.javascript.typedarrays.**", to: "org.mozilla.javascript.**"
+}

--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -43,21 +43,56 @@ publishing {
     }
 }
 decycle {
-    // package o.m.j.json contains only one class. Maybe move it to o.m.j
-    ignoring from: "org.mozilla.javascript.json.JsonParser", to: "org.mozilla.javascript.**"
-    // o.m.j.commonjs is strongly coupled to o.m.j
-    ignoring from: "org.mozilla.javascript.commonjs.**", to: "org.mozilla.javascript.**"
-    // o.m.j.debug is strongly coupled to o.m.j
-    ignoring from: "org.mozilla.javascript.debug.**", to: "org.mozilla.javascript.**"
-    // o.m.j.xml is strongly coupled to o.m.j (xmlimpl already in separate module)
-    ignoring from: "org.mozilla.javascript.xml.**", to: "org.mozilla.javascript.**"
+    /*
+     * The Decycle plugin is designed to ensure cycle-freedom between Java
+     * packages or to explicitly document cases where a cycle is tolerated
+     * or intentional.
+     * From a modularization perspective, it is always beneficial to keep the
+     * architecture as cycle-free as possible. If future development in Rhino
+     * introduces new cycles, developers must assess whether there is a valid
+     * justification for the cycle or whether it can be avoided - e.g., by
+     * using the ServiceLoader mechanism
+     */
 
-    // TODO: easy to remove
-    ignoring from: "org.mozilla.classfile.**", to: "org.mozilla.javascript.Kit"
+    // accepted cycle: package o.m.j.json contains only one class. Maybe move it to o.m.j
+    ignoring from: "org.mozilla.javascript.NativeJSON", to: "org.mozilla.javascript.json.JsonParser*"
 
-    // TODO: Should be possible to remove cycle between o.m.j.ast and o.m.j
-    ignoring from: "org.mozilla.javascript.ast.**", to: "org.mozilla.javascript.**"
+    // accepted cycle: but would be easy to solve - FunctionObject uses only an "instanceOf ModuleScope"
+    ignoring from: "org.mozilla.javascript.FunctionObject", to: "org.mozilla.javascript.commonjs.module.ModuleScope"
 
-    // TODO: o.m.j.typedarrays can be decoupled with serviceLoader pattern
-    ignoring from: "org.mozilla.javascript.typedarrays.**", to: "org.mozilla.javascript.**"
+    // accepted cycle: o.m.j.debug is strongly coupled to o.m.j
+    ignoring from: "org.mozilla.javascript.debug.*", to: "org.mozilla.javascript.Kit"
+    ignoring from: "org.mozilla.javascript.debug.*", to: "org.mozilla.javascript.Context"
+    ignoring from: "org.mozilla.javascript.debug.*", to: "org.mozilla.javascript.Scriptable"
+
+    // accepted cycle: o.m.j.xml is strongly coupled to o.m.j (xmlimpl already in separate module)
+    ignoring from: "org.mozilla.javascript.*", to: "org.mozilla.javascript.xml.*"
+
+    // accepted cycle: o.m.j.ast is strongly coupled to o.m.j
+    ignoring from: "org.mozilla.javascript.*", to: "org.mozilla.javascript.ast.*"
+
+    // accepted cycle: typedarrays are strongly coupled. (See #1893 of an idea, how to remove)
+    ignoring from: "org.mozilla.javascript.ScriptRuntime", to: "org.mozilla.javascript.typedarrays.*"
+    ignoring from: "org.mozilla.javascript.NativeArrayIterator", to: "org.mozilla.javascript.typedarrays.NativeTypedArrayView"
+
+    // TODO: easy to remove: See #1890
+    ignoring from: "org.mozilla.classfile.ClassFileWriter\$StackMapTable", to: "org.mozilla.javascript.Kit"
+
+    // TODO: Long-term-plan: LiveConnect should be moved to a separate module
+    // TODO: Move all "Native*" classes to o.m.j.lc
+    ignoring from: "org.mozilla.javascript.Native*", to: "org.mozilla.javascript.lc.type.TypeInfo*"
+    // CHECKME: Can we move JavaMembers + MemberBox also to o.m.j.lc
+    ignoring from: "org.mozilla.javascript.JavaMembers", to: "org.mozilla.javascript.lc.type.TypeInfo*"
+    ignoring from: "org.mozilla.javascript.MemberBox", to: "org.mozilla.javascript.lc.type.TypeInfo*"
+    ignoring from: "org.mozilla.javascript.AccessorSlot\$MemberBoxSetter", to: "org.mozilla.javascript.lc.type.TypeInfo"
+    // CHECKME: Can we remove dependency to typeinfo from these objects?
+    ignoring from: "org.mozilla.javascript.ScriptableObject", to: "org.mozilla.javascript.lc.type.TypeInfoFactory"
+    ignoring from: "org.mozilla.javascript.FunctionObject", to: "org.mozilla.javascript.lc.type.TypeInfo*"
+    ignoring from: "org.mozilla.javascript.Context", to: "org.mozilla.javascript.lc.type.TypeInfo*"
+
+    // currently accepted cycles (may be resolved, when it is clear, how to separate the liveconnect stuff)
+    ignoring from: "org.mozilla.javascript.lc.type.TypeInfoFactory", to: "org.mozilla.javascript.lc.type.impl.factory.*"
+    ignoring from: "org.mozilla.javascript.lc.type.TypeInfo", to: "org.mozilla.javascript.lc.type.impl.*"
+    ignoring from: "org.mozilla.javascript.lc.type.TypeFormatContext", to: "org.mozilla.javascript.lc.type.impl.ClassSignatureFormatContext"
+
 }


### PR DESCRIPTION
This is the beginning of an approach to keep the codebase cycle-free. 
So I would like to introduce a check tool, that enforces cycle-free packages for newly developed features

I will create 2-3 PRs where I would try remove existing cycles.

ChatGPT means (and I would agree this):
> Keeping packages cycle-free in Java is important for several reasons:
> - Maintainability: When packages have cyclic dependencies, it becomes difficult to understand and manage the relationships between them. This can make it harder to make changes, add new features, or fix bugs in the codebase.
> - Reusability: Cyclic dependencies can limit the reusability of code. When packages are tightly coupled, it becomes more challenging to extract and reuse individual components in other projects or modules.
> - Testability: Cyclic dependencies can also make it harder to write unit tests for the code. When packages are tightly intertwined, it can be difficult to isolate and test individual components without bringing in unnecessary dependencies.
> - Scalability: As the project grows, cyclic dependencies can lead to increased complexity and potential for bugs. By keeping packages cycle-free, it is easier to scale the project and add new functionality without introducing unexpected issues. 
>
> Overall, keeping packages cycle-free makes the codebase more maintainable, reusable, testable, and scalable, which ultimately leads to a more robust and reliable software application.
