### PR TITLE
Made spotless as separate convention

### DIFF
--- a/buildSrc/src/main/groovy/rhino.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.java-conventions.gradle
@@ -4,7 +4,7 @@
 
 plugins {
     id 'java-library'
-    id 'com.diffplug.spotless'
+    id 'rhino.spotless-conventions'
 }
 
 int testJavaVersion = -1
@@ -56,15 +56,3 @@ test {
     useJUnitPlatform()
 }
 
-spotless {
-    // There is no version of googleJavaFormat that works for Java 11 and 17,
-    // and different versions format differently. We're using a version that
-    // requires at least Java 17.
-    if (JavaVersion.current() >= JavaVersion.VERSION_17) {
-        java {
-            googleJavaFormat('1.23.0').aosp()
-        }
-    } else {
-        System.out.println("Not running Spotless: Java language version is " + JavaVersion.current())
-    }
-}

--- a/buildSrc/src/main/groovy/rhino.spotless-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.spotless-conventions.gradle
@@ -1,0 +1,20 @@
+// This file contains Gradle "conventions" that we use in all of our projects.
+// It is the appropriate set of conventions to use for modules that will not be
+// published, such as test modules.
+
+plugins {
+    id 'com.diffplug.spotless'
+}
+
+spotless {
+    // There is no version of googleJavaFormat that works for Java 11 and 17,
+    // and different versions format differently. We're using a version that
+    // requires at least Java 17.
+    if (JavaVersion.current() >= JavaVersion.VERSION_17) {
+        java {
+            googleJavaFormat('1.23.0').aosp()
+        }
+    } else {
+        System.out.println("Not running Spotless: Java language version is " + JavaVersion.current())
+    }
+}


### PR DESCRIPTION
Moved the spotless configuration to a separte convention file, so that it can be used in non-java based subprojects like android (in PR #2036)