### PR TITLE
Replace internal use of old "FunctionAndThis" methods

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -377,26 +377,24 @@ public class ArrayLikeAbstractOperations {
 
     public static ElementComparator getSortComparatorFromArguments(
             Context cx, Scriptable scope, Object[] args) {
-        final Callable jsCompareFunction = ScriptRuntime.getValueFunctionAndThis(args[0], cx);
-        final Scriptable funThis = ScriptRuntime.lastStoredScriptable(cx);
+        var compareFunc = ScriptRuntime.getValueAndThis(args[0], cx);
+        Callable compare = compareFunc.getCallable();
+        Scriptable compareThis = compareFunc.getThis();
         final Object[] cmpBuf = new Object[2]; // Buffer for cmp arguments
         return new ElementComparator(
-                new Comparator<Object>() {
-                    @Override
-                    public int compare(final Object x, final Object y) {
-                        // This comparator is invoked only for non-undefined objects
-                        cmpBuf[0] = x;
-                        cmpBuf[1] = y;
-                        Object ret = jsCompareFunction.call(cx, scope, funThis, cmpBuf);
-                        double d = ScriptRuntime.toNumber(ret);
-                        int cmp = Double.compare(d, 0);
-                        if (cmp < 0) {
-                            return -1;
-                        } else if (cmp > 0) {
-                            return +1;
-                        }
-                        return 0;
+                (x, y) -> {
+                    // This comparator is invoked only for non-undefined objects
+                    cmpBuf[0] = x;
+                    cmpBuf[1] = y;
+                    Object ret = compare.call(cx, scope, compareThis, cmpBuf);
+                    double d = ScriptRuntime.toNumber(ret);
+                    int cmp = Double.compare(d, 0);
+                    if (cmp < 0) {
+                        return -1;
+                    } else if (cmp > 0) {
+                        return +1;
                     }
+                    return 0;
                 });
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -129,11 +129,8 @@ public final class ES6Generator extends IdScriptableObject {
                             ? ScriptRuntime.emptyArgs
                             : new Object[] {value};
 
-            Callable nextFn =
-                    ScriptRuntime.getPropFunctionAndThis(
-                            delegee, ES6Iterator.NEXT_METHOD, cx, scope);
-            Scriptable nextThis = ScriptRuntime.lastStoredScriptable(cx);
-            Object nr = nextFn.call(cx, scope, nextThis, nextArgs);
+            var nextFn = ScriptRuntime.getPropAndThis(delegee, ES6Iterator.NEXT_METHOD, cx, scope);
+            Object nr = nextFn.call(cx, scope, nextArgs);
 
             Scriptable nextResult = ScriptableObject.ensureScriptable(nr);
             if (ScriptRuntime.isIteratorDone(cx, nextResult)) {
@@ -160,9 +157,8 @@ public final class ES6Generator extends IdScriptableObject {
         boolean returnCalled = false;
         try {
             // Delegate to "throw" method. If it's not defined we'll get an error here.
-            Callable throwFn = ScriptRuntime.getPropFunctionAndThis(delegee, "throw", cx, scope);
-            Scriptable nextThis = ScriptRuntime.lastStoredScriptable(cx);
-            Object throwResult = throwFn.call(cx, scope, nextThis, new Object[] {value});
+            var throwFn = ScriptRuntime.getPropAndThis(delegee, "throw", cx, scope);
+            Object throwResult = throwFn.call(cx, scope, new Object[] {value});
 
             if (ScriptRuntime.isIteratorDone(cx, throwResult)) {
                 // Iterator is "done".

--- a/rhino/src/main/java/org/mozilla/javascript/IteratorLikeIterable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IteratorLikeIterable.java
@@ -31,8 +31,9 @@ public class IteratorLikeIterable implements Iterable<Object>, Closeable {
         this.cx = cx;
         this.scope = scope;
         // This will throw if "next" is not a function or undefined
-        next = ScriptRuntime.getPropFunctionAndThis(target, ES6Iterator.NEXT_METHOD, cx, scope);
-        iterator = ScriptRuntime.lastStoredScriptable(cx);
+        var nextCall = ScriptRuntime.getPropAndThis(target, ES6Iterator.NEXT_METHOD, cx, scope);
+        next = nextCall.getCallable();
+        iterator = nextCall.getThis();
         Object retObj =
                 ScriptRuntime.getObjectPropNoWarn(target, ES6Iterator.RETURN_PROPERTY, cx, scope);
         // We only care about "return" if it is not null or undefined

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -997,13 +997,9 @@ public class NativeArray extends ScriptableObject implements List {
 
                     } else {
                         if (toLocale) {
-                            Callable fun;
-                            Scriptable funThis;
-                            fun =
-                                    ScriptRuntime.getPropFunctionAndThis(
-                                            elem, "toLocaleString", cx, scope);
-                            funThis = ScriptRuntime.lastStoredScriptable(cx);
-                            elem = fun.call(cx, scope, funThis, ScriptRuntime.emptyArgs);
+                            var fun =
+                                    ScriptRuntime.getPropAndThis(elem, "toLocaleString", cx, scope);
+                            elem = fun.call(cx, scope, ScriptRuntime.emptyArgs);
                         }
                         result.append(ScriptRuntime.toString(elem));
                     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -264,9 +264,8 @@ public class NativeMap extends ScriptableObject {
         // been replaced. Since we're not fully constructed yet, create a dummy instance
         // so that we can get our own prototype.
         Scriptable proto = ScriptableObject.getClassPrototype(scope, map.getClassName());
-        final Callable set = ScriptRuntime.getPropFunctionAndThis(proto, "set", cx, scope);
-        ScriptRuntime.lastStoredScriptable(cx);
-
+        var setCall = ScriptRuntime.getPropAndThis(proto, "set", cx, scope);
+        Callable set = setCall.getCallable();
         ScriptRuntime.loadFromIterable(
                 cx,
                 scope,

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -242,8 +242,7 @@ public class NativePromise extends ScriptableObject {
             IteratorLikeIterable.Itr iterator,
             Scriptable thisObj,
             Capability cap) {
-        Callable resolve = ScriptRuntime.getPropFunctionAndThis(thisObj, "resolve", cx, scope);
-        Scriptable localThis = ScriptRuntime.lastStoredScriptable(cx);
+        var resolve = ScriptRuntime.getPropAndThis(thisObj, "resolve", cx, scope);
 
         // Manually iterate for exception handling purposes
         while (true) {
@@ -267,17 +266,12 @@ public class NativePromise extends ScriptableObject {
             }
 
             // Call "resolve" to get the next promise in the chain
-            Object nextPromise = resolve.call(cx, scope, localThis, new Object[] {nextVal});
+            Object nextPromise = resolve.call(cx, scope, new Object[] {nextVal});
 
             // And then call "then" on it.
             // Logic in the resolution function ensures we don't deliver duplicate results
-            Callable thenFunc =
-                    ScriptRuntime.getPropFunctionAndThis(nextPromise, "then", cx, scope);
-            thenFunc.call(
-                    cx,
-                    scope,
-                    ScriptRuntime.lastStoredScriptable(cx),
-                    new Object[] {cap.resolve, cap.reject});
+            var thenFunc = ScriptRuntime.getPropAndThis(nextPromise, "then", cx, scope);
+            thenFunc.call(cx, scope, new Object[] {cap.resolve, cap.reject});
         }
     }
 
@@ -362,12 +356,8 @@ public class NativePromise extends ScriptableObject {
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
         Scriptable coercedThis = ScriptRuntime.toObject(cx, scope, thisObj);
         // No guarantee that the caller didn't change the prototype of "then"!
-        Callable thenFunc = ScriptRuntime.getPropFunctionAndThis(coercedThis, "then", cx, scope);
-        return thenFunc.call(
-                cx,
-                scope,
-                ScriptRuntime.lastStoredScriptable(cx),
-                new Object[] {Undefined.instance, arg});
+        var thenFunc = ScriptRuntime.getPropAndThis(coercedThis, "then", cx, scope);
+        return thenFunc.call(cx, scope, new Object[] {Undefined.instance, arg});
     }
 
     // Promise.prototype.finally
@@ -390,9 +380,8 @@ public class NativePromise extends ScriptableObject {
             thenFinally = makeThenFinally(scope, constructor, callableOnFinally);
             catchFinally = makeCatchFinally(scope, constructor, callableOnFinally);
         }
-        Callable thenFunc = ScriptRuntime.getPropFunctionAndThis(thisObj, "then", cx, scope);
-        Scriptable to = ScriptRuntime.lastStoredScriptable(cx);
-        return thenFunc.call(cx, scope, to, new Object[] {thenFinally, catchFinally});
+        var thenFunc = ScriptRuntime.getPropAndThis(thisObj, "then", cx, scope);
+        return thenFunc.call(cx, scope, new Object[] {thenFinally, catchFinally});
     }
 
     // Abstract "Then Finally Function"
@@ -416,13 +405,8 @@ public class NativePromise extends ScriptableObject {
                                     Undefined.SCRIPTABLE_UNDEFINED,
                                     ScriptRuntime.emptyArgs);
                     Object promise = resolveInternal(cx, scope, constructor, result);
-                    Callable thenFunc =
-                            ScriptRuntime.getPropFunctionAndThis(promise, "then", cx, scope);
-                    return thenFunc.call(
-                            cx,
-                            scope,
-                            ScriptRuntime.lastStoredScriptable(cx),
-                            new Object[] {valueThunk});
+                    var thenFunc = ScriptRuntime.getPropAndThis(promise, "then", cx, scope);
+                    return thenFunc.call(cx, scope, new Object[] {valueThunk});
                 });
     }
 
@@ -448,13 +432,8 @@ public class NativePromise extends ScriptableObject {
                                     Undefined.SCRIPTABLE_UNDEFINED,
                                     ScriptRuntime.emptyArgs);
                     Object promise = resolveInternal(cx, scope, constructor, result);
-                    Callable thenFunc =
-                            ScriptRuntime.getPropFunctionAndThis(promise, "then", cx, scope);
-                    return thenFunc.call(
-                            cx,
-                            scope,
-                            ScriptRuntime.lastStoredScriptable(cx),
-                            new Object[] {reasonThrower});
+                    var thenFunc = ScriptRuntime.getPropAndThis(promise, "then", cx, scope);
+                    return thenFunc.call(cx, scope, new Object[] {reasonThrower});
                 });
     }
 
@@ -749,9 +728,7 @@ public class NativePromise extends ScriptableObject {
             int index = 0;
             // Do this first because we should catch any exception before
             // invoking the iterator.
-            Callable resolve =
-                    ScriptRuntime.getPropFunctionAndThis(thisObj, "resolve", topCx, topScope);
-            Scriptable storedThis = ScriptRuntime.lastStoredScriptable(topCx);
+            var resolve = ScriptRuntime.getPropAndThis(thisObj, "resolve", topCx, topScope);
 
             // Iterate manually because we need to catch exceptions in a special way.
             while (true) {
@@ -783,8 +760,7 @@ public class NativePromise extends ScriptableObject {
                 values.add(Undefined.instance);
 
                 // Call "resolve" to get the next promise in the chain
-                Object nextPromise =
-                        resolve.call(topCx, topScope, storedThis, new Object[] {nextVal});
+                Object nextPromise = resolve.call(topCx, topScope, new Object[] {nextVal});
 
                 // Create a resolution func that will stash its result in the right place
                 PromiseElementResolver eltResolver = new PromiseElementResolver(index);
@@ -830,13 +806,8 @@ public class NativePromise extends ScriptableObject {
                 remainingElements++;
 
                 // Call "then" on the promise with the resolution func
-                Callable thenFunc =
-                        ScriptRuntime.getPropFunctionAndThis(nextPromise, "then", topCx, topScope);
-                thenFunc.call(
-                        topCx,
-                        topScope,
-                        ScriptRuntime.lastStoredScriptable(topCx),
-                        new Object[] {resolveFunc, rejectFunc});
+                var thenFunc = ScriptRuntime.getPropAndThis(nextPromise, "then", topCx, topScope);
+                thenFunc.call(topCx, topScope, new Object[] {resolveFunc, rejectFunc});
                 index++;
             }
         }
@@ -870,9 +841,7 @@ public class NativePromise extends ScriptableObject {
             int index = 0;
             // Do this first because we should catch any exception before
             // invoking the iterator.
-            Callable resolve =
-                    ScriptRuntime.getPropFunctionAndThis(thisObj, "resolve", topCx, topScope);
-            Scriptable storedThis = ScriptRuntime.lastStoredScriptable(topCx);
+            var resolve = ScriptRuntime.getPropAndThis(thisObj, "resolve", topCx, topScope);
 
             // Iterate manually because we need to catch exceptions in a special way.
             while (true) {
@@ -911,8 +880,7 @@ public class NativePromise extends ScriptableObject {
                 errors.add(Undefined.instance);
 
                 // Call "resolve" to get the next promise in the chain
-                Object nextPromise =
-                        resolve.call(topCx, topScope, storedThis, new Object[] {nextVal});
+                Object nextPromise = resolve.call(topCx, topScope, new Object[] {nextVal});
 
                 // Create a resolution func that will stash its result in the right place
                 PromiseElementResolver eltResolver = new PromiseElementResolver(index);
@@ -930,13 +898,8 @@ public class NativePromise extends ScriptableObject {
                 remainingElements++;
 
                 // Call "then" on the promise with the resolution func
-                Callable thenFunc =
-                        ScriptRuntime.getPropFunctionAndThis(nextPromise, "then", topCx, topScope);
-                thenFunc.call(
-                        topCx,
-                        topScope,
-                        ScriptRuntime.lastStoredScriptable(topCx),
-                        new Object[] {capability.resolve, rejectFunc});
+                var thenFunc = ScriptRuntime.getPropAndThis(nextPromise, "then", topCx, topScope);
+                thenFunc.call(topCx, topScope, new Object[] {capability.resolve, rejectFunc});
                 index++;
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -211,10 +211,8 @@ public class NativeSet extends ScriptableObject {
         // been replaced. Since we're not fully constructed yet, create a dummy instance
         // so that we can get our own prototype.
         ScriptableObject dummy = ensureScriptableObject(cx.newObject(scope, set.getClassName()));
-        final Callable add =
-                ScriptRuntime.getPropFunctionAndThis(dummy.getPrototype(), "add", cx, scope);
-        // Clean up the value left around by the previous function
-        ScriptRuntime.lastStoredScriptable(cx);
+        var addCall = ScriptRuntime.getPropAndThis(dummy.getPrototype(), "add", cx, scope);
+        Callable add = addCall.getCallable();
 
         // Finally, run through all the iterated values and add them!
         try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, ito)) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -2825,7 +2825,7 @@ public class ScriptRuntime {
      *
      * @deprecated use {@link #getNameAndThis(String, Context, Scriptable)}
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getNameFunctionAndThis(String name, Context cx, Scriptable scope) {
         return getNameFunctionAndThisInner(name, cx, scope, false);
     }
@@ -2833,7 +2833,7 @@ public class ScriptRuntime {
     /**
      * @deprecated use {@link #getNameAndThisOptional(String, Context, Scriptable)}
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getNameFunctionAndThisOptional(
             String name, Context cx, Scriptable scope) {
         return getNameFunctionAndThisInner(name, cx, scope, true);
@@ -2927,7 +2927,7 @@ public class ScriptRuntime {
      *
      * @deprecated use {@link #getElemAndThis(Object, Object, Context, Scriptable)}
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getElemFunctionAndThis(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemFunctionAndThisInner(obj, elem, cx, scope, false);
@@ -2936,7 +2936,7 @@ public class ScriptRuntime {
     /**
      * @deprecated use {@link #getElemAndThisOptional(Object, Object, Context, Scriptable)}
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getElemFunctionAndThisOptional(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemFunctionAndThisInner(obj, elem, cx, scope, true);
@@ -3057,7 +3057,7 @@ public class ScriptRuntime {
      *
      * @deprecated Use {@link #getPropAndThis(Object, String, Context, Scriptable)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getPropFunctionAndThis(
             Object obj, String property, Context cx, Scriptable scope) {
         return getPropFunctionAndThisInner(obj, property, cx, scope, false);
@@ -3066,7 +3066,7 @@ public class ScriptRuntime {
     /**
      * @deprecated Use {@link #getPropAndThis(Object, String, Context, Scriptable)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getPropFunctionAndThisOptional(
             Object obj, String property, Context cx, Scriptable scope) {
         return getPropFunctionAndThisInner(obj, property, cx, scope, true);
@@ -3188,7 +3188,7 @@ public class ScriptRuntime {
     /**
      * @deprecated Use {@link #getValueAndThisOptional(Object, Context)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getValueFunctionAndThisOptional(Object value, Context cx) {
         return getValueFunctionAndThisInner(value, cx, true);
     }
@@ -5899,21 +5899,21 @@ public class ScriptRuntime {
         return value;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     private static void storeScriptable(Context cx, Scriptable value) {
         // The previously stored scratchScriptable should be consumed
         if (cx.scratchScriptable != null) throw new IllegalStateException();
         cx.scratchScriptable = value;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static Scriptable lastStoredScriptable(Context cx) {
         Scriptable result = cx.scratchScriptable;
         cx.scratchScriptable = null;
         return result;
     }
 
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
     public static void discardLastStoredScriptable(Context cx) {
         if (cx.scratchScriptable == null) throw new IllegalStateException();
         cx.scratchScriptable = null;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -2822,11 +2822,18 @@ public class ScriptRuntime {
      * Prepare for calling name(...): return function corresponding to name and make current top
      * scope available as ScriptRuntime.lastStoredScriptable() for consumption as thisObj. The
      * caller must call ScriptRuntime.lastStoredScriptable() immediately after calling this method.
+     *
+     * @deprecated use {@link #getNameAndThis(String, Context, Scriptable)}
      */
+    @Deprecated
     public static Callable getNameFunctionAndThis(String name, Context cx, Scriptable scope) {
         return getNameFunctionAndThisInner(name, cx, scope, false);
     }
 
+    /**
+     * @deprecated use {@link #getNameAndThisOptional(String, Context, Scriptable)}
+     */
+    @Deprecated
     public static Callable getNameFunctionAndThisOptional(
             String name, Context cx, Scriptable scope) {
         return getNameFunctionAndThisInner(name, cx, scope, true);
@@ -2862,8 +2869,7 @@ public class ScriptRuntime {
 
     /**
      * Prepare for calling name(...): return function corresponding to name and make current top
-     * scope available as ScriptRuntime.lastStoredScriptable() for consumption as thisObj. The
-     * caller must call ScriptRuntime.lastStoredScriptable() immediately after calling this method.
+     * scope available as part of the result.
      */
     public static LookupResult getNameAndThis(String name, Context cx, Scriptable scope) {
         return getNameAndThisInner(name, cx, scope, false);
@@ -2918,12 +2924,19 @@ public class ScriptRuntime {
      * properly converted to Scriptable available as ScriptRuntime.lastStoredScriptable() for
      * consumption as thisObj. The caller must call ScriptRuntime.lastStoredScriptable() immediately
      * after calling this method.
+     *
+     * @deprecated use {@link #getElemAndThis(Object, Object, Context, Scriptable)}
      */
+    @Deprecated
     public static Callable getElemFunctionAndThis(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemFunctionAndThisInner(obj, elem, cx, scope, false);
     }
 
+    /**
+     * @deprecated use {@link #getElemAndThisOptional(Object, Object, Context, Scriptable)}
+     */
+    @Deprecated
     public static Callable getElemFunctionAndThisOptional(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemFunctionAndThisInner(obj, elem, cx, scope, true);
@@ -2970,6 +2983,10 @@ public class ScriptRuntime {
         return (Callable) value;
     }
 
+    /**
+     * Prepare for calling obj[id](...): return function corresponding to obj[id] and make obj
+     * properly converted to Scriptable available in the result.
+     */
     public static LookupResult getElemAndThis(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemAndThisInner(obj, elem, cx, scope, false);
@@ -3037,12 +3054,19 @@ public class ScriptRuntime {
      * obj properly converted to Scriptable available as ScriptRuntime.lastStoredScriptable() for
      * consumption as thisObj. The caller must call ScriptRuntime.lastStoredScriptable() immediately
      * after calling this method.
+     *
+     * @deprecated Use {@link #getPropAndThis(Object, String, Context, Scriptable)} instead
      */
+    @Deprecated
     public static Callable getPropFunctionAndThis(
             Object obj, String property, Context cx, Scriptable scope) {
         return getPropFunctionAndThisInner(obj, property, cx, scope, false);
     }
 
+    /**
+     * @deprecated Use {@link #getPropAndThis(Object, String, Context, Scriptable)} instead
+     */
+    @Deprecated
     public static Callable getPropFunctionAndThisOptional(
             Object obj, String property, Context cx, Scriptable scope) {
         return getPropFunctionAndThisInner(obj, property, cx, scope, true);
@@ -3096,9 +3120,7 @@ public class ScriptRuntime {
 
     /**
      * Prepare for calling obj.property(...): return function corresponding to obj.property and make
-     * obj properly converted to Scriptable available as ScriptRuntime.lastStoredScriptable() for
-     * consumption as thisObj. The caller must call ScriptRuntime.lastStoredScriptable() immediately
-     * after calling this method.
+     * obj properly converted to Scriptable in the result.
      */
     public static LookupResult getPropAndThis(
             Object obj, String property, Context cx, Scriptable scope) {
@@ -3155,11 +3177,18 @@ public class ScriptRuntime {
      * &lt;expression&gt; and make parent scope of the function available as
      * ScriptRuntime.lastStoredScriptable() for consumption as thisObj. The caller must call
      * ScriptRuntime.lastStoredScriptable() immediately after calling this method.
+     *
+     * @deprecated Use {@link #getValueAndThis(Object, Context)} instead
      */
+    @Deprecated
     public static Callable getValueFunctionAndThis(Object value, Context cx) {
         return getValueFunctionAndThisInner(value, cx, false);
     }
 
+    /**
+     * @deprecated Use {@link #getValueAndThisOptional(Object, Context)} instead
+     */
+    @Deprecated
     public static Callable getValueFunctionAndThisOptional(Object value, Context cx) {
         return getValueFunctionAndThisInner(value, cx, true);
     }
@@ -3199,6 +3228,10 @@ public class ScriptRuntime {
         return f;
     }
 
+    /**
+     * Prepare for calling &lt;expression&gt;(...): return function corresponding to
+     * &lt;expression&gt; and make parent scope of the function available in the result.
+     */
     public static LookupResult getValueAndThis(Object value, Context cx) {
         return getValueAndThisInner(value, cx, false);
     }
@@ -5866,18 +5899,21 @@ public class ScriptRuntime {
         return value;
     }
 
+    @Deprecated
     private static void storeScriptable(Context cx, Scriptable value) {
         // The previously stored scratchScriptable should be consumed
         if (cx.scratchScriptable != null) throw new IllegalStateException();
         cx.scratchScriptable = value;
     }
 
+    @Deprecated
     public static Scriptable lastStoredScriptable(Context cx) {
         Scriptable result = cx.scratchScriptable;
         cx.scratchScriptable = null;
         return result;
     }
 
+    @Deprecated
     public static void discardLastStoredScriptable(Context cx) {
         if (cx.scratchScriptable == null) throw new IllegalStateException();
         cx.scratchScriptable = null;
@@ -6040,6 +6076,14 @@ public class ScriptRuntime {
                 throw notFunctionError(result, name);
             }
             return (Callable) result;
+        }
+
+        /**
+         * A convenience method to coerce the result to a Callable as in "getCallable()", then call
+         * the result with ths stored "this".
+         */
+        public Object call(Context cx, Scriptable scope, Object[] args) {
+            return getCallable().call(cx, scope, thisObj, args);
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -61,7 +61,8 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     /** Implement name(args) call shrinking optimizer code. */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
+    @SuppressWarnings("removal")
     public static Object callName(Object[] args, String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
@@ -69,14 +70,16 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     /** Implement name() call shrinking optimizer code. */
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
+    @SuppressWarnings("removal")
     public static Object callName0(String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
+    @SuppressWarnings("removal")
     public static Object callName0Optional(String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThisOptional(name, cx, scope);
         if (f == null) {
@@ -86,7 +89,8 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
+    @SuppressWarnings("removal")
     /** Implement x.property() call shrinking optimizer code. */
     public static Object callProp0(Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
@@ -94,7 +98,8 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
-    @Deprecated
+    @Deprecated(since = "1.8.1", forRemoval = true)
+    @SuppressWarnings("removal")
     public static Object callProp0Optional(
             Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThisOptional(value, property, cx, scope);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -61,6 +61,7 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     /** Implement name(args) call shrinking optimizer code. */
+    @Deprecated
     public static Object callName(Object[] args, String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
@@ -68,12 +69,14 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     /** Implement name() call shrinking optimizer code. */
+    @Deprecated
     public static Object callName0(String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
+    @Deprecated
     public static Object callName0Optional(String name, Context cx, Scriptable scope) {
         Callable f = getNameFunctionAndThisOptional(name, cx, scope);
         if (f == null) {
@@ -83,6 +86,7 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
+    @Deprecated
     /** Implement x.property() call shrinking optimizer code. */
     public static Object callProp0(Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
@@ -90,6 +94,7 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
+    @Deprecated
     public static Object callProp0Optional(
             Object value, String property, Context cx, Scriptable scope) {
         Callable f = getPropFunctionAndThisOptional(value, property, cx, scope);

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -527,9 +527,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     private Object getElemForToString(Context cx, Scriptable scope, int index, boolean useLocale) {
         var elem = js_get(index);
         if (useLocale) {
-            Callable fun = ScriptRuntime.getPropFunctionAndThis(elem, "toLocaleString", cx, scope);
-            Scriptable funThis = ScriptRuntime.lastStoredScriptable(cx);
-            return fun.call(cx, scope, funThis, ScriptRuntime.emptyArgs);
+            var toLocaleString = ScriptRuntime.getPropAndThis(elem, "toLocaleString", cx, scope);
+            return toLocaleString.call(cx, scope, ScriptRuntime.emptyArgs);
         } else {
             return elem;
         }


### PR DESCRIPTION
Replace usages of all the old "getXFunctionAndThis" functions with the newer functions that return a LookupResult. This keeps us consistent with the rest of the runtime. All of the old functions are deprecated and could be removed if we can be sure that they're no longer used outside this project.