### PR TITLE
Handle bound args correctly when bound function is `call`.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -3288,6 +3288,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                         cx,
                                         stack,
                                         sDbl,
+                                        boundArgs,
                                         state.stackTop + 1,
                                         state.indexReg,
                                         fun,
@@ -4566,14 +4567,19 @@ public final class Interpreter extends Icode implements Evaluator {
             Context cx,
             Object[] stack,
             double[] sDbl,
+            Object[] boundArgs,
             int thisIdx,
             int indexReg,
             Callable target,
             CallFrame frame) {
         Object obj;
         if (indexReg != 0) {
-            obj = stack[thisIdx];
-            if (obj == DOUBLE_MARK) obj = ScriptRuntime.wrapNumber(sDbl[thisIdx]);
+            if (boundArgs != null && boundArgs.length > 0) {
+                obj = boundArgs[0];
+            } else {
+                obj = stack[thisIdx];
+                if (obj == DOUBLE_MARK) obj = ScriptRuntime.wrapNumber(sDbl[thisIdx]);
+            }
         } else {
             obj = null;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -3308,7 +3308,7 @@ public final class Interpreter extends Icode implements Evaluator {
                         } else {
                             // Call: shift args left, starting from 2nd
                             if (state.indexReg > 0) {
-                                if (state.indexReg > 1) {
+                                if (state.indexReg > 1 && blen == 0) {
                                     System.arraycopy(
                                             stack,
                                             state.stackTop + 2,
@@ -3321,6 +3321,10 @@ public final class Interpreter extends Icode implements Evaluator {
                                             sDbl,
                                             state.stackTop + 1,
                                             state.indexReg - 1);
+                                } else if (state.indexReg > 1) {
+                                    System.arraycopy(
+                                            boundArgs, 1, boundArgs, 0, boundArgs.length - 1);
+                                    blen--;
                                 }
                                 state.indexReg--;
                             }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -3296,14 +3296,23 @@ public final class Interpreter extends Icode implements Evaluator {
                             // Apply: second argument after new "this"
                             // should be array-like
                             // and we'll spread its elements on the stack
-                            Object[] callArgs =
-                                    state.indexReg < 2
-                                            ? ScriptRuntime.emptyArgs
-                                            : ScriptRuntime.getApplyArguments(
-                                                    cx, stack[state.stackTop + 2]);
+                            final Object[] callArgs;
+                            if (blen > 1) {
+                                callArgs = ScriptRuntime.getApplyArguments(cx, boundArgs[1]);
+                            } else if (state.indexReg < 2) {
+                                callArgs = ScriptRuntime.emptyArgs;
+                            } else {
+                                callArgs =
+                                        ScriptRuntime.getApplyArguments(
+                                                cx, stack[state.stackTop - blen + 2]);
+                            }
+
                             int alen = callArgs.length;
-                            boundArgs = appendBoundArgs(boundArgs, callArgs);
-                            blen = blen + alen;
+                            // We're coming from the outside, so this
+                            // is replacing any bound args we might
+                            // have had already.
+                            boundArgs = callArgs;
+                            blen = alen;
                             state.indexReg = alen;
                         } else {
                             // Call: shift args left, starting from 2nd
@@ -3343,7 +3352,7 @@ public final class Interpreter extends Icode implements Evaluator {
                     fun = bfun.getTargetFunction();
                     funThisObj = bfun.getCallThis(cx, calleeScope);
                     Object[] bArgs = bfun.getBoundArgs();
-                    boundArgs = appendBoundArgs(boundArgs, bArgs);
+                    boundArgs = addBoundArgs(boundArgs, bArgs);
                     blen = blen + bArgs.length;
                     state.indexReg += blen;
                 } else if (fun instanceof NoSuchMethodShim) {
@@ -4435,14 +4444,18 @@ public final class Interpreter extends Icode implements Evaluator {
         }
     }
 
-    private static Object[] appendBoundArgs(Object[] boundArgs, Object[] newArgs) {
+    /**
+     * Adds the new args to the bound args. Because we're unwrapping things in reverse order they
+     * are actually prepended.
+     */
+    private static Object[] addBoundArgs(Object[] boundArgs, Object[] newArgs) {
         if (newArgs.length == 0) {
             return boundArgs;
         } else if (boundArgs == null) {
             return newArgs;
         } else {
-            Object[] result = Arrays.copyOf(boundArgs, boundArgs.length + newArgs.length);
-            System.arraycopy(newArgs, 0, result, boundArgs.length, newArgs.length);
+            Object[] result = Arrays.copyOf(newArgs, boundArgs.length + newArgs.length);
+            System.arraycopy(boundArgs, 0, result, newArgs.length, boundArgs.length);
             return result;
         }
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ApplyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ApplyTest.java
@@ -6,14 +6,34 @@ import org.mozilla.javascript.testutils.Utils;
 public class ApplyTest {
 
     @Test
-    public void invokeBoundCallManyArgs() {
-        /* This test is a little fiddly. The call to bind causes the
-        max stack size to be high enough that it could mask the
-        bug, so we have to make the call to the bound in function
-        in another function which has a smaller stsck. */
+    public void applyThisFromBoundArgs() {
+        // The `toString` call here converts the `NativeString` that
+        // is the bound `this` to a simple `String` that we can
+        // easily assert against.
+        String code =
+                "var f = function(x) { return this.toString(); };\n"
+                        + "var a = f.apply;\n"
+                        + "var b = a.bind(f, 'Hello!');\n"
+                        + "b([1,2]);\n";
+        Utils.assertWithAllModes_ES6("Hello!", code);
+    }
+
+    @Test
+    public void applyToApplyCallsCorrectFunction() {
         String code =
                 "Function.prototype.apply.apply(function(x) {return x;}, ['b', ['Hello!', 'Goodbye!']]);";
 
         Utils.assertWithAllModes_ES6("Hello!", code);
+    }
+
+    @Test
+    public void applyToApplySetsCorrectFunctionThis() {
+        // The `toString` call here converts the `NativeString` that
+        // is the bound `this` to a simple `String` that we can
+        // easily assert against.
+        String code =
+                "Function.prototype.apply.apply(function(x) {return this.toString();}, ['b', ['Hello!', 'Goodbye!']]);";
+
+        Utils.assertWithAllModes_ES6("b", code);
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ApplyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ApplyTest.java
@@ -1,0 +1,19 @@
+package org.mozilla.javascript.tests.es6;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+public class ApplyTest {
+
+    @Test
+    public void invokeBoundCallManyArgs() {
+        /* This test is a little fiddly. The call to bind causes the
+        max stack size to be high enough that it could mask the
+        bug, so we have to make the call to the bound in function
+        in another function which has a smaller stsck. */
+        String code =
+                "Function.prototype.apply.apply(function(x) {return x;}, ['b', ['Hello!', 'Goodbye!']]);";
+
+        Utils.assertWithAllModes_ES6("Hello!", code);
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/BoundFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/BoundFunctionTest.java
@@ -18,4 +18,18 @@ public class BoundFunctionTest {
 
         Utils.assertWithAllModes_ES6("bound foo", code);
     }
+
+    @Test
+    public void invokeBoundCallManyArgs() {
+        /* This test is a little fiddly. The call to bind causes the
+        max stack size to be high enough that it could mask the
+        bug, so we have to make the call to the bound in function
+        in another function which has a smaller stack. */
+        String code =
+                "function f() { return 'Hello!'; };\n"
+                        + "var b = f.call.bind(f, 1, 2, 3);\n"
+                        + "(function(){ return b(); })();";
+
+        Utils.assertWithAllModes_ES6("Hello!", code);
+    }
 }


### PR DESCRIPTION
Found this issue while investigating #2006.