### PR TITLE
Minor test warning cleanup

### DIFF
--- a/buildSrc/src/main/groovy/rhino.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.java-conventions.gradle
@@ -24,9 +24,6 @@ dependencies {
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.hamcrest:hamcrest:3.0"
-    testImplementation "org.yaml:snakeyaml:1.33"
-    testImplementation "javax.xml.soap:javax.xml.soap-api:1.4.0"
-    testImplementation "javax.activation:javax.activation-api:1.2.0"
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/buildSrc/src/main/groovy/rhino.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.library-conventions.gradle
@@ -40,8 +40,6 @@ tasks.withType(JavaCompile).configureEach {
         "EscapedEntity",
         "MissingSummary",
         "InvalidBlockTag",
-        "InvalidLink",
-        "InvalidParam",
         "NotJavadoc",
         "UnicodeEscape",
         // Great ideas for when minimum version is more than Java 11
@@ -54,7 +52,11 @@ tasks.withType(JavaCompile).configureEach {
         "InlineMeSuggester",
         // This one either alerts for parameters that we don't use,
         // or spuriously for local variables in my opinion.
-        "UnusedVariable")
+        "UnusedVariable",
+        // This requires annotations that are difficult to incorporate
+        // without adding a dependency for everyon who uses Rhino.
+        "AnnotateFormatMethod"
+        )
     options.errorprone.enable(
         // These two do the last thing that Checkstyle used to do for us
         "RemoveUnusedImports",

--- a/rhino/src/main/java/org/mozilla/javascript/KnownBuiltInFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/KnownBuiltInFunction.java
@@ -26,7 +26,6 @@ public class KnownBuiltInFunction extends LambdaFunction {
      * @param length the arity of the function
      * @param target an object that implements the function in Java. Since Callable is a
      *     single-function interface this will typically be implemented as a lambda.
-     * @param defaultPrototype set up a prototype on the new function
      */
     public KnownBuiltInFunction(
             Object tag,

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -16,13 +16,16 @@ dependencies {
         exclude group: 'junit'
     }
     testImplementation("org.slf4j:slf4j-simple:2.0.17")
+    testImplementation "org.yaml:snakeyaml:1.33"
+    testImplementation "javax.xml.soap:javax.xml.soap-api:1.4.0"
+    testImplementation "javax.activation:javax.activation-api:1.2.0"
 }
 
 tasks.withType(JavaCompile) {
     // We have deprecated things, like "optimization level", and have
     // not yet removed them from all tests, so turn this warning off.
     options.compilerArgs = [
-            '-Xlint:-deprecation'
+            '-Xlint:-deprecation,unchecked'
     ]
 }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -81,8 +81,8 @@ public class Test262SuiteTest {
     private static final boolean statsEnabled;
     private static final boolean includeUnsupported;
 
-    static Map<String, Script> HARNESS_SCRIPT_CACHE = new ConcurrentHashMap<>();
-    static Map<Test262Case, TestResultTracker> RESULT_TRACKERS = new LinkedHashMap<>();
+    static final Map<String, Script> HARNESS_SCRIPT_CACHE = new ConcurrentHashMap<>();
+    static final Map<Test262Case, TestResultTracker> RESULT_TRACKERS = new LinkedHashMap<>();
 
     static ShellContextFactory CTX_FACTORY = new ShellContextFactory();
 
@@ -267,7 +267,7 @@ public class Test262SuiteTest {
                                                         .relativize(testFilePath)
                                                         .toString()
                                                         .replace("\\", "/")
-                                                + (statsEnabled && testResult != ""
+                                                + (statsEnabled && !testResult.isEmpty()
                                                         ? " " + testResult
                                                         : "");
                                 if (tt.comment != null && !tt.comment.isEmpty()) {
@@ -543,14 +543,7 @@ public class Test262SuiteTest {
 
             boolean failedEarly = false;
             try {
-                Scriptable scope;
-                try {
-                    scope = buildScope(cx, testCase, testMode == TestMode.INTERPRETED);
-                } catch (Exception ex) {
-                    throw new RuntimeException(
-                            "Failed to build a scope with the harness files.", ex);
-                }
-
+                Scriptable scope = buildScope(cx, testCase, testMode == TestMode.INTERPRETED);
                 String str = testCase.source;
                 int line = 1;
                 if (useStrict) {
@@ -610,7 +603,7 @@ public class Test262SuiteTest {
                         tracker.passes(testMode, useStrict);
                     }
                 }
-            } catch (Exception ex) {
+            } catch (RuntimeException ex) {
                 // enable line below to print out stacktraces of unexpected exceptions
                 // disabled for now because too many exceptions are throw
                 // Unexpected non-Rhino-Exception here, so print the exception so it stands out
@@ -993,7 +986,7 @@ public class Test262SuiteTest {
     }
 
     private static class TestResultTracker {
-        private Set<String> modes = new HashSet<>();
+        private final Set<String> modes = new HashSet<>();
         private boolean onlyStrict;
         private boolean noStrict;
         private boolean expectedFailure;
@@ -1061,7 +1054,7 @@ public class Test262SuiteTest {
             }
 
             // simplify the output for some cases
-            ArrayList res = new ArrayList<>(modes);
+            ArrayList<String> res = new ArrayList<>(modes);
             if (res.contains("compiled-non-strict") && res.contains("interpreted-non-strict")) {
                 res.remove("compiled-non-strict");
                 res.remove("interpreted-non-strict");


### PR DESCRIPTION
* Get rid of an unchecked warning in Test262SuiteTest
* Change some unnnecesary exception handling there
* Optimize classpath
* Get rid of a less-helpful errorprone warning
* Turn back on some Javadoc checks thanks to other fixes