### PR TITLE
Preparation for interpreter refactoring.

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/GeneratorBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/GeneratorBenchmark.java
@@ -1,0 +1,64 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class GeneratorBenchmark {
+    @State(Scope.Thread)
+    public static class GeneratorState {
+        Context cx;
+        Scriptable scope;
+
+        Function nativeGenerator;
+        Function transpiledGenerator;
+        Function noReturnGenerator;
+
+        @Param({"false", "true"})
+        public boolean interpreted;
+
+        @Setup(Level.Trial)
+        public void setup() throws IOException {
+            cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            scope = cx.initStandardObjects();
+
+            try (FileReader rdr =
+                    new FileReader("testsrc/benchmarks/micro/generator-benchmarks.js")) {
+                cx.evaluateReader(scope, rdr, "generator-benchmarks.js", 1, null);
+            }
+            nativeGenerator = (Function) ScriptableObject.getProperty(scope, "nativeGenerator");
+            transpiledGenerator =
+                    (Function) ScriptableObject.getProperty(scope, "transpiledGenerator");
+            noReturnGenerator = (Function) ScriptableObject.getProperty(scope, "noReturnGenerator");
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            cx.close();
+        }
+    }
+
+    @Benchmark
+    public Object nativeGenerator(GeneratorState state) {
+        return state.nativeGenerator.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object transpiledGenerator(GeneratorState state) {
+        return state.transpiledGenerator.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object noReturnGenerator(GeneratorState state) {
+        return state.noReturnGenerator.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+}

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ThrowBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ThrowBenchmark.java
@@ -1,0 +1,62 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ThrowBenchmark {
+    @State(Scope.Thread)
+    public static class GeneratorState {
+        Context cx;
+        Scriptable scope;
+
+        Function shallowThrow;
+        Function mediumThrow;
+        Function deepThrow;
+
+        @Param({"false", "true"})
+        public boolean interpreted;
+
+        @Setup(Level.Trial)
+        public void setup() throws IOException {
+            cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            scope = cx.initStandardObjects();
+
+            try (FileReader rdr = new FileReader("testsrc/benchmarks/micro/throw-benchmarks.js")) {
+                cx.evaluateReader(scope, rdr, "throw-benchmarks.js", 1, null);
+            }
+            shallowThrow = (Function) ScriptableObject.getProperty(scope, "shallowThrow");
+            mediumThrow = (Function) ScriptableObject.getProperty(scope, "mediumThrow");
+            deepThrow = (Function) ScriptableObject.getProperty(scope, "deepThrow");
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            cx.close();
+        }
+    }
+
+    @Benchmark
+    public Object shallowThrow(GeneratorState state) {
+        return state.shallowThrow.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object mediumThrow(GeneratorState state) {
+        return state.mediumThrow.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object deepThrow(GeneratorState state) {
+        return state.deepThrow.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+}

--- a/benchmarks/testsrc/benchmarks/micro/generator-benchmarks.js
+++ b/benchmarks/testsrc/benchmarks/micro/generator-benchmarks.js
@@ -1,0 +1,166 @@
+function* myGenerator(limit) {
+    for (i = 0; i < limit; i++) {
+        yield i;
+    }
+    return -1;
+}
+
+function _ts_generator(thisArg, body) {
+    var f, y, t, g, _ = {
+        label: 0,
+        sent: function() {
+            if (t[0] & 1) throw t[1];
+            return t[1];
+        },
+        trys: [],
+        ops: []
+    };
+    return g = {
+        next: verb(0),
+        "throw": verb(1),
+        "return": verb(2)
+    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
+        return this;
+    }), g;
+    function verb(n) {
+        return function(v) {
+            return step([
+                n,
+                v
+            ]);
+        };
+    }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while(_)try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [
+                op[0] & 2,
+                t.value
+            ];
+            switch(op[0]){
+                case 0:
+                case 1:
+                    t = op;
+                    break;
+                case 4:
+                    _.label++;
+                    return {
+                        value: op[1],
+                        done: false
+                    };
+                case 5:
+                    _.label++;
+                    y = op[1];
+                    op = [
+                        0
+                    ];
+                    continue;
+                case 7:
+                    op = _.ops.pop();
+                    _.trys.pop();
+                    continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) {
+                        _ = 0;
+                        continue;
+                    }
+                    if (op[0] === 3 && (!t || op[1] > t[0] && op[1] < t[3])) {
+                        _.label = op[1];
+                        break;
+                    }
+                    if (op[0] === 6 && _.label < t[1]) {
+                        _.label = t[1];
+                        t = op;
+                        break;
+                    }
+                    if (t && _.label < t[2]) {
+                        _.label = t[2];
+                        _.ops.push(op);
+                        break;
+                    }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop();
+                    continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) {
+            op = [
+                6,
+                e
+            ];
+            y = 0;
+        } finally{
+            f = t = 0;
+        }
+        if (op[0] & 5) throw op[1];
+        return {
+            value: op[0] ? op[1] : void 0,
+            done: true
+        };
+    }
+}
+
+function myGenerator2(limit) {
+    return _ts_generator(this, function(_state) {
+        switch(_state.label){
+            case 0:
+                i = 0;
+                _state.label = 1;
+            case 1:
+                if (!(i < limit)) return [
+                    3,
+                    4
+                ];
+                return [
+                    4,
+                    i
+                ];
+            case 2:
+                _state.sent();
+                _state.label = 3;
+            case 3:
+                i++;
+                return [
+                    3,
+                    1
+                ];
+            case 4:
+                return [
+                    2,
+                    -1
+                ];
+        }
+    });
+}
+
+function nativeGenerator() {
+    const gen = myGenerator(1_000);
+    count = 0;
+    while (! (gen.next().done)) {
+        count++;
+    }
+    return count;
+}
+
+function transpiledGenerator() {
+    const gen = myGenerator2(1_000);
+    count = 0;
+    while (! (gen.next().done)) {
+        count++;
+    }
+    return count;
+}
+
+function noReturnGenerator() {
+    const gen = myGenerator(1_000_000);
+    count = 0;
+    while (gen.next().value <= 1_000) {
+        count++;
+    }
+    return count;
+}
+
+nativeGenerator();
+transpiledGenerator();
+noReturnGenerator();

--- a/benchmarks/testsrc/benchmarks/micro/throw-benchmarks.js
+++ b/benchmarks/testsrc/benchmarks/micro/throw-benchmarks.js
@@ -1,0 +1,30 @@
+function f(depth) {
+    try {
+        g(depth);
+    } catch (e) {
+        return -1;
+    }
+}
+
+function g(depth) {
+    if (depth <= 0) {
+        throw new Error("depth reached!");
+    }
+    g(depth - 1.0);
+}
+
+function shallowThrow() {
+    f(0.0);
+}
+
+function mediumThrow() {
+    f(10.0);
+}
+
+function deepThrow() {
+    f(100.0);
+}
+
+shallowThrow();
+mediumThrow();
+deepThrow();

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2092,7 +2092,7 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Icode_SETCONSTVAR1:
                                 indexReg = iCode[frame.pc++];
                             // fallthrough
-                            case Token.SETCONSTVAR:
+                            case Icode_SETCONSTVAR:
                                 stackTop =
                                         doSetConstVar(
                                                 frame,

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
@@ -18,7 +18,7 @@ public class GeneratorStackTraceTest {
     }
 
     private static void runWithExpectedStackTrace(final String _source, final String expected) {
-        Utils.runWithMode(
+        Utils.runWithAllModes(
                 cx -> {
                     final Scriptable scope = cx.initStandardObjects();
                     try {
@@ -28,8 +28,7 @@ public class GeneratorStackTraceTest {
                         return null;
                     }
                     throw new RuntimeException("Exception expected!");
-                },
-                true);
+                });
     }
 
     @Test
@@ -49,7 +48,7 @@ public class GeneratorStackTraceTest {
                         + "g.next();\n"
                         + "g.next();"; // This should throw
 
-        Utils.runWithMode(
+        Utils.runWithAllModes(
                 context -> {
                     try {
                         final Scriptable scope = context.initStandardObjects();
@@ -70,8 +69,7 @@ public class GeneratorStackTraceTest {
                         System.out.println("Nested Generator Exception Stack: \n" + stack);
                     }
                     return null;
-                },
-                true);
+                });
     }
 
     // Doesn't work due to our implementation of yield*.
@@ -90,7 +88,7 @@ public class GeneratorStackTraceTest {
                         + "g.next();\n"
                         + "g.next();"; // This should throw
 
-        Utils.runWithMode(
+        Utils.runWithAllModes(
                 context -> {
                     try {
                         final Scriptable scope = context.initStandardObjects();
@@ -111,13 +109,12 @@ public class GeneratorStackTraceTest {
                         System.out.println("Nested Generator Exception Stack: \n" + stack);
                     }
                     return null;
-                },
-                true);
+                });
     }
 
     @Test
     public void testJavaCallbackThrowsFromGenerator() {
-        Utils.runWithMode(
+        Utils.runWithAllModes(
                 context -> {
                     Scriptable scope = context.initStandardObjects();
                     LambdaFunction f =
@@ -156,7 +153,6 @@ public class GeneratorStackTraceTest {
                         System.out.println("Caught Java Exception from JS: " + e.getMessage());
                     }
                     return null;
-                },
-                true);
+                });
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
@@ -1,0 +1,162 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.testutils.Utils;
+
+public class GeneratorStackTraceTest {
+
+    @Test
+    public void testGeneratorStackTraces() {
+        String script =
+                "function* f2() { yield 1; throw 'hello'; yield 3; }; var g = f2(); g.next(); g.next();";
+        String expected = "\tat test.js:0 (f2)\n" + "\tat test.js:0\n";
+        runWithExpectedStackTrace(script, expected);
+    }
+
+    private static void runWithExpectedStackTrace(final String _source, final String expected) {
+        Utils.runWithMode(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    try {
+                        cx.evaluateString(scope, _source, "test.js", 0, null);
+                    } catch (final JavaScriptException e) {
+                        assertEquals(expected, e.getScriptStackTrace());
+                        return null;
+                    }
+                    throw new RuntimeException("Exception expected!");
+                },
+                true);
+    }
+
+    @Test
+    public void testNestedGeneratorsException() {
+        String jsCode =
+                ""
+                        + "function* innerGen() {\n"
+                        + "    yield 1;\n"
+                        + "    throw new Error('Inner Exception'); // Line 4\n"
+                        + "}\n"
+                        + "function* outerGen() {\n"
+                        + "    var f = innerGen();\n"
+                        + "    yield f.next().value;\n"
+                        + "    yield f.next().value;\n"
+                        + "}\n"
+                        + "var g = outerGen();\n"
+                        + "g.next();\n"
+                        + "g.next();"; // This should throw
+
+        Utils.runWithMode(
+                context -> {
+                    try {
+                        final Scriptable scope = context.initStandardObjects();
+                        context.evaluateString(scope, jsCode, "nestedGeneratorTest.js", 1, null);
+                        Assert.fail("Expected exception from nested generator not thrown.");
+                    } catch (JavaScriptException e) {
+                        String stack = e.getScriptStackTrace();
+
+                        // Validate that both generator functions appear in the stack
+                        Assert.assertTrue(
+                                "Stack trace should include innerGen", stack.contains("innerGen"));
+                        Assert.assertTrue(
+                                "Stack trace should include outerGen", stack.contains("outerGen"));
+
+                        // Validate line number for the throw
+                        assertEquals("Line number of exception should be 3", 3, e.lineNumber());
+
+                        System.out.println("Nested Generator Exception Stack: \n" + stack);
+                    }
+                    return null;
+                },
+                true);
+    }
+
+    // Doesn't work due to our implementation of yield*.
+    @Test(expected = AssertionError.class)
+    public void testNestedGeneratorsYieldStarException() {
+        String jsCode =
+                ""
+                        + "function* innerGen() {\n"
+                        + "    yield 1;\n"
+                        + "    throw new Error('Inner Exception'); // Line 4\n"
+                        + "}\n"
+                        + "function* outerGen() {\n"
+                        + "    yield* innerGen();\n"
+                        + "}\n"
+                        + "var g = outerGen();\n"
+                        + "g.next();\n"
+                        + "g.next();"; // This should throw
+
+        Utils.runWithMode(
+                context -> {
+                    try {
+                        final Scriptable scope = context.initStandardObjects();
+                        context.evaluateString(scope, jsCode, "nestedGeneratorTest.js", 1, null);
+                        Assert.fail("Expected exception from nested generator not thrown.");
+                    } catch (JavaScriptException e) {
+                        String stack = e.getScriptStackTrace();
+
+                        // Validate that both generator functions appear in the stack
+                        Assert.assertTrue(
+                                "Stack trace should include innerGen", stack.contains("innerGen"));
+                        Assert.assertTrue(
+                                "Stack trace should include outerGen", stack.contains("outerGen"));
+
+                        // Validate line number for the throw
+                        assertEquals("Line number of exception should be 3", 3, e.lineNumber());
+
+                        System.out.println("Nested Generator Exception Stack: \n" + stack);
+                    }
+                    return null;
+                },
+                true);
+    }
+
+    @Test
+    public void testJavaCallbackThrowsFromGenerator() {
+        Utils.runWithMode(
+                context -> {
+                    Scriptable scope = context.initStandardObjects();
+                    LambdaFunction f =
+                            new LambdaFunction(
+                                    scope,
+                                    "javaHelper",
+                                    0,
+                                    (Context ctx,
+                                            Scriptable scope2,
+                                            Scriptable thisObj,
+                                            Object[] args) -> {
+                                        throw new RuntimeException("Java-side failure!");
+                                    });
+                    ScriptableObject.putProperty(scope, "javaHelper", f);
+
+                    String jsCode =
+                            ""
+                                    + "function* generatorWithCallback() {\n"
+                                    + "    yield 1;\n"
+                                    + "    javaHelper();\n"
+                                    + // This should throw from Java
+                                    "}\n"
+                                    + "var g = generatorWithCallback();\n"
+                                    + "g.next();\n"
+                                    + // Move to the first yield
+                                    "g.next();"; // This should throw
+
+                    try {
+                        context.evaluateString(scope, jsCode, "javaCallbackTest.js", 1, null);
+                        Assert.fail("Expected Java exception not thrown.");
+                    } catch (RuntimeException e) {
+                        // Rhino should surface the Java exception directly
+                        Assert.assertTrue(
+                                "Exception message should contain 'Java-side failure!'",
+                                e.getMessage().contains("Java-side failure!"));
+                        System.out.println("Caught Java Exception from JS: " + e.getMessage());
+                    }
+                    return null;
+                },
+                true);
+    }
+}

--- a/tests/testsrc/jstests/const-white-box.js
+++ b/tests/testsrc/jstests/const-white-box.js
@@ -60,4 +60,154 @@ for (let i = 0; i < ITERATIONS; i++) {
    objectConstness();
 }
 
+/* Test we can actually have a lot of consts in a function. */
+function manyConsts() {
+    const a0 = 0;
+    const a1 = 1;
+    const a2 = 2;
+    const a3 = 3;
+    const a4 = 4;
+    const a5 = 5;
+    const a6 = 6;
+    const a7 = 7;
+    const a8 = 8;
+    const a9 = 9;
+    const a10 = 10;
+    const a11 = 11;
+    const a12 = 12;
+    const a13 = 13;
+    const a14 = 14;
+    const a15 = 15;
+    const a16 = 16;
+    const a17 = 17;
+    const a18 = 18;
+    const a19 = 19;
+    const a20 = 20;
+    const a21 = 21;
+    const a22 = 22;
+    const a23 = 23;
+    const a24 = 24;
+    const a25 = 25;
+    const a26 = 26;
+    const a27 = 27;
+    const a28 = 28;
+    const a29 = 29;
+    const a30 = 30;
+    const a31 = 31;
+    const a32 = 32;
+    const a33 = 33;
+    const a34 = 34;
+    const a35 = 35;
+    const a36 = 36;
+    const a37 = 37;
+    const a38 = 38;
+    const a39 = 39;
+    const a40 = 40;
+    const a41 = 41;
+    const a42 = 42;
+    const a43 = 43;
+    const a44 = 44;
+    const a45 = 45;
+    const a46 = 46;
+    const a47 = 47;
+    const a48 = 48;
+    const a49 = 49;
+    const a50 = 50;
+    const a51 = 51;
+    const a52 = 52;
+    const a53 = 53;
+    const a54 = 54;
+    const a55 = 55;
+    const a56 = 56;
+    const a57 = 57;
+    const a58 = 58;
+    const a59 = 59;
+    const a60 = 60;
+    const a61 = 61;
+    const a62 = 62;
+    const a63 = 63;
+    const a64 = 64;
+    const a65 = 65;
+    const a66 = 66;
+    const a67 = 67;
+    const a68 = 68;
+    const a69 = 69;
+    const a70 = 70;
+    const a71 = 71;
+    const a72 = 72;
+    const a73 = 73;
+    const a74 = 74;
+    const a75 = 75;
+    const a76 = 76;
+    const a77 = 77;
+    const a78 = 78;
+    const a79 = 79;
+    const a80 = 80;
+    const a81 = 81;
+    const a82 = 82;
+    const a83 = 83;
+    const a84 = 84;
+    const a85 = 85;
+    const a86 = 86;
+    const a87 = 87;
+    const a88 = 88;
+    const a89 = 89;
+    const a90 = 90;
+    const a91 = 91;
+    const a92 = 92;
+    const a93 = 93;
+    const a94 = 94;
+    const a95 = 95;
+    const a96 = 96;
+    const a97 = 97;
+    const a98 = 98;
+    const a99 = 99;
+    const a100 = 100;
+    const a101 = 101;
+    const a102 = 102;
+    const a103 = 103;
+    const a104 = 104;
+    const a105 = 105;
+    const a106 = 106;
+    const a107 = 107;
+    const a108 = 108;
+    const a109 = 109;
+    const a110 = 110;
+    const a111 = 111;
+    const a112 = 112;
+    const a113 = 113;
+    const a114 = 114;
+    const a115 = 115;
+    const a116 = 116;
+    const a117 = 117;
+    const a118 = 118;
+    const a119 = 119;
+    const a120 = 120;
+    const a121 = 121;
+    const a122 = 122;
+    const a123 = 123;
+    const a124 = 124;
+    const a125 = 125;
+    const a126 = 126;
+    const a127 = 127;
+    const a128 = 128;
+    const a129 = 129;
+
+    return a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 +
+        a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 +
+        a20 + a21 + a22 + a23 + a24 + a25 + a26 + a27 + a28 + a29 +
+        a30 + a31 + a32 + a33 + a34 + a35 + a36 + a37 + a38 + a39 +
+        a40 + a41 + a42 + a43 + a44 + a45 + a46 + a47 + a48 + a49 +
+        a50 + a51 + a52 + a53 + a54 + a55 + a56 + a57 + a58 + a59 +
+        a60 + a61 + a62 + a63 + a64 + a65 + a66 + a67 + a68 + a69 +
+        a70 + a71 + a72 + a73 + a74 + a75 + a76 + a77 + a78 + a79 +
+        a80 + a81 + a82 + a83 + a84 + a85 + a86 + a87 + a88 + a89 +
+        a90 + a91 + a92 + a93 + a94 + a95 + a96 + a97 + a98 + a99 +
+        a100 + a101 + a102 + a103 + a104 + a105 + a106 + a107 + a108 + a109 +
+        a110 + a111 + a112 + a113 + a114 + a115 + a116 + a117 + a118 + a119 +
+        a120 + a121 + a122 + a123 + a124 + a125 + a126 + a127 + a128 + a129
+}
+
+manyConsts();
+
 'success';


### PR DESCRIPTION
# Interpreter refactoring for error reporting and performance.

This is a the first in a set of stacked PRs covering all the changes made as part of our work on #1933. The overall goal of this has been to refactor the interpreter to allow for better error reporting, without losing any interpreter performance in the process. These changes are not presented in the order in which they were made internally and have been reorganised extensively to make them easier
to review.

## Original motivation

Internally we use a modified JVM that has been tightly coupled to the Rhino interpreter in order to enable better error reporting in some circumstances. This is done by changing the stack frames in exception stack traces to reflect the scripts being executed - similar to decoration done within the interpreter for Rhino exceptions. Since the interpreter stack structure and the information about PC are held in mutable structures this information must be captured at the point where the exception is generated, and this is too expensive to be done for all exceptions and stack traces that might be generated in the system.

Many of the prototype versions of this work showed some regression in interpreter benchmarks, and an increase in memory footprint, so in combination with this work we also worked hard to mitigate these issues. Taking those changes to their logical conclusion showed a substantial performance improvement across the benchmarks, and so we include them with this work. They also have helped provide some good pointers for further optimisation work that we may attempt.

### Exception throwing and reporting

Generating exceptions can be a pretty common occurrence, but the reporting of exception stack traces is generally much rarer, so in general we should make the process of throwing an exception as light as possible, and shift heavier work to the process of reporting. To facilitate this we want to be able to represent the stack by a linked list effectively immutable objects which can be captured by a simple operation. By their nature call frames are mutable in many respects, but we can make enough aspects of them immutable to reuse them as this structure. Let's start by thinking about what we need to decorate a Java stack trace with additional information for interpreted scripts.

#### Basic stack structure

We already have fields for parent frame and a count of how deep this
stack is, we will make these final to avoid mutations breaking our
structure.

#### Matching call frames to interpreter calls

Next, we need to be able to know which call frames map to each interpreter invocation. We have previously used a deque on the context to hold this, but we'd like to make this an immutable structure instead. We add a field referencing the call frame from the previous interpreter invocation. We will keep this separate from the parent frame field to make navigation easier when processing the call frame structure without having to traverse the entire list.

So, for each call to the interpreter we can navigate the set of frames associated with it by iterating through parent frames, with `null` indicating we've reached the end of that set, and we can iterate through the interpreter frames using the `previousInterpreterFrame` field.

#### Getting line number information

Every call frame has its current line number available, but that is mutable so may well have changed by the time we come to report the stack trace. To avoid this we will store the information of each parent frame's current line in its children's `parentPC` field. We'll also need to populate that field when we have a new interpreter call and populate the `previousInterpreterFrame`.

## Other issues found during this work (this PR)

While investigating this work it was also noticed that some other features in Rhino that involve exceptions (such as generators) can perform particularly poorly in benchmarks and were in fact slower than the transpiled version produced by SWC. We have added micro benchmarks to track these and avoid future issues.

It was also noticed that there had been a bug in the interpretation of `const` and we have added a test and a fix for this as well.

## Interpreter frame refactoring (#1955)

We want to be able to reliably model the stack of interpreter frames in an immutable way. To make this problem more tractable we make everything intended to be final actually final by moving calculation of true maximum stack size to the creation of the frame. We record the PC of the caller in callee frames so that the stack can be reliably reconstructed, and we introduce methods to copy frames in situations where we might have previously mutated them.

## Changes to exception decoration and construction (#1956 )

We move from using a deque on `Context` for holding the stack to it being represented purely by the linked parent frames and previous interpreter frames. We change the exception construction code to simply capture the current interpreter frame, and change the decoration code to walk this tree to produce the required stacks.

## Boxing / unboxing reduction (#1957 )

While doing this work several areas in the interpreter were spotted where we box doubles in order to perform simple operations. We have endeavoured to reduce this boxing and unboxing and will use this to help guide us in further optimisation work.

## Instruction dispatch (#1958, #1959)

During this work several instructions were extracted from the main interpreter method to help keep it under the JVM's 8k threshold. Some further prototyping showed that extracting all the instructions to be objects which are dispatched to gave significantly better overall performance. This work consists of extracting the inner loop, adding the ability to dispatch to instructions, a series of commits extracting all the instructions, and finally some tidying up once all instructions are extracted. I'm guessing people will not want to review 30 separate PRs, but I also think it's important we preserve these commits to make life easy for anybody maintaining a fork.

## Benchmark results

| Benchmark                                                   |      Score |     Error |  New Score | New Error | Units | % perf improvement |
|---|---|---|---|---|---|---|
| GeneratorBenchmark.nativeGenerator                          |  38507.045 | 12151.986 |    252.340 |     4.918 | us/op |          99.344691 |
| GeneratorBenchmark.noReturnGenerator                        |    421.062 |    93.580 |    258.216 |     7.141 | us/op |          38.675064 |
| GeneratorBenchmark.transpiledGenerator                      |   4727.404 |   235.836 |   2928.891 |    46.732 | us/op |          38.044411 |
| SunSpiderBenchmark.AccessBinaryTreesState.accessBinaryTrees |  34751.248 | 20096.198 |  22092.018 |   612.319 | us/op |          36.428131 |
| SunSpiderBenchmark.AccessFannAccessNsieveState.accessNsieve | 110745.263 |  6458.761 |  84316.461 |  2198.357 | us/op |          23.864499 |
| SunSpiderBenchmark.AccessFannkuchState.accessFannkuch       | 206581.653 | 15475.813 | 119034.799 |  1439.329 | us/op |          42.378814 |
| SunSpiderBenchmark.AccessNBodyState.accessNBody             | 107004.136 | 10591.070 |  66285.473 |  5885.346 | us/op |          38.053354 |
| SunSpiderBenchmark.Bitops3BitState.bitops3BitBitsInByte     |  84771.027 |  1253.212 |  54397.599 |  3141.704 | us/op |          35.829963 |
| SunSpiderBenchmark.BitopsAndState.bitopsBitwiseAnd          |  52400.594 |  3845.000 |  52098.127 |   604.952 | us/op |         0.57722056 |
| SunSpiderBenchmark.BitopsBitsState.bitopsBitsInByte         | 104684.925 |  1153.506 |  87441.751 |  3895.710 | us/op |          16.471497 |
| SunSpiderBenchmark.BitopsNsieveState.bitopsNsieveBits       | 103980.452 | 97847.010 |  75234.600 |  4685.286 | us/op |          27.645439 |
| SunSpiderBenchmark.CryptoAesState.cryptoAes                 |  56111.701 |  2495.730 |  39109.408 |  1879.414 | us/op |          30.300798 |
| SunSpiderBenchmark.CryptoMd5State.cryptoMd5                 |  44223.204 |  3467.751 |  32111.436 | 16960.138 | us/op |          27.387812 |
| SunSpiderBenchmark.CryptoShaState.cryptoSha1                |  49989.547 |   233.562 |  35502.798 |   803.666 | us/op |          28.979556 |
| SunSpiderBenchmark.DateFormatToFteState.dateFormatToFte     |  41366.291 |  1147.810 |  36823.851 | 10580.727 | us/op |          10.981018 |
| SunSpiderBenchmark.DateFormatXparbState.dateFormatXparb     |  26914.044 |   818.883 |  20688.481 |   841.108 | us/op |          23.131280 |
| SunSpiderBenchmark.MathCordicState.mathCordic               | 131722.462 | 11228.776 |  78523.640 |  5459.335 | us/op |          40.387054 |
| SunSpiderBenchmark.MathPartialState.mathPartialSums         |  73093.750 |  9888.646 |  40326.374 |  2978.195 | us/op |          44.829245 |
| SunSpiderBenchmark.MathSpectralNormState.mathSpectralNorm   |  52905.160 |  1361.999 |  35324.990 |   961.693 | us/op |          33.229594 |
| SunSpiderBenchmark.RecursiveState.controlflowRecursive      |  49057.605 |  1599.582 |  34918.938 |  1043.614 | us/op |          28.820541 |
| SunSpiderBenchmark.RegexpState.regexpDna                    |  50114.322 |  1238.022 |  52051.081 |  4673.053 | us/op |         -3.8646816 |
| SunSpiderBenchmark.StringBase64State.stringBase64           |  52139.724 |  8065.039 |  29363.214 |  2431.562 | us/op |          43.683603 |
| SunSpiderBenchmark.StringFastaState.stringFasta             |  65779.012 |   458.002 |  45673.900 |  3035.140 | us/op |          30.564631 |
| SunSpiderBenchmark.StringTagcloudState.stringTagcloud       |  41507.281 |   305.399 |  34051.067 |   782.571 | us/op |          17.963629 |
| SunSpiderBenchmark.StringUnpackState.stringUnpackCode       |  45930.157 |  1125.107 |  41474.694 |  2051.064 | us/op |          9.7005177 |
| SunSpiderBenchmark.StringValidateState.stringValidateInput  |  39390.182 |   759.869 |  25796.280 |   940.380 | us/op |          34.510889 |
| SunSpiderBenchmark.ThreeDCubeState.threeDCube               |  61385.550 |   990.864 |  51051.183 |   834.764 | us/op |          16.835179 |
| SunSpiderBenchmark.ThreeDMorphState.threeDMorph             |  78911.113 |  4967.159 |  43000.044 |   557.646 | us/op |          45.508253 |
| SunSpiderBenchmark.ThreeDRayState.threeDRayTrace            |  55733.251 |  7326.321 |  41318.087 |   331.578 | us/op |          25.864567 |
| V8Benchmark.boyer                                           | 256903.584 |  3321.435 | 217803.256 | 67776.791 | us/op |          15.219845 |
| V8Benchmark.cryptoDecrypt                                   | 640532.638 | 41633.601 | 308146.687 | 10325.692 | us/op |          51.892118 |
| V8Benchmark.cryptoEncrpyt                                   |  33345.999 |  3224.295 |  16656.599 |   651.730 | us/op |          50.049183 |
| V8Benchmark.deltaBlue                                       |  19895.400 |   230.528 |  18843.446 |   310.124 | us/op |          5.2874232 |
| V8Benchmark.earley                                          |  18275.641 |   243.078 |  14527.591 |   524.977 | us/op |          20.508446 |
| V8Benchmark.rayTrace                                        |  94394.689 |   739.711 |  65438.330 |  1189.817 | us/op |          30.675835 |
| V8Benchmark.regExp                                          | 186647.334 |  5172.279 | 188960.919 | 22036.702 | us/op |         -1.2395489 |
| V8Benchmark.richards                                        |   9729.381 |    81.687 |   9811.934 |   274.778 | us/op |        -0.84849180 |
| V8Benchmark.splay                                           |   4912.434 |   484.418 |   4001.878 |    76.930 | us/op |          18.535740 |
