### PR TITLE
move `defineFunctionProperties(...)` to after `init(...)` in ShellTest

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -482,26 +482,26 @@ public class ShellTest {
         BufferedReader r =
                 new BufferedReader(
                         new InputStreamReader(new ByteArrayInputStream(out.toByteArray())));
-        StringBuilder failures = new StringBuilder();
+        String failures = "";
         for (; ; ) {
-            String line = r.readLine();
-            if (line == null) {
+            String s = r.readLine();
+            if (s == null) {
                 break;
             }
-            if (line.contains("FAILED!")) {
-                failures.append(line).append('\n');
+            if (s.contains("FAILED!")) {
+                failures += s + '\n';
             }
-            int expex = line.indexOf("EXPECT EXIT CODE ");
+            int expex = s.indexOf("EXPECT EXIT CODE ");
             if (expex != -1) {
-                expectedExitCode = line.charAt(expex + "EXPECT EXIT CODE ".length()) - '0';
+                expectedExitCode = s.charAt(expex + "EXPECT EXIT CODE ".length()) - '0';
             }
         }
         if (thrown[0] != null) {
             status.threw(thrown[0]);
         }
         status.exitCodesWere(expectedExitCode, testState.exitCode);
-        if (failures.length() > 0) {
-            status.failed(failures.toString());
+        if (!failures.isEmpty()) {
+            status.failed(failures);
         }
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -439,41 +439,37 @@ public class ShellTest {
         }
         final Throwable thrown[] = {null};
 
-        try {
-            shellContextFactory.call(
-                    cx -> {
-                        status.running(jsFile);
-                        testState.errors = new ErrorReporterWrapper(cx.getErrorReporter());
-                        cx.setErrorReporter(testState.errors);
-                        global.init(cx);
+        try (var cx = shellContextFactory.enterContext()) {
+            status.running(jsFile);
+            testState.errors = new ErrorReporterWrapper(cx.getErrorReporter());
+            cx.setErrorReporter(testState.errors);
+            global.init(cx);
 
-                        // invoke after init(...) to make sure ClassCache is available for FunctionObject
-                        global.defineFunctionProperties(
-                            new String[] {"options"},
-                            ShellTest.class,
-                            ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
+            // invoke after init(...) to make sure ClassCache is available for FunctionObject
+            global.defineFunctionProperties(
+                new String[] {"options"},
+                ShellTest.class,
+                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
 
-                        try {
-                            runFileIfExists(
-                                    cx,
-                                    global,
-                                    new File(
-                                            jsFile.getParentFile().getParentFile().getParentFile(),
-                                            "shell.js"));
-                            runFileIfExists(
-                                    cx,
-                                    global,
-                                    new File(jsFile.getParentFile().getParentFile(), "shell.js"));
-                            runFileIfExists(
-                                    cx, global, new File(jsFile.getParentFile(), "shell.js"));
-                            runFileIfExists(cx, global, jsFile);
-                            status.hadErrors(
-                                    jsFile, testState.errors.errors.toArray(new Status.JsError[0]));
-                        } catch (Throwable t) {
-                            status.threw(t);
-                        }
-                        return null;
-                    });
+            try {
+                runFileIfExists(
+                    cx,
+                    global,
+                    new File(
+                        jsFile.getParentFile().getParentFile().getParentFile(),
+                        "shell.js"));
+                runFileIfExists(
+                    cx,
+                    global,
+                    new File(jsFile.getParentFile().getParentFile(), "shell.js"));
+                runFileIfExists(
+                    cx, global, new File(jsFile.getParentFile(), "shell.js"));
+                runFileIfExists(cx, global, jsFile);
+                status.hadErrors(
+                    jsFile, testState.errors.errors.toArray(new Status.JsError[0]));
+            } catch (Throwable t) {
+                status.threw(t);
+            }
         } catch (Error t) {
             thrown[0] = t;
         } catch (RuntimeException t) {

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -447,26 +447,24 @@ public class ShellTest {
 
             // invoke after init(...) to make sure ClassCache is available for FunctionObject
             global.defineFunctionProperties(
-                new String[] {"options"},
-                ShellTest.class,
-                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
+                    new String[] {"options"},
+                    ShellTest.class,
+                    ScriptableObject.DONTENUM
+                            | ScriptableObject.PERMANENT
+                            | ScriptableObject.READONLY);
 
             try {
                 runFileIfExists(
-                    cx,
-                    global,
-                    new File(
-                        jsFile.getParentFile().getParentFile().getParentFile(),
-                        "shell.js"));
+                        cx,
+                        global,
+                        new File(
+                                jsFile.getParentFile().getParentFile().getParentFile(),
+                                "shell.js"));
                 runFileIfExists(
-                    cx,
-                    global,
-                    new File(jsFile.getParentFile().getParentFile(), "shell.js"));
-                runFileIfExists(
-                    cx, global, new File(jsFile.getParentFile(), "shell.js"));
+                        cx, global, new File(jsFile.getParentFile().getParentFile(), "shell.js"));
+                runFileIfExists(cx, global, new File(jsFile.getParentFile(), "shell.js"));
                 runFileIfExists(cx, global, jsFile);
-                status.hadErrors(
-                    jsFile, testState.errors.errors.toArray(new Status.JsError[0]));
+                status.hadErrors(jsFile, testState.errors.errors.toArray(new Status.JsError[0]));
             } catch (Throwable t) {
                 status.threw(t);
             }

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -431,10 +431,6 @@ public class ShellTest {
         final PrintStream p = new PrintStream(out);
         global.setOut(p);
         global.setErr(p);
-        global.defineFunctionProperties(
-                new String[] {"options"},
-                ShellTest.class,
-                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
         // test suite expects keywords to be disallowed as identifiers
         shellContextFactory.setAllowReservedKeywords(false);
         final TestState testState = new TestState();
@@ -450,6 +446,13 @@ public class ShellTest {
                         testState.errors = new ErrorReporterWrapper(cx.getErrorReporter());
                         cx.setErrorReporter(testState.errors);
                         global.init(cx);
+
+                        // invoke after init(...) to make sure ClassCache is available for FunctionObject
+                        global.defineFunctionProperties(
+                            new String[] {"options"},
+                            ShellTest.class,
+                            ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
+
                         try {
                             runFileIfExists(
                                     cx,

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -437,7 +437,7 @@ public class ShellTest {
         if (jsFile.getName().endsWith("-n.js")) {
             status.setNegative();
         }
-        final Throwable thrown[] = {null};
+        final Throwable[] thrown = {null};
 
         try (var cx = shellContextFactory.enterContext()) {
             status.running(jsFile);
@@ -480,30 +480,30 @@ public class ShellTest {
 
         int expectedExitCode = 0;
         p.flush();
-        status.outputWas(new String(out.toByteArray()));
+        status.outputWas(out.toString());
         BufferedReader r =
                 new BufferedReader(
                         new InputStreamReader(new ByteArrayInputStream(out.toByteArray())));
-        String failures = "";
+        StringBuilder failures = new StringBuilder();
         for (; ; ) {
-            String s = r.readLine();
-            if (s == null) {
+            String line = r.readLine();
+            if (line == null) {
                 break;
             }
-            if (s.indexOf("FAILED!") != -1) {
-                failures += s + '\n';
+            if (line.contains("FAILED!")) {
+                failures.append(line).append('\n');
             }
-            int expex = s.indexOf("EXPECT EXIT CODE ");
+            int expex = line.indexOf("EXPECT EXIT CODE ");
             if (expex != -1) {
-                expectedExitCode = s.charAt(expex + "EXPECT EXIT CODE ".length()) - '0';
+                expectedExitCode = line.charAt(expex + "EXPECT EXIT CODE ".length()) - '0';
             }
         }
         if (thrown[0] != null) {
             status.threw(thrown[0]);
         }
         status.exitCodesWere(expectedExitCode, testState.exitCode);
-        if (failures != "") {
-            status.failed(failures);
+        if (failures.length() > 0) {
+            status.failed(failures.toString());
         }
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -15,7 +15,6 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.StringJoiner;
-
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ErrorReporter;
 import org.mozilla.javascript.EvaluatorException;
@@ -48,13 +47,14 @@ public class ShellTest {
     }
 
     public static final FileFilter DIRECTORY_FILTER =
-        pathname -> pathname.isDirectory() && !pathname.getName().equals("CVS");
+            pathname -> pathname.isDirectory() && !pathname.getName().equals("CVS");
 
     public static final FileFilter TEST_FILTER =
-        pathname -> pathname.getName().endsWith(".js")
-                && !pathname.getName().equals("shell.js")
-                && !pathname.getName().equals("browser.js")
-                && !pathname.getName().equals("template.js");
+            pathname ->
+                    pathname.getName().endsWith(".js")
+                            && !pathname.getName().equals("shell.js")
+                            && !pathname.getName().equals("browser.js")
+                            && !pathname.getName().equals("template.js");
 
     public static String getStackTrace(Throwable t) {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -309,62 +309,60 @@ public class ShellTest {
         final Throwable[] thrown = {null};
 
         Thread thread =
-                new Thread(() -> {
-                        try (var cx = shellContextFactory.enterContext()) {
-                            status.running(jsFile);
-                            testState.errors =
-                                new ErrorReporterWrapper(
-                                    cx.getErrorReporter());
-                            cx.setErrorReporter(testState.errors);
-                            global.init(cx);
+                new Thread(
+                        () -> {
+                            try (var cx = shellContextFactory.enterContext()) {
+                                status.running(jsFile);
+                                testState.errors = new ErrorReporterWrapper(cx.getErrorReporter());
+                                cx.setErrorReporter(testState.errors);
+                                global.init(cx);
 
-                            // invoke after init(...) to make sure ClassCache is available for FunctionObject
-                            global.defineFunctionProperties(
-                                new String[] {"options"},
-                                ShellTest.class,
-                                ScriptableObject.DONTENUM | ScriptableObject.PERMANENT | ScriptableObject.READONLY);
+                                // invoke after init(...) to make sure ClassCache is available for
+                                // FunctionObject
+                                global.defineFunctionProperties(
+                                        new String[] {"options"},
+                                        ShellTest.class,
+                                        ScriptableObject.DONTENUM
+                                                | ScriptableObject.PERMANENT
+                                                | ScriptableObject.READONLY);
 
-                            try {
-                                runFileIfExists(
-                                    cx,
-                                    global,
-                                    new File(
-                                        jsFile.getParentFile()
-                                            .getParentFile()
-                                            .getParentFile(),
-                                        "shell.js"));
-                                runFileIfExists(
-                                    cx,
-                                    global,
-                                    new File(
-                                        jsFile.getParentFile()
-                                            .getParentFile(),
-                                        "shell.js"));
-                                runFileIfExists(
-                                    cx,
-                                    global,
-                                    new File(
-                                        jsFile.getParentFile(),
-                                        "shell.js"));
-                                runFileIfExists(cx, global, jsFile);
-                                status.hadErrors(
-                                    jsFile,
-                                    testState.errors.errors.toArray(
-                                        new Status.JsError[0]));
-                            } catch (ThreadDeath e) {
-                            } catch (Throwable t) {
-                                status.threw(t);
+                                try {
+                                    runFileIfExists(
+                                            cx,
+                                            global,
+                                            new File(
+                                                    jsFile.getParentFile()
+                                                            .getParentFile()
+                                                            .getParentFile(),
+                                                    "shell.js"));
+                                    runFileIfExists(
+                                            cx,
+                                            global,
+                                            new File(
+                                                    jsFile.getParentFile().getParentFile(),
+                                                    "shell.js"));
+                                    runFileIfExists(
+                                            cx,
+                                            global,
+                                            new File(jsFile.getParentFile(), "shell.js"));
+                                    runFileIfExists(cx, global, jsFile);
+                                    status.hadErrors(
+                                            jsFile,
+                                            testState.errors.errors.toArray(new Status.JsError[0]));
+                                } catch (ThreadDeath e) {
+                                } catch (Throwable t) {
+                                    status.threw(t);
+                                }
+                            } catch (Error t) {
+                                thrown[0] = t;
+                            } catch (RuntimeException t) {
+                                thrown[0] = t;
+                            } finally {
+                                synchronized (testState) {
+                                    testState.finished = true;
+                                }
                             }
-                        } catch (Error t) {
-                            thrown[0] = t;
-                        } catch (RuntimeException t) {
-                            thrown[0] = t;
-                        } finally {
-                            synchronized (testState) {
-                                testState.finished = true;
-                            }
-                        }
-                    },
+                        },
                         jsFile.getPath());
         thread.setDaemon(true);
         thread.start();


### PR DESCRIPTION
most of changes in this PR are just doing the same thing with different syntax, except for moving `defineFunctionProperties(...)`: https://github.com/mozilla/rhino/commit/79a0d275e41385799d37d310f861392c5c631726

This is a fix for the problem described in https://github.com/mozilla/rhino/pull/1849#discussion_r2122515817 , which is not fatal now, but will cause `MozillaSuiteTest` to fail if #1849 is merged