### PR TITLE
Do not check interpreted mode in Codegen and always optimize

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -177,27 +177,26 @@ public class Codegen implements Evaluator {
     private void transform(ScriptNode tree) {
         initOptFunctions_r(tree);
 
-        boolean optimizing = !compilerEnv.isInterpretedMode();
-
+        if (!compilerEnv.isInterpretedMode()) {
+            Kit.codeBug("Codegen nust not run in interpreted Mode");
+        }
         Map<String, OptFunctionNode> possibleDirectCalls = null;
-        if (optimizing) {
-            /*
-             * Collect all of the contained functions into a hashtable
-             * so that the call optimizer can access the class name & parameter
-             * count for any call it encounters
-             */
-            if (tree.getType() == Token.SCRIPT) {
-                int functionCount = tree.getFunctionCount();
-                for (int i = 0; i != functionCount; ++i) {
-                    OptFunctionNode ofn = OptFunctionNode.get(tree, i);
-                    if (ofn.fnode.getFunctionType() == FunctionNode.FUNCTION_STATEMENT) {
-                        String name = ofn.fnode.getName();
-                        if (name.length() != 0) {
-                            if (possibleDirectCalls == null) {
-                                possibleDirectCalls = new HashMap<>();
-                            }
-                            possibleDirectCalls.put(name, ofn);
+        /*
+         * Collect all of the contained functions into a hashtable
+         * so that the call optimizer can access the class name & parameter
+         * count for any call it encounters
+         */
+        if (tree.getType() == Token.SCRIPT) {
+            int functionCount = tree.getFunctionCount();
+            for (int i = 0; i != functionCount; ++i) {
+                OptFunctionNode ofn = OptFunctionNode.get(tree, i);
+                if (ofn.fnode.getFunctionType() == FunctionNode.FUNCTION_STATEMENT) {
+                    String name = ofn.fnode.getName();
+                    if (name.length() != 0) {
+                        if (possibleDirectCalls == null) {
+                            possibleDirectCalls = new HashMap<>();
                         }
+                        possibleDirectCalls.put(name, ofn);
                     }
                 }
             }
@@ -210,9 +209,7 @@ public class Codegen implements Evaluator {
         OptTransformer ot = new OptTransformer(possibleDirectCalls, directCallTargets);
         ot.transform(tree, compilerEnv);
 
-        if (optimizing) {
-            new Optimizer().optimize(tree);
-        }
+        new Optimizer().optimize(tree);
     }
 
     private static void initOptFunctions_r(ScriptNode scriptOrFn) {


### PR DESCRIPTION
While debugging, I discovered some quirks in Codegen.

Possible it was overlooked in https://github.com/mozilla/rhino/commit/8f8c3dc6807bfe273fcacaa3b94dbc0d47b02226

@gbrail, could you check if this makes sense? Are there any code paths where Codegen is invoked in interpreted mode?
