### PR TITLE
Initialise `TopLevel` scopes for 262 tests, and update properties.

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -49,6 +49,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.drivers.TestUtils;
 import org.mozilla.javascript.tools.SourceReader;
@@ -465,7 +466,7 @@ public class Test262SuiteTest {
 
         public static $262 createRealm(
                 Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-            ScriptableObject realm = cx.initSafeStandardObjects();
+            ScriptableObject realm = (ScriptableObject) cx.initSafeStandardObjects(new TopLevel());
             return install(realm, thisObj.getPrototype());
         }
 
@@ -486,7 +487,7 @@ public class Test262SuiteTest {
     }
 
     private Scriptable buildScope(Context cx, Test262Case testCase, boolean interpretedMode) {
-        ScriptableObject scope = cx.initSafeStandardObjects();
+        ScriptableObject scope = (ScriptableObject) cx.initSafeStandardObjects(new TopLevel());
 
         for (String harnessFile : testCase.harnessFiles) {
             String harnessKey = harnessFile + '-' + interpretedMode;

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -124,7 +124,7 @@ built-ins/Array 264/3074 (8.59%)
     prototype/pop/set-length-array-is-frozen.js
     prototype/pop/set-length-array-length-is-non-writable.js
     prototype/pop/set-length-zero-array-is-frozen.js non-strict
-    prototype/pop/set-length-zero-array-length-is-non-writable.js
+    prototype/pop/set-length-zero-array-length-is-non-writable.js non-strict
     prototype/pop/throws-with-string-receiver.js non-strict
     prototype/push/length-near-integer-limit-set-failure.js non-strict
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
@@ -149,7 +149,7 @@ built-ins/Array 264/3074 (8.59%)
     prototype/shift/set-length-array-is-frozen.js
     prototype/shift/set-length-array-length-is-non-writable.js
     prototype/shift/set-length-zero-array-is-frozen.js non-strict
-    prototype/shift/set-length-zero-array-length-is-non-writable.js
+    prototype/shift/set-length-zero-array-length-is-non-writable.js non-strict
     prototype/shift/throws-when-this-value-length-is-writable-false.js
     prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
@@ -554,7 +554,7 @@ built-ins/Error 5/41 (12.2%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 136/508 (26.77%)
+built-ins/Function 134/508 (26.38%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
     prototype/apply/15.3.4.3-1-s.js strict
@@ -609,8 +609,6 @@ built-ins/Function 136/508 (26.77%)
     prototype/toString/class-expression-explicit-ctor.js
     prototype/toString/class-expression-implicit-ctor.js
     prototype/toString/Function.js
-    prototype/toString/generator-function-declaration.js
-    prototype/toString/generator-function-expression.js
     prototype/toString/generator-method.js
     prototype/toString/GeneratorFunction.js
     prototype/toString/getter-class-expression.js
@@ -686,24 +684,48 @@ built-ins/Function 136/508 (26.77%)
     proto-from-ctor-realm-prototype.js
     StrictFunction_restricted-properties.js strict
 
-~built-ins/GeneratorFunction
+built-ins/GeneratorFunction 9/23 (39.13%)
+    prototype/constructor.js
+    prototype/not-callable.js
+    prototype/prototype.js
+    prototype/Symbol.toStringTag.js
+    instance-construct-throws.js
+    instance-prototype.js
+    instance-restricted-properties.js
+    name.js
+    proto-from-ctor-realm-prototype.js
 
-built-ins/GeneratorPrototype 38/60 (63.33%)
+built-ins/GeneratorPrototype 32/60 (53.33%)
     next/from-state-executing.js compiled
     next/length.js
     next/name.js
     next/not-a-constructor.js
     next/property-descriptor.js
-    next/this-val-not-generator.js
-    next/this-val-not-object.js
-    return 22/22 (100.0%)
+    return/from-state-completed.js
+    return/from-state-executing.js compiled
+    return/from-state-suspended-start.js
+    return/length.js
+    return/name.js
+    return/not-a-constructor.js
+    return/property-descriptor.js
+    return/try-catch-before-try.js
+    return/try-catch-following-catch.js
+    return/try-catch-within-catch.js
+    return/try-catch-within-try.js
+    return/try-finally-before-try.js
+    return/try-finally-following-finally.js
+    return/try-finally-nested-try-catch-within-catch.js
+    return/try-finally-nested-try-catch-within-finally.js
+    return/try-finally-nested-try-catch-within-inner-try.js
+    return/try-finally-nested-try-catch-within-outer-try-after-nested.js
+    return/try-finally-nested-try-catch-within-outer-try-before-nested.js
+    return/try-finally-within-finally.js
+    return/try-finally-within-try.js
     throw/from-state-executing.js compiled
     throw/length.js
     throw/name.js
     throw/not-a-constructor.js
     throw/property-descriptor.js
-    throw/this-val-not-generator.js
-    throw/this-val-not-object.js
     constructor.js
     Symbol.toStringTag.js
 
@@ -778,7 +800,7 @@ built-ins/Number 8/335 (2.39%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 146/3408 (4.28%)
+built-ins/Object 145/3408 (4.25%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order.js
@@ -918,7 +940,6 @@ built-ins/Object 146/3408 (4.28%)
     seal/seal-bigint64array.js
     seal/seal-biguint64array.js
     seal/seal-finalizationregistry.js
-    seal/seal-generatorfunction.js
     seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     seal/seal-weakref.js
     values/observable-operations.js
@@ -4071,7 +4092,7 @@ language/expressions/function 149/264 (56.44%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 185/290 (63.79%)
+language/expressions/generators 184/290 (63.45%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4204,7 +4225,7 @@ language/expressions/generators 185/290 (63.79%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    forbidden-ext/b1 2/2 (100.0%)
+    forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js non-strict
     arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
     default-proto.js
@@ -4410,7 +4431,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 715/1169 (61.16%)
+language/expressions/object 714/1169 (61.08%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4845,7 +4866,6 @@ language/expressions/object 715/1169 (61.16%)
     method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-functions, async]}
     method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-functions, async]}
     method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-caller.js non-strict
     method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-iteration, async]}
@@ -5207,7 +5227,75 @@ language/expressions/strict-equals 0/30 (0.0%)
 language/expressions/subtraction 1/38 (2.63%)
     order-of-evaluation.js
 
-~language/expressions/super
+language/expressions/super 68/86 (79.07%)
+    call-arg-evaluation-err.js {unsupported: [class]}
+    call-bind-this-value.js {unsupported: [class]}
+    call-bind-this-value-twice.js {unsupported: [class]}
+    call-construct-error.js {unsupported: [class]}
+    call-construct-invocation.js {unsupported: [new.target, class]}
+    call-expr-value.js {unsupported: [class]}
+    call-poisoned-underscore-proto.js {unsupported: [class]}
+    call-proto-not-ctor.js {unsupported: [class]}
+    call-spread-err-mult-err-expr-throws.js
+    call-spread-err-mult-err-iter-get-value.js
+    call-spread-err-mult-err-itr-get-call.js
+    call-spread-err-mult-err-itr-get-get.js
+    call-spread-err-mult-err-itr-step.js
+    call-spread-err-mult-err-itr-value.js
+    call-spread-err-mult-err-obj-unresolvable.js
+    call-spread-err-mult-err-unresolvable.js
+    call-spread-err-sngl-err-expr-throws.js
+    call-spread-err-sngl-err-itr-get-call.js
+    call-spread-err-sngl-err-itr-get-get.js
+    call-spread-err-sngl-err-itr-get-value.js
+    call-spread-err-sngl-err-itr-step.js
+    call-spread-err-sngl-err-itr-value.js
+    call-spread-err-sngl-err-obj-unresolvable.js
+    call-spread-err-sngl-err-unresolvable.js
+    call-spread-mult-empty.js
+    call-spread-mult-expr.js
+    call-spread-mult-iter.js
+    call-spread-mult-literal.js
+    call-spread-mult-obj-ident.js
+    call-spread-mult-obj-null.js
+    call-spread-mult-obj-undefined.js
+    call-spread-obj-getter-descriptor.js
+    call-spread-obj-getter-init.js
+    call-spread-obj-manipulate-outter-obj-in-getter.js
+    call-spread-obj-mult-spread.js
+    call-spread-obj-mult-spread-getter.js
+    call-spread-obj-null.js
+    call-spread-obj-override-immutable.js
+    call-spread-obj-overrides-prev-properties.js
+    call-spread-obj-skip-non-enumerable.js
+    call-spread-obj-spread-order.js
+    call-spread-obj-symbol-property.js
+    call-spread-obj-undefined.js
+    call-spread-obj-with-overrides.js
+    call-spread-sngl-empty.js
+    call-spread-sngl-expr.js
+    call-spread-sngl-iter.js
+    call-spread-sngl-literal.js
+    call-spread-sngl-obj-ident.js
+    prop-dot-cls-null-proto.js {unsupported: [class]}
+    prop-dot-cls-ref-strict.js {unsupported: [class]}
+    prop-dot-cls-ref-this.js
+    prop-dot-cls-this-uninit.js {unsupported: [class]}
+    prop-dot-cls-val.js {unsupported: [class]}
+    prop-dot-cls-val-from-arrow.js {unsupported: [class]}
+    prop-dot-cls-val-from-eval.js {unsupported: [class]}
+    prop-expr-cls-err.js {unsupported: [class]}
+    prop-expr-cls-key-err.js {unsupported: [class]}
+    prop-expr-cls-null-proto.js {unsupported: [class]}
+    prop-expr-cls-ref-strict.js {unsupported: [class]}
+    prop-expr-cls-ref-this.js
+    prop-expr-cls-this-uninit.js {unsupported: [class]}
+    prop-expr-cls-unresolvable.js {unsupported: [class]}
+    prop-expr-cls-val.js {unsupported: [class]}
+    prop-expr-cls-val-from-arrow.js {unsupported: [class]}
+    prop-expr-cls-val-from-eval.js {unsupported: [class]}
+    realm.js
+    super-reference-resolution.js {unsupported: [class]}
 
 language/expressions/tagged-template 3/27 (11.11%)
     call-expression-context-strict.js strict
@@ -6564,7 +6652,7 @@ language/statements/function 162/451 (35.92%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 170/266 (63.91%)
+language/statements/generators 169/266 (63.53%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6697,7 +6785,7 @@ language/statements/generators 170/266 (63.91%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    forbidden-ext/b1 2/2 (100.0%)
+    forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js non-strict
     arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js


### PR DESCRIPTION
Our test 262 test suite runner initialised standard objects without passing in a scope, which was then defaulted to `new NativeObject()`. Since that isn't a `TopLevel` it does not get the builtin objects cached, so didn't get `GeneratorFunction` initialised.

This PR changes main, and realm, initialisation to be done with `TopLevel` scopes, and updates the properties to allow the `GeneratorFunction` tests to be run, and also updates the `language/expressions/super` tests which did not have the `~` removed when `super` was implemented.