### PR TITLE
Fix deadlock when promoting to `ThreadSafeHashSlotMap`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -131,7 +131,7 @@ public class EmbeddedSlotMap implements SlotMap {
         // Check if the table is not too full before inserting.
         if (4 * (count + 1) > 3 * slots.length) {
             // table size must be a power of 2 -- always grow by x2!
-            if (count > SlotMapOwner.LARGE_HASH_SIZE) {
+            if (slots.length * 2 > SlotMapOwner.LARGE_HASH_SIZE) {
                 promoteMap(owner, newSlot);
                 return;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -131,7 +131,7 @@ public class EmbeddedSlotMap implements SlotMap {
         // Check if the table is not too full before inserting.
         if (4 * (count + 1) > 3 * slots.length) {
             // table size must be a power of 2 -- always grow by x2!
-            if (slots.length * 2 > SlotMapOwner.LARGE_HASH_SIZE) {
+            if (count >= SlotMapOwner.LARGE_HASH_SIZE) {
                 promoteMap(owner, newSlot);
                 return;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -10,7 +10,12 @@ import java.util.Objects;
 public abstract class SlotMapOwner {
     private static final long serialVersionUID = 1L;
 
-    static final int LARGE_HASH_SIZE = 2000;
+    /**
+     * Maximum size of an {@link EmbeddedSlotMap} before it is promoted to a {@link HashSlotMap}.
+     * The value must be 3/4 of a power of two, because the embedded slot map's slot size must be a
+     * power of two, and it is resized when it is 3/4 full.
+     */
+    static final int LARGE_HASH_SIZE = (1 << 10) + (1 << 9);
 
     static final SlotMap EMPTY_SLOT_MAP = new EmptySlotMap();
 

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
@@ -34,7 +34,7 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
 
     @Override
     public int dirtySize() {
-        assert lock.isReadLocked();
+        assert lock.isReadLocked() || lock.isWriteLocked();
         return current.sizeWithLock();
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
@@ -26,11 +26,7 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     public ThreadSafeHashSlotMap(StampedLock lock, SlotMap oldMap, Slot newSlot) {
-        super(
-                1
-                        + ((oldMap instanceof LockAwareSlotMap)
-                                ? ((LockAwareSlotMap) oldMap).sizeWithLock()
-                                : oldMap.size()));
+        super(oldMap.dirtySize() + 1);
         this.lock = lock;
         for (Slot n : oldMap) {
             addWithLock(null, n.copySlot());
@@ -56,7 +52,7 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
 
     @Override
     public int dirtySize() {
-        assert lock.isReadLocked();
+        assert lock.isReadLocked() || lock.isWriteLocked();
         return super.size();
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
@@ -26,7 +26,11 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     public ThreadSafeHashSlotMap(StampedLock lock, SlotMap oldMap, Slot newSlot) {
-        super(oldMap.size() + 1);
+        super(
+                1
+                        + ((oldMap instanceof LockAwareSlotMap)
+                                ? ((LockAwareSlotMap) oldMap).sizeWithLock()
+                                : oldMap.size()));
         this.lock = lock;
         for (Slot n : oldMap) {
             addWithLock(null, n.copySlot());

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
@@ -48,7 +48,7 @@ class SlotMapPromotionTest {
     public void promotionFromThreadSafeEmbeddedToHash() {
         assertPromotes(
                 () -> {
-                    var map = new ThreadSafeEmbeddedSlotMap(SlotMapOwner.LARGE_HASH_SIZE);
+                    var map = new ThreadSafeEmbeddedSlotMap();
                     fillToCapacity(SlotMapOwner.LARGE_HASH_SIZE, map);
                     return map;
                 },
@@ -56,11 +56,7 @@ class SlotMapPromotionTest {
     }
 
     private static void fillToCapacity(int size, EmbeddedSlotMap map) {
-        // The EmbeddedSlotMap will promote once it's 3/4s full. It also
-        // is always sized to a power of two.
-        int b = Integer.highestOneBit(size);
-        int nextPowerOfTwo = b << (size > b ? 1 : 0);
-        for (int i = 0; i < nextPowerOfTwo / 4 * 3; ++i) {
+        for (int i = 0; i < size; ++i) {
             map.add(null, new Slot(Integer.toString(i), i, 0));
         }
     }

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
@@ -69,7 +69,7 @@ class SlotMapPromotionTest {
         ScriptableObject obj = new TestScriptableObject();
         obj.setMap(slotMapSupplier.get());
 
-        // add one more slot to ensure the promotion
+        // Add one more slot to ensure the promotion
         obj.put("xxx", obj, "one more property");
 
         assertEquals(expectedClass, obj.getMap().getClass());

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
-import org.mozilla.javascript.testutils.Utils;
 
 /** Ensures that slot map promotion */
 class SlotMapPromotionTest {
@@ -33,7 +32,9 @@ class SlotMapPromotionTest {
 
     @Test
     public void promotionFromThreadSafeEmptyToSingleSlot() {
-        assertPromotes(() -> SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP, SlotMapOwner.ThreadSafeSingleEntrySlotMap.class);
+        assertPromotes(
+                () -> SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP,
+                SlotMapOwner.ThreadSafeSingleEntrySlotMap.class);
     }
 
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
@@ -1,0 +1,34 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/** Ensures that slot map promotion */
+class SlotMapPromotionTest {
+    @Test
+    void nonThreadSafe() {
+        assertCanPutAndGetManyPropertiesInAnObject();
+    }
+
+    @Test
+    void threadSafe() {
+        ContextFactory contextFactory =
+                Utils.contextFactoryWithFeatures(Context.FEATURE_THREAD_SAFE_OBJECTS);
+        try (Context unused = contextFactory.enterContext()) {
+            assertCanPutAndGetManyPropertiesInAnObject();
+        }
+    }
+
+    private void assertCanPutAndGetManyPropertiesInAnObject() {
+        NativeObject o = new NativeObject();
+        int a_LARGE_SIZE = SlotMapOwner.LARGE_HASH_SIZE * 2;
+        for (int i = 0; i < a_LARGE_SIZE; ++i) {
+            o.put(String.valueOf(i), o, i);
+        }
+        for (int i = 0; i < a_LARGE_SIZE; ++i) {
+            assertEquals(i, o.get(i, o));
+        }
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
@@ -2,33 +2,82 @@ package org.mozilla.javascript;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.testutils.Utils;
 
 /** Ensures that slot map promotion */
 class SlotMapPromotionTest {
     @Test
-    void nonThreadSafe() {
-        assertCanPutAndGetManyPropertiesInAnObject();
+    public void promotionFromEmptyToSingleSlot() {
+        assertPromotes(() -> SlotMapOwner.EMPTY_SLOT_MAP, SlotMapOwner.SingleEntrySlotMap.class);
     }
 
     @Test
-    void threadSafe() {
-        ContextFactory contextFactory =
-                Utils.contextFactoryWithFeatures(Context.FEATURE_THREAD_SAFE_OBJECTS);
-        try (Context unused = contextFactory.enterContext()) {
-            assertCanPutAndGetManyPropertiesInAnObject();
+    public void promotionFromSingleToEmbedded() {
+        assertPromotes(
+                () -> new SlotMapOwner.SingleEntrySlotMap(new Slot(new Object(), 0, 0)),
+                EmbeddedSlotMap.class);
+    }
+
+    @Test
+    public void promotionFromEmbeddedToHash() {
+        assertPromotes(
+                () -> {
+                    var map = new EmbeddedSlotMap(SlotMapOwner.LARGE_HASH_SIZE);
+                    fillToCapacity(SlotMapOwner.LARGE_HASH_SIZE, map);
+                    return map;
+                },
+                HashSlotMap.class);
+    }
+
+    @Test
+    public void promotionFromThreadSafeEmptyToSingleSlot() {
+        assertPromotes(() -> SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP, SlotMapOwner.ThreadSafeSingleEntrySlotMap.class);
+    }
+
+    @Test
+    public void promotionFromThreadSafeSingleToEmbedded() {
+        assertPromotes(
+                () -> new SlotMapOwner.ThreadSafeSingleEntrySlotMap(new Slot(new Object(), 0, 0)),
+                ThreadSafeEmbeddedSlotMap.class);
+    }
+
+    @Test
+    public void promotionFromThreadSafeEmbeddedToHash() {
+        assertPromotes(
+                () -> {
+                    var map = new ThreadSafeEmbeddedSlotMap(SlotMapOwner.LARGE_HASH_SIZE);
+                    fillToCapacity(SlotMapOwner.LARGE_HASH_SIZE, map);
+                    return map;
+                },
+                ThreadSafeHashSlotMap.class);
+    }
+
+    private static void fillToCapacity(int size, EmbeddedSlotMap map) {
+        // The EmbeddedSlotMap will promote once it's 3/4s full. It also
+        // is always sized to a power of two.
+        int b = Integer.highestOneBit(size);
+        int nextPowerOfTwo = b << (size > b ? 1 : 0);
+        for (int i = 0; i < nextPowerOfTwo / 4 * 3; ++i) {
+            map.add(null, new Slot(Integer.toString(i), i, 0));
         }
     }
 
-    private void assertCanPutAndGetManyPropertiesInAnObject() {
-        NativeObject o = new NativeObject();
-        int a_LARGE_SIZE = SlotMapOwner.LARGE_HASH_SIZE * 2;
-        for (int i = 0; i < a_LARGE_SIZE; ++i) {
-            o.put(String.valueOf(i), o, i);
-        }
-        for (int i = 0; i < a_LARGE_SIZE; ++i) {
-            assertEquals(i, o.get(i, o));
+    private void assertPromotes(
+            Supplier<SlotMap> slotMapSupplier, Class<? extends SlotMap> expectedClass) {
+        ScriptableObject obj = new TestScriptableObject();
+        obj.setMap(slotMapSupplier.get());
+
+        // add one more slot to ensure the promotion
+        obj.put("xxx", obj, "one more property");
+
+        assertEquals(expectedClass, obj.getMap().getClass());
+    }
+
+    private static class TestScriptableObject extends ScriptableObject {
+        public String getClassName() {
+            return "foo";
         }
     }
 }


### PR DESCRIPTION
The implementation of thread-safe slot map promotion done in https://github.com/mozilla/rhino/pull/1785 has a critical bug: appending enough properties to an object created with the thread-safe slot maps will cause a promotion to `ThreadSafeHashSlotMap`, which will deadlock.

I have added a test that reproduces the problem and a fix for it.