### PR TITLE
Added GH gradle cache for CodeQl

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Cache Gradle Modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/wrapper
+          ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -57,3 +65,9 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+
+    - name: Cleanup Gradle Cache
+      # Cleans up the Gradle caches before being cached
+      run: |
+        rm -f ~/.gradle/caches/modules-2/modules-2.lock
+        rm -f ~/.gradle/caches/modules-2/gc.properties


### PR DESCRIPTION
There's no harm without benefit. While debugging my CodeQL plugin, I figured out how to speed it up. (#1993 / #1994)


This will reduce check time about 40s and the traffic to plugins.gradle.org/m2

inspired by
https://github.com/gradle/gradle/commit/3d4f7a16de894a1cfb075737e0d3ed7b654a5b8a 

https://github.com/gradle/gradle/blob/master/.github/workflows/codeql-analysis.yml