### PR TITLE
WIP: added a test to reproduce stack overflows in IRFactory

### DIFF
--- a/rhino/src/test/java/org/mozilla/javascript/LongExpressionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/LongExpressionTest.java
@@ -1,0 +1,58 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+class LongExpressionTest {
+	private static final int ONE_MIB = 1 << 20;
+	private static final int BIG_EXPRESSION_LENGTH = 10_000;
+
+	@Test
+	void canProcessVeryLongExpressionsWithoutStackOverflow() throws InterruptedException {
+		// Run in a separate thread to have a consistent, small-ish stack size
+		AtomicReference<Throwable> thrown = new AtomicReference<>(null);
+		Thread t = new Thread(null, () -> {
+			try {
+				checkCanProcessLongAdditionChain();
+			} catch (Throwable e) {
+				//noinspection CallToPrintStackTrace
+				e.printStackTrace();
+				thrown.set(e);
+			}
+		}, "small-stack-thread", ONE_MIB);
+		t.start();
+		t.join();
+
+		assertNull(thrown.get(), "should not have thrown an exception");
+	}
+
+	private void checkCanProcessLongAdditionChain() {
+		String script = buildScript();
+		Utils.runWithAllModes(cx -> {
+			ScriptableObject scope = cx.initStandardObjects();
+			Assertions.assertDoesNotThrow(() -> {
+				cx.evaluateString(scope, script, "test", 1, null);
+			});
+			return null;
+		});
+	}
+
+	// Build a script "v0 + v1 + v2 + ..."
+	private static String buildScript() {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < BIG_EXPRESSION_LENGTH; ++i) {
+			sb.append("v").append(i).append(" = '").append(i).append("';\n");
+		}
+		sb.append("var res = \n");
+		for (int i = 0; i < BIG_EXPRESSION_LENGTH; ++i) {
+			sb.append("  v").append(i).append(" + \n");
+		}
+		sb.append("'';\n");
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
This test simply tries to execute a very long expression `v0 + v1 + v2 + ...`. Unfortunately this fails with the following stack trace:

```
Caused by: java.lang.StackOverflowError
	at org.mozilla.javascript.IRFactory.transformInfix(IRFactory.java)
	at org.mozilla.javascript.IRFactory.transform(IRFactory.java:249)
	at org.mozilla.javascript.IRFactory.transformInfix(IRFactory.java:866)
	at org.mozilla.javascript.IRFactory.transform(IRFactory.java:249)
	at org.mozilla.javascript.IRFactory.transformInfix(IRFactory.java:866)
	at org.mozilla.javascript.IRFactory.transform(IRFactory.java:249)
	at org.mozilla.javascript.IRFactory.transformInfix(IRFactory.java:866)
	at org.mozilla.javascript.IRFactory.transform(IRFactory.java:249)
	at org.mozilla.javascript.IRFactory.transformInfix(IRFactory.java:866)
	at org.mozilla.javascript.IRFactory.transform(IRFactory.java:249)
	at org.mozilla.javascript.IRFactory.transformInfix(IRFactory.java:866)
...
```

I am not sure how to fix it, honestly. The ast tree is very deep, which makes sense, and we walk it recursively because that's the natural way to implement it. However, this ends up blowing up the stack in IRFactory. The only way I can see to improve on it would be to turn IRFactory into something of a state machine, which would be more akin to a rewrite than a refactor.
Anyone has any better idea?