### PR TITLE
Jdk 11 262

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
     id 'org.jetbrains.kotlin.jvm' version '2.1.21' apply false
 }
 rootProject.name = 'rhino-root'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -50,7 +50,7 @@ test {
 
     systemProperty 'test262properties', System.getProperty('test262properties')
     if (System.getProperty('updateTest262properties') != null) {
-        if (System.getenv("RHINO_TEST_JAVA_VERSION") != "11") {
+        if ("11".equals(System.getenv("RHINO_TEST_JAVA_VERSION"))) {
             System.out.println("Test262 properties update is only accurate on Java 11 and you have " + JavaVersion.current())
             System.out.println("Set RHINO_TEST_JAVA_VERSION in the environment to use this feature")
             throw new Exception("Incorrect Java version for Test 262 properties update")


### PR DESCRIPTION
was no longer able to build with with jdk 11
* revert org.gradle.toolchains.foojay-resolver-convention to version 0.10.0 because 1.0.0 requires jdk 17
* small tweak to build.gradle to make the jdk 11 check work on my maschine