### PR TITLE
Fixes edge case in `Array::from`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -650,7 +650,7 @@ public class NativeArray extends ScriptableObject implements List {
         final Scriptable items =
                 ScriptRuntime.toObject(scope, (args.length >= 1) ? args[0] : Undefined.instance);
         Object mapArg = (args.length >= 2) ? args[1] : Undefined.instance;
-        Scriptable thisArg = Undefined.SCRIPTABLE_UNDEFINED;
+        Scriptable thisArg = null;
         final boolean mapping = !Undefined.isUndefined(mapArg);
         Function mapFn = null;
 
@@ -659,9 +659,9 @@ public class NativeArray extends ScriptableObject implements List {
                 throw ScriptRuntime.typeErrorById("msg.map.function.not");
             }
             mapFn = (Function) mapArg;
-            if (args.length >= 3) {
-                thisArg = ensureScriptable(args[2]);
-            }
+
+            Object callThisArg = args.length >= 3 ? args[2] : Undefined.SCRIPTABLE_UNDEFINED;
+            thisArg = ScriptRuntime.getApplyOrCallThis(cx, scope, callThisArg, 1, mapFn);
         }
 
         Object iteratorProp = ScriptableObject.getProperty(items, SymbolKey.ITERATOR);

--- a/tests/testsrc/jstests/es6/array.js
+++ b/tests/testsrc/jstests/es6/array.js
@@ -50,4 +50,69 @@ assertEquals(a.map(_ => 'a'), ['a', 'a']);
 	assertEquals(JSON.stringify(symbolValues), symbolValuesToAssert);
 })();
 
+(function TestArrayFromThisArgWithMapping() {
+	var thisValue = {multiplier: 2};
+	
+	var result = Array.from([1, 2, 3], function(x) {
+		return x * this.multiplier;
+	}, thisValue);
+	
+	assertEquals(result, [2, 4, 6]);
+})();
+
+(function TestArrayFromThisArgWithIterator() {
+	var thisValue = {prefix: 'item'};
+	var iterable = new Set(['a', 'b', 'c']);
+	
+	var result = Array.from(iterable, function(x, i) {
+		return this.prefix + i + ':' + x;
+	}, thisValue);
+	
+	assertEquals(result, ['item0:a', 'item1:b', 'item2:c']);
+})();
+
+(function TestArrayFromThisArgUndefined() {
+	var result = Array.from([1, 2], function(x) {
+		return typeof this === 'object' && this !== null;
+	}, undefined);
+	
+	assertEquals(result, [true, true]);
+})();
+
+(function TestArrayFromThisArgNull() {
+	var result = Array.from([1, 2], function(x) {
+		return typeof this === 'object' && this !== null;
+	}, null);
+	
+	assertEquals(result, [true, true]);
+})();
+
+(function TestArrayFromThisArgStrictModeUndefined() {
+	'use strict';
+	var result = Array.from([1, 2], function(x) {
+		return this === undefined;
+	}, undefined);
+	
+	assertEquals(result, [true, true]);
+})();
+
+(function TestArrayFromThisArgStrictModeNull() {
+	'use strict';
+	var result = Array.from([1, 2], function(x) {
+		return this === null;
+	}, null);
+	
+	assertEquals(result, [true, true]);
+})();
+
+(function TestArrayFromThisArgStrictModeObject() {
+	'use strict';
+	var thisValue = {value: 'strict'};
+	var result = Array.from([1], function(x) {
+		return this.value === 'strict';
+	}, thisValue);
+	
+	assertEquals(result, [true]);
+})();
+
 "success";

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -27,11 +27,9 @@ harness 23/116 (19.83%)
     isConstructor.js
     nativeFunctionMatcher.js
 
-built-ins/Array 265/3077 (8.61%)
+built-ins/Array 263/3077 (8.55%)
     fromAsync 95/95 (100.0%)
-    from/calling-from-valid-1-noStrict.js non-strict Spec pretty clearly says this should be undefined
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
-    from/iter-map-fn-this-non-strict.js non-strict Error propagation needs work in general
     from/proto-from-ctor-realm.js
     from/source-object-constructor.js Error propagation needs work in general
     length/define-own-prop-length-coercion-order-set.js


### PR DESCRIPTION
This fixes how `this` is handled when calling `Array.from` in some edge cases, when `null` or `undefined` were passed as the `this` argument.