### PR TITLE
Fix: seal all builtins prototypes correctly

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -66,6 +66,7 @@ final class NativeBigInt extends ScriptableObject {
                 SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
@@ -40,6 +40,7 @@ final class NativeBoolean extends ScriptableObject {
         ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -137,6 +137,7 @@ public class NativeMap extends ScriptableObject {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
@@ -122,6 +122,7 @@ final class NativeNumber extends ScriptableObject {
         ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -78,6 +78,7 @@ public class NativePromise extends ScriptableObject {
                 SymbolKey.TO_STRING_TAG, "Promise", DONTENUM | READONLY);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -118,6 +118,7 @@ public class NativeSet extends ScriptableObject {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
@@ -81,6 +81,7 @@ public class NativeWeakMap extends ScriptableObject {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
@@ -66,6 +66,7 @@ public class NativeWeakSet extends ScriptableObject {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -241,7 +241,6 @@ public class ScriptRuntime {
             new LazilyLoadedCtor(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
             new LazilyLoadedCtor(scope, "BigInt64Array", sealed, true, NativeBigInt64Array::init);
             new LazilyLoadedCtor(scope, "BigUint64Array", sealed, true, NativeBigUint64Array::init);
-            new LazilyLoadedCtor(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
             new LazilyLoadedCtor(scope, "Float32Array", sealed, true, NativeFloat32Array::init);
             new LazilyLoadedCtor(scope, "Float64Array", sealed, true, NativeFloat64Array::init);
             new LazilyLoadedCtor(scope, "DataView", sealed, true, NativeDataView::init);

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -63,6 +63,7 @@ public class NativeArrayBuffer extends ScriptableObject {
 
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -63,6 +64,7 @@ public class NativeBigInt64Array extends NativeBigIntArrayView {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -63,6 +64,7 @@ public class NativeBigUint64Array extends NativeBigIntArrayView {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 
@@ -224,6 +225,7 @@ public class NativeDataView extends NativeArrayBufferView {
 
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -62,6 +63,7 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -62,6 +63,7 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -61,6 +62,7 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -62,6 +63,7 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -55,6 +56,7 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -61,6 +62,7 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -61,6 +62,7 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -55,6 +56,7 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -57,6 +58,7 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
         if (sealed) {
             constructor.sealObject();
+            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
         }
         return constructor;
     }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/BuiltinsSealingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/BuiltinsSealingTest.java
@@ -1,0 +1,194 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.testutils.Utils;
+
+class BuiltinsSealingTest {
+    @Test
+    public void object() {
+        assertIsSealed("Object");
+    }
+
+    @Test
+    public void function() {
+        assertIsSealed("Function");
+    }
+
+    @Test
+    public void errors() {
+        assertIsSealed("Error");
+        assertIsSealed("AggregateError");
+        assertIsSealed("EvalError");
+        assertIsSealed("RangeError");
+        assertIsSealed("ReferenceError");
+        assertIsSealed("SyntaxError");
+        assertIsSealed("TypeError");
+        assertIsSealed("URIError");
+        assertIsSealed("InternalError");
+        assertIsSealed("JavaException");
+    }
+
+    @Test
+    public void array() {
+        assertIsSealed("Array");
+    }
+
+    @Test
+    public void string() {
+        assertIsSealed("String");
+    }
+
+    @Test
+    public void jsBoolean() {
+        assertIsSealed("Boolean");
+    }
+
+    @Test
+    public void number() {
+        assertIsSealed("Number");
+    }
+
+    @Test
+    public void date() {
+        assertIsSealed("Date");
+    }
+
+    @Test
+    public void math() {
+        assertIsSealedNoPrototype("Math");
+    }
+
+    @Test
+    public void json() {
+        assertIsSealedNoPrototype("JSON");
+    }
+
+    @Test
+    void regexp() {
+        assertIsSealed("RegExp");
+    }
+
+    @Test
+    public void rhinoNonStandard() {
+        assertIsSealed("With");
+        assertIsSealed("Call");
+        assertIsSealed("CallSite");
+        assertIsSealed("Iterator");
+        assertIsSealed("Continuation");
+    }
+
+    @Test
+    public void typedArrays() {
+        assertIsSealed("ArrayBuffer");
+        assertIsSealed("Int8Array");
+        assertIsSealed("Uint8Array");
+        assertIsSealed("Uint8ClampedArray");
+        assertIsSealed("Int16Array");
+        assertIsSealed("Uint16Array");
+        assertIsSealed("Int32Array");
+        assertIsSealed("Uint32Array");
+        assertIsSealed("BigInt64Array");
+        assertIsSealed("BigUint64Array");
+        assertIsSealed("Float32Array");
+        assertIsSealed("Float64Array");
+        assertIsSealed("DataView");
+    }
+
+    @Test
+    public void map() {
+        assertIsSealed("Map");
+    }
+
+    @Test
+    public void promise() {
+        assertIsSealed("Promise");
+    }
+
+    @Test
+    public void set() {
+        assertIsSealed("Set");
+    }
+
+    @Test
+    public void weakMap() {
+        assertIsSealed("WeakMap");
+    }
+
+    @Test
+    public void weakSet() {
+        assertIsSealed("WeakSet");
+    }
+
+    @Test
+    public void bigInt() {
+        assertIsSealed("BigInt");
+    }
+
+    @Test
+    public void proxy() {
+        assertIsSealedNoPrototype("Proxy");
+    }
+
+    @Test
+    public void reflect() {
+        assertIsSealedNoPrototype("Reflect");
+    }
+
+    /** Checks both X and X.prototype */
+    private static void assertIsSealed(String builtinName) {
+        Utils.runWithAllModes(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ECMASCRIPT);
+                    TopLevel scope = new TopLevel();
+                    cx.initStandardObjects(scope, true);
+
+                    assertThrows(
+                            EvaluatorException.class,
+                            () ->
+                                    cx.evaluateString(
+                                            scope, builtinName + ".a = 'a'", "test.js", 1, null));
+                    assertThrows(
+                            EvaluatorException.class,
+                            () ->
+                                    cx.evaluateString(
+                                            scope,
+                                            builtinName + ".prototype.a = 'a'",
+                                            "test.js",
+                                            1,
+                                            null));
+                    return null;
+                });
+    }
+
+    /** Checks only X, doesn't try to access X.prototype (but checks it's undefined) */
+    private static void assertIsSealedNoPrototype(String builtinName) {
+        Utils.runWithAllModes(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ECMASCRIPT);
+                    TopLevel scope = new TopLevel();
+                    cx.initStandardObjects(scope, true);
+
+                    assertThrows(
+                            EvaluatorException.class,
+                            () ->
+                                    cx.evaluateString(
+                                            scope, builtinName + ".a = 'a'", "test.js", 1, null));
+                    assertTrue(
+                            Undefined.isUndefined(
+                                    cx.evaluateString(
+                                            scope,
+                                            builtinName + ".prototype",
+                                            "test.js",
+                                            1,
+                                            null)));
+                    return null;
+                });
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
@@ -6,14 +6,11 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 import java.util.Locale;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -85,25 +82,6 @@ public class NativeStringTest {
 
                     final Object rep = cx.evaluateString(scope, js, "test.js", 0, null);
                     assertEquals("\u0069", rep);
-                    return null;
-                });
-    }
-
-    @Test
-    public void stringIsSealedCorrectly() {
-        Utils.runWithAllModes(
-                cx -> {
-                    TopLevel scope = new TopLevel();
-                    cx.initStandardObjects(scope, true);
-
-                    assertThrows(
-                            EvaluatorException.class,
-                            () -> cx.evaluateString(scope, "String.a = 'a'", "test.js", 1, null));
-                    assertThrows(
-                            EvaluatorException.class,
-                            () ->
-                                    cx.evaluateString(
-                                            scope, "String.prototype.a = 'a'", "test.js", 1, null));
                     return null;
                 });
     }


### PR DESCRIPTION
Extended the test and fix of https://github.com/mozilla/rhino/pull/1962 to all builtins. Now we ensure that, whenever
`ScriptRuntime::initStandardObject(sealed = true)` is called, all objects have both themselves and their prototype property sealed.

I have not reworked the API in `ScriptRuntime` suggested by @rPraml in this PR, but if someone wants to do that, we now have a test to ensure there are no regressions. 😊