### PR TITLE
move NativeJavaObject.init(..) and NativeJavaMap.init() to initStandardObjects()

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -12,14 +12,14 @@ import java.util.Map;
 
 /**
  * <code>NativeJavaMap</code> is a wrapper for java objects implementing <code>java.util.Map
- * </code> interface. When {@link Context#FEATURE_ENABLE_JAVA_MAP_ACCESS} is enabled, property based
+ * </code> interface. When {@link Context#FEATURE_ENABLE_JAVA_MAP_ACCESS} is enabled, property-based
  * access like <code>map[key]</code> is delegated to {@link Map#get(Object)} or {@link
  * Map#put(Object, Object)} operations so that a <code>JavaMap</code> acts very similar to a
  * javascript <code>Object</code> There is also an iterator to iterate over entries with <code>
  * for .. of</code>.
  *
  * <p><b>Limitations:</b> The wrapped map should have <code>String</code> or <code>Integer</code> as
- * key. Otherwise, property based access may not work properly.
+ * key. Otherwise, property-based access may not work properly.
  */
 public class NativeJavaMap extends NativeJavaObject {
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -22,7 +22,7 @@ import org.mozilla.javascript.lc.type.TypeInfo;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
 
 /**
- * This class reflects non-Array Java objects into the JavaScript environment. It reflect fields
+ * This class reflects non-Array Java objects into the JavaScript environment. It reflects fields
  * directly, and uses NativeJavaMethod objects to reflect (possibly overloaded) methods. It also
  * provides iterator support for all iterable objects.
  *

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -214,9 +214,6 @@ public class ScriptRuntime {
         NativeStringIterator.init(scope, sealed);
         registerRegExp(cx, scope, sealed);
 
-        NativeJavaObject.init(scope, sealed);
-        NativeJavaMap.init(scope, sealed);
-
         // define lazy-loaded properties using their class name
         // Depends on the old reflection-based lazy loading mechanism
         // to property initialize the prototype.
@@ -279,6 +276,9 @@ public class ScriptRuntime {
     public static ScriptableObject initStandardObjects(
             Context cx, ScriptableObject scope, boolean sealed) {
         ScriptableObject s = initSafeStandardObjects(cx, scope, sealed);
+
+        NativeJavaObject.init(s, sealed);
+        NativeJavaMap.init(s, sealed);
 
         // These depend on the legacy initialization behavior of the lazy loading mechanism
         new LazilyLoadedCtor(

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -121,7 +121,7 @@ public class TopLevel extends IdScriptableObject {
         }
     }
 
-    /** Clears the cache, this is necessary, when standard objects are reinitialized. */
+    /** Clears the cache; this is necessary, when standard objects are reinitialized. */
     void clearCache() {
         ctors = null;
         errors = null;


### PR DESCRIPTION
NativeJavaObject.init(..) and NativeJavaMap.init() have to be part of initStandardObjects instead of initSafeStandardObjects()