### PR TITLE
Enable the V8 regexp benchmark.

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/V8Benchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/V8Benchmark.java
@@ -178,31 +178,32 @@ public class V8Benchmark {
         return state.rt.call(state.cx, state.scope, state.scope, emptyArgs);
     }
 
-    /* TODO not working right now
     @State(Scope.Thread)
     public static class RegExpState extends AbstractState {
-      Callable re;
+        Callable re;
 
-      @Setup(Level.Trial)
-      public void setUp() {
-        initialize();
-        evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/regexp.js");
-        runSetup();
-        re = getRunFunc("RegExp");
-      }
+        @Param({"false", "true"})
+        public boolean interpreted;
 
-      @TearDown(Level.Trial)
-      public void tearDown() {
-        runCleanup();
-        cleanup();
-      }
+        @Setup(Level.Trial)
+        public void setUp() {
+            initialize(interpreted);
+            evaluateSource(cx, scope, "testsrc/benchmarks/v8-benchmarks-v6/regexp.js");
+            runSetup();
+            re = getRunFunc("RegExpBench");
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            runCleanup();
+            cleanup();
+        }
     }
 
     @Benchmark
     public Object regExp(RegExpState state) {
-      return state.re.call(state.cx, state.scope, state.scope, emptyArgs);
+        return state.re.call(state.cx, state.scope, state.scope, emptyArgs);
     }
-     */
 
     @State(Scope.Thread)
     public static class RichardsState extends AbstractState {

--- a/benchmarks/testsrc/benchmarks/v8-benchmarks-v6/regexp.js
+++ b/benchmarks/testsrc/benchmarks/v8-benchmarks-v6/regexp.js
@@ -37,8 +37,8 @@
 // scrambled to exercise the regexp engine on different input strings.
 
 
-var RegExp = new BenchmarkSuite('RegExp', 910985, [
-  new Benchmark("RegExp", RegExpRun, RegExpSetup, RegExpTearDown)
+var RegExpBench = new BenchmarkSuite('RegExpBench', 910985, [
+  new Benchmark("RegExpBench", RegExpRun, RegExpSetup, RegExpTearDown)
 ]);
 
 var regExpBenchmark = null;


### PR DESCRIPTION
Since work has been going on round regex features I'd like to make sure this benchmark is available to help avoid accidental performance regressions.