### PR TITLE
Add ArrayBuffer detach

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -26,7 +26,7 @@ public class NativeArrayBuffer extends ScriptableObject {
 
     private static final byte[] EMPTY_BUF = new byte[0];
 
-    final byte[] buffer;
+    byte[] buffer;
 
     @Override
     public String getClassName() {
@@ -55,6 +55,8 @@ public class NativeArrayBuffer extends ScriptableObject {
                 DONTENUM | READONLY);
         constructor.definePrototypeProperty(
                 cx, "byteLength", NativeArrayBuffer::js_byteLength, DONTENUM | READONLY);
+        constructor.definePrototypeProperty(
+                cx, "detached", NativeArrayBuffer::js_detached, DONTENUM | READONLY);
 
         if (sealed) {
             constructor.sealObject();
@@ -94,7 +96,7 @@ public class NativeArrayBuffer extends ScriptableObject {
 
     /** Get the number of bytes in the buffer. */
     public int getLength() {
-        return buffer.length;
+        return buffer != null ? buffer.length : 0;
     }
 
     /**
@@ -103,6 +105,14 @@ public class NativeArrayBuffer extends ScriptableObject {
      */
     public byte[] getBuffer() {
         return buffer;
+    }
+
+    public void detach() {
+        buffer = null;
+    }
+
+    public boolean isDetached() {
+        return buffer == null;
     }
 
     /**
@@ -120,9 +130,9 @@ public class NativeArrayBuffer extends ScriptableObject {
         // Clamp as per the spec to between 0 and length
         int end =
                 ScriptRuntime.toInt32(
-                        Math.max(0, Math.min(buffer.length, (e < 0 ? buffer.length + e : e))));
+                        Math.max(0, Math.min(getLength(), (e < 0 ? getLength() + e : e))));
         int start =
-                ScriptRuntime.toInt32(Math.min(end, Math.max(0, (s < 0 ? buffer.length + s : s))));
+                ScriptRuntime.toInt32(Math.min(end, Math.max(0, (s < 0 ? getLength() + s : s))));
         int len = end - start;
 
         NativeArrayBuffer newBuf = new NativeArrayBuffer(len);
@@ -151,6 +161,11 @@ public class NativeArrayBuffer extends ScriptableObject {
             LambdaConstructor defaultConstructor,
             Object[] args) {
         NativeArrayBuffer self = getSelf(thisObj);
+
+        if (self.isDetached()) {
+            throw ScriptRuntime.typeErrorById("msg.arraybuf.detached");
+        }
+
         double start = isArg(args, 0) ? ScriptRuntime.toNumber(args[0]) : 0;
         double end = isArg(args, 1) ? ScriptRuntime.toNumber(args[1]) : self.getLength();
         int endI =
@@ -189,6 +204,10 @@ public class NativeArrayBuffer extends ScriptableObject {
 
     private static Object js_byteLength(Scriptable thisObj) {
         return getSelf(thisObj).getLength();
+    }
+
+    private static Object js_detached(Scriptable thisObj) {
+        return getSelf(thisObj).isDetached();
     }
 
     private static boolean isArg(Object[] args, int i) {

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBufferView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBufferView.java
@@ -24,13 +24,13 @@ public abstract class NativeArrayBufferView extends ScriptableObject {
     private static Boolean useLittleEndian = null;
 
     /** Many view objects can share the same backing array */
-    protected final NativeArrayBuffer arrayBuffer;
+    protected NativeArrayBuffer arrayBuffer;
 
     /** The offset, in bytes, from the start of the backing array */
-    protected final int offset;
+    protected int offset;
 
     /** The length, in bytes, of the portion of the backing array that we use */
-    protected final int byteLength;
+    protected int byteLength;
 
     public NativeArrayBufferView() {
         arrayBuffer = new NativeArrayBuffer();

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -246,14 +246,14 @@ public class NativeDataView extends NativeArrayBufferView {
 
         int bufferByteLength = ab.getLength();
         if (pos > bufferByteLength) {
-            throw ScriptRuntime.rangeError("offset out of range");
+            throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
         }
 
         int len;
         if (isArg(args, 2)) {
             len = ScriptRuntime.toIndex(args[2]);
             if (pos + len > bufferByteLength) {
-                throw ScriptRuntime.rangeError("length out of range");
+                throw ScriptRuntime.rangeErrorById("msg.dataview.length.range");
             }
         } else {
             len = bufferByteLength - pos;
@@ -267,12 +267,12 @@ public class NativeDataView extends NativeArrayBufferView {
 
         bufferByteLength = ab.getLength();
         if (pos > bufferByteLength) {
-            throw ScriptRuntime.rangeError("offset out of range");
+            throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
         }
 
         if (isArg(args, 2)) {
             if (pos + len > bufferByteLength) {
-                throw ScriptRuntime.rangeError("length out of range");
+                throw ScriptRuntime.rangeErrorById("msg.dataview.length.range");
             }
         }
 
@@ -289,12 +289,12 @@ public class NativeDataView extends NativeArrayBufferView {
 
         var viewRecord = DataViewBufferWitnessRecord.create(this);
         if (viewRecord.isViewOutOfBounds()) {
-            throw ScriptRuntime.typeError("view out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
         }
 
         int viewSize = viewRecord.getViewByteLength();
         if (pos + bytes > viewSize) {
-            throw ScriptRuntime.rangeError("offset out of range");
+            throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
         }
 
         switch (bytes) {
@@ -326,12 +326,12 @@ public class NativeDataView extends NativeArrayBufferView {
 
         var viewRecord = DataViewBufferWitnessRecord.create(this);
         if (viewRecord.isViewOutOfBounds()) {
-            throw ScriptRuntime.typeError("view out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
         }
 
         int viewSize = viewRecord.getViewByteLength();
         if (pos + bytes > viewSize) {
-            throw ScriptRuntime.rangeError("offset out of range");
+            throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
         }
 
         switch (bytes) {
@@ -353,12 +353,12 @@ public class NativeDataView extends NativeArrayBufferView {
 
         var viewRecord = DataViewBufferWitnessRecord.create(this);
         if (viewRecord.isViewOutOfBounds()) {
-            throw ScriptRuntime.typeError("view out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
         }
 
         int viewSize = viewRecord.getViewByteLength();
         if (pos + bytes > viewSize) {
-            throw ScriptRuntime.rangeError("offset out of range");
+            throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
         }
 
         switch (bytes) {
@@ -366,13 +366,13 @@ public class NativeDataView extends NativeArrayBufferView {
                 if (signed) {
                     int value = Conversions.toInt8(val);
                     if (pos + bytes > byteLength) {
-                        throw ScriptRuntime.rangeError("offset out of range");
+                        throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
                     }
                     ByteIo.writeInt8(arrayBuffer.buffer, offset + pos, value);
                 } else {
                     int value = Conversions.toUint8(val);
                     if (pos + bytes > byteLength) {
-                        throw ScriptRuntime.rangeError("offset out of range");
+                        throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
                     }
                     ByteIo.writeUint8(arrayBuffer.buffer, offset + pos, value);
                 }
@@ -381,13 +381,13 @@ public class NativeDataView extends NativeArrayBufferView {
                 if (signed) {
                     int value = Conversions.toInt16(val);
                     if (pos + bytes > byteLength) {
-                        throw ScriptRuntime.rangeError("offset out of range");
+                        throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
                     }
                     ByteIo.writeInt16(arrayBuffer.buffer, offset + pos, value, littleEndian);
                 } else {
                     int value = Conversions.toUint16(val);
                     if (pos + bytes > byteLength) {
-                        throw ScriptRuntime.rangeError("offset out of range");
+                        throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
                     }
                     ByteIo.writeUint16(arrayBuffer.buffer, offset + pos, value, littleEndian);
                 }
@@ -396,13 +396,13 @@ public class NativeDataView extends NativeArrayBufferView {
                 if (signed) {
                     int value = Conversions.toInt32(val);
                     if (pos + bytes > byteLength) {
-                        throw ScriptRuntime.rangeError("offset out of range");
+                        throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
                     }
                     ByteIo.writeInt32(arrayBuffer.buffer, offset + pos, value, littleEndian);
                 } else {
                     long value = Conversions.toUint32(val);
                     if (pos + bytes > byteLength) {
-                        throw ScriptRuntime.rangeError("offset out of range");
+                        throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
                     }
                     ByteIo.writeUint32(arrayBuffer.buffer, offset + pos, value, littleEndian);
                 }
@@ -421,12 +421,12 @@ public class NativeDataView extends NativeArrayBufferView {
 
         var viewRecord = DataViewBufferWitnessRecord.create(this);
         if (viewRecord.isViewOutOfBounds()) {
-            throw ScriptRuntime.typeError("view out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
         }
 
         int viewSize = viewRecord.getViewByteLength();
         if (pos + bytes > viewSize) {
-            throw ScriptRuntime.rangeError("offset out of range");
+            throw ScriptRuntime.rangeErrorById("msg.dataview.offset.range");
         }
 
         switch (bytes) {

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -227,12 +227,6 @@ public class NativeDataView extends NativeArrayBufferView {
         return constructor;
     }
 
-    private void rangeCheck(int pos, int len) {
-        if ((pos < 0) || ((pos + len) > byteLength)) {
-            throw ScriptRuntime.rangeError("offset out of range");
-        }
-    }
-
     private static NativeDataView realThis(Scriptable thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeDataView.class);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -54,12 +54,26 @@ public class NativeDataView extends NativeArrayBufferView {
         constructor.definePrototypeProperty(
                 cx,
                 "byteLength",
-                (Scriptable thisObj) -> realThis(thisObj).byteLength,
+                (Scriptable thisObj) -> {
+                    NativeDataView self = realThis(thisObj);
+                    var viewRecord = DataViewBufferWitnessRecord.create(self);
+                    if (viewRecord.isViewOutOfBounds()) {
+                        throw ScriptRuntime.typeError("view out of bounds");
+                    }
+                    return viewRecord.getViewByteLength();
+                },
                 DONTENUM | READONLY);
         constructor.definePrototypeProperty(
                 cx,
                 "byteOffset",
-                (Scriptable thisObj) -> realThis(thisObj).offset,
+                (Scriptable thisObj) -> {
+                    NativeDataView self = realThis(thisObj);
+                    var viewRecord = DataViewBufferWitnessRecord.create(self);
+                    if (viewRecord.isViewOutOfBounds()) {
+                        throw ScriptRuntime.typeError("view out of bounds");
+                    }
+                    return self.offset;
+                },
                 DONTENUM | READONLY);
 
         constructor.definePrototypeMethod(
@@ -213,17 +227,6 @@ public class NativeDataView extends NativeArrayBufferView {
         return constructor;
     }
 
-    private static int determinePos(Object[] args) {
-        if (isArg(args, 0)) {
-            double doublePos = ScriptRuntime.toNumber(args[0]);
-            if (Double.isInfinite(doublePos)) {
-                throw ScriptRuntime.rangeError("offset out of range");
-            }
-            return ScriptRuntime.toInt32(doublePos);
-        }
-        return 0;
-    }
-
     private void rangeCheck(int pos, int len) {
         if ((pos < 0) || ((pos + len) > byteLength)) {
             throw ScriptRuntime.rangeError("offset out of range");
@@ -241,42 +244,64 @@ public class NativeDataView extends NativeArrayBufferView {
 
         NativeArrayBuffer ab = (NativeArrayBuffer) args[0];
 
-        int pos;
-        if (isArg(args, 1)) {
-            double doublePos = ScriptRuntime.toNumber(args[1]);
-            if (Double.isInfinite(doublePos)) {
-                throw ScriptRuntime.rangeError("offset out of range");
-            }
-            pos = ScriptRuntime.toInt32(doublePos);
-        } else {
-            pos = 0;
+        int pos = ScriptRuntime.toIndex(isArg(args, 1) ? args[1] : Undefined.instance);
+
+        if (ab.isDetached()) {
+            throw ScriptRuntime.typeErrorById("msg.arraybuf.detached");
+        }
+
+        int bufferByteLength = ab.getLength();
+        if (pos > bufferByteLength) {
+            throw ScriptRuntime.rangeError("offset out of range");
         }
 
         int len;
         if (isArg(args, 2)) {
-            double doublePos = ScriptRuntime.toNumber(args[2]);
-            if (Double.isInfinite(doublePos)) {
-                throw ScriptRuntime.rangeError("offset out of range");
+            len = ScriptRuntime.toIndex(args[2]);
+            if (pos + len > bufferByteLength) {
+                throw ScriptRuntime.rangeError("length out of range");
             }
-            len = ScriptRuntime.toInt32(doublePos);
         } else {
-            len = ab.getLength() - pos;
+            len = bufferByteLength - pos;
         }
 
-        if (len < 0) {
-            throw ScriptRuntime.rangeError("length out of range");
+        var instance = new NativeDataView();
+
+        if (ab.isDetached()) {
+            throw ScriptRuntime.typeErrorById("msg.arraybuf.detached");
         }
-        if ((pos < 0) || ((pos + len) > ab.getLength())) {
+
+        bufferByteLength = ab.getLength();
+        if (pos > bufferByteLength) {
             throw ScriptRuntime.rangeError("offset out of range");
         }
-        return new NativeDataView(ab, pos, len);
+
+        if (isArg(args, 2)) {
+            if (pos + len > bufferByteLength) {
+                throw ScriptRuntime.rangeError("length out of range");
+            }
+        }
+
+        instance.arrayBuffer = ab;
+        instance.byteLength = len;
+        instance.offset = pos;
+        return instance;
     }
 
     private Object js_getInt(int bytes, boolean signed, Object[] args) {
-        int pos = determinePos(args);
-        rangeCheck(pos, bytes);
+        int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
 
         boolean littleEndian = isArg(args, 1) && (bytes > 1) && ScriptRuntime.toBoolean(args[1]);
+
+        var viewRecord = DataViewBufferWitnessRecord.create(this);
+        if (viewRecord.isViewOutOfBounds()) {
+            throw ScriptRuntime.typeError("view out of bounds");
+        }
+
+        int viewSize = viewRecord.getViewByteLength();
+        if (pos + bytes > viewSize) {
+            throw ScriptRuntime.rangeError("offset out of range");
+        }
 
         switch (bytes) {
             case 1:
@@ -301,10 +326,19 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private Object js_getFloat(int bytes, Object[] args) {
-        int pos = determinePos(args);
-        rangeCheck(pos, bytes);
+        int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
 
         boolean littleEndian = isArg(args, 1) && (bytes > 1) && ScriptRuntime.toBoolean(args[1]);
+
+        var viewRecord = DataViewBufferWitnessRecord.create(this);
+        if (viewRecord.isViewOutOfBounds()) {
+            throw ScriptRuntime.typeError("view out of bounds");
+        }
+
+        int viewSize = viewRecord.getViewByteLength();
+        if (pos + bytes > viewSize) {
+            throw ScriptRuntime.rangeError("offset out of range");
+        }
 
         switch (bytes) {
             case 4:
@@ -317,16 +351,20 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private void js_setInt(int bytes, boolean signed, Object[] args) {
-        int pos = determinePos(args);
-        if (pos < 0) {
-            throw ScriptRuntime.rangeError("offset out of range");
-        }
+        int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
+
+        Object val = isArg(args, 1) ? ScriptRuntime.toNumber(args[1]) : ScriptRuntime.zeroObj;
 
         boolean littleEndian = isArg(args, 2) && (bytes > 1) && ScriptRuntime.toBoolean(args[2]);
 
-        Object val = ScriptRuntime.zeroObj;
-        if (args.length > 1) {
-            val = args[1];
+        var viewRecord = DataViewBufferWitnessRecord.create(this);
+        if (viewRecord.isViewOutOfBounds()) {
+            throw ScriptRuntime.typeError("view out of bounds");
+        }
+
+        int viewSize = viewRecord.getViewByteLength();
+        if (pos + bytes > viewSize) {
+            throw ScriptRuntime.rangeError("offset out of range");
         }
 
         switch (bytes) {
@@ -381,19 +419,19 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private void js_setFloat(int bytes, Object[] args) {
-        int pos = determinePos(args);
-        if (pos < 0) {
-            throw ScriptRuntime.rangeError("offset out of range");
-        }
+        int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
+
+        double val = isArg(args, 1) ? ScriptRuntime.toNumber(args[1]) : Double.NaN;
 
         boolean littleEndian = isArg(args, 2) && (bytes > 1) && ScriptRuntime.toBoolean(args[2]);
 
-        double val = Double.NaN;
-        if (args.length > 1) {
-            val = ScriptRuntime.toNumber(args[1]);
+        var viewRecord = DataViewBufferWitnessRecord.create(this);
+        if (viewRecord.isViewOutOfBounds()) {
+            throw ScriptRuntime.typeError("view out of bounds");
         }
 
-        if (pos + bytes > byteLength) {
+        int viewSize = viewRecord.getViewByteLength();
+        if (pos + bytes > viewSize) {
             throw ScriptRuntime.rangeError("offset out of range");
         }
 
@@ -406,6 +444,42 @@ public class NativeDataView extends NativeArrayBufferView {
                 break;
             default:
                 throw new AssertionError();
+        }
+    }
+
+    private static class DataViewBufferWitnessRecord {
+        private final NativeDataView object;
+        private final int cachedBufferByteLength;
+        private static final int DETACHED = -1;
+
+        private DataViewBufferWitnessRecord(NativeDataView object, int cachedBufferByteLength) {
+            this.object = object;
+            this.cachedBufferByteLength = cachedBufferByteLength;
+        }
+
+        static DataViewBufferWitnessRecord create(NativeDataView object) {
+            var buffer = object.arrayBuffer;
+            return new DataViewBufferWitnessRecord(
+                    object,
+                    buffer.isDetached() ? DETACHED : buffer.getLength()
+            );
+        }
+
+        public int getViewByteLength() {
+            return object.byteLength;
+        }
+
+        public boolean isViewOutOfBounds() {
+            NativeDataView view = object;
+            int bufferByteLength = cachedBufferByteLength;
+            if (bufferByteLength == DETACHED) {
+                return true;
+            }
+
+            int byteOffsetStart = view.offset;
+            int byteOffsetEnd = byteOffsetStart + view.byteLength;
+
+            return byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength;
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -1168,6 +1168,53 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
+    private static class TypedArrayBufferWitnessRecord {
+        private final NativeTypedArrayView<?> object;
+        private final int cachedBufferByteLength;
+        private static final int DETACHED = -1;
+
+        private TypedArrayBufferWitnessRecord(NativeTypedArrayView<?> object, int cachedBufferByteLength) {
+            this.object = object;
+            this.cachedBufferByteLength = cachedBufferByteLength;
+        }
+
+        static TypedArrayBufferWitnessRecord create(NativeTypedArrayView<?> object) {
+            var buffer = object.arrayBuffer;
+            return new TypedArrayBufferWitnessRecord(
+                    object,
+                    buffer.isDetached() ? DETACHED : buffer.getLength()
+            );
+        }
+
+        public int getTypedArrayByteLength() {
+            if (isTypedArrayOutOfBounds()) {
+                return 0;
+            }
+            int length = getTypedArrayLength();
+            if (length == 0) {
+                return 0;
+            }
+            return object.byteLength;
+        }
+
+        public int getTypedArrayLength() {
+            return object.getArrayLength();
+        }
+
+        public boolean isTypedArrayOutOfBounds() {
+            var ta = object;
+            int bufferByteLength = cachedBufferByteLength;
+            if (bufferByteLength == DETACHED) {
+                return true;
+            }
+
+            int byteOffsetStart = ta.offset;
+            int byteOffsetEnd = byteOffsetStart + ta.byteLength;
+
+            return byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength;
+        }
+    }
+
     // External Array implementation
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -136,6 +136,40 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return ret;
     }
 
+    @Override
+    protected boolean defineOwnProperty(
+            Context cx, Object id, ScriptableObject desc, boolean checkValid) {
+        if (id instanceof CharSequence) {
+            String name = id.toString();
+            Optional<Double> num = ScriptRuntime.canonicalNumericIndexString(name);
+            if (num.isPresent()) {
+                int idx = num.get().intValue();
+                if (checkIndex(idx)) {
+                    return false;
+                }
+
+                if (Boolean.FALSE.equals(getProperty(desc, "configurable"))) {
+                    return false;
+                }
+                if (Boolean.FALSE.equals(getProperty(desc, "enumerable"))) {
+                    return false;
+                }
+                if (isAccessorDescriptor(desc)) {
+                    return false;
+                }
+                if (Boolean.FALSE.equals(getProperty(desc, "writable"))) {
+                    return false;
+                }
+                Object value = getProperty(desc, "value");
+                if (value != NOT_FOUND) {
+                    js_set(idx, value);
+                }
+                return true;
+            }
+        }
+        return super.defineOwnProperty(cx, id, desc, checkValid);
+    }
+
     /**
      * To aid in parsing: Return a positive (or zero) integer if the double is a valid array index,
      * and -1 if not.
@@ -194,8 +228,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "entries",
                 0,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
-                    return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.ENTRIES);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+                    return new NativeArrayIterator(lscope, thisObj, ARRAY_ITERATOR_TYPE.ENTRIES);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -204,9 +238,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "every",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.EVERY, lscope, self, args);
+                            lcx, IterativeOperation.EVERY, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -223,11 +257,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "filter",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     Object array =
                             ArrayLikeAbstractOperations.iterativeMethod(
-                                    lcx, IterativeOperation.FILTER, lscope, self, args);
-                    return self.typedArraySpeciesCreate(
+                                    lcx, IterativeOperation.FILTER, lscope, thisObj, args);
+                    return record.object.typedArraySpeciesCreate(
                             lcx, lscope, new Object[] {array}, "filter");
                 },
                 DONTENUM,
@@ -237,9 +271,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "find",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.FIND, lscope, self, args);
+                            lcx, IterativeOperation.FIND, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -248,9 +282,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "findIndex",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.FIND_INDEX, lscope, self, args);
+                            lcx, IterativeOperation.FIND_INDEX, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -259,9 +293,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "findLast",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.FIND_LAST, lscope, self, args);
+                            lcx, IterativeOperation.FIND_LAST, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -270,9 +304,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "findLastIndex",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.FIND_LAST_INDEX, lscope, self, args);
+                            lcx, IterativeOperation.FIND_LAST_INDEX, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -281,9 +315,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "forEach",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.FOR_EACH, lscope, self, args);
+                            lcx, IterativeOperation.FOR_EACH, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -316,8 +350,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "keys",
                 0,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
-                    return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.KEYS);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+                    return new NativeArrayIterator(lscope, thisObj, ARRAY_ITERATOR_TYPE.KEYS);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -334,11 +368,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "map",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     Object array =
                             ArrayLikeAbstractOperations.iterativeMethod(
                                     lcx, IterativeOperation.MAP, lscope, thisObj, args);
-                    return self.typedArraySpeciesCreate(lcx, lscope, new Object[] {array}, "map");
+                    return record.object.typedArraySpeciesCreate(
+                            lcx, lscope, new Object[] {array}, "map");
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -347,9 +382,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "reduce",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.reduceMethod(
-                            lcx, ReduceOperation.REDUCE, lscope, self, args);
+                            lcx, ReduceOperation.REDUCE, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -358,9 +393,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "reduceRight",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.reduceMethod(
-                            lcx, ReduceOperation.REDUCE_RIGHT, lscope, self, args);
+                            lcx, ReduceOperation.REDUCE_RIGHT, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -393,9 +428,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "some",
                 1,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
                     return ArrayLikeAbstractOperations.iterativeMethod(
-                            lcx, IterativeOperation.SOME, lscope, self, args);
+                            lcx, IterativeOperation.SOME, lscope, thisObj, args);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -452,8 +487,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 "values",
                 0,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
-                    return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.VALUES);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+                    return new NativeArrayIterator(lscope, thisObj, ARRAY_ITERATOR_TYPE.VALUES);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -470,8 +505,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 SymbolKey.ITERATOR,
                 0,
                 (Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) -> {
-                    NativeTypedArrayView<?> self = realThis.realThis(thisObj);
-                    return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.VALUES);
+                    TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+                    return new NativeArrayIterator(lscope, thisObj, ARRAY_ITERATOR_TYPE.VALUES);
                 },
                 DONTENUM,
                 DONTENUM | READONLY);
@@ -479,7 +514,18 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     /** Returns <code>true</code>, if the index is wrong. */
     protected boolean checkIndex(int index) {
-        return ((index < 0) || (index >= length));
+        if (arrayBuffer.isDetached()) {
+            return true;
+        }
+        if (index < 0) {
+            return true;
+        }
+        var record = TypedArrayBufferWitnessRecord.create(this);
+        if (record.isTypedArrayOutOfBounds()) {
+            return true;
+        }
+
+        return index >= record.getTypedArrayLength();
     }
 
     /**
@@ -557,39 +603,48 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         if (arg0 instanceof NativeArrayBuffer) {
             // Make a slice of an existing buffer, with shared storage
             NativeArrayBuffer na = (NativeArrayBuffer) arg0;
-            int byteOff = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : 0;
+            int byteOff = isArg(args, 1) ? ScriptRuntime.toIndex(args[1]) : 0;
 
-            int byteLen;
+            if ((byteOff % bytesPerElement) != 0) {
+                throw ScriptRuntime.rangeErrorById(
+                        "msg.typed.array.bad.offset.byte.size", byteOff, bytesPerElement);
+            }
+
+            int newLength = 0;
             if (isArg(args, 2)) {
-                byteLen = ScriptRuntime.toInt32(args[2]) * bytesPerElement;
+                newLength = ScriptRuntime.toIndex(args[2]);
+            }
+
+            if (na.isDetached()) {
+                throw ScriptRuntime.typeErrorById("msg.arraybuf.detached");
+            }
+            int bufferByteLength = na.getLength();
+
+            int newByteLength;
+            if (!isArg(args, 2)) {
+                if ((bufferByteLength % bytesPerElement) != 0) {
+                    throw ScriptRuntime.rangeErrorById(
+                            "msg.typed.array.bad.buffer.length.byte.size",
+                            bufferByteLength,
+                            bytesPerElement);
+                }
+                newByteLength = bufferByteLength - byteOff;
+                if (newByteLength < 0) {
+                    throw ScriptRuntime.rangeErrorById("msg.typed.array.bad.length", newByteLength);
+                }
             } else {
-                byteLen = na.getLength() - byteOff;
+                newByteLength = newLength * bytesPerElement;
+
+                if (byteOff + newByteLength > bufferByteLength) {
+                    throw ScriptRuntime.rangeErrorById("msg.typed.array.bad.offset", byteOff);
+                }
             }
 
             if ((byteOff < 0) || (byteOff > na.getLength())) {
-                String msg = ScriptRuntime.getMessageById("msg.typed.array.bad.offset", byteOff);
-                throw ScriptRuntime.rangeError(msg);
-            }
-            if ((byteLen < 0) || ((byteOff + byteLen) > na.getLength())) {
-                String msg = ScriptRuntime.getMessageById("msg.typed.array.bad.length", byteLen);
-                throw ScriptRuntime.rangeError(msg);
-            }
-            if ((byteOff % bytesPerElement) != 0) {
-                String msg =
-                        ScriptRuntime.getMessageById(
-                                "msg.typed.array.bad.offset.byte.size", byteOff, bytesPerElement);
-                throw ScriptRuntime.rangeError(msg);
-            }
-            if ((byteLen % bytesPerElement) != 0) {
-                String msg =
-                        ScriptRuntime.getMessageById(
-                                "msg.typed.array.bad.buffer.length.byte.size",
-                                byteLen,
-                                bytesPerElement);
-                throw ScriptRuntime.rangeError(msg);
+                throw ScriptRuntime.rangeErrorById("msg.typed.array.bad.offset", byteOff);
             }
 
-            return constructable.construct(na, byteOff, byteLen / bytesPerElement);
+            return constructable.construct(na, byteOff, newByteLength / bytesPerElement);
         }
 
         if (arg0 instanceof NativeArray) {
@@ -629,46 +684,56 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private void setRange(NativeTypedArrayView<?> v, int off) {
-        if (off < 0 || off > length) {
-            String msg = ScriptRuntime.getMessageById("msg.typed.array.bad.offset", off);
-            throw ScriptRuntime.rangeError(msg);
+        var targetRecord = TypedArrayBufferWitnessRecord.create(this);
+        if (targetRecord.isTypedArrayOutOfBounds()) {
+            throw ScriptRuntime.typeError("typed array out of bounds");
         }
+        int targetLength = targetRecord.getTypedArrayLength();
 
-        if (v.length > (length - off)) {
-            String msg = ScriptRuntime.getMessageById("msg.typed.array.bad.source.array");
-            throw ScriptRuntime.rangeError(msg);
+        var srcRecord = TypedArrayBufferWitnessRecord.create(v);
+        if (srcRecord.isTypedArrayOutOfBounds()) {
+            throw ScriptRuntime.typeError("typed array out of bounds");
+        }
+        int srcLength = srcRecord.getTypedArrayLength();
+
+
+        if (srcLength + off > targetLength) {
+            throw ScriptRuntime.rangeErrorById("msg.typed.array.bad.source.array");
         }
 
         if (v.arrayBuffer == arrayBuffer) {
             // Copy to temporary space first, as per spec, to avoid messing up overlapping copies
-            Object[] tmp = new Object[v.length];
-            for (int i = 0; i < v.length; i++) {
+            Object[] tmp = new Object[srcLength];
+            for (int i = 0; i < srcLength; i++) {
                 tmp[i] = v.js_get(i);
             }
-            for (int i = 0; i < v.length; i++) {
+            for (int i = 0; i < srcLength; i++) {
                 js_set(i + off, tmp[i]);
             }
         } else {
-            for (int i = 0; i < v.length; i++) {
+            for (int i = 0; i < srcLength; i++) {
                 js_set(i + off, v.js_get(i));
             }
         }
     }
 
-    private void setRange(NativeArray a, int off) {
-        if (off < 0 || off > length) {
-            String msg = ScriptRuntime.getMessageById("msg.typed.array.bad.offset", off);
-            throw ScriptRuntime.rangeError(msg);
+    private void setRange(Scriptable a, int off) {
+        var targetRecord = TypedArrayBufferWitnessRecord.create(this);
+        if (targetRecord.isTypedArrayOutOfBounds()) {
+            throw ScriptRuntime.typeError("typed array out of bounds");
         }
-        if ((off + a.size()) > length) {
-            String msg = ScriptRuntime.getMessageById("msg.typed.array.bad.source.array");
-            throw ScriptRuntime.rangeError(msg);
+        int targetLength = targetRecord.getTypedArrayLength();
+
+        ScriptableObject src = ScriptableObject.ensureScriptableObject(a);
+        long srcLength = ScriptRuntime.toLength(src.get("length", src));
+
+        if (srcLength + off > targetLength) {
+            throw ScriptRuntime.rangeErrorById("msg.typed.array.bad.source.array");
         }
 
-        int pos = off;
-        for (Object val : a) {
-            js_set(pos, val);
-            pos++;
+        for (int k = 0; k < srcLength; k++) {
+            Object value = src.get(k, src);
+            js_set(k + off, value);
         }
     }
 
@@ -678,17 +743,26 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Object js_byteLength(Scriptable thisObj, RealThis realThis) {
         NativeTypedArrayView<?> o = realThis.realThis(thisObj);
-        return o.byteLength;
+        var record = TypedArrayBufferWitnessRecord.create(o);
+        return record.getTypedArrayByteLength();
     }
 
     private static Object js_byteOffset(Scriptable thisObj, RealThis realThis) {
         NativeTypedArrayView<?> o = realThis.realThis(thisObj);
-        return o.offset;
+        var record = TypedArrayBufferWitnessRecord.create(o);
+        if (record.isTypedArrayOutOfBounds()) {
+            return 0;
+        }
+        return o.getByteOffset();
     }
 
     private static Object js_length(Scriptable thisObj, RealThis realThis) {
         NativeTypedArrayView<?> o = realThis.realThis(thisObj);
-        return o.length;
+        var record = TypedArrayBufferWitnessRecord.create(o);
+        if (record.isTypedArrayOutOfBounds()) {
+            return 0;
+        }
+        return record.getTypedArrayLength();
     }
 
     private static String js_toString(
@@ -725,10 +799,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Boolean js_includes(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
-        Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
-        if (self.length == 0) return Boolean.FALSE;
+        if (len == 0) return Boolean.FALSE;
+
+        Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         long start;
         if (args.length < 2) {
@@ -736,13 +812,13 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         } else {
             start = (long) ScriptRuntime.toInteger(args[1]);
             if (start < 0) {
-                start += self.length;
+                start += len;
                 if (start < 0) start = 0;
             }
-            if (start > self.length - 1) return Boolean.FALSE;
+            if (start > len - 1) return Boolean.FALSE;
         }
-        for (int i = (int) start; i < self.length; i++) {
-            Object val = self.js_get(i);
+        for (int i = (int) start; i < len; i++) {
+            Object val = record.object.js_get(i);
             if (ScriptRuntime.sameZero(val, compareTo)) {
                 return Boolean.TRUE;
             }
@@ -752,11 +828,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Object js_indexOf(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
+
+        if (len == 0) return -1;
 
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
-
-        if (self.length == 0) return -1;
 
         long start;
         if (args.length < 2) {
@@ -765,13 +842,15 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         } else {
             start = (long) ScriptRuntime.toInteger(args[1]);
             if (start < 0) {
-                start += self.length;
+                start += len;
                 if (start < 0) start = 0;
             }
-            if (start > self.length - 1) return -1;
+            if (start > len - 1) return -1;
         }
-        for (int i = (int) start; i < self.length; i++) {
-            Object val = self.js_get(i);
+        for (int i = (int) start; i < len; i++) {
+            // TODO: if looking for undefined and the buffer is detached, it shouldn't find it.
+            //       need to investigate more
+            Object val = record.object.js_get(i);
             if (val != NOT_FOUND && ScriptRuntime.shallowEq(val, compareTo)) {
                 return (long) i;
             }
@@ -781,24 +860,25 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Object js_lastIndexOf(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
+
+        if (len == 0) return -1;
 
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
-
-        if (self.length == 0) return -1;
 
         long start;
         if (args.length < 2) {
             // default
-            start = self.length - 1L;
+            start = len - 1L;
         } else {
             start = (long) ScriptRuntime.toInteger(args[1]);
-            if (start >= self.length) start = self.length - 1L;
-            else if (start < 0) start += self.length;
+            if (start >= len) start = len - 1L;
+            else if (start < 0) start += len;
             if (start < 0) return -1;
         }
         for (int i = (int) start; i >= 0; i--) {
-            Object val = self.js_get(i);
+            Object val = record.object.js_get(i);
             if (val != NOT_FOUND && ScriptRuntime.shallowEq(val, compareTo)) {
                 return (long) i;
             }
@@ -809,21 +889,23 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     private static Scriptable js_slice(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
         NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int srcLength = record.getTypedArrayLength();
 
         long begin, end;
         if (args.length == 0) {
             begin = 0;
-            end = self.length;
+            end = srcLength;
         } else {
             begin =
                     ArrayLikeAbstractOperations.toSliceIndex(
-                            ScriptRuntime.toInteger(args[0]), self.length);
+                            ScriptRuntime.toInteger(args[0]), srcLength);
             if (args.length == 1 || args[1] == Undefined.instance) {
-                end = self.length;
+                end = srcLength;
             } else {
                 end =
                         ArrayLikeAbstractOperations.toSliceIndex(
-                                ScriptRuntime.toInteger(args[1]), self.length);
+                                ScriptRuntime.toInteger(args[1]), srcLength);
             }
         }
 
@@ -834,40 +916,55 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
         long count = Math.max(end - begin, 0);
 
-        return self.typedArraySpeciesCreate(
-                cx,
-                scope,
-                new Object[] {
-                    self.arrayBuffer, begin * self.getBytesPerElement(), Math.max(0, end - begin)
-                },
-                "slice");
+        var a = (NativeTypedArrayView<?>) record.object.typedArraySpeciesCreate(
+                cx, scope, new Object[] {count}, "slice");
+
+        if (count > 0) {
+            record = TypedArrayBufferWitnessRecord.create(self);
+            if (record.isTypedArrayOutOfBounds()) {
+                throw ScriptRuntime.typeError("typed array out of bounds");
+            }
+            end = Math.min(end, record.getTypedArrayLength());
+
+            // TODO: fix impl to be spec compliant with different types
+            int otherIndex = 0;
+            for (long i = begin; i < end; i++) {
+                Object val = self.js_get((int) i);
+                a.js_set(otherIndex, val);
+                otherIndex++;
+            }
+        }
+
+        return a;
     }
 
     private static String js_join(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
         // if no args, use "," as separator
         String separator =
                 (args.length < 1 || args[0] == Undefined.instance)
                         ? ","
                         : ScriptRuntime.toString(args[0]);
-        if (self.length == 0) {
+        if (len == 0) {
             return "";
         }
-        String[] buf = new String[self.length];
+
+        String[] buf = new String[len];
         int total_size = 0;
-        for (int i = 0; i != self.length; i++) {
-            Object temp = self.js_get(i);
+        for (int i = 0; i != len; i++) {
+            Object temp = record.object.js_get(i);
             if (temp != null && temp != Undefined.instance) {
                 String str = ScriptRuntime.toString(temp);
                 total_size += str.length();
                 buf[i] = str;
             }
         }
-        total_size += (self.length - 1) * separator.length();
+        total_size += (len - 1) * separator.length();
         StringBuilder sb = new StringBuilder(total_size);
-        for (int i = 0; i != self.length; i++) {
+        for (int i = 0; i != len; i++) {
             if (i != 0) {
                 sb.append(separator);
             }
@@ -882,19 +979,24 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static NativeTypedArrayView<?> js_reverse(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
-        for (int i = 0, j = self.length - 1; i < j; i++, j--) {
-            Object temp = self.js_get(i);
-            self.js_set(i, self.js_get(j));
-            self.js_set(j, temp);
+        for (int i = 0, j = len - 1; i < j; i++, j--) {
+            Object temp = record.object.js_get(i);
+            record.object.js_set(i, record.object.js_get(j));
+            record.object.js_set(j, temp);
         }
-        return self;
+        return record.object;
     }
 
     private static NativeTypedArrayView<?> js_fill(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
         NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
+
+        Object value = ScriptRuntime.toNumber(isArg(args, 0) ? args[0] : Undefined.instance);
 
         long relativeStart = 0;
         if (args.length >= 2) {
@@ -902,23 +1004,30 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         }
         final long k;
         if (relativeStart < 0) {
-            k = Math.max((self.length + relativeStart), 0);
+            k = Math.max((len + relativeStart), 0);
         } else {
-            k = Math.min(relativeStart, self.length);
+            k = Math.min(relativeStart, len);
         }
 
-        long relativeEnd = self.length;
-        if (args.length >= 3 && !Undefined.isUndefined(args[2])) {
+        long relativeEnd = len;
+        if (isArg(args, 2)) {
             relativeEnd = (long) ScriptRuntime.toInteger(args[2]);
         }
-        final long fin;
+        long fin;
         if (relativeEnd < 0) {
-            fin = Math.max((self.length + relativeEnd), 0);
+            fin = Math.max((len + relativeEnd), 0);
         } else {
-            fin = Math.min(relativeEnd, self.length);
+            fin = Math.min(relativeEnd, len);
         }
 
-        Object value = args.length > 0 ? args[0] : Undefined.instance;
+        record = TypedArrayBufferWitnessRecord.create(self);
+        if (record.isTypedArrayOutOfBounds()) {
+            throw ScriptRuntime.typeError("typed array out of bounds");
+        }
+        len = record.getTypedArrayLength();
+
+        fin = Math.min(len, fin);
+
         for (int i = (int) k; i < fin; i++) {
             self.js_set(i, value);
         }
@@ -932,14 +1041,15 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             throw ScriptRuntime.typeErrorById("msg.function.expected");
         }
 
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
-        Object[] working = self.sortTemporaryArray(cx, scope, args);
-        for (int i = 0; i < self.length; ++i) {
-            self.js_set(i, working[i]);
+        Object[] working = record.object.sortTemporaryArray(cx, scope, args);
+        for (int i = 0; i < len; ++i) {
+            record.object.js_set(i, working[i]);
         }
 
-        return self;
+        return record.object;
     }
 
     private Object[] sortTemporaryArray(Context cx, Scriptable scope, Object[] args) {
@@ -958,38 +1068,45 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Object js_copyWithin(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
         Object targetArg = (args.length >= 1) ? args[0] : Undefined.instance;
         long relativeTarget = (long) ScriptRuntime.toInteger(targetArg);
         long to;
         if (relativeTarget < 0) {
-            to = Math.max((self.length + relativeTarget), 0);
+            to = Math.max((len + relativeTarget), 0);
         } else {
-            to = Math.min(relativeTarget, self.length);
+            to = Math.min(relativeTarget, len);
         }
 
         Object startArg = (args.length >= 2) ? args[1] : Undefined.instance;
         long relativeStart = (long) ScriptRuntime.toInteger(startArg);
         long from;
         if (relativeStart < 0) {
-            from = Math.max((self.length + relativeStart), 0);
+            from = Math.max((len + relativeStart), 0);
         } else {
-            from = Math.min(relativeStart, self.length);
+            from = Math.min(relativeStart, len);
         }
 
-        long relativeEnd = self.length;
-        if (args.length >= 3 && !Undefined.isUndefined(args[2])) {
+        long relativeEnd = len;
+        if (isArg(args, 2)) {
             relativeEnd = (long) ScriptRuntime.toInteger(args[2]);
         }
         final long fin;
         if (relativeEnd < 0) {
-            fin = Math.max((self.length + relativeEnd), 0);
+            fin = Math.max((len + relativeEnd), 0);
         } else {
-            fin = Math.min(relativeEnd, self.length);
+            fin = Math.min(relativeEnd, len);
         }
 
-        long count = Math.min(fin - from, self.length - to);
+        long count = Math.min(fin - from, len - to);
+
+        record = TypedArrayBufferWitnessRecord.create(realThis.realThis(thisObj));
+        if (record.isTypedArrayOutOfBounds()) {
+            throw ScriptRuntime.typeError("typed array out of bounds");
+        }
+
         int direction = 1;
         if (from < to && to < from + count) {
             direction = -1;
@@ -998,54 +1115,47 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         }
 
         for (; count > 0; count--) {
-            final Object temp = self.js_get((int) from);
-            self.js_set((int) to, temp);
+            final Object temp = record.object.js_get((int) from);
+            record.object.js_set((int) to, temp);
             from += direction;
             to += direction;
         }
 
-        return self;
+        return record.object;
     }
 
     private static Object js_set(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
         NativeTypedArrayView<?> self = realThis.realThis(thisObj);
-        if (args.length > 0) {
-            if (args[0] instanceof NativeTypedArrayView) {
-                int offset = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : 0;
-                NativeTypedArrayView<?> nativeView = (NativeTypedArrayView<?>) args[0];
-                self.setRange(nativeView, offset);
-                return Undefined.instance;
-            }
-            if (args[0] instanceof NativeArray) {
-                int offset = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : 0;
-                self.setRange((NativeArray) args[0], offset);
-                return Undefined.instance;
-            }
-            if (args[0] instanceof Scriptable) {
-                // Tests show that we need to ignore a non-array object
-                return Undefined.instance;
-            }
-            if (isArg(args, 2)) {
-                return self.js_set(ScriptRuntime.toInt32(args[0]), args[1]);
-            }
+        int offset = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : 0;
+        if (offset < 0) {
+            throw ScriptRuntime.rangeErrorById("msg.typed.array.bad.offset", offset);
         }
-        throw ScriptRuntime.constructError("Error", "invalid arguments");
+
+        if (args[0] instanceof NativeTypedArrayView) {
+            NativeTypedArrayView<?> source = (NativeTypedArrayView<?>) args[0];
+            self.setRange(source, offset);
+        } else {
+            self.setRange(ScriptableObject.ensureScriptable(args[0]), offset);
+        }
+        return Undefined.instance;
     }
 
     private static Object js_subarray(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
         NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.create(self);
+        int srcLength = record.isTypedArrayOutOfBounds() ? 0 : record.getTypedArrayLength();
 
         int start = isArg(args, 0) ? ScriptRuntime.toInt32(args[0]) : 0;
-        int end = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : self.length;
+        int end = isArg(args, 1) ? ScriptRuntime.toInt32(args[1]) : srcLength;
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 || args.length > 0) {
-            start = (start < 0 ? self.length + start : start);
-            end = (end < 0 ? self.length + end : end);
+            start = (start < 0 ? srcLength + start : start);
+            end = (end < 0 ? srcLength + end : end);
 
             // Clamping behavior as described by the spec.
             start = Math.max(0, start);
-            end = Math.min(self.length, end);
+            end = Math.min(srcLength, end);
             int len = Math.max(0, (end - start));
             int byteOff =
                     Math.min(
@@ -1060,16 +1170,17 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Object js_at(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
         long relativeIndex = 0;
         if (args.length >= 1) {
             relativeIndex = (long) ScriptRuntime.toInteger(args[0]);
         }
 
-        long k = (relativeIndex >= 0) ? relativeIndex : self.length + relativeIndex;
+        long k = (relativeIndex >= 0) ? relativeIndex : len + relativeIndex;
 
-        if ((k < 0) || (k >= self.length)) {
+        if ((k < 0) || (k >= len)) {
             return Undefined.instance;
         }
 
@@ -1088,23 +1199,38 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         if (!(newArray instanceof NativeTypedArrayView<?>)) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.ctor.incompatible", methodName);
         }
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(newArray, null);
+        if (args.length == 1) {
+            Object arg0 = ScriptRuntime.toPrimitive(args[0]);
+            if (arg0 instanceof Number) {
+                if (record.isTypedArrayOutOfBounds()) {
+                    throw ScriptRuntime.typeError("typed array out of bounds");
+                }
+                int length = record.getTypedArrayLength();
+                if (length < ScriptRuntime.toNumber(arg0)) {
+                    throw ScriptRuntime.typeError("bad length");
+                }
+            }
+        }
         return newArray;
     }
 
     private static Object js_toReversed(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
         NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
         NativeArrayBuffer newBuffer =
-                new NativeArrayBuffer(self.length * self.getBytesPerElement());
+                new NativeArrayBuffer(len * self.getBytesPerElement());
         Scriptable result =
                 cx.newObject(
                         scope,
                         self.getClassName(),
-                        new Object[] {newBuffer, 0, self.length, self.getBytesPerElement()});
+                        new Object[] {newBuffer, 0, len, self.getBytesPerElement()});
 
-        for (int k = 0; k < self.length; ++k) {
-            int from = self.length - k - 1;
+        for (int k = 0; k < len; ++k) {
+            int from = len - k - 1;
             Object fromValue = self.js_get(from);
             result.put(k, result, fromValue);
         }
@@ -1115,18 +1241,20 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     private static Object js_toSorted(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
         NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
         Object[] working = self.sortTemporaryArray(cx, scope, args);
 
         // Move value in a new typed array of the same type
         NativeArrayBuffer newBuffer =
-                new NativeArrayBuffer(self.length * self.getBytesPerElement());
+                new NativeArrayBuffer(len * self.getBytesPerElement());
         Scriptable result =
                 cx.newObject(
                         scope,
                         self.getClassName(),
-                        new Object[] {newBuffer, 0, self.length, self.getBytesPerElement()});
-        for (int k = 0; k < self.length; ++k) {
+                        new Object[] {newBuffer, 0, len, self.getBytesPerElement()});
+        for (int k = 0; k < len; ++k) {
             result.put(k, result, working[k]);
         }
 
@@ -1135,33 +1263,34 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static Object js_with(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args, RealThis realThis) {
-        NativeTypedArrayView<?> self = realThis.realThis(thisObj);
+        var record = TypedArrayBufferWitnessRecord.validateTypedArray(thisObj, realThis);
+        int len = record.getTypedArrayLength();
 
         long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(args[0]) : 0;
-        long actualIndex = relativeIndex >= 0 ? relativeIndex : self.length + relativeIndex;
+        long actualIndex = relativeIndex >= 0 ? relativeIndex : len + relativeIndex;
 
         Object argsValue = args.length > 1 ? ScriptRuntime.toNumber(args[1]) : 0.0;
 
-        if (actualIndex < 0 || actualIndex >= self.length) {
+        if (actualIndex < 0 || actualIndex >= len) {
             String msg =
                     ScriptRuntime.getMessageById(
                             "msg.typed.array.index.out.of.bounds",
                             relativeIndex,
-                            self.length * -1,
-                            self.length - 1);
+                            len * -1,
+                            len - 1);
             throw ScriptRuntime.rangeError(msg);
         }
 
         NativeArrayBuffer newBuffer =
-                new NativeArrayBuffer(self.length * self.getBytesPerElement());
+                new NativeArrayBuffer(len * record.object.getBytesPerElement());
         Scriptable result =
                 cx.newObject(
                         scope,
-                        self.getClassName(),
-                        new Object[] {newBuffer, 0, self.length, self.getBytesPerElement()});
+                        record.object.getClassName(),
+                        new Object[] {newBuffer, 0, len, record.object.getBytesPerElement()});
 
-        for (int k = 0; k < self.length; ++k) {
-            Object fromValue = (k == actualIndex) ? argsValue : self.js_get(k);
+        for (int k = 0; k < len; ++k) {
+            Object fromValue = (k == actualIndex) ? argsValue : record.object.js_get(k);
             result.put(k, result, fromValue);
         }
 
@@ -1184,6 +1313,28 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                     object,
                     buffer.isDetached() ? DETACHED : buffer.getLength()
             );
+        }
+
+        static TypedArrayBufferWitnessRecord validateTypedArray(Scriptable object, RealThis realThis) {
+            if (realThis != null) {
+                var o = realThis.realThis(object);
+                var record = create(o);
+                if (record.isTypedArrayOutOfBounds()) {
+                    throw ScriptRuntime.typeError("typed array out of bounds");
+                }
+                return record;
+            }
+
+            if (object instanceof NativeTypedArrayView<?>) {
+                var o = (NativeTypedArrayView<?>) object;
+                var record = create(o);
+                if (record.isTypedArrayOutOfBounds()) {
+                    throw ScriptRuntime.typeError("typed array out of bounds");
+                }
+                return record;
+            }
+
+            throw ScriptRuntime.typeError("Expected a TypedArray instance");
         }
 
         public int getTypedArrayByteLength() {

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -686,13 +686,13 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     private void setRange(NativeTypedArrayView<?> v, int off) {
         var targetRecord = TypedArrayBufferWitnessRecord.create(this);
         if (targetRecord.isTypedArrayOutOfBounds()) {
-            throw ScriptRuntime.typeError("typed array out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
         int targetLength = targetRecord.getTypedArrayLength();
 
         var srcRecord = TypedArrayBufferWitnessRecord.create(v);
         if (srcRecord.isTypedArrayOutOfBounds()) {
-            throw ScriptRuntime.typeError("typed array out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
         int srcLength = srcRecord.getTypedArrayLength();
 
@@ -720,7 +720,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     private void setRange(Scriptable a, int off) {
         var targetRecord = TypedArrayBufferWitnessRecord.create(this);
         if (targetRecord.isTypedArrayOutOfBounds()) {
-            throw ScriptRuntime.typeError("typed array out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
         int targetLength = targetRecord.getTypedArrayLength();
 
@@ -922,7 +922,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         if (count > 0) {
             record = TypedArrayBufferWitnessRecord.create(self);
             if (record.isTypedArrayOutOfBounds()) {
-                throw ScriptRuntime.typeError("typed array out of bounds");
+                throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
             }
             end = Math.min(end, record.getTypedArrayLength());
 
@@ -1022,7 +1022,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
         record = TypedArrayBufferWitnessRecord.create(self);
         if (record.isTypedArrayOutOfBounds()) {
-            throw ScriptRuntime.typeError("typed array out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
         len = record.getTypedArrayLength();
 
@@ -1104,7 +1104,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
         record = TypedArrayBufferWitnessRecord.create(realThis.realThis(thisObj));
         if (record.isTypedArrayOutOfBounds()) {
-            throw ScriptRuntime.typeError("typed array out of bounds");
+            throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
 
         int direction = 1;
@@ -1204,11 +1204,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             Object arg0 = ScriptRuntime.toPrimitive(args[0]);
             if (arg0 instanceof Number) {
                 if (record.isTypedArrayOutOfBounds()) {
-                    throw ScriptRuntime.typeError("typed array out of bounds");
+                    throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
                 }
                 int length = record.getTypedArrayLength();
                 if (length < ScriptRuntime.toNumber(arg0)) {
-                    throw ScriptRuntime.typeError("bad length");
+                    throw ScriptRuntime.typeErrorById("msg.typed.array.bad.length", arg0);
                 }
             }
         }
@@ -1320,7 +1320,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 var o = realThis.realThis(object);
                 var record = create(o);
                 if (record.isTypedArrayOutOfBounds()) {
-                    throw ScriptRuntime.typeError("typed array out of bounds");
+                    throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
                 }
                 return record;
             }
@@ -1329,7 +1329,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 var o = (NativeTypedArrayView<?>) object;
                 var record = create(o);
                 if (record.isTypedArrayOutOfBounds()) {
-                    throw ScriptRuntime.typeError("typed array out of bounds");
+                    throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
                 }
                 return record;
             }

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -1027,6 +1027,9 @@ msg.typed.array.bad.source.array = \
 msg.typed.array.index.out.of.bounds =\
     index {0} is out of bounds [{1}..{2}]
 
+msg.typed.array.out.of.bounds =\
+  TypedArray is out of bounds
+
 # Error
 msg.iterable.expected =\
   Expected the first argument to be iterable
@@ -1043,3 +1046,13 @@ msg.arraybuf.same =\
 
 msg.arraybuf.detached =\
   Expected ArrayBuffer to not be detached
+
+# DataView
+msg.dataview.bounds =\
+  DataView is out of bounds
+
+msg.dataview.offset.range =\
+  DataView offset is out of range
+
+msg.dataview.length.range =\
+  DataView length is out of range

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -1040,3 +1040,6 @@ msg.arraybuf.smaller.len =\
 
 msg.arraybuf.same =\
   Expected different ArrayBuffer
+
+msg.arraybuf.detached =\
+  Expected ArrayBuffer to not be detached

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -54,6 +54,7 @@ import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.drivers.TestUtils;
 import org.mozilla.javascript.tools.SourceReader;
 import org.mozilla.javascript.tools.shell.ShellContextFactory;
+import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
 
@@ -472,8 +473,11 @@ public class Test262SuiteTest {
 
         public static Object detachArrayBuffer(
                 Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-            throw new UnsupportedOperationException(
-                    "$262.detachArrayBuffer() method not yet implemented");
+            Scriptable buf = ScriptRuntime.toObject(scope, args[0]);
+            if (buf instanceof NativeArrayBuffer) {
+                ((NativeArrayBuffer) buf).detach();
+            }
+            return Undefined.instance;
         }
 
         public static Object getAgent(Scriptable scriptable) {

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -200,12 +200,13 @@ built-ins/Array 264/3074 (8.59%)
     proto-from-ctor-realm-two.js
     proto-from-ctor-realm-zero.js
 
-built-ins/ArrayBuffer 121/191 (63.35%)
+built-ins/ArrayBuffer 112/191 (58.64%)
     isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
     isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
-    prototype/byteLength/detached-buffer.js
     prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    prototype/detached 11/11 (100.0%)
+    prototype/detached/detached-buffer-resizable.js {unsupported: [resizable-arraybuffer]}
+    prototype/detached/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/detached/this-is-sharedarraybuffer-resizable.js {unsupported: [SharedArrayBuffer]}
     prototype/maxByteLength 11/11 (100.0%)
     prototype/resizable 10/10 (100.0%)
     prototype/resize 20/20 (100.0%)
@@ -255,24 +256,18 @@ built-ins/BigInt 7/75 (9.33%)
 built-ins/Boolean 1/51 (1.96%)
     proto-from-ctor-realm.js
 
-built-ins/DataView 222/550 (40.36%)
-    prototype/buffer/detached-buffer.js
+built-ins/DataView 151/550 (27.45%)
     prototype/buffer/return-buffer-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/buffer/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/byteLength/detached-buffer.js
-    prototype/byteLength/instance-has-detached-buffer.js
     prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/return-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteLength/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/byteOffset/detached-buffer.js
     prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getBigInt64/detached-buffer.js
     prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
-    prototype/getBigInt64/detached-buffer-before-outofrange-byteoffset.js
     prototype/getBigInt64/index-is-out-of-range.js
     prototype/getBigInt64/length.js
     prototype/getBigInt64/name.js
@@ -288,9 +283,7 @@ built-ins/DataView 222/550 (40.36%)
     prototype/getBigInt64/toindex-byteoffset-errors.js
     prototype/getBigInt64/toindex-byteoffset-toprimitive.js
     prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
-    prototype/getBigUint64/detached-buffer.js
     prototype/getBigUint64/detached-buffer-after-toindex-byteoffset.js
-    prototype/getBigUint64/detached-buffer-before-outofrange-byteoffset.js
     prototype/getBigUint64/index-is-out-of-range.js
     prototype/getBigUint64/length.js
     prototype/getBigUint64/name.js
@@ -306,9 +299,7 @@ built-ins/DataView 222/550 (40.36%)
     prototype/getBigUint64/toindex-byteoffset-errors.js
     prototype/getBigUint64/toindex-byteoffset-toprimitive.js
     prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
-    prototype/getFloat16/detached-buffer.js
     prototype/getFloat16/detached-buffer-after-toindex-byteoffset.js
-    prototype/getFloat16/detached-buffer-before-outofrange-byteoffset.js
     prototype/getFloat16/index-is-out-of-range.js
     prototype/getFloat16/length.js
     prototype/getFloat16/minus-zero.js
@@ -324,21 +315,9 @@ built-ins/DataView 222/550 (40.36%)
     prototype/getFloat16/return-values-custom-offset.js
     prototype/getFloat16/to-boolean-littleendian.js
     prototype/getFloat16/toindex-byteoffset.js
-    prototype/getFloat32/detached-buffer.js
-    prototype/getFloat32/detached-buffer-after-toindex-byteoffset.js
-    prototype/getFloat32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getFloat64/detached-buffer.js
-    prototype/getFloat64/detached-buffer-after-toindex-byteoffset.js
-    prototype/getFloat64/detached-buffer-before-outofrange-byteoffset.js
     prototype/getFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getInt16/detached-buffer.js
-    prototype/getInt16/detached-buffer-after-toindex-byteoffset.js
-    prototype/getInt16/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getInt32/detached-buffer.js
-    prototype/getInt32/detached-buffer-after-toindex-byteoffset.js
-    prototype/getInt32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
@@ -350,26 +329,12 @@ built-ins/DataView 222/550 (40.36%)
     prototype/getInt32/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/to-boolean-littleendian-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getInt32/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt8/detached-buffer.js
-    prototype/getInt8/detached-buffer-after-toindex-byteoffset.js
-    prototype/getInt8/detached-buffer-before-outofrange-byteoffset.js
     prototype/getInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getUint16/detached-buffer.js
-    prototype/getUint16/detached-buffer-after-toindex-byteoffset.js
-    prototype/getUint16/detached-buffer-before-outofrange-byteoffset.js
     prototype/getUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getUint32/detached-buffer.js
-    prototype/getUint32/detached-buffer-after-toindex-byteoffset.js
-    prototype/getUint32/detached-buffer-before-outofrange-byteoffset.js
     prototype/getUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getUint8/detached-buffer.js
-    prototype/getUint8/detached-buffer-after-toindex-byteoffset.js
-    prototype/getUint8/detached-buffer-before-outofrange-byteoffset.js
     prototype/getUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setBigInt64/detached-buffer.js
     prototype/setBigInt64/detached-buffer-after-bigint-value.js
     prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
-    prototype/setBigInt64/detached-buffer-before-outofrange-byteoffset.js
     prototype/setBigInt64/index-check-before-value-conversion.js
     prototype/setBigInt64/index-is-out-of-range.js
     prototype/setBigInt64/length.js
@@ -385,10 +350,8 @@ built-ins/DataView 222/550 (40.36%)
     prototype/setBigInt64/to-boolean-littleendian.js
     prototype/setBigInt64/toindex-byteoffset.js
     prototype/setBigUint64 2/2 (100.0%)
-    prototype/setFloat16/detached-buffer.js
     prototype/setFloat16/detached-buffer-after-number-value.js
     prototype/setFloat16/detached-buffer-after-toindex-byteoffset.js
-    prototype/setFloat16/detached-buffer-before-outofrange-byteoffset.js
     prototype/setFloat16/index-check-before-value-conversion.js
     prototype/setFloat16/index-is-out-of-range.js
     prototype/setFloat16/length.js
@@ -404,45 +367,13 @@ built-ins/DataView 222/550 (40.36%)
     prototype/setFloat16/set-values-return-undefined.js
     prototype/setFloat16/to-boolean-littleendian.js
     prototype/setFloat16/toindex-byteoffset.js
-    prototype/setFloat32/detached-buffer.js
-    prototype/setFloat32/detached-buffer-after-number-value.js
-    prototype/setFloat32/detached-buffer-after-toindex-byteoffset.js
-    prototype/setFloat32/detached-buffer-before-outofrange-byteoffset.js
     prototype/setFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setFloat64/detached-buffer.js
-    prototype/setFloat64/detached-buffer-after-number-value.js
-    prototype/setFloat64/detached-buffer-after-toindex-byteoffset.js
-    prototype/setFloat64/detached-buffer-before-outofrange-byteoffset.js
     prototype/setFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setInt16/detached-buffer.js
-    prototype/setInt16/detached-buffer-after-number-value.js
-    prototype/setInt16/detached-buffer-after-toindex-byteoffset.js
-    prototype/setInt16/detached-buffer-before-outofrange-byteoffset.js
     prototype/setInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setInt32/detached-buffer.js
-    prototype/setInt32/detached-buffer-after-number-value.js
-    prototype/setInt32/detached-buffer-after-toindex-byteoffset.js
-    prototype/setInt32/detached-buffer-before-outofrange-byteoffset.js
     prototype/setInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setInt8/detached-buffer.js
-    prototype/setInt8/detached-buffer-after-number-value.js
-    prototype/setInt8/detached-buffer-after-toindex-byteoffset.js
-    prototype/setInt8/detached-buffer-before-outofrange-byteoffset.js
     prototype/setInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setUint16/detached-buffer.js
-    prototype/setUint16/detached-buffer-after-number-value.js
-    prototype/setUint16/detached-buffer-after-toindex-byteoffset.js
-    prototype/setUint16/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setUint32/detached-buffer.js
-    prototype/setUint32/detached-buffer-after-number-value.js
-    prototype/setUint32/detached-buffer-after-toindex-byteoffset.js
-    prototype/setUint32/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setUint8/detached-buffer.js
-    prototype/setUint8/detached-buffer-after-number-value.js
-    prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
-    prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/Symbol.toStringTag.js
     buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -461,7 +392,6 @@ built-ins/DataView 222/550 (40.36%)
     defined-bytelength-and-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     defined-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
     defined-byteoffset-undefined-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    detached-buffer.js
     excessive-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
     excessive-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
     instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
@@ -1837,7 +1767,7 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 1084/1422 (76.23%)
+built-ins/TypedArray 1002/1422 (70.46%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/from-array-mapper-detaches-result.js
@@ -1863,7 +1793,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/at 14/14 (100.0%)
     prototype/buffer/BigInt 2/2 (100.0%)
-    prototype/buffer/detached-buffer.js
     prototype/buffer/invoked-as-func.js
     prototype/buffer/length.js
     prototype/buffer/name.js
@@ -1872,7 +1801,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/buffer/this-inherits-typedarray.js
     prototype/buffer/this-is-not-object.js
     prototype/byteLength/BigInt 4/4 (100.0%)
-    prototype/byteLength/detached-buffer.js
     prototype/byteLength/invoked-as-func.js
     prototype/byteLength/length.js
     prototype/byteLength/name.js
@@ -1885,7 +1813,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/byteLength/this-has-no-typedarrayname-internal.js
     prototype/byteLength/this-is-not-object.js
     prototype/byteOffset/BigInt 4/4 (100.0%)
-    prototype/byteOffset/detached-buffer.js
     prototype/byteOffset/invoked-as-func.js
     prototype/byteOffset/length.js
     prototype/byteOffset/name.js
@@ -1898,10 +1825,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/copyWithin/BigInt 24/24 (100.0%)
     prototype/copyWithin/coerced-target-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/coerced-target-start-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/coerced-values-end-detached.js
-    prototype/copyWithin/coerced-values-end-detached-prototype.js
-    prototype/copyWithin/coerced-values-start-detached.js
-    prototype/copyWithin/detached-buffer.js
     prototype/copyWithin/get-length-ignores-length-prop.js
     prototype/copyWithin/invoked-as-func.js
     prototype/copyWithin/invoked-as-method.js
@@ -1914,7 +1837,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/copyWithin/this-is-not-object.js
     prototype/copyWithin/this-is-not-typedarray-instance.js
     prototype/entries/BigInt 4/4 (100.0%)
-    prototype/entries/detached-buffer.js
     prototype/entries/invoked-as-func.js
     prototype/entries/invoked-as-method.js
     prototype/entries/length.js
@@ -1928,9 +1850,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/entries/this-is-not-object.js
     prototype/entries/this-is-not-typedarray-instance.js
     prototype/every/BigInt 16/16 (100.0%)
-    prototype/every/callbackfn-detachbuffer.js
     prototype/every/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/detached-buffer.js
     prototype/every/get-length-uses-internal-arraylength.js
     prototype/every/invoked-as-func.js
     prototype/every/invoked-as-method.js
@@ -1946,12 +1866,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/every/this-is-not-typedarray-instance.js
     prototype/fill/BigInt 18/18 (100.0%)
     prototype/fill/absent-indices-computed-from-initial-length.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/coerced-end-detach.js
-    prototype/fill/coerced-start-detach.js
-    prototype/fill/coerced-value-detach.js
     prototype/fill/coerced-value-start-end-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/detached-buffer.js
-    prototype/fill/fill-values-conversion-once.js
     prototype/fill/get-length-ignores-length-prop.js
     prototype/fill/invoked-as-func.js
     prototype/fill/invoked-as-method.js
@@ -1965,9 +1880,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/fill/this-is-not-typedarray-instance.js
     prototype/filter/BigInt 36/36 (100.0%)
     prototype/filter/arraylength-internal.js
-    prototype/filter/callbackfn-detachbuffer.js
     prototype/filter/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/detached-buffer.js
     prototype/filter/invoked-as-func.js
     prototype/filter/invoked-as-method.js
     prototype/filter/length.js
@@ -1987,7 +1900,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/find/BigInt 13/13 (100.0%)
     prototype/findIndex/BigInt 13/13 (100.0%)
     prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/detached-buffer.js
     prototype/findIndex/get-length-ignores-length-prop.js
     prototype/findIndex/invoked-as-func.js
     prototype/findIndex/invoked-as-method.js
@@ -1995,7 +1907,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/findIndex/name.js
     prototype/findIndex/not-a-constructor.js
     prototype/findIndex/predicate-call-this-strict.js strict
-    prototype/findIndex/predicate-may-detach-buffer.js
     prototype/findIndex/prop-desc.js
     prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2006,7 +1917,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/findLast/BigInt 13/13 (100.0%)
     prototype/findLastIndex/BigInt 13/13 (100.0%)
     prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/detached-buffer.js
     prototype/findLastIndex/get-length-ignores-length-prop.js
     prototype/findLastIndex/invoked-as-func.js
     prototype/findLastIndex/invoked-as-method.js
@@ -2014,7 +1924,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/findLastIndex/name.js
     prototype/findLastIndex/not-a-constructor.js
     prototype/findLastIndex/predicate-call-this-strict.js strict
-    prototype/findLastIndex/predicate-may-detach-buffer.js
     prototype/findLastIndex/prop-desc.js
     prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2023,7 +1932,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/findLastIndex/this-is-not-object.js
     prototype/findLastIndex/this-is-not-typedarray-instance.js
     prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/detached-buffer.js
     prototype/findLast/get-length-ignores-length-prop.js
     prototype/findLast/invoked-as-func.js
     prototype/findLast/invoked-as-method.js
@@ -2031,7 +1939,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/findLast/name.js
     prototype/findLast/not-a-constructor.js
     prototype/findLast/predicate-call-this-strict.js strict
-    prototype/findLast/predicate-may-detach-buffer.js
     prototype/findLast/prop-desc.js
     prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2040,7 +1947,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/findLast/this-is-not-object.js
     prototype/findLast/this-is-not-typedarray-instance.js
     prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/detached-buffer.js
     prototype/find/get-length-ignores-length-prop.js
     prototype/find/invoked-as-func.js
     prototype/find/invoked-as-method.js
@@ -2048,7 +1954,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/find/name.js
     prototype/find/not-a-constructor.js
     prototype/find/predicate-call-this-strict.js strict
-    prototype/find/predicate-may-detach-buffer.js
     prototype/find/prop-desc.js
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2058,9 +1963,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/find/this-is-not-typedarray-instance.js
     prototype/forEach/BigInt 15/15 (100.0%)
     prototype/forEach/arraylength-internal.js
-    prototype/forEach/callbackfn-detachbuffer.js
     prototype/forEach/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/detached-buffer.js
     prototype/forEach/invoked-as-func.js
     prototype/forEach/invoked-as-method.js
     prototype/forEach/length.js
@@ -2075,9 +1978,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/forEach/this-is-not-typedarray-instance.js
     prototype/includes/BigInt 14/14 (100.0%)
     prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/detached-buffer.js
-    prototype/includes/detached-buffer-during-fromIndex-returns-false-for-zero.js
-    prototype/includes/detached-buffer-during-fromIndex-returns-true-for-undefined.js
     prototype/includes/get-length-uses-internal-arraylength.js
     prototype/includes/index-compared-against-initial-length.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/index-compared-against-initial-length-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
@@ -2095,9 +1995,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/indexOf/BigInt 15/15 (100.0%)
     prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/detached-buffer.js
     prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
-    prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
     prototype/indexOf/get-length-uses-internal-arraylength.js
     prototype/indexOf/invoked-as-func.js
     prototype/indexOf/invoked-as-method.js
@@ -2113,8 +2011,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/join/BigInt 9/9 (100.0%)
     prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/detached-buffer.js
-    prototype/join/detached-buffer-during-fromIndex-returns-single-comma.js
     prototype/join/get-length-uses-internal-arraylength.js
     prototype/join/invoked-as-func.js
     prototype/join/invoked-as-method.js
@@ -2128,7 +2024,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/join/this-is-not-object.js
     prototype/join/this-is-not-typedarray-instance.js
     prototype/keys/BigInt 4/4 (100.0%)
-    prototype/keys/detached-buffer.js
     prototype/keys/invoked-as-func.js
     prototype/keys/invoked-as-method.js
     prototype/keys/length.js
@@ -2144,9 +2039,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/lastIndexOf/BigInt 14/14 (100.0%)
     prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/detached-buffer.js
     prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
-    prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
     prototype/lastIndexOf/get-length-uses-internal-arraylength.js
     prototype/lastIndexOf/invoked-as-func.js
     prototype/lastIndexOf/invoked-as-method.js
@@ -2160,7 +2053,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/lastIndexOf/this-is-not-object.js
     prototype/lastIndexOf/this-is-not-typedarray-instance.js
     prototype/length/BigInt 4/4 (100.0%)
-    prototype/length/detached-buffer.js
     prototype/length/invoked-as-func.js
     prototype/length/length.js
     prototype/length/name.js
@@ -2174,9 +2066,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/length/this-is-not-object.js
     prototype/map/BigInt 34/34 (100.0%)
     prototype/map/arraylength-internal.js
-    prototype/map/callbackfn-detachbuffer.js
     prototype/map/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/detached-buffer.js
     prototype/map/invoked-as-func.js
     prototype/map/invoked-as-method.js
     prototype/map/length.js
@@ -2199,9 +2089,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/map/this-is-not-typedarray-instance.js
     prototype/reduce/BigInt 19/19 (100.0%)
     prototype/reduceRight/BigInt 19/19 (100.0%)
-    prototype/reduceRight/callbackfn-detachbuffer.js
     prototype/reduceRight/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/detached-buffer.js
     prototype/reduceRight/get-length-uses-internal-arraylength.js
     prototype/reduceRight/invoked-as-func.js
     prototype/reduceRight/invoked-as-method.js
@@ -2215,9 +2103,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/this-is-not-object.js
     prototype/reduceRight/this-is-not-typedarray-instance.js
-    prototype/reduce/callbackfn-detachbuffer.js
     prototype/reduce/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/detached-buffer.js
     prototype/reduce/get-length-uses-internal-arraylength.js
     prototype/reduce/invoked-as-func.js
     prototype/reduce/invoked-as-method.js
@@ -2232,7 +2118,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/reduce/this-is-not-object.js
     prototype/reduce/this-is-not-typedarray-instance.js
     prototype/reverse/BigInt 6/6 (100.0%)
-    prototype/reverse/detached-buffer.js
     prototype/reverse/get-length-uses-internal-arraylength.js
     prototype/reverse/invoked-as-func.js
     prototype/reverse/invoked-as-method.js
@@ -2247,21 +2132,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/set/BigInt 49/49 (100.0%)
     prototype/set/array-arg-negative-integer-offset-throws.js
     prototype/set/array-arg-primitive-toobject.js
-    prototype/set/array-arg-return-abrupt-from-src-get-length.js
-    prototype/set/array-arg-return-abrupt-from-src-get-value.js
-    prototype/set/array-arg-return-abrupt-from-src-length.js
-    prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
-    prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
-    prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
-    prototype/set/array-arg-return-abrupt-from-toobject-offset.js
-    prototype/set/array-arg-set-values.js
-    prototype/set/array-arg-set-values-in-order.js
-    prototype/set/array-arg-src-tonumber-value-conversions.js
-    prototype/set/array-arg-src-values-are-not-cached.js
     prototype/set/array-arg-target-arraylength-internal.js
-    prototype/set/array-arg-targetbuffer-detached-on-get-src-value-no-throw.js
-    prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
-    prototype/set/array-arg-targetbuffer-detached-throws.js
     prototype/set/array-arg-value-conversion-resizes-array-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/set/invoked-as-func.js
     prototype/set/invoked-as-method.js
@@ -2288,22 +2159,13 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/set/typedarray-arg-src-byteoffset-internal.js
     prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
-    prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
     prototype/set/typedarray-arg-target-arraylength-internal.js
     prototype/set/typedarray-arg-target-byteoffset-internal.js
     prototype/set/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
     prototype/slice/BigInt 38/38 (100.0%)
     prototype/slice/arraylength-internal.js
     prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/detached-buffer.js
-    prototype/slice/detached-buffer-custom-ctor-other-targettype.js
-    prototype/slice/detached-buffer-custom-ctor-same-targettype.js
-    prototype/slice/detached-buffer-get-ctor.js
-    prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
-    prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
-    prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
     prototype/slice/invoked-as-func.js
     prototype/slice/invoked-as-method.js
     prototype/slice/length.js
@@ -2312,19 +2174,13 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/slice/prop-desc.js
     prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/set-values-from-different-ctor-type.js
     prototype/slice/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/speciesctor-get-species-custom-ctor.js
-    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/speciesctor-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/this-is-not-object.js
     prototype/slice/this-is-not-typedarray-instance.js
     prototype/some/BigInt 16/16 (100.0%)
-    prototype/some/callbackfn-detachbuffer.js
     prototype/some/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/detached-buffer.js
     prototype/some/get-length-uses-internal-arraylength.js
     prototype/some/invoked-as-func.js
     prototype/some/invoked-as-method.js
@@ -2343,7 +2199,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/detached-buffer.js
     prototype/sort/invoked-as-func.js
     prototype/sort/invoked-as-method.js
     prototype/sort/length.js
@@ -2352,13 +2207,11 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/sort/prop-desc.js
     prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/sort-tonumber.js
     prototype/sort/this-is-not-object.js
     prototype/sort/this-is-not-typedarray-instance.js
     prototype/subarray/BigInt 27/27 (100.0%)
     prototype/subarray/coerced-begin-end-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/coerced-begin-end-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/subarray/detached-buffer.js
     prototype/subarray/infinity.js
     prototype/subarray/invoked-as-func.js
     prototype/subarray/invoked-as-method.js
@@ -2383,7 +2236,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/subarray/this-is-not-typedarray-instance.js
     prototype/Symbol.iterator/not-a-constructor.js
     prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
-    prototype/Symbol.toStringTag/detached-buffer.js
     prototype/Symbol.toStringTag/invoked-as-accessor.js
     prototype/Symbol.toStringTag/invoked-as-func.js
     prototype/Symbol.toStringTag/length.js
@@ -2392,7 +2244,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
     prototype/Symbol.toStringTag/this-is-not-object.js
     prototype/toLocaleString/BigInt 14/14 (100.0%)
-    prototype/toLocaleString/detached-buffer.js
     prototype/toLocaleString/get-length-uses-internal-arraylength.js
     prototype/toLocaleString/invoked-as-func.js
     prototype/toLocaleString/invoked-as-method.js
@@ -2409,15 +2260,12 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/toReversed/metadata 3/3 (100.0%)
     prototype/toReversed/length-property-ignored.js
     prototype/toReversed/not-a-constructor.js
-    prototype/toReversed/this-value-invalid.js
     prototype/toSorted/metadata 3/3 (100.0%)
     prototype/toSorted/length-property-ignored.js
     prototype/toSorted/not-a-constructor.js
-    prototype/toSorted/this-value-invalid.js
     prototype/toString/BigInt/detached-buffer.js
     prototype/toString 2/2 (100.0%)
     prototype/values/BigInt 4/4 (100.0%)
-    prototype/values/detached-buffer.js
     prototype/values/invoked-as-func.js
     prototype/values/invoked-as-method.js
     prototype/values/length.js
@@ -2448,7 +2296,7 @@ built-ins/TypedArray 1084/1422 (76.23%)
     resizable-buffer-length-tracking-1.js {unsupported: [resizable-arraybuffer]}
     resizable-buffer-length-tracking-2.js {unsupported: [resizable-arraybuffer]}
 
-built-ins/TypedArrayConstructors 559/735 (76.05%)
+built-ins/TypedArrayConstructors 514/735 (69.93%)
     BigInt64Array/prototype 4/4 (100.0%)
     BigInt64Array 8/8 (100.0%)
     BigUint64Array/prototype 4/4 (100.0%)
@@ -2459,21 +2307,17 @@ built-ins/TypedArrayConstructors 559/735 (76.05%)
     ctors-bigint/object-arg 31/31 (100.0%)
     ctors-bigint/typedarray-arg 11/11 (100.0%)
     ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-is-negative-throws.js
     ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-to-number-detachbuffer.js
     ctors/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/custom-proto-access-throws.js
     ctors/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/defined-negative-length.js
     ctors/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/detachedbuffer.js
     ctors/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/excessive-offset-throws-resizable-ab.js {unsupported: [resizable-arraybuffer]}
     ctors/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2481,7 +2325,6 @@ built-ins/TypedArrayConstructors 559/735 (76.05%)
     ctors/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/length-to-number-detachbuffer.js
     ctors/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/proto-from-ctor-realm.js
     ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2557,39 +2400,35 @@ built-ins/TypedArrayConstructors 559/735 (76.05%)
     Int32Array/prototype/proto.js
     Int8Array/prototype/proto.js
     internals/DefineOwnProperty/BigInt 26/26 (100.0%)
-    internals/DefineOwnProperty/conversion-operation.js
-    internals/DefineOwnProperty/conversion-operation-consistent-nan.js
-    internals/DefineOwnProperty/desc-value-throws.js
-    internals/DefineOwnProperty/detached-buffer.js
-    internals/DefineOwnProperty/detached-buffer-throws.js
-    internals/DefineOwnProperty/detached-buffer-throws-realm.js
-    internals/DefineOwnProperty/key-is-greater-than-last-index.js
-    internals/DefineOwnProperty/key-is-lower-than-zero.js
-    internals/DefineOwnProperty/key-is-minus-zero.js
     internals/DefineOwnProperty/key-is-not-canonical-index.js
-    internals/DefineOwnProperty/key-is-not-integer.js
     internals/DefineOwnProperty/key-is-numericindex.js
-    internals/DefineOwnProperty/key-is-numericindex-accessor-desc.js
     internals/DefineOwnProperty/key-is-numericindex-accessor-desc-throws.js
-    internals/DefineOwnProperty/key-is-numericindex-desc-configurable.js
     internals/DefineOwnProperty/key-is-numericindex-desc-not-configurable-throws.js
-    internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable.js
     internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable-throws.js
-    internals/DefineOwnProperty/key-is-numericindex-desc-not-writable.js
     internals/DefineOwnProperty/key-is-numericindex-desc-not-writable-throws.js
     internals/DefineOwnProperty/non-extensible-redefine-key.js
-    internals/DefineOwnProperty/set-value.js
     internals/DefineOwnProperty/tonumber-value-detached-buffer.js
-    internals/Delete/BigInt 19/19 (100.0%)
-    internals/Delete/detached-buffer.js
-    internals/Delete/detached-buffer-key-is-not-numeric-index.js
-    internals/Delete/detached-buffer-key-is-symbol.js
-    internals/Delete/detached-buffer-realm.js
+    internals/Delete/BigInt/detached-buffer.js
+    internals/Delete/BigInt/detached-buffer-key-is-not-numeric-index.js
+    internals/Delete/BigInt/indexed-value-ab-non-strict.js non-strict
+    internals/Delete/BigInt/indexed-value-ab-strict.js strict
+    internals/Delete/BigInt/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/infinity-detached-buffer.js
+    internals/Delete/BigInt/key-is-not-canonical-index-non-strict.js non-strict
+    internals/Delete/BigInt/key-is-not-canonical-index-strict.js strict
+    internals/Delete/BigInt/key-is-not-minus-zero-non-strict.js non-strict
+    internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
+    internals/Delete/BigInt/key-is-not-numeric-index-get-throws.js
+    internals/Delete/BigInt/key-is-not-numeric-index-non-strict.js non-strict
+    internals/Delete/BigInt/key-is-not-numeric-index-strict.js strict
+    internals/Delete/BigInt/key-is-out-of-bounds-non-strict.js non-strict
+    internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
+    internals/Delete/BigInt/key-is-symbol.js
     internals/Delete/indexed-value-ab-non-strict.js non-strict
     internals/Delete/indexed-value-ab-strict.js strict
     internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/infinity-detached-buffer.js
     internals/Delete/key-is-not-canonical-index-non-strict.js non-strict
     internals/Delete/key-is-not-canonical-index-strict.js strict
     internals/Delete/key-is-not-integer.js
@@ -2601,19 +2440,9 @@ built-ins/TypedArrayConstructors 559/735 (76.05%)
     internals/Delete/key-is-out-of-bounds-strict.js strict
     internals/Get/BigInt 14/14 (100.0%)
     internals/GetOwnProperty/BigInt 12/12 (100.0%)
-    internals/GetOwnProperty/detached-buffer.js
-    internals/GetOwnProperty/detached-buffer-key-is-not-number.js
-    internals/GetOwnProperty/detached-buffer-key-is-symbol.js
-    internals/GetOwnProperty/detached-buffer-realm.js
-    internals/GetOwnProperty/enumerate-detached-buffer.js
     internals/GetOwnProperty/index-prop-desc.js
-    internals/Get/detached-buffer.js
-    internals/Get/detached-buffer-key-is-not-numeric-index.js
-    internals/Get/detached-buffer-key-is-symbol.js
-    internals/Get/detached-buffer-realm.js
     internals/Get/indexed-value.js
     internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
-    internals/Get/infinity-detached-buffer.js
     internals/Get/key-is-not-canonical-index.js
     internals/Get/key-is-not-integer.js
     internals/Get/key-is-not-minus-zero.js
@@ -2622,11 +2451,6 @@ built-ins/TypedArrayConstructors 559/735 (76.05%)
     internals/Get/key-is-symbol.js
     internals/HasProperty/BigInt 15/15 (100.0%)
     internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
-    internals/HasProperty/detached-buffer.js
-    internals/HasProperty/detached-buffer-key-is-not-number.js
-    internals/HasProperty/detached-buffer-key-is-symbol.js
-    internals/HasProperty/detached-buffer-realm.js
-    internals/HasProperty/infinity-with-detached-buffer.js non-strict
     internals/HasProperty/inherited-property.js
     internals/HasProperty/key-is-greater-than-last-index.js
     internals/HasProperty/key-is-lower-than-zero.js
@@ -2643,9 +2467,6 @@ built-ins/TypedArrayConstructors 559/735 (76.05%)
     internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     internals/Set/BigInt 27/27 (100.0%)
     internals/Set/detached-buffer.js
-    internals/Set/detached-buffer-key-is-not-numeric-index.js
-    internals/Set/detached-buffer-key-is-symbol.js
-    internals/Set/detached-buffer-realm.js
     internals/Set/indexed-value.js
     internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/key-is-canonical-invalid-index-reflect-set.js


### PR DESCRIPTION
I was planning on having this PR be a lot smaller than it is, but from the way ArrayBuffer interacts with DataView and TypedArrays, I ended up doing more than expected. There are still some tests that are failing related to detach, so I will continue to try and solve them, but this is most of them.

TypedArray has a lot of work to do to get spec compliant, so I think this is a good continuation in that effort. (I haven't investigated much, but a lot of the method/{name, propdesc, invoked-as-func, etc}.js are failing, but I'm not too sure why. Hopefully that is an easy-ish fix)

For some of the tests relating to DataView, we are "passing" some tests relating to BigInts and Float16s, even though we don't have either of those implemented (most likely throwing type errors but for the wrong reason).

Should resolve #1527 