### PR TITLE
fix TypeInfoFactory used in FunctionObject

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -80,7 +80,7 @@ public class FunctionObject extends BaseFunction {
      * @see org.mozilla.javascript.Scriptable
      */
     public FunctionObject(String name, Member methodOrConstructor, Scriptable scope) {
-        var typeInfoFactory = TypeInfoFactory.get(this);
+        var typeInfoFactory = TypeInfoFactory.get(scope);
 
         if (methodOrConstructor instanceof Constructor) {
             member = new MemberBox((Constructor<?>) methodOrConstructor, typeInfoFactory);

--- a/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
@@ -260,8 +260,8 @@ public interface TypeInfoFactory extends Serializable {
      * Associate this TypeInfoFactory object with the given top-level scope.
      *
      * @param topScope scope to associate this TypeInfoFactory object with.
-     * @return {@code true} if no previous TypeInfoFactory object were associated with the scope and
-     *     this TypeInfoFactory were successfully associated, false otherwise.
+     * @return {@code true} if no previous TypeInfoFactory object was associated with the scope and
+     *     this TypeInfoFactory is successfully associated, {@code false} otherwise.
      * @throws IllegalArgumentException if provided scope is not top scope
      * @see #get(Scriptable scope)
      */
@@ -291,8 +291,6 @@ public interface TypeInfoFactory extends Serializable {
             // we expect this to not happen frequently, so computing top scope twice is acceptable
             var topScope = ScriptableObject.getTopLevelScope(scope);
             if (!(topScope instanceof ScriptableObject)) {
-                // Note: it's originally a RuntimeException, the super class of
-                // IllegalArgumentException, so this will not break error catching
                 throw new IllegalArgumentException(
                         "top scope have no associated TypeInfoFactory and cannot have TypeInfoFactory associated due to not being a ScriptableObject");
             }

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/AlwaysFailFactory.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/AlwaysFailFactory.java
@@ -1,0 +1,53 @@
+package org.mozilla.javascript.tests.type_info;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.List;
+import org.mozilla.javascript.lc.type.TypeInfo;
+import org.mozilla.javascript.lc.type.TypeInfoFactory;
+
+/**
+ * @author ZZZank
+ */
+enum AlwaysFailFactory implements TypeInfoFactory {
+    INSTANCE;
+
+    public static final String MESSAGE = "attempting to create TypeInfo on AlwaysFailFactory";
+
+    @Override
+    public TypeInfo create(Class<?> clazz) {
+        throw new AssertionError(MESSAGE);
+    }
+
+    @Override
+    public TypeInfo create(GenericArrayType genericArrayType) {
+        throw new AssertionError(MESSAGE);
+    }
+
+    @Override
+    public TypeInfo create(TypeVariable<?> typeVariable) {
+        throw new AssertionError(MESSAGE);
+    }
+
+    @Override
+    public TypeInfo create(ParameterizedType parameterizedType) {
+        throw new AssertionError(MESSAGE);
+    }
+
+    @Override
+    public TypeInfo create(WildcardType wildcardType) {
+        throw new AssertionError(MESSAGE);
+    }
+
+    @Override
+    public TypeInfo toArray(TypeInfo component) {
+        throw new AssertionError(MESSAGE);
+    }
+
+    @Override
+    public TypeInfo attachParam(TypeInfo base, List<TypeInfo> params) {
+        throw new AssertionError(MESSAGE);
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/NoGenericNoCacheFactory.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/NoGenericNoCacheFactory.java
@@ -3,7 +3,7 @@ package org.mozilla.javascript.tests.type_info;
 import java.lang.reflect.TypeVariable;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.lc.type.TypeInfo;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
 import org.mozilla.javascript.lc.type.VariableTypeInfo;
@@ -13,9 +13,8 @@ import org.mozilla.javascript.lc.type.impl.InterfaceTypeInfo;
 import org.mozilla.javascript.lc.type.impl.factory.FactoryBase;
 
 /**
- * {@link org.mozilla.javascript.lc.type.TypeInfoFactory} implementation with no cache, and no
- * generic support, as an example usage of custom type factory via {@link
- * org.mozilla.javascript.ContextFactory#setTypeFactoryProvider(Function)}
+ * {@link TypeInfoFactory} implementation with no cache, and no generic support, as an example usage
+ * of custom type factory via {@link TypeInfoFactory#associate(ScriptableObject)}
  *
  * @author ZZZank
  */


### PR DESCRIPTION
The `TypeInfoFactory` used in `FunctionObject` is currently obtained via:

```java
TypeInfoFactory.get(this)
```

where the `this` is FunctionObject itself, which doesn't make any sense because it's trying to obtained a TypeInfoFactory from a not-yet-initialized object. `scope` should be used instead.