### PR TITLE
Fixed a problem with strict flag in compiled mode

### DIFF
--- a/rhino/src/test/java/org/mozilla/javascript/tests/NestedFunctionStrictFlagTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NestedFunctionStrictFlagTest.java
@@ -1,0 +1,35 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeFunction;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.testutils.Utils;
+
+class NestedFunctionStrictFlagTest {
+    @Test
+    void functionNestedInAStrictFunctionAreStrict() {
+        String script = "(() => {\n  'use strict';\n  return function nested() {}\n})()";
+
+        Utils.runWithAllModes(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    TopLevel topLevel = new TopLevel();
+                    cx.initStandardObjects(topLevel);
+
+                    Object res = cx.evaluateString(topLevel, script, "test", 1, null);
+                    NativeFunction function = assertInstanceOf(NativeFunction.class, res);
+                    assertTrue(
+                            function.isStrict(),
+                            () ->
+                                    "should be strict in "
+                                            + (cx.isInterpretedMode() ? "interpreted" : "compiled")
+                                            + " mode");
+
+                    return null;
+                });
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1436,7 +1436,7 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 1010/1868 (54.07%)
+built-ins/RegExp 1009/1868 (54.01%)
     CharacterClassEscapes 12/12 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -1554,7 +1554,6 @@ built-ins/RegExp 1010/1868 (54.07%)
     prototype/Symbol.match/u-advance-after-empty.js
     prototype/Symbol.replace/coerce-global.js
     prototype/Symbol.replace/coerce-unicode.js
-    prototype/Symbol.replace/fn-invoke-this-strict.js compiled-strict
     prototype/Symbol.replace/get-global-err.js
     prototype/Symbol.replace/get-unicode-error.js
     prototype/Symbol.replace/named-groups.js
@@ -5300,11 +5299,9 @@ language/expressions/yield 4/63 (6.35%)
     star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 98/217 (45.16%)
+language/function-code 96/217 (44.24%)
     10.4.3-1-1-s.js non-strict
     10.4.3-1-10-s.js non-strict
-    10.4.3-1-102-s.js compiled
-    10.4.3-1-102gs.js compiled
     10.4.3-1-104.js strict
     10.4.3-1-106.js strict
     10.4.3-1-10gs.js non-strict


### PR DESCRIPTION
When a function is nested inside a strict function, we should propagate the strict flag in the nested function. This was done for interpreted functions because the strict flag is set when the function is instantiated, at run time. However, for compiled functions we need to do this correctly at compile time.

I initially set out to do this in the `CodeGenerator`, but it turned out to be _much_ easier to do during the IR generation, in `IRFactory`.

This fixed a very small number of cases in test262