### PR TITLE
Callframe refactor

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/GeneratorBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/GeneratorBenchmark.java
@@ -1,0 +1,64 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class GeneratorBenchmark {
+    @State(Scope.Thread)
+    public static class GeneratorState {
+        Context cx;
+        Scriptable scope;
+
+        Function nativeGenerator;
+        Function transpiledGenerator;
+        Function noReturnGenerator;
+
+        @Param({"false", "true"})
+        public boolean interpreted;
+
+        @Setup(Level.Trial)
+        public void setup() throws IOException {
+            cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            scope = cx.initStandardObjects();
+
+            try (FileReader rdr =
+                    new FileReader("testsrc/benchmarks/micro/generator-benchmarks.js")) {
+                cx.evaluateReader(scope, rdr, "generator-benchmarks.js", 1, null);
+            }
+            nativeGenerator = (Function) ScriptableObject.getProperty(scope, "nativeGenerator");
+            transpiledGenerator =
+                    (Function) ScriptableObject.getProperty(scope, "transpiledGenerator");
+            noReturnGenerator = (Function) ScriptableObject.getProperty(scope, "noReturnGenerator");
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            cx.close();
+        }
+    }
+
+    @Benchmark
+    public Object nativeGenerator(GeneratorState state) {
+        return state.nativeGenerator.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object transpiledGenerator(GeneratorState state) {
+        return state.transpiledGenerator.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object noReturnGenerator(GeneratorState state) {
+        return state.noReturnGenerator.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+}

--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ThrowBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/ThrowBenchmark.java
@@ -1,0 +1,62 @@
+package org.mozilla.javascript.benchmarks;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.openjdk.jmh.annotations.*;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ThrowBenchmark {
+    @State(Scope.Thread)
+    public static class GeneratorState {
+        Context cx;
+        Scriptable scope;
+
+        Function shallowThrow;
+        Function mediumThrow;
+        Function deepThrow;
+
+        @Param({"false", "true"})
+        public boolean interpreted;
+
+        @Setup(Level.Trial)
+        public void setup() throws IOException {
+            cx = Context.enter();
+            cx.setInterpretedMode(interpreted);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            scope = cx.initStandardObjects();
+
+            try (FileReader rdr = new FileReader("testsrc/benchmarks/micro/throw-benchmarks.js")) {
+                cx.evaluateReader(scope, rdr, "throw-benchmarks.js", 1, null);
+            }
+            shallowThrow = (Function) ScriptableObject.getProperty(scope, "shallowThrow");
+            mediumThrow = (Function) ScriptableObject.getProperty(scope, "mediumThrow");
+            deepThrow = (Function) ScriptableObject.getProperty(scope, "deepThrow");
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            cx.close();
+        }
+    }
+
+    @Benchmark
+    public Object shallowThrow(GeneratorState state) {
+        return state.shallowThrow.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object mediumThrow(GeneratorState state) {
+        return state.mediumThrow.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+
+    @Benchmark
+    public Object deepThrow(GeneratorState state) {
+        return state.deepThrow.call(state.cx, state.scope, null, ScriptRuntime.emptyArgs);
+    }
+}

--- a/benchmarks/testsrc/benchmarks/micro/generator-benchmarks.js
+++ b/benchmarks/testsrc/benchmarks/micro/generator-benchmarks.js
@@ -1,0 +1,166 @@
+function* myGenerator(limit) {
+    for (i = 0; i < limit; i++) {
+        yield i;
+    }
+    return -1;
+}
+
+function _ts_generator(thisArg, body) {
+    var f, y, t, g, _ = {
+        label: 0,
+        sent: function() {
+            if (t[0] & 1) throw t[1];
+            return t[1];
+        },
+        trys: [],
+        ops: []
+    };
+    return g = {
+        next: verb(0),
+        "throw": verb(1),
+        "return": verb(2)
+    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
+        return this;
+    }), g;
+    function verb(n) {
+        return function(v) {
+            return step([
+                n,
+                v
+            ]);
+        };
+    }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while(_)try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [
+                op[0] & 2,
+                t.value
+            ];
+            switch(op[0]){
+                case 0:
+                case 1:
+                    t = op;
+                    break;
+                case 4:
+                    _.label++;
+                    return {
+                        value: op[1],
+                        done: false
+                    };
+                case 5:
+                    _.label++;
+                    y = op[1];
+                    op = [
+                        0
+                    ];
+                    continue;
+                case 7:
+                    op = _.ops.pop();
+                    _.trys.pop();
+                    continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) {
+                        _ = 0;
+                        continue;
+                    }
+                    if (op[0] === 3 && (!t || op[1] > t[0] && op[1] < t[3])) {
+                        _.label = op[1];
+                        break;
+                    }
+                    if (op[0] === 6 && _.label < t[1]) {
+                        _.label = t[1];
+                        t = op;
+                        break;
+                    }
+                    if (t && _.label < t[2]) {
+                        _.label = t[2];
+                        _.ops.push(op);
+                        break;
+                    }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop();
+                    continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) {
+            op = [
+                6,
+                e
+            ];
+            y = 0;
+        } finally{
+            f = t = 0;
+        }
+        if (op[0] & 5) throw op[1];
+        return {
+            value: op[0] ? op[1] : void 0,
+            done: true
+        };
+    }
+}
+
+function myGenerator2(limit) {
+    return _ts_generator(this, function(_state) {
+        switch(_state.label){
+            case 0:
+                i = 0;
+                _state.label = 1;
+            case 1:
+                if (!(i < limit)) return [
+                    3,
+                    4
+                ];
+                return [
+                    4,
+                    i
+                ];
+            case 2:
+                _state.sent();
+                _state.label = 3;
+            case 3:
+                i++;
+                return [
+                    3,
+                    1
+                ];
+            case 4:
+                return [
+                    2,
+                    -1
+                ];
+        }
+    });
+}
+
+function nativeGenerator() {
+    const gen = myGenerator(1_000);
+    count = 0;
+    while (! (gen.next().done)) {
+        count++;
+    }
+    return count;
+}
+
+function transpiledGenerator() {
+    const gen = myGenerator2(1_000);
+    count = 0;
+    while (! (gen.next().done)) {
+        count++;
+    }
+    return count;
+}
+
+function noReturnGenerator() {
+    const gen = myGenerator(1_000_000);
+    count = 0;
+    while (gen.next().value <= 1_000) {
+        count++;
+    }
+    return count;
+}
+
+nativeGenerator();
+transpiledGenerator();
+noReturnGenerator();

--- a/benchmarks/testsrc/benchmarks/micro/throw-benchmarks.js
+++ b/benchmarks/testsrc/benchmarks/micro/throw-benchmarks.js
@@ -1,0 +1,30 @@
+function f(depth) {
+    try {
+        g(depth);
+    } catch (e) {
+        return -1;
+    }
+}
+
+function g(depth) {
+    if (depth <= 0) {
+        throw new Error("depth reached!");
+    }
+    g(depth - 1.0);
+}
+
+function shallowThrow() {
+    f(0.0);
+}
+
+function mediumThrow() {
+    f(10.0);
+}
+
+function deepThrow() {
+    f(100.0);
+}
+
+shallowThrow();
+mediumThrow();
+deepThrow();

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2092,7 +2092,7 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Icode_SETCONSTVAR1:
                                 indexReg = iCode[frame.pc++];
                             // fallthrough
-                            case Token.SETCONSTVAR:
+                            case Icode_SETCONSTVAR:
                                 stackTop =
                                         doSetConstVar(
                                                 frame,

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -44,9 +44,12 @@ public final class Interpreter extends Icode implements Evaluator {
         // fields marked "final" in a comment are effectively final except when they're modified
         // immediately after cloning.
 
-        /*final*/ CallFrame parentFrame;
+        final CallFrame parentFrame;
         // amount of stack frames before this one on the interpretation stack
-        /*final*/ int frameIndex;
+        final short frameIndex;
+        // The frame that the iterator was executing.
+        final CallFrame previousInterpreterFrame;
+        final int parentPC;
         // If true indicates read-only frame that is a part of continuation
         boolean frozen;
 
@@ -59,13 +62,12 @@ public final class Interpreter extends Icode implements Evaluator {
         // stack[emptyStackTop < i < stack.length]: stack data
         // sDbl[i]: if stack[i] is UniqueTag.DOUBLE_MARK, sDbl[i] holds the number value
 
-        /*final*/ Object[] stack;
-        /*final*/ int[] stackAttributes;
-        /*final*/ double[] sDbl;
+        final Object[] stack;
+        final byte[] stackAttributes;
+        final double[] sDbl;
 
         final CallFrame varSource; // defaults to this unless continuation frame
-        final int localShift;
-        final int emptyStackTop;
+        final short emptyStackTop;
 
         final DebugFrame debuggerFrame;
         final boolean useActivation;
@@ -90,20 +92,28 @@ public final class Interpreter extends Icode implements Evaluator {
                 Context cx,
                 Scriptable thisObj,
                 InterpretedFunction fnOrScript,
-                CallFrame parentFrame) {
+                CallFrame parentFrame,
+                CallFrame previousInterpreterFrame) {
             idata = fnOrScript.idata;
-
             debuggerFrame = cx.debugger != null ? cx.debugger.getFrame(cx, idata) : null;
             useActivation = debuggerFrame != null || idata.itsNeedsActivation;
 
-            emptyStackTop = idata.itsMaxVars + idata.itsMaxLocals - 1;
+            emptyStackTop = (short) (idata.itsMaxVars + idata.itsMaxLocals - 1);
+            int maxFrameArray = idata.itsMaxFrameArray;
+            if (maxFrameArray != emptyStackTop + idata.itsMaxStack + 1) Kit.codeBug();
+
+            stack = new Object[maxFrameArray];
+            stackAttributes = new byte[maxFrameArray];
+            sDbl = new double[maxFrameArray];
+
             this.fnOrScript = fnOrScript;
             varSource = this;
-            localShift = idata.itsMaxVars;
             this.thisObj = thisObj;
 
             this.parentFrame = parentFrame;
-            frameIndex = (parentFrame == null) ? 0 : parentFrame.frameIndex + 1;
+            this.parentPC = parentFrame == null ? -1 : parentFrame.pcSourceLineStart;
+            this.previousInterpreterFrame = previousInterpreterFrame;
+            frameIndex = (short) ((parentFrame == null) ? 0 : parentFrame.frameIndex + 1);
             if (frameIndex > cx.getMaximumInterpreterStackDepth()) {
                 throw Context.reportRuntimeError("Exceeded maximum stack depth");
             }
@@ -116,22 +126,76 @@ public final class Interpreter extends Icode implements Evaluator {
             savedStackTop = emptyStackTop;
         }
 
+        private CallFrame(CallFrame original, boolean makeOrphan) {
+            this(
+                    original,
+                    makeOrphan ? null : original.parentFrame,
+                    makeOrphan ? null : original.previousInterpreterFrame);
+        }
+
+        private CallFrame(
+                CallFrame original, CallFrame parentFrame, CallFrame previousInterpreterFrame) {
+            if (!original.frozen) Kit.codeBug();
+
+            stack = Arrays.copyOf(original.stack, original.stack.length);
+            stackAttributes =
+                    Arrays.copyOf(original.stackAttributes, original.stackAttributes.length);
+            sDbl = Arrays.copyOf(original.sDbl, original.sDbl.length);
+
+            frozen = false;
+            this.parentFrame = parentFrame;
+            this.previousInterpreterFrame = previousInterpreterFrame;
+            if (parentFrame == null) {
+                frameIndex = 0;
+                parentPC = -1;
+            } else {
+                frameIndex = original.frameIndex;
+                parentPC = parentFrame.pcSourceLineStart;
+            }
+
+            fnOrScript = original.fnOrScript;
+            idata = original.idata;
+
+            varSource = original.varSource;
+            emptyStackTop = original.emptyStackTop;
+
+            debuggerFrame = original.debuggerFrame;
+            useActivation = original.useActivation;
+            isContinuationsTopFrame = original.isContinuationsTopFrame;
+
+            thisObj = original.thisObj;
+
+            result = original.result;
+            resultDbl = original.resultDbl;
+            pc = original.pc;
+            pcPrevBranch = original.pcPrevBranch;
+            pcSourceLineStart = original.pcSourceLineStart;
+            scope = original.scope;
+
+            savedStackTop = original.savedStackTop;
+            savedCallOp = original.savedCallOp;
+            throwable = original.throwable;
+        }
+
         void initializeArgs(
                 Context cx,
                 Scriptable callerScope,
                 Object[] args,
                 double[] argsDbl,
+                Object[] boundArgs,
                 int argShift,
                 int argCount,
                 Scriptable homeObject) {
             if (useActivation) {
                 // Copy args to new array to pass to enterActivationFunction
                 // or debuggerFrame.onEnter
-                if (argsDbl != null) {
-                    args = getArgsArray(args, argsDbl, argShift, argCount);
+                if (argsDbl != null || boundArgs != null) {
+                    int blen = boundArgs == null ? 0 : boundArgs.length;
+                    args = getArgsArray(args, argsDbl, boundArgs, blen, argShift, argCount);
                 }
                 argShift = 0;
                 argsDbl = null;
+                boundArgs = null;
             }
 
             if (idata.itsFunctionType != 0) {
@@ -164,8 +228,7 @@ public final class Interpreter extends Icode implements Evaluator {
                 }
             } else {
                 scope = callerScope;
-                ScriptRuntime.initScript(
-                        fnOrScript, thisObj, cx, scope, fnOrScript.idata.evalScriptFlag);
+                ScriptRuntime.initScript(fnOrScript, thisObj, cx, scope, idata.evalScriptFlag);
             }
 
             if (idata.itsNestedFunctions != null) {
@@ -179,14 +242,6 @@ public final class Interpreter extends Icode implements Evaluator {
             }
 
             final int maxFrameArray = idata.itsMaxFrameArray;
-            // TODO: move this check into InterpreterData construction
-            if (maxFrameArray != emptyStackTop + idata.itsMaxStack + 1) Kit.codeBug();
-
-            // Initialize args, vars, locals and stack
-
-            stack = new Object[maxFrameArray];
-            stackAttributes = new int[maxFrameArray];
-            sDbl = new double[maxFrameArray];
 
             int varCount = idata.getParamAndVarCount();
             for (int i = 0; i < varCount; i++) {
@@ -199,9 +254,18 @@ public final class Interpreter extends Icode implements Evaluator {
 
             // Fill the frame structure
 
-            System.arraycopy(args, argShift, stack, 0, definedArgs);
+            int blen = 0;
+            if (boundArgs != null) {
+                blen = boundArgs.length;
+                if (blen > definedArgs) {
+                    blen = definedArgs;
+                }
+                System.arraycopy(boundArgs, 0, stack, 0, blen);
+            }
+
+            System.arraycopy(args, argShift, stack, blen, definedArgs - blen);
             if (argsDbl != null) {
-                System.arraycopy(argsDbl, argShift, sDbl, 0, definedArgs);
+                System.arraycopy(argsDbl, argShift, sDbl, blen, definedArgs - blen);
             }
             for (int i = definedArgs; i != idata.itsMaxVars; ++i) {
                 stack[i] = Undefined.instance;
@@ -228,39 +292,12 @@ public final class Interpreter extends Icode implements Evaluator {
             }
         }
 
-        // While maximum stack sizes are normally statically calculated by the compiler, in some
-        // situations we can dynamically need a larger stack, specifically when we're peeling bound
-        // functions, Function.apply, and no-such-method handlers for invocation.
-        Object[] ensureStackLength(int length) {
-            if (length > stack.length) {
-                stack = Arrays.copyOf(stack, length);
-                sDbl = Arrays.copyOf(sDbl, length);
-                stackAttributes = Arrays.copyOf(stackAttributes, length);
-                // TODO: adjust idata idata.itsMaxFrameArray & idata.itsMaxStack so they start with
-                // larger stacks next time? Not clear this is always a good idea.
-            }
-            return stack;
+        CallFrame cloneFrozen() {
+            return new CallFrame(this, false);
         }
 
-        CallFrame cloneFrozen() {
-            if (!frozen) Kit.codeBug();
-
-            CallFrame copy;
-            try {
-                copy = (CallFrame) clone();
-            } catch (CloneNotSupportedException ex) {
-                throw new IllegalStateException();
-            }
-
-            // clone stack but keep varSource to point to values
-            // from this frame to share variables.
-
-            copy.stack = stack.clone();
-            copy.stackAttributes = stackAttributes.clone();
-            copy.sDbl = sDbl.clone();
-
-            copy.frozen = false;
-            return copy;
+        CallFrame cloneFrozen(CallFrame newParent, CallFrame newPreviousInterpreeterFrame) {
+            return new CallFrame(this, newParent, newPreviousInterpreeterFrame);
         }
 
         @Override
@@ -352,6 +389,10 @@ public final class Interpreter extends Icode implements Evaluator {
                     && equal.equalGraphs(fnOrScript, other.fnOrScript)
                     && equal.equalGraphs(scope, other.scope);
         }
+
+        CallFrame captureForGenerator() {
+            return new CallFrame(this, true);
+        }
     }
 
     private static boolean compareIdata(InterpreterData i1, InterpreterData i2) {
@@ -411,12 +452,8 @@ public final class Interpreter extends Icode implements Evaluator {
 
     private static CallFrame captureFrameForGenerator(CallFrame frame) {
         frame.frozen = true;
-        CallFrame result = frame.cloneFrozen();
+        CallFrame result = frame.captureForGenerator();
         frame.frozen = false;
-
-        // now isolate this frame from its previous context
-        result.parentFrame = null;
-        result.frameIndex = 0;
 
         return result;
     }
@@ -1151,6 +1188,7 @@ public final class Interpreter extends Icode implements Evaluator {
                         ifun.getHomeObject(),
                         args,
                         null,
+                        null,
                         0,
                         args.length,
                         ifun,
@@ -1242,12 +1280,10 @@ public final class Interpreter extends Icode implements Evaluator {
     }
 
     private static final class ContinueLoop extends NewState {
-        private final CallFrame frame;
         private final int stackTop;
         private final int indexReg;
 
-        private ContinueLoop(CallFrame frame, int stackTop, int indexReg) {
-            this.frame = frame;
+        private ContinueLoop(int stackTop, int indexReg) {
             this.stackTop = stackTop;
             this.indexReg = indexReg;
         }
@@ -1319,12 +1355,13 @@ public final class Interpreter extends Icode implements Evaluator {
                 // for faster access
                 Object[] stack = frame.stack;
                 double[] sDbl = frame.sDbl;
-                Object[] vars = frame.varSource.stack;
-                double[] varDbls = frame.varSource.sDbl;
-                int[] varAttributes = frame.varSource.stackAttributes;
-                byte[] iCode = frame.idata.itsICode;
-                String[] strings = frame.idata.itsStringTable;
-                BigInteger[] bigInts = frame.idata.itsBigIntTable;
+                final Object[] vars = frame.varSource.stack;
+                final double[] varDbls = frame.varSource.sDbl;
+                final byte[] varAttributes = frame.varSource.stackAttributes;
+                final InterpreterData iData = frame.idata;
+                final byte[] iCode = iData.itsICode;
+                final String[] strings = iData.itsStringTable;
+                final BigInteger[] bigInts = iData.itsBigIntTable;
 
                 // Use local for stackTop as well. Since execption handlers
                 // can only exist at statement level where stack is empty,
@@ -1376,6 +1413,9 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Token.YIELD:
                             case Icode_YIELD_STAR:
                                 {
+                                    /* This is both where we yield
+                                     * from and re-enter the
+                                     * generator. */
                                     if (!frame.frozen) {
                                         return freezeGenerator(
                                                 cx,
@@ -1400,7 +1440,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                             new JavaScriptException(
                                                     NativeIterator.getStopIterationObject(
                                                             frame.scope),
-                                                    frame.idata.itsSourceFile,
+                                                    iData.itsSourceFile,
                                                     sourceLine);
                                     break Loop;
                                 }
@@ -1421,7 +1461,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                     int sourceLine = getIndex(iCode, frame.pc);
                                     generatorState.returnedException =
                                             new JavaScriptException(
-                                                    si, frame.idata.itsSourceFile, sourceLine);
+                                                    si, iData.itsSourceFile, sourceLine);
                                     break Loop;
                                 }
                             case Token.THROW:
@@ -1434,12 +1474,12 @@ public final class Interpreter extends Icode implements Evaluator {
                                     int sourceLine = getIndex(iCode, frame.pc);
                                     throwable =
                                             new JavaScriptException(
-                                                    value, frame.idata.itsSourceFile, sourceLine);
+                                                    value, iData.itsSourceFile, sourceLine);
                                     break withoutExceptions;
                                 }
                             case Token.RETHROW:
                                 {
-                                    indexReg += frame.localShift;
+                                    indexReg += iData.itsMaxVars;
                                     throwable = stack[indexReg];
                                     break withoutExceptions;
                                 }
@@ -1524,7 +1564,7 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Icode_STARTSUB:
                                 if (stackTop == frame.emptyStackTop + 1) {
                                     // Call from Icode_GOSUB: store return PC address in the local
-                                    indexReg += frame.localShift;
+                                    indexReg += iData.itsMaxVars;
                                     stack[indexReg] = stack[stackTop];
                                     sDbl[indexReg] = sDbl[stackTop];
                                     --stackTop;
@@ -1541,7 +1581,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                     if (instructionCounting) {
                                         addInstructionCount(cx, frame, 0);
                                     }
-                                    indexReg += frame.localShift;
+                                    indexReg += iData.itsMaxVars;
                                     Object value = stack[indexReg];
                                     if (value != DBL_MRK) {
                                         // Invocation from exception handler, restore object to
@@ -1839,12 +1879,12 @@ public final class Interpreter extends Icode implements Evaluator {
                                 }
                             case Token.LOCAL_LOAD:
                                 ++stackTop;
-                                indexReg += frame.localShift;
+                                indexReg += iData.itsMaxVars;
                                 stack[stackTop] = stack[indexReg];
                                 sDbl[stackTop] = sDbl[indexReg];
                                 continue Loop;
                             case Icode_LOCAL_CLEAR:
-                                indexReg += frame.localShift;
+                                indexReg += iData.itsMaxVars;
                                 stack[indexReg] = null;
                                 continue Loop;
                             case Icode_NAME_AND_THIS:
@@ -1963,7 +2003,6 @@ public final class Interpreter extends Icode implements Evaluator {
                                                     indexReg);
                                     if (callState instanceof ContinueLoop) {
                                         var contLoop = (ContinueLoop) callState;
-                                        frame = contLoop.frame;
                                         stack = frame.stack;
                                         sDbl = frame.sDbl;
                                         stackTop = contLoop.stackTop;
@@ -2011,6 +2050,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                                             newInstance,
                                                             stack,
                                                             sDbl,
+                                                            null,
                                                             stackTop + 1,
                                                             indexReg,
                                                             f,
@@ -2075,7 +2115,7 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Token.NUMBER:
                                 ++stackTop;
                                 stack[stackTop] = DBL_MRK;
-                                sDbl[stackTop] = frame.idata.itsDoubleTable[indexReg];
+                                sDbl[stackTop] = iData.itsDoubleTable[indexReg];
                                 continue Loop;
                             case Token.BIGINT:
                                 stack[++stackTop] = bigIntReg;
@@ -2209,9 +2249,9 @@ public final class Interpreter extends Icode implements Evaluator {
                                     // stringReg: name of exception variable
                                     // indexReg: local for exception scope
                                     --stackTop;
-                                    indexReg += frame.localShift;
+                                    indexReg += iData.itsMaxVars;
 
-                                    boolean afterFirstScope = (frame.idata.itsICode[frame.pc] != 0);
+                                    boolean afterFirstScope = (iData.itsICode[frame.pc] != 0);
                                     Throwable caughtException = (Throwable) stack[stackTop + 1];
                                     Scriptable lastCatchScope;
                                     if (!afterFirstScope) {
@@ -2238,7 +2278,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                     if (lhs == DBL_MRK)
                                         lhs = ScriptRuntime.wrapNumber(sDbl[stackTop]);
                                     --stackTop;
-                                    indexReg += frame.localShift;
+                                    indexReg += iData.itsMaxVars;
                                     int enumType =
                                             op == Token.ENUM_INIT_KEYS
                                                     ? ScriptRuntime.ENUMERATE_KEYS
@@ -2255,7 +2295,7 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Token.ENUM_NEXT:
                             case Token.ENUM_ID:
                                 {
-                                    indexReg += frame.localShift;
+                                    indexReg += iData.itsMaxVars;
                                     Object val = stack[indexReg];
                                     ++stackTop;
                                     stack[stackTop] =
@@ -2305,11 +2345,11 @@ public final class Interpreter extends Icode implements Evaluator {
                                     continue Loop;
                                 }
                             case Icode_SCOPE_LOAD:
-                                indexReg += frame.localShift;
+                                indexReg += iData.itsMaxVars;
                                 frame.scope = (Scriptable) stack[indexReg];
                                 continue Loop;
                             case Icode_SCOPE_SAVE:
-                                indexReg += frame.localShift;
+                                indexReg += iData.itsMaxVars;
                                 stack[indexReg] = frame.scope;
                                 continue Loop;
                             case Icode_CLOSURE_EXPR:
@@ -2342,11 +2382,11 @@ public final class Interpreter extends Icode implements Evaluator {
                                 initFunction(cx, frame.scope, frame.fnOrScript, indexReg);
                                 continue Loop;
                             case Token.REGEXP:
-                                Object re = frame.idata.itsRegExpLiterals[indexReg];
+                                Object re = iData.itsRegExpLiterals[indexReg];
                                 stack[++stackTop] = ScriptRuntime.wrapRegExp(cx, frame.scope, re);
                                 continue Loop;
                             case Icode_TEMPLATE_LITERAL_CALLSITE:
-                                Object[] templateLiterals = frame.idata.itsTemplateLiterals;
+                                Object[] templateLiterals = iData.itsTemplateLiterals;
                                 stack[++stackTop] =
                                         ScriptRuntime.getTemplateLiteralCallSite(
                                                 cx, frame.scope, templateLiterals, indexReg);
@@ -2354,7 +2394,7 @@ public final class Interpreter extends Icode implements Evaluator {
                             case Icode_LITERAL_NEW_OBJECT:
                                 {
                                     // indexReg: index of constant with the keys
-                                    Object[] ids = (Object[]) frame.idata.literalIds[indexReg];
+                                    Object[] ids = (Object[]) iData.literalIds[indexReg];
                                     boolean copyArray = iCode[frame.pc] != 0;
                                     ++frame.pc;
                                     ++stackTop;
@@ -2443,7 +2483,7 @@ public final class Interpreter extends Icode implements Evaluator {
 
                                     int[] skipIndexces = null;
                                     if (op == Icode_SPARE_ARRAYLIT) {
-                                        skipIndexces = (int[]) frame.idata.literalIds[indexReg];
+                                        skipIndexces = (int[]) iData.literalIds[indexReg];
                                     }
                                     val =
                                             ScriptRuntime.newArrayLiteral(
@@ -2592,7 +2632,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                 frame.pc += 4;
                                 continue Loop;
                             default:
-                                dumpICode(frame.idata);
+                                dumpICode(iData);
                                 throw new RuntimeException(
                                         "Unknown icode : " + op + " @ pc : " + (frame.pc - 1));
                         } // end of interpreter switch
@@ -2608,7 +2648,7 @@ public final class Interpreter extends Icode implements Evaluator {
                         // -1 accounts for pc pointing to jump opcode + 1
                         frame.pc += offset - 1;
                     } else {
-                        frame.pc = frame.idata.longJumps.get(frame.pc);
+                        frame.pc = iData.longJumps.get(frame.pc);
                     }
                     if (instructionCounting) {
                         frame.pcPrevBranch = frame.pc;
@@ -2797,6 +2837,8 @@ public final class Interpreter extends Icode implements Evaluator {
 
         Object[] stack = frame.stack;
         double[] sDbl = frame.sDbl;
+        Object[] boundArgs = null;
+        int blen = 0;
 
         if (instructionCounting) {
             cx.instructionCount += INVOCATION_COST;
@@ -2825,7 +2867,7 @@ public final class Interpreter extends Icode implements Evaluator {
                     ScriptRuntime.callRef(
                             fun, funThisObj,
                             outArgs, cx);
-            return new ContinueLoop(frame, stackTop, indexReg);
+            return new ContinueLoop(stackTop, indexReg);
         }
         Scriptable calleeScope = frame.scope;
         if (frame.useActivation) {
@@ -2863,9 +2905,8 @@ public final class Interpreter extends Icode implements Evaluator {
                                         ? ScriptRuntime.emptyArgs
                                         : ScriptRuntime.getApplyArguments(cx, stack[stackTop + 2]);
                         int alen = callArgs.length;
-                        stack = frame.ensureStackLength(alen + stackTop + 1);
-                        sDbl = frame.sDbl;
-                        System.arraycopy(callArgs, 0, stack, stackTop + 1, alen);
+                        boundArgs = appendBoundArgs(boundArgs, callArgs);
+                        blen = blen + alen;
                         indexReg = alen;
                     } else {
                         // Call: shift args left, starting from 2nd
@@ -2892,27 +2933,22 @@ public final class Interpreter extends Icode implements Evaluator {
                 BoundFunction bfun = (BoundFunction) fun;
                 fun = bfun.getTargetFunction();
                 funThisObj = bfun.getCallThis(cx, calleeScope);
-                Object[] boundArgs = bfun.getBoundArgs();
-                int blen = boundArgs.length;
-                if (blen > 0) {
-                    stack = frame.ensureStackLength(blen + stackTop + 1 + indexReg);
-                    sDbl = frame.sDbl;
-                    System.arraycopy(stack, stackTop + 1, stack, stackTop + 1 + blen, indexReg);
-                    System.arraycopy(sDbl, stackTop + 1, sDbl, stackTop + 1 + blen, indexReg);
-                    System.arraycopy(boundArgs, 0, stack, stackTop + 1, blen);
-                    indexReg += blen;
-                }
+                Object[] bArgs = bfun.getBoundArgs();
+                boundArgs = appendBoundArgs(boundArgs, bArgs);
+                blen = blen + bArgs.length;
+                indexReg += blen;
             } else if (fun instanceof NoSuchMethodShim) {
                 NoSuchMethodShim nsmfun = (NoSuchMethodShim) fun;
                 // Bug 447697 -- make best effort to keep
                 // __noSuchMethod__ within this interpreter loop
                 // invocation.
-                stack = frame.ensureStackLength(stackTop + 3);
-                sDbl = frame.sDbl;
-                Object[] elements = getArgsArray(stack, sDbl, stackTop + 1, indexReg);
+                Object[] elements =
+                        getArgsArray(stack, sDbl, boundArgs, blen, stackTop + 1, indexReg);
                 fun = nsmfun.noSuchMethodMethod;
-                stack[stackTop + 1] = nsmfun.methodName;
-                stack[stackTop + 2] = cx.newArray(calleeScope, elements);
+                boundArgs = new Object[2];
+                blen = 2;
+                boundArgs[0] = nsmfun.methodName;
+                boundArgs[1] = cx.newArray(calleeScope, elements);
                 indexReg = 2;
             } else if (fun == null) {
                 throw ScriptRuntime.notFunctionError(null, null);
@@ -2959,6 +2995,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                 funHomeObj,
                                 stack,
                                 sDbl,
+                                boundArgs,
                                 stackTop + 1,
                                 indexReg,
                                 ifun,
@@ -2993,11 +3030,10 @@ public final class Interpreter extends Icode implements Evaluator {
             IdFunctionObject ifun = (IdFunctionObject) fun;
             if (NativeContinuation.isContinuationConstructor(ifun)) {
                 frame.stack[stackTop] = captureContinuation(cx, frame.parentFrame, false);
-                return new ContinueLoop(frame, stackTop, indexReg);
+                return new ContinueLoop(stackTop, indexReg);
             }
         }
 
-        cx.lastInterpreterFrame = frame;
         frame.savedCallOp = op;
         frame.savedStackTop = stackTop;
         stack[stackTop] =
@@ -3005,9 +3041,21 @@ public final class Interpreter extends Icode implements Evaluator {
                         cx,
                         calleeScope,
                         funThisObj,
-                        getArgsArray(stack, sDbl, stackTop + 1, indexReg));
+                        getArgsArray(stack, sDbl, boundArgs, blen, stackTop + 1, indexReg));
 
-        return new ContinueLoop(frame, stackTop, indexReg);
+        return new ContinueLoop(stackTop, indexReg);
+    }
+
+    private static Object[] appendBoundArgs(Object[] boundArgs, Object[] newArgs) {
+        if (newArgs.length == 0) {
+            return boundArgs;
+        } else if (boundArgs == null) {
+            return newArgs;
+        } else {
+            Object[] result = Arrays.copyOf(boundArgs, boundArgs.length + newArgs.length);
+            System.arraycopy(newArgs, 0, result, boundArgs.length, newArgs.length);
+            return result;
+        }
     }
 
     private static Scriptable getCurrentFrameHomeObject(CallFrame frame) {
@@ -3278,7 +3326,7 @@ public final class Interpreter extends Icode implements Evaluator {
             int stackTop,
             Object[] vars,
             double[] varDbls,
-            int[] varAttributes,
+            byte[] varAttributes,
             int indexReg) {
         if (!frame.useActivation) {
             if ((varAttributes[indexReg] & ScriptableObject.READONLY) == 0) {
@@ -3309,7 +3357,7 @@ public final class Interpreter extends Icode implements Evaluator {
             int stackTop,
             Object[] vars,
             double[] varDbls,
-            int[] varAttributes,
+            byte[] varAttributes,
             int indexReg) {
         if (!frame.useActivation) {
             if ((varAttributes[indexReg] & ScriptableObject.READONLY) == 0) {
@@ -3352,7 +3400,7 @@ public final class Interpreter extends Icode implements Evaluator {
             int stackTop,
             Object[] vars,
             double[] varDbls,
-            int[] varAttributes,
+            byte[] varAttributes,
             int indexReg) {
         // indexReg : varindex
         ++stackTop;
@@ -3523,8 +3571,9 @@ public final class Interpreter extends Icode implements Evaluator {
             }
 
             frame.savedStackTop = frame.emptyStackTop;
-            int scopeLocal = frame.localShift + table[indexReg + EXCEPTION_SCOPE_SLOT];
-            int exLocal = frame.localShift + table[indexReg + EXCEPTION_LOCAL_SLOT];
+            int localShift = frame.idata.itsMaxVars;
+            int scopeLocal = localShift + table[indexReg + EXCEPTION_SCOPE_SLOT];
+            int exLocal = localShift + table[indexReg + EXCEPTION_LOCAL_SLOT];
             frame.scope = (Scriptable) frame.stack[scopeLocal];
             frame.stack[exLocal] = throwable;
 
@@ -3664,12 +3713,22 @@ public final class Interpreter extends Icode implements Evaluator {
             Scriptable homeObj,
             Object[] args,
             double[] argsDbl,
+            Object[] boundArgs,
             int argShift,
             int argCount,
             InterpretedFunction fnOrScript,
             CallFrame parentFrame) {
-        CallFrame frame = new CallFrame(cx, thisObj, fnOrScript, parentFrame);
-        frame.initializeArgs(cx, callerScope, args, argsDbl, argShift, argCount, homeObj);
+        CallFrame frame =
+                new CallFrame(
+                        cx,
+                        thisObj,
+                        fnOrScript,
+                        parentFrame,
+                        parentFrame == null
+                                ? (CallFrame) cx.lastInterpreterFrame
+                                : parentFrame.previousInterpreterFrame);
+        frame.initializeArgs(
+                cx, callerScope, args, argsDbl, boundArgs, argShift, argCount, homeObj);
         enterFrame(cx, frame, args, false);
         return frame;
     }
@@ -3983,11 +4042,20 @@ public final class Interpreter extends Icode implements Evaluator {
     }
 
     private static Object[] getArgsArray(Object[] stack, double[] sDbl, int shift, int count) {
+        return getArgsArray(stack, sDbl, new Object[0], 0, shift, count);
+    }
+
+    private static Object[] getArgsArray(
+            Object[] stack, double[] sDbl, Object[] bound, int bCount, int shift, int count) {
         if (count == 0) {
             return ScriptRuntime.emptyArgs;
         }
         Object[] args = new Object[count];
-        for (int i = 0; i != count; ++i, ++shift) {
+        for (int i = 0; i < bCount; i++) {
+            args[i] = bound[i];
+        }
+
+        for (int i = bCount; i != count; ++i, ++shift) {
             Object val = stack[shift];
             if (val == UniqueTag.DOUBLE_MARK) {
                 val = ScriptRuntime.wrapNumber(sDbl[shift]);

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
@@ -1,0 +1,162 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.testutils.Utils;
+
+public class GeneratorStackTraceTest {
+
+    @Test
+    public void testGeneratorStackTraces() {
+        String script =
+                "function* f2() { yield 1; throw 'hello'; yield 3; }; var g = f2(); g.next(); g.next();";
+        String expected = "\tat test.js:0 (f2)\n" + "\tat test.js:0\n";
+        runWithExpectedStackTrace(script, expected);
+    }
+
+    private static void runWithExpectedStackTrace(final String _source, final String expected) {
+        Utils.runWithMode(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    try {
+                        cx.evaluateString(scope, _source, "test.js", 0, null);
+                    } catch (final JavaScriptException e) {
+                        assertEquals(expected, e.getScriptStackTrace());
+                        return null;
+                    }
+                    throw new RuntimeException("Exception expected!");
+                },
+                true);
+    }
+
+    @Test
+    public void testNestedGeneratorsException() {
+        String jsCode =
+                ""
+                        + "function* innerGen() {\n"
+                        + "    yield 1;\n"
+                        + "    throw new Error('Inner Exception'); // Line 4\n"
+                        + "}\n"
+                        + "function* outerGen() {\n"
+                        + "    var f = innerGen();\n"
+                        + "    yield f.next().value;\n"
+                        + "    yield f.next().value;\n"
+                        + "}\n"
+                        + "var g = outerGen();\n"
+                        + "g.next();\n"
+                        + "g.next();"; // This should throw
+
+        Utils.runWithMode(
+                context -> {
+                    try {
+                        final Scriptable scope = context.initStandardObjects();
+                        context.evaluateString(scope, jsCode, "nestedGeneratorTest.js", 1, null);
+                        Assert.fail("Expected exception from nested generator not thrown.");
+                    } catch (JavaScriptException e) {
+                        String stack = e.getScriptStackTrace();
+
+                        // Validate that both generator functions appear in the stack
+                        Assert.assertTrue(
+                                "Stack trace should include innerGen", stack.contains("innerGen"));
+                        Assert.assertTrue(
+                                "Stack trace should include outerGen", stack.contains("outerGen"));
+
+                        // Validate line number for the throw
+                        assertEquals("Line number of exception should be 3", 3, e.lineNumber());
+
+                        System.out.println("Nested Generator Exception Stack: \n" + stack);
+                    }
+                    return null;
+                },
+                true);
+    }
+
+    // Doesn't work due to our implementation of yield*.
+    @Test(expected = AssertionError.class)
+    public void testNestedGeneratorsYieldStarException() {
+        String jsCode =
+                ""
+                        + "function* innerGen() {\n"
+                        + "    yield 1;\n"
+                        + "    throw new Error('Inner Exception'); // Line 4\n"
+                        + "}\n"
+                        + "function* outerGen() {\n"
+                        + "    yield* innerGen();\n"
+                        + "}\n"
+                        + "var g = outerGen();\n"
+                        + "g.next();\n"
+                        + "g.next();"; // This should throw
+
+        Utils.runWithMode(
+                context -> {
+                    try {
+                        final Scriptable scope = context.initStandardObjects();
+                        context.evaluateString(scope, jsCode, "nestedGeneratorTest.js", 1, null);
+                        Assert.fail("Expected exception from nested generator not thrown.");
+                    } catch (JavaScriptException e) {
+                        String stack = e.getScriptStackTrace();
+
+                        // Validate that both generator functions appear in the stack
+                        Assert.assertTrue(
+                                "Stack trace should include innerGen", stack.contains("innerGen"));
+                        Assert.assertTrue(
+                                "Stack trace should include outerGen", stack.contains("outerGen"));
+
+                        // Validate line number for the throw
+                        assertEquals("Line number of exception should be 3", 3, e.lineNumber());
+
+                        System.out.println("Nested Generator Exception Stack: \n" + stack);
+                    }
+                    return null;
+                },
+                true);
+    }
+
+    @Test
+    public void testJavaCallbackThrowsFromGenerator() {
+        Utils.runWithMode(
+                context -> {
+                    Scriptable scope = context.initStandardObjects();
+                    LambdaFunction f =
+                            new LambdaFunction(
+                                    scope,
+                                    "javaHelper",
+                                    0,
+                                    (Context ctx,
+                                            Scriptable scope2,
+                                            Scriptable thisObj,
+                                            Object[] args) -> {
+                                        throw new RuntimeException("Java-side failure!");
+                                    });
+                    ScriptableObject.putProperty(scope, "javaHelper", f);
+
+                    String jsCode =
+                            ""
+                                    + "function* generatorWithCallback() {\n"
+                                    + "    yield 1;\n"
+                                    + "    javaHelper();\n"
+                                    + // This should throw from Java
+                                    "}\n"
+                                    + "var g = generatorWithCallback();\n"
+                                    + "g.next();\n"
+                                    + // Move to the first yield
+                                    "g.next();"; // This should throw
+
+                    try {
+                        context.evaluateString(scope, jsCode, "javaCallbackTest.js", 1, null);
+                        Assert.fail("Expected Java exception not thrown.");
+                    } catch (RuntimeException e) {
+                        // Rhino should surface the Java exception directly
+                        Assert.assertTrue(
+                                "Exception message should contain 'Java-side failure!'",
+                                e.getMessage().contains("Java-side failure!"));
+                        System.out.println("Caught Java Exception from JS: " + e.getMessage());
+                    }
+                    return null;
+                },
+                true);
+    }
+}

--- a/tests/testsrc/jstests/const-white-box.js
+++ b/tests/testsrc/jstests/const-white-box.js
@@ -60,4 +60,154 @@ for (let i = 0; i < ITERATIONS; i++) {
    objectConstness();
 }
 
+/* Test we can actually have a lot of consts in a function. */
+function manyConsts() {
+    const a0 = 0;
+    const a1 = 1;
+    const a2 = 2;
+    const a3 = 3;
+    const a4 = 4;
+    const a5 = 5;
+    const a6 = 6;
+    const a7 = 7;
+    const a8 = 8;
+    const a9 = 9;
+    const a10 = 10;
+    const a11 = 11;
+    const a12 = 12;
+    const a13 = 13;
+    const a14 = 14;
+    const a15 = 15;
+    const a16 = 16;
+    const a17 = 17;
+    const a18 = 18;
+    const a19 = 19;
+    const a20 = 20;
+    const a21 = 21;
+    const a22 = 22;
+    const a23 = 23;
+    const a24 = 24;
+    const a25 = 25;
+    const a26 = 26;
+    const a27 = 27;
+    const a28 = 28;
+    const a29 = 29;
+    const a30 = 30;
+    const a31 = 31;
+    const a32 = 32;
+    const a33 = 33;
+    const a34 = 34;
+    const a35 = 35;
+    const a36 = 36;
+    const a37 = 37;
+    const a38 = 38;
+    const a39 = 39;
+    const a40 = 40;
+    const a41 = 41;
+    const a42 = 42;
+    const a43 = 43;
+    const a44 = 44;
+    const a45 = 45;
+    const a46 = 46;
+    const a47 = 47;
+    const a48 = 48;
+    const a49 = 49;
+    const a50 = 50;
+    const a51 = 51;
+    const a52 = 52;
+    const a53 = 53;
+    const a54 = 54;
+    const a55 = 55;
+    const a56 = 56;
+    const a57 = 57;
+    const a58 = 58;
+    const a59 = 59;
+    const a60 = 60;
+    const a61 = 61;
+    const a62 = 62;
+    const a63 = 63;
+    const a64 = 64;
+    const a65 = 65;
+    const a66 = 66;
+    const a67 = 67;
+    const a68 = 68;
+    const a69 = 69;
+    const a70 = 70;
+    const a71 = 71;
+    const a72 = 72;
+    const a73 = 73;
+    const a74 = 74;
+    const a75 = 75;
+    const a76 = 76;
+    const a77 = 77;
+    const a78 = 78;
+    const a79 = 79;
+    const a80 = 80;
+    const a81 = 81;
+    const a82 = 82;
+    const a83 = 83;
+    const a84 = 84;
+    const a85 = 85;
+    const a86 = 86;
+    const a87 = 87;
+    const a88 = 88;
+    const a89 = 89;
+    const a90 = 90;
+    const a91 = 91;
+    const a92 = 92;
+    const a93 = 93;
+    const a94 = 94;
+    const a95 = 95;
+    const a96 = 96;
+    const a97 = 97;
+    const a98 = 98;
+    const a99 = 99;
+    const a100 = 100;
+    const a101 = 101;
+    const a102 = 102;
+    const a103 = 103;
+    const a104 = 104;
+    const a105 = 105;
+    const a106 = 106;
+    const a107 = 107;
+    const a108 = 108;
+    const a109 = 109;
+    const a110 = 110;
+    const a111 = 111;
+    const a112 = 112;
+    const a113 = 113;
+    const a114 = 114;
+    const a115 = 115;
+    const a116 = 116;
+    const a117 = 117;
+    const a118 = 118;
+    const a119 = 119;
+    const a120 = 120;
+    const a121 = 121;
+    const a122 = 122;
+    const a123 = 123;
+    const a124 = 124;
+    const a125 = 125;
+    const a126 = 126;
+    const a127 = 127;
+    const a128 = 128;
+    const a129 = 129;
+
+    return a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 +
+        a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 +
+        a20 + a21 + a22 + a23 + a24 + a25 + a26 + a27 + a28 + a29 +
+        a30 + a31 + a32 + a33 + a34 + a35 + a36 + a37 + a38 + a39 +
+        a40 + a41 + a42 + a43 + a44 + a45 + a46 + a47 + a48 + a49 +
+        a50 + a51 + a52 + a53 + a54 + a55 + a56 + a57 + a58 + a59 +
+        a60 + a61 + a62 + a63 + a64 + a65 + a66 + a67 + a68 + a69 +
+        a70 + a71 + a72 + a73 + a74 + a75 + a76 + a77 + a78 + a79 +
+        a80 + a81 + a82 + a83 + a84 + a85 + a86 + a87 + a88 + a89 +
+        a90 + a91 + a92 + a93 + a94 + a95 + a96 + a97 + a98 + a99 +
+        a100 + a101 + a102 + a103 + a104 + a105 + a106 + a107 + a108 + a109 +
+        a110 + a111 + a112 + a113 + a114 + a115 + a116 + a117 + a118 + a119 +
+        a120 + a121 + a122 + a123 + a124 + a125 + a126 + a127 + a128 + a129
+}
+
+manyConsts();
+
 'success';


### PR DESCRIPTION
2nd PR for #1933,  see #1954 for overall details.

We want to be able to reliably model the stack of interpreter frames in an immutable way. To make this problem more tractable we make everything intended to be final actually final by moving calculation of true maximum stack size to the creation of the frame. We record the PC of the caller in callee frames so that the stack can be reliably reconstructed, and we introduce methods to copy frames in situations where we might have previously mutated them.
