### PR TITLE
Fix: methods should not have a prototype property

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeFunction.java
@@ -27,7 +27,9 @@ public abstract class NativeFunction extends BaseFunction {
     public final void initScriptFunction(
             Context cx, Scriptable scope, boolean es6GeneratorFunction, boolean isShorthand) {
         ScriptRuntime.setFunctionProtoAndParent(this, cx, scope, es6GeneratorFunction);
-        setupDefaultPrototype(scope);
+        if (!isShorthand) { // Methods don't have the prototype property!
+            setupDefaultPrototype(scope);
+        }
         this.isShorthand = isShorthand;
     }
 

--- a/tests/testsrc/jstests/harmony/method-definition.js
+++ b/tests/testsrc/jstests/harmony/method-definition.js
@@ -12,7 +12,9 @@ obj = {
   }
 };
 assertEquals(123, obj.a());
-// assertEquals("a", obj.a.name);
+assertEquals("a", obj.a.name);
+assertEquals(undefined, obj.a.prototype);
+assertEquals(undefined, Object.getOwnPropertyDescriptor(obj.a, 'prototype'));
 
 assertEquals("abcefg", {
   abc() {

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4279,7 +4279,7 @@ language/expressions/new 22/59 (37.29%)
 
 ~language/expressions/new.target
 
-language/expressions/object 709/1170 (60.6%)
+language/expressions/object 708/1170 (60.51%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4907,7 +4907,6 @@ language/expressions/object 709/1170 (60.6%)
     method-definition/name-param-redecl.js
     method-definition/name-prop-name-yield-expr.js non-strict
     method-definition/name-prop-name-yield-id.js non-strict
-    method-definition/name-prototype-prop.js
     method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
     method-definition/params-dflt-meth-ref-arguments.js
     method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}


### PR DESCRIPTION
The spec says that these two should be `undefined`:

```js
let o = { f(){} };
o.f.prototype;
Object.getOwnPropertyDescriptor(o.f, 'prototype')
```

However, rhino was always creating the `prototype` property even for shorthand methods.