### PR TITLE
Usability improvements for benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ You can also run the benchmarks:
 
     ./gradlew jmh
 
+When running the benchmarks you may find a couple of environment variables useful.
+* `BENCHMARKS` if set will limit the benchmarks run to those matching
+  the regular expression given.
+* `INTERPRETED` can be set to `true` or `false` to only run the
+  benchmarks in interpreted or compiled mode.
+* `PROFILERS` can be set to `cpu` or `alloc` to run the async profiler
+  for cpu time or memory allocations, or can be set to any other
+  string which will be passed to jmh as the value of the profilers
+  argument. This allows for things like running JFR as the profiler to
+  collect information on lock contention or other events.
+
 ### Testing on other Java Versions
 
 It is a good idea to test major changes on Java 11 before assuming that they will pass the CI

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -12,10 +12,31 @@ jmh {
     if (System.getenv('BENCHMARK') != null) {
       includes = [System.getenv('BENCHMARK')]
     }
+    if (System.getenv('INTERPRETED') != null) {
+       def vals = System.getenv('INTERPRETED').split(",")
+       def aParams = project.objects.listProperty(String)
+       for (String v : vals) {
+           aParams.add(v)
+       }
+       benchmarkParameters = [interpreted: aParams]
+    }
+    if (System.getenv('PROFILERS') != null) {
+        if ('cpu'.equals(System.getenv('PROFILERS'))) {
+            profilers = ['async:output=jfr']
+        } else if ('alloc'.equals(System.getenv('PROFILERS'))) {
+            profilers = ['async:output=jfr;event=alloc']
+        } else {
+            profilers = []
+            for (String v :System.getenv('PROFILERS').split(',')) {
+                profilers.add(v)
+            }
+        }
+    }
+    jvmArgs = ['-XX:+BackgroundCompilation']
     benchmarkMode = ['avgt']
     fork = 1
     iterations = 5
     timeOnIteration = '2s'
-    warmupIterations = 3
+    warmupIterations = 4
     warmup = '5s'
 }


### PR DESCRIPTION
I got annoyed about keeping a stash to enable profiling or just run the benchmarks in interpreted mode, so I made those accessible via environment variables.