### PR TITLE
Refactor exception handling

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -19,7 +19,6 @@ import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2805,12 +2804,9 @@ public class Context implements Closeable {
     /** This is the list of names of objects forcing the creation of function activation records. */
     Set<String> activationNames;
 
-    // For the interpreter to store the last frame for error reports etc.
+    // For the interpreter to store the last frame for error reports
+    // etc. Previous frames can all be derived from this.
     Object lastInterpreterFrame;
-
-    // For the interpreter to store information about previous invocations
-    // interpreter invocations
-    Deque<Object> previousInterpreterInvocations;
 
     // For instruction counting (interpreter only)
     int instructionCount;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug482203Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug482203Test.java
@@ -34,7 +34,7 @@ public class Bug482203Test {
                 counter++;
                 ((Callable) cont).call(cx, scope, scope, new Object[] {null});
             }
-            assertEquals(counter, 5);
+            assertEquals(5, counter);
             assertEquals(Double.valueOf(3), ScriptableObject.getProperty(scope, "result"));
         }
     }
@@ -57,7 +57,7 @@ public class Bug482203Test {
                 counter++;
                 cx.resumeContinuation(cont, scope, null);
             }
-            assertEquals(counter, 5);
+            assertEquals(5, counter);
             assertEquals(Double.valueOf(3), ScriptableObject.getProperty(scope, "result"));
         }
     }


### PR DESCRIPTION
Part of the work on #1933, see #1954 for overall details.

We move from using a deque on Context for holding the stack to it being represented purely by the linked parent frames and previous interpreter frames. We change the exception construction code to simply capture the current interpreter frame, and change the decoration code to walk this tree to produce the required stacks.