### PR TITLE
Replaced Context implement Closeable by AutoCloseable

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -63,7 +63,7 @@ This release includes committs from 29 different committers. Thanks to you all f
 [All Java Interop related cases](https://github.com/mozilla/rhino/issues?q=milestone%3A%22Release+1.7.14%22+label%3A%22Java+Interop%22)
 
 ## Embedding Rhino
-* #864 Context now implements Closable (@gbrail)
+* #864 Context now implements Closeable (@gbrail)
 * #865 Introduction of LambdaFunction and LambdaConstructor, to be used to represent Java lambda functions as native JavaScript functions and also can be used to construct an entire class out of lambdas (@gbrail)
 * #911 Throw InternalError instead of wrapped JavaException if thrown Java Exception class is not visible due to class shutter (@youngj)
 

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -55,7 +55,7 @@ import org.mozilla.javascript.xml.XMLLib;
  * @author Norris Boyd
  * @author Brendan Eich
  */
-public class Context implements Closeable {
+public class Context implements AutoCloseable {
     /**
      * Language versions.
      *


### PR DESCRIPTION
With #864 Context was extended to implemet Closeable. But this does not meet the interface contract.

Javadoc of AutoCloseable.close(): Note that unlike the close method of Closeable, this close method is not required to be idempotent. In other words, calling this close method more than once may have some visible side effect, unlike Closeable.close which is required to have no effect if called more than once. However, implementers of this interface are strongly encouraged to make their close methods idempotent.

In other words, when "Context implements Closeable"
```java
Context cx = Context.enter();
cx.close();
cx.close(); // will fail
```
must not fail.

If only Autocloseable is implemented, it is allowed (though not recommended)