### PR TITLE
improve super put processing

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2025,31 +2025,6 @@ public final class IRFactory {
             }
             parser.checkActivationName(name, Token.GETPROP);
 
-            if (target.getType() == Token.SUPER && NativeObject.PROTO_PROPERTY.equals(name)) {
-                // We have access to super.__proto__.
-                // This needs to behave in the same way as this.__proto__ - it really is not
-                // obvious why, but you can test it in v8 or any other engine. So, we just
-                // replace SUPER with THIS in the AST. It's a bit hacky, but it works - see the
-                // test cases in SuperTest!
-                if (!(target instanceof KeywordLiteral)) {
-                    throw Kit.codeBug();
-                }
-                KeywordLiteral oldTarget = (KeywordLiteral) target;
-                target =
-                        new KeywordLiteral(
-                                oldTarget.getPosition(), oldTarget.getLength(), Token.THIS);
-                target.setLineColumnNumber(oldTarget.getLineno(), oldTarget.getColumn());
-
-                Node ref = new Node(Token.REF_SPECIAL, target);
-                ref.putProp(Node.NAME_PROP, name);
-                Node getRef = new Node(Token.GET_REF, ref);
-                if (type == Token.QUESTION_DOT) {
-                    ref.putIntProp(Node.OPTIONAL_CHAINING, 1);
-                    getRef.putIntProp(Node.OPTIONAL_CHAINING, 1);
-                }
-                return getRef;
-            }
-
             if (parser.compilerEnv.getLanguageVersion() < Context.VERSION_ES6
                     && ScriptRuntime.isSpecialProperty(name)) {
                 Node ref = new Node(Token.REF_SPECIAL, target);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2506,7 +2506,10 @@ public abstract class ScriptableObject extends SlotMapOwner
     /** Variant of putProperty to handle super[key] = value where key is a symbol */
     public static void putSuperProperty(
             Scriptable superObj, Scriptable thisObj, Symbol key, Object value) {
-        ensureSymbolScriptable(superObj).put(key, thisObj, value);
+        // in contrast to putProperty we start searching at superObj
+        Scriptable base = getBase(superObj, key);
+        if (base == null) base = superObj;
+        ensureSymbolScriptable(base).put(key, thisObj, value);
     }
 
     /**
@@ -2554,7 +2557,10 @@ public abstract class ScriptableObject extends SlotMapOwner
     /** Variant of putProperty to handle super[index] = value where index is integer */
     public static void putSuperProperty(
             Scriptable superObj, Scriptable thisObj, int index, Object value) {
-        superObj.put(index, thisObj, value);
+        // in contrast to putProperty we start searching at superObj
+        Scriptable base = getBase(superObj, index);
+        if (base == null) base = superObj;
+        base.put(index, thisObj, value);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2490,7 +2490,10 @@ public abstract class ScriptableObject extends SlotMapOwner
     /** Variant of putProperty to handle super.name = value */
     public static void putSuperProperty(
             Scriptable superObj, Scriptable thisObj, String name, Object value) {
-        superObj.put(name, thisObj, value);
+        // in contrast to putProperty we start searching at superObj
+        Scriptable base = getBase(superObj, name);
+        if (base == null) base = superObj;
+        base.put(name, thisObj, value);
     }
 
     /** This is a version of putProperty for Symbol keys. */

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ProtoProperty2Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ProtoProperty2Test.java
@@ -546,12 +546,8 @@ public class ProtoProperty2Test {
                         + "c.f();"
                         + "res;";
 
-        // this is only partially supported
-        // see org.mozilla.javascript.IRFactory.createPropertyGet()
-        // Utils.assertWithAllModes_ES6("truetrue-truetrue / truetrue-truetrue / truetrue-truetrue",
-        // script);
         Utils.assertWithAllModes_ES6(
-                "truetrue-truetrue / truefalse-truetrue / truefalse-truetrue", script);
+                "truetrue-truetrue / truetrue-truetrue / truetrue-truetrue", script);
     }
 
     @Test


### PR DESCRIPTION
Found somewhere the hint that super is more or less about starting the property search at super but calling the final setter on this. Therefore this changes the put implementation like that and 'magically' the super.__proto__ handling works now and all the other tests are still green.