### PR TITLE
Typed array cleanup

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -26,6 +26,10 @@ public class ArrayLikeAbstractOperations {
         REDUCE_RIGHT,
     }
 
+    public interface LengthAccessor {
+        public long getLength(Context cx, Scriptable o);
+    }
+
     /**
      * Implements the methods "every", "filter", "forEach", "map", and "some" without using an
      * IdFunctionObject.
@@ -35,8 +39,9 @@ public class ArrayLikeAbstractOperations {
             IterativeOperation operation,
             Scriptable scope,
             Scriptable thisObj,
-            Object[] args) {
-        return iterativeMethod(cx, null, operation, scope, thisObj, args, true);
+            Object[] args,
+            LengthAccessor lengthAccessor) {
+        return iterativeMethod(cx, null, operation, scope, thisObj, args, lengthAccessor, true);
     }
 
     /**
@@ -49,8 +54,9 @@ public class ArrayLikeAbstractOperations {
             IterativeOperation operation,
             Scriptable scope,
             Scriptable thisObj,
-            Object[] args) {
-        return iterativeMethod(cx, fun, operation, scope, thisObj, args, false);
+            Object[] args,
+            LengthAccessor lengthAccessor) {
+        return iterativeMethod(cx, fun, operation, scope, thisObj, args, lengthAccessor, false);
     }
 
     private static Object iterativeMethod(
@@ -60,6 +66,7 @@ public class ArrayLikeAbstractOperations {
             Scriptable scope,
             Scriptable thisObj,
             Object[] args,
+            LengthAccessor lengthAccessor,
             boolean skipCoercibleCheck) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
@@ -72,7 +79,8 @@ public class ArrayLikeAbstractOperations {
             }
         }
 
-        return coercibleIterativeMethod(cx, operation, scope, args, o);
+        long length = lengthAccessor.getLength(cx, o);
+        return coercibleIterativeMethod(cx, operation, scope, o, args, length);
     }
 
     public static Object iterativeMethod(
@@ -82,8 +90,10 @@ public class ArrayLikeAbstractOperations {
             IterativeOperation operation,
             Scriptable scope,
             Scriptable thisObj,
-            Object[] args) {
-        return iterativeMethod(cx, tag, name, operation, scope, thisObj, args, false);
+            Object[] args,
+            LengthAccessor lengthAccessor) {
+        return iterativeMethod(
+                cx, tag, name, operation, scope, thisObj, args, lengthAccessor, false);
     }
 
     private static Object iterativeMethod(
@@ -94,6 +104,7 @@ public class ArrayLikeAbstractOperations {
             Scriptable scope,
             Scriptable thisObj,
             Object[] args,
+            LengthAccessor lengthAccessor,
             boolean skipCoercibleCheck) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
@@ -106,16 +117,17 @@ public class ArrayLikeAbstractOperations {
             }
         }
 
-        return coercibleIterativeMethod(cx, operation, scope, args, o);
+        long length = lengthAccessor.getLength(cx, o);
+        return coercibleIterativeMethod(cx, operation, scope, o, args, length);
     }
 
-    private static Object coercibleIterativeMethod(
+    public static Object coercibleIterativeMethod(
             Context cx,
             IterativeOperation operation,
             Scriptable scope,
+            Scriptable o,
             Object[] args,
-            Scriptable o) {
-        long length = getLengthProperty(cx, o);
+            long length) {
         if (operation == IterativeOperation.MAP && length > Integer.MAX_VALUE) {
             String msg = ScriptRuntime.getMessageById("msg.arraylength.bad");
             throw ScriptRuntime.rangeError(msg);
@@ -281,7 +293,7 @@ public class ArrayLikeAbstractOperations {
 
     // same as NativeArray::getElem, but without converting NOT_FOUND to undefined
     static Object getRawElem(Scriptable target, long index) {
-        if (index > Integer.MAX_VALUE) {
+        if (index < 0 || index > Integer.MAX_VALUE) {
             return ScriptableObject.getProperty(target, Long.toString(index));
         }
         return ScriptableObject.getProperty(target, (int) index);
@@ -313,6 +325,17 @@ public class ArrayLikeAbstractOperations {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         long length = getLengthProperty(cx, o);
+        return reduceMethodWithLength(cx, operation, scope, o, args, length);
+    }
+
+    public static Object reduceMethodWithLength(
+            Context cx,
+            ReduceOperation operation,
+            Scriptable scope,
+            Scriptable o,
+            Object[] args,
+            long length) {
+
         Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
         if (callbackArg == null || !(callbackArg instanceof Function)) {
             throw ScriptRuntime.notFunctionError(callbackArg);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -321,6 +321,16 @@ public class LambdaConstructor extends LambdaFunction {
         proto.defineProperty(cx, name, getter, setter, attributes);
     }
 
+    public void definePrototypeProperty(
+            Context cx,
+            Symbol key,
+            ScriptableObject.LambdaGetterFunction getter,
+            ScriptableObject.LambdaSetterFunction setter,
+            int attributes) {
+        ScriptableObject proto = getPrototypeScriptable();
+        proto.defineProperty(cx, key, getter, setter, attributes);
+    }
+
     /** Define a property on the prototype that has the same value as another property. */
     public void definePrototypeAlias(String name, SymbolKey alias, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -44,6 +44,8 @@ public class NativeArray extends ScriptableObject implements List {
      * always gets at least an object back, even when Array == null.
      */
 
+    static final long MAX_ARRAY_INDEX = 0xfffffffel;
+
     private static final Object ARRAY_TAG = "Array";
     private static final String CLASS_NAME = "Array";
     private static final Long NEGATIVE_ONE = Long.valueOf(-1);
@@ -1950,46 +1952,102 @@ public class NativeArray extends ScriptableObject implements List {
     private static Object js_every(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "every", IterativeOperation.EVERY, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "every",
+                IterativeOperation.EVERY,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_filter(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "filter", IterativeOperation.FILTER, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "filter",
+                IterativeOperation.FILTER,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_forEach(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "forEach", IterativeOperation.FOR_EACH, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "forEach",
+                IterativeOperation.FOR_EACH,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_map(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "map", IterativeOperation.MAP, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "map",
+                IterativeOperation.MAP,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_some(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "some", IterativeOperation.SOME, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "some",
+                IterativeOperation.SOME,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_find(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "find", IterativeOperation.FIND, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "find",
+                IterativeOperation.FIND,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_findIndex(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "findIndex", IterativeOperation.FIND_INDEX, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "findIndex",
+                IterativeOperation.FIND_INDEX,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_findLast(
             Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
-                cx, ARRAY_TAG, "findLast", IterativeOperation.FIND_LAST, scope, thisObj, args);
+                cx,
+                ARRAY_TAG,
+                "findLast",
+                IterativeOperation.FIND_LAST,
+                scope,
+                thisObj,
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_findLastIndex(
@@ -2001,7 +2059,8 @@ public class NativeArray extends ScriptableObject implements List {
                 IterativeOperation.FIND_LAST_INDEX,
                 scope,
                 thisObj,
-                args);
+                args,
+                NativeArray::getLengthProperty);
     }
 
     private static Object js_reduce(

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -23,6 +23,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
+import org.mozilla.javascript.typedarrays.NativeBigInt64Array;
+import org.mozilla.javascript.typedarrays.NativeBigUint64Array;
 import org.mozilla.javascript.typedarrays.NativeDataView;
 import org.mozilla.javascript.typedarrays.NativeFloat32Array;
 import org.mozilla.javascript.typedarrays.NativeFloat64Array;
@@ -235,6 +237,9 @@ public class ScriptRuntime {
             new LazilyLoadedCtor(scope, "Int16Array", sealed, true, NativeInt16Array::init);
             new LazilyLoadedCtor(scope, "Uint16Array", sealed, true, NativeUint16Array::init);
             new LazilyLoadedCtor(scope, "Int32Array", sealed, true, NativeInt32Array::init);
+            new LazilyLoadedCtor(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
+            new LazilyLoadedCtor(scope, "BigInt64Array", sealed, true, NativeBigInt64Array::init);
+            new LazilyLoadedCtor(scope, "BigUint64Array", sealed, true, NativeBigUint64Array::init);
             new LazilyLoadedCtor(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
             new LazilyLoadedCtor(scope, "Float32Array", sealed, true, NativeFloat32Array::init);
             new LazilyLoadedCtor(scope, "Float64Array", sealed, true, NativeFloat64Array::init);
@@ -1376,12 +1381,25 @@ public class ScriptRuntime {
         return toInt32(toNumber(val));
     }
 
+    // We return a double here because we *must* maintain infinities
+    // for the purposes of error reporting.
+    public static double toIntegerOrInfinity(Object val) {
+        // short circuit for common integer values
+        if (val instanceof Integer) return ((Integer) val).doubleValue();
+
+        return toIntegerOrInfinity(toNumber(val));
+    }
+
     public static int toInt32(Object[] args, int index) {
         return (index < args.length) ? toInt32(args[index]) : 0;
     }
 
     public static int toInt32(double d) {
         return DoubleConversion.doubleToInt32(d);
+    }
+
+    public static double toIntegerOrInfinity(double d) {
+        return DoubleConversion.truncate(d);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1851,8 +1851,7 @@ public abstract class ScriptableObject extends SlotMapOwner
         if (getter == null && setter == null)
             throw ScriptRuntime.typeError("at least one of {getter, setter} is required");
 
-        LambdaAccessorSlot newSlot =
-                createLambdaAccessorSlot(key.toString(), 0, getter, setter, attributes);
+        LambdaAccessorSlot newSlot = createLambdaAccessorSlot(key, 0, getter, setter, attributes);
         replaceLambdaAccessorSlot(cx, key, newSlot);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -55,6 +56,8 @@ public class NativeArrayBuffer extends ScriptableObject {
                 DONTENUM | READONLY);
         constructor.definePrototypeProperty(
                 cx, "byteLength", NativeArrayBuffer::js_byteLength, DONTENUM | READONLY);
+        constructor.definePrototypeProperty(
+                SymbolKey.TO_STRING_TAG, "ArrayBuffer", DONTENUM | READONLY);
 
         if (sealed) {
             constructor.sealObject();

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBufferView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBufferView.java
@@ -7,10 +7,7 @@
 package org.mozilla.javascript.typedarrays;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.Symbol;
-import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -73,13 +70,5 @@ public abstract class NativeArrayBufferView extends ScriptableObject {
 
     protected static boolean isArg(Object[] args, int i) {
         return ((args.length > i) && !Undefined.instance.equals(args[i]));
-    }
-
-    @Override
-    public Object get(Symbol key, Scriptable start) {
-        if (SymbolKey.TO_STRING_TAG.equals(key)) {
-            return getClassName();
-        }
-        return super.get(key, start);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
@@ -1,0 +1,121 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.typedarrays;
+
+import java.math.BigInteger;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.ScriptRuntimeES6;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
+
+/**
+ * An array view that stores 64-bit quantities and implements the JavaScript "Float64Array"
+ * interface. It also implements List&lt;Double&gt; for direct manipulation in Java.
+ */
+public class NativeBigInt64Array extends NativeTypedArrayView<BigInteger> {
+    private static final long serialVersionUID = -1255405650050639335L;
+
+    private static final String CLASS_NAME = "BigInt64Array";
+    private static final int BYTES_PER_ELEMENT = 8;
+
+    public NativeBigInt64Array() {}
+
+    public NativeBigInt64Array(NativeArrayBuffer ab, int off, int len) {
+        super(ab, off, len, len * BYTES_PER_ELEMENT);
+    }
+
+    public NativeBigInt64Array(int len) {
+        this(new NativeArrayBuffer((double) len * BYTES_PER_ELEMENT), 0, len);
+    }
+
+    @Override
+    public String getClassName() {
+        return CLASS_NAME;
+    }
+
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+        LambdaConstructor constructor =
+                new LambdaConstructor(
+                        scope,
+                        CLASS_NAME,
+                        3,
+                        LambdaConstructor.CONSTRUCTOR_NEW,
+                        (Context lcx, Scriptable lscope, Object[] args) ->
+                                NativeTypedArrayView.js_constructor(
+                                        lcx,
+                                        lscope,
+                                        args,
+                                        NativeBigInt64Array::new,
+                                        BYTES_PER_ELEMENT));
+        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
+        NativeTypedArrayView.init(cx, scope, constructor, NativeBigInt64Array::realThis);
+        constructor.defineProperty(
+                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
+        constructor.definePrototypeProperty(
+                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
+
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
+        if (sealed) {
+            constructor.sealObject();
+        }
+        return constructor;
+    }
+
+    @Override
+    public int getBytesPerElement() {
+        return BYTES_PER_ELEMENT;
+    }
+
+    private static NativeFloat64Array realThis(Scriptable thisObj) {
+        return LambdaConstructor.convertThisObject(thisObj, NativeFloat64Array.class);
+    }
+
+    @Override
+    protected Object js_get(int index) {
+        if (checkIndex(index)) {
+            return Undefined.instance;
+        }
+        long base =
+                ByteIo.readUint64Primitive(
+                        arrayBuffer.buffer,
+                        (index * BYTES_PER_ELEMENT) + offset,
+                        useLittleEndian());
+        return BigInteger.valueOf(base);
+    }
+
+    @Override
+    protected Object js_set(int index, Object c) {
+        if (checkIndex(index)) {
+            return Undefined.instance;
+        }
+        var val = ScriptRuntime.toBigInt(c);
+
+        long base = val.longValue();
+
+        ByteIo.writeUint64(
+                arrayBuffer.buffer, (index * BYTES_PER_ELEMENT) + offset, base, useLittleEndian());
+        return null;
+    }
+
+    @Override
+    public BigInteger get(int i) {
+        if (checkIndex(i)) {
+            throw new IndexOutOfBoundsException();
+        }
+        return (BigInteger) js_get(i);
+    }
+
+    @Override
+    public BigInteger set(int i, BigInteger aByte) {
+        if (checkIndex(i)) {
+            throw new IndexOutOfBoundsException();
+        }
+        return (BigInteger) js_set(i, aByte);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
@@ -1,0 +1,128 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.typedarrays;
+
+import java.math.BigInteger;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.ScriptRuntimeES6;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
+
+/**
+ * An array view that stores 64-bit quantities and implements the JavaScript "Float64Array"
+ * interface. It also implements List&lt;Double&gt; for direct manipulation in Java.
+ */
+public class NativeBigUint64Array extends NativeTypedArrayView<BigInteger> {
+    private static final long serialVersionUID = -1255405650050639335L;
+
+    private static final String CLASS_NAME = "BigUint64Array";
+    private static final int BYTES_PER_ELEMENT = 8;
+
+    public NativeBigUint64Array() {}
+
+    public NativeBigUint64Array(NativeArrayBuffer ab, int off, int len) {
+        super(ab, off, len, len * BYTES_PER_ELEMENT);
+    }
+
+    public NativeBigUint64Array(int len) {
+        this(new NativeArrayBuffer((double) len * BYTES_PER_ELEMENT), 0, len);
+    }
+
+    @Override
+    public String getClassName() {
+        return CLASS_NAME;
+    }
+
+    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+        LambdaConstructor constructor =
+                new LambdaConstructor(
+                        scope,
+                        CLASS_NAME,
+                        3,
+                        LambdaConstructor.CONSTRUCTOR_NEW,
+                        (Context lcx, Scriptable lscope, Object[] args) ->
+                                NativeTypedArrayView.js_constructor(
+                                        lcx,
+                                        lscope,
+                                        args,
+                                        NativeBigUint64Array::new,
+                                        BYTES_PER_ELEMENT));
+        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
+        NativeTypedArrayView.init(cx, scope, constructor, NativeBigUint64Array::realThis);
+        constructor.defineProperty(
+                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
+        constructor.definePrototypeProperty(
+                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
+
+        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
+        if (sealed) {
+            constructor.sealObject();
+        }
+        return constructor;
+    }
+
+    @Override
+    public int getBytesPerElement() {
+        return BYTES_PER_ELEMENT;
+    }
+
+    private static NativeFloat64Array realThis(Scriptable thisObj) {
+        return LambdaConstructor.convertThisObject(thisObj, NativeFloat64Array.class);
+    }
+
+    @Override
+    protected Object js_get(int index) {
+        if (checkIndex(index)) {
+            return Undefined.instance;
+        }
+        long base =
+                ByteIo.readUint64Primitive(
+                        arrayBuffer.buffer,
+                        (index * BYTES_PER_ELEMENT) + offset,
+                        useLittleEndian());
+        if ((base & 0x8000000000000000l) == 0) {
+            return BigInteger.valueOf(base);
+        } else {
+            // Do it in two parts
+            var lsw = BigInteger.valueOf(base & 0xffffffff);
+            var msw = BigInteger.valueOf((base >> 32) & 0xffffffff).shiftLeft(32);
+            return msw.add(lsw);
+        }
+    }
+
+    @Override
+    protected Object js_set(int index, Object c) {
+        if (checkIndex(index)) {
+            return Undefined.instance;
+        }
+        var val = ScriptRuntime.toBigInt(c);
+
+        long base = val.longValue();
+
+        ByteIo.writeUint64(
+                arrayBuffer.buffer, (index * BYTES_PER_ELEMENT) + offset, base, useLittleEndian());
+        return null;
+    }
+
+    @Override
+    public BigInteger get(int i) {
+        if (checkIndex(i)) {
+            throw new IndexOutOfBoundsException();
+        }
+        return (BigInteger) js_get(i);
+    }
+
+    @Override
+    public BigInteger set(int i, BigInteger aByte) {
+        if (checkIndex(i)) {
+            throw new IndexOutOfBoundsException();
+        }
+        return (BigInteger) js_set(i, aByte);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -62,6 +63,8 @@ public class NativeDataView extends NativeArrayBufferView {
                 (Scriptable thisObj) -> realThis(thisObj).offset,
                 DONTENUM | READONLY);
 
+        constructor.definePrototypeProperty(
+                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
         constructor.definePrototypeMethod(
                 scope,
                 "getFloat32",

--- a/rhino/src/main/java/org/mozilla/javascript/v8dtoa/DoubleConversion.java
+++ b/rhino/src/main/java/org/mozilla/javascript/v8dtoa/DoubleConversion.java
@@ -79,4 +79,11 @@ public final class DoubleConversion {
         long s = significand(d64);
         return sign(d64) * (int) (exponent < 0 ? s >> -exponent : s << exponent);
     }
+
+    public static double truncate(double x) {
+        if (!Double.isFinite(x)) {
+            return x;
+        }
+        return x < 0.0 ? Math.ceil(x) : Math.floor(x);
+    }
 }

--- a/tests/testsrc/jstests/es6/dataview.js
+++ b/tests/testsrc/jstests/es6/dataview.js
@@ -16,7 +16,7 @@ load("testsrc/assert.js");
   assertEquals('DataView', d[Symbol.toStringTag]);
   assertEquals(false, d.hasOwnProperty(Symbol.toStringTag));
   assertEquals(false, DataView.hasOwnProperty(Symbol.toStringTag));
-  assertEquals(false, DataView.prototype.hasOwnProperty(Symbol.toStringTag));
+  assertEquals(true, DataView.prototype.hasOwnProperty(Symbol.toStringTag));
 })();
 
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -200,7 +200,7 @@ built-ins/Array 264/3074 (8.59%)
     proto-from-ctor-realm-two.js
     proto-from-ctor-realm-zero.js
 
-built-ins/ArrayBuffer 121/191 (63.35%)
+built-ins/ArrayBuffer 120/191 (62.83%)
     isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
     isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
     prototype/byteLength/detached-buffer.js
@@ -212,7 +212,6 @@ built-ins/ArrayBuffer 121/191 (63.35%)
     prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/transferToFixedLength 23/23 (100.0%)
     prototype/transfer 23/23 (100.0%)
-    prototype/Symbol.toStringTag.js
     Symbol.species 4/4 (100.0%)
     data-allocation-after-object-creation.js
     options-maxbytelength-allocation-limit.js {unsupported: [resizable-arraybuffer]}
@@ -255,7 +254,7 @@ built-ins/BigInt 7/75 (9.33%)
 built-ins/Boolean 1/51 (1.96%)
     proto-from-ctor-realm.js
 
-built-ins/DataView 222/550 (40.36%)
+built-ins/DataView 221/550 (40.18%)
     prototype/buffer/detached-buffer.js
     prototype/buffer/return-buffer-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/buffer/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
@@ -444,7 +443,6 @@ built-ins/DataView 222/550 (40.36%)
     prototype/setUint8/detached-buffer-after-toindex-byteoffset.js
     prototype/setUint8/detached-buffer-before-outofrange-byteoffset.js
     prototype/setUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/Symbol.toStringTag.js
     buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
     buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
     byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -791,7 +789,7 @@ built-ins/Number 8/335 (2.39%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 141/3408 (4.14%)
+built-ins/Object 139/3408 (4.08%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order.js
@@ -925,8 +923,6 @@ built-ins/Object 141/3408 (4.14%)
     seal/seal-asyncarrowfunction.js
     seal/seal-asyncfunction.js
     seal/seal-asyncgeneratorfunction.js
-    seal/seal-bigint64array.js
-    seal/seal-biguint64array.js
     seal/seal-finalizationregistry.js
     seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     seal/seal-weakref.js
@@ -1814,7 +1810,7 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 1084/1422 (76.23%)
+built-ins/TypedArray 455/1422 (32.0%)
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/from-array-mapper-detaches-result.js
@@ -1838,90 +1834,58 @@ built-ins/TypedArray 1084/1422 (76.23%)
     of/prop-desc.js
     of/resized-with-out-of-bounds-and-in-bounds-indices.js {unsupported: [resizable-arraybuffer]}
     prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/at 14/14 (100.0%)
-    prototype/buffer/BigInt 2/2 (100.0%)
+    prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/buffer/BigInt/detached-buffer.js
     prototype/buffer/detached-buffer.js
-    prototype/buffer/invoked-as-func.js
-    prototype/buffer/length.js
-    prototype/buffer/name.js
-    prototype/buffer/prop-desc.js
-    prototype/buffer/this-has-no-typedarrayname-internal.js
-    prototype/buffer/this-inherits-typedarray.js
-    prototype/buffer/this-is-not-object.js
-    prototype/byteLength/BigInt 4/4 (100.0%)
+    prototype/byteLength/BigInt/detached-buffer.js
+    prototype/byteLength/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/detached-buffer.js
-    prototype/byteLength/invoked-as-func.js
-    prototype/byteLength/length.js
-    prototype/byteLength/name.js
-    prototype/byteLength/prop-desc.js
     prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
     prototype/byteLength/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/this-has-no-typedarrayname-internal.js
-    prototype/byteLength/this-is-not-object.js
-    prototype/byteOffset/BigInt 4/4 (100.0%)
+    prototype/byteOffset/BigInt/detached-buffer.js
+    prototype/byteOffset/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/detached-buffer.js
-    prototype/byteOffset/invoked-as-func.js
-    prototype/byteOffset/length.js
-    prototype/byteOffset/name.js
-    prototype/byteOffset/prop-desc.js
     prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/byteOffset/resized-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/this-has-no-typedarrayname-internal.js
-    prototype/byteOffset/this-is-not-object.js
-    prototype/copyWithin/BigInt 24/24 (100.0%)
+    prototype/copyWithin/BigInt/detached-buffer.js
+    prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/coerced-target-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/coerced-target-start-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/coerced-values-end-detached.js
     prototype/copyWithin/coerced-values-end-detached-prototype.js
     prototype/copyWithin/coerced-values-start-detached.js
     prototype/copyWithin/detached-buffer.js
-    prototype/copyWithin/get-length-ignores-length-prop.js
-    prototype/copyWithin/invoked-as-func.js
-    prototype/copyWithin/invoked-as-method.js
     prototype/copyWithin/length.js
-    prototype/copyWithin/name.js
-    prototype/copyWithin/not-a-constructor.js
-    prototype/copyWithin/prop-desc.js
     prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/this-is-not-object.js
-    prototype/copyWithin/this-is-not-typedarray-instance.js
-    prototype/entries/BigInt 4/4 (100.0%)
+    prototype/entries/BigInt/detached-buffer.js
+    prototype/entries/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/detached-buffer.js
-    prototype/entries/invoked-as-func.js
-    prototype/entries/invoked-as-method.js
-    prototype/entries/length.js
-    prototype/entries/name.js
-    prototype/entries/not-a-constructor.js
-    prototype/entries/prop-desc.js
     prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/this-is-not-object.js
-    prototype/entries/this-is-not-typedarray-instance.js
-    prototype/every/BigInt 16/16 (100.0%)
+    prototype/every/BigInt/callbackfn-detachbuffer.js
+    prototype/every/BigInt/detached-buffer.js
+    prototype/every/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/every/callbackfn-detachbuffer.js
     prototype/every/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/every/detached-buffer.js
-    prototype/every/get-length-uses-internal-arraylength.js
-    prototype/every/invoked-as-func.js
-    prototype/every/invoked-as-method.js
-    prototype/every/length.js
-    prototype/every/name.js
-    prototype/every/not-a-constructor.js
-    prototype/every/prop-desc.js
     prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/every/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/this-is-not-object.js
-    prototype/every/this-is-not-typedarray-instance.js
-    prototype/fill/BigInt 18/18 (100.0%)
+    prototype/fill/BigInt/detached-buffer.js
+    prototype/fill/BigInt/fill-values-conversion-once.js
+    prototype/fill/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/absent-indices-computed-from-initial-length.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/coerced-end-detach.js
     prototype/fill/coerced-start-detach.js
@@ -1929,28 +1893,18 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/fill/coerced-value-start-end-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/detached-buffer.js
     prototype/fill/fill-values-conversion-once.js
-    prototype/fill/get-length-ignores-length-prop.js
-    prototype/fill/invoked-as-func.js
-    prototype/fill/invoked-as-method.js
-    prototype/fill/length.js
-    prototype/fill/name.js
-    prototype/fill/not-a-constructor.js
-    prototype/fill/prop-desc.js
     prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/this-is-not-object.js
-    prototype/fill/this-is-not-typedarray-instance.js
-    prototype/filter/BigInt 36/36 (100.0%)
-    prototype/filter/arraylength-internal.js
+    prototype/filter/BigInt/callbackfn-detachbuffer.js
+    prototype/filter/BigInt/detached-buffer.js
+    prototype/filter/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/callbackfn-detachbuffer.js
     prototype/filter/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/detached-buffer.js
-    prototype/filter/invoked-as-func.js
-    prototype/filter/invoked-as-method.js
-    prototype/filter/length.js
-    prototype/filter/name.js
-    prototype/filter/not-a-constructor.js
-    prototype/filter/prop-desc.js
     prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -1959,207 +1913,139 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/this-is-not-object.js
-    prototype/filter/this-is-not-typedarray-instance.js
-    prototype/find/BigInt 13/13 (100.0%)
-    prototype/findIndex/BigInt 13/13 (100.0%)
+    prototype/find/BigInt/detached-buffer.js
+    prototype/find/BigInt/predicate-call-this-strict.js strict
+    prototype/find/BigInt/predicate-may-detach-buffer.js
+    prototype/find/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/BigInt/detached-buffer.js
+    prototype/findIndex/BigInt/predicate-call-this-strict.js strict
+    prototype/findIndex/BigInt/predicate-may-detach-buffer.js
+    prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/detached-buffer.js
-    prototype/findIndex/get-length-ignores-length-prop.js
-    prototype/findIndex/invoked-as-func.js
-    prototype/findIndex/invoked-as-method.js
-    prototype/findIndex/length.js
-    prototype/findIndex/name.js
-    prototype/findIndex/not-a-constructor.js
     prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/predicate-may-detach-buffer.js
-    prototype/findIndex/prop-desc.js
     prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/this-is-not-object.js
-    prototype/findIndex/this-is-not-typedarray-instance.js
-    prototype/findLast/BigInt 13/13 (100.0%)
-    prototype/findLastIndex/BigInt 13/13 (100.0%)
+    prototype/findLast/BigInt/detached-buffer.js
+    prototype/findLast/BigInt/predicate-call-this-strict.js strict
+    prototype/findLast/BigInt/predicate-may-detach-buffer.js
+    prototype/findLast/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/BigInt/detached-buffer.js
+    prototype/findLastIndex/BigInt/predicate-call-this-strict.js strict
+    prototype/findLastIndex/BigInt/predicate-may-detach-buffer.js
+    prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/detached-buffer.js
-    prototype/findLastIndex/get-length-ignores-length-prop.js
-    prototype/findLastIndex/invoked-as-func.js
-    prototype/findLastIndex/invoked-as-method.js
-    prototype/findLastIndex/length.js
-    prototype/findLastIndex/name.js
-    prototype/findLastIndex/not-a-constructor.js
     prototype/findLastIndex/predicate-call-this-strict.js strict
     prototype/findLastIndex/predicate-may-detach-buffer.js
-    prototype/findLastIndex/prop-desc.js
     prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/this-is-not-object.js
-    prototype/findLastIndex/this-is-not-typedarray-instance.js
     prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/detached-buffer.js
-    prototype/findLast/get-length-ignores-length-prop.js
-    prototype/findLast/invoked-as-func.js
-    prototype/findLast/invoked-as-method.js
-    prototype/findLast/length.js
-    prototype/findLast/name.js
-    prototype/findLast/not-a-constructor.js
     prototype/findLast/predicate-call-this-strict.js strict
     prototype/findLast/predicate-may-detach-buffer.js
-    prototype/findLast/prop-desc.js
     prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/this-is-not-object.js
-    prototype/findLast/this-is-not-typedarray-instance.js
     prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/find/detached-buffer.js
-    prototype/find/get-length-ignores-length-prop.js
-    prototype/find/invoked-as-func.js
-    prototype/find/invoked-as-method.js
-    prototype/find/length.js
-    prototype/find/name.js
-    prototype/find/not-a-constructor.js
     prototype/find/predicate-call-this-strict.js strict
     prototype/find/predicate-may-detach-buffer.js
-    prototype/find/prop-desc.js
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/this-is-not-object.js
-    prototype/find/this-is-not-typedarray-instance.js
-    prototype/forEach/BigInt 15/15 (100.0%)
-    prototype/forEach/arraylength-internal.js
+    prototype/forEach/BigInt/callbackfn-detachbuffer.js
+    prototype/forEach/BigInt/detached-buffer.js
+    prototype/forEach/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/callbackfn-detachbuffer.js
     prototype/forEach/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/detached-buffer.js
-    prototype/forEach/invoked-as-func.js
-    prototype/forEach/invoked-as-method.js
-    prototype/forEach/length.js
-    prototype/forEach/name.js
-    prototype/forEach/not-a-constructor.js
-    prototype/forEach/prop-desc.js
     prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/this-is-not-object.js
-    prototype/forEach/this-is-not-typedarray-instance.js
-    prototype/includes/BigInt 14/14 (100.0%)
+    prototype/includes/BigInt/detached-buffer.js
+    prototype/includes/BigInt/detached-buffer-during-fromIndex-returns-false-for-zero.js
+    prototype/includes/BigInt/detached-buffer-during-fromIndex-returns-true-for-undefined.js
+    prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/detached-buffer.js
     prototype/includes/detached-buffer-during-fromIndex-returns-false-for-zero.js
     prototype/includes/detached-buffer-during-fromIndex-returns-true-for-undefined.js
-    prototype/includes/get-length-uses-internal-arraylength.js
     prototype/includes/index-compared-against-initial-length.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/index-compared-against-initial-length-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/invoked-as-func.js
-    prototype/includes/invoked-as-method.js
-    prototype/includes/length.js
-    prototype/includes/name.js
-    prototype/includes/not-a-constructor.js
-    prototype/includes/prop-desc.js
     prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
     prototype/includes/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/this-is-not-object.js
-    prototype/includes/this-is-not-typedarray-instance.js
-    prototype/indexOf/BigInt 15/15 (100.0%)
+    prototype/indexOf/BigInt/detached-buffer.js
+    prototype/indexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+    prototype/indexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
+    prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/detached-buffer.js
     prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
     prototype/indexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
-    prototype/indexOf/get-length-uses-internal-arraylength.js
-    prototype/indexOf/invoked-as-func.js
-    prototype/indexOf/invoked-as-method.js
-    prototype/indexOf/length.js
-    prototype/indexOf/name.js
-    prototype/indexOf/not-a-constructor.js
-    prototype/indexOf/prop-desc.js
     prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/this-is-not-object.js
-    prototype/indexOf/this-is-not-typedarray-instance.js
-    prototype/join/BigInt 9/9 (100.0%)
+    prototype/join/BigInt/detached-buffer.js
+    prototype/join/BigInt/detached-buffer-during-fromIndex-returns-single-comma.js
+    prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/join/detached-buffer.js
     prototype/join/detached-buffer-during-fromIndex-returns-single-comma.js
-    prototype/join/get-length-uses-internal-arraylength.js
-    prototype/join/invoked-as-func.js
-    prototype/join/invoked-as-method.js
-    prototype/join/length.js
-    prototype/join/name.js
-    prototype/join/not-a-constructor.js
-    prototype/join/prop-desc.js
     prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/join/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/join/separator-tostring-once-after-resized.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/this-is-not-object.js
-    prototype/join/this-is-not-typedarray-instance.js
-    prototype/keys/BigInt 4/4 (100.0%)
+    prototype/keys/BigInt/detached-buffer.js
+    prototype/keys/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/keys/detached-buffer.js
-    prototype/keys/invoked-as-func.js
-    prototype/keys/invoked-as-method.js
-    prototype/keys/length.js
-    prototype/keys/name.js
-    prototype/keys/not-a-constructor.js
-    prototype/keys/prop-desc.js
     prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/keys/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/this-is-not-object.js
-    prototype/keys/this-is-not-typedarray-instance.js
-    prototype/lastIndexOf/BigInt 14/14 (100.0%)
+    prototype/lastIndexOf/BigInt/detached-buffer.js
+    prototype/lastIndexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
+    prototype/lastIndexOf/BigInt/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
+    prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/detached-buffer.js
     prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-undefined.js
     prototype/lastIndexOf/detached-buffer-during-fromIndex-returns-minus-one-for-zero.js
-    prototype/lastIndexOf/get-length-uses-internal-arraylength.js
-    prototype/lastIndexOf/invoked-as-func.js
-    prototype/lastIndexOf/invoked-as-method.js
-    prototype/lastIndexOf/length.js
-    prototype/lastIndexOf/name.js
-    prototype/lastIndexOf/not-a-constructor.js
-    prototype/lastIndexOf/prop-desc.js
     prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/this-is-not-object.js
-    prototype/lastIndexOf/this-is-not-typedarray-instance.js
-    prototype/length/BigInt 4/4 (100.0%)
+    prototype/length/BigInt/detached-buffer.js
+    prototype/length/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/length/detached-buffer.js
-    prototype/length/invoked-as-func.js
-    prototype/length/length.js
-    prototype/length/name.js
-    prototype/length/prop-desc.js
     prototype/length/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     prototype/length/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     prototype/length/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
     prototype/length/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
     prototype/length/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/this-has-no-typedarrayname-internal.js
-    prototype/length/this-is-not-object.js
-    prototype/map/BigInt 34/34 (100.0%)
-    prototype/map/arraylength-internal.js
+    prototype/map/BigInt/callbackfn-detachbuffer.js
+    prototype/map/BigInt/detached-buffer.js
+    prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
     prototype/map/callbackfn-detachbuffer.js
     prototype/map/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/map/detached-buffer.js
-    prototype/map/invoked-as-func.js
-    prototype/map/invoked-as-method.js
-    prototype/map/length.js
-    prototype/map/name.js
-    prototype/map/not-a-constructor.js
-    prototype/map/prop-desc.js
     prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2172,57 +2058,54 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
     prototype/map/speciesctor-resizable-buffer-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-resizable-buffer-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/this-is-not-object.js
-    prototype/map/this-is-not-typedarray-instance.js
-    prototype/reduce/BigInt 19/19 (100.0%)
-    prototype/reduceRight/BigInt 19/19 (100.0%)
+    prototype/reduce/BigInt/callbackfn-detachbuffer.js
+    prototype/reduce/BigInt/detached-buffer.js
+    prototype/reduce/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/BigInt/callbackfn-detachbuffer.js
+    prototype/reduceRight/BigInt/detached-buffer.js
+    prototype/reduceRight/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/callbackfn-detachbuffer.js
     prototype/reduceRight/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/detached-buffer.js
-    prototype/reduceRight/get-length-uses-internal-arraylength.js
-    prototype/reduceRight/invoked-as-func.js
-    prototype/reduceRight/invoked-as-method.js
-    prototype/reduceRight/length.js
-    prototype/reduceRight/name.js
-    prototype/reduceRight/not-a-constructor.js
-    prototype/reduceRight/prop-desc.js
     prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/this-is-not-object.js
-    prototype/reduceRight/this-is-not-typedarray-instance.js
     prototype/reduce/callbackfn-detachbuffer.js
     prototype/reduce/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/detached-buffer.js
-    prototype/reduce/get-length-uses-internal-arraylength.js
-    prototype/reduce/invoked-as-func.js
-    prototype/reduce/invoked-as-method.js
-    prototype/reduce/length.js
-    prototype/reduce/name.js
-    prototype/reduce/not-a-constructor.js
-    prototype/reduce/prop-desc.js
     prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/this-is-not-object.js
-    prototype/reduce/this-is-not-typedarray-instance.js
-    prototype/reverse/BigInt 6/6 (100.0%)
+    prototype/reverse/BigInt/detached-buffer.js
+    prototype/reverse/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/reverse/detached-buffer.js
-    prototype/reverse/get-length-uses-internal-arraylength.js
-    prototype/reverse/invoked-as-func.js
-    prototype/reverse/invoked-as-method.js
-    prototype/reverse/length.js
-    prototype/reverse/name.js
-    prototype/reverse/not-a-constructor.js
-    prototype/reverse/prop-desc.js
     prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reverse/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reverse/this-is-not-object.js
-    prototype/reverse/this-is-not-typedarray-instance.js
-    prototype/set/BigInt 49/49 (100.0%)
-    prototype/set/array-arg-negative-integer-offset-throws.js
+    prototype/set/BigInt/array-arg-primitive-toobject.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-get-length.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-get-value.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
+    prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
+    prototype/set/BigInt/array-arg-set-values.js
+    prototype/set/BigInt/array-arg-set-values-in-order.js
+    prototype/set/BigInt/array-arg-src-values-are-not-cached.js
+    prototype/set/BigInt/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
+    prototype/set/BigInt/array-arg-targetbuffer-detached-throws.js
+    prototype/set/BigInt/bigint-tobiguint64.js
+    prototype/set/BigInt/number-tobigint.js
+    prototype/set/BigInt/src-typedarray-not-big-throws.js
+    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/BigInt/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
+    prototype/set/BigInt/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/BigInt/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
     prototype/set/array-arg-primitive-toobject.js
     prototype/set/array-arg-return-abrupt-from-src-get-length.js
     prototype/set/array-arg-return-abrupt-from-src-get-value.js
@@ -2235,43 +2118,40 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/set/array-arg-set-values-in-order.js
     prototype/set/array-arg-src-tonumber-value-conversions.js
     prototype/set/array-arg-src-values-are-not-cached.js
-    prototype/set/array-arg-target-arraylength-internal.js
     prototype/set/array-arg-targetbuffer-detached-on-get-src-value-no-throw.js
     prototype/set/array-arg-targetbuffer-detached-on-tointeger-offset-throws.js
     prototype/set/array-arg-targetbuffer-detached-throws.js
     prototype/set/array-arg-value-conversion-resizes-array-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/invoked-as-func.js
-    prototype/set/invoked-as-method.js
     prototype/set/length.js
-    prototype/set/name.js
-    prototype/set/not-a-constructor.js
-    prototype/set/prop-desc.js
-    prototype/set/src-typedarray-big-throws.js
     prototype/set/target-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/set/target-grow-source-length-getter.js {unsupported: [resizable-arraybuffer]}
     prototype/set/target-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/set/target-shrink-source-length-getter.js {unsupported: [resizable-arraybuffer]}
     prototype/set/this-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/this-is-not-object.js
-    prototype/set/this-is-not-typedarray-instance.js
-    prototype/set/typedarray-arg-negative-integer-offset-throws.js
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/typedarray-arg-src-arraylength-internal.js
     prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/typedarray-arg-src-byteoffset-internal.js
-    prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
     prototype/set/typedarray-arg-srcbuffer-detached-during-tointeger-offset-throws.js
-    prototype/set/typedarray-arg-target-arraylength-internal.js
-    prototype/set/typedarray-arg-target-byteoffset-internal.js
     prototype/set/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/set/typedarray-arg-targetbuffer-detached-during-tointeger-offset-throws.js
-    prototype/slice/BigInt 38/38 (100.0%)
-    prototype/slice/arraylength-internal.js
+    prototype/slice/BigInt/detached-buffer.js
+    prototype/slice/BigInt/detached-buffer-custom-ctor-other-targettype.js
+    prototype/slice/BigInt/detached-buffer-custom-ctor-same-targettype.js
+    prototype/slice/BigInt/detached-buffer-get-ctor.js
+    prototype/slice/BigInt/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
+    prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-other-targettype.js
+    prototype/slice/BigInt/detached-buffer-zero-count-custom-ctor-same-targettype.js
+    prototype/slice/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/BigInt/set-values-from-different-ctor-type.js
+    prototype/slice/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/detached-buffer.js
@@ -2281,12 +2161,6 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/slice/detached-buffer-speciesctor-get-species-custom-ctor-throws.js
     prototype/slice/detached-buffer-zero-count-custom-ctor-other-targettype.js
     prototype/slice/detached-buffer-zero-count-custom-ctor-same-targettype.js
-    prototype/slice/invoked-as-func.js
-    prototype/slice/invoked-as-method.js
-    prototype/slice/length.js
-    prototype/slice/name.js
-    prototype/slice/not-a-constructor.js
-    prototype/slice/prop-desc.js
     prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/set-values-from-different-ctor-type.js
@@ -2296,53 +2170,42 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/speciesctor-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/this-is-not-object.js
-    prototype/slice/this-is-not-typedarray-instance.js
-    prototype/some/BigInt 16/16 (100.0%)
+    prototype/some/BigInt/callbackfn-detachbuffer.js
+    prototype/some/BigInt/detached-buffer.js
+    prototype/some/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/some/callbackfn-detachbuffer.js
     prototype/some/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
     prototype/some/detached-buffer.js
-    prototype/some/get-length-uses-internal-arraylength.js
-    prototype/some/invoked-as-func.js
-    prototype/some/invoked-as-method.js
-    prototype/some/length.js
-    prototype/some/name.js
-    prototype/some/not-a-constructor.js
-    prototype/some/prop-desc.js
     prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/some/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/this-is-not-object.js
-    prototype/some/this-is-not-typedarray-instance.js
-    prototype/sort/BigInt 10/10 (100.0%)
-    prototype/sort/arraylength-internal.js
+    prototype/sort/BigInt/detached-buffer.js
+    prototype/sort/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/detached-buffer.js
-    prototype/sort/invoked-as-func.js
-    prototype/sort/invoked-as-method.js
-    prototype/sort/length.js
-    prototype/sort/name.js
-    prototype/sort/not-a-constructor.js
-    prototype/sort/prop-desc.js
     prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/sort-tonumber.js
-    prototype/sort/this-is-not-object.js
-    prototype/sort/this-is-not-typedarray-instance.js
-    prototype/subarray/BigInt 27/27 (100.0%)
+    prototype/subarray/BigInt/detached-buffer.js
+    prototype/subarray/BigInt/infinity.js
+    prototype/subarray/BigInt/speciesctor-get-ctor.js
+    prototype/subarray/BigInt/speciesctor-get-ctor-abrupt.js
+    prototype/subarray/BigInt/speciesctor-get-ctor-inherited.js
+    prototype/subarray/BigInt/speciesctor-get-ctor-returns-throws.js
+    prototype/subarray/BigInt/speciesctor-get-species.js
+    prototype/subarray/BigInt/speciesctor-get-species-abrupt.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-throws.js
+    prototype/subarray/BigInt/speciesctor-get-species-returns-throws.js
     prototype/subarray/coerced-begin-end-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/coerced-begin-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/detached-buffer.js
     prototype/subarray/infinity.js
-    prototype/subarray/invoked-as-func.js
-    prototype/subarray/invoked-as-method.js
-    prototype/subarray/length.js
-    prototype/subarray/name.js
-    prototype/subarray/not-a-constructor.js
-    prototype/subarray/prop-desc.js
     prototype/subarray/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/result-byteOffset-from-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/speciesctor-get-ctor.js
@@ -2356,68 +2219,44 @@ built-ins/TypedArray 1084/1422 (76.23%)
     prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js
     prototype/subarray/speciesctor-get-species-custom-ctor-throws.js
     prototype/subarray/speciesctor-get-species-returns-throws.js
-    prototype/subarray/this-is-not-object.js
-    prototype/subarray/this-is-not-typedarray-instance.js
-    prototype/Symbol.iterator/not-a-constructor.js
-    prototype/Symbol.toStringTag/BigInt 9/9 (100.0%)
+    prototype/Symbol.toStringTag/BigInt/detached-buffer.js
+    prototype/Symbol.toStringTag/BigInt/invoked-as-accessor.js
+    prototype/Symbol.toStringTag/BigInt/invoked-as-func.js
+    prototype/Symbol.toStringTag/BigInt/name.js
+    prototype/Symbol.toStringTag/BigInt/this-has-no-typedarrayname-internal.js
+    prototype/Symbol.toStringTag/BigInt/this-is-not-object.js
     prototype/Symbol.toStringTag/detached-buffer.js
     prototype/Symbol.toStringTag/invoked-as-accessor.js
     prototype/Symbol.toStringTag/invoked-as-func.js
-    prototype/Symbol.toStringTag/length.js
     prototype/Symbol.toStringTag/name.js
-    prototype/Symbol.toStringTag/prop-desc.js
     prototype/Symbol.toStringTag/this-has-no-typedarrayname-internal.js
     prototype/Symbol.toStringTag/this-is-not-object.js
-    prototype/toLocaleString/BigInt 14/14 (100.0%)
+    prototype/toLocaleString/BigInt/detached-buffer.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/detached-buffer.js
-    prototype/toLocaleString/get-length-uses-internal-arraylength.js
-    prototype/toLocaleString/invoked-as-func.js
-    prototype/toLocaleString/invoked-as-method.js
-    prototype/toLocaleString/length.js
-    prototype/toLocaleString/name.js
-    prototype/toLocaleString/not-a-constructor.js
-    prototype/toLocaleString/prop-desc.js
     prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/this-is-not-object.js
-    prototype/toLocaleString/this-is-not-typedarray-instance.js
     prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/toReversed/metadata 3/3 (100.0%)
-    prototype/toReversed/length-property-ignored.js
-    prototype/toReversed/not-a-constructor.js
     prototype/toReversed/this-value-invalid.js
-    prototype/toSorted/metadata 3/3 (100.0%)
-    prototype/toSorted/length-property-ignored.js
-    prototype/toSorted/not-a-constructor.js
     prototype/toSorted/this-value-invalid.js
     prototype/toString/BigInt/detached-buffer.js
-    prototype/toString 2/2 (100.0%)
-    prototype/values/BigInt 4/4 (100.0%)
+    prototype/toString/detached-buffer.js
+    prototype/values/BigInt/detached-buffer.js
+    prototype/values/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/values/detached-buffer.js
-    prototype/values/invoked-as-func.js
-    prototype/values/invoked-as-method.js
-    prototype/values/length.js
     prototype/values/make-in-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
     prototype/values/make-out-of-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/name.js
-    prototype/values/not-a-constructor.js
-    prototype/values/prop-desc.js
     prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/values/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/this-is-not-object.js
-    prototype/values/this-is-not-typedarray-instance.js
     prototype/with/BigInt/early-type-coercion-bigint.js
-    prototype/with/metadata 3/3 (100.0%)
     prototype/with/index-validated-against-current-length.js {unsupported: [resizable-arraybuffer]}
-    prototype/with/length-property-ignored.js
-    prototype/with/not-a-constructor.js
-    prototype 4/4 (100.0%)
+    prototype/resizable-and-fixed-have-same-prototype.js {unsupported: [resizable-arraybuffer]}
+    prototype/Symbol.iterator.js
+    prototype/toString.js
     Symbol.species 4/4 (100.0%)
-    invoked.js
-    name.js
     out-of-bounds-behaves-like-detached.js {unsupported: [resizable-arraybuffer]}
     out-of-bounds-get-and-set.js {unsupported: [resizable-arraybuffer]}
     out-of-bounds-has.js {unsupported: [resizable-arraybuffer]}
@@ -2425,16 +2264,70 @@ built-ins/TypedArray 1084/1422 (76.23%)
     resizable-buffer-length-tracking-1.js {unsupported: [resizable-arraybuffer]}
     resizable-buffer-length-tracking-2.js {unsupported: [resizable-arraybuffer]}
 
-built-ins/TypedArrayConstructors 558/735 (75.92%)
-    BigInt64Array/prototype 4/4 (100.0%)
-    BigInt64Array 8/8 (100.0%)
-    BigUint64Array/prototype 4/4 (100.0%)
-    BigUint64Array 8/8 (100.0%)
-    ctors-bigint/buffer-arg 52/52 (100.0%)
-    ctors-bigint/length-arg 12/12 (100.0%)
-    ctors-bigint/no-args 7/7 (100.0%)
-    ctors-bigint/object-arg 31/31 (100.0%)
-    ctors-bigint/typedarray-arg 11/11 (100.0%)
+built-ins/TypedArrayConstructors 341/735 (46.39%)
+    ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-is-negative-throws.js
+    ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-to-number-detachbuffer.js
+    ctors-bigint/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/custom-proto-access-throws.js
+    ctors-bigint/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-negative-length.js
+    ctors-bigint/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/detachedbuffer.js
+    ctors-bigint/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/length-to-number-detachbuffer.js
+    ctors-bigint/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/proto-from-ctor-realm.js
+    ctors-bigint/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/use-custom-proto-if-object.js
+    ctors-bigint/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/length-arg/custom-proto-access-throws.js
+    ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
+    ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
+    ctors-bigint/length-arg/is-symbol-throws.js
+    ctors-bigint/length-arg/proto-from-ctor-realm.js
+    ctors-bigint/length-arg/toindex-length.js
+    ctors-bigint/length-arg/use-custom-proto-if-object.js
+    ctors-bigint/no-args/custom-proto-access-throws.js
+    ctors-bigint/no-args/proto-from-ctor-realm.js
+    ctors-bigint/no-args/use-custom-proto-if-object.js
+    ctors-bigint/object-arg/as-generator-iterable-returns.js
+    ctors-bigint/object-arg/bigint-tobiguint64.js
+    ctors-bigint/object-arg/custom-proto-access-throws.js
+    ctors-bigint/object-arg/iterating-throws.js
+    ctors-bigint/object-arg/iterator-not-callable-throws.js
+    ctors-bigint/object-arg/iterator-throws.js
+    ctors-bigint/object-arg/length-excessive-throws.js
+    ctors-bigint/object-arg/length-is-symbol-throws.js
+    ctors-bigint/object-arg/length-throws.js
+    ctors-bigint/object-arg/new-instance-extensibility.js
+    ctors-bigint/object-arg/number-tobigint.js
+    ctors-bigint/object-arg/proto-from-ctor-realm.js
+    ctors-bigint/object-arg/throws-from-property.js
+    ctors-bigint/object-arg/throws-setting-property.js
+    ctors-bigint/object-arg/throws-setting-symbol-property.js
+    ctors-bigint/object-arg/undefined-tobigint.js
+    ctors-bigint/object-arg/use-custom-proto-if-object.js
+    ctors-bigint/typedarray-arg/custom-proto-access-throws.js
+    ctors-bigint/typedarray-arg/proto-from-ctor-realm.js
+    ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
     ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-throws.js
     ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2500,13 +2393,29 @@ built-ins/TypedArrayConstructors 558/735 (75.92%)
     ctors/object-arg/use-custom-proto-if-object.js
     ctors/typedarray-arg/custom-proto-access-throws.js
     ctors/typedarray-arg/proto-from-ctor-realm.js
-    ctors/typedarray-arg/src-typedarray-big-throws.js
     ctors/typedarray-arg/src-typedarray-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     ctors/typedarray-arg/use-custom-proto-if-object.js
     ctors/no-species.js
-    Float32Array/prototype/proto.js
-    Float64Array/prototype/proto.js
-    from/BigInt 28/28 (100.0%)
+    from/BigInt/arylk-get-length-error.js
+    from/BigInt/arylk-to-length-error.js
+    from/BigInt/custom-ctor.js
+    from/BigInt/custom-ctor-returns-other-instance.js
+    from/BigInt/iter-access-error.js
+    from/BigInt/iter-invoke-error.js
+    from/BigInt/iter-next-error.js
+    from/BigInt/iter-next-value-error.js
+    from/BigInt/mapfn-abrupt-completion.js
+    from/BigInt/mapfn-arguments.js
+    from/BigInt/mapfn-this-with-thisarg.js
+    from/BigInt/mapfn-this-without-thisarg-non-strict.js non-strict
+    from/BigInt/mapfn-this-without-thisarg-strict.js strict
+    from/BigInt/new-instance-empty.js
+    from/BigInt/new-instance-from-ordinary-object.js
+    from/BigInt/new-instance-using-custom-ctor.js
+    from/BigInt/new-instance-with-mapfn.js
+    from/BigInt/new-instance-without-mapfn.js
+    from/BigInt/property-abrupt-completion.js
+    from/BigInt/set-value-abrupt-completion.js
     from/arylk-get-length-error.js
     from/arylk-to-length-error.js
     from/custom-ctor.js
@@ -2530,10 +2439,27 @@ built-ins/TypedArrayConstructors 558/735 (75.92%)
     from/new-instance-without-mapfn.js
     from/property-abrupt-completion.js
     from/set-value-abrupt-completion.js
-    Int16Array/prototype/proto.js
-    Int32Array/prototype/proto.js
-    Int8Array/prototype/proto.js
-    internals/DefineOwnProperty/BigInt 26/26 (100.0%)
+    internals/DefineOwnProperty/BigInt/desc-value-throws.js
+    internals/DefineOwnProperty/BigInt/detached-buffer.js
+    internals/DefineOwnProperty/BigInt/detached-buffer-throws.js
+    internals/DefineOwnProperty/BigInt/detached-buffer-throws-realm.js
+    internals/DefineOwnProperty/BigInt/key-is-greater-than-last-index.js
+    internals/DefineOwnProperty/BigInt/key-is-lower-than-zero.js
+    internals/DefineOwnProperty/BigInt/key-is-minus-zero.js
+    internals/DefineOwnProperty/BigInt/key-is-not-canonical-index.js
+    internals/DefineOwnProperty/BigInt/key-is-not-integer.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-accessor-desc.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-accessor-desc-throws.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-configurable.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-configurable-throws.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-enumerable.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-enumerable-throws.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-writable.js
+    internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-writable-throws.js
+    internals/DefineOwnProperty/BigInt/non-extensible-redefine-key.js
+    internals/DefineOwnProperty/BigInt/set-value.js
+    internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer.js
     internals/DefineOwnProperty/conversion-operation.js
     internals/DefineOwnProperty/conversion-operation-consistent-nan.js
     internals/DefineOwnProperty/desc-value-throws.js
@@ -2557,27 +2483,41 @@ built-ins/TypedArrayConstructors 558/735 (75.92%)
     internals/DefineOwnProperty/non-extensible-redefine-key.js
     internals/DefineOwnProperty/set-value.js
     internals/DefineOwnProperty/tonumber-value-detached-buffer.js
-    internals/Delete/BigInt 19/19 (100.0%)
+    internals/Delete/BigInt/detached-buffer.js
+    internals/Delete/BigInt/detached-buffer-key-is-not-numeric-index.js
+    internals/Delete/BigInt/detached-buffer-key-is-symbol.js
+    internals/Delete/BigInt/detached-buffer-realm.js
+    internals/Delete/BigInt/indexed-value-ab-strict.js strict
+    internals/Delete/BigInt/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/infinity-detached-buffer.js
+    internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
+    internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
     internals/Delete/detached-buffer.js
     internals/Delete/detached-buffer-key-is-not-numeric-index.js
     internals/Delete/detached-buffer-key-is-symbol.js
     internals/Delete/detached-buffer-realm.js
-    internals/Delete/indexed-value-ab-non-strict.js non-strict
     internals/Delete/indexed-value-ab-strict.js strict
     internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/infinity-detached-buffer.js
-    internals/Delete/key-is-not-canonical-index-non-strict.js non-strict
-    internals/Delete/key-is-not-canonical-index-strict.js strict
-    internals/Delete/key-is-not-integer.js
-    internals/Delete/key-is-not-minus-zero-non-strict.js non-strict
     internals/Delete/key-is-not-minus-zero-strict.js strict
-    internals/Delete/key-is-not-numeric-index-non-strict.js non-strict
-    internals/Delete/key-is-not-numeric-index-strict.js strict
-    internals/Delete/key-is-out-of-bounds-non-strict.js non-strict
     internals/Delete/key-is-out-of-bounds-strict.js strict
-    internals/Get/BigInt 14/14 (100.0%)
-    internals/GetOwnProperty/BigInt 12/12 (100.0%)
+    internals/Get/BigInt/detached-buffer.js
+    internals/Get/BigInt/detached-buffer-key-is-not-numeric-index.js
+    internals/Get/BigInt/detached-buffer-key-is-symbol.js
+    internals/Get/BigInt/detached-buffer-realm.js
+    internals/Get/BigInt/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
+    internals/Get/BigInt/infinity-detached-buffer.js
+    internals/Get/BigInt/key-is-not-integer.js
+    internals/Get/BigInt/key-is-not-minus-zero.js
+    internals/Get/BigInt/key-is-out-of-bounds.js
+    internals/GetOwnProperty/BigInt/detached-buffer.js
+    internals/GetOwnProperty/BigInt/detached-buffer-key-is-not-number.js
+    internals/GetOwnProperty/BigInt/detached-buffer-key-is-symbol.js
+    internals/GetOwnProperty/BigInt/detached-buffer-realm.js
+    internals/GetOwnProperty/BigInt/enumerate-detached-buffer.js
+    internals/GetOwnProperty/BigInt/index-prop-desc.js
     internals/GetOwnProperty/detached-buffer.js
     internals/GetOwnProperty/detached-buffer-key-is-not-number.js
     internals/GetOwnProperty/detached-buffer-key-is-symbol.js
@@ -2588,42 +2528,58 @@ built-ins/TypedArrayConstructors 558/735 (75.92%)
     internals/Get/detached-buffer-key-is-not-numeric-index.js
     internals/Get/detached-buffer-key-is-symbol.js
     internals/Get/detached-buffer-realm.js
-    internals/Get/indexed-value.js
     internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/infinity-detached-buffer.js
-    internals/Get/key-is-not-canonical-index.js
     internals/Get/key-is-not-integer.js
     internals/Get/key-is-not-minus-zero.js
-    internals/Get/key-is-not-numeric-index.js
     internals/Get/key-is-out-of-bounds.js
-    internals/Get/key-is-symbol.js
-    internals/HasProperty/BigInt 15/15 (100.0%)
+    internals/HasProperty/BigInt/abrupt-from-ordinary-has-parent-hasproperty.js
+    internals/HasProperty/BigInt/detached-buffer.js
+    internals/HasProperty/BigInt/detached-buffer-key-is-not-number.js
+    internals/HasProperty/BigInt/detached-buffer-key-is-symbol.js
+    internals/HasProperty/BigInt/detached-buffer-realm.js
+    internals/HasProperty/BigInt/infinity-with-detached-buffer.js non-strict
+    internals/HasProperty/BigInt/key-is-lower-than-zero.js
+    internals/HasProperty/BigInt/key-is-minus-zero.js
+    internals/HasProperty/BigInt/key-is-not-integer.js
     internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
     internals/HasProperty/detached-buffer.js
     internals/HasProperty/detached-buffer-key-is-not-number.js
     internals/HasProperty/detached-buffer-key-is-symbol.js
     internals/HasProperty/detached-buffer-realm.js
     internals/HasProperty/infinity-with-detached-buffer.js non-strict
-    internals/HasProperty/inherited-property.js
-    internals/HasProperty/key-is-greater-than-last-index.js
     internals/HasProperty/key-is-lower-than-zero.js
     internals/HasProperty/key-is-minus-zero.js
-    internals/HasProperty/key-is-not-canonical-index.js
     internals/HasProperty/key-is-not-integer.js
     internals/HasProperty/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     internals/HasProperty/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    internals/OwnPropertyKeys/BigInt 4/4 (100.0%)
+    internals/OwnPropertyKeys/BigInt/integer-indexes.js
+    internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-and-symbol-keys-.js
+    internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-keys.js
     internals/OwnPropertyKeys/integer-indexes.js
     internals/OwnPropertyKeys/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/integer-indexes-and-string-keys.js
     internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
     internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    internals/Set/BigInt 27/27 (100.0%)
+    internals/Set/BigInt/bigint-tobiguint64.js
+    internals/Set/BigInt/detached-buffer.js
+    internals/Set/BigInt/detached-buffer-key-is-not-numeric-index.js
+    internals/Set/BigInt/detached-buffer-key-is-symbol.js
+    internals/Set/BigInt/detached-buffer-realm.js
+    internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js
+    internals/Set/BigInt/key-is-canonical-invalid-index-reflect-set.js
+    internals/Set/BigInt/key-is-not-canonical-index.js
+    internals/Set/BigInt/key-is-not-numeric-index.js
+    internals/Set/BigInt/key-is-symbol.js
+    internals/Set/BigInt/key-is-valid-index-prototype-chain-set.js
+    internals/Set/BigInt/key-is-valid-index-reflect-set.js
+    internals/Set/BigInt/number-tobigint.js
+    internals/Set/BigInt/tonumber-value-detached-buffer.js
+    internals/Set/BigInt/tonumber-value-throws.js
     internals/Set/detached-buffer.js
     internals/Set/detached-buffer-key-is-not-numeric-index.js
     internals/Set/detached-buffer-key-is-symbol.js
     internals/Set/detached-buffer-realm.js
-    internals/Set/indexed-value.js
     internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/key-is-canonical-invalid-index-reflect-set.js
     internals/Set/key-is-not-canonical-index.js
@@ -2636,7 +2592,12 @@ built-ins/TypedArrayConstructors 558/735 (75.92%)
     internals/Set/resized-out-of-bounds-to-in-bounds-index.js {unsupported: [resizable-arraybuffer]}
     internals/Set/tonumber-value-detached-buffer.js
     internals/Set/tonumber-value-throws.js
-    of/BigInt 12/12 (100.0%)
+    of/BigInt/argument-number-value-throws.js
+    of/BigInt/custom-ctor.js
+    of/BigInt/custom-ctor-returns-other-instance.js
+    of/BigInt/new-instance.js
+    of/BigInt/new-instance-empty.js
+    of/BigInt/new-instance-using-custom-ctor.js
     of/argument-number-value-throws.js
     of/custom-ctor.js
     of/custom-ctor-returns-other-instance.js
@@ -2645,40 +2606,6 @@ built-ins/TypedArrayConstructors 558/735 (75.92%)
     of/new-instance-empty.js
     of/new-instance-from-zero.js
     of/new-instance-using-custom-ctor.js
-    prototype/buffer 2/2 (100.0%)
-    prototype/byteLength 2/2 (100.0%)
-    prototype/byteOffset 2/2 (100.0%)
-    prototype/copyWithin 2/2 (100.0%)
-    prototype/entries 2/2 (100.0%)
-    prototype/every 2/2 (100.0%)
-    prototype/fill 2/2 (100.0%)
-    prototype/filter 2/2 (100.0%)
-    prototype/findIndex 2/2 (100.0%)
-    prototype/find 2/2 (100.0%)
-    prototype/forEach 2/2 (100.0%)
-    prototype/indexOf 2/2 (100.0%)
-    prototype/join 2/2 (100.0%)
-    prototype/keys 2/2 (100.0%)
-    prototype/lastIndexOf 2/2 (100.0%)
-    prototype/length 2/2 (100.0%)
-    prototype/map 2/2 (100.0%)
-    prototype/reduceRight 2/2 (100.0%)
-    prototype/reduce 2/2 (100.0%)
-    prototype/reverse 2/2 (100.0%)
-    prototype/set 2/2 (100.0%)
-    prototype/slice 2/2 (100.0%)
-    prototype/some 2/2 (100.0%)
-    prototype/sort 2/2 (100.0%)
-    prototype/subarray 2/2 (100.0%)
-    prototype/Symbol.toStringTag/bigint-inherited.js
-    prototype/toLocaleString 2/2 (100.0%)
-    prototype/toString 2/2 (100.0%)
-    prototype/values 2/2 (100.0%)
-    prototype 2/2 (100.0%)
-    Uint16Array/prototype/proto.js
-    Uint32Array/prototype/proto.js
-    Uint8Array/prototype/proto.js
-    Uint8ClampedArray/prototype/proto.js
 
 built-ins/WeakMap 1/102 (0.98%)
     proto-from-ctor-realm.js


### PR DESCRIPTION
This PR does a bunch of refactoring to tidy up the prototypes of typed arrays. I was hoping this would help reduce the size of @camnwalter's change for detached buffers, but I'm not sure it helps much, but we may need to decide which goes on top the other as neither is that easy to rebase.