### PR TITLE
cleanup wrapping for Java method args, constructor args, and method return value

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -310,6 +310,61 @@ final class MemberBox implements Serializable {
         }
     }
 
+    Object[] wrapArgsInternal(Object[] args) {
+        var argTypes = getArgTypes();
+        var argTypesLen = argTypes.size();
+        var argLen = args.length;
+
+        if (!this.vararg) {
+            // fast path for common cases
+            if (argLen == 0) {
+                return args;
+            } else if (argLen == 1) {
+                args[0] = Context.jsToJava(args[0], argTypes.get(0));
+                return args;
+            }
+
+            var wrappedArgs = args;
+            for (int i = 0; i < argLen; i++) {
+                var arg = args[i];
+                var coerced = Context.jsToJava(arg, argTypes.get(i));
+                if (coerced != arg) {
+                    if (wrappedArgs == args) {
+                        wrappedArgs = args.clone();
+                    }
+                    wrappedArgs[i] = coerced;
+                }
+            }
+            return wrappedArgs;
+        }
+
+        // marshall the explicit parameters
+        var wrappedArgs = new Object[argTypesLen];
+        for (int i = 0; i < argTypesLen - 1; i++) {
+            wrappedArgs[i] = Context.jsToJava(args[i], argTypes.get(i));
+        }
+
+        // Handle special situation where a single variable parameter
+        // is given, and it is a Java or ECMA array or is null.
+        if (argLen == argTypesLen) {
+            var lastArg = args[argLen - 1];
+            if (lastArg == null || lastArg instanceof NativeArray || lastArg instanceof NativeJavaArray) {
+                // convert the ECMA array into a native array
+                wrappedArgs[argLen - 1] = Context.jsToJava(lastArg, argTypes.get(argTypesLen - 1));
+                return wrappedArgs;
+            }
+        }
+
+        // marshall the variable parameters
+        var varArgs = (Object[]) argTypes.get(argTypesLen - 1).getComponentType().newArray(argLen - argTypesLen + 1);
+        for (int i = 0; i < varArgs.length; i++) {
+            varArgs[i] = Context.jsToJava(args[argTypesLen - 1 + i], argTypes.get(argTypesLen - 1).getComponentType());
+        }
+        wrappedArgs[argTypesLen - 1] = varArgs;
+
+        return wrappedArgs;
+    }
+
     @SuppressWarnings("deprecation")
     private static boolean tryToMakeAccessible(AccessibleObject accessible) {
         if (!accessible.isAccessible()) {

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -320,8 +320,9 @@ final class MemberBox implements Serializable {
             if (argLen == 0) {
                 return args;
             } else if (argLen == 1) {
-                args[0] = Context.jsToJava(args[0], argTypes.get(0));
-                return args;
+                var arg = args[0];
+                var wrapped = Context.jsToJava(args[0], argTypes.get(0));
+                return wrapped == arg ? args : new Object[] {wrapped};
             }
 
             var wrappedArgs = args;

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -11,6 +11,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
@@ -360,15 +361,14 @@ final class MemberBox implements Serializable {
 
         // marshall the variable parameters
         var varArgs =
-                (Object[])
-                        argTypes.get(argTypesLen - 1)
-                                .getComponentType()
-                                .newArray(argLen - argTypesLen + 1);
-        for (int i = 0; i < varArgs.length; i++) {
-            varArgs[i] =
+                argTypes.get(argTypesLen - 1).getComponentType().newArray(argLen - argTypesLen + 1);
+        for (int i = 0, arrayLen = Array.getLength(varArgs); i < arrayLen; i++) {
+            Array.set(
+                    varArgs,
+                    i,
                     Context.jsToJava(
                             args[argTypesLen - 1 + i],
-                            argTypes.get(argTypesLen - 1).getComponentType());
+                            argTypes.get(argTypesLen - 1).getComponentType()));
         }
         wrappedArgs[argTypesLen - 1] = varArgs;
 

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -348,7 +348,9 @@ final class MemberBox implements Serializable {
         // is given, and it is a Java or ECMA array or is null.
         if (argLen == argTypesLen) {
             var lastArg = args[argLen - 1];
-            if (lastArg == null || lastArg instanceof NativeArray || lastArg instanceof NativeJavaArray) {
+            if (lastArg == null
+                    || lastArg instanceof NativeArray
+                    || lastArg instanceof NativeJavaArray) {
                 // convert the ECMA array into a native array
                 wrappedArgs[argLen - 1] = Context.jsToJava(lastArg, argTypes.get(argTypesLen - 1));
                 return wrappedArgs;
@@ -356,9 +358,16 @@ final class MemberBox implements Serializable {
         }
 
         // marshall the variable parameters
-        var varArgs = (Object[]) argTypes.get(argTypesLen - 1).getComponentType().newArray(argLen - argTypesLen + 1);
+        var varArgs =
+                (Object[])
+                        argTypes.get(argTypesLen - 1)
+                                .getComponentType()
+                                .newArray(argLen - argTypesLen + 1);
         for (int i = 0; i < varArgs.length; i++) {
-            varArgs[i] = Context.jsToJava(args[argTypesLen - 1 + i], argTypes.get(argTypesLen - 1).getComponentType());
+            varArgs[i] =
+                    Context.jsToJava(
+                            args[argTypesLen - 1 + i],
+                            argTypes.get(argTypesLen - 1).getComponentType());
         }
         wrappedArgs[argTypesLen - 1] = varArgs;
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -189,53 +189,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
     }
 
     static Object constructInternal(Object[] args, MemberBox ctor) {
-        var argTypes = ctor.getArgTypes();
-
-        if (ctor.vararg) {
-            // marshall the explicit parameter
-            Object[] newArgs = new Object[argTypes.size()];
-            for (int i = 0; i < argTypes.size() - 1; i++) {
-                newArgs[i] = Context.jsToJava(args[i], argTypes.get(i));
-            }
-
-            Object varArgs;
-
-            // Handle special situation where a single variable parameter
-            // is given and it is a Java or ECMA array.
-            if (args.length == argTypes.size()
-                    && (args[args.length - 1] == null
-                            || args[args.length - 1] instanceof NativeArray
-                            || args[args.length - 1] instanceof NativeJavaArray)) {
-                // convert the ECMA array into a native array
-                varArgs =
-                        Context.jsToJava(args[args.length - 1], argTypes.get(argTypes.size() - 1));
-            } else {
-                // marshall the variable parameter
-                var componentType = argTypes.get(argTypes.size() - 1).getComponentType();
-                varArgs = componentType.newArray(args.length - argTypes.size() + 1);
-                for (int i = 0; i < Array.getLength(varArgs); i++) {
-                    Object value = Context.jsToJava(args[argTypes.size() - 1 + i], componentType);
-                    Array.set(varArgs, i, value);
-                }
-            }
-
-            // add varargs
-            newArgs[argTypes.size() - 1] = varArgs;
-            // replace the original args with the new one
-            args = newArgs;
-        } else {
-            Object[] origArgs = args;
-            for (int i = 0; i < args.length; i++) {
-                Object arg = args[i];
-                Object x = Context.jsToJava(arg, argTypes.get(i));
-                if (x != arg) {
-                    if (args == origArgs) {
-                        args = origArgs.clone();
-                    }
-                    args[i] = x;
-                }
-            }
-        }
+        args = ctor.wrapArgsInternal(args);
 
         return ctor.newInstance(args);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -6,7 +6,6 @@
 
 package org.mozilla.javascript;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -166,33 +166,35 @@ public class NativeJavaMethod extends BaseFunction {
             printDebug("Calling ", meth, args);
         }
 
-        Object retval = meth.invoke(javaObject, args);
-        Class<?> staticType = meth.method().getReturnType();
+        Object returnValue = meth.invoke(javaObject, args);
+        Class<?> returnType = meth.method().getReturnType();
 
         if (debug) {
-            Class<?> actualType = (retval == null) ? null : retval.getClass();
+            Class<?> actualType = (returnValue == null) ? null : returnValue.getClass();
             System.err.println(
                     " ----- Returned "
-                            + retval
+                            + returnValue
                             + " actual = "
                             + actualType
                             + " expect = "
-                            + staticType);
+                            + returnType);
+        }
+
+        if (returnType == Void.TYPE) {
+            // skip result wrapping if we don't need result at all
+            return Undefined.instance;
         }
 
         Object wrapped =
                 cx.getWrapFactory()
                         .wrap(
                                 cx, scope,
-                                retval, staticType);
+                                returnValue, returnType);
         if (debug) {
             Class<?> actualType = (wrapped == null) ? null : wrapped.getClass();
             System.err.println(" ----- Wrapped as " + wrapped + " class = " + actualType);
         }
 
-        if (wrapped == null && staticType == Void.TYPE) {
-            wrapped = Undefined.instance;
-        }
         return wrapped;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -6,7 +6,6 @@
 
 package org.mozilla.javascript;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -137,54 +136,9 @@ public class NativeJavaMethod extends BaseFunction {
         }
 
         MemberBox meth = methods[index];
-        var argTypes = meth.getArgTypes();
 
-        if (meth.vararg) {
-            // marshall the explicit parameters
-            Object[] newArgs = new Object[argTypes.size()];
-            for (int i = 0; i < argTypes.size() - 1; i++) {
-                newArgs[i] = Context.jsToJava(args[i], argTypes.get(i));
-            }
+        args = meth.wrapArgsInternal(args);
 
-            Object varArgs;
-
-            // Handle special situation where a single variable parameter
-            // is given, and it is a Java or ECMA array or is null.
-            if (args.length == argTypes.size()
-                    && (args[args.length - 1] == null
-                            || args[args.length - 1] instanceof NativeArray
-                            || args[args.length - 1] instanceof NativeJavaArray)) {
-                // convert the ECMA array into a native array
-                varArgs =
-                        Context.jsToJava(args[args.length - 1], argTypes.get(argTypes.size() - 1));
-            } else {
-                // marshall the variable parameters
-                var componentType = argTypes.get(argTypes.size() - 1).getComponentType();
-                varArgs = componentType.newArray(args.length - argTypes.size() + 1);
-                for (int i = 0; i < Array.getLength(varArgs); i++) {
-                    Object value = Context.jsToJava(args[argTypes.size() - 1 + i], componentType);
-                    Array.set(varArgs, i, value);
-                }
-            }
-
-            // add varargs
-            newArgs[argTypes.size() - 1] = varArgs;
-            // replace the original args with the new one
-            args = newArgs;
-        } else {
-            // First, we marshall the args.
-            Object[] origArgs = args;
-            for (int i = 0; i < args.length; i++) {
-                Object arg = args[i];
-                Object coerced = Context.jsToJava(arg, argTypes.get(i));
-                if (coerced != arg) {
-                    if (origArgs == args) {
-                        args = args.clone();
-                    }
-                    args[i] = coerced;
-                }
-            }
-        }
         Object javaObject;
         if (meth.isStatic()) {
             javaObject = null; // don't need an object


### PR DESCRIPTION
- extract wrapping code for method/constructor args to `MemberBox.wrapArgsInternal(...)`
- skip wrapping for method return value if return type is `void`