### PR TITLE
Infer function names

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ArrowFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrowFunction.java
@@ -75,6 +75,14 @@ public class ArrowFunction extends BaseFunction {
     }
 
     @Override
+    public String getFunctionName() {
+        if (targetFunction instanceof BaseFunction) {
+            return ((BaseFunction) targetFunction).getFunctionName();
+        }
+        return super.getFunctionName();
+    }
+
+    @Override
     public int getArity() {
         return getLength();
     }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2389,7 +2389,7 @@ public final class IRFactory {
 
         if (left instanceof Name && right != null && right.type == Token.FUNCTION) {
             Name name = (Name) left;
-            if (name.getIdentifier().equals("__proto__")) {
+            if (name.getIdentifier().equals(NativeObject.PROTO_PROPERTY)) {
                 // Ignore weird edge case
                 return;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2391,10 +2391,7 @@ public final class IRFactory {
                 Name name = (Name) left;
 
                 if (prefix != null) {
-                    Name newName = new Name(name.getPosition(), name.getLength());
-                    newName.setIdentifier(prefix + name.getIdentifier());
-                    newName.setLineColumnNumber(name.getLineno(), name.getColumn());
-                    functionNode.setFunctionName(newName);
+                    functionNode.setFunctionName(name.withPrefix(prefix));
                 } else {
                     functionNode.setFunctionName(name);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2381,14 +2381,13 @@ public final class IRFactory {
         throw Kit.codeBug();
     }
 
-    /** Infer function name is missing on rhs. In the future, will also handle class names. */
+    /** Infer function name is missing on rhs. In the future, should also handle class names. */
     private void inferNameIfMissing(Object left, Node right, String prefix) {
         if (left instanceof Name && right != null && right.type == Token.FUNCTION) {
             var fnIndex = right.getExistingIntProp(Node.FUNCTION_PROP);
             FunctionNode functionNode = parser.currentScriptOrFn.getFunctionNode(fnIndex);
             if (functionNode.getType() != 0 && functionNode.getFunctionName() == null) {
                 Name name = (Name) left;
-
                 if (prefix != null) {
                     functionNode.setFunctionName(name.withPrefix(prefix));
                 } else {

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1470,7 +1470,6 @@ public final class IRFactory {
                 // function's name to the function value, but only if the
                 // function doesn't already define a formal parameter, var,
                 // or nested function with the same name.
-                // Note that it doesn't make sense on method shorthands!
                 fnNode.putSymbol(new Symbol(Token.FUNCTION, name.getIdentifier()));
                 Node setFn =
                         new Node(

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1223,6 +1223,15 @@ public final class IRFactory {
                 right = transform(init);
             }
 
+            // Infer function name is missing on rhs
+            if (left instanceof Name && right instanceof Name && right.type == Token.FUNCTION) {
+                var fnIndex = right.getExistingIntProp(Node.FUNCTION_PROP);
+                FunctionNode functionNode = parser.currentScriptOrFn.getFunctionNode(fnIndex);
+                if (functionNode.getType() != 0 && functionNode.getFunctionName() == null) {
+                    functionNode.setFunctionName((Name) left);
+                }
+            }
+
             if (var.isDestructuring()) {
                 if (right == null) { // TODO:  should this ever happen?
                     node.addChildToBack(left);

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2383,18 +2383,24 @@ public final class IRFactory {
 
     /** Infer function name is missing on rhs. In the future, should also handle class names. */
     private void inferNameIfMissing(Object left, Node right, String prefix) {
+        if (parser.compilerEnv.getLanguageVersion() < Context.VERSION_ES6) {
+            return;
+        }
+
         if (left instanceof Name && right != null && right.type == Token.FUNCTION) {
+            Name name = (Name) left;
+            if (name.getIdentifier().equals("__proto__")) {
+                // Ignore weird edge case
+                return;
+            }
+
             var fnIndex = right.getExistingIntProp(Node.FUNCTION_PROP);
             FunctionNode functionNode = parser.currentScriptOrFn.getFunctionNode(fnIndex);
             if (functionNode.getType() != 0 && functionNode.getFunctionName() == null) {
-                Name name = (Name) left;
                 if (prefix != null) {
                     functionNode.setFunctionName(name.withPrefix(prefix));
                 } else {
-                    // Ignore weird edge case
-                    if (!name.getIdentifier().equals("__proto__")) {
-                        functionNode.setFunctionName(name);
-                    }
+                    functionNode.setFunctionName(name);
                 }
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1224,7 +1224,7 @@ public final class IRFactory {
             }
 
             // Infer function name is missing on rhs
-            if (left instanceof Name && right instanceof Name && right.type == Token.FUNCTION) {
+            if (left instanceof Name && right != null && right.type == Token.FUNCTION) {
                 var fnIndex = right.getExistingIntProp(Node.FUNCTION_PROP);
                 FunctionNode functionNode = parser.currentScriptOrFn.getFunctionNode(fnIndex);
                 if (functionNode.getType() != 0 && functionNode.getFunctionName() == null) {

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1244,9 +1244,6 @@ public final class IRFactory {
                 right = transform(init);
             }
 
-            // Infer function name is missing on rhs
-            inferNameIfMissing(left, right, null);
-
             if (var.isDestructuring()) {
                 if (right == null) { // TODO:  should this ever happen?
                     node.addChildToBack(left);
@@ -1262,6 +1259,7 @@ public final class IRFactory {
                     }
                 }
             } else {
+                inferNameIfMissing(left, right, null);
                 if (right != null) {
                     left.addChildToBack(right);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2391,7 +2391,10 @@ public final class IRFactory {
                 if (prefix != null) {
                     functionNode.setFunctionName(name.withPrefix(prefix));
                 } else {
-                    functionNode.setFunctionName(name);
+                    // Ignore weird edge case
+                    if (!name.getIdentifier().equals("__proto__")) {
+                        functionNode.setFunctionName(name);
+                    }
                 }
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4028,17 +4028,14 @@ public class Parser {
             case GET_ENTRY:
                 pn.setIsGetterMethod();
                 fn.setFunctionIsGetterMethod();
-                createNameForMethod(fn, propName, "get ");
                 break;
             case SET_ENTRY:
                 pn.setIsSetterMethod();
                 fn.setFunctionIsSetterMethod();
-                createNameForMethod(fn, propName, "set ");
                 break;
             case METHOD_ENTRY:
                 pn.setIsNormalMethod();
                 fn.setFunctionIsNormalMethod();
-                createNameForMethod(fn, propName, "");
                 if (isGenerator) {
                     fn.setIsES6Generator();
                 }
@@ -4056,25 +4053,6 @@ public class Parser {
 
     private Name createNameNode() {
         return createNameNode(false, Token.NAME);
-    }
-
-    private void createNameForMethod(FunctionNode fn, AstNode propName, String prefix) {
-        if (propName instanceof GeneratorMethodDefinition) {
-            // Unwrap
-            propName = ((GeneratorMethodDefinition) propName).getMethodName();
-        }
-        if (propName instanceof ComputedPropertyKey) {
-            // We need to do this at runtime
-            return;
-        }
-
-        String identifier = prefix + propName.toSource();
-
-        Name name = new Name(propName.getPosition(), propName.getLength());
-        name.setIdentifier(identifier);
-        name.setType(propName.getType());
-        name.setLineColumnNumber(propName.getLineno(), propName.getColumn());
-        fn.setFunctionName(name);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4028,14 +4028,17 @@ public class Parser {
             case GET_ENTRY:
                 pn.setIsGetterMethod();
                 fn.setFunctionIsGetterMethod();
+                createNameForMethod(fn, propName, "get ");
                 break;
             case SET_ENTRY:
                 pn.setIsSetterMethod();
                 fn.setFunctionIsSetterMethod();
+                createNameForMethod(fn, propName, "set ");
                 break;
             case METHOD_ENTRY:
                 pn.setIsNormalMethod();
                 fn.setFunctionIsNormalMethod();
+                createNameForMethod(fn, propName, "");
                 if (isGenerator) {
                     fn.setIsES6Generator();
                 }
@@ -4053,6 +4056,25 @@ public class Parser {
 
     private Name createNameNode() {
         return createNameNode(false, Token.NAME);
+    }
+
+    private void createNameForMethod(FunctionNode fn, AstNode propName, String prefix) {
+        if (propName instanceof GeneratorMethodDefinition) {
+            // Unwrap
+            propName = ((GeneratorMethodDefinition) propName).getMethodName();
+        }
+        if (propName instanceof ComputedPropertyKey) {
+            // We need to do this at runtime
+            return;
+        }
+
+        String identifier = prefix + propName.toSource();
+
+        Name name = new Name(propName.getPosition(), propName.getLength());
+        name.setIdentifier(identifier);
+        name.setType(propName.getType());
+        name.setLineColumnNumber(propName.getLineno(), propName.getColumn());
+        fn.setFunctionName(name);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/ast/Name.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/Name.java
@@ -137,6 +137,12 @@ public class Name extends AstNode {
         return makeIndent(depth) + (identifier == null ? "<null>" : identifier);
     }
 
+    public Name withPrefix(String prefix) {
+        Name clone = new Name(this.getPosition(), this.getLength(), prefix + this.identifier);
+        clone.setLineColumnNumber(this.getLineno(), this.getColumn());
+        return clone;
+    }
+
     /** Visits this node. There are no children to visit. */
     @Override
     public void visit(NodeVisitor v) {

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionPrototypeSymbolHasInstanceTest.java
@@ -145,7 +145,7 @@ public class FunctionPrototypeSymbolHasInstanceTest {
                         + "f.prototype = Symbol(); \n"
                         + "f[Symbol.hasInstance]({})";
         Utils.assertEcmaErrorES6(
-                "TypeError: 'prototype' property of '' is not an object. (test#3)", script);
+                "TypeError: 'prototype' property of 'f' is not an object. (test#3)", script);
     }
 
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
@@ -77,8 +77,8 @@ public class GeneratedMethodNameTest {
                 "var myFunc = function() {\n"
                         + " var m = javaNameGetter.readCurrentFunctionJavaName();\n"
                         + "  if (m != 'myFunc') throw 'got '  + m;"
-                        + "}\n" +
-                        "myFunc();";
+                        + "}\n"
+                        + "myFunc();";
         doTest(scriptCode);
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
@@ -64,11 +64,21 @@ public class GeneratedMethodNameTest {
     @Test
     public void anonymousFunction() throws Exception {
         final String scriptCode =
-                "var myFunc = function() {\n"
+                "(function() {\n"
                         + " var m = javaNameGetter.readCurrentFunctionJavaName();\n"
                         + "  if (m != 'anonymous') throw 'got '  + m;"
-                        + "}\n"
-                        + "myFunc();";
+                        + "})();";
+        doTest(scriptCode);
+    }
+
+    @Test
+    public void anonymousFunctionAssignedToVariable() throws Exception {
+        final String scriptCode =
+                "var myFunc = function() {\n"
+                        + " var m = javaNameGetter.readCurrentFunctionJavaName();\n"
+                        + "  if (m != 'myFunc') throw 'got '  + m;"
+                        + "}\n" +
+                        "myFunc();";
         doTest(scriptCode);
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -21,7 +21,7 @@ class FunctionNameTest {
 
     @Test
     void letEqualsArrowFunction() {
-        Utils.assertWithAllModes_ES6("f", "var f = () => {}; f.name");
+        Utils.assertWithAllModes_ES6("f", "let f = () => {}; f.name");
     }
 
     @Test
@@ -31,6 +31,6 @@ class FunctionNameTest {
 
     @Test
     void constEqualsArrowFunction() {
-        Utils.assertWithAllModes_ES6("f", "var f = () => {}; f.name");
+        Utils.assertWithAllModes_ES6("f", "const f = () => {}; f.name");
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -35,6 +35,11 @@ class FunctionNameTest {
     }
 
     @Test
+    void nonAnonymousFunctionsDontGetOverriddenInDeclaration() {
+        Utils.assertWithAllModes_ES6("g", "var f = function g() {}; f.name");
+    }
+
+    @Test
     void assignmentVarFunction() {
         Utils.assertWithAllModes_ES6("f", "var f; f = function(){}; f.name");
     }
@@ -57,5 +62,10 @@ class FunctionNameTest {
     @Test
     void assignmentShouldNotInferIfParenthesized() {
         Utils.assertWithAllModes_ES6("", "var f; (f) = function(){}; f.name");
+    }
+
+    @Test
+    void nonAnonymousFunctionsDontGetOverriddenInAssignment() {
+        Utils.assertWithAllModes_ES6("g", "var f; f = function g() {}; f.name");
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -86,47 +86,47 @@ class FunctionNameTest {
 
     @Test
     void propertyArrow() {
-        Utils.assertWithAllModes_ES6("x", "({x: () => {}}).x.name");
+        Utils.assertWithAllModes_ES6("x", "o = { x: () => {} }; o.x.name");
     }
 
     @Test
     void method() {
-        Utils.assertWithAllModes_ES6("x", "({x() {}}).x.name");
+        Utils.assertWithAllModes_ES6("x", "o = { x() {} }; o.x.name");
     }
 
     @Test
     void methodNumericLiteral() {
-        Utils.assertWithAllModes_ES6("1", "({1() {}})['1'].name");
+        Utils.assertWithAllModes_ES6("1", "o = { 1() {} }; o['1'].name");
     }
 
     @Test
     void methodBooleanLiteral() {
-        Utils.assertWithAllModes_ES6("false", "({false() {}})['false'].name");
+        Utils.assertWithAllModes_ES6("false", "o = { false() {} }; o['false'].name");
     }
 
     @Test
     void methodComputedProperty() {
         // TODO: this is not working at the moment, because it cannot be done statically
         //  but needs to be done at runtime
-        Utils.assertWithAllModes_ES6("", "({ [1 + 2]() {}})['3'].name");
+        Utils.assertWithAllModes_ES6("", "o = { [1 + 2]() {} }; o['3'].name");
     }
 
     @Test
     void methodGenerators() {
-        Utils.assertWithAllModes_ES6("x", "({*x() {}}).x.name");
+        Utils.assertWithAllModes_ES6("x", "o = { *x() {} }; o.x.name");
     }
 
     @Test
     void getter() {
         Utils.assertWithAllModes_ES6(
                 "get x",
-                "var o = {get x(){}}; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.get.name");
+                "var o = { get x(){} }; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.get.name");
     }
 
     @Test
     void setter() {
         Utils.assertWithAllModes_ES6(
                 "set x",
-                "var o = {set x(v){}}; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.set.name");
+                "var o = { set x(v){} }; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.set.name");
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -1,0 +1,36 @@
+package org.mozilla.javascript.tests.es6;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+class FunctionNameTest {
+    @Test
+    void varEqualsFunction() {
+        Utils.assertWithAllModes_ES6("f", "var f = function() {}; f.name");
+    }
+
+    @Test
+    void varEqualsArrowFunction() {
+        Utils.assertWithAllModes_ES6("f", "var f = () => {}; f.name");
+    }
+
+    @Test
+    void letEqualsFunction() {
+        Utils.assertWithAllModes_ES6("f", "let f = function() {}; f.name");
+    }
+
+    @Test
+    void letEqualsArrowFunction() {
+        Utils.assertWithAllModes_ES6("f", "var f = () => {}; f.name");
+    }
+
+    @Test
+    void constEqualsFunction() {
+        Utils.assertWithAllModes_ES6("f", "const f = function() {}; f.name");
+    }
+
+    @Test
+    void constEqualsArrowFunction() {
+        Utils.assertWithAllModes_ES6("f", "var f = () => {}; f.name");
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -68,4 +68,9 @@ class FunctionNameTest {
     void nonAnonymousFunctionsDontGetOverriddenInAssignment() {
         Utils.assertWithAllModes_ES6("g", "var f; f = function g() {}; f.name");
     }
+
+    @Test
+    void reassignDoesntOverride() {
+        Utils.assertWithAllModes_ES6("f", "var f; f = function() {}; g = f; g.name");
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -73,4 +73,55 @@ class FunctionNameTest {
     void reassignDoesntOverride() {
         Utils.assertWithAllModes_ES6("f", "var f; f = function() {}; g = f; g.name");
     }
+
+    @Test
+    void propertyFunction() {
+        Utils.assertWithAllModes_ES6("x", "o = { x: function(){} }; o.x.name");
+    }
+
+    @Test
+    void propertyArrow() {
+        Utils.assertWithAllModes_ES6("x", "({x: () => {}}).x.name");
+    }
+
+    @Test
+    void method() {
+        Utils.assertWithAllModes_ES6("x", "({x() {}}).x.name");
+    }
+
+    @Test
+    void methodNumericLiteral() {
+        Utils.assertWithAllModes_ES6("1", "({1() {}})['1'].name");
+    }
+
+    @Test
+    void methodBooleanLiteral() {
+        Utils.assertWithAllModes_ES6("false", "({false() {}})['false'].name");
+    }
+
+    @Test
+    void methodComputedProperty() {
+        // TODO: this is not working at the moment, because it cannot be done statically
+        //  but needs to be done at runtime
+        Utils.assertWithAllModes_ES6("", "({ [1 + 2]() {}})['3'].name");
+    }
+
+    @Test
+    void methodGenerators() {
+        Utils.assertWithAllModes_ES6("x", "({*x() {}}).x.name");
+    }
+
+    @Test
+    void getter() {
+        Utils.assertWithAllModes_ES6(
+                "get x",
+                "var o = {get x(){}}; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.get.name");
+    }
+
+    @Test
+    void setter() {
+        Utils.assertWithAllModes_ES6(
+                "set x",
+                "var o = {set x(v){}}; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.set.name");
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -33,4 +33,29 @@ class FunctionNameTest {
     void constEqualsArrowFunction() {
         Utils.assertWithAllModes_ES6("f", "const f = () => {}; f.name");
     }
+
+    @Test
+    void assignmentVarFunction() {
+        Utils.assertWithAllModes_ES6("f", "var f; f = function(){}; f.name");
+    }
+
+    @Test
+    void assignmentVarArrow() {
+        Utils.assertWithAllModes_ES6("f", "var f; f = () => {}; f.name");
+    }
+
+    @Test
+    void assignmentLetFunction() {
+        Utils.assertWithAllModes_ES6("f", "let f; f = function(){}; f.name");
+    }
+
+    @Test
+    void assignmentLetArrow() {
+        Utils.assertWithAllModes_ES6("f", "let f; f = () => {}; f.name");
+    }
+
+    @Test
+    void assignmentShouldNotInferIfParenthesized() {
+        Utils.assertWithAllModes_ES6("", "var f; (f) = function(){}; f.name");
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -129,4 +129,14 @@ class FunctionNameTest {
                 "set x",
                 "var o = { set x(v){} }; var desc = Object.getOwnPropertyDescriptor(o, \"x\"); desc.set.name");
     }
+
+    @Test
+    void protoIsASpecialName() {
+        Utils.assertWithAllModes_ES6("", "var o = { __proto__() {} }; o.__proto__.name");
+    }
+
+    @Test
+    void inferenceIsNotUsedInEs5() {
+        Utils.assertWithAllModes_1_8("", "var f = function() {}; f.name");
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -75,6 +75,11 @@ class FunctionNameTest {
     }
 
     @Test
+    void declarationMixedWithAssignment() {
+        Utils.assertWithAllModes_ES6("g", "var f = g = () => {}; f.name");
+    }
+
+    @Test
     void propertyFunction() {
         Utils.assertWithAllModes_ES6("x", "o = { x: function(){} }; o.x.name");
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ProtoProperty2Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ProtoProperty2Test.java
@@ -1224,10 +1224,8 @@ public class ProtoProperty2Test {
                 "false / false / undefined / undefined /  # truetrue / new", script);
         Utils.assertWithAllModes_1_8(
                 "false / false / undefined / undefined /  # truetrue / new", script);
-        // Utils.assertWithAllModes_ES6("true / false / undefined / get __proto__ / set # truetrue /
-        // new", script);
         Utils.assertWithAllModes_ES6(
-                "true / false / undefined / get __proto__ /  # truetrue / new", script);
+                "true / false / undefined / get __proto__ / set # truetrue / new", script);
     }
 
     @Test

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4416,7 +4416,7 @@ language/expressions/new 41/59 (69.49%)
 
 ~language/expressions/new.target
 
-language/expressions/object 715/1170 (61.11%)
+language/expressions/object 713/1170 (60.94%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -5021,7 +5021,6 @@ language/expressions/object 715/1170 (61.11%)
     method-definition/gen-yield-spread-obj.js
     method-definition/generator-invoke-fn-strict.js non-strict
     method-definition/generator-length-dflt.js
-    method-definition/generator-name-prop-string.js
     method-definition/generator-name-prop-symbol.js
     method-definition/generator-param-init-yield.js non-strict
     method-definition/generator-param-redecl-let.js
@@ -5039,7 +5038,6 @@ language/expressions/object 715/1170 (61.11%)
     method-definition/meth-rest-param-strict-body.js
     method-definition/name-invoke-fn-strict.js non-strict
     method-definition/name-length-dflt.js
-    method-definition/name-name-prop-string.js
     method-definition/name-name-prop-symbol.js
     method-definition/name-param-id-yield.js non-strict
     method-definition/name-param-init-yield.js non-strict

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4091,7 +4091,7 @@ language/expressions/function 149/264 (56.44%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators 183/290 (63.1%)
+language/expressions/generators 182/290 (62.76%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4237,7 +4237,6 @@ language/expressions/generators 183/290 (63.1%)
     eval-body-proto-realm.js
     eval-var-scope-syntax-err.js non-strict
     has-instance.js
-    implicit-name.js
     invoke-as-constructor.js
     length-dflt.js
     named-no-strict-reassign-fn-name-in-body.js non-strict
@@ -5672,7 +5671,7 @@ language/statements/break 0/20 (0.0%)
 
 ~language/statements/class
 
-language/statements/const 91/136 (66.91%)
+language/statements/const 87/136 (63.97%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5752,11 +5751,7 @@ language/statements/const 91/136 (66.91%)
     block-local-closure-get-before-initialization.js
     block-local-use-before-initialization-in-declaration-statement.js
     block-local-use-before-initialization-in-prior-statement.js
-    fn-name-arrow.js
     fn-name-class.js {unsupported: [class]}
-    fn-name-cover.js
-    fn-name-fn.js
-    fn-name-gen.js
     function-local-closure-get-before-initialization.js
     function-local-use-before-initialization-in-declaration-statement.js
     function-local-use-before-initialization-in-prior-statement.js
@@ -6893,7 +6888,7 @@ language/statements/labeled 15/24 (62.5%)
     value-yield-non-strict.js non-strict
     value-yield-non-strict-escaped.js non-strict
 
-language/statements/let 84/145 (57.93%)
+language/statements/let 80/145 (55.17%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6964,11 +6959,7 @@ language/statements/let 84/145 (57.93%)
     block-local-closure-set-before-initialization.js
     block-local-use-before-initialization-in-declaration-statement.js
     block-local-use-before-initialization-in-prior-statement.js
-    fn-name-arrow.js
     fn-name-class.js {unsupported: [class]}
-    fn-name-cover.js
-    fn-name-fn.js
-    fn-name-gen.js
     function-local-closure-get-before-initialization.js
     function-local-closure-set-before-initialization.js
     function-local-use-before-initialization-in-declaration-statement.js
@@ -7163,7 +7154,7 @@ language/statements/try 113/201 (56.22%)
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable 66/178 (37.08%)
+language/statements/variable 62/178 (34.83%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7224,11 +7215,7 @@ language/statements/variable 66/178 (37.08%)
     12.2.1-20-s.js strict
     12.2.1-21-s.js strict
     12.2.1-9-s.js strict
-    fn-name-arrow.js
     fn-name-class.js {unsupported: [class]}
-    fn-name-cover.js
-    fn-name-fn.js
-    fn-name-gen.js
     static-init-await-binding-valid.js
 
 language/statements/while 13/38 (34.21%)

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -3481,7 +3481,7 @@ language/expressions/arrow-function 151/343 (44.02%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/assignment 186/481 (38.67%)
+language/expressions/assignment 182/481 (37.84%)
     destructuring 4/4 (100.0%)
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -3655,11 +3655,7 @@ language/expressions/assignment 186/481 (38.67%)
     11.13.1-2-s.js strict
     assignment-operator-calls-putvalue-lref--rval-.js non-strict
     assignment-operator-calls-putvalue-lref--rval--1.js non-strict
-    fn-name-arrow.js
     fn-name-class.js {unsupported: [class]}
-    fn-name-cover.js
-    fn-name-fn.js
-    fn-name-gen.js
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
     target-super-computed-reference.js
@@ -4322,7 +4318,7 @@ language/expressions/less-than-or-equal 0/47 (0.0%)
 language/expressions/logical-and 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/logical-assignment 46/78 (58.97%)
+language/expressions/logical-assignment 40/78 (51.28%)
     left-hand-side-private-reference-accessor-property-and.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-nullish.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-or.js {unsupported: [class-fields-private]}
@@ -4346,26 +4342,20 @@ language/expressions/logical-assignment 46/78 (58.97%)
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
     lgcl-and-arguments-strict.js strict
     lgcl-and-assignment-operator-lhs-before-rhs.js
-    lgcl-and-assignment-operator-namedevaluation-arrow-function.js
     lgcl-and-assignment-operator-namedevaluation-class-expression.js
-    lgcl-and-assignment-operator-namedevaluation-function.js
     lgcl-and-assignment-operator-no-set-put.js strict
     lgcl-and-assignment-operator-non-extensible.js strict
     lgcl-and-assignment-operator-non-simple-lhs.js
     lgcl-and-assignment-operator-non-writeable.js strict
     lgcl-nullish-arguments-strict.js strict
     lgcl-nullish-assignment-operator-lhs-before-rhs.js
-    lgcl-nullish-assignment-operator-namedevaluation-arrow-function.js
     lgcl-nullish-assignment-operator-namedevaluation-class-expression.js
-    lgcl-nullish-assignment-operator-namedevaluation-function.js
     lgcl-nullish-assignment-operator-no-set-put.js strict
     lgcl-nullish-assignment-operator-non-simple-lhs.js
     lgcl-nullish-assignment-operator-non-writeable.js strict
     lgcl-or-arguments-strict.js strict
     lgcl-or-assignment-operator-lhs-before-rhs.js
-    lgcl-or-assignment-operator-namedevaluation-arrow-function.js
     lgcl-or-assignment-operator-namedevaluation-class-expression.js
-    lgcl-or-assignment-operator-namedevaluation-function.js
     lgcl-or-assignment-operator-no-set-put.js strict
     lgcl-or-assignment-operator-non-simple-lhs.js
     lgcl-or-assignment-operator-non-writeable.js strict


### PR DESCRIPTION
This PR solves most of the problems highlighted in https://github.com/mozilla/rhino/issues/1297 about function name inference, i.e. all of these now work:

```js
var f = function() {}; f.name  // f
var f; f = () => {}; f.name  // f
o = { x: function(){} }; o.x.name  // x
o = { x() {} }; o.x.name  // x
var o = { get x(){} }; var desc = Object.getOwnPropertyDescriptor(o, "x"); desc.get.name  // get x
var o = { set x(v){} }; var desc = Object.getOwnPropertyDescriptor(o, "x"); desc.set.name  // set x
```

Note that this PR implements name inference only _statically_, i.e. when the name can be known at parse times. The ES6 spec says that name inference should happen also for computed properties, at runtime, but this PR does not implement that:

```js
function f() { return 'f'; }
o = { [f()]() {} }
o.f.name // spec says should be 'f' but Rhino says it's empty string
```

Please squash if accepted :)