### PR TITLE
Update shadow plugin to 9.0.1

### DIFF
--- a/rhino-all/build.gradle
+++ b/rhino-all/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'rhino.library-conventions'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '9.0.1'
     id 'application'
 }
 


### PR DESCRIPTION
this fixes warnings like

> The CopyProcessingSpec.setFileMode(Integer) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the filePermissions(Action) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#unix_file_permissions_deprecated

The ID has changed. See https://github.com/GradleUp/shadow/blob/main/README.md