### PR TITLE
Fix parsing problem with optional chaining when xml feature is disabled

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -3087,23 +3087,6 @@ public class Parser {
             memberTypeFlags = Node.DESCENDANTS_FLAG;
         }
 
-        if (!compilerEnv.isXmlAvailable()) {
-            int maybeName = nextToken();
-            if (maybeName != Token.NAME
-                    && !(compilerEnv.isReservedKeywordAsIdentifier()
-                            && TokenStream.isKeyword(
-                                    ts.getString(),
-                                    compilerEnv.getLanguageVersion(),
-                                    inUseStrictDirective))) {
-                reportError("msg.no.name.after.dot");
-            }
-
-            Name name = createNameNode(true, Token.GETPROP);
-            PropertyGet pg = new PropertyGet(pn, name, dotPos);
-            pg.setLineColumnNumber(lineno, column);
-            return pg;
-        }
-
         AstNode ref = null; // right side of . or .. operator
         int token = nextToken();
         switch (token) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
@@ -1,6 +1,12 @@
 package org.mozilla.javascript.tests;
 
+import static org.junit.Assert.assertEquals;
+import static org.mozilla.javascript.Context.FEATURE_E4X;
+
 import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -208,5 +214,15 @@ public class OptionalChainingOperatorTest {
     @Test
     public void optionalChainingOperatorFollowedByDigitsIsAHook() {
         Utils.assertWithAllModes_ES6(0.5, "true ?.5 : false");
+    }
+
+    @Test
+    public void canParseOptionalChainingEvenWithoutXml() {
+        try (Context cx = Utils.contextFactoryWithFeatureDisabled(FEATURE_E4X).enterContext()) {
+            Scriptable scope = cx.initStandardObjects(new TopLevel());
+            String source = "o = {a: true}; o?.['a']\n";
+            Object result = cx.evaluateString(scope, source, "test", 1, null);
+            assertEquals(Boolean.TRUE, result);
+        }
     }
 }

--- a/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
+++ b/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
@@ -459,20 +459,36 @@ public class Utils {
      * @return a new {@link ContextFactory} with all provided features enabled
      */
     public static ContextFactory contextFactoryWithFeatures(int... features) {
-        return new ContextFactoryWithFeatures(features);
+        return new ContextFactoryWithFeatures(features, new int[0]);
+    }
+
+    /**
+     * Construct a new {@link ContextFactory}
+     *
+     * @param features the features to forcibly disable, overriding the default from {@link
+     *     ContextFactory}
+     * @return a new {@link ContextFactory} with all provided features disabled
+     */
+    public static ContextFactory contextFactoryWithFeatureDisabled(int... features) {
+        return new ContextFactoryWithFeatures(new int[0], features);
     }
 
     private static class ContextFactoryWithFeatures extends ContextFactory {
-        private final int[] features;
+        private final int[] enabledFeatures;
+        private final int[] disabledFeatures;
 
-        private ContextFactoryWithFeatures(int... features) {
-            this.features = features;
+        private ContextFactoryWithFeatures(int[] enabledFeatures, int[] disabledFeatures) {
+            this.enabledFeatures = enabledFeatures;
+            this.disabledFeatures = disabledFeatures;
         }
 
         @Override
         protected boolean hasFeature(Context cx, int featureIndex) {
-            if (IntStream.of(features).anyMatch(x -> x == featureIndex)) {
+            if (IntStream.of(enabledFeatures).anyMatch(x -> x == featureIndex)) {
                 return true;
+            }
+            if (IntStream.of(disabledFeatures).anyMatch(x -> x == featureIndex)) {
+                return false;
             }
 
             return super.hasFeature(cx, featureIndex);


### PR DESCRIPTION
In `Parser::propertyAccess` the code that supports optional chaining is not executed if the context does not have the feature `FEATURE_E4X`. This flag is enabled by default, which is why we never noticed it. I've completely removed the old "fallback" code, because it seems obsolete. Removing it doesn't seem to cause any regression.