### PR TITLE
Fix performance regression from `LookupResult` change.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3216,7 +3216,7 @@ public class ScriptRuntime {
                             || Undefined.isUndefined(value))) {
                 return null;
             }
-            return new LookupResult(value, null, value == null ? "null" : value.toString());
+            return new LookupResult(value, null, value);
         }
 
         Callable f = (Callable) value;
@@ -3237,7 +3237,7 @@ public class ScriptRuntime {
                 thisObj = ScriptableObject.getTopLevelScope(thisObj);
             }
         }
-        return new LookupResult(f, thisObj, value == null ? "null" : value.toString());
+        return new LookupResult(f, thisObj, value);
     }
 
     /**
@@ -6011,9 +6011,9 @@ public class ScriptRuntime {
 
         private final Object result;
         private final Scriptable thisObj;
-        private final String name;
+        private final Object name;
 
-        LookupResult(Object result, Scriptable thisObj, String name) {
+        LookupResult(Object result, Scriptable thisObj, Object name) {
             this.result = result;
             this.thisObj = thisObj;
             this.name = name;
@@ -6028,7 +6028,7 @@ public class ScriptRuntime {
         }
 
         public String getName() {
-            return name;
+            return name == null ? "null" : name.toString();
         }
 
         /**


### PR DESCRIPTION
I should have run more benchmarks before approving that change.

Benchmarks that depended heavily on the performance of `getValueAndThis` showed a major regression with the `LookupResult` change because the value was being eagerly converted to a string. I've changed this to be lazy. This is especially true of several of the sun spider bitops benchmarks.

I noticed this while doing a quick comparison to see how we had improved / regressed since the last release.