### PR TITLE
Introduce concept of compound operations to make certain slot map operations thread safe.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -78,7 +78,11 @@ public class AbstractEcmaObjectOperations {
 
         if (obj.isExtensible()) return false;
 
-        for (Object name : obj.getIds(true, true)) {
+        Object[] ids;
+        try (var map = obj.startCompoundOp(false)) {
+            ids = obj.getIds(map, true, true);
+        }
+        for (Object name : ids) {
             ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, name);
             if (Boolean.TRUE.equals(desc.get("configurable"))) return false;
 
@@ -141,7 +145,11 @@ public class AbstractEcmaObjectOperations {
             return false;
         }
 
-        for (Object key : obj.getIds(true, true)) {
+        Object[] ids;
+        try (var map = obj.startCompoundOp(false)) {
+            ids = obj.getIds(map, true, true);
+        }
+        for (Object key : ids) {
             ScriptableObject desc = obj.getOwnPropertyDescriptor(cx, key);
 
             if (level == INTEGRITY_LEVEL.SEALED) {

--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -288,8 +288,8 @@ final class Arguments extends IdScriptableObject {
     }
 
     @Override
-    Object[] getIds(boolean getNonEnumerable, boolean getSymbols) {
-        Object[] ids = super.getIds(getNonEnumerable, getSymbols);
+    Object[] getIds(CompoundOperationMap map, boolean getNonEnumerable, boolean getSymbols) {
+        Object[] ids = super.getIds(map, getNonEnumerable, getSymbols);
         if (args.length != 0) {
             boolean[] present = new boolean[args.length];
             int extraCount = args.length;

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -597,7 +597,7 @@ public class BaseFunction extends ScriptableObject implements Function {
                         this,
                         PROTOTYPE_PROPERTY_NAME,
                         0,
-                        (k, i, s) -> {
+                        (k, i, s, m, o) -> {
                             if (s != null) {
                                 s.setAttributes(attributes);
                             }

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -227,15 +227,31 @@ public class BaseFunction extends ScriptableObject implements Function {
     }
 
     protected void createPrototypeProperty() {
-        if (!has(PROTOTYPE_PROPERTY_NAME, this)) {
-            ScriptableObject.defineBuiltInProperty(
-                    this,
-                    PROTOTYPE_PROPERTY_NAME,
-                    prototypePropertyAttributes,
-                    BaseFunction::prototypeGetter,
-                    BaseFunction::prototypeSetter,
-                    BaseFunction::prototypeAttrSetter);
+        try (var map = startCompoundOp(true)) {
+            createPrototypeProperty(map);
         }
+    }
+
+    protected void createPrototypeProperty(CompoundOperationMap compoundOp) {
+        compoundOp.compute(
+                this,
+                compoundOp,
+                PROTOTYPE_PROPERTY_NAME,
+                0,
+                (k, i, s, m, o) -> {
+                    if (s == null) {
+                        return new BuiltInSlot<BaseFunction>(
+                                PROTOTYPE_PROPERTY_NAME,
+                                0,
+                                prototypePropertyAttributes,
+                                this,
+                                BaseFunction::prototypeGetter,
+                                BaseFunction::prototypeSetter,
+                                BaseFunction::prototypeAttrSetter,
+                                BaseFunction::prototypeDescSetter);
+                    }
+                    return s;
+                });
     }
 
     private static Object prototypeGetter(BaseFunction function, Scriptable start) {
@@ -248,12 +264,39 @@ public class BaseFunction extends ScriptableObject implements Function {
             Scriptable owner,
             Scriptable start,
             boolean isThrow) {
-        function.setPrototypeProperty(value == null ? UniqueTag.NULL_VALUE : value);
+        function.prototypeProperty = value == null ? UniqueTag.NULL_VALUE : value;
         return true;
     }
 
     private static void prototypeAttrSetter(BaseFunction function, int attributes) {
         function.prototypePropertyAttributes = attributes;
+    }
+
+    protected static boolean prototypeDescSetter(
+            BaseFunction builtIn,
+            BuiltInSlot<BaseFunction> current,
+            Object id,
+            ScriptableObject.DescriptorInfo info,
+            boolean checkValid,
+            Object key,
+            int index) {
+        try (var map = builtIn.startCompoundOp(true)) {
+            return ScriptableObject.defineOrdinaryProperty(
+                    (o, i, k, e, m, s) -> {
+                        if (i.value != NOT_FOUND) {
+                            builtIn.prototypeProperty =
+                                    i.value == null ? UniqueTag.NULL_VALUE : i.value;
+                        }
+                        return s;
+                    },
+                    builtIn,
+                    map,
+                    id,
+                    info,
+                    checkValid,
+                    key,
+                    index);
+        }
     }
 
     protected final boolean defaultHas(String name) {

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
@@ -194,6 +194,9 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
             boolean checkValid,
             Object key,
             int index) {
-        return ScriptableObject.defineOrdinaryProperty(builtIn, id, info, checkValid, key, index);
+        try (var map = builtIn.startCompoundOp(true)) {
+            return ScriptableObject.defineOrdinaryProperty(
+                    builtIn, map, id, info, checkValid, key, index);
+        }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
@@ -1,6 +1,7 @@
 package org.mozilla.javascript;
 
 import java.io.Serializable;
+import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * This is a specialization of property access using some lambda functions designed for properties
@@ -40,7 +41,7 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
                 U builtIn,
                 BuiltInSlot<U> current,
                 Object id,
-                ScriptableObject desc,
+                DescriptorInfo info,
                 boolean checkValid,
                 Object key,
                 int index);
@@ -172,8 +173,8 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
 
     @SuppressWarnings("unchecked")
     boolean applyNewDescriptor(
-            Object id, ScriptableObject desc, boolean checkValid, Object key, int index) {
-        return propDescSetter.apply(((T) this.value), this, id, desc, checkValid, key, index);
+            Object id, DescriptorInfo info, boolean checkValid, Object key, int index) {
+        return propDescSetter.apply(((T) this.value), this, id, info, checkValid, key, index);
     }
 
     private static <T extends ScriptableObject> boolean defaultSetter(
@@ -189,10 +190,10 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
             T builtIn,
             BuiltInSlot<T> current,
             Object id,
-            ScriptableObject desc,
+            DescriptorInfo info,
             boolean checkValid,
             Object key,
             int index) {
-        return ScriptableObject.defineOrdinaryProperty(builtIn, id, desc, checkValid, key, index);
+        return ScriptableObject.defineOrdinaryProperty(builtIn, id, info, checkValid, key, index);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
@@ -196,7 +196,7 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
             int index) {
         try (var map = builtIn.startCompoundOp(true)) {
             return ScriptableObject.defineOrdinaryProperty(
-                    builtIn, map, id, info, checkValid, key, index);
+                    ScriptableObject::setSlotValue, builtIn, map, id, info, checkValid, key, index);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/CompoundOperationMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompoundOperationMap.java
@@ -1,0 +1,103 @@
+package org.mozilla.javascript;
+
+import java.util.Iterator;
+
+/**
+ * This class represents a compound operation performed on a non-thread safe map. As such it does
+ * the minimum work possible and does not enforce locking, instead it simply records whether the map
+ * has been mutated as part of the operation to allow the underlying map to delegate operations as
+ * required.
+ */
+public class CompoundOperationMap implements SlotMap, AutoCloseable {
+    protected final SlotMapOwner owner;
+    protected SlotMap map;
+    boolean touched = false;
+
+    public CompoundOperationMap(SlotMapOwner owner) {
+        this.owner = owner;
+        this.map = owner.getMap();
+    }
+
+    protected void updateMap(boolean resetTouched) {
+        if (touched) {
+            map = owner.getMap();
+            touched = resetTouched ? false : touched;
+        }
+    }
+
+    public boolean isTouched() {
+        return touched;
+    }
+
+    @Override
+    public void add(SlotMapOwner owner, Slot newSlot) {
+        map.add(owner, newSlot);
+        touched = true;
+    }
+
+    @Override
+    public <S extends Slot> S compute(
+            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
+        updateMap(true);
+        var res = map.compute(owner, this, key, index, compute);
+        touched = true;
+        return res;
+    }
+
+    @Override
+    public <S extends Slot> S compute(
+            SlotMapOwner owner,
+            CompoundOperationMap compoundOp,
+            Object key,
+            int index,
+            SlotComputer<S> compute) {
+        assert (compoundOp == this);
+        updateMap(true);
+        var res = map.compute(owner, this, key, index, compute);
+        touched = true;
+        return res;
+    }
+
+    @Override
+    public int dirtySize() {
+        updateMap(false);
+        return map.dirtySize();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        updateMap(false);
+        return map.isEmpty();
+    }
+
+    @Override
+    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+        updateMap(true);
+        var res = map.modify(owner, key, index, attributes);
+        touched = true;
+        return res;
+    }
+
+    @Override
+    public Slot query(Object key, int index) {
+        updateMap(false);
+        return map.query(key, index);
+    }
+
+    @Override
+    public int size() {
+        updateMap(false);
+        return map.size();
+    }
+
+    @Override
+    public Iterator<Slot> iterator() {
+        updateMap(false);
+        return map.iterator();
+    }
+
+    @Override
+    public void close() {
+        // This version doesn't need to do anything on clean up.
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EqualObjectGraphs.java
@@ -340,7 +340,9 @@ final class EqualObjectGraphs {
     private static Object[] getIds(final Scriptable s) {
         if (s instanceof ScriptableObject) {
             // Grabs symbols too
-            return ((ScriptableObject) s).getIds(true, true);
+            try (var map = ((ScriptableObject) s).startCompoundOp(false)) {
+                return ((ScriptableObject) s).getIds(map, true, true);
+            }
         } else if (s instanceof DebuggableObject) {
             return ((DebuggableObject) s).getAllIds();
         } else {

--- a/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
@@ -67,9 +67,15 @@ public class HashSlotMap implements SlotMap {
     @SuppressWarnings("unchecked")
     @Override
     public <S extends Slot> S compute(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> c) {
+            SlotMapOwner owner,
+            CompoundOperationMap compoundOp,
+            Object key,
+            int index,
+            SlotComputer<S> c) {
         Object name = makeKey(key, index);
-        Slot ret = map.compute(name, (n, existing) -> c.compute(key, index, existing));
+        Slot ret =
+                map.compute(
+                        name, (n, existing) -> c.compute(key, index, existing, compoundOp, owner));
         return (S) ret;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -597,8 +597,8 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     }
 
     @Override
-    Object[] getIds(boolean getNonEnumerable, boolean getSymbols) {
-        Object[] result = super.getIds(getNonEnumerable, getSymbols);
+    Object[] getIds(CompoundOperationMap map, boolean getNonEnumerable, boolean getSymbols) {
+        Object[] result = super.getIds(map, getNonEnumerable, getSymbols);
 
         if (prototypeValues != null) {
             result = prototypeValues.getNames(getNonEnumerable, getSymbols, result);

--- a/rhino/src/main/java/org/mozilla/javascript/LockAwareSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LockAwareSlotMap.java
@@ -23,7 +23,11 @@ interface LockAwareSlotMap extends SlotMap {
      * org.mozilla.javascript.SlotMap.SlotComputer)}.
      */
     <S extends Slot> S computeWithLock(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute);
+            SlotMapOwner owner,
+            CompoundOperationMap compoundOp,
+            Object key,
+            int index,
+            SlotComputer<S> compute);
 
     /** The equivalent of {@link SlotMap#add(SlotMapOwner, Slot)}. */
     void addWithLock(SlotMapOwner owner, Slot newSlot);

--- a/rhino/src/main/java/org/mozilla/javascript/LockAwareSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LockAwareSlotMap.java
@@ -31,4 +31,16 @@ interface LockAwareSlotMap extends SlotMap {
 
     /** The equivalent of {@link SlotMap#add(SlotMapOwner, Slot)}. */
     void addWithLock(SlotMapOwner owner, Slot newSlot);
+
+    long getReadLock();
+
+    long getWriteLock();
+
+    void releaseLock(long lock);
+
+    @Override
+    default CompoundOperationMap startCompoundOp(SlotMapOwner owner, boolean forWriting) {
+        long stamp = forWriting ? getWriteLock() : getReadLock();
+        return new ThreadSafeCompoundOperationMap(owner, this, stamp);
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -573,28 +573,28 @@ public class NativeArray extends ScriptableObject implements List {
             NativeArray builtIn,
             BuiltInSlot<NativeArray> current,
             Object id,
-            ScriptableObject desc,
+            DescriptorInfo info,
             boolean checkValid,
             Object key,
             int index) {
         // 10.2.4.2 Step 1.
-        Object value = getProperty(desc, "value");
+        Object value = info.value;
 
         if (value == NOT_FOUND) {
             return ScriptableObject.defineOrdinaryProperty(
-                    builtIn, id, desc, checkValid, key, index);
+                    builtIn, id, info, checkValid, key, index);
         }
 
         // 10.2.4.2 Steps 2 - 6
         long newLength = checkLength(value);
 
-        Object writable = getProperty(desc, "writable");
+        Object writable = info.writable;
         // 10.2.4.2 9 is true by definition
 
         // 10.2.4.2 10-11
         if (newLength >= builtIn.length) {
             return ScriptableObject.defineOrdinaryProperty(
-                    builtIn, id, desc, checkValid, key, index);
+                    builtIn, id, info, checkValid, key, index);
         }
 
         boolean currentWritable = ((current.getAttributes() & READONLY) == 0);
@@ -604,12 +604,12 @@ public class NativeArray extends ScriptableObject implements List {
         boolean newWritable = true;
         if (writable != NOT_FOUND) {
             newWritable = isTrue(writable);
-            putProperty(desc, "writable", true);
+            info.writable = true;
         }
 
         // The standard set path that will be done by this call will
         // clear any elements as required.
-        if (ScriptableObject.defineOrdinaryProperty(builtIn, id, desc, checkValid, key, index)) {
+        if (ScriptableObject.defineOrdinaryProperty(builtIn, id, info, checkValid, key, index)) {
             var currentAttrs = current.getAttributes();
             var newAttrs = newWritable ? (currentAttrs & ~READONLY) : (currentAttrs | READONLY);
             current.setAttributes(newAttrs);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -930,6 +930,7 @@ public class NativeArray extends ScriptableObject implements List {
         }
     }
 
+    /* This version explicitly checks whether the target is  sealed. The other implementation which does not take a compound op does not do so explicitly, but it does rely on the underlying `delete` implementation doing that check. */
     private static void deleteElem(
             CompoundOperationMap compoundOp, NativeArray target, long index) {
         int i = (int) index;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -390,8 +390,8 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     @Override
-    public Object[] getIds(boolean nonEnumerable, boolean getSymbols) {
-        Object[] superIds = super.getIds(nonEnumerable, getSymbols);
+    public Object[] getIds(CompoundOperationMap map, boolean nonEnumerable, boolean getSymbols) {
+        Object[] superIds = super.getIds(map, nonEnumerable, getSymbols);
         if (dense == null) {
             return superIds;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -535,7 +535,10 @@ public class NativeObject extends ScriptableObject implements Map {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s = getCompatibleObject(cx, scope, arg);
         ScriptableObject obj = ensureScriptableObject(s);
-        Object[] ids = obj.getIds(true, false);
+        Object[] ids;
+        try (var map = obj.startCompoundOp(false)) {
+            ids = obj.getIds(map, true, false);
+        }
         for (int i = 0; i < ids.length; i++) {
             ids[i] = ScriptRuntime.toString(ids[i]);
         }
@@ -547,7 +550,10 @@ public class NativeObject extends ScriptableObject implements Map {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s = getCompatibleObject(cx, scope, arg);
         ScriptableObject obj = ensureScriptableObject(s);
-        Object[] ids = obj.getIds(true, true);
+        Object[] ids;
+        try (var map = obj.startCompoundOp(false)) {
+            ids = obj.getIds(map, true, true);
+        }
         ArrayList<Object> syms = new ArrayList<>();
         for (Object o : ids) {
             if (o instanceof Symbol) {
@@ -577,7 +583,11 @@ public class NativeObject extends ScriptableObject implements Map {
         ScriptableObject obj = ensureScriptableObject(s);
 
         ScriptableObject descs = (ScriptableObject) cx.newObject(scope);
-        for (Object key : obj.getIds(true, true)) {
+        Object[] ids;
+        try (var map = obj.startCompoundOp(false)) {
+            ids = obj.getIds(map, true, true);
+        }
+        for (Object key : ids) {
             Scriptable desc = obj.getOwnPropertyDescriptor(cx, key);
             if (desc == null) {
                 continue;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -734,7 +734,10 @@ public class NativeObject extends ScriptableObject implements Map {
             Scriptable sourceObj = ScriptRuntime.toObject(cx, scope, args[i]);
             Object[] ids;
             if (sourceObj instanceof ScriptableObject) {
-                ids = ((ScriptableObject) sourceObj).getIds(false, true);
+                var scriptable = (ScriptableObject) sourceObj;
+                try (var map = scriptable.startCompoundOp(false)) {
+                    ids = scriptable.getIds(map, false, true);
+                }
             } else {
                 ids = sourceObj.getIds();
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -286,7 +286,7 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
      * [[OwnPropertyKeys]] ()</a>
      */
     @Override
-    Object[] getIds(boolean getNonEnumerable, boolean getSymbols) {
+    Object[] getIds(CompoundOperationMap map, boolean getNonEnumerable, boolean getSymbols) {
         /*
         * 1. Let handler be O.[[ProxyHandler]].
         * 2. If handler is null, throw a TypeError exception.
@@ -349,7 +349,10 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
 
             boolean extensibleTarget = target.isExtensible();
             // don't use the provided values here we have to check all
-            Object[] targetKeys = target.getIds(true, true);
+            Object[] targetKeys;
+            try (var targetMap = target.startCompoundOp(false)) {
+                targetKeys = target.getIds(targetMap, true, true);
+            }
 
             HashSet<Object> uncheckedResultKeys = new HashSet<Object>(trapResult);
             if (uncheckedResultKeys.size() != trapResult.size()) {
@@ -397,7 +400,9 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
             // target is not extensible, fall back to the target call
         }
 
-        return target.getIds(getNonEnumerable, getSymbols);
+        try (var targetMap = target.startCompoundOp(false)) {
+            return target.getIds(targetMap, getNonEnumerable, getSymbols);
+        }
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -316,7 +316,11 @@ final class NativeReflect extends ScriptableObject {
         final List<Object> strings = new ArrayList<>();
         final List<Object> symbols = new ArrayList<>();
 
-        for (Object o : target.getIds(true, true)) {
+        Object[] ids;
+        try (var map = target.startCompoundOp(false)) {
+            ids = target.getIds(map, true, true);
+        }
+        for (Object o : ids) {
             if (o instanceof Symbol) {
                 symbols.add(o);
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -555,11 +555,11 @@ final class NativeString extends ScriptableObject {
     }
 
     @Override
-    protected Object[] getIds(boolean nonEnumerable, boolean getSymbols) {
+    protected Object[] getIds(CompoundOperationMap map, boolean nonEnumerable, boolean getSymbols) {
         // In ES6, Strings have entries in the property map for each character.
         Context cx = Context.getCurrentContext();
         if ((cx != null) && (cx.getLanguageVersion() >= Context.VERSION_ES6)) {
-            Object[] sids = super.getIds(nonEnumerable, getSymbols);
+            Object[] sids = super.getIds(map, nonEnumerable, getSymbols);
             Object[] a = new Object[sids.length + string.length()];
             int i;
             for (i = 0; i < string.length(); i++) {
@@ -568,7 +568,7 @@ final class NativeString extends ScriptableObject {
             System.arraycopy(sids, 0, a, i, sids.length);
             return a;
         }
-        return super.getIds(nonEnumerable, getSymbols);
+        return super.getIds(map, nonEnumerable, getSymbols);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NewLiteralStorage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NewLiteralStorage.java
@@ -51,7 +51,10 @@ public final class NewLiteralStorage {
             Scriptable src = ScriptRuntime.toObject(cx, scope, source);
             Object[] ids;
             if (src instanceof ScriptableObject) {
-                ids = ((ScriptableObject) src).getIds(false, true);
+                var scriptable = (ScriptableObject) src;
+                try (var map = scriptable.startCompoundOp(false)) {
+                    ids = scriptable.getIds(map, false, true);
+                }
             } else {
                 ids = src.getIds();
             }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -393,7 +393,8 @@ public abstract class ScriptableObject extends SlotMapOwner
         getMap().compute(this, key, 0, ScriptableObject::checkSlotRemoval);
     }
 
-    private static Slot checkSlotRemoval(Object key, int index, Slot slot) {
+    private static Slot checkSlotRemoval(
+            Object key, int index, Slot slot, CompoundOperationMap compoundOp, SlotMapOwner owner) {
         if ((slot != null) && ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0)) {
             Context cx = Context.getContext();
             if (cx.isStrictMode()) {
@@ -1707,7 +1708,7 @@ public abstract class ScriptableObject extends SlotMapOwner
                         owner,
                         key,
                         index,
-                        (k, ix, existing) -> {
+                        (k, ix, existing, compoundOpMap, o) -> {
                             if (checkValid) {
                                 owner.checkPropertyChangeForSlot(id, existing, desc);
                             }
@@ -1874,7 +1875,7 @@ public abstract class ScriptableObject extends SlotMapOwner
                         this,
                         key,
                         0,
-                        (id, index, existing) -> {
+                        (id, index, existing, compoundOpMap, o) -> {
                             if (existing != null) {
                                 // it's dangerous to use `this` as scope inside slotMap.compute.
                                 // It can cause deadlock when ThreadSafeSlotMapContainer is used
@@ -2951,7 +2952,8 @@ public abstract class ScriptableObject extends SlotMapOwner
     /*
      * These are handy for changing slot types in one "compute" operation.
      */
-    private static AccessorSlot ensureAccessorSlot(Object name, int index, Slot existing) {
+    private static AccessorSlot ensureAccessorSlot(
+            Object name, int index, Slot existing, SlotMap compoundOp, SlotMapOwner owner) {
         if (existing == null) {
             return new AccessorSlot(name, index);
         } else if (existing instanceof AccessorSlot) {
@@ -2961,7 +2963,8 @@ public abstract class ScriptableObject extends SlotMapOwner
         }
     }
 
-    private static LazyLoadSlot ensureLazySlot(Object name, int index, Slot existing) {
+    private static LazyLoadSlot ensureLazySlot(
+            Object name, int index, Slot existing, SlotMap compoundOp, SlotMapOwner owner) {
         if (existing == null) {
             return new LazyLoadSlot(name, index);
         } else if (existing instanceof LazyLoadSlot) {
@@ -2971,7 +2974,8 @@ public abstract class ScriptableObject extends SlotMapOwner
         }
     }
 
-    private static LambdaSlot ensureLambdaSlot(Object name, int index, Slot existing) {
+    private static LambdaSlot ensureLambdaSlot(
+            Object name, int index, Slot existing, SlotMap compoundOp, SlotMapOwner owner) {
         if (existing == null) {
             return new LambdaSlot(name, index);
         } else if (existing instanceof LambdaSlot) {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2250,9 +2250,8 @@ public abstract class ScriptableObject extends SlotMapOwner
             }
             toInitialize.clear();
 
-            long stamp = getMap().readLock();
-            try {
-                for (Slot slot : getMap()) {
+            try (var map = startCompoundOp(false)) {
+                for (Slot slot : map) {
                     Object value = slot.value;
                     if (value instanceof LazilyLoadedCtor) {
                         toInitialize.add(slot);
@@ -2261,8 +2260,6 @@ public abstract class ScriptableObject extends SlotMapOwner
                 if (toInitialize.isEmpty()) {
                     isSealed = true;
                 }
-            } finally {
-                getMap().unlockRead(stamp);
             }
         }
     }
@@ -2989,9 +2986,8 @@ public abstract class ScriptableObject extends SlotMapOwner
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        final long stamp = getMap().readLock();
-        try {
-            int objectsCount = getMap().dirtySize();
+        try (var map = startCompoundOp(false)) {
+            int objectsCount = map.dirtySize();
             if (objectsCount == 0) {
                 out.writeInt(0);
             } else {
@@ -3000,8 +2996,6 @@ public abstract class ScriptableObject extends SlotMapOwner
                     out.writeObject(slot);
                 }
             }
-        } finally {
-            getMap().unlockRead(stamp);
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
@@ -83,15 +83,6 @@ public interface SlotMap extends Iterable<Slot> {
      */
     void add(SlotMapOwner owner, Slot newSlot);
 
-    default long readLock() {
-        // No locking in the default implementation
-        return 0L;
-    }
-
-    default void unlockRead(long stamp) {
-        // No locking in the default implementation
-    }
-
     default int dirtySize() {
         return size();
     }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -88,8 +88,8 @@ public abstract class SlotMapOwner {
             var newSlot = c.compute(key, index, null, compoundOp, owner);
             if (newSlot != null) {
                 if (!compoundOp.isTouched()) {
-                var map = new SingleEntrySlotMap(newSlot);
-                owner.setMap(map);
+                    var map = new SingleEntrySlotMap(newSlot);
+                    owner.setMap(map);
                 } else {
                     // The map has been touched so delegate the add (can't do
                     // a compute because that might be recursive).

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeCompoundOperationMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeCompoundOperationMap.java
@@ -37,10 +37,11 @@ class ThreadSafeCompoundOperationMap extends CompoundOperationMap {
     @Override
     public <S extends Slot> S compute(
             SlotMapOwner owner,
-            CompoundOperationMap mutableMap,
+            CompoundOperationMap compoundOp,
             Object key,
             int index,
             SlotComputer<S> compute) {
+        assert (compoundOp == this);
         updateMap(true);
         S res = ((LockAwareSlotMap) map).computeWithLock(owner, this, key, index, compute);
         touched = true;

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeCompoundOperationMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeCompoundOperationMap.java
@@ -1,0 +1,107 @@
+package org.mozilla.javascript;
+
+import java.util.Iterator;
+
+/**
+ * This class represents a compound operation performed on a thread safe slot map. As each compound
+ * operation creates a new instance the class itself does not need to consider access by multiple
+ * threads. This means that the instance fields do not need to be volatile as we are only
+ * considering access from this thread.
+ */
+class ThreadSafeCompoundOperationMap extends CompoundOperationMap {
+    private boolean closed = false;
+    private long lockStamp = 0;
+
+    public ThreadSafeCompoundOperationMap(
+            SlotMapOwner owner, LockAwareSlotMap map, long lockStamp) {
+        super(owner);
+        this.map = map;
+        this.lockStamp = lockStamp;
+    }
+
+    @Override
+    public void add(SlotMapOwner owner, Slot newSlot) {
+        ((LockAwareSlotMap) map).addWithLock(owner, newSlot);
+        touched = true;
+    }
+
+    @Override
+    public <S extends Slot> S compute(
+            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
+        updateMap(true);
+        S res = ((LockAwareSlotMap) map).computeWithLock(owner, this, key, index, compute);
+        touched = true;
+        return res;
+    }
+
+    @Override
+    public <S extends Slot> S compute(
+            SlotMapOwner owner,
+            CompoundOperationMap mutableMap,
+            Object key,
+            int index,
+            SlotComputer<S> compute) {
+        updateMap(true);
+        S res = ((LockAwareSlotMap) map).computeWithLock(owner, this, key, index, compute);
+        touched = true;
+        return res;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        updateMap(false);
+        return ((LockAwareSlotMap) map).isEmptyWithLock();
+    }
+
+    @Override
+    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+        updateMap(true);
+        Slot res = ((LockAwareSlotMap) map).modifyWithLock(owner, key, index, attributes);
+        touched = true;
+        return res;
+    }
+
+    @Override
+    public Slot query(Object key, int index) {
+        updateMap(false);
+        return ((LockAwareSlotMap) map).queryWithLock(key, index);
+    }
+
+    @Override
+    public int size() {
+        updateMap(false);
+        return ((LockAwareSlotMap) map).sizeWithLock();
+    }
+
+    @Override
+    public Iterator<Slot> iterator() {
+        updateMap(false);
+        return new Iter(map.iterator());
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            ((LockAwareSlotMap) owner.getMap()).releaseLock(lockStamp);
+            closed = true;
+        }
+    }
+
+    private static class Iter implements Iterator<Slot> {
+        private final Iterator<Slot> mapIterator;
+
+        private Iter(Iterator<Slot> mapIterator) {
+            this.mapIterator = mapIterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return mapIterator.hasNext();
+        }
+
+        @Override
+        public Slot next() {
+            return mapIterator.next();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
@@ -136,12 +136,17 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    public long readLock() {
+    public long getReadLock() {
         return lock.readLock();
     }
 
     @Override
-    public void unlockRead(long stamp) {
+    public long getWriteLock() {
+        return lock.writeLock();
+    }
+
+    @Override
+    public void releaseLock(long stamp) {
         lock.unlock(stamp);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
@@ -66,13 +66,12 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
 
     @Override
     public <S extends Slot> S compute(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> c) {
-        final long stamp = lock.writeLock();
-        try {
-            return current.computeWithLock(owner, key, index, c);
-        } finally {
-            lock.unlockWrite(stamp);
-        }
+            SlotMapOwner owner,
+            CompoundOperationMap mutableMap,
+            Object key,
+            int index,
+            SlotComputer<S> c) {
+        return current.computeWithLock(owner, mutableMap, key, index, c);
     }
 
     @Override
@@ -108,8 +107,12 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
 
     @Override
     public <S extends Slot> S computeWithLock(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
-        return super.compute(owner, key, index, compute);
+            SlotMapOwner owner,
+            CompoundOperationMap mutableMap,
+            Object key,
+            int index,
+            SlotComputer<S> compute) {
+        return super.compute(owner, mutableMap, key, index, compute);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
@@ -84,10 +84,14 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
 
     @Override
     public <S extends Slot> S compute(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> c) {
+            SlotMapOwner owner,
+            CompoundOperationMap mutableMap,
+            Object key,
+            int index,
+            SlotComputer<S> c) {
         final long stamp = lock.writeLock();
         try {
-            return super.compute(owner, key, index, c);
+            return super.compute(owner, mutableMap, key, index, c);
         } finally {
             lock.unlockWrite(stamp);
         }
@@ -126,8 +130,12 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
 
     @Override
     public <S extends Slot> S computeWithLock(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
-        return super.compute(owner, key, index, compute);
+            SlotMapOwner owner,
+            CompoundOperationMap mutableMap,
+            Object key,
+            int index,
+            SlotComputer<S> compute) {
+        return super.compute(owner, mutableMap, key, index, compute);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
@@ -159,12 +159,17 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public long readLock() {
+    public long getReadLock() {
         return lock.readLock();
     }
 
     @Override
-    public void unlockRead(long stamp) {
+    public long getWriteLock() {
+        return lock.writeLock();
+    }
+
+    @Override
+    public void releaseLock(long stamp) {
         lock.unlock(stamp);
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapConcurrentLocksPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapConcurrentLocksPromotionTest.java
@@ -1,0 +1,78 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class SlotMapConcurrentLocksPromotionTest {
+    @Test
+    public void singleThreadPromotionInCompute_emptyToOne() {
+        ScriptableObject obj = new TestScriptableObject();
+        obj.setMap(SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP);
+
+        obj.getMap()
+                .compute(
+                        obj,
+                        "foo",
+                        0,
+                        (key, index, existing, mutableMap, owner) -> {
+                            assertSame(owner, obj);
+
+                            mutableMap.add(owner, new Slot("a", 1, 0));
+
+                            return null;
+                        });
+
+        assertArrayEquals(new Object[] {"a"}, obj.getIds());
+    }
+
+    @Test
+    public void singleThreadPromotionInCompute_emptyToTwo() {
+        ScriptableObject obj = new TestScriptableObject();
+        obj.setMap(SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP);
+
+        obj.getMap()
+                .compute(
+                        obj,
+                        "foo",
+                        0,
+                        (key, index, existing, mutableMap, owner) -> {
+                            assertSame(owner, obj);
+
+                            mutableMap.add(owner, new Slot("a", 1, 0));
+                            mutableMap.add(owner, new Slot("b", 2, 0));
+
+                            return null;
+                        });
+
+        assertArrayEquals(new Object[] {"a", "b"}, obj.getIds());
+    }
+
+    @Test
+    public void singleThreadPromotionInCompute_oneToTwo() {
+        ScriptableObject obj = new TestScriptableObject();
+        obj.setMap(new SlotMapOwner.SingleEntrySlotMap(new Slot("a", 1, 0)));
+
+        obj.getMap()
+                .compute(
+                        obj,
+                        "foo",
+                        0,
+                        (key, index, existing, mutableMap, owner) -> {
+                            assertSame(owner, obj);
+
+                            mutableMap.add(owner, new Slot("b", 2, 0));
+
+                            return null;
+                        });
+
+        assertArrayEquals(new Object[] {"a", "b"}, obj.getIds());
+    }
+
+    private static class TestScriptableObject extends ScriptableObject {
+        public String getClassName() {
+            return "foo";
+        }
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
@@ -81,11 +81,11 @@ public class SlotMapTest {
         assertEquals(1 + startingSize, obj.getMap().size());
         assertFalse(obj.getMap().isEmpty());
         Slot newSlot = new Slot(slot);
-        obj.getMap().compute(obj, "foo", 0, (k, i, e) -> newSlot);
+        obj.getMap().compute(obj, "foo", 0, (k, i, e, m, o) -> newSlot);
         Slot foundNewSlot = obj.getMap().query("foo", 0);
         assertEquals("Testing", foundNewSlot.value);
         assertSame(foundNewSlot, newSlot);
-        obj.getMap().compute(obj, "foo", 0, (k, ii, e) -> null);
+        obj.getMap().compute(obj, "foo", 0, (k, ii, e, m, o) -> null);
         assertNull(obj.getMap().query("foo", 0));
         assertEquals(0 + startingSize, obj.getMap().size());
         if (startingSize == 0) {
@@ -104,11 +104,11 @@ public class SlotMapTest {
         assertEquals(1 + startingSize, obj.getMap().size());
         assertFalse(obj.getMap().isEmpty());
         Slot newSlot = new Slot(slot);
-        obj.getMap().compute(obj, null, 11, (k, i, e) -> newSlot);
+        obj.getMap().compute(obj, null, 11, (k, i, e, m, o) -> newSlot);
         Slot foundNewSlot = obj.getMap().query(null, 11);
         assertEquals("Testing", foundNewSlot.value);
         assertSame(foundNewSlot, newSlot);
-        obj.getMap().compute(obj, null, 11, (k, ii, e) -> null);
+        obj.getMap().compute(obj, null, 11, (k, ii, e, m, o) -> null);
         assertNull(obj.getMap().query(null, 11));
         assertEquals(0 + startingSize, obj.getMap().size());
         if (startingSize == 0) {
@@ -128,7 +128,7 @@ public class SlotMapTest {
                                 obj,
                                 "one",
                                 0,
-                                (k, i, e) -> {
+                                (k, i, e, m, o) -> {
                                     assertEquals(k, "one");
                                     assertEquals(i, 0);
                                     assertNotNull(e);
@@ -151,7 +151,7 @@ public class SlotMapTest {
                                 obj,
                                 "one",
                                 0,
-                                (k, i, e) -> {
+                                (k, i, e, m, o) -> {
                                     assertEquals(k, "one");
                                     assertEquals(i, 0);
                                     assertNull(e);
@@ -177,7 +177,7 @@ public class SlotMapTest {
                                 obj,
                                 "one",
                                 0,
-                                (k, i, e) -> {
+                                (k, i, e, m, o) -> {
                                     assertEquals(k, "one");
                                     assertEquals(i, 0);
                                     assertNotNull(e);
@@ -211,13 +211,13 @@ public class SlotMapTest {
             int ix = rand.nextInt(NUM_INDICES);
             Slot slot = obj.getMap().query(null, ix);
             assertNotNull(slot);
-            obj.getMap().compute(obj, null, ix, (k, j, e) -> new Slot(slot));
+            obj.getMap().compute(obj, null, ix, (k, j, e, m, o) -> new Slot(slot));
         }
         for (int i = 0; i < 20; i++) {
             int ix = rand.nextInt(KEYS.length);
             Slot slot = obj.getMap().query(KEYS[ix], 0);
             assertNotNull(slot);
-            obj.getMap().compute(obj, KEYS[ix], 0, (k, j, e) -> new Slot(slot));
+            obj.getMap().compute(obj, KEYS[ix], 0, (k, j, e, m, o) -> new Slot(slot));
         }
         verifyIndicesAndKeys();
 
@@ -226,13 +226,13 @@ public class SlotMapTest {
         HashSet<Integer> removedIds = new HashSet<>();
         for (int i = 0; i < 20; i++) {
             int ix = rand.nextInt(NUM_INDICES);
-            obj.getMap().compute(obj, null, ix, (k, ii, e) -> null);
+            obj.getMap().compute(obj, null, ix, (k, ii, e, m, o) -> null);
             removedIds.add(ix);
         }
         HashSet<String> removedKeys = new HashSet<>();
         for (int i = 0; i < 20; i++) {
             int ix = rand.nextInt(NUM_INDICES);
-            obj.getMap().compute(obj, KEYS[ix], ix, (k, ii, e) -> null);
+            obj.getMap().compute(obj, KEYS[ix], ix, (k, idx, e, m, o) -> null);
             removedKeys.add(KEYS[ix]);
         }
 

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
@@ -257,31 +257,27 @@ public class SlotMapTest {
     }
 
     private void verifyIndicesAndKeys() {
-        long lockStamp = 0;
-        lockStamp = obj.getMap().readLock();
-        try {
-            Iterator<Slot> it = obj.getMap().iterator();
+        try (var map = obj.startCompoundOp(false)) {
+            Iterator<Slot> it = map.iterator();
             for (int i = 0; i < startingSize; i++) {
                 // Skip initial slots
                 it.next();
             }
             for (int i = 0; i < NUM_INDICES; i++) {
-                Slot slot = obj.getMap().query(null, i);
+                Slot slot = map.query(null, i);
                 assertNotNull(slot);
                 assertEquals(i, slot.value);
                 assertTrue(it.hasNext());
                 assertEquals(slot, it.next());
             }
             for (String key : KEYS) {
-                Slot slot = obj.getMap().query(key, 0);
+                Slot slot = map.query(key, 0);
                 assertNotNull(slot);
                 assertEquals(key, slot.value);
                 assertTrue(it.hasNext());
                 assertEquals(slot, it.next());
             }
             assertFalse(it.hasNext());
-        } finally {
-            obj.getMap().unlockRead(lockStamp);
         }
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeArrayTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeArrayTest.java
@@ -7,6 +7,7 @@ package org.mozilla.javascript.tests;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -17,6 +18,8 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.testutils.Utils;
 
 public class NativeArrayTest {
     private NativeArray array;
@@ -136,6 +139,31 @@ public class NativeArrayTest {
             Scriptable scope = cx.initStandardObjects();
             String result = cx.evaluateString(scope, source, "source", 1, null).toString();
             Assert.assertEquals("0,1,0,1", result);
+        }
+    }
+
+    @Test
+    public void shouldNotDeadlockWhenDefiningPropertyLength() {
+        final String script =
+                ""
+                        + "var arr = [0, 1, 2];\n"
+                        + "\n"
+                        + "Object.defineProperty(arr, \"1\", {\n"
+                        + "  configurable: false\n"
+                        + "});\n"
+                        + "\n"
+                        + "Object.defineProperties(arr, {\n"
+                        + "  length: {\n"
+                        + "    value: 1\n"
+                        + "  }\n"
+                        + "});\n";
+
+        var contextFactory = Utils.contextFactoryWithFeatures(Context.FEATURE_THREAD_SAFE_OBJECTS);
+        try (Context cx = contextFactory.enterContext()) {
+            cx.setLanguageVersion(Context.VERSION_ECMASCRIPT);
+            Scriptable scope = cx.initSafeStandardObjects(new TopLevel());
+
+            assertNotNull(cx.evaluateString(scope, script, "test", 1, null));
         }
     }
 }


### PR DESCRIPTION
When converting arrays and functions from `IdScriptableObject` to being lambda based we accidentally broke thread safety. This PR fixes those issues by in introducing compound operations that can wrap up the multiple modifications that may happen in a compound operation that can be passed around internally.

With this change all tests pass with thread safe objects enabled, and we can then do a PR to enable this in CI.