### PR TITLE
Speed up bitwise/arithmetic ops

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -346,18 +346,18 @@ public class ScriptRuntime {
     }
 
     public static Boolean wrapBoolean(boolean b) {
-        return Boolean.valueOf(b);
+        return b;
     }
 
     public static Integer wrapInt(int i) {
-        return Integer.valueOf(i);
+        return i;
     }
 
     public static Number wrapNumber(double x) {
         if (Double.isNaN(x)) {
             return ScriptRuntime.NaNobj;
         }
-        return Double.valueOf(x);
+        return x;
     }
 
     /**
@@ -3759,6 +3759,10 @@ public class ScriptRuntime {
         }
     }
 
+    public static double bitwiseAND(double val1, double val2) {
+        return (double) (toInt32(val1) & toInt32(val2));
+    }
+
     public static Number bitwiseAND(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).and((BigInteger) val2);
@@ -3770,6 +3774,10 @@ public class ScriptRuntime {
             int result = toInt32(val1.doubleValue()) & toInt32(val2.doubleValue());
             return Double.valueOf(result);
         }
+    }
+
+    public static double bitwiseOR(double val1, double val2) {
+        return (double) (toInt32(val1) | toInt32(val2));
     }
 
     public static Number bitwiseOR(Number val1, Number val2) {
@@ -3785,6 +3793,10 @@ public class ScriptRuntime {
         }
     }
 
+    public static double bitwiseXOR(double val1, double val2) {
+        return (double) (toInt32(val1) ^ toInt32(val2));
+    }
+
     public static Number bitwiseXOR(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).xor((BigInteger) val2);
@@ -3796,6 +3808,10 @@ public class ScriptRuntime {
             int result = toInt32(val1.doubleValue()) ^ toInt32(val2.doubleValue());
             return Double.valueOf(result);
         }
+    }
+
+    public static double leftShift(double val1, double val2) {
+        return (double) (toInt32(val1) << toInt32(val2));
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
@@ -3818,6 +3834,10 @@ public class ScriptRuntime {
         }
     }
 
+    public static double signedRightShift(double val1, double val2) {
+        return (double) (toInt32(val1) >> toInt32(val2));
+    }
+
     @SuppressWarnings("AndroidJdkLibsChecker")
     public static Number signedRightShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
@@ -3836,6 +3856,10 @@ public class ScriptRuntime {
             int result = toInt32(val1.doubleValue()) >> toInt32(val2.doubleValue());
             return Double.valueOf(result);
         }
+    }
+
+    public static double bitwiseNot(double val) {
+        return (double) ~toInt32(val);
     }
 
     public static Number bitwiseNOT(Number val) {
@@ -4637,7 +4661,7 @@ public class ScriptRuntime {
         }
     }
 
-    private static boolean compareTo(double d1, double d2, int op) {
+    static boolean compareTo(double d1, double d2, int op) {
         switch (op) {
             case Token.GE:
                 return d1 >= d2;


### PR DESCRIPTION
Extracted from `aardvark179/rhino/aardvark179-interpreter-stack-structure`

Gains in the V8Benchmarks,

```
Benchmark                                                    (interpreted)  Mode  Cnt       Score      Error  Units
V8Benchmark.cryptoDecrypt                                            false  avgt    5   36304.939 ±  1802.689  us/op
V8Benchmark.cryptoDecrypt                                             true  avgt    5  354004.807 ±  2369.907  us/op
V8Benchmark.cryptoEncrpyt                                            false  avgt    5    2076.825 ±    13.929  us/op
V8Benchmark.cryptoEncrpyt                                             true  avgt    5   22290.675 ±   193.434  us/op
 ```
 
 vs (in master)
 
```
Benchmark                                                    (interpreted)  Mode  Cnt       Score      Error  Units
V8Benchmark.cryptoDecrypt                                            false  avgt    5   35144.445 ±  260.885  us/op
V8Benchmark.cryptoDecrypt                                             true  avgt    5  638266.915 ± 5330.412  us/op
V8Benchmark.cryptoEncrpyt                                            false  avgt    5    2091.919 ±   41.633  us/op
V8Benchmark.cryptoEncrpyt                                             true  avgt    5   32958.706 ±  731.946  us/op
```