### PR TITLE
Added some micro-benchmarks on object literals creation

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
@@ -129,4 +129,42 @@ public class ObjectBenchmark {
         delete.call(
                 state.cx, state.scope, null, new Object[] {count, o, state.strings, state.ints});
     }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    @SuppressWarnings("unused")
+    public void objectLiteralEmpty(FieldTestState state) {
+        Function create =
+                (Function) ScriptableObject.getProperty(state.scope, "objectLiteralEmpty");
+        create.call(state.cx, state.scope, null, new Object[] {count});
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    @SuppressWarnings("unused")
+    public void objectLiteralSimple(FieldTestState state) {
+        Function create =
+                (Function) ScriptableObject.getProperty(state.scope, "objectLiteralSimple");
+        create.call(state.cx, state.scope, null, new Object[] {count});
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    @SuppressWarnings("unused")
+    public void objectLiteralComputedProperties(FieldTestState state) {
+        Function create =
+                (Function)
+                        ScriptableObject.getProperty(
+                                state.scope, "objectLiteralComputedProperties");
+        create.call(state.cx, state.scope, null, new Object[] {count});
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    @SuppressWarnings("unused")
+    public void objectLiteralGetterSetter(FieldTestState state) {
+        Function create =
+                (Function) ScriptableObject.getProperty(state.scope, "objectLiteralGetterSetter");
+        create.call(state.cx, state.scope, null, new Object[] {count});
+    }
 }

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ObjectBenchmark.java
@@ -167,4 +167,12 @@ public class ObjectBenchmark {
                 (Function) ScriptableObject.getProperty(state.scope, "objectLiteralGetterSetter");
         create.call(state.cx, state.scope, null, new Object[] {count});
     }
+
+    @Benchmark
+    @OperationsPerInvocation(1000)
+    @SuppressWarnings("unused")
+    public void arrayLiteral(FieldTestState state) {
+        Function create = (Function) ScriptableObject.getProperty(state.scope, "arrayLiteral");
+        create.call(state.cx, state.scope, null, new Object[] {count});
+    }
 }

--- a/benchmarks/testsrc/benchmarks/caliper/fieldTests.js
+++ b/benchmarks/testsrc/benchmarks/caliper/fieldTests.js
@@ -73,3 +73,68 @@ function deleteObject(iterations, o, strings, ints) {
     }
   }
 }
+
+function objectLiteralEmpty(iterations) {
+  var o;
+  for (var ct = 0; ct < iterations; ct++) {
+    o = {};
+  }
+}
+
+function objectLiteralSimple(iterations) {
+  var o;
+  for (var ct = 0; ct < iterations; ct++) {
+    o = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+      f: 6,
+      g: 7,
+      h: 8,
+      i: 9,
+      j: 10,
+    };
+  }
+}
+
+function objectLiteralComputedProperties(iterations) {
+  function helper(s) {
+    return s;
+  }
+
+  var o;
+  for (var ct = 0; ct < iterations; ct++) {
+    o = {
+      a: 1,
+      b: 2,
+      c: 3,
+      [helper('d')]: 4,
+      e: 5,
+      f: 6,
+      g: 7,
+      h: 8,
+      i: 9,
+      [helper('j')]: 10,
+    };
+  }
+}
+
+function objectLiteralGetterSetter(iterations) {
+  function helper(s) {
+    return s;
+  }
+
+  var o;
+  for (var ct = 0; ct < iterations; ct++) {
+    o = {
+      _x: 0,
+      get x() { return this._x; },
+      set x(value) { this._x = value; },
+      next() {
+        this._x++;
+      }
+    };
+  }
+}

--- a/benchmarks/testsrc/benchmarks/caliper/fieldTests.js
+++ b/benchmarks/testsrc/benchmarks/caliper/fieldTests.js
@@ -138,3 +138,10 @@ function objectLiteralGetterSetter(iterations) {
     };
   }
 }
+
+function arrayLiteral(iterations) {
+  var a;
+  for (var ct = 0; ct < iterations; ct++) {
+    a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  }
+}


### PR DESCRIPTION
Since me and @0xe are working on implementing the spread operator for object literal (first only object literals, arrays and functions will come after), we thought it would be good to write some microbenchmarks for "normal" object literal creation, to ensure we don't introduce big regressions.

This PR simply adds a few microbenchmarks for creation of object literals.

Some numbers from my (noisy!) laptop:

```
Benchmark                                        (interpreted)  Mode  Cnt    Score     Error  Units
ObjectBenchmark.arrayLiteral                             false  avgt    5    0.016 ±  0.001  us/op
ObjectBenchmark.arrayLiteral                              true  avgt    5    0.163 ±  0.002  us/op
ObjectBenchmark.objectLiteralComputedProperties          false  avgt    5    0.343 ±  0.008  us/op
ObjectBenchmark.objectLiteralComputedProperties           true  avgt    5    0.781 ±  0.037  us/op
ObjectBenchmark.objectLiteralEmpty                       false  avgt    5    0.008 ±  0.001  us/op
ObjectBenchmark.objectLiteralEmpty                        true  avgt    5    0.076 ±  0.003  us/op
ObjectBenchmark.objectLiteralGetterSetter                false  avgt    5    0.466 ±  0.013  us/op
ObjectBenchmark.objectLiteralGetterSetter                 true  avgt    5    0.612 ±  0.037  us/op
ObjectBenchmark.objectLiteralSimple                      false  avgt    5    0.262 ±  0.017  us/op
ObjectBenchmark.objectLiteralSimple                       true  avgt    5    0.441 ±  0.065  us/op
```

