### PR TITLE
Infer function names at runtime for computed properties

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -226,6 +226,11 @@ public class BaseFunction extends ScriptableObject implements Function {
         return true;
     }
 
+    /** Forces setting the function's name, bypassing all "readonly" checks. */
+    void setFunctionName(String name) {
+        nameSetter(this, name, this, this, false);
+    }
+
     protected void createPrototypeProperty() {
         if (!has(PROTOTYPE_PROPERTY_NAME, this)) {
             ScriptableObject.defineBuiltInProperty(

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -228,7 +228,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     /** Forces setting the function's name, bypassing all "readonly" checks. */
     void setFunctionName(String name) {
-        nameSetter(this, name, this, this, false);
+        nameValue = name;
     }
 
     protected void createPrototypeProperty() {

--- a/rhino/src/main/java/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EqualObjectGraphs.java
@@ -315,7 +315,7 @@ final class EqualObjectGraphs {
                             // As long as people bother to reasonably name their symbols,
                             // this will work. If there's clashes in symbol names (e.g.
                             // lots of unnamed symbols) it can lead to false inequalities.
-                            return getSymbolName((Symbol) a).compareTo(getSymbolName((Symbol) b));
+                            return ((Symbol) a).getName().compareTo(((Symbol) b).getName());
                         } else if (b instanceof Integer || b instanceof String) {
                             return 1; // symbols after ints and strings
                         }
@@ -324,17 +324,6 @@ final class EqualObjectGraphs {
                     throw new ClassCastException();
                 });
         return ids;
-    }
-
-    private static String getSymbolName(final Symbol s) {
-        if (s instanceof SymbolKey) {
-            return ((SymbolKey) s).getName();
-        } else if (s instanceof NativeSymbol) {
-            return ((NativeSymbol) s).getKey().getName();
-        } else {
-            // We can only handle native Rhino Symbol types
-            throw new ClassCastException();
-        }
     }
 
     private static Object[] getIds(final Scriptable s) {

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -4175,12 +4175,14 @@ public final class Interpreter extends Icode implements Evaluator {
             // indexReg > 0: index of constant with the keys
             // indexReg < 0: we have a spread, so no keys array, but we know the length
             if (state.indexReg < 0) {
-                frame.stack[state.stackTop] = new NewLiteralStorage(-state.indexReg - 1, true);
+                frame.stack[state.stackTop] =
+                        NewLiteralStorage.create(cx, -state.indexReg - 1, true);
             } else {
                 Object[] ids = (Object[]) frame.idata.literalIds[state.indexReg];
                 boolean copyArray = frame.idata.itsICode[frame.pc] != 0;
                 frame.stack[state.stackTop] =
-                        new NewLiteralStorage(copyArray ? Arrays.copyOf(ids, ids.length) : ids);
+                        NewLiteralStorage.create(
+                                cx, copyArray ? Arrays.copyOf(ids, ids.length) : ids);
             }
 
             return null;
@@ -4191,7 +4193,7 @@ public final class Interpreter extends Icode implements Evaluator {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
             // indexReg: number of values in the literal
-            frame.stack[++state.stackTop] = new NewLiteralStorage(state.indexReg, false);
+            frame.stack[++state.stackTop] = NewLiteralStorage.create(cx, state.indexReg, false);
             return null;
         }
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -192,6 +192,11 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
         return key.toString();
     }
 
+    @Override
+    public String getName() {
+        return key.getName();
+    }
+
     // Symbol objects have a special property that one cannot add properties.
 
     private static boolean isStrictMode() {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -192,6 +192,7 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
         return key.toString();
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return key.getName();

--- a/rhino/src/main/java/org/mozilla/javascript/NewLiteralStorage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NewLiteralStorage.java
@@ -11,72 +11,29 @@ import static org.mozilla.javascript.NativeObject.PROTO_PROPERTY;
 import java.util.Arrays;
 
 /** Used to store the support structures for a literal object (or array) being built. */
-public final class NewLiteralStorage {
-    private Object[] keys;
-    private int[] getterSetters;
-    private Object[] values;
-    private int index = 0;
+public abstract class NewLiteralStorage {
+    protected Object[] keys;
+    protected int[] getterSetters;
+    protected Object[] values;
+    protected int index = 0;
 
-    public NewLiteralStorage(Object[] ids) {
-        this.keys = ids;
-        this.getterSetters = new int[ids.length];
-        this.values = new Object[ids.length];
-    }
-
-    public NewLiteralStorage(int length, boolean createKeys) {
-        this.keys = createKeys ? new Object[length] : null;
-        this.getterSetters = new int[length];
-        this.values = new Object[length];
+    protected NewLiteralStorage(Object[] ids, int length, boolean createKeys) {
+        int l;
+        if (ids != null) {
+            this.keys = ids;
+            l = ids.length;
+        } else {
+            this.keys = createKeys ? new Object[length] : null;
+            l = length;
+        }
+        this.getterSetters = new int[l];
+        this.values = new Object[l];
     }
 
     public void pushValue(Object value) {
         values[index] = value;
         attemptToInferFunctionName(value);
         ++index;
-    }
-
-    private void attemptToInferFunctionName(Object value) {
-        // Try to infer the name if the value is a normal JS function
-        if (this.keys == null
-                || (!(value instanceof NativeFunction) && !(value instanceof ArrowFunction))) {
-            return;
-        }
-
-        BaseFunction fun = (BaseFunction) value;
-        if (!"".equals(fun.get("name", fun))) {
-            return;
-        }
-
-        String prefix = "";
-        if (getterSetters[index] == -1) {
-            prefix = "get ";
-        } else if (getterSetters[index] == +1) {
-            prefix = "set ";
-        }
-
-        Object propKey = this.keys[index];
-        if (propKey instanceof Symbol) {
-            // For symbol keys, valid names are: `[foo]`, `get [foo]`
-            // However `[]` or `get []` aren't, and become `` and `get `
-            String symbolName = ((Symbol) propKey).getName();
-            if (!symbolName.isEmpty()) {
-                fun.setFunctionName(prefix + "[" + symbolName + "]");
-            } else if (!prefix.isEmpty()) {
-                fun.setFunctionName(prefix);
-            }
-        } else {
-            // Key was already converted to a string
-            if (!propKey.equals(PROTO_PROPERTY)) {
-                fun.setFunctionName(prefix + propKey);
-            } else {
-                // `__proto__` is, as usual, weird and applies only to methods, meaning:
-                // - { __proto__(){} } infers the name
-                // - { __proto__: function(){} } does not!
-                if (fun instanceof NativeFunction && ((NativeFunction) fun).isShorthand()) {
-                    fun.setFunctionName(prefix + propKey);
-                }
-            }
-        }
     }
 
     public void pushGetter(Object value) {
@@ -143,5 +100,88 @@ public final class NewLiteralStorage {
 
     public Object[] getValues() {
         return values;
+    }
+
+    public static NewLiteralStorage create(Context cx, Object[] ids) {
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
+            return new NameInference(ids, -1, false);
+        } else {
+            return new NoInference(ids, -1, false);
+        }
+    }
+
+    public static NewLiteralStorage create(Context cx, int length, boolean createKeys) {
+        if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
+            return new NameInference(null, length, createKeys);
+        } else {
+            return new NoInference(null, length, createKeys);
+        }
+    }
+
+    // In version < ES6, we don't do name inference for functions. Thus, we have NewLiteralStorage
+    // as an abstract class, with two subclasses, depending on the language version. In this way, we
+    // pay the cost of the check only once, rather than for each key.
+    protected abstract void attemptToInferFunctionName(Object value);
+
+    private static final class NoInference extends NewLiteralStorage {
+        NoInference(Object[] ids, int length, boolean createKeys) {
+            super(ids, length, createKeys);
+        }
+
+        @Override
+        protected void attemptToInferFunctionName(Object value) {
+            // Do nothing
+        }
+    }
+
+    private static final class NameInference extends NewLiteralStorage {
+        NameInference(Object[] ids, int length, boolean createKeys) {
+            super(ids, length, createKeys);
+        }
+
+        @Override
+        protected void attemptToInferFunctionName(Object value) {
+            // Try to infer the name if the value is a normal JS function
+            if (this.keys == null
+                    || (!(value instanceof NativeFunction) && !(value instanceof ArrowFunction))) {
+                return;
+            }
+
+            BaseFunction fun = (BaseFunction) value;
+            if (!"".equals(fun.get("name", fun))) {
+                return;
+            }
+
+            String prefix = "";
+            if (getterSetters[index] == -1) {
+                prefix = "get ";
+            } else if (getterSetters[index] == +1) {
+                prefix = "set ";
+            }
+
+            Object propKey = this.keys[index];
+            if (propKey instanceof Symbol) {
+                // For symbol keys, valid names are: `[foo]`, `get [foo]`
+                // However `[]` or `get []` aren't, and become `` and `get `
+                String symbolName = ((Symbol) propKey).getName();
+                if (!symbolName.isEmpty()) {
+                    fun.setFunctionName(prefix + "[" + symbolName + "]");
+                } else if (!prefix.isEmpty()) {
+                    fun.setFunctionName(prefix);
+                }
+            } else {
+                // Key was already converted to a string
+                if (!propKey.equals(PROTO_PROPERTY)) {
+                    fun.setFunctionName(prefix + propKey);
+                } else {
+                    // `__proto__` is, as usual, weird and applies only to methods, meaning:
+                    // - { __proto__(){} } infers the name
+                    // - { __proto__: function(){} } does not!
+                    if (fun instanceof NativeFunction && ((NativeFunction) fun).isShorthand()) {
+                        fun.setFunctionName(prefix + propKey);
+                    }
+                }
+            }
+        }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Symbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Symbol.java
@@ -13,5 +13,9 @@ package org.mozilla.javascript;
  * @since 1.7.8
  */
 public interface Symbol {
+    /**
+     * Returns the symbol's name. Returns empty string for anonymous symbol (i.e. something created
+     * with <code>Symbol()</code>).
+     */
     String getName();
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Symbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Symbol.java
@@ -12,4 +12,6 @@ package org.mozilla.javascript;
  *
  * @since 1.7.8
  */
-public interface Symbol {}
+public interface Symbol {
+    String getName();
+}

--- a/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
@@ -37,6 +37,7 @@ public class SymbolKey implements Symbol, Serializable {
      * Returns the symbol's name. Returns empty string for anonymous symbol (i.e. something created
      * with <code>Symbol()</code>).
      */
+    @Override
     public String getName() {
         return name != null ? name : "";
     }

--- a/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
@@ -33,10 +33,7 @@ public class SymbolKey implements Symbol, Serializable {
         this.name = name;
     }
 
-    /**
-     * Returns the symbol's name. Returns empty string for anonymous symbol (i.e. something created
-     * with <code>Symbol()</code>).
-     */
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name != null ? name : "";

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -2251,15 +2251,14 @@ class BodyCodegen {
 
     /** load two arrays with property ids and values */
     private void addLoadProperty(Node node, Node child, Object[] properties, int count) {
-        cfw.add(ByteCode.NEW, "org/mozilla/javascript/NewLiteralStorage");
-        cfw.add(ByteCode.DUP);
+        cfw.addALoad(contextLocal);
         cfw.addLoadConstant(count - node.getIntProp(Node.NUMBER_OF_SPREAD, 0));
         cfw.addLoadConstant(1);
         cfw.addInvoke(
-                ByteCode.INVOKESPECIAL,
+                ByteCode.INVOKESTATIC,
                 "org/mozilla/javascript/NewLiteralStorage",
-                "<init>",
-                "(IZ)V");
+                "create",
+                "(Lorg/mozilla/javascript/Context;IZ)Lorg/mozilla/javascript/NewLiteralStorage;");
 
         if (count == 0) {
             return;

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -106,9 +106,23 @@ class FunctionNameTest {
 
     @Test
     void methodComputedProperty() {
-        // TODO: this is not working at the moment, because it cannot be done statically
-        //  but needs to be done at runtime
-        Utils.assertWithAllModes_ES6("", "o = { [1 + 2]() {} }; o['3'].name");
+        Utils.assertWithAllModes_ES6("3", "o = { [1 + 2]() {} }; o['3'].name");
+    }
+
+    @Test
+    void methodComputedPropertyNamedSymbol() {
+        Utils.assertWithAllModes_ES6("[foo]", "s = Symbol('foo'); o = { [s]() {} }; o[s].name");
+    }
+
+    @Test
+    void methodComputedPropertyAnonymousSymbol() {
+        Utils.assertWithAllModes_ES6("", "s = Symbol(); o = { [s]() {} }; o[s].name");
+    }
+
+    @Test
+    void methodComputedPropertyBuiltInSymbol() {
+        Utils.assertWithAllModes_ES6(
+                "[Symbol.iterator]", "s = Symbol.iterator; o = { [s]() {} }; o[s].name");
     }
 
     @Test
@@ -124,6 +138,20 @@ class FunctionNameTest {
     }
 
     @Test
+    void getterComputedName() {
+        Utils.assertWithAllModes_ES6(
+                "get [foo]",
+                "var s = Symbol('foo'); var o = { get [s](){} }; var desc = Object.getOwnPropertyDescriptor(o, s); desc.get.name");
+    }
+
+    @Test
+    void getterComputedNameAnonymousSymbol() {
+        Utils.assertWithAllModes_ES6(
+                "get ",
+                "var s = Symbol(); var o = { get [s](){} }; var desc = Object.getOwnPropertyDescriptor(o, s); desc.get.name");
+    }
+
+    @Test
     void setter() {
         Utils.assertWithAllModes_ES6(
                 "set x",
@@ -131,8 +159,55 @@ class FunctionNameTest {
     }
 
     @Test
-    void protoIsASpecialName() {
-        Utils.assertWithAllModes_ES6("", "var o = { __proto__() {} }; o.__proto__.name");
+    void setterComputedName() {
+        Utils.assertWithAllModes_ES6(
+                "set [foo]",
+                "var s = Symbol('foo'); var o = { set [s](v){} }; var desc = Object.getOwnPropertyDescriptor(o, s); desc.set.name");
+    }
+
+    @Test
+    void setterComputedNameAnonymousSymbol() {
+        Utils.assertWithAllModes_ES6(
+                "set ",
+                "var s = Symbol(); var o = { set [s](v){} }; var desc = Object.getOwnPropertyDescriptor(o, s); desc.set.name");
+    }
+
+    @Test
+    void arrowInObject() {
+        Utils.assertWithAllModes_ES6(
+                "id",
+                "var o = { id: () => {} }; var desc = Object.getOwnPropertyDescriptor(o, 'id'); desc.value.name");
+    }
+
+    @Test
+    void computedNameArrow() {
+        Utils.assertWithAllModes_ES6(
+                "Id",
+                "var id = 'Id'; var o = { [id]: () => {} }; var desc = Object.getOwnPropertyDescriptor(o, 'Id'); desc.value.name");
+    }
+
+    @Test
+    void computedNameArrowSymbol() {
+        Utils.assertWithAllModes_ES6(
+                "[foo]",
+                "var s = Symbol('foo'); var o = { [s]: () => {} }; var desc = Object.getOwnPropertyDescriptor(o, s); desc.value.name");
+    }
+
+    @Test
+    void computedNameArrowAnonymousSymbol() {
+        Utils.assertWithAllModes_ES6(
+                "",
+                "var s = Symbol(); var o = { [s]: () => {} }; var desc = Object.getOwnPropertyDescriptor(o, s); desc.value.name");
+    }
+
+    @Test
+    void protoIsNotASpecialNameForMethods() {
+        Utils.assertWithAllModes_ES6("__proto__", "var o = { __proto__() {} }; o.__proto__.name");
+    }
+
+    @Test
+    void protoIsASpecialNameForNormalPropFunctionValue() {
+        Utils.assertWithAllModes_ES6("", "var o = { __proto__: function() {} }; o.__proto__.name");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNameTest.java
@@ -214,4 +214,9 @@ class FunctionNameTest {
     void inferenceIsNotUsedInEs5() {
         Utils.assertWithAllModes_1_8("", "var f = function() {}; f.name");
     }
+
+    @Test
+    void inferenceIsNotUsedInEs5InObjectLiteral() {
+        Utils.assertWithAllModes_1_8("", "o = { f: function() {} }; o.f.name");
+    }
 }

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4270,7 +4270,7 @@ language/expressions/new 22/59 (37.29%)
 
 ~language/expressions/new.target
 
-language/expressions/object 708/1170 (60.51%)
+language/expressions/object 698/1170 (59.66%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -4856,8 +4856,6 @@ language/expressions/object 708/1170 (60.51%)
     method-definition/escaped-set-e.js
     method-definition/escaped-set-s.js
     method-definition/escaped-set-t.js
-    method-definition/fn-name-fn.js
-    method-definition/fn-name-gen.js
     method-definition/gen-meth-array-destructuring-param-strict-body.js
     method-definition/gen-meth-dflt-params-abrupt.js
     method-definition/gen-meth-dflt-params-duplicates.js non-strict
@@ -4875,7 +4873,6 @@ language/expressions/object 708/1170 (60.51%)
     method-definition/gen-yield-spread-obj.js
     method-definition/generator-invoke-fn-strict.js non-strict
     method-definition/generator-length-dflt.js
-    method-definition/generator-name-prop-symbol.js
     method-definition/generator-param-init-yield.js non-strict
     method-definition/generator-param-redecl-let.js
     method-definition/generator-prop-name-yield-expr.js non-strict
@@ -4892,7 +4889,6 @@ language/expressions/object 708/1170 (60.51%)
     method-definition/meth-rest-param-strict-body.js
     method-definition/name-invoke-fn-strict.js non-strict
     method-definition/name-length-dflt.js
-    method-definition/name-name-prop-symbol.js
     method-definition/name-param-id-yield.js non-strict
     method-definition/name-param-init-yield.js non-strict
     method-definition/name-param-redecl.js
@@ -4930,17 +4926,11 @@ language/expressions/object 708/1170 (60.51%)
     accessor-name-computed-in.js
     accessor-name-computed-yield-id.js non-strict
     computed-__proto__.js
-    computed-property-name-topropertykey-before-value-evaluation.js
     cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
     cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
     cpn-obj-lit-computed-property-name-from-yield-expression.js
-    fn-name-accessor-get.js
-    fn-name-accessor-set.js
-    fn-name-arrow.js
     fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
-    fn-name-fn.js
-    fn-name-gen.js
     getter-body-strict-inside.js non-strict
     getter-param-dflt.js
     ident-name-prop-name-literal-await-static-init.js


### PR DESCRIPTION
This continues the work of https://github.com/mozilla/rhino/pull/1949 and applies inference of function names at runtime for computed properties. There's some special handling necessary if the key is a Symbol, or if the key is `__proto__`, but I think I have added a test case for every combination.

Makes a few more test262 cases pass. Should close https://github.com/mozilla/rhino/issues/1297.

I've also changed the recently-implemented `NewLiteralStorage` to ensure that we apply only the behavior in version >= ES6.