### PR TITLE
Fix BigInt.asUintN and BigInt.asIntN implementation (fixes #1573)

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -116,7 +116,7 @@ final class NativeBigInt extends ScriptableObject {
         }
 
         BigInteger modulus = BigInteger.ONE.shiftLeft(bits); // 2^bits
-        
+
         if (isSigned) {
             return asSignedN(bigInt, bits, modulus);
         } else {
@@ -127,12 +127,12 @@ final class NativeBigInt extends ScriptableObject {
     private static BigInteger asUnsignedN(BigInteger bigInt, BigInteger modulus) {
         // For unsigned: return bigInt modulo 2^bits, ensuring non-negative result
         BigInteger result = bigInt.remainder(modulus);
-        
+
         // Ensure result is non-negative for unsigned representation
         if (result.signum() < 0) {
             result = result.add(modulus);
         }
-        
+
         return result;
     }
 
@@ -141,20 +141,20 @@ final class NativeBigInt extends ScriptableObject {
         BigInteger halfModulus = BigInteger.ONE.shiftLeft(bits - 1); // 2^(bits-1)
         BigInteger minValue = halfModulus.negate(); // -2^(bits-1)
         BigInteger maxValue = halfModulus.subtract(BigInteger.ONE); // 2^(bits-1) - 1
-        
+
         // If the number already fits in the signed range, return as is
         if (bigInt.compareTo(minValue) >= 0 && bigInt.compareTo(maxValue) <= 0) {
             return bigInt;
         }
-        
+
         // Compute unsigned result first
         BigInteger result = asUnsignedN(bigInt, modulus);
-        
+
         // Convert to signed range if needed
         if (result.compareTo(halfModulus) >= 0) {
             result = result.subtract(modulus);
         }
-        
+
         return result;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -7,7 +7,6 @@
 package org.mozilla.javascript;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 
 /** This class implements the BigInt native object. */
 final class NativeBigInt extends ScriptableObject {
@@ -116,28 +115,47 @@ final class NativeBigInt extends ScriptableObject {
             return BigInteger.ZERO;
         }
 
-        byte[] bytes = bigInt.toByteArray();
+        BigInteger modulus = BigInteger.ONE.shiftLeft(bits); // 2^bits
+        
+        if (isSigned) {
+            return asSignedN(bigInt, bits, modulus);
+        } else {
+            return asUnsignedN(bigInt, modulus);
+        }
+    }
 
-        int newBytesLen = (bits / Byte.SIZE) + 1;
-        if (newBytesLen > bytes.length) {
+    private static BigInteger asUnsignedN(BigInteger bigInt, BigInteger modulus) {
+        // For unsigned: return bigInt modulo 2^bits, ensuring non-negative result
+        BigInteger result = bigInt.remainder(modulus);
+        
+        // Ensure result is non-negative for unsigned representation
+        if (result.signum() < 0) {
+            result = result.add(modulus);
+        }
+        
+        return result;
+    }
+
+    private static BigInteger asSignedN(BigInteger bigInt, int bits, BigInteger modulus) {
+        // For signed: use two's complement representation
+        BigInteger halfModulus = BigInteger.ONE.shiftLeft(bits - 1); // 2^(bits-1)
+        BigInteger minValue = halfModulus.negate(); // -2^(bits-1)
+        BigInteger maxValue = halfModulus.subtract(BigInteger.ONE); // 2^(bits-1) - 1
+        
+        // If the number already fits in the signed range, return as is
+        if (bigInt.compareTo(minValue) >= 0 && bigInt.compareTo(maxValue) <= 0) {
             return bigInt;
         }
-
-        byte[] newBytes = Arrays.copyOfRange(bytes, bytes.length - newBytesLen, bytes.length);
-
-        int mod = bits % Byte.SIZE;
-        if (isSigned) {
-            if (mod == 0) {
-                newBytes[0] = newBytes[1] < 0 ? (byte) -1 : 0;
-            } else if ((newBytes[0] & (1 << (mod - 1))) != 0) {
-                newBytes[0] = (byte) (newBytes[0] | (-1 << mod));
-            } else {
-                newBytes[0] = (byte) (newBytes[0] & ((1 << mod) - 1));
-            }
-        } else {
-            newBytes[0] = (byte) (newBytes[0] & ((1 << mod) - 1));
+        
+        // Compute unsigned result first
+        BigInteger result = asUnsignedN(bigInt, modulus);
+        
+        // Convert to signed range if needed
+        if (result.compareTo(halfModulus) >= 0) {
+            result = result.subtract(modulus);
         }
-        return new BigInteger(newBytes);
+        
+        return result;
     }
 
     @Override

--- a/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
@@ -46,4 +46,48 @@ public class BigIntTest {
         Utils.assertWithAllModes_ES6(true, "'9007199254740993' >= 9007199254740992n");
         Utils.assertWithAllModes_ES6(true, "'9007199254740993' > 9007199254740992n");
     }
+
+    @Test
+    public void asUintN() {
+        // Test the specific issue reported in GitHub issue #1573
+        Utils.assertWithAllModes_ES6("18446744073709551615", "BigInt.asUintN(64, -1n).toString()");
+        Utils.assertWithAllModes_ES6("4294967295", "BigInt.asUintN(32, -1n).toString()");
+        Utils.assertWithAllModes_ES6("65535", "BigInt.asUintN(16, -1n).toString()");
+        Utils.assertWithAllModes_ES6("255", "BigInt.asUintN(8, -1n).toString()");
+        Utils.assertWithAllModes_ES6("15", "BigInt.asUintN(4, -1n).toString()");
+        Utils.assertWithAllModes_ES6("1", "BigInt.asUintN(1, -1n).toString()");
+        
+        // Test positive values
+        Utils.assertWithAllModes_ES6("255", "BigInt.asUintN(8, 255n).toString()");
+        Utils.assertWithAllModes_ES6("0", "BigInt.asUintN(8, 256n).toString()");
+        Utils.assertWithAllModes_ES6("1", "BigInt.asUintN(8, 257n).toString()");
+        
+        // Test zero bits edge case
+        Utils.assertWithAllModes_ES6("0", "BigInt.asUintN(0, 123n).toString()");
+        
+        // Test equality with expected BigInt values (the main issue case)
+        Utils.assertWithAllModes_ES6(true, "BigInt.asUintN(64, -1n) === BigInt('0xffffffffffffffff')");
+    }
+
+    @Test
+    public void asIntN() {
+        // Test signed truncation
+        Utils.assertWithAllModes_ES6("127", "BigInt.asIntN(8, 127n).toString()");
+        Utils.assertWithAllModes_ES6("-128", "BigInt.asIntN(8, 128n).toString()");
+        Utils.assertWithAllModes_ES6("-1", "BigInt.asIntN(8, 255n).toString()");
+        Utils.assertWithAllModes_ES6("0", "BigInt.asIntN(8, 256n).toString()");
+        
+        // Test negative values
+        Utils.assertWithAllModes_ES6("-1", "BigInt.asIntN(8, -1n).toString()");
+        Utils.assertWithAllModes_ES6("-128", "BigInt.asIntN(8, -128n).toString()");
+        Utils.assertWithAllModes_ES6("127", "BigInt.asIntN(8, -129n).toString()");
+        
+        // Test 32-bit boundaries
+        Utils.assertWithAllModes_ES6("2147483647", "BigInt.asIntN(32, 2147483647n).toString()");
+        Utils.assertWithAllModes_ES6("-2147483648", "BigInt.asIntN(32, 2147483648n).toString()");
+        Utils.assertWithAllModes_ES6("-1", "BigInt.asIntN(32, 4294967295n).toString()");
+        
+        // Test zero bits edge case
+        Utils.assertWithAllModes_ES6("0", "BigInt.asIntN(0, 123n).toString()");
+    }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
@@ -56,17 +56,18 @@ public class BigIntTest {
         Utils.assertWithAllModes_ES6("255", "BigInt.asUintN(8, -1n).toString()");
         Utils.assertWithAllModes_ES6("15", "BigInt.asUintN(4, -1n).toString()");
         Utils.assertWithAllModes_ES6("1", "BigInt.asUintN(1, -1n).toString()");
-        
+
         // Test positive values
         Utils.assertWithAllModes_ES6("255", "BigInt.asUintN(8, 255n).toString()");
         Utils.assertWithAllModes_ES6("0", "BigInt.asUintN(8, 256n).toString()");
         Utils.assertWithAllModes_ES6("1", "BigInt.asUintN(8, 257n).toString()");
-        
+
         // Test zero bits edge case
         Utils.assertWithAllModes_ES6("0", "BigInt.asUintN(0, 123n).toString()");
-        
+
         // Test equality with expected BigInt values (the main issue case)
-        Utils.assertWithAllModes_ES6(true, "BigInt.asUintN(64, -1n) === BigInt('0xffffffffffffffff')");
+        Utils.assertWithAllModes_ES6(
+                true, "BigInt.asUintN(64, -1n) === BigInt('0xffffffffffffffff')");
     }
 
     @Test
@@ -76,17 +77,17 @@ public class BigIntTest {
         Utils.assertWithAllModes_ES6("-128", "BigInt.asIntN(8, 128n).toString()");
         Utils.assertWithAllModes_ES6("-1", "BigInt.asIntN(8, 255n).toString()");
         Utils.assertWithAllModes_ES6("0", "BigInt.asIntN(8, 256n).toString()");
-        
+
         // Test negative values
         Utils.assertWithAllModes_ES6("-1", "BigInt.asIntN(8, -1n).toString()");
         Utils.assertWithAllModes_ES6("-128", "BigInt.asIntN(8, -128n).toString()");
         Utils.assertWithAllModes_ES6("127", "BigInt.asIntN(8, -129n).toString()");
-        
+
         // Test 32-bit boundaries
         Utils.assertWithAllModes_ES6("2147483647", "BigInt.asIntN(32, 2147483647n).toString()");
         Utils.assertWithAllModes_ES6("-2147483648", "BigInt.asIntN(32, 2147483648n).toString()");
         Utils.assertWithAllModes_ES6("-1", "BigInt.asIntN(32, 4294967295n).toString()");
-        
+
         // Test zero bits edge case
         Utils.assertWithAllModes_ES6("0", "BigInt.asIntN(0, 123n).toString()");
     }


### PR DESCRIPTION
## Summary

Fixes issue #1573 where BigInt.asUintN(64, -1n) incorrectly returned -1n instead of the expected 18446744073709551615n.

## Problem

The previous implementation used byte array manipulation which had several issues:
- For larger bit widths, it would return the original BigInt without truncation
- The modular arithmetic was incorrect for negative numbers
- The algorithm did not follow the ECMAScript specification

## Solution

Replaced the byte array approach with proper modular arithmetic following the ECMAScript specification:

- BigInt.asUintN(bits, bigint): Returns bigint modulo 2^bits as unsigned integer
- BigInt.asIntN(bits, bigint): Returns signed representation using two's complement

## Changes

- Implemented correct ECMAScript algorithm using BigInteger.remainder() and bit shifting
- Refactored code into asUnsignedN() and asSignedN() helper methods for clarity  
- Added comprehensive test cases covering edge cases and boundary conditions
- Removed unused import (java.util.Arrays)

## Test Results

Before the fix:
BigInt.asUintN(64, -1n) === -1n  // Wrong

After the fix:
BigInt.asUintN(64, -1n) === BigInt('0xffffffffffffffff')  // Correct

All existing tests pass, and new comprehensive tests validate the fix.

Fixes #1573