### PR TITLE
Replace `addScriptRuntimeInvoke("string-literal")` with method info computed at runtime

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.optimizer.ScriptRuntimeMethodSig.*;
+
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
@@ -349,6 +351,7 @@ public class ScriptRuntime {
         return Boolean.valueOf(b);
     }
 
+    @CodeGenMarker(wrapInt)
     public static Integer wrapInt(int i) {
         return Integer.valueOf(i);
     }
@@ -836,6 +839,7 @@ public class ScriptRuntime {
      * are undefined if not supplied; this function pads the argument array out to the expected
      * length, if necessary.
      */
+    @CodeGenMarker(padArguments)
     public static Object[] padArguments(Object[] args, int count) {
         if (count < args.length) return args;
 
@@ -852,6 +856,7 @@ public class ScriptRuntime {
      * are undefined if not supplied; this function pads the argument array out to the expected
      * length, if necessary. Also the rest parameter array construction is done here.
      */
+    @CodeGenMarker(padAndRestArguments)
     public static Object[] padAndRestArguments(
             Context cx, Scriptable scope, Object[] args, int argCount) {
         Object[] result = new Object[argCount];
@@ -1395,6 +1400,7 @@ public class ScriptRuntime {
         return (index < args.length) ? toInt32(args[index]) : 0;
     }
 
+    @CodeGenMarker(toInt32)
     public static int toInt32(double d) {
         return DoubleConversion.doubleToInt32(d);
     }
@@ -1461,6 +1467,7 @@ public class ScriptRuntime {
     // properly and separates namespace form Scriptable.get etc.
     private static final String DEFAULT_NS_TAG = "__default_namespace__";
 
+    @CodeGenMarker(setDefaultNamespace)
     public static Object setDefaultNamespace(Object namespace, Context cx) {
         Scriptable scope = cx.currentActivationCall;
         if (scope == null) {
@@ -2124,6 +2131,7 @@ public class ScriptRuntime {
         return result;
     }
 
+    @CodeGenMarker(refGet)
     public static Object refGet(Ref ref, Context cx) {
         return ref.get(cx);
     }
@@ -2136,10 +2144,12 @@ public class ScriptRuntime {
         return refSet(ref, value, cx, getTopCallScope(cx));
     }
 
+    @CodeGenMarker(refSet)
     public static Object refSet(Ref ref, Object value, Context cx, Scriptable scope) {
         return ref.set(cx, scope, value);
     }
 
+    @CodeGenMarker(refDel)
     public static Object refDel(Ref ref, Context cx) {
         return wrapBoolean(ref.delete(cx));
     }
@@ -2156,6 +2166,7 @@ public class ScriptRuntime {
         return specialRef(obj, specialProperty, cx, getTopCallScope(cx));
     }
 
+    @CodeGenMarker(specialRef)
     public static Ref specialRef(Object obj, String specialProperty, Context cx, Scriptable scope) {
         return SpecialRef.createSpecial(cx, scope, obj, specialProperty);
     }
@@ -2180,6 +2191,7 @@ public class ScriptRuntime {
      * @deprecated Use {@link #delete(Object, Object, Context, Scriptable, boolean)} instead
      */
     @Deprecated
+    @CodeGenMarker(delete)
     public static Object delete(Object obj, Object id, Context cx, boolean isName) {
         return delete(obj, id, cx, getTopCallScope(cx), isName);
     }
@@ -2578,6 +2590,7 @@ public class ScriptRuntime {
         return enumInit(value, cx, getTopCallScope(cx), enumType);
     }
 
+    @CodeGenMarker(enumInit)
     public static Object enumInit(Object value, Context cx, Scriptable scope, int enumType) {
         IdEnumeration x = new IdEnumeration();
         x.obj = toObjectOrNull(cx, value, scope);
@@ -2646,6 +2659,7 @@ public class ScriptRuntime {
         return enumNext(enumObj, Context.getContext());
     }
 
+    @CodeGenMarker(enumNext)
     public static Boolean enumNext(Object enumObj, Context cx) {
         IdEnumeration x = (IdEnumeration) enumObj;
         if (x.iterator != null) {
@@ -2711,6 +2725,7 @@ public class ScriptRuntime {
         return Boolean.TRUE;
     }
 
+    @CodeGenMarker(enumId)
     public static Object enumId(Object enumObj, Context cx) {
         IdEnumeration x = (IdEnumeration) enumObj;
         if (x.iterator != null) {
@@ -2987,11 +3002,13 @@ public class ScriptRuntime {
      * Prepare for calling obj[id](...): return function corresponding to obj[id] and make obj
      * properly converted to Scriptable available in the result.
      */
+    @CodeGenMarker(getElemAndThis)
     public static LookupResult getElemAndThis(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemAndThisInner(obj, elem, cx, scope, false);
     }
 
+    @CodeGenMarker(getElemAndThisOptional)
     public static LookupResult getElemAndThisOptional(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemAndThisInner(obj, elem, cx, scope, true);
@@ -3232,10 +3249,12 @@ public class ScriptRuntime {
      * Prepare for calling &lt;expression&gt;(...): return function corresponding to
      * &lt;expression&gt; and make parent scope of the function available in the result.
      */
+    @CodeGenMarker(getValueAndThis)
     public static LookupResult getValueAndThis(Object value, Context cx) {
         return getValueAndThisInner(value, cx, false);
     }
 
+    @CodeGenMarker(getValueAndThisOptional)
     public static LookupResult getValueAndThisOptional(Object value, Context cx) {
         return getValueAndThisInner(value, cx, true);
     }
@@ -3303,6 +3322,7 @@ public class ScriptRuntime {
      * GC-reachable after this method returns. If this is necessary, store args.clone(), not args
      * array itself.
      */
+    @CodeGenMarker(callRef)
     public static Ref callRef(Callable function, Scriptable thisObj, Object[] args, Context cx) {
         if (function instanceof RefCallable) {
             RefCallable rfunction = (RefCallable) function;
@@ -3323,6 +3343,7 @@ public class ScriptRuntime {
      *
      * <p>See ECMA 11.2.2
      */
+    @CodeGenMarker(newObject)
     public static Scriptable newObject(Object ctor, Context cx, Scriptable scope, Object[] args) {
         if (!(ctor instanceof Constructable)) {
             throw notFunctionError(ctor);
@@ -3330,6 +3351,7 @@ public class ScriptRuntime {
         return ((Constructable) ctor).construct(cx, scope, args);
     }
 
+    @CodeGenMarker(callSpecial)
     public static Object callSpecial(
             Context cx,
             Callable fun,
@@ -3360,6 +3382,7 @@ public class ScriptRuntime {
         return fun.call(cx, scope, thisObj, args);
     }
 
+    @CodeGenMarker(newSpecial)
     public static Object newSpecial(
             Context cx, Object fun, Object[] args, Scriptable scope, int callType) {
         if (callType == Node.SPECIALCALL_EVAL) {
@@ -3555,6 +3578,7 @@ public class ScriptRuntime {
     }
 
     /** The typeof operator */
+    @CodeGenMarker(typeof)
     public static String typeof(Object value) {
         if (value == null) return "object";
         if (value == Undefined.instance) return "undefined";
@@ -3570,6 +3594,7 @@ public class ScriptRuntime {
     }
 
     /** The typeof operator that correctly handles the undefined case */
+    @CodeGenMarker(typeofName)
     public static String typeofName(Scriptable scope, String id) {
         Context cx = Context.getContext();
         Scriptable val = bind(cx, scope, id);
@@ -3688,6 +3713,7 @@ public class ScriptRuntime {
         return new ConsString(toCharSequence(val1), val2);
     }
 
+    @CodeGenMarker(subtract)
     public static Number subtract(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).subtract((BigInteger) val2);
@@ -3700,6 +3726,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(multiply)
     public static Number multiply(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).multiply((BigInteger) val2);
@@ -3712,6 +3739,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(divide)
     public static Number divide(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (val2.equals(BigInteger.ZERO)) {
@@ -3727,6 +3755,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(remainder)
     public static Number remainder(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (val2.equals(BigInteger.ZERO)) {
@@ -3772,6 +3801,7 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    @CodeGenMarker(exponentiate)
     public static Number exponentiate(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (((BigInteger) val2).signum() == -1) {
@@ -3792,6 +3822,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(bitwiseAND)
     public static Number bitwiseAND(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).and((BigInteger) val2);
@@ -3805,6 +3836,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(bitwiseOR)
     public static Number bitwiseOR(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).or((BigInteger) val2);
@@ -3818,6 +3850,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(bitwiseXOR)
     public static Number bitwiseXOR(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).xor((BigInteger) val2);
@@ -3832,6 +3865,7 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    @CodeGenMarker(leftShift)
     public static Number leftShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             try {
@@ -3852,6 +3886,7 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    @CodeGenMarker(signedRightShift)
     public static Number signedRightShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             try {
@@ -3871,6 +3906,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(bitwiseNOT)
     public static Number bitwiseNOT(Number val) {
         if (val instanceof BigInteger) {
             return ((BigInteger) val).not();
@@ -3892,6 +3928,7 @@ public class ScriptRuntime {
         return nameIncrDecr(scopeChain, id, Context.getContext(), incrDecrMask);
     }
 
+    @CodeGenMarker(nameIncrDecr)
     public static Object nameIncrDecr(
             Scriptable scopeChain, String id, Context cx, int incrDecrMask) {
         Scriptable target;
@@ -3929,6 +3966,7 @@ public class ScriptRuntime {
         return propIncrDecr(obj, id, cx, getTopCallScope(cx), incrDecrMask);
     }
 
+    @CodeGenMarker(propIncrDecr)
     public static Object propIncrDecr(
             Object obj, String id, Context cx, Scriptable scope, int incrDecrMask) {
         Scriptable start = asScriptableOrThrowUndefReadError(cx, scope, obj, id);
@@ -4001,6 +4039,7 @@ public class ScriptRuntime {
         return elemIncrDecr(obj, index, cx, getTopCallScope(cx), incrDecrMask);
     }
 
+    @CodeGenMarker(elemIncrDecr)
     public static Object elemIncrDecr(
             Object obj, Object index, Context cx, Scriptable scope, int incrDecrMask) {
         Object value = getObjectElem(obj, index, cx, scope);
@@ -4049,6 +4088,7 @@ public class ScriptRuntime {
         return refIncrDecr(ref, cx, getTopCallScope(cx), incrDecrMask);
     }
 
+    @CodeGenMarker(refIncrDecr)
     public static Object refIncrDecr(Ref ref, Context cx, Scriptable scope, int incrDecrMask) {
         Object value = ref.get(cx);
         boolean post = ((incrDecrMask & Node.POST_FLAG) != 0);
@@ -4088,6 +4128,7 @@ public class ScriptRuntime {
         return result;
     }
 
+    @CodeGenMarker(negate)
     public static Number negate(Number val) {
         if (val instanceof BigInteger) {
             return ((BigInteger) val).negate();
@@ -4528,6 +4569,7 @@ public class ScriptRuntime {
      *
      * @return a instanceof b
      */
+    @CodeGenMarker(instanceOf)
     public static boolean instanceOf(Object a, Object b, Context cx) {
         // Check RHS is an object
         if (!(b instanceof Scriptable)) {
@@ -4569,6 +4611,7 @@ public class ScriptRuntime {
      * @param b the right hand operand
      * @return true if property name or element number a is a property of b
      */
+    @CodeGenMarker(in)
     public static boolean in(Object a, Object b, Context cx) {
         if (!(b instanceof Scriptable)) {
             throw typeErrorById("msg.in.not.object");
@@ -4782,6 +4825,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(addInstructionCount)
     public static void addInstructionCount(Context cx, int instructionsToAdd) {
         cx.instructionCount += instructionsToAdd;
         if (cx.instructionCount > cx.instructionThreshold) {
@@ -4790,6 +4834,7 @@ public class ScriptRuntime {
         }
     }
 
+    @CodeGenMarker(initScript)
     public static void initScript(
             NativeFunction funObj,
             Scriptable thisObj,
@@ -4880,6 +4925,7 @@ public class ScriptRuntime {
                 funObj, cx, scope, args, false, isStrict, argsHasRest, true, homeObject);
     }
 
+    @CodeGenMarker(createFunctionActivation)
     public static Scriptable createFunctionActivation(
             NativeFunction funObj,
             Context cx,
@@ -4937,6 +4983,7 @@ public class ScriptRuntime {
                 funObj, cx, scope, args, true, isStrict, argsHasRest, true, homeObject);
     }
 
+    @CodeGenMarker(createArrowFunctionActivation)
     public static Scriptable createArrowFunctionActivation(
             NativeFunction funObj,
             Context cx,
@@ -4958,6 +5005,7 @@ public class ScriptRuntime {
                 homeObject);
     }
 
+    @CodeGenMarker(enterActivationFunction)
     public static void enterActivationFunction(Context cx, Scriptable scope) {
         if (cx.topCallScope == null) throw new IllegalStateException();
         NativeCall call = (NativeCall) scope;
@@ -4966,6 +5014,7 @@ public class ScriptRuntime {
         call.defineAttributesForArguments();
     }
 
+    @CodeGenMarker(exitActivationFunction)
     public static void exitActivationFunction(Context cx) {
         NativeCall call = cx.currentActivationCall;
         cx.currentActivationCall = call.parentActivationCall;
@@ -4981,6 +5030,7 @@ public class ScriptRuntime {
         return null;
     }
 
+    @CodeGenMarker(newCatchScope)
     public static Scriptable newCatchScope(
             Throwable t,
             Scriptable lastCatchScope,
@@ -5193,6 +5243,7 @@ public class ScriptRuntime {
         return shutter == null || shutter.visibleToScripts(obj.getClass().getName());
     }
 
+    @CodeGenMarker(enterWith)
     public static Scriptable enterWith(Object obj, Context cx, Scriptable scope) {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
@@ -5205,11 +5256,13 @@ public class ScriptRuntime {
         return new NativeWith(scope, sobj);
     }
 
+    @CodeGenMarker(leaveWith)
     public static Scriptable leaveWith(Scriptable scope) {
         NativeWith nw = (NativeWith) scope;
         return nw.getParentScope();
     }
 
+    @CodeGenMarker(enterDotQuery)
     public static Scriptable enterDotQuery(Object value, Scriptable scope) {
         if (!(value instanceof XMLObject)) {
             throw notXmlError(value);
@@ -5218,12 +5271,14 @@ public class ScriptRuntime {
         return object.enterDotQuery(scope);
     }
 
+    @CodeGenMarker(updateDotQuery)
     public static Object updateDotQuery(boolean value, Scriptable scope) {
         // Return null to continue looping
         NativeWith nw = (NativeWith) scope;
         return nw.updateDotQuery(value);
     }
 
+    @CodeGenMarker(leaveDotQuery)
     public static Scriptable leaveDotQuery(Scriptable scope) {
         NativeWith nw = (NativeWith) scope;
         return nw.getParentScope();
@@ -5390,6 +5445,7 @@ public class ScriptRuntime {
         return object;
     }
 
+    @CodeGenMarker(fillObjectLiteral)
     public static void fillObjectLiteral(
             Scriptable object,
             Object[] propertyIds,
@@ -5844,6 +5900,7 @@ public class ScriptRuntime {
      * @param value Unescaped text
      * @return The escaped text
      */
+    @CodeGenMarker(escapeAttributeValue)
     public static String escapeAttributeValue(Object value, Context cx) {
         XMLLib xmlLib = currentXMLLib(cx);
         return xmlLib.escapeAttributeValue(value);
@@ -5855,11 +5912,13 @@ public class ScriptRuntime {
      * @param value Unescaped text
      * @return The escaped text
      */
+    @CodeGenMarker(escapeTextValue)
     public static String escapeTextValue(Object value, Context cx) {
         XMLLib xmlLib = currentXMLLib(cx);
         return xmlLib.escapeTextValue(value);
     }
 
+    @CodeGenMarker(memberRef_member)
     public static Ref memberRef(Object obj, Object elem, Context cx, int memberTypeFlags) {
         if (!(obj instanceof XMLObject)) {
             throw notXmlError(obj);
@@ -5868,6 +5927,7 @@ public class ScriptRuntime {
         return xmlObject.memberRef(cx, elem, memberTypeFlags);
     }
 
+    @CodeGenMarker(memberRef_namespaceMember)
     public static Ref memberRef(
             Object obj, Object namespace, Object elem, Context cx, int memberTypeFlags) {
         if (!(obj instanceof XMLObject)) {
@@ -5877,11 +5937,13 @@ public class ScriptRuntime {
         return xmlObject.memberRef(cx, namespace, elem, memberTypeFlags);
     }
 
+    @CodeGenMarker(memberRef_name)
     public static Ref nameRef(Object name, Context cx, Scriptable scope, int memberTypeFlags) {
         XMLLib xmlLib = currentXMLLib(cx);
         return xmlLib.nameRef(cx, name, scope, memberTypeFlags);
     }
 
+    @CodeGenMarker(memberRef_namespaceName)
     public static Ref nameRef(
             Object namespace, Object name, Context cx, Scriptable scope, int memberTypeFlags) {
         XMLLib xmlLib = currentXMLLib(cx);
@@ -6000,6 +6062,7 @@ public class ScriptRuntime {
     }
 
     /** Throws a ReferenceError "cannot delete a super property". See ECMAScript spec 13.5.1.2 */
+    @CodeGenMarker(throwDeleteOnSuperPropertyNotAllowed)
     public static void throwDeleteOnSuperPropertyNotAllowed() {
         throw referenceError("msg.delete.super");
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -6,8 +6,6 @@
 
 package org.mozilla.javascript;
 
-import static org.mozilla.javascript.optimizer.ScriptRuntimeMethodSig.*;
-
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
@@ -24,6 +22,8 @@ import java.util.ServiceLoader;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.optimizer.ScriptRuntimeMethodSig;
+import org.mozilla.javascript.optimizer.ScriptRuntimeMethodSig.CodeGenMarker;
 import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
 import org.mozilla.javascript.typedarrays.NativeBigInt64Array;
 import org.mozilla.javascript.typedarrays.NativeBigUint64Array;
@@ -351,7 +351,7 @@ public class ScriptRuntime {
         return Boolean.valueOf(b);
     }
 
-    @CodeGenMarker(wrapInt)
+    @CodeGenMarker(ScriptRuntimeMethodSig.wrapInt)
     public static Integer wrapInt(int i) {
         return Integer.valueOf(i);
     }
@@ -839,7 +839,7 @@ public class ScriptRuntime {
      * are undefined if not supplied; this function pads the argument array out to the expected
      * length, if necessary.
      */
-    @CodeGenMarker(padArguments)
+    @CodeGenMarker(ScriptRuntimeMethodSig.padArguments)
     public static Object[] padArguments(Object[] args, int count) {
         if (count < args.length) return args;
 
@@ -856,7 +856,7 @@ public class ScriptRuntime {
      * are undefined if not supplied; this function pads the argument array out to the expected
      * length, if necessary. Also the rest parameter array construction is done here.
      */
-    @CodeGenMarker(padAndRestArguments)
+    @CodeGenMarker(ScriptRuntimeMethodSig.padAndRestArguments)
     public static Object[] padAndRestArguments(
             Context cx, Scriptable scope, Object[] args, int argCount) {
         Object[] result = new Object[argCount];
@@ -1400,7 +1400,7 @@ public class ScriptRuntime {
         return (index < args.length) ? toInt32(args[index]) : 0;
     }
 
-    @CodeGenMarker(toInt32)
+    @CodeGenMarker(ScriptRuntimeMethodSig.toInt32)
     public static int toInt32(double d) {
         return DoubleConversion.doubleToInt32(d);
     }
@@ -1467,7 +1467,7 @@ public class ScriptRuntime {
     // properly and separates namespace form Scriptable.get etc.
     private static final String DEFAULT_NS_TAG = "__default_namespace__";
 
-    @CodeGenMarker(setDefaultNamespace)
+    @CodeGenMarker(ScriptRuntimeMethodSig.setDefaultNamespace)
     public static Object setDefaultNamespace(Object namespace, Context cx) {
         Scriptable scope = cx.currentActivationCall;
         if (scope == null) {
@@ -2131,7 +2131,7 @@ public class ScriptRuntime {
         return result;
     }
 
-    @CodeGenMarker(refGet)
+    @CodeGenMarker(ScriptRuntimeMethodSig.refGet)
     public static Object refGet(Ref ref, Context cx) {
         return ref.get(cx);
     }
@@ -2144,12 +2144,12 @@ public class ScriptRuntime {
         return refSet(ref, value, cx, getTopCallScope(cx));
     }
 
-    @CodeGenMarker(refSet)
+    @CodeGenMarker(ScriptRuntimeMethodSig.refSet)
     public static Object refSet(Ref ref, Object value, Context cx, Scriptable scope) {
         return ref.set(cx, scope, value);
     }
 
-    @CodeGenMarker(refDel)
+    @CodeGenMarker(ScriptRuntimeMethodSig.refDel)
     public static Object refDel(Ref ref, Context cx) {
         return wrapBoolean(ref.delete(cx));
     }
@@ -2166,7 +2166,7 @@ public class ScriptRuntime {
         return specialRef(obj, specialProperty, cx, getTopCallScope(cx));
     }
 
-    @CodeGenMarker(specialRef)
+    @CodeGenMarker(ScriptRuntimeMethodSig.specialRef)
     public static Ref specialRef(Object obj, String specialProperty, Context cx, Scriptable scope) {
         return SpecialRef.createSpecial(cx, scope, obj, specialProperty);
     }
@@ -2191,7 +2191,7 @@ public class ScriptRuntime {
      * @deprecated Use {@link #delete(Object, Object, Context, Scriptable, boolean)} instead
      */
     @Deprecated
-    @CodeGenMarker(delete)
+    @CodeGenMarker(ScriptRuntimeMethodSig.delete)
     public static Object delete(Object obj, Object id, Context cx, boolean isName) {
         return delete(obj, id, cx, getTopCallScope(cx), isName);
     }
@@ -2590,7 +2590,7 @@ public class ScriptRuntime {
         return enumInit(value, cx, getTopCallScope(cx), enumType);
     }
 
-    @CodeGenMarker(enumInit)
+    @CodeGenMarker(ScriptRuntimeMethodSig.enumInit)
     public static Object enumInit(Object value, Context cx, Scriptable scope, int enumType) {
         IdEnumeration x = new IdEnumeration();
         x.obj = toObjectOrNull(cx, value, scope);
@@ -2659,7 +2659,7 @@ public class ScriptRuntime {
         return enumNext(enumObj, Context.getContext());
     }
 
-    @CodeGenMarker(enumNext)
+    @CodeGenMarker(ScriptRuntimeMethodSig.enumNext)
     public static Boolean enumNext(Object enumObj, Context cx) {
         IdEnumeration x = (IdEnumeration) enumObj;
         if (x.iterator != null) {
@@ -2725,7 +2725,7 @@ public class ScriptRuntime {
         return Boolean.TRUE;
     }
 
-    @CodeGenMarker(enumId)
+    @CodeGenMarker(ScriptRuntimeMethodSig.enumId)
     public static Object enumId(Object enumObj, Context cx) {
         IdEnumeration x = (IdEnumeration) enumObj;
         if (x.iterator != null) {
@@ -3002,13 +3002,13 @@ public class ScriptRuntime {
      * Prepare for calling obj[id](...): return function corresponding to obj[id] and make obj
      * properly converted to Scriptable available in the result.
      */
-    @CodeGenMarker(getElemAndThis)
+    @CodeGenMarker(ScriptRuntimeMethodSig.getElemAndThis)
     public static LookupResult getElemAndThis(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemAndThisInner(obj, elem, cx, scope, false);
     }
 
-    @CodeGenMarker(getElemAndThisOptional)
+    @CodeGenMarker(ScriptRuntimeMethodSig.getElemAndThisOptional)
     public static LookupResult getElemAndThisOptional(
             Object obj, Object elem, Context cx, Scriptable scope) {
         return getElemAndThisInner(obj, elem, cx, scope, true);
@@ -3249,12 +3249,12 @@ public class ScriptRuntime {
      * Prepare for calling &lt;expression&gt;(...): return function corresponding to
      * &lt;expression&gt; and make parent scope of the function available in the result.
      */
-    @CodeGenMarker(getValueAndThis)
+    @CodeGenMarker(ScriptRuntimeMethodSig.getValueAndThis)
     public static LookupResult getValueAndThis(Object value, Context cx) {
         return getValueAndThisInner(value, cx, false);
     }
 
-    @CodeGenMarker(getValueAndThisOptional)
+    @CodeGenMarker(ScriptRuntimeMethodSig.getValueAndThisOptional)
     public static LookupResult getValueAndThisOptional(Object value, Context cx) {
         return getValueAndThisInner(value, cx, true);
     }
@@ -3322,7 +3322,7 @@ public class ScriptRuntime {
      * GC-reachable after this method returns. If this is necessary, store args.clone(), not args
      * array itself.
      */
-    @CodeGenMarker(callRef)
+    @CodeGenMarker(ScriptRuntimeMethodSig.callRef)
     public static Ref callRef(Callable function, Scriptable thisObj, Object[] args, Context cx) {
         if (function instanceof RefCallable) {
             RefCallable rfunction = (RefCallable) function;
@@ -3343,7 +3343,7 @@ public class ScriptRuntime {
      *
      * <p>See ECMA 11.2.2
      */
-    @CodeGenMarker(newObject)
+    @CodeGenMarker(ScriptRuntimeMethodSig.newObject)
     public static Scriptable newObject(Object ctor, Context cx, Scriptable scope, Object[] args) {
         if (!(ctor instanceof Constructable)) {
             throw notFunctionError(ctor);
@@ -3351,7 +3351,7 @@ public class ScriptRuntime {
         return ((Constructable) ctor).construct(cx, scope, args);
     }
 
-    @CodeGenMarker(callSpecial)
+    @CodeGenMarker(ScriptRuntimeMethodSig.callSpecial)
     public static Object callSpecial(
             Context cx,
             Callable fun,
@@ -3382,7 +3382,7 @@ public class ScriptRuntime {
         return fun.call(cx, scope, thisObj, args);
     }
 
-    @CodeGenMarker(newSpecial)
+    @CodeGenMarker(ScriptRuntimeMethodSig.newSpecial)
     public static Object newSpecial(
             Context cx, Object fun, Object[] args, Scriptable scope, int callType) {
         if (callType == Node.SPECIALCALL_EVAL) {
@@ -3578,7 +3578,7 @@ public class ScriptRuntime {
     }
 
     /** The typeof operator */
-    @CodeGenMarker(typeof)
+    @CodeGenMarker(ScriptRuntimeMethodSig.typeof)
     public static String typeof(Object value) {
         if (value == null) return "object";
         if (value == Undefined.instance) return "undefined";
@@ -3594,7 +3594,7 @@ public class ScriptRuntime {
     }
 
     /** The typeof operator that correctly handles the undefined case */
-    @CodeGenMarker(typeofName)
+    @CodeGenMarker(ScriptRuntimeMethodSig.typeofName)
     public static String typeofName(Scriptable scope, String id) {
         Context cx = Context.getContext();
         Scriptable val = bind(cx, scope, id);
@@ -3713,7 +3713,7 @@ public class ScriptRuntime {
         return new ConsString(toCharSequence(val1), val2);
     }
 
-    @CodeGenMarker(subtract)
+    @CodeGenMarker(ScriptRuntimeMethodSig.subtract)
     public static Number subtract(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).subtract((BigInteger) val2);
@@ -3726,7 +3726,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(multiply)
+    @CodeGenMarker(ScriptRuntimeMethodSig.multiply)
     public static Number multiply(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).multiply((BigInteger) val2);
@@ -3739,7 +3739,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(divide)
+    @CodeGenMarker(ScriptRuntimeMethodSig.divide)
     public static Number divide(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (val2.equals(BigInteger.ZERO)) {
@@ -3755,7 +3755,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(remainder)
+    @CodeGenMarker(ScriptRuntimeMethodSig.remainder)
     public static Number remainder(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (val2.equals(BigInteger.ZERO)) {
@@ -3801,7 +3801,7 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
-    @CodeGenMarker(exponentiate)
+    @CodeGenMarker(ScriptRuntimeMethodSig.exponentiate)
     public static Number exponentiate(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (((BigInteger) val2).signum() == -1) {
@@ -3822,7 +3822,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(bitwiseAND)
+    @CodeGenMarker(ScriptRuntimeMethodSig.bitwiseAND)
     public static Number bitwiseAND(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).and((BigInteger) val2);
@@ -3836,7 +3836,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(bitwiseOR)
+    @CodeGenMarker(ScriptRuntimeMethodSig.bitwiseOR)
     public static Number bitwiseOR(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).or((BigInteger) val2);
@@ -3850,7 +3850,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(bitwiseXOR)
+    @CodeGenMarker(ScriptRuntimeMethodSig.bitwiseXOR)
     public static Number bitwiseXOR(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             return ((BigInteger) val1).xor((BigInteger) val2);
@@ -3865,7 +3865,7 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
-    @CodeGenMarker(leftShift)
+    @CodeGenMarker(ScriptRuntimeMethodSig.leftShift)
     public static Number leftShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             try {
@@ -3886,7 +3886,7 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
-    @CodeGenMarker(signedRightShift)
+    @CodeGenMarker(ScriptRuntimeMethodSig.signedRightShift)
     public static Number signedRightShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             try {
@@ -3906,7 +3906,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(bitwiseNOT)
+    @CodeGenMarker(ScriptRuntimeMethodSig.bitwiseNOT)
     public static Number bitwiseNOT(Number val) {
         if (val instanceof BigInteger) {
             return ((BigInteger) val).not();
@@ -3928,7 +3928,7 @@ public class ScriptRuntime {
         return nameIncrDecr(scopeChain, id, Context.getContext(), incrDecrMask);
     }
 
-    @CodeGenMarker(nameIncrDecr)
+    @CodeGenMarker(ScriptRuntimeMethodSig.nameIncrDecr)
     public static Object nameIncrDecr(
             Scriptable scopeChain, String id, Context cx, int incrDecrMask) {
         Scriptable target;
@@ -3966,7 +3966,7 @@ public class ScriptRuntime {
         return propIncrDecr(obj, id, cx, getTopCallScope(cx), incrDecrMask);
     }
 
-    @CodeGenMarker(propIncrDecr)
+    @CodeGenMarker(ScriptRuntimeMethodSig.propIncrDecr)
     public static Object propIncrDecr(
             Object obj, String id, Context cx, Scriptable scope, int incrDecrMask) {
         Scriptable start = asScriptableOrThrowUndefReadError(cx, scope, obj, id);
@@ -4039,7 +4039,7 @@ public class ScriptRuntime {
         return elemIncrDecr(obj, index, cx, getTopCallScope(cx), incrDecrMask);
     }
 
-    @CodeGenMarker(elemIncrDecr)
+    @CodeGenMarker(ScriptRuntimeMethodSig.elemIncrDecr)
     public static Object elemIncrDecr(
             Object obj, Object index, Context cx, Scriptable scope, int incrDecrMask) {
         Object value = getObjectElem(obj, index, cx, scope);
@@ -4088,7 +4088,7 @@ public class ScriptRuntime {
         return refIncrDecr(ref, cx, getTopCallScope(cx), incrDecrMask);
     }
 
-    @CodeGenMarker(refIncrDecr)
+    @CodeGenMarker(ScriptRuntimeMethodSig.refIncrDecr)
     public static Object refIncrDecr(Ref ref, Context cx, Scriptable scope, int incrDecrMask) {
         Object value = ref.get(cx);
         boolean post = ((incrDecrMask & Node.POST_FLAG) != 0);
@@ -4128,7 +4128,7 @@ public class ScriptRuntime {
         return result;
     }
 
-    @CodeGenMarker(negate)
+    @CodeGenMarker(ScriptRuntimeMethodSig.negate)
     public static Number negate(Number val) {
         if (val instanceof BigInteger) {
             return ((BigInteger) val).negate();
@@ -4569,7 +4569,7 @@ public class ScriptRuntime {
      *
      * @return a instanceof b
      */
-    @CodeGenMarker(instanceOf)
+    @CodeGenMarker(ScriptRuntimeMethodSig.instanceOf)
     public static boolean instanceOf(Object a, Object b, Context cx) {
         // Check RHS is an object
         if (!(b instanceof Scriptable)) {
@@ -4611,7 +4611,7 @@ public class ScriptRuntime {
      * @param b the right hand operand
      * @return true if property name or element number a is a property of b
      */
-    @CodeGenMarker(in)
+    @CodeGenMarker(ScriptRuntimeMethodSig.in)
     public static boolean in(Object a, Object b, Context cx) {
         if (!(b instanceof Scriptable)) {
             throw typeErrorById("msg.in.not.object");
@@ -4825,7 +4825,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(addInstructionCount)
+    @CodeGenMarker(ScriptRuntimeMethodSig.addInstructionCount)
     public static void addInstructionCount(Context cx, int instructionsToAdd) {
         cx.instructionCount += instructionsToAdd;
         if (cx.instructionCount > cx.instructionThreshold) {
@@ -4834,7 +4834,7 @@ public class ScriptRuntime {
         }
     }
 
-    @CodeGenMarker(initScript)
+    @CodeGenMarker(ScriptRuntimeMethodSig.initScript)
     public static void initScript(
             NativeFunction funObj,
             Scriptable thisObj,
@@ -4925,7 +4925,7 @@ public class ScriptRuntime {
                 funObj, cx, scope, args, false, isStrict, argsHasRest, true, homeObject);
     }
 
-    @CodeGenMarker(createFunctionActivation)
+    @CodeGenMarker(ScriptRuntimeMethodSig.createFunctionActivation)
     public static Scriptable createFunctionActivation(
             NativeFunction funObj,
             Context cx,
@@ -4983,7 +4983,7 @@ public class ScriptRuntime {
                 funObj, cx, scope, args, true, isStrict, argsHasRest, true, homeObject);
     }
 
-    @CodeGenMarker(createArrowFunctionActivation)
+    @CodeGenMarker(ScriptRuntimeMethodSig.createArrowFunctionActivation)
     public static Scriptable createArrowFunctionActivation(
             NativeFunction funObj,
             Context cx,
@@ -5005,7 +5005,7 @@ public class ScriptRuntime {
                 homeObject);
     }
 
-    @CodeGenMarker(enterActivationFunction)
+    @CodeGenMarker(ScriptRuntimeMethodSig.enterActivationFunction)
     public static void enterActivationFunction(Context cx, Scriptable scope) {
         if (cx.topCallScope == null) throw new IllegalStateException();
         NativeCall call = (NativeCall) scope;
@@ -5014,7 +5014,7 @@ public class ScriptRuntime {
         call.defineAttributesForArguments();
     }
 
-    @CodeGenMarker(exitActivationFunction)
+    @CodeGenMarker(ScriptRuntimeMethodSig.exitActivationFunction)
     public static void exitActivationFunction(Context cx) {
         NativeCall call = cx.currentActivationCall;
         cx.currentActivationCall = call.parentActivationCall;
@@ -5030,7 +5030,7 @@ public class ScriptRuntime {
         return null;
     }
 
-    @CodeGenMarker(newCatchScope)
+    @CodeGenMarker(ScriptRuntimeMethodSig.newCatchScope)
     public static Scriptable newCatchScope(
             Throwable t,
             Scriptable lastCatchScope,
@@ -5243,7 +5243,7 @@ public class ScriptRuntime {
         return shutter == null || shutter.visibleToScripts(obj.getClass().getName());
     }
 
-    @CodeGenMarker(enterWith)
+    @CodeGenMarker(ScriptRuntimeMethodSig.enterWith)
     public static Scriptable enterWith(Object obj, Context cx, Scriptable scope) {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
@@ -5256,13 +5256,13 @@ public class ScriptRuntime {
         return new NativeWith(scope, sobj);
     }
 
-    @CodeGenMarker(leaveWith)
+    @CodeGenMarker(ScriptRuntimeMethodSig.leaveWith)
     public static Scriptable leaveWith(Scriptable scope) {
         NativeWith nw = (NativeWith) scope;
         return nw.getParentScope();
     }
 
-    @CodeGenMarker(enterDotQuery)
+    @CodeGenMarker(ScriptRuntimeMethodSig.enterDotQuery)
     public static Scriptable enterDotQuery(Object value, Scriptable scope) {
         if (!(value instanceof XMLObject)) {
             throw notXmlError(value);
@@ -5271,14 +5271,14 @@ public class ScriptRuntime {
         return object.enterDotQuery(scope);
     }
 
-    @CodeGenMarker(updateDotQuery)
+    @CodeGenMarker(ScriptRuntimeMethodSig.updateDotQuery)
     public static Object updateDotQuery(boolean value, Scriptable scope) {
         // Return null to continue looping
         NativeWith nw = (NativeWith) scope;
         return nw.updateDotQuery(value);
     }
 
-    @CodeGenMarker(leaveDotQuery)
+    @CodeGenMarker(ScriptRuntimeMethodSig.leaveDotQuery)
     public static Scriptable leaveDotQuery(Scriptable scope) {
         NativeWith nw = (NativeWith) scope;
         return nw.getParentScope();
@@ -5445,7 +5445,7 @@ public class ScriptRuntime {
         return object;
     }
 
-    @CodeGenMarker(fillObjectLiteral)
+    @CodeGenMarker(ScriptRuntimeMethodSig.fillObjectLiteral)
     public static void fillObjectLiteral(
             Scriptable object,
             Object[] propertyIds,
@@ -5900,7 +5900,7 @@ public class ScriptRuntime {
      * @param value Unescaped text
      * @return The escaped text
      */
-    @CodeGenMarker(escapeAttributeValue)
+    @CodeGenMarker(ScriptRuntimeMethodSig.escapeAttributeValue)
     public static String escapeAttributeValue(Object value, Context cx) {
         XMLLib xmlLib = currentXMLLib(cx);
         return xmlLib.escapeAttributeValue(value);
@@ -5912,13 +5912,13 @@ public class ScriptRuntime {
      * @param value Unescaped text
      * @return The escaped text
      */
-    @CodeGenMarker(escapeTextValue)
+    @CodeGenMarker(ScriptRuntimeMethodSig.escapeTextValue)
     public static String escapeTextValue(Object value, Context cx) {
         XMLLib xmlLib = currentXMLLib(cx);
         return xmlLib.escapeTextValue(value);
     }
 
-    @CodeGenMarker(memberRef_member)
+    @CodeGenMarker(ScriptRuntimeMethodSig.memberRef_member)
     public static Ref memberRef(Object obj, Object elem, Context cx, int memberTypeFlags) {
         if (!(obj instanceof XMLObject)) {
             throw notXmlError(obj);
@@ -5927,7 +5927,7 @@ public class ScriptRuntime {
         return xmlObject.memberRef(cx, elem, memberTypeFlags);
     }
 
-    @CodeGenMarker(memberRef_namespaceMember)
+    @CodeGenMarker(ScriptRuntimeMethodSig.memberRef_namespaceMember)
     public static Ref memberRef(
             Object obj, Object namespace, Object elem, Context cx, int memberTypeFlags) {
         if (!(obj instanceof XMLObject)) {
@@ -5937,13 +5937,13 @@ public class ScriptRuntime {
         return xmlObject.memberRef(cx, namespace, elem, memberTypeFlags);
     }
 
-    @CodeGenMarker(memberRef_name)
+    @CodeGenMarker(ScriptRuntimeMethodSig.memberRef_name)
     public static Ref nameRef(Object name, Context cx, Scriptable scope, int memberTypeFlags) {
         XMLLib xmlLib = currentXMLLib(cx);
         return xmlLib.nameRef(cx, name, scope, memberTypeFlags);
     }
 
-    @CodeGenMarker(memberRef_namespaceName)
+    @CodeGenMarker(ScriptRuntimeMethodSig.memberRef_namespaceName)
     public static Ref nameRef(
             Object namespace, Object name, Context cx, Scriptable scope, int memberTypeFlags) {
         XMLLib xmlLib = currentXMLLib(cx);
@@ -6062,7 +6062,7 @@ public class ScriptRuntime {
     }
 
     /** Throws a ReferenceError "cannot delete a super property". See ECMAScript spec 13.5.1.2 */
-    @CodeGenMarker(throwDeleteOnSuperPropertyNotAllowed)
+    @CodeGenMarker(ScriptRuntimeMethodSig.throwDeleteOnSuperPropertyNotAllowed)
     public static void throwDeleteOnSuperPropertyNotAllowed() {
         throw referenceError("msg.delete.super");
     }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -129,17 +129,7 @@ class BodyCodegen {
                 "org/mozilla/javascript/BaseFunction",
                 "getHomeObject",
                 "()Lorg/mozilla/javascript/Scriptable;");
-        addScriptRuntimeInvoke(
-                "createFunctionActivation",
-                "(Lorg/mozilla/javascript/NativeFunction;"
-                        + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "[Ljava/lang/Object;"
-                        + "Z"
-                        + "Z"
-                        + "Z"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + ")Lorg/mozilla/javascript/Scriptable;");
+        ScriptRuntimeMethodSig.createFunctionActivation.addInvoke(cfw);
         cfw.addAStore(variableObjectLocal);
 
         // create a function object
@@ -343,14 +333,7 @@ class BodyCodegen {
                     cfw.addALoad(variableObjectLocal);
                     cfw.addALoad(argsLocal);
                     cfw.addPush(parmCount);
-                    addScriptRuntimeInvoke(
-                            "padAndRestArguments",
-                            "("
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
-                                    + "[Ljava/lang/Object;"
-                                    + "I"
-                                    + ")[Ljava/lang/Object;");
+                    ScriptRuntimeMethodSig.padAndRestArguments.addInvoke(cfw);
                     cfw.addAStore(argsLocal);
                 } else {
                     // check length of arguments, pad if need be
@@ -361,8 +344,7 @@ class BodyCodegen {
                     cfw.add(ByteCode.IF_ICMPGE, label);
                     cfw.addALoad(argsLocal);
                     cfw.addPush(parmCount);
-                    addScriptRuntimeInvoke(
-                            "padArguments", "([Ljava/lang/Object;I)[Ljava/lang/Object;");
+                    ScriptRuntimeMethodSig.padArguments.addInvoke(cfw);
                     cfw.addAStore(argsLocal);
                     cfw.markLabel(label);
                 }
@@ -472,27 +454,15 @@ class BodyCodegen {
                 cfw.markLabel(after);
             }
 
-            String methodName =
-                    isArrow ? "createArrowFunctionActivation" : "createFunctionActivation";
-            addScriptRuntimeInvoke(
-                    methodName,
-                    "(Lorg/mozilla/javascript/NativeFunction;"
-                            + "Lorg/mozilla/javascript/Context;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
-                            + "[Ljava/lang/Object;"
-                            + "Z"
-                            + "Z"
-                            + "Z"
-                            + "Lorg/mozilla/javascript/Scriptable;"
-                            + ")Lorg/mozilla/javascript/Scriptable;");
+            if (isArrow) {
+                ScriptRuntimeMethodSig.createArrowFunctionActivation.addInvoke(cfw);
+            } else {
+                ScriptRuntimeMethodSig.createFunctionActivation.addInvoke(cfw);
+            }
             cfw.addAStore(variableObjectLocal);
             cfw.addALoad(contextLocal);
             cfw.addALoad(variableObjectLocal);
-            addScriptRuntimeInvoke(
-                    "enterActivationFunction",
-                    "(Lorg/mozilla/javascript/Context;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
-                            + ")V");
+            ScriptRuntimeMethodSig.enterActivationFunction.addInvoke(cfw);
         } else {
             debugVariableName = "global";
             cfw.addALoad(funObjLocal);
@@ -500,14 +470,7 @@ class BodyCodegen {
             cfw.addALoad(contextLocal);
             cfw.addALoad(variableObjectLocal);
             cfw.addPush(0); // false to indicate it is not eval script
-            addScriptRuntimeInvoke(
-                    "initScript",
-                    "(Lorg/mozilla/javascript/NativeFunction;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
-                            + "Lorg/mozilla/javascript/Context;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
-                            + "Z"
-                            + ")V");
+            ScriptRuntimeMethodSig.initScript.addInvoke(cfw);
         }
 
         enterAreaStartLabel = cfw.acquireLabel();
@@ -692,7 +655,7 @@ class BodyCodegen {
     private void generateActivationExit() {
         if (fnCurrent == null || hasVarsInRegs) throw Kit.codeBug();
         cfw.addALoad(contextLocal);
-        addScriptRuntimeInvoke("exitActivationFunction", "(Lorg/mozilla/javascript/Context;)V");
+        ScriptRuntimeMethodSig.exitActivationFunction.addInvoke(cfw);
     }
 
     private void generateStatement(Node node) {
@@ -785,14 +748,7 @@ class BodyCodegen {
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
 
-                    addScriptRuntimeInvoke(
-                            "newCatchScope",
-                            "(Ljava/lang/Throwable;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
-                                    + "Ljava/lang/String;"
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
-                                    + ")Lorg/mozilla/javascript/Scriptable;");
+                    ScriptRuntimeMethodSig.newCatchScope.addInvoke(cfw);
                     cfw.addAStore(local);
                 }
                 break;
@@ -841,22 +797,14 @@ class BodyCodegen {
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "enterWith",
-                        "(Ljava/lang/Object;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
-                                + ")Lorg/mozilla/javascript/Scriptable;");
+                ScriptRuntimeMethodSig.enterWith.addInvoke(cfw);
                 cfw.addAStore(variableObjectLocal);
                 incReferenceWordLocal(variableObjectLocal);
                 break;
 
             case Token.LEAVEWITH:
                 cfw.addALoad(variableObjectLocal);
-                addScriptRuntimeInvoke(
-                        "leaveWith",
-                        "(Lorg/mozilla/javascript/Scriptable;"
-                                + ")Lorg/mozilla/javascript/Scriptable;");
+                ScriptRuntimeMethodSig.leaveWith.addInvoke(cfw);
                 cfw.addAStore(variableObjectLocal);
                 decReferenceWordLocal(variableObjectLocal);
                 break;
@@ -877,13 +825,7 @@ class BodyCodegen {
                                                 ? ScriptRuntime.ENUMERATE_VALUES_IN_ORDER
                                                 : ScriptRuntime.ENUMERATE_ARRAY;
                 cfw.addPush(enumType);
-                addScriptRuntimeInvoke(
-                        "enumInit",
-                        "(Ljava/lang/Object;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
-                                + "I"
-                                + ")Ljava/lang/Object;");
+                ScriptRuntimeMethodSig.enumInit.addInvoke(cfw);
                 cfw.addAStore(getLocalBlockRegister(node));
                 break;
 
@@ -1067,13 +1009,7 @@ class BodyCodegen {
                 child = child.getNext();
                 generateCallArgArray(node, child, false);
                 cfw.addALoad(contextLocal);
-                addScriptRuntimeInvoke(
-                        "callRef",
-                        "(Lorg/mozilla/javascript/Callable;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
-                                + "[Ljava/lang/Object;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + ")Lorg/mozilla/javascript/Ref;");
+                ScriptRuntimeMethodSig.callRef.addInvoke(cfw);
                 break;
 
             case Token.NUMBER:
@@ -1211,17 +1147,9 @@ class BodyCodegen {
                     cfw.addALoad(local);
                     cfw.addALoad(contextLocal);
                     if (type == Token.ENUM_NEXT) {
-                        addScriptRuntimeInvoke(
-                                "enumNext",
-                                "(Ljava/lang/Object;"
-                                        + "Lorg/mozilla/javascript/Context;"
-                                        + ")Ljava/lang/Boolean;");
+                        ScriptRuntimeMethodSig.enumNext.addInvoke(cfw);
                     } else {
-                        addScriptRuntimeInvoke(
-                                "enumId",
-                                "(Ljava/lang/Object;"
-                                        + "Lorg/mozilla/javascript/Context;"
-                                        + ")Ljava/lang/Object;");
+                        ScriptRuntimeMethodSig.enumId.addInvoke(cfw);
                     }
                     break;
                 }
@@ -1267,7 +1195,7 @@ class BodyCodegen {
 
             case Token.TYPEOF:
                 generateExpression(child, node);
-                addScriptRuntimeInvoke("typeof", "(Ljava/lang/Object;" + ")Ljava/lang/String;");
+                ScriptRuntimeMethodSig.typeof.addInvoke(cfw);
                 break;
 
             case Token.TYPEOFNAME:
@@ -1376,8 +1304,7 @@ class BodyCodegen {
                     generateExpression(child, node);
                     if (childNumberFlag == -1) {
                         addObjectToNumeric();
-                        addScriptRuntimeInvoke(
-                                "negate", "(Ljava/lang/Number;" + ")Ljava/lang/Number;");
+                        ScriptRuntimeMethodSig.negate.addInvoke(cfw);
                     } else {
                         cfw.add(ByteCode.DNEG);
                     }
@@ -1528,33 +1455,19 @@ class BodyCodegen {
                     if (type == Token.SET_REF_OP) {
                         cfw.add(ByteCode.DUP);
                         cfw.addALoad(contextLocal);
-                        addScriptRuntimeInvoke(
-                                "refGet",
-                                "(Lorg/mozilla/javascript/Ref;"
-                                        + "Lorg/mozilla/javascript/Context;"
-                                        + ")Ljava/lang/Object;");
+                        ScriptRuntimeMethodSig.refGet.addInvoke(cfw);
                     }
                     generateExpression(child, node);
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
-                    addScriptRuntimeInvoke(
-                            "refSet",
-                            "(Lorg/mozilla/javascript/Ref;"
-                                    + "Ljava/lang/Object;"
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
-                                    + ")Ljava/lang/Object;");
+                    ScriptRuntimeMethodSig.refSet.addInvoke(cfw);
                 }
                 break;
 
             case Token.DEL_REF:
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
-                addScriptRuntimeInvoke(
-                        "refDel",
-                        "(Lorg/mozilla/javascript/Ref;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + ")Ljava/lang/Object;");
+                ScriptRuntimeMethodSig.refDel.addInvoke(cfw);
                 break;
 
             case Token.DELPROP:
@@ -1572,16 +1485,11 @@ class BodyCodegen {
                     // bytecode, it's fine.
                     cfw.add(ByteCode.POP2);
                     cfw.addLoadConstant(0);
-                    addScriptRuntimeInvoke("throwDeleteOnSuperPropertyNotAllowed", "()V");
+                    ScriptRuntimeMethodSig.throwDeleteOnSuperPropertyNotAllowed.addInvoke(cfw);
                 } else {
                     cfw.addALoad(contextLocal);
                     cfw.addPush(isName);
-                    addScriptRuntimeInvoke(
-                            "delete",
-                            "(Ljava/lang/Object;"
-                                    + "Ljava/lang/Object;"
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + "Z)Ljava/lang/Object;");
+                    ScriptRuntimeMethodSig.delete.addInvoke(cfw);
                 }
                 break;
 
@@ -1642,53 +1550,28 @@ class BodyCodegen {
                         child = child.getNext();
                     } while (child != null);
                     cfw.addALoad(contextLocal);
-                    String methodName, signature;
                     switch (type) {
                         case Token.REF_MEMBER:
-                            methodName = "memberRef";
-                            signature =
-                                    "(Ljava/lang/Object;"
-                                            + "Ljava/lang/Object;"
-                                            + "Lorg/mozilla/javascript/Context;"
-                                            + "I"
-                                            + ")Lorg/mozilla/javascript/Ref;";
+                            cfw.addPush(memberTypeFlags);
+                            ScriptRuntimeMethodSig.memberRef_member.addInvoke(cfw);
                             break;
                         case Token.REF_NS_MEMBER:
-                            methodName = "memberRef";
-                            signature =
-                                    "(Ljava/lang/Object;"
-                                            + "Ljava/lang/Object;"
-                                            + "Ljava/lang/Object;"
-                                            + "Lorg/mozilla/javascript/Context;"
-                                            + "I"
-                                            + ")Lorg/mozilla/javascript/Ref;";
+                            cfw.addPush(memberTypeFlags);
+                            ScriptRuntimeMethodSig.memberRef_namespaceMember.addInvoke(cfw);
                             break;
                         case Token.REF_NAME:
-                            methodName = "nameRef";
-                            signature =
-                                    "(Ljava/lang/Object;"
-                                            + "Lorg/mozilla/javascript/Context;"
-                                            + "Lorg/mozilla/javascript/Scriptable;"
-                                            + "I"
-                                            + ")Lorg/mozilla/javascript/Ref;";
                             cfw.addALoad(variableObjectLocal);
+                            cfw.addPush(memberTypeFlags);
+                            ScriptRuntimeMethodSig.memberRef_name.addInvoke(cfw);
                             break;
                         case Token.REF_NS_NAME:
-                            methodName = "nameRef";
-                            signature =
-                                    "(Ljava/lang/Object;"
-                                            + "Ljava/lang/Object;"
-                                            + "Lorg/mozilla/javascript/Context;"
-                                            + "Lorg/mozilla/javascript/Scriptable;"
-                                            + "I"
-                                            + ")Lorg/mozilla/javascript/Ref;";
                             cfw.addALoad(variableObjectLocal);
+                            cfw.addPush(memberTypeFlags);
+                            ScriptRuntimeMethodSig.memberRef_namespaceName.addInvoke(cfw);
                             break;
                         default:
                             throw Kit.codeBug();
                     }
-                    cfw.addPush(memberTypeFlags);
-                    addScriptRuntimeInvoke(methodName, signature);
                 }
                 break;
 
@@ -1699,31 +1582,19 @@ class BodyCodegen {
             case Token.ESCXMLATTR:
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
-                addScriptRuntimeInvoke(
-                        "escapeAttributeValue",
-                        "(Ljava/lang/Object;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + ")Ljava/lang/String;");
+                ScriptRuntimeMethodSig.escapeAttributeValue.addInvoke(cfw);
                 break;
 
             case Token.ESCXMLTEXT:
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
-                addScriptRuntimeInvoke(
-                        "escapeTextValue",
-                        "(Ljava/lang/Object;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + ")Ljava/lang/String;");
+                ScriptRuntimeMethodSig.escapeTextValue.addInvoke(cfw);
                 break;
 
             case Token.DEFAULTNAMESPACE:
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
-                addScriptRuntimeInvoke(
-                        "setDefaultNamespace",
-                        "(Ljava/lang/Object;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + ")Ljava/lang/Object;");
+                ScriptRuntimeMethodSig.setDefaultNamespace.addInvoke(cfw);
                 break;
 
             case Token.YIELD:
@@ -1792,11 +1663,7 @@ class BodyCodegen {
 
     private void finishGetRefGeneration() {
         cfw.addALoad(contextLocal);
-        addScriptRuntimeInvoke(
-                "refGet",
-                "(Lorg/mozilla/javascript/Ref;"
-                        + "Lorg/mozilla/javascript/Context;"
-                        + ")Ljava/lang/Object;");
+        ScriptRuntimeMethodSig.refGet.addInvoke(cfw);
     }
 
     private void finishRefSpecialGeneration(Node node) {
@@ -1804,13 +1671,7 @@ class BodyCodegen {
         cfw.addPush(special);
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        addScriptRuntimeInvoke(
-                "specialRef",
-                "(Ljava/lang/Object;"
-                        + "Ljava/lang/String;"
-                        + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + ")Lorg/mozilla/javascript/Ref;");
+        ScriptRuntimeMethodSig.specialRef.addInvoke(cfw);
     }
 
     // Descend down the tree and return the first child that represents a yield
@@ -2343,7 +2204,7 @@ class BodyCodegen {
                 cfw.addPush((String) id);
             } else {
                 cfw.addPush(((Integer) id).intValue());
-                addScriptRuntimeInvoke("wrapInt", "(I)Ljava/lang/Integer;");
+                ScriptRuntimeMethodSig.wrapInt.addInvoke(cfw);
             }
         }
     }
@@ -2431,16 +2292,7 @@ class BodyCodegen {
 
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
-        addScriptRuntimeInvoke(
-                "fillObjectLiteral",
-                "("
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "[Ljava/lang/Object;"
-                        + "[Ljava/lang/Object;"
-                        + "[I"
-                        + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + ")V");
+        ScriptRuntimeMethodSig.fillObjectLiteral.addInvoke(cfw);
     }
 
     private void visitSpecialCall(Node node, int type, int specialType, Node child) {
@@ -2461,14 +2313,7 @@ class BodyCodegen {
         cfw.addALoad(variableObjectLocal);
         cfw.addPush(specialType);
 
-        addScriptRuntimeInvoke(
-                "newSpecial",
-                "(Lorg/mozilla/javascript/Context;"
-                        + "Ljava/lang/Object;"
-                        + "[Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "I"
-                        + ")Ljava/lang/Object;");
+        ScriptRuntimeMethodSig.newSpecial.addInvoke(cfw);
     }
 
     private void visitSpecialNormalCall(Node node, int specialType, Node child) {
@@ -2485,17 +2330,7 @@ class BodyCodegen {
         cfw.addPush(itsLineNumber);
         cfw.addPush(false);
 
-        addScriptRuntimeInvoke(
-                "callSpecial",
-                "(Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Callable;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "[Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "I"
-                        + "Ljava/lang/String;IZ"
-                        + ")Ljava/lang/Object;");
+        ScriptRuntimeMethodSig.callSpecial.addInvoke(cfw);
     }
 
     private void visitSpecialOptionalChainingCall(Node node, int specialType, Node child) {
@@ -2533,17 +2368,7 @@ class BodyCodegen {
         cfw.addPush(itsLineNumber);
         cfw.addPush(true);
 
-        addScriptRuntimeInvoke(
-                "callSpecial",
-                "(Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Callable;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "[Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "I"
-                        + "Ljava/lang/String;IZ"
-                        + ")Ljava/lang/Object;");
+        ScriptRuntimeMethodSig.callSpecial.addInvoke(cfw);
 
         cfw.markLabel(afterLabel);
     }
@@ -2639,13 +2464,7 @@ class BodyCodegen {
         cfw.addALoad(variableObjectLocal);
         // stack: ... functionObj cx scope
         generateCallArgArray(node, firstArgChild, false);
-        addScriptRuntimeInvoke(
-                "newObject",
-                "(Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + "[Ljava/lang/Object;"
-                        + ")Lorg/mozilla/javascript/Scriptable;");
+        ScriptRuntimeMethodSig.newObject.addInvoke(cfw);
     }
 
     private void visitOptimizedCall(Node node, OptFunctionNode target, int type, Node child) {
@@ -2742,13 +2561,7 @@ class BodyCodegen {
         generateCallArgArray(node, firstArgChild, true);
 
         if (type == Token.NEW) {
-            addScriptRuntimeInvoke(
-                    "newObject",
-                    "(Ljava/lang/Object;"
-                            + "Lorg/mozilla/javascript/Context;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
-                            + "[Ljava/lang/Object;"
-                            + ")Lorg/mozilla/javascript/Scriptable;");
+            ScriptRuntimeMethodSig.newObject.addInvoke(cfw);
         } else {
             cfw.addInvoke(
                     ByteCode.INVOKEINTERFACE,
@@ -2862,17 +2675,12 @@ class BodyCodegen {
                         if (node.getIntProp(Node.ISNUMBER_PROP, -1) != -1) addDoubleWrap();
                         cfw.addALoad(contextLocal);
                         cfw.addALoad(variableObjectLocal);
-                        String name =
-                                isOptionalChainingCall
-                                        ? "getElemAndThisOptional"
-                                        : "getElemAndThis";
-                        addScriptRuntimeInvoke(
-                                name,
-                                "(Ljava/lang/Object;"
-                                        + "Ljava/lang/Object;"
-                                        + "Lorg/mozilla/javascript/Context;"
-                                        + "Lorg/mozilla/javascript/Scriptable;"
-                                        + ")Lorg/mozilla/javascript/ScriptRuntime$LookupResult;");
+
+                        if (isOptionalChainingCall) {
+                            ScriptRuntimeMethodSig.getElemAndThisOptional.addInvoke(cfw);
+                        } else {
+                            ScriptRuntimeMethodSig.getElemAndThis.addInvoke(cfw);
+                        }
                     }
                     break;
                 }
@@ -2893,13 +2701,12 @@ class BodyCodegen {
                 {
                     generateExpression(node, parent);
                     cfw.addALoad(contextLocal);
-                    String name =
-                            isOptionalChainingCall ? "getValueAndThisOptional" : "getValueAndThis";
-                    addScriptRuntimeInvoke(
-                            name,
-                            "(Ljava/lang/Object;"
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + ")Lorg/mozilla/javascript/ScriptRuntime$LookupResult;");
+
+                    if (isOptionalChainingCall) {
+                        ScriptRuntimeMethodSig.getValueAndThisOptional.addInvoke(cfw);
+                    } else {
+                        ScriptRuntimeMethodSig.getValueAndThis.addInvoke(cfw);
+                    }
                     break;
                 }
         }
@@ -3482,7 +3289,7 @@ class BodyCodegen {
                     cfw.add(ByteCode.IF_ACMPEQ, isNumberLabel);
                     int stack = cfw.getStackTop();
                     cfw.addALoad(dcp_register);
-                    addScriptRuntimeInvoke("typeof", "(Ljava/lang/Object;" + ")Ljava/lang/String;");
+                    ScriptRuntimeMethodSig.typeof.addInvoke(cfw);
                     int beyond = cfw.acquireLabel();
                     cfw.add(ByteCode.GOTO, beyond);
                     cfw.markLabel(isNumberLabel, stack);
@@ -3490,18 +3297,14 @@ class BodyCodegen {
                     cfw.markLabel(beyond);
                 } else {
                     cfw.addALoad(varRegisters[varIndex]);
-                    addScriptRuntimeInvoke("typeof", "(Ljava/lang/Object;" + ")Ljava/lang/String;");
+                    ScriptRuntimeMethodSig.typeof.addInvoke(cfw);
                 }
                 return;
             }
         }
         cfw.addALoad(variableObjectLocal);
         cfw.addPush(node.getString());
-        addScriptRuntimeInvoke(
-                "typeofName",
-                "(Lorg/mozilla/javascript/Scriptable;"
-                        + "Ljava/lang/String;"
-                        + ")Ljava/lang/String;");
+        ScriptRuntimeMethodSig.typeofName.addInvoke(cfw);
     }
 
     /**
@@ -3534,7 +3337,7 @@ class BodyCodegen {
     private void addInstructionCount(int count) {
         cfw.addALoad(contextLocal);
         cfw.addPush(count);
-        addScriptRuntimeInvoke("addInstructionCount", "(Lorg/mozilla/javascript/Context;" + "I)V");
+        ScriptRuntimeMethodSig.addInstructionCount.addInvoke(cfw);
     }
 
     private void visitIncDec(Node node) {
@@ -3635,12 +3438,7 @@ class BodyCodegen {
                 cfw.addPush(child.getString()); // push name
                 cfw.addALoad(contextLocal);
                 cfw.addPush(incrDecrMask);
-                addScriptRuntimeInvoke(
-                        "nameIncrDecr",
-                        "(Lorg/mozilla/javascript/Scriptable;"
-                                + "Ljava/lang/String;"
-                                + "Lorg/mozilla/javascript/Context;"
-                                + "I)Ljava/lang/Object;");
+                ScriptRuntimeMethodSig.nameIncrDecr.addInvoke(cfw);
                 break;
             case Token.GETPROPNOWARN:
                 throw Kit.codeBug();
@@ -3652,13 +3450,7 @@ class BodyCodegen {
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
                     cfw.addPush(incrDecrMask);
-                    addScriptRuntimeInvoke(
-                            "propIncrDecr",
-                            "(Ljava/lang/Object;"
-                                    + "Ljava/lang/String;"
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
-                                    + "I)Ljava/lang/Object;");
+                    ScriptRuntimeMethodSig.propIncrDecr.addInvoke(cfw);
                     break;
                 }
             case Token.GETELEM:
@@ -3679,14 +3471,7 @@ class BodyCodegen {
                                         + "I"
                                         + ")Ljava/lang/Object;");
                     } else {
-                        addScriptRuntimeInvoke(
-                                "elemIncrDecr",
-                                "(Ljava/lang/Object;"
-                                        + "Ljava/lang/Object;"
-                                        + "Lorg/mozilla/javascript/Context;"
-                                        + "Lorg/mozilla/javascript/Scriptable;"
-                                        + "I"
-                                        + ")Ljava/lang/Object;");
+                        ScriptRuntimeMethodSig.elemIncrDecr.addInvoke(cfw);
                     }
                     break;
                 }
@@ -3697,12 +3482,7 @@ class BodyCodegen {
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
                     cfw.addPush(incrDecrMask);
-                    addScriptRuntimeInvoke(
-                            "refIncrDecr",
-                            "(Lorg/mozilla/javascript/Ref;"
-                                    + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
-                                    + "I)Ljava/lang/Object;");
+                    ScriptRuntimeMethodSig.refIncrDecr.addInvoke(cfw);
                     break;
                 }
             default:
@@ -3826,21 +3606,16 @@ class BodyCodegen {
 
             switch (type) {
                 case Token.SUB:
-                    addScriptRuntimeInvoke(
-                            "subtract", "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.subtract.addInvoke(cfw);
                     break;
                 case Token.MUL:
-                    addScriptRuntimeInvoke(
-                            "multiply", "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.multiply.addInvoke(cfw);
                     break;
                 case Token.DIV:
-                    addScriptRuntimeInvoke(
-                            "divide", "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.divide.addInvoke(cfw);
                     break;
                 case Token.MOD:
-                    addScriptRuntimeInvoke(
-                            "remainder",
-                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.remainder.addInvoke(cfw);
                     break;
                 default:
                     throw Kit.codeBug(Token.typeToName(type));
@@ -3864,8 +3639,7 @@ class BodyCodegen {
             cfw.addALoad(reg);
             addObjectToNumeric();
 
-            addScriptRuntimeInvoke(
-                    "exponentiate", "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+            ScriptRuntimeMethodSig.exponentiate.addInvoke(cfw);
         }
     }
 
@@ -3874,9 +3648,9 @@ class BodyCodegen {
         generateExpression(child, node);
         if (childNumberFlag == -1) {
             addObjectToNumeric();
-            addScriptRuntimeInvoke("bitwiseNOT", "(Ljava/lang/Number;)Ljava/lang/Number;");
+            ScriptRuntimeMethodSig.bitwiseNOT.addInvoke(cfw);
         } else {
-            addScriptRuntimeInvoke("toInt32", "(D)I");
+            ScriptRuntimeMethodSig.toInt32.addInvoke(cfw);
             cfw.addPush(-1); // implement ~a as (a ^ -1)
             cfw.add(ByteCode.IXOR);
             cfw.add(ByteCode.I2D);
@@ -3910,37 +3684,27 @@ class BodyCodegen {
 
             switch (type) {
                 case Token.BITOR:
-                    addScriptRuntimeInvoke(
-                            "bitwiseOR",
-                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.bitwiseOR.addInvoke(cfw);
                     break;
                 case Token.BITXOR:
-                    addScriptRuntimeInvoke(
-                            "bitwiseXOR",
-                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.bitwiseXOR.addInvoke(cfw);
                     break;
                 case Token.BITAND:
-                    addScriptRuntimeInvoke(
-                            "bitwiseAND",
-                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.bitwiseAND.addInvoke(cfw);
                     break;
                 case Token.RSH:
-                    addScriptRuntimeInvoke(
-                            "signedRightShift",
-                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.signedRightShift.addInvoke(cfw);
                     break;
                 case Token.LSH:
-                    addScriptRuntimeInvoke(
-                            "leftShift",
-                            "(Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;");
+                    ScriptRuntimeMethodSig.leftShift.addInvoke(cfw);
                     break;
                 default:
                     throw Kit.codeBug(Token.typeToName(type));
             }
         } else {
-            addScriptRuntimeInvoke("toInt32", "(D)I");
+            ScriptRuntimeMethodSig.toInt32.addInvoke(cfw);
             generateExpression(child.getNext(), node);
-            addScriptRuntimeInvoke("toInt32", "(D)I");
+            ScriptRuntimeMethodSig.toInt32.addInvoke(cfw);
 
             switch (type) {
                 case Token.BITOR:
@@ -4014,12 +3778,11 @@ class BodyCodegen {
             generateExpression(child, node);
             generateExpression(rChild, node);
             cfw.addALoad(contextLocal);
-            addScriptRuntimeInvoke(
-                    (type == Token.INSTANCEOF) ? "instanceOf" : "in",
-                    "(Ljava/lang/Object;"
-                            + "Ljava/lang/Object;"
-                            + "Lorg/mozilla/javascript/Context;"
-                            + ")Z");
+            if (type == Token.INSTANCEOF) {
+                ScriptRuntimeMethodSig.instanceOf.addInvoke(cfw);
+            } else {
+                ScriptRuntimeMethodSig.in.addInvoke(cfw);
+            }
             cfw.add(ByteCode.IFNE, trueGOTO);
             cfw.add(ByteCode.GOTO, falseGOTO);
             return;
@@ -4448,11 +4211,7 @@ class BodyCodegen {
         updateLineNumber(node);
         generateExpression(child, node);
         cfw.addALoad(variableObjectLocal);
-        addScriptRuntimeInvoke(
-                "enterDotQuery",
-                "(Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + ")Lorg/mozilla/javascript/Scriptable;");
+        ScriptRuntimeMethodSig.enterDotQuery.addInvoke(cfw);
         cfw.addAStore(variableObjectLocal);
 
         // add push null/pop with label in between to simplify code for loop
@@ -4466,16 +4225,12 @@ class BodyCodegen {
         generateExpression(child.getNext(), node);
         addDynamicInvoke("MATH:TOBOOLEAN", Signatures.MATH_TO_BOOLEAN);
         cfw.addALoad(variableObjectLocal);
-        addScriptRuntimeInvoke(
-                "updateDotQuery",
-                "(Z" + "Lorg/mozilla/javascript/Scriptable;" + ")Ljava/lang/Object;");
+        ScriptRuntimeMethodSig.updateDotQuery.addInvoke(cfw);
         cfw.add(ByteCode.DUP);
         cfw.add(ByteCode.IFNULL, queryLoopStart);
         // stack: ... non_null_result_of_updateDotQuery
         cfw.addALoad(variableObjectLocal);
-        addScriptRuntimeInvoke(
-                "leaveDotQuery",
-                "(Lorg/mozilla/javascript/Scriptable;" + ")Lorg/mozilla/javascript/Scriptable;");
+        ScriptRuntimeMethodSig.leaveDotQuery.addInvoke(cfw);
         cfw.addAStore(variableObjectLocal);
     }
 
@@ -4543,14 +4298,6 @@ class BodyCodegen {
             cfw.addPush(size);
             cfw.add(ByteCode.ANEWARRAY, "java/lang/Object");
         }
-    }
-
-    private void addScriptRuntimeInvoke(String methodName, String methodSignature) {
-        cfw.addInvoke(
-                ByteCode.INVOKESTATIC,
-                "org.mozilla.javascript.ScriptRuntime",
-                methodName,
-                methodSignature);
     }
 
     private void addOptRuntimeInvoke(String methodName, String methodSignature) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ScriptRuntimeMethodSig.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ScriptRuntimeMethodSig.java
@@ -1,0 +1,132 @@
+package org.mozilla.javascript.optimizer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.invoke.MethodType;
+import org.mozilla.classfile.ByteCode;
+import org.mozilla.classfile.ClassFileWriter;
+import org.mozilla.javascript.ScriptRuntime;
+
+/**
+ * Holder of {@link ScriptRuntime} method information, to help with codegen
+ *
+ * <p>Each enum value is linked to a method in {@link ScriptRuntime} via {@link CodeGenMarker}. For
+ * each enum value, there should be at least and at most one method linked to it, or a fatal
+ * exception will be thrown at class initialization.
+ *
+ * <p>Calling {@link #addInvoke(ClassFileWriter)} will insert a static method invoke with class
+ * being {@link ScriptRuntime}, method name and descriptor being the name and descriptor of the
+ * linked method
+ *
+ * @author ZZZank
+ */
+public enum ScriptRuntimeMethodSig {
+    padAndRestArguments,
+    padArguments,
+    createArrowFunctionActivation,
+    createFunctionActivation,
+    enterActivationFunction,
+    initScript,
+    exitActivationFunction,
+    newCatchScope,
+    enterWith,
+    leaveWith,
+    enumInit,
+    enumNext,
+    enumId,
+    callRef,
+    typeof,
+    negate,
+    refGet,
+    refSet,
+    refDel,
+    throwDeleteOnSuperPropertyNotAllowed,
+    delete,
+    memberRef_member,
+    memberRef_namespaceMember,
+    memberRef_name,
+    memberRef_namespaceName,
+    escapeAttributeValue,
+    escapeTextValue,
+    setDefaultNamespace,
+    specialRef,
+    wrapInt,
+    fillObjectLiteral,
+    newSpecial,
+    callSpecial,
+    newObject,
+    getElemAndThisOptional,
+    getElemAndThis,
+    getValueAndThisOptional,
+    getValueAndThis,
+    typeofName,
+    addInstructionCount,
+    nameIncrDecr,
+    propIncrDecr,
+    elemIncrDecr,
+    refIncrDecr,
+    subtract,
+    multiply,
+    divide,
+    remainder,
+    exponentiate,
+    bitwiseNOT,
+    toInt32,
+    bitwiseOR,
+    bitwiseXOR,
+    bitwiseAND,
+    signedRightShift,
+    leftShift,
+    instanceOf,
+    in,
+    enterDotQuery,
+    updateDotQuery,
+    leaveDotQuery;
+
+    private static final String CLASS_INTERNAL_NAME =
+            ScriptRuntime.class.getName().replace('.', '/');
+
+    static {
+        // init
+        for (var method : ScriptRuntime.class.getDeclaredMethods()) {
+            var marker = method.getAnnotation(CodeGenMarker.class);
+            if (marker == null) {
+                continue;
+            }
+            var annot = marker.value();
+            if (annot.methodName != null) {
+                throw new IllegalStateException("found two method with same marker: " + annot);
+            }
+            annot.methodName = method.getName();
+            annot.methodDesc =
+                    MethodType.methodType(method.getReturnType(), method.getParameterTypes())
+                            .toMethodDescriptorString();
+        }
+        // validation
+        for (var value : values()) {
+            if (value.methodName == null) {
+                throw new IllegalStateException("not initialized: " + value);
+            }
+        }
+    }
+
+    private String methodName;
+    private String methodDesc;
+
+    public void addInvoke(ClassFileWriter cfw) {
+        cfw.addInvoke(ByteCode.INVOKESTATIC, CLASS_INTERNAL_NAME, methodName, methodDesc);
+    }
+
+    /**
+     * For linking method and corresponding enum value
+     *
+     * @see ScriptRuntimeMethodSig
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface CodeGenMarker {
+        ScriptRuntimeMethodSig value();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ScriptRuntimeMethodSig.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ScriptRuntimeMethodSig.java
@@ -10,7 +10,9 @@ import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.ScriptRuntime;
 
 /**
- * Holder of {@link ScriptRuntime} method information, to help with codegen
+ * INTERNAL API
+ *
+ * <p>Holder of {@link ScriptRuntime} method information, to help with codegen
  *
  * <p>Each enum value is linked to a method in {@link ScriptRuntime} via {@link CodeGenMarker}. For
  * each enum value, there should be at least and at most one method linked to it, or a fatal
@@ -120,7 +122,9 @@ public enum ScriptRuntimeMethodSig {
     }
 
     /**
-     * For linking method and corresponding enum value
+     * INTERNAL API
+     *
+     * <p>For linking method and corresponding enum value
      *
      * @see ScriptRuntimeMethodSig
      */


### PR DESCRIPTION
The intention of this PR is the same as #1948 : to make code gen works even after a package renaming (aka relocating)

In order to handle such a large amount of method references to `ScriptRuntime`, a new enum class `ScriptRuntimeMethodSig` is introduced, with each enum value holding code gen related information for a method in `ScriptRuntime`.

In theory this PR is completed and ready for review, but I dont know how to suppress the "ImmutableEnum" error when doing `gradle check`, so draft for now