### PR TITLE
Save some memory in `BaseFunction`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -726,11 +726,18 @@ public class BaseFunction extends ScriptableObject implements Function {
     }
 
     public void setHomeObject(Scriptable homeObject) {
-        this.homeObject = homeObject;
+        assert getHomeObject() == null;
+
+        // The if is necessary because, for lambda inside an activation, we always try to propagate
+        // the home object from the activation, regardless of whether it is null or not. It's easier
+        // to do one check here than two, one in the interpreter and one in the compiled classes.
+        if (homeObject != null) {
+            associateValue(HOME_OBJECT_KEY, homeObject);
+        }
     }
 
     public Scriptable getHomeObject() {
-        return homeObject;
+        return (Scriptable) getAssociatedValue(HOME_OBJECT_KEY);
     }
 
     private static final int Id_constructor = 1,
@@ -746,7 +753,8 @@ public class BaseFunction extends ScriptableObject implements Function {
     private Object argumentsObj = NOT_FOUND;
     private Object nameValue = null;
     private boolean isGeneratorFunction = false;
-    private Scriptable homeObject = null;
+
+    private static final String HOME_OBJECT_KEY = "_funHomeObject";
 
     // For function object instances, attributes are
     //  {configurable:false, enumerable:false};


### PR DESCRIPTION
When we implemented `super`, we added a property `homeObject` to `BaseFunction`. This property is often null; it's not null only for functions that actually are members of some objects. This patch changes the implementation to use the `associatedValue` feature of `ScriptableObject`, to save some memory in the general case.

I cannot offer any real measurements from our ServiceNow fork, because we have a transpiler step that strips away all the methods declaration, i.e. it transform `o = { f() {} }` to `o = { f: function() {} }`, and therefore no function has the home object step. We will eventually disable it since Rhino now supports that syntax, but that's a bit off in our roadmap. 
I've added a bit of instrumentation for Test262 and I see that only 7,758 out of 32,133,646 actually _have_ an home object. Test262 is not a particular representative sample of average JS code, but I think in general the vast majority of functions aren't methods and thus won't have the home object set.

Unfortunately, it seems that the actual size of an `InterpretedFunction` is not changing with this change, because of padding, so I am uncertain this is worth merging at this point and I would like some feedback 🙂  