### PR TITLE
Reduce allocation in arg nullability provider

### DIFF
--- a/rhino-kotlin/src/main/java/org/mozilla/kotlin/KotlinNullabilityDetector.java
+++ b/rhino-kotlin/src/main/java/org/mozilla/kotlin/KotlinNullabilityDetector.java
@@ -17,7 +17,7 @@ import org.mozilla.javascript.NullabilityDetector;
 public class KotlinNullabilityDetector implements NullabilityDetector {
     @Override
     public NullabilityAccessor getParameterNullability(Method method) {
-        int paramCount = method.getParameterCount();
+        int paramCount = method.getParameterTypes().length;
         KmClass kmClass = getKmClassForJavaClass(method.getDeclaringClass());
         return getMethodParameterNullabilityFromKotlinMetadata(
                 kmClass, method.getName(), paramCount);
@@ -25,7 +25,7 @@ public class KotlinNullabilityDetector implements NullabilityDetector {
 
     @Override
     public NullabilityAccessor getParameterNullability(Constructor<?> constructor) {
-        int paramCount = constructor.getParameterCount();
+        int paramCount = constructor.getParameterTypes().length;
         KmClass kmClass = getKmClassForJavaClass(constructor.getDeclaringClass());
         return getConstructorParameterNullabilityFromKotlinMetadata(kmClass, paramCount);
     }

--- a/rhino-kotlin/src/main/java/org/mozilla/kotlin/KotlinNullabilityDetector.java
+++ b/rhino-kotlin/src/main/java/org/mozilla/kotlin/KotlinNullabilityDetector.java
@@ -17,7 +17,7 @@ import org.mozilla.javascript.NullabilityDetector;
 public class KotlinNullabilityDetector implements NullabilityDetector {
     @Override
     public NullabilityAccessor getParameterNullability(Method method) {
-        int paramCount = method.getParameterTypes().length;
+        int paramCount = method.getParameterCount();
         KmClass kmClass = getKmClassForJavaClass(method.getDeclaringClass());
         return getMethodParameterNullabilityFromKotlinMetadata(
                 kmClass, method.getName(), paramCount);
@@ -25,7 +25,7 @@ public class KotlinNullabilityDetector implements NullabilityDetector {
 
     @Override
     public NullabilityAccessor getParameterNullability(Constructor<?> constructor) {
-        int paramCount = constructor.getParameterTypes().length;
+        int paramCount = constructor.getParameterCount();
         KmClass kmClass = getKmClassForJavaClass(constructor.getDeclaringClass());
         return getConstructorParameterNullabilityFromKotlinMetadata(kmClass, paramCount);
     }
@@ -77,6 +77,6 @@ public class KotlinNullabilityDetector implements NullabilityDetector {
         for (int i = 0; i < params.size(); i++) {
             result[i] = isNullable(params.get(i).getType());
         }
-        return index -> result[index];
+        return NullabilityAccessor.compress(result);
     }
 }

--- a/rhino-kotlin/src/main/java/org/mozilla/kotlin/KotlinNullabilityDetector.java
+++ b/rhino-kotlin/src/main/java/org/mozilla/kotlin/KotlinNullabilityDetector.java
@@ -79,8 +79,4 @@ public class KotlinNullabilityDetector implements NullabilityDetector {
         }
         return index -> result[index];
     }
-
-    private boolean[] createFallbackNullabilityArray(int paramCount) {
-        return new boolean[paramCount];
-    }
 }

--- a/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinNullabilityDetectorTest.java
+++ b/rhino-kotlin/src/test/java/org/mozilla/kotlin/tests/KotlinNullabilityDetectorTest.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mozilla.javascript.NullabilityDetector;
 import org.mozilla.kotlin.KotlinNullabilityDetector;
 
 public class KotlinNullabilityDetectorTest {
@@ -16,38 +18,32 @@ public class KotlinNullabilityDetectorTest {
 
     @Test
     public void testKotlinFunction() {
-        boolean[] nullability =
+        var nullability =
                 detector.getParameterNullability(findMethod(KotlinClass.class, "function", 3));
 
-        boolean[] expectedNullability = new boolean[] {true, false, true};
-        assertThat(nullability, is(expectedNullability));
+        assertNullabilityMatch(nullability, true, false, true);
     }
 
     @Test
     public void testKotlinConstructor() {
-        boolean[] nullability =
-                detector.getParameterNullability(findConstructor(KotlinClass.class, 2));
+        var nullability = detector.getParameterNullability(findConstructor(KotlinClass.class, 2));
 
-        boolean[] expectedNullability = new boolean[] {false, true};
-        assertThat(nullability, is(expectedNullability));
+        assertNullabilityMatch(nullability, false, true);
     }
 
     @Test
     public void testJavaFunction() {
-        boolean[] nullability =
+        var nullability =
                 detector.getParameterNullability(findMethod(JavaClass.class, "function", 2));
 
-        boolean[] expectedNullability = new boolean[] {false, false};
-        assertThat(nullability, is(expectedNullability));
+        assertNullabilityMatch(nullability, false, false);
     }
 
     @Test
     public void testJavaConstructor() {
-        boolean[] nullability =
-                detector.getParameterNullability(findConstructor(JavaClass.class, 2));
+        var nullability = detector.getParameterNullability(findConstructor(JavaClass.class, 2));
 
-        boolean[] expectedNullability = new boolean[] {false, false};
-        assertThat(nullability, is(expectedNullability));
+        assertNullabilityMatch(nullability, false, false);
     }
 
     @Test
@@ -59,10 +55,20 @@ public class KotlinNullabilityDetectorTest {
         // Since we cannot distinguish overloads with same number of params, we have to fallback to
         // no-op
         boolean[] expectedNullability = new boolean[] {false, false, false};
-        overloadedMethods.forEach(
-                method ->
-                        assertThat(
-                                detector.getParameterNullability(method), is(expectedNullability)));
+        for (var overloadedMethod : overloadedMethods) {
+            assertNullabilityMatch(
+                    detector.getParameterNullability(overloadedMethod), expectedNullability);
+        }
+    }
+
+    private static void assertNullabilityMatch(
+            NullabilityDetector.NullabilityAccessor nullabilityAccessor, boolean... expected) {
+        var actual = new boolean[expected.length];
+        for (int i = 0; i < actual.length; i++) {
+            actual[i] = nullabilityAccessor.isNullable(i);
+        }
+
+        Assertions.assertArrayEquals(expected, actual);
     }
 
     private Method findMethod(Class<?> clazz, String methodName, int paramCount) {

--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -235,7 +235,7 @@ public class AccessorSlot extends Slot {
             // XXX: cache tag since it is already calculated in
             // defineProperty ?
             var valueType = pTypes.get(pTypes.size() - 1);
-            boolean isNullable = member.argNullability[pTypes.size() - 1];
+            boolean isNullable = member.argNullability.isNullable(pTypes.size() - 1);
             int tag = valueType.getTypeTag();
             Object actualArg = FunctionObject.convertArg(cx, start, value, tag, isNullable);
 

--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -235,7 +235,7 @@ public class AccessorSlot extends Slot {
             // XXX: cache tag since it is already calculated in
             // defineProperty ?
             var valueType = pTypes.get(pTypes.size() - 1);
-            boolean isNullable = member.argNullability.isNullable(pTypes.size() - 1);
+            boolean isNullable = member.getArgNullability().isNullable(pTypes.size() - 1);
             int tag = valueType.getTypeTag();
             Object actualArg = FunctionObject.convertArg(cx, start, value, tag, isNullable);
 

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -418,7 +418,12 @@ public class FunctionObject extends BaseFunction {
                 for (int i = 0; i != parmsLength; ++i) {
                     Object arg = args[i];
                     Object converted =
-                            convertArg(cx, scope, arg, typeTags[i], member.argNullability.isNullable(i));
+                            convertArg(
+                                    cx,
+                                    scope,
+                                    arg,
+                                    typeTags[i],
+                                    member.argNullability.isNullable(i));
                     if (arg != converted) {
                         if (invokeArgs == args) {
                             invokeArgs = args.clone();
@@ -433,7 +438,12 @@ public class FunctionObject extends BaseFunction {
                 for (int i = 0; i != parmsLength; ++i) {
                     Object arg = (i < argsLength) ? args[i] : Undefined.instance;
                     invokeArgs[i] =
-                            convertArg(cx, scope, arg, typeTags[i], member.argNullability.isNullable(i));
+                            convertArg(
+                                    cx,
+                                    scope,
+                                    arg,
+                                    typeTags[i],
+                                    member.argNullability.isNullable(i));
                 }
             }
 

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -423,7 +423,7 @@ public class FunctionObject extends BaseFunction {
                                     scope,
                                     arg,
                                     typeTags[i],
-                                    member.argNullability.isNullable(i));
+                                    member.getArgNullability().isNullable(i));
                     if (arg != converted) {
                         if (invokeArgs == args) {
                             invokeArgs = args.clone();
@@ -443,7 +443,7 @@ public class FunctionObject extends BaseFunction {
                                     scope,
                                     arg,
                                     typeTags[i],
-                                    member.argNullability.isNullable(i));
+                                    member.getArgNullability().isNullable(i));
                 }
             }
 

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -418,7 +418,7 @@ public class FunctionObject extends BaseFunction {
                 for (int i = 0; i != parmsLength; ++i) {
                     Object arg = args[i];
                     Object converted =
-                            convertArg(cx, scope, arg, typeTags[i], member.argNullability[i]);
+                            convertArg(cx, scope, arg, typeTags[i], member.argNullability.isNullable(i));
                     if (arg != converted) {
                         if (invokeArgs == args) {
                             invokeArgs = args.clone();
@@ -433,7 +433,7 @@ public class FunctionObject extends BaseFunction {
                 for (int i = 0; i != parmsLength; ++i) {
                     Object arg = (i < argsLength) ? args[i] : Undefined.instance;
                     invokeArgs[i] =
-                            convertArg(cx, scope, arg, typeTags[i], member.argNullability[i]);
+                            convertArg(cx, scope, arg, typeTags[i], member.argNullability.isNullable(i));
                 }
             }
 

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -29,9 +29,9 @@ final class MemberBox implements Serializable {
     private static final long serialVersionUID = 6358550398665688245L;
 
     private transient Member memberObject;
-    private transient volatile List<TypeInfo> argTypeInfos;
-    private transient volatile TypeInfo returnTypeInfo;
-    private transient volatile NullabilityDetector.NullabilityAccessor argNullability;
+    private transient List<TypeInfo> argTypeInfos;
+    private transient TypeInfo returnTypeInfo;
+    private transient NullabilityDetector.NullabilityAccessor argNullability;
     transient boolean vararg;
 
     transient Function asGetterFunction;

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -31,7 +31,7 @@ final class MemberBox implements Serializable {
     private transient Member memberObject;
     private transient volatile List<TypeInfo> argTypeInfos;
     private transient volatile TypeInfo returnTypeInfo;
-    transient boolean[] argNullability;
+    transient NullabilityDetector.NullabilityAccessor argNullability;
     transient boolean vararg;
 
     transient Function asGetterFunction;
@@ -53,7 +53,7 @@ final class MemberBox implements Serializable {
         this.memberObject = method;
         this.argNullability =
                 nullDetector == null
-                        ? new boolean[method.getParameters().length]
+                        ? NullabilityDetector.NullabilityAccessor.FALSE
                         : nullDetector.getParameterNullability(method);
         this.vararg = method.isVarArgs();
         this.argTypeInfos = factory.createList(method.getGenericParameterTypes());
@@ -64,7 +64,7 @@ final class MemberBox implements Serializable {
         this.memberObject = constructor;
         this.argNullability =
                 nullDetector == null
-                        ? new boolean[constructor.getParameters().length]
+                        ? NullabilityDetector.NullabilityAccessor.FALSE
                         : nullDetector.getParameterNullability(constructor);
         this.vararg = constructor.isVarArgs();
         this.argTypeInfos = factory.createList(constructor.getGenericParameterTypes());
@@ -210,7 +210,7 @@ final class MemberBox implements Serializable {
                                                     thisObj,
                                                     originalArgs[0],
                                                     nativeSetter.getArgTypes().get(0).getTypeTag(),
-                                                    nativeSetter.argNullability[0])
+                                                    nativeSetter.argNullability.isNullable(0))
                                             : Undefined.instance;
                             if (nativeSetter.delegateTo == null) {
                                 setterThis = thisObj;

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -225,7 +225,7 @@ final class MemberBox implements Serializable {
                                                     thisObj,
                                                     originalArgs[0],
                                                     nativeSetter.getArgTypes().get(0).getTypeTag(),
-                                                    nativeSetter.argNullability.isNullable(0))
+                                                    nativeSetter.getArgNullability().isNullable(0))
                                             : Undefined.instance;
                             if (nativeSetter.delegateTo == null) {
                                 setterThis = thisObj;

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -115,9 +115,10 @@ final class MemberBox implements Serializable {
             synchronized (this) {
                 got = this.argNullability;
                 if (got == null) {
-                    got = this.isMethod()
-                        ? nullDetector.getParameterNullability(this.method())
-                        : nullDetector.getParameterNullability(this.ctor());
+                    got =
+                            this.isMethod()
+                                    ? nullDetector.getParameterNullability(this.method())
+                                    : nullDetector.getParameterNullability(this.ctor());
                     this.argNullability = got;
                 }
             }

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -112,16 +112,14 @@ final class MemberBox implements Serializable {
     public NullabilityDetector.NullabilityAccessor getArgNullability() {
         var got = this.argNullability;
         if (got == null) {
-            synchronized (this) {
-                got = this.argNullability;
-                if (got == null) {
-                    got =
-                            this.isMethod()
-                                    ? nullDetector.getParameterNullability(this.method())
-                                    : nullDetector.getParameterNullability(this.ctor());
-                    this.argNullability = got;
-                }
-            }
+            // synchronization is optional, because `getParameterNullability(...)` will always
+            // give `NullabilityAccessor` with same behaviour, which is because arg nullability
+            // for a certain method/constructor will not change at runtime
+            got =
+                    this.isMethod()
+                            ? nullDetector.getParameterNullability(this.method())
+                            : nullDetector.getParameterNullability(this.ctor());
+            this.argNullability = got;
         }
         return got;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
@@ -8,7 +8,6 @@ public interface NullabilityDetector {
 
     NullabilityAccessor getParameterNullability(Constructor<?> constructor);
 
-    @FunctionalInterface
     interface NullabilityAccessor {
         NullabilityAccessor FALSE = (ignored) -> false;
         /**

--- a/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
@@ -4,7 +4,18 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
 public interface NullabilityDetector {
-    boolean[] getParameterNullability(Method method);
+    NullabilityAccessor getParameterNullability(Method method);
 
-    boolean[] getParameterNullability(Constructor<?> constructor);
+    NullabilityAccessor getParameterNullability(Constructor<?> constructor);
+
+    @FunctionalInterface
+    interface NullabilityAccessor {
+        NullabilityAccessor FALSE = (ignored) -> false;
+        /**
+         * @param index parameter index
+         * @return {@code true} if the parameter at specified index is nullable, {@code false} otherwise
+         * @throws IndexOutOfBoundsException if index is out of bounds of the method/constructor parameters
+         */
+        boolean isNullable(int index);
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
@@ -10,10 +10,17 @@ public interface NullabilityDetector {
 
     interface NullabilityAccessor {
         NullabilityAccessor FALSE = (ignored) -> false;
+
         /**
+         * Note: The return value when providing out-of-bound index is "not defined". There's no
+         * guarantee that it will provide a result that makes sense, or throw an {@link
+         * IndexOutOfBoundsException} when providing out-of-bound index
+         *
          * @param index parameter index
-         * @return {@code true} if the parameter at specified index is nullable, {@code false} otherwise
-         * @throws IndexOutOfBoundsException if index is out of bounds of the method/constructor parameters
+         * @return {@code true} if the parameter at specified index is nullable, {@code false}
+         *     otherwise
+         * @throws IndexOutOfBoundsException if index is out of bounds of the method/constructor
+         *     parameters
          */
         boolean isNullable(int index);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullabilityDetector.java
@@ -9,7 +9,13 @@ public interface NullabilityDetector {
     NullabilityAccessor getParameterNullability(Constructor<?> constructor);
 
     interface NullabilityAccessor {
+        NullabilityAccessor TRUE = (ignored) -> true;
         NullabilityAccessor FALSE = (ignored) -> false;
+        NullabilityAccessor INDEX_OUT_OF_BOUNDS =
+                (i) -> {
+                    throw new IndexOutOfBoundsException(
+                            String.format("Index %s out of bounds [0,0)", i));
+                };
 
         /**
          * Note: The return value when providing out-of-bound index is "not defined". There's no
@@ -23,5 +29,41 @@ public interface NullabilityDetector {
          *     parameters
          */
         boolean isNullable(int index);
+
+        static NullabilityAccessor compress(boolean[] values) {
+            var length = values.length;
+            // empty
+            if (length == 0) {
+                return INDEX_OUT_OF_BOUNDS;
+            }
+            // single element
+            if (length == 1) {
+                return values[0] ? TRUE : FALSE;
+            }
+            // same elements
+            Boolean allMatch = values[0];
+            for (var value : values) {
+                if (allMatch != value) {
+                    allMatch = null;
+                    break;
+                }
+            }
+            if (allMatch != null) {
+                return allMatch ? TRUE : FALSE;
+            }
+            // use smaller object (int) as backend
+            if (length < 32) { // length: [2, 31]
+                var compressed = 0;
+                for (int i = 0; i < length; i++) {
+                    if (values[i]) {
+                        compressed |= (1 << i);
+                    }
+                }
+                final var compressedFinal = compressed;
+                return i -> ((compressedFinal >> i) & 1) != 0;
+            }
+            // fallback
+            return i -> values[i];
+        }
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -1,12 +1,10 @@
 package org.mozilla.javascript;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
 
 public class NullabilityDetectorTest {
@@ -14,39 +12,45 @@ public class NullabilityDetectorTest {
     public void testNullableDetectorForMethodWithoutArgs() {
         MemberBox memberBox =
                 new MemberBox(getTestClassMethod("function1"), TypeInfoFactory.GLOBAL);
-        assertThat(memberBox.argNullability, is(new boolean[] {}));
+        assertNullabilityMatch(memberBox.argNullability);
     }
 
     @Test
     public void testNullableDetectorForMethodWithOneArg() {
         MemberBox memberBox =
                 new MemberBox(getTestClassMethod("function2"), TypeInfoFactory.GLOBAL);
-        assertThat(memberBox.argNullability, is(new boolean[] {true}));
+        assertNullabilityMatch(memberBox.argNullability, true);
     }
 
     @Test
     public void testNullableDetectorForMethodWithSeveralArgs() {
         MemberBox memberBox =
                 new MemberBox(getTestClassMethod("function3"), TypeInfoFactory.GLOBAL);
-        assertThat(memberBox.argNullability, is(new boolean[] {true, true, true, true}));
+        assertNullabilityMatch(memberBox.argNullability, true, true, true, true);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithoutArgs() {
         MemberBox memberBox = new MemberBox(getTestClassConstructor(0), TypeInfoFactory.GLOBAL);
-        assertThat(memberBox.argNullability, is(new boolean[] {}));
+        assertNullabilityMatch(memberBox.argNullability);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithOneArg() {
         MemberBox memberBox = new MemberBox(getTestClassConstructor(1), TypeInfoFactory.GLOBAL);
-        assertThat(memberBox.argNullability, is(new boolean[] {true}));
+        assertNullabilityMatch(memberBox.argNullability, true);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithSeveralArgs() {
         MemberBox memberBox = new MemberBox(getTestClassConstructor(4), TypeInfoFactory.GLOBAL);
-        assertThat(memberBox.argNullability, is(new boolean[] {true, false, true, false}));
+        assertNullabilityMatch(memberBox.argNullability, true, false, true, false);
+    }
+
+    private static void assertNullabilityMatch(NullabilityDetector.NullabilityAccessor nullabilityAccessor, boolean... expected) {
+        for (int i = 0; i < expected.length; i++) {
+            Assertions.assertEquals(nullabilityAccessor.isNullable(i), expected[i]);
+        }
     }
 
     private Method getTestClassMethod(String methodName) {

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -48,9 +48,12 @@ public class NullabilityDetectorTest {
     }
 
     private static void assertNullabilityMatch(NullabilityDetector.NullabilityAccessor nullabilityAccessor, boolean... expected) {
-        for (int i = 0; i < expected.length; i++) {
-            Assertions.assertEquals(nullabilityAccessor.isNullable(i), expected[i]);
+        var actual = new boolean[expected.length];
+        for (int i = 0; i < actual.length; i++) {
+            actual[i] = nullabilityAccessor.isNullable(i);
         }
+
+        Assertions.assertArrayEquals(expected, actual);
     }
 
     private Method getTestClassMethod(String methodName) {

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -3,8 +3,10 @@ package org.mozilla.javascript;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mozilla.javascript.NullabilityDetector.NullabilityAccessor;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
 
 public class NullabilityDetectorTest {
@@ -47,8 +49,22 @@ public class NullabilityDetectorTest {
         assertNullabilityMatch(memberBox.argNullability, true, false, true, false);
     }
 
+    @Test
+    public void testNullabilityCompressor() {
+        for (var nullabilityPolicy :
+                List.<NullabilityAccessor>of(i -> i % 2 != 0, i -> false, i -> true)) {
+            for (var paramCount : new int[] {1, 2, 5, 12, 31, 32, 33, 34, 56, 78}) {
+                var toTest = new boolean[paramCount];
+                for (var i = 0; i < toTest.length; i++) {
+                    toTest[i] = nullabilityPolicy.isNullable(i);
+                }
+                assertNullabilityMatch(NullabilityAccessor.compress(toTest), toTest);
+            }
+        }
+    }
+
     private static void assertNullabilityMatch(
-            NullabilityDetector.NullabilityAccessor nullabilityAccessor, boolean... expected) {
+            NullabilityAccessor nullabilityAccessor, boolean... expected) {
         var actual = new boolean[expected.length];
         for (int i = 0; i < actual.length; i++) {
             actual[i] = nullabilityAccessor.isNullable(i);

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -53,12 +53,25 @@ public class NullabilityDetectorTest {
     public void testNullabilityCompressor() {
         for (var nullabilityPolicy :
                 List.<NullabilityAccessor>of(i -> i % 2 != 0, i -> false, i -> true)) {
-            for (var paramCount : new int[] {1, 2, 5, 12, 31, 32, 33, 34, 56, 78}) {
+            for (var paramCount : new int[] {0, 1, 2, 5, 12, 31, 32, 33, 34, 56, 78}) {
                 var toTest = new boolean[paramCount];
                 for (var i = 0; i < toTest.length; i++) {
                     toTest[i] = nullabilityPolicy.isNullable(i);
                 }
-                assertNullabilityMatch(NullabilityAccessor.compress(toTest), toTest);
+                var compressed = NullabilityAccessor.compress(toTest);
+
+                assertNullabilityMatch(compressed, toTest);
+                for (var invalidInputs : new int[] {-2, -1, paramCount, paramCount + 1, paramCount * 2}) {
+                    try {
+                        compressed.isNullable(invalidInputs);
+                        // no exception -> valid
+                    } catch (IndexOutOfBoundsException ignored) {
+                        // IndexOutOfBounds -> valid
+                    } catch (Throwable e) {
+                        // exceptions not listed in javadoc -> invalid
+                        Assertions.fail("NullabilityAccessor threw an exception that is not IndexOutOfBoundsException", e);
+                    }
+                }
             }
         }
     }

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -61,7 +61,8 @@ public class NullabilityDetectorTest {
                 var compressed = NullabilityAccessor.compress(toTest);
 
                 assertNullabilityMatch(compressed, toTest);
-                for (var invalidInputs : new int[] {-2, -1, paramCount, paramCount + 1, paramCount * 2}) {
+                for (var invalidInputs :
+                        new int[] {-2, -1, paramCount, paramCount + 1, paramCount * 2}) {
                     try {
                         compressed.isNullable(invalidInputs);
                         // no exception -> valid
@@ -69,7 +70,9 @@ public class NullabilityDetectorTest {
                         // IndexOutOfBounds -> valid
                     } catch (Throwable e) {
                         // exceptions not listed in javadoc -> invalid
-                        Assertions.fail("NullabilityAccessor threw an exception that is not IndexOutOfBoundsException", e);
+                        Assertions.fail(
+                                "NullabilityAccessor threw an exception that is not IndexOutOfBoundsException",
+                                e);
                     }
                 }
             }

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -14,39 +14,39 @@ public class NullabilityDetectorTest {
     public void testNullableDetectorForMethodWithoutArgs() {
         MemberBox memberBox =
                 new MemberBox(getTestClassMethod("function1"), TypeInfoFactory.GLOBAL);
-        assertNullabilityMatch(memberBox.argNullability);
+        assertNullabilityMatch(memberBox.getArgNullability());
     }
 
     @Test
     public void testNullableDetectorForMethodWithOneArg() {
         MemberBox memberBox =
                 new MemberBox(getTestClassMethod("function2"), TypeInfoFactory.GLOBAL);
-        assertNullabilityMatch(memberBox.argNullability, true);
+        assertNullabilityMatch(memberBox.getArgNullability(), true);
     }
 
     @Test
     public void testNullableDetectorForMethodWithSeveralArgs() {
         MemberBox memberBox =
                 new MemberBox(getTestClassMethod("function3"), TypeInfoFactory.GLOBAL);
-        assertNullabilityMatch(memberBox.argNullability, true, true, true, true);
+        assertNullabilityMatch(memberBox.getArgNullability(), true, true, true, true);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithoutArgs() {
         MemberBox memberBox = new MemberBox(getTestClassConstructor(0), TypeInfoFactory.GLOBAL);
-        assertNullabilityMatch(memberBox.argNullability);
+        assertNullabilityMatch(memberBox.getArgNullability());
     }
 
     @Test
     public void testNullableDetectorForConstructorWithOneArg() {
         MemberBox memberBox = new MemberBox(getTestClassConstructor(1), TypeInfoFactory.GLOBAL);
-        assertNullabilityMatch(memberBox.argNullability, true);
+        assertNullabilityMatch(memberBox.getArgNullability(), true);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithSeveralArgs() {
         MemberBox memberBox = new MemberBox(getTestClassConstructor(4), TypeInfoFactory.GLOBAL);
-        assertNullabilityMatch(memberBox.argNullability, true, false, true, false);
+        assertNullabilityMatch(memberBox.getArgNullability(), true, false, true, false);
     }
 
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -47,7 +47,8 @@ public class NullabilityDetectorTest {
         assertNullabilityMatch(memberBox.argNullability, true, false, true, false);
     }
 
-    private static void assertNullabilityMatch(NullabilityDetector.NullabilityAccessor nullabilityAccessor, boolean... expected) {
+    private static void assertNullabilityMatch(
+            NullabilityDetector.NullabilityAccessor nullabilityAccessor, boolean... expected) {
         var actual = new boolean[expected.length];
         for (int i = 0; i < actual.length; i++) {
             actual[i] = nullabilityAccessor.isNullable(i);

--- a/rhino/src/test/java/org/mozilla/javascript/TestNullabilityDetector.java
+++ b/rhino/src/test/java/org/mozilla/javascript/TestNullabilityDetector.java
@@ -2,7 +2,6 @@ package org.mozilla.javascript;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 
 public class TestNullabilityDetector implements NullabilityDetector {
     @Override

--- a/rhino/src/test/java/org/mozilla/javascript/TestNullabilityDetector.java
+++ b/rhino/src/test/java/org/mozilla/javascript/TestNullabilityDetector.java
@@ -6,22 +6,14 @@ import java.util.Arrays;
 
 public class TestNullabilityDetector implements NullabilityDetector {
     @Override
-    public boolean[] getParameterNullability(Method method) {
-        int paramCount = method.getParameters().length;
-        boolean[] result = new boolean[paramCount];
+    public NullabilityAccessor getParameterNullability(Method method) {
         // All arguments are nullable
-        Arrays.fill(result, true);
-        return result;
+        return i -> true;
     }
 
     @Override
-    public boolean[] getParameterNullability(Constructor<?> constructor) {
-        int paramCount = constructor.getParameters().length;
-        boolean[] result = new boolean[paramCount];
-        for (int i = 0; i < paramCount; i++) {
-            // Even arguments are nullable
-            result[i] = i % 2 == 0;
-        }
-        return result;
+    public NullabilityAccessor getParameterNullability(Constructor<?> constructor) {
+        // Even arguments are nullable
+        return i -> i % 2 == 0;
     }
 }


### PR DESCRIPTION
The `MemberBox#argNullability` is currently using a `boolean[]` to store nullability information. This means that for Java class, each `MemberBox` initialization will allocate a `new boolean[method.getParameters().length]` that only contains `false`.

This PR replaced `boolean[]` with `NullabilityAccessor` so that for pure Java class, we can prevent allocation by reusing the same `NullabilityAccessor.FALSE` object:

```java
    interface NullabilityAccessor {
        NullabilityAccessor FALSE = (ignored) -> false;

        boolean isNullable(int index);
    }
```