### PR TITLE
Fix: seal `String.prototype` correctly

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -148,6 +148,7 @@ final class NativeString extends ScriptableObject {
 
         if (sealed) {
             c.sealObject();
+            ((NativeString) c.getPrototypeProperty()).sealObject();
         }
         ScriptableObject.defineProperty(scope, CLASS_NAME, c, DONTENUM);
     }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
@@ -6,11 +6,14 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Locale;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -82,6 +85,25 @@ public class NativeStringTest {
 
                     final Object rep = cx.evaluateString(scope, js, "test.js", 0, null);
                     assertEquals("\u0069", rep);
+                    return null;
+                });
+    }
+
+    @Test
+    public void stringIsSealedCorrectly() {
+        Utils.runWithAllModes(
+                cx -> {
+                    TopLevel scope = new TopLevel();
+                    cx.initStandardObjects(scope, true);
+
+                    assertThrows(
+                            EvaluatorException.class,
+                            () -> cx.evaluateString(scope, "String.a = 'a'", "test.js", 1, null));
+                    assertThrows(
+                            EvaluatorException.class,
+                            () ->
+                                    cx.evaluateString(
+                                            scope, "String.prototype.a = 'a'", "test.js", 1, null));
                     return null;
                 });
     }


### PR DESCRIPTION
When `Context::initStandardObject(sealed = true)` is called, `String` is sealed, but `String.prototype` is not after the changes done in https://github.com/mozilla/rhino/pull/1852.
This patch fixes it.