### PR TITLE
Regexp: Use lambda instead of reflection for init

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -145,7 +145,7 @@ public class NativeRegExp extends IdScriptableObject {
 
     private static final int ANCHOR_BOL = -2;
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
 
         NativeRegExp proto = NativeRegExpInstantiator.withLanguageVersion(cx.getLanguageVersion());
         proto.re = compileRE(cx, "", null, false);
@@ -170,6 +170,8 @@ public class NativeRegExp extends IdScriptableObject {
         ScriptableObject.defineProperty(scope, "RegExp", ctor, ScriptableObject.DONTENUM);
 
         ScriptRuntimeES6.addSymbolSpecies(cx, scope, ctor);
+
+        return ctor;
     }
 
     NativeRegExp(Scriptable scope, RECompiled regexpCompiled) {

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -22,8 +22,7 @@ public class RegExpImpl implements RegExpProxy {
     @Override
     public void register(ScriptableObject scope, boolean sealed) {
         NativeRegExpStringIterator.init(scope, sealed);
-        new LazilyLoadedCtor(
-                scope, "RegExp", "org.mozilla.javascript.regexp.NativeRegExp", sealed, true);
+        new LazilyLoadedCtor(scope, "RegExp", sealed, true, NativeRegExp::init);
     }
 
     @Override


### PR DESCRIPTION
2nd PR for #1983 

For regexp, we use now a lambda expression for init. This allows us an easier separation of liveconnect classes later