### PR TITLE
document android libs issues in o.m.j package

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -320,6 +320,8 @@ public final class JavaAdapter implements IdFunctionCall {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    // https://developer.android.com/reference/java/lang/reflect/Method#isDefault() added in API
+    // level 24
     public static byte[] createAdapterCode(
             Map<String, Integer> functionNames,
             String adapterName,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeDate.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeDate.java
@@ -24,6 +24,7 @@ import java.util.Locale;
  *     <a href="https://dxr.mozilla.org/mozilla-central/source/js/src/jsdate.cpp">jsdate.cpp</a>
  */
 @SuppressWarnings("AndroidJdkLibsChecker")
+// java.time.format API added in API level 26
 final class NativeDate extends IdScriptableObject {
     private static final long serialVersionUID = -8307438915861678966L;
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3770,6 +3770,8 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    // java.math.BigInteger#intValueExact() available in API-level 31
+    // https://developer.android.com/reference/java/math/BigInteger#intValueExact()
     public static Number exponentiate(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             if (((BigInteger) val2).signum() == -1) {
@@ -3846,6 +3848,8 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    // java.math.BigInteger#intValueExact() available in API-level 31
+    // https://developer.android.com/reference/java/math/BigInteger#intValueExact()
     public static Number leftShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             try {
@@ -3870,6 +3874,8 @@ public class ScriptRuntime {
     }
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    // java.math.BigInteger#intValueExact() available in API-level 31
+    // https://developer.android.com/reference/java/math/BigInteger#intValueExact()
     public static Number signedRightShift(Number val1, Number val2) {
         if (val1 instanceof BigInteger && val2 instanceof BigInteger) {
             try {

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
@@ -18,6 +18,7 @@ package org.mozilla.javascript;
 public interface SlotMap extends Iterable<Slot> {
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    // https://developer.android.com/reference/java/lang/FunctionalInterface added in API level 24
     @FunctionalInterface
     public interface SlotComputer<S extends Slot> {
         S compute(Object key, int index, Slot existing);

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -22,6 +22,8 @@ public abstract class SlotMapOwner {
     static final SlotMap THREAD_SAFE_EMPTY_SLOT_MAP = new ThreadSafeEmptySlotMap();
 
     @SuppressWarnings("AndroidJdkLibsChecker")
+    // https://developer.android.com/reference/java/lang/invoke/VarHandle added in API level 33
+    // Note: Due presence of this class, dexing of rhino will not be possible for APIs < 26
     static final class ThreadedAccess {
 
         private static final VarHandle SLOT_MAP = getSlotMapHandle();

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
@@ -3,6 +3,8 @@ package org.mozilla.javascript;
 import java.util.concurrent.locks.StampedLock;
 
 @SuppressWarnings("AndroidJdkLibsChecker")
+// https://developer.android.com/reference/java/util/concurrent/locks/StampedLock added in API level
+// 24
 class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
 
     private final StampedLock lock;

--- a/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
@@ -577,11 +577,11 @@ class TokenStream implements Parser.CurrentPositionReporter {
         return id & 0xff;
     }
 
-    @SuppressWarnings("AndroidJdkLibsChecker")
     private static boolean isValidIdentifierName(String str) {
         int i = 0;
-        for (int c : str.codePoints().toArray()) {
-            if (i++ == 0) {
+        while (i < str.length()) {
+            int c = str.codePointAt(i);
+            if (i == 0) {
                 if (c != '$' && c != '_' && !Character.isUnicodeIdentifierStart(c)) {
                     return false;
                 }
@@ -593,6 +593,7 @@ class TokenStream implements Parser.CurrentPositionReporter {
                     return false;
                 }
             }
+            i += Character.charCount(c);
         }
         return true;
     }


### PR DESCRIPTION
This PR adds documentation regarding the usage of special Android libraries.

Note: The AndroidJdkLibsChecker currently checks against API level 1 only.  
Therefore, if you use certain APIs that were introduced in later Android versions, the AndroidJdkLibsChecker may flag them as incompatible – even though they might function correctly on newer Android versions.

Current status:

- SlotMap.ThreadAccess utilizes a VM-specific API (compareAndExchange), which ties us to a minimum SDK version of 26. There is currently no straightforward workaround for this.
- Other missing APIs (such as java.time.format) can be "emulated" via Android's desugaring process, enabling compatibility with a minimum SDK version of 21. (See #2042)