### PR TITLE
Implement ES2025 Math.f16round method

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
@@ -294,7 +294,7 @@ final class NativeMath extends ScriptableObject {
 
         // Handle mantissa overflow
         if (mantissa >= (1L << 10)) {
-            mantissa >>>= 1;
+            mantissa = 0; // Overflow to next power of 2
             exponent++;
             if (exponent >= 31) {
                 return ScriptRuntime.wrapNumber(

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
@@ -304,9 +304,9 @@ final class NativeMath extends ScriptableObject {
 
         // Reconstruct as double precision
         if (exponent == 0) {
-            // Subnormal
-            long resultBits = ((long) sign << 63) | (mantissa << 42);
-            return ScriptRuntime.wrapNumber(Double.longBitsToDouble(resultBits));
+            // Subnormal float16: value = 2^-14 * (mantissa / 1024)
+            double value = Math.scalb((double) mantissa / 1024.0, -14);
+            return ScriptRuntime.wrapNumber((sign != 0) ? -value : value);
         } else {
             // Normal
             long resultBits =

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2025/MathF16roundTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2025/MathF16roundTest.java
@@ -1,0 +1,109 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mozilla.javascript.tests.es2025;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/** Tests for ES2025 Math.f16round */
+public class MathF16roundTest {
+
+    @Test
+    public void testBasicNumbers() {
+        Utils.assertWithAllModes_ES6(1.0, "Math.f16round(1)");
+        Utils.assertWithAllModes_ES6(-1.0, "Math.f16round(-1)");
+        Utils.assertWithAllModes_ES6(2.0, "Math.f16round(2)");
+        Utils.assertWithAllModes_ES6(0.5, "Math.f16round(0.5)");
+    }
+
+    @Test
+    public void testZeros() {
+        Utils.assertWithAllModes_ES6(0.0, "Math.f16round(0)");
+        Utils.assertWithAllModes_ES6(-0.0, "Math.f16round(-0)");
+        Utils.assertWithAllModes_ES6(0.0, "Math.f16round(0.0)");
+        Utils.assertWithAllModes_ES6(-0.0, "Math.f16round(-0.0)");
+    }
+
+    @Test
+    public void testSpecialValues() {
+        Utils.assertWithAllModes_ES6(Double.NaN, "Math.f16round(NaN)");
+        Utils.assertWithAllModes_ES6(Double.POSITIVE_INFINITY, "Math.f16round(Infinity)");
+        Utils.assertWithAllModes_ES6(Double.NEGATIVE_INFINITY, "Math.f16round(-Infinity)");
+    }
+
+    @Test
+    public void testMaxMinValues() {
+        // Max finite half precision value: 65504
+        Utils.assertWithAllModes_ES6(65504.0, "Math.f16round(65504)");
+        Utils.assertWithAllModes_ES6(-65504.0, "Math.f16round(-65504)");
+
+        // Values that overflow to infinity
+        Utils.assertWithAllModes_ES6(Double.POSITIVE_INFINITY, "Math.f16round(65536)");
+        Utils.assertWithAllModes_ES6(Double.NEGATIVE_INFINITY, "Math.f16round(-65536)");
+    }
+
+    @Test
+    public void testSmallValues() {
+        // Min positive normal: 2^-14 = 0.00006103515625
+        final String script1 = "Math.f16round(0.00006103515625)";
+        Utils.assertWithAllModes_ES6(0.00006103515625, script1);
+
+        // Values that underflow to zero
+        Utils.assertWithAllModes_ES6(0.0, "Math.f16round(1e-8)");
+        Utils.assertWithAllModes_ES6(-0.0, "Math.f16round(-1e-8)");
+    }
+
+    @Test
+    public void testRounding() {
+        // Test basic rounding behavior
+        Utils.assertWithAllModes_ES6(1.0, "Math.f16round(1.0)");
+        Utils.assertWithAllModes_ES6(2.0, "Math.f16round(2.0)");
+    }
+
+    @Test
+    public void testPrecisionLoss() {
+        // Test that precision is lost appropriately
+        final String script = "Math.f16round(Math.PI)";
+        Utils.assertWithAllModes_ES6(3.140625, script);
+    }
+
+    @Test
+    public void testPropertyDescriptor() {
+        final String script =
+                "var desc = Object.getOwnPropertyDescriptor(Math, 'f16round');"
+                        + "desc.writable === true && "
+                        + "desc.enumerable === false && "
+                        + "desc.configurable === true && "
+                        + "typeof desc.value === 'function';";
+        Utils.assertWithAllModes_ES6(true, script);
+    }
+
+    @Test
+    public void testFunctionProperties() {
+        Utils.assertWithAllModes_ES6("f16round", "Math.f16round.name");
+        Utils.assertWithAllModes_ES6(1.0, "Math.f16round.length");
+    }
+
+    @Test
+    public void testNoArguments() {
+        Utils.assertWithAllModes_ES6(Double.NaN, "Math.f16round()");
+    }
+
+    @Test
+    public void testMultipleArguments() {
+        Utils.assertWithAllModes_ES6(1.0, "Math.f16round(1, 2, 3)");
+    }
+
+    @Test
+    public void testNonNumericArguments() {
+        Utils.assertWithAllModes_ES6(Double.NaN, "Math.f16round('abc')");
+        Utils.assertWithAllModes_ES6(Double.NaN, "Math.f16round(undefined)");
+        Utils.assertWithAllModes_ES6(0.0, "Math.f16round(null)");
+        Utils.assertWithAllModes_ES6(1.0, "Math.f16round(true)");
+        Utils.assertWithAllModes_ES6(0.0, "Math.f16round(false)");
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1,7 +1,6 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-annexB/built-ins 58/241 (24.07%)
-    Array/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+annexB/built-ins
     Date/prototype/getYear/not-a-constructor.js
     Date/prototype/setYear/not-a-constructor.js
     Date/prototype/setYear/year-number-relative.js
@@ -9,578 +8,468 @@ annexB/built-ins 58/241 (24.07%)
     Function/createdynfn-html-close-comment-params.js
     Function/createdynfn-html-open-comment-params.js
     Function/createdynfn-no-line-terminator-html-close-comment-body.js
-    Object/is/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    RegExp/legacy-accessors/index 4/4 (100.0%)
-    RegExp/legacy-accessors/input 4/4 (100.0%)
-    RegExp/legacy-accessors/lastMatch 4/4 (100.0%)
-    RegExp/legacy-accessors/lastParen 4/4 (100.0%)
-    RegExp/legacy-accessors/leftContext 4/4 (100.0%)
-    RegExp/legacy-accessors/rightContext 4/4 (100.0%)
+    RegExp/legacy-accessors/index/prop-desc.js
+    RegExp/legacy-accessors/index/this-cross-realm-constructor.js
+    RegExp/legacy-accessors/index/this-not-regexp-constructor.js
+    RegExp/legacy-accessors/input/prop-desc.js
+    RegExp/legacy-accessors/input/this-cross-realm-constructor.js
+    RegExp/legacy-accessors/input/this-not-regexp-constructor.js
+    RegExp/legacy-accessors/lastMatch/prop-desc.js
+    RegExp/legacy-accessors/lastMatch/this-cross-realm-constructor.js
+    RegExp/legacy-accessors/lastMatch/this-not-regexp-constructor.js
+    RegExp/legacy-accessors/lastParen/prop-desc.js
+    RegExp/legacy-accessors/lastParen/this-cross-realm-constructor.js
+    RegExp/legacy-accessors/lastParen/this-not-regexp-constructor.js
+    RegExp/legacy-accessors/leftContext/prop-desc.js
+    RegExp/legacy-accessors/leftContext/this-cross-realm-constructor.js
+    RegExp/legacy-accessors/leftContext/this-not-regexp-constructor.js
+    RegExp/legacy-accessors/rightContext/prop-desc.js
+    RegExp/legacy-accessors/rightContext/this-cross-realm-constructor.js
+    RegExp/legacy-accessors/rightContext/this-not-regexp-constructor.js
     RegExp/prototype/compile/pattern-regexp-flags-defined.js
     RegExp/prototype/compile/this-cross-realm-instance.js
-    RegExp/prototype/compile/this-subclass-instance.js {unsupported: [class]}
-    RegExp/prototype/flags/order-after-compile.js {unsupported: [regexp-dotall]}
     RegExp/prototype/Symbol.split/Symbol.match-getter-recompiles-source.js
     RegExp/incomplete_hex_unicode_escape.js
-    RegExp/RegExp-control-escape-russian-letter.js compiled
+    RegExp/RegExp-control-escape-russian-letter.js
     RegExp/RegExp-leading-escape-BMP.js
     RegExp/RegExp-trailing-escape-BMP.js
     String/prototype/anchor/length.js
     String/prototype/fontcolor/length.js
     String/prototype/fontsize/length.js
     String/prototype/link/length.js
-    String/prototype/matchAll/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/match/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/replaceAll/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/replace/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/search/custom-searcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/split/custom-splitter-emulates-undefined.js {unsupported: [IsHTMLDDA]}
     String/prototype/substr/start-and-length-as-numbers.js
     String/prototype/trimLeft/name.js
     String/prototype/trimLeft/reference-trimStart.js
     String/prototype/trimRight/name.js
     String/prototype/trimRight/reference-trimEnd.js
-    TypedArrayConstructors/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
 
-annexB/language 380/838 (45.35%)
+annexB/language
     comments/multi-line-html-close.js
     comments/single-line-html-close.js
-    comments/single-line-html-close-first-line-3.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/global-block-decl-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-switch-case-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/var-env-lower-lex-catch-non-strict.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
-    expressions/assignment/dstr 2/2 (100.0%)
-    expressions/coalesce/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/conditional/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/logical-and/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/logical-assignment 3/3 (100.0%)
-    expressions/logical-not/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/logical-or/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/strict-does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/strict-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/template-literal/legacy-octal-escape-sequence-strict.js strict
-    expressions/typeof/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/yield 2/2 (100.0%)
-    function-code/block-decl-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/block-decl-func-init.js interpreted-non-strict
-    function-code/block-decl-func-no-skip-try.js interpreted-non-strict
-    function-code/block-decl-func-skip-arguments.js non-strict
-    function-code/block-decl-func-skip-dft-param.js non-strict
-    function-code/block-decl-func-skip-early-err.js non-strict
-    function-code/block-decl-func-skip-early-err-block.js non-strict
-    function-code/block-decl-func-skip-early-err-for.js non-strict
-    function-code/block-decl-func-skip-early-err-for-in.js non-strict
-    function-code/block-decl-func-skip-early-err-for-of.js non-strict
-    function-code/block-decl-func-skip-early-err-switch.js non-strict
-    function-code/block-decl-func-skip-early-err-try.js non-strict
-    function-code/block-decl-func-skip-param.js non-strict
-    function-code/block-decl-nested-blocks-with-fun-decl.js non-strict
-    function-code/block-decl-nostrict.js interpreted-non-strict
-    function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-else-decl-a-func-skip-dft-param.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-block.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-for.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-try.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-param.js non-strict
-    function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-else-decl-b-func-skip-dft-param.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-block.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-for.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-try.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-param.js non-strict
-    function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-else-stmt-func-skip-dft-param.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-block.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-for.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-try.js non-strict
-    function-code/if-decl-else-stmt-func-skip-param.js non-strict
-    function-code/if-decl-no-else-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-no-else-func-skip-dft-param.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-block.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-for.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-try.js non-strict
-    function-code/if-decl-no-else-func-skip-param.js non-strict
-    function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-stmt-else-decl-func-skip-dft-param.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-block.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-for.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-for-in.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-for-of.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-switch.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-try.js non-strict
-    function-code/if-stmt-else-decl-func-skip-param.js non-strict
-    function-code/switch-case-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/switch-case-func-skip-dft-param.js non-strict
-    function-code/switch-case-func-skip-early-err.js non-strict
-    function-code/switch-case-func-skip-early-err-block.js non-strict
-    function-code/switch-case-func-skip-early-err-for.js non-strict
-    function-code/switch-case-func-skip-early-err-for-in.js non-strict
-    function-code/switch-case-func-skip-early-err-for-of.js non-strict
-    function-code/switch-case-func-skip-early-err-switch.js non-strict
-    function-code/switch-case-func-skip-early-err-try.js non-strict
-    function-code/switch-case-func-skip-param.js non-strict
-    function-code/switch-dflt-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/switch-dflt-func-skip-dft-param.js non-strict
-    function-code/switch-dflt-func-skip-early-err.js non-strict
-    function-code/switch-dflt-func-skip-early-err-block.js non-strict
-    function-code/switch-dflt-func-skip-early-err-for.js non-strict
-    function-code/switch-dflt-func-skip-early-err-for-in.js non-strict
-    function-code/switch-dflt-func-skip-early-err-for-of.js non-strict
-    function-code/switch-dflt-func-skip-early-err-switch.js non-strict
-    function-code/switch-dflt-func-skip-early-err-try.js non-strict
-    function-code/switch-dflt-func-skip-param.js non-strict
-    global-code/block-decl-global-block-scoping.js non-strict
-    global-code/block-decl-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/block-decl-global-init.js interpreted-non-strict
-    global-code/block-decl-global-no-skip-try.js interpreted-non-strict
-    global-code/block-decl-global-skip-early-err.js non-strict
-    global-code/block-decl-global-skip-early-err-block.js non-strict
-    global-code/block-decl-global-skip-early-err-for.js non-strict
-    global-code/block-decl-global-skip-early-err-for-in.js non-strict
-    global-code/block-decl-global-skip-early-err-for-of.js non-strict
-    global-code/block-decl-global-skip-early-err-switch.js non-strict
-    global-code/block-decl-global-skip-early-err-try.js non-strict
-    global-code/if-decl-else-decl-a-global-block-scoping.js non-strict
-    global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-block.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-for.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-try.js non-strict
-    global-code/if-decl-else-decl-b-global-block-scoping.js non-strict
-    global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-block.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-for.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-try.js non-strict
-    global-code/if-decl-else-stmt-global-block-scoping.js non-strict
-    global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-block.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-for.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-try.js non-strict
-    global-code/if-decl-no-else-global-block-scoping.js non-strict
-    global-code/if-decl-no-else-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-no-else-global-skip-early-err.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-block.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-for.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-try.js non-strict
-    global-code/if-stmt-else-decl-global-block-scoping.js non-strict
-    global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-block.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-for.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-for-in.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-for-of.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-switch.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-try.js non-strict
-    global-code/script-decl-lex-collision.js non-strict
-    global-code/switch-case-global-block-scoping.js non-strict
-    global-code/switch-case-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/switch-case-global-skip-early-err.js non-strict
-    global-code/switch-case-global-skip-early-err-block.js non-strict
-    global-code/switch-case-global-skip-early-err-for.js non-strict
-    global-code/switch-case-global-skip-early-err-for-in.js non-strict
-    global-code/switch-case-global-skip-early-err-for-of.js non-strict
-    global-code/switch-case-global-skip-early-err-switch.js non-strict
-    global-code/switch-case-global-skip-early-err-try.js non-strict
-    global-code/switch-dflt-global-block-scoping.js non-strict
-    global-code/switch-dflt-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/switch-dflt-global-skip-early-err.js non-strict
-    global-code/switch-dflt-global-skip-early-err-block.js non-strict
-    global-code/switch-dflt-global-skip-early-err-for.js non-strict
-    global-code/switch-dflt-global-skip-early-err-for-in.js non-strict
-    global-code/switch-dflt-global-skip-early-err-for-of.js non-strict
-    global-code/switch-dflt-global-skip-early-err-switch.js non-strict
-    global-code/switch-dflt-global-skip-early-err-try.js non-strict
+    comments/single-line-html-close-first-line-3.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js
+    eval-code/direct/global-block-decl-eval-global-block-scoping.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
+    eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
+    eval-code/direct/global-switch-case-eval-global-block-scoping.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js
+    eval-code/direct/global-switch-dflt-eval-global-block-scoping.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js
+    eval-code/direct/var-env-lower-lex-catch-non-strict.js
+    eval-code/indirect/global-block-decl-eval-global-block-scoping.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-switch-case-eval-global-block-scoping.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js
+    eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js
+    expressions/template-literal/legacy-octal-escape-sequence-strict.js
+    function-code/block-decl-func-existing-block-fn-no-init.js
+    function-code/block-decl-func-init.js
+    function-code/block-decl-func-no-skip-try.js
+    function-code/block-decl-func-skip-arguments.js
+    function-code/block-decl-func-skip-dft-param.js
+    function-code/block-decl-func-skip-early-err.js
+    function-code/block-decl-func-skip-early-err-block.js
+    function-code/block-decl-func-skip-early-err-for.js
+    function-code/block-decl-func-skip-early-err-for-in.js
+    function-code/block-decl-func-skip-early-err-for-of.js
+    function-code/block-decl-func-skip-early-err-switch.js
+    function-code/block-decl-func-skip-early-err-try.js
+    function-code/block-decl-func-skip-param.js
+    function-code/block-decl-nested-blocks-with-fun-decl.js
+    function-code/block-decl-nostrict.js
+    function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js
+    function-code/if-decl-else-decl-a-func-skip-dft-param.js
+    function-code/if-decl-else-decl-a-func-skip-early-err.js
+    function-code/if-decl-else-decl-a-func-skip-early-err-block.js
+    function-code/if-decl-else-decl-a-func-skip-early-err-for.js
+    function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
+    function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
+    function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
+    function-code/if-decl-else-decl-a-func-skip-early-err-try.js
+    function-code/if-decl-else-decl-a-func-skip-param.js
+    function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js
+    function-code/if-decl-else-decl-b-func-skip-dft-param.js
+    function-code/if-decl-else-decl-b-func-skip-early-err.js
+    function-code/if-decl-else-decl-b-func-skip-early-err-block.js
+    function-code/if-decl-else-decl-b-func-skip-early-err-for.js
+    function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
+    function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
+    function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
+    function-code/if-decl-else-decl-b-func-skip-early-err-try.js
+    function-code/if-decl-else-decl-b-func-skip-param.js
+    function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js
+    function-code/if-decl-else-stmt-func-skip-dft-param.js
+    function-code/if-decl-else-stmt-func-skip-early-err.js
+    function-code/if-decl-else-stmt-func-skip-early-err-block.js
+    function-code/if-decl-else-stmt-func-skip-early-err-for.js
+    function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
+    function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
+    function-code/if-decl-else-stmt-func-skip-early-err-switch.js
+    function-code/if-decl-else-stmt-func-skip-early-err-try.js
+    function-code/if-decl-else-stmt-func-skip-param.js
+    function-code/if-decl-no-else-func-existing-block-fn-no-init.js
+    function-code/if-decl-no-else-func-skip-dft-param.js
+    function-code/if-decl-no-else-func-skip-early-err.js
+    function-code/if-decl-no-else-func-skip-early-err-block.js
+    function-code/if-decl-no-else-func-skip-early-err-for.js
+    function-code/if-decl-no-else-func-skip-early-err-for-in.js
+    function-code/if-decl-no-else-func-skip-early-err-for-of.js
+    function-code/if-decl-no-else-func-skip-early-err-switch.js
+    function-code/if-decl-no-else-func-skip-early-err-try.js
+    function-code/if-decl-no-else-func-skip-param.js
+    function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js
+    function-code/if-stmt-else-decl-func-skip-dft-param.js
+    function-code/if-stmt-else-decl-func-skip-early-err.js
+    function-code/if-stmt-else-decl-func-skip-early-err-block.js
+    function-code/if-stmt-else-decl-func-skip-early-err-for.js
+    function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
+    function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
+    function-code/if-stmt-else-decl-func-skip-early-err-switch.js
+    function-code/if-stmt-else-decl-func-skip-early-err-try.js
+    function-code/if-stmt-else-decl-func-skip-param.js
+    function-code/switch-case-func-existing-block-fn-no-init.js
+    function-code/switch-case-func-skip-dft-param.js
+    function-code/switch-case-func-skip-early-err.js
+    function-code/switch-case-func-skip-early-err-block.js
+    function-code/switch-case-func-skip-early-err-for.js
+    function-code/switch-case-func-skip-early-err-for-in.js
+    function-code/switch-case-func-skip-early-err-for-of.js
+    function-code/switch-case-func-skip-early-err-switch.js
+    function-code/switch-case-func-skip-early-err-try.js
+    function-code/switch-case-func-skip-param.js
+    function-code/switch-dflt-func-existing-block-fn-no-init.js
+    function-code/switch-dflt-func-skip-dft-param.js
+    function-code/switch-dflt-func-skip-early-err.js
+    function-code/switch-dflt-func-skip-early-err-block.js
+    function-code/switch-dflt-func-skip-early-err-for.js
+    function-code/switch-dflt-func-skip-early-err-for-in.js
+    function-code/switch-dflt-func-skip-early-err-for-of.js
+    function-code/switch-dflt-func-skip-early-err-switch.js
+    function-code/switch-dflt-func-skip-early-err-try.js
+    function-code/switch-dflt-func-skip-param.js
+    global-code/block-decl-global-block-scoping.js
+    global-code/block-decl-global-existing-block-fn-no-init.js
+    global-code/block-decl-global-init.js
+    global-code/block-decl-global-no-skip-try.js
+    global-code/block-decl-global-skip-early-err.js
+    global-code/block-decl-global-skip-early-err-block.js
+    global-code/block-decl-global-skip-early-err-for.js
+    global-code/block-decl-global-skip-early-err-for-in.js
+    global-code/block-decl-global-skip-early-err-for-of.js
+    global-code/block-decl-global-skip-early-err-switch.js
+    global-code/block-decl-global-skip-early-err-try.js
+    global-code/if-decl-else-decl-a-global-block-scoping.js
+    global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js
+    global-code/if-decl-else-decl-a-global-skip-early-err.js
+    global-code/if-decl-else-decl-a-global-skip-early-err-block.js
+    global-code/if-decl-else-decl-a-global-skip-early-err-for.js
+    global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js
+    global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js
+    global-code/if-decl-else-decl-a-global-skip-early-err-switch.js
+    global-code/if-decl-else-decl-a-global-skip-early-err-try.js
+    global-code/if-decl-else-decl-b-global-block-scoping.js
+    global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js
+    global-code/if-decl-else-decl-b-global-skip-early-err.js
+    global-code/if-decl-else-decl-b-global-skip-early-err-block.js
+    global-code/if-decl-else-decl-b-global-skip-early-err-for.js
+    global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js
+    global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js
+    global-code/if-decl-else-decl-b-global-skip-early-err-switch.js
+    global-code/if-decl-else-decl-b-global-skip-early-err-try.js
+    global-code/if-decl-else-stmt-global-block-scoping.js
+    global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js
+    global-code/if-decl-else-stmt-global-skip-early-err.js
+    global-code/if-decl-else-stmt-global-skip-early-err-block.js
+    global-code/if-decl-else-stmt-global-skip-early-err-for.js
+    global-code/if-decl-else-stmt-global-skip-early-err-for-in.js
+    global-code/if-decl-else-stmt-global-skip-early-err-for-of.js
+    global-code/if-decl-else-stmt-global-skip-early-err-switch.js
+    global-code/if-decl-else-stmt-global-skip-early-err-try.js
+    global-code/if-decl-no-else-global-block-scoping.js
+    global-code/if-decl-no-else-global-existing-block-fn-no-init.js
+    global-code/if-decl-no-else-global-skip-early-err.js
+    global-code/if-decl-no-else-global-skip-early-err-block.js
+    global-code/if-decl-no-else-global-skip-early-err-for.js
+    global-code/if-decl-no-else-global-skip-early-err-for-in.js
+    global-code/if-decl-no-else-global-skip-early-err-for-of.js
+    global-code/if-decl-no-else-global-skip-early-err-switch.js
+    global-code/if-decl-no-else-global-skip-early-err-try.js
+    global-code/if-stmt-else-decl-global-block-scoping.js
+    global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js
+    global-code/if-stmt-else-decl-global-skip-early-err.js
+    global-code/if-stmt-else-decl-global-skip-early-err-block.js
+    global-code/if-stmt-else-decl-global-skip-early-err-for.js
+    global-code/if-stmt-else-decl-global-skip-early-err-for-in.js
+    global-code/if-stmt-else-decl-global-skip-early-err-for-of.js
+    global-code/if-stmt-else-decl-global-skip-early-err-switch.js
+    global-code/if-stmt-else-decl-global-skip-early-err-try.js
+    global-code/script-decl-lex-collision.js
+    global-code/switch-case-global-block-scoping.js
+    global-code/switch-case-global-existing-block-fn-no-init.js
+    global-code/switch-case-global-skip-early-err.js
+    global-code/switch-case-global-skip-early-err-block.js
+    global-code/switch-case-global-skip-early-err-for.js
+    global-code/switch-case-global-skip-early-err-for-in.js
+    global-code/switch-case-global-skip-early-err-for-of.js
+    global-code/switch-case-global-skip-early-err-switch.js
+    global-code/switch-case-global-skip-early-err-try.js
+    global-code/switch-dflt-global-block-scoping.js
+    global-code/switch-dflt-global-existing-block-fn-no-init.js
+    global-code/switch-dflt-global-skip-early-err.js
+    global-code/switch-dflt-global-skip-early-err-block.js
+    global-code/switch-dflt-global-skip-early-err-for.js
+    global-code/switch-dflt-global-skip-early-err-for-in.js
+    global-code/switch-dflt-global-skip-early-err-for-of.js
+    global-code/switch-dflt-global-skip-early-err-switch.js
+    global-code/switch-dflt-global-skip-early-err-try.js
     literals/regexp/class-escape.js
     literals/regexp/identity-escape.js
     literals/regexp/legacy-octal-escape.js
-    statements/class/subclass 2/2 (100.0%)
-    statements/const/dstr 2/2 (100.0%)
-    statements/for-await-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [async-iteration, IsHTMLDDA, async]}
     statements/for-in/let-initializer.js
-    statements/for-in/strict-initializer.js strict
-    statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [IsHTMLDDA]}
-    statements/function/default-parameters-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    statements/if/emulated-undefined.js {unsupported: [IsHTMLDDA]}
-    statements/switch/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    statements/for-in/strict-initializer.js
 
-harness 23/116 (19.83%)
-    assert-notsamevalue-tostring.js {unsupported: [async-functions]}
-    assert-samevalue-tostring.js {unsupported: [async-functions]}
-    assert-tostring.js {unsupported: [async-functions]}
-    asyncHelpers-asyncTest-returns-undefined.js {unsupported: [async]}
-    asyncHelpers-asyncTest-then-rejects.js {unsupported: [async]}
-    asyncHelpers-asyncTest-then-resolves.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-custom.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-custom-typeerror.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-func-never-settles.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-func-throws-sync.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-incorrect-ctor.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-invalid-func.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-native.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-no-arg.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-no-error.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-null.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-primitive.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-resolved-error.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-same-realm.js {unsupported: [async]}
-    asyncHelpers-throwsAsync-single-arg.js {unsupported: [async]}
+harness
     compare-array-arguments.js
     isConstructor.js
     nativeFunctionMatcher.js
 
-built-ins/Array 263/3077 (8.55%)
-    fromAsync 95/95 (100.0%)
+built-ins/Array
+    fromAsync/builtin.js
+    fromAsync/length.js
+    fromAsync/name.js
+    fromAsync/not-a-constructor.js
+    fromAsync/prop-desc.js
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/proto-from-ctor-realm.js
     from/source-object-constructor.js Error propagation needs work in general
     length/define-own-prop-length-coercion-order-set.js
     of/proto-from-ctor-realm.js
-    prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/at/typed-array-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/concat/Array.prototype.concat_non-array.js
     prototype/concat/create-proto-from-ctor-realm-array.js
     prototype/concat/create-proxy.js
     prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
-    prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
-    prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/15.4.4.16-5-1-s.js non-strict
-    prototype/every/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/typed-array-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/15.4.4.20-5-1-s.js non-strict
-    prototype/filter/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/return-abrupt-from-delete-target.js Not throwing properly on unwritable
+    prototype/every/15.4.4.16-5-1-s.js
+    prototype/filter/15.4.4.20-5-1-s.js
     prototype/filter/create-proto-from-ctor-realm-array.js
     prototype/filter/create-proxy.js
-    prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/predicate-call-this-strict.js strict
-    prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/predicate-call-this-strict.js strict
-    prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/predicate-call-this-strict.js strict
-    prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/predicate-call-this-strict.js strict
-    prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/predicate-call-this-strict.js
+    prototype/findLastIndex/predicate-call-this-strict.js
+    prototype/findLast/predicate-call-this-strict.js
+    prototype/find/predicate-call-this-strict.js
     prototype/flatMap/proxy-access-count.js
     prototype/flatMap/this-value-ctor-non-object.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    prototype/flatMap/thisArg-argument.js strict
+    prototype/flatMap/thisArg-argument.js
     prototype/flat/proxy-access-count.js
-    prototype/forEach/15.4.4.18-5-1-s.js non-strict
-    prototype/forEach/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/15.4.4.18-5-1-s.js
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js
-    prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/length-zero-returns-minus-one.js
-    prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js
-    prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/length-zero-returns-minus-one.js
-    prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/15.4.4.19-5-1-s.js non-strict
-    prototype/map/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/15.4.4.19-5-1-s.js
     prototype/map/create-proto-from-ctor-realm-array.js
     prototype/map/create-proxy.js
-    prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/pop/set-length-array-is-frozen.js
     prototype/pop/set-length-array-length-is-non-writable.js
-    prototype/pop/set-length-zero-array-is-frozen.js non-strict
-    prototype/pop/set-length-zero-array-length-is-non-writable.js non-strict
-    prototype/pop/throws-with-string-receiver.js non-strict
-    prototype/push/length-near-integer-limit-set-failure.js non-strict
+    prototype/pop/set-length-zero-array-is-frozen.js
+    prototype/pop/set-length-zero-array-length-is-non-writable.js
+    prototype/pop/throws-with-string-receiver.js
+    prototype/push/length-near-integer-limit-set-failure.js
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/set-length-array-is-frozen.js
     prototype/push/set-length-array-length-is-non-writable.js
-    prototype/push/set-length-zero-array-is-frozen.js non-strict
+    prototype/push/set-length-zero-array-is-frozen.js
     prototype/push/set-length-zero-array-length-is-non-writable.js
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
-    prototype/push/throws-with-string-receiver.js non-strict
-    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
-    prototype/reduceRight/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
-    prototype/reduce/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/push/throws-with-string-receiver.js
+    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js
+    prototype/reduce/15.4.4.21-9-c-ii-4-s.js
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
-    prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/shift/set-length-array-is-frozen.js
     prototype/shift/set-length-array-length-is-non-writable.js
-    prototype/shift/set-length-zero-array-is-frozen.js non-strict
-    prototype/shift/set-length-zero-array-length-is-non-writable.js non-strict
-    prototype/shift/throws-when-this-value-length-is-writable-false.js non-strict
-    prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/shift/set-length-zero-array-is-frozen.js
+    prototype/shift/set-length-zero-array-length-is-non-writable.js
+    prototype/shift/throws-when-this-value-length-is-writable-false.js
     prototype/slice/create-proto-from-ctor-realm-array.js
     prototype/slice/create-proxy.js
     prototype/slice/create-species.js
-    prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/15.4.4.17-5-1-s.js non-strict
-    prototype/some/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/S15.4.4.11_A8.js non-strict
+    prototype/some/15.4.4.17-5-1-s.js
+    prototype/sort/S15.4.4.11_A8.js
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-proto-from-ctor-realm-array.js
     prototype/splice/create-proto-from-ctor-realm-non-array.js
@@ -590,75 +479,34 @@ built-ins/Array 263/3077 (8.55%)
     prototype/splice/create-species-length-exceeding-integer-limit.js
     prototype/splice/property-traps-order-with-species.js
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
-    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
+    prototype/splice/S15.4.4.12_A6.1_T3.js
     prototype/splice/set_length_no_args.js
     prototype/Symbol.unscopables/change-array-by-copy.js
     prototype/toLocaleString/invoke-element-tolocalestring.js
-    prototype/toLocaleString/primitive_this_value.js strict
-    prototype/toLocaleString/primitive_this_value_getter.js strict
-    prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/primitive_this_value.js
+    prototype/toLocaleString/primitive_this_value_getter.js
     prototype/toString/call-with-boolean.js
     prototype/toString/non-callable-join-string-tag.js
     prototype/unshift/set-length-array-is-frozen.js
     prototype/unshift/set-length-array-length-is-non-writable.js
-    prototype/unshift/set-length-zero-array-is-frozen.js non-strict
+    prototype/unshift/set-length-zero-array-is-frozen.js
     prototype/unshift/set-length-zero-array-length-is-non-writable.js
-    prototype/unshift/throws-with-string-receiver.js non-strict
-    prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/unshift/throws-with-string-receiver.js
     prototype/methods-called-as-functions.js
     proto-from-ctor-realm-one.js
     proto-from-ctor-realm-two.js
     proto-from-ctor-realm-zero.js
 
-built-ins/ArrayBuffer 84/192 (43.75%)
-    isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
-    isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
-    prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    prototype/detached/detached-buffer-resizable.js {unsupported: [resizable-arraybuffer]}
-    prototype/detached/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    prototype/detached/this-is-sharedarraybuffer-resizable.js {unsupported: [SharedArrayBuffer]}
-    prototype/maxByteLength 11/11 (100.0%)
-    prototype/resizable 10/10 (100.0%)
-    prototype/resize 21/21 (100.0%)
-    prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    prototype/transferToFixedLength/from-fixed-to-larger.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-fixed-to-same.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-fixed-to-smaller.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-fixed-to-zero.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-resizable-to-larger.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-resizable-to-same.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-resizable-to-smaller.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/from-resizable-to-zero.js {unsupported: [resizable-arraybuffer]}
-    prototype/transferToFixedLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    prototype/transfer/from-fixed-to-larger.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-fixed-to-same.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-fixed-to-smaller.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-fixed-to-zero.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-resizable-to-larger.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-resizable-to-same.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-resizable-to-smaller.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/from-resizable-to-zero.js {unsupported: [resizable-arraybuffer]}
-    prototype/transfer/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
-    Symbol.species 4/4 (100.0%)
+built-ins/ArrayBuffer
+    Symbol.species/length.js
+    Symbol.species/return-value.js
+    Symbol.species/symbol-species.js
+    Symbol.species/symbol-species-name.js
     data-allocation-after-object-creation.js
-    options-maxbytelength-allocation-limit.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-compared-before-object-creation.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-data-allocation-after-object-creation.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-diminuitive.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-excessive.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-negative.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-object.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-poisoned.js {unsupported: [resizable-arraybuffer]}
-    options-maxbytelength-undefined.js {unsupported: [resizable-arraybuffer]}
-    options-non-object.js {unsupported: [resizable-arraybuffer]}
     proto-from-ctor-realm.js
     prototype-from-newtarget.js
 
-built-ins/ArrayIteratorPrototype 0/27 (0.0%)
+built-ins/ArrayIteratorPrototype
 
 ~built-ins/AsyncFromSyncIteratorPrototype
 
@@ -672,7 +520,7 @@ built-ins/ArrayIteratorPrototype 0/27 (0.0%)
 
 ~built-ins/Atomics
 
-built-ins/BigInt 7/75 (9.33%)
+built-ins/BigInt
     asIntN/bigint-tobigint-errors.js
     asIntN/bits-toindex-errors.js
     asIntN/bits-toindex-wrapped-values.js
@@ -681,27 +529,16 @@ built-ins/BigInt 7/75 (9.33%)
     asUintN/bits-toindex-wrapped-values.js
     wrapper-object-ordinary-toprimitive.js
 
-built-ins/Boolean 1/51 (1.96%)
+built-ins/Boolean
     proto-from-ctor-realm.js
 
-built-ins/DataView 150/550 (27.27%)
-    prototype/buffer/return-buffer-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/buffer/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/return-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/byteLength/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
+built-ins/DataView
     prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigInt64/index-is-out-of-range.js
     prototype/getBigInt64/length.js
     prototype/getBigInt64/name.js
     prototype/getBigInt64/negative-byteoffset-throws.js
     prototype/getBigInt64/not-a-constructor.js
-    prototype/getBigInt64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigInt64/return-value-clean-arraybuffer.js
     prototype/getBigInt64/return-values.js
@@ -717,7 +554,6 @@ built-ins/DataView 150/550 (27.27%)
     prototype/getBigUint64/name.js
     prototype/getBigUint64/negative-byteoffset-throws.js
     prototype/getBigUint64/not-a-constructor.js
-    prototype/getBigUint64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigUint64/return-value-clean-arraybuffer.js
     prototype/getBigUint64/return-values.js
@@ -734,7 +570,6 @@ built-ins/DataView 150/550 (27.27%)
     prototype/getFloat16/name.js
     prototype/getFloat16/negative-byteoffset-throws.js
     prototype/getFloat16/not-a-constructor.js
-    prototype/getFloat16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getFloat16/return-abrupt-from-tonumber-byteoffset.js
     prototype/getFloat16/return-infinity.js
     prototype/getFloat16/return-nan.js
@@ -743,24 +578,6 @@ built-ins/DataView 150/550 (27.27%)
     prototype/getFloat16/return-values-custom-offset.js
     prototype/getFloat16/to-boolean-littleendian.js
     prototype/getFloat16/toindex-byteoffset.js
-    prototype/getFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/return-value-clean-arraybuffer-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/return-values-custom-offset-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/return-values-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/to-boolean-littleendian-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt32/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/getInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/getUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setBigInt64/detached-buffer-after-bigint-value.js
     prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/setBigInt64/index-check-before-value-conversion.js
@@ -770,14 +587,13 @@ built-ins/DataView 150/550 (27.27%)
     prototype/setBigInt64/negative-byteoffset-throws.js
     prototype/setBigInt64/not-a-constructor.js
     prototype/setBigInt64/range-check-after-value-conversion.js
-    prototype/setBigInt64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setBigInt64/return-abrupt-from-tobigint-value.js
     prototype/setBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/setBigInt64/set-values-little-endian-order.js
     prototype/setBigInt64/set-values-return-undefined.js
     prototype/setBigInt64/to-boolean-littleendian.js
     prototype/setBigInt64/toindex-byteoffset.js
-    prototype/setBigUint64 2/2 (100.0%)
+    prototype/setBigUint64/not-a-constructor.js
     prototype/setFloat16/detached-buffer-after-number-value.js
     prototype/setFloat16/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat16/index-check-before-value-conversion.js
@@ -788,54 +604,18 @@ built-ins/DataView 150/550 (27.27%)
     prototype/setFloat16/no-value-arg.js
     prototype/setFloat16/not-a-constructor.js
     prototype/setFloat16/range-check-after-value-conversion.js
-    prototype/setFloat16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setFloat16/return-abrupt-from-tonumber-byteoffset.js
     prototype/setFloat16/return-abrupt-from-tonumber-value.js
     prototype/setFloat16/set-values-little-endian-order.js
     prototype/setFloat16/set-values-return-undefined.js
     prototype/setFloat16/to-boolean-littleendian.js
     prototype/setFloat16/toindex-byteoffset.js
-    prototype/setFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/setUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
-    byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     custom-proto-access-detaches-buffer.js
-    custom-proto-access-resizes-buffer-invalid-by-length.js {unsupported: [resizable-arraybuffer]}
-    custom-proto-access-resizes-buffer-invalid-by-offset.js {unsupported: [resizable-arraybuffer]}
-    custom-proto-access-resizes-buffer-valid-by-length.js {unsupported: [resizable-arraybuffer]}
-    custom-proto-access-resizes-buffer-valid-by-offset.js {unsupported: [resizable-arraybuffer]}
     custom-proto-access-throws.js
-    custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    custom-proto-if-not-object-fallbacks-to-default-prototype-sab.js {unsupported: [SharedArrayBuffer]}
     custom-proto-if-object-is-used.js
-    custom-proto-if-object-is-used-sab.js {unsupported: [SharedArrayBuffer]}
-    defined-bytelength-and-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    defined-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    defined-byteoffset-undefined-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    excessive-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    excessive-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
-    negative-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    newtarget-undefined-throws-sab.js {unsupported: [SharedArrayBuffer]}
     proto-from-ctor-realm.js
-    proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
-    return-abrupt-tonumber-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    return-abrupt-tonumber-bytelength-symbol-sab.js {unsupported: [SharedArrayBuffer]}
-    return-abrupt-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    return-abrupt-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
-    return-instance-sab.js {unsupported: [SharedArrayBuffer]}
-    toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
 
-built-ins/Date 85/594 (14.31%)
+built-ins/Date
     now/not-a-constructor.js
     parse/not-a-constructor.js
     parse/year-zero.js
@@ -900,7 +680,14 @@ built-ins/Date 85/594 (14.31%)
     prototype/toLocaleTimeString/not-a-constructor.js
     prototype/toString/non-date-receiver.js
     prototype/toString/not-a-constructor.js
-    prototype/toTemporalInstant 8/8 (100.0%)
+    prototype/toTemporalInstant/length.js
+    prototype/toTemporalInstant/name.js
+    prototype/toTemporalInstant/not-a-constructor.js
+    prototype/toTemporalInstant/prop-desc.js
+    prototype/toTemporalInstant/this-value-invalid-date.js
+    prototype/toTemporalInstant/this-value-non-date.js
+    prototype/toTemporalInstant/this-value-non-object.js
+    prototype/toTemporalInstant/this-value-valid-date.js
     prototype/toTimeString/not-a-constructor.js
     prototype/toUTCString/not-a-constructor.js
     prototype/valueOf/not-a-constructor.js
@@ -915,8 +702,18 @@ built-ins/Date 85/594 (14.31%)
     proto-from-ctor-realm-zero.js
     year-zero.js
 
-built-ins/Error 17/53 (32.08%)
-    isError 12/12 (100.0%)
+built-ins/Error
+    isError/bigints.js
+    isError/errors.js
+    isError/errors-other-realm.js
+    isError/fake-errors.js
+    isError/is-a-constructor.js
+    isError/name.js
+    isError/non-error-objects.js
+    isError/non-error-objects-other-realm.js
+    isError/primitives.js
+    isError/prop-desc.js
+    isError/symbols.js
     prototype/toString/not-a-constructor.js
     prototype/no-error-data.js
     prototype/S15.11.4_A2.js
@@ -925,24 +722,19 @@ built-ins/Error 17/53 (32.08%)
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function 128/509 (25.15%)
-    internals/Call 2/2 (100.0%)
-    internals/Construct 6/6 (100.0%)
-    prototype/apply/15.3.4.3-1-s.js strict
-    prototype/apply/15.3.4.3-2-s.js strict
-    prototype/apply/15.3.4.3-3-s.js strict
+built-ins/Function
+    internals/Construct/base-ctor-revoked-proxy.js
+    internals/Construct/base-ctor-revoked-proxy-realm.js
+    prototype/apply/15.3.4.3-1-s.js
+    prototype/apply/15.3.4.3-2-s.js
+    prototype/apply/15.3.4.3-3-s.js
     prototype/apply/argarray-not-object.js
     prototype/apply/argarray-not-object-realm.js
-    prototype/apply/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/apply/this-not-callable-realm.js
     prototype/arguments/prop-desc.js
     prototype/bind/BoundFunction_restricted-properties.js
     prototype/bind/get-fn-realm.js
     prototype/bind/get-fn-realm-recursive.js
-    prototype/bind/instance-construct-newtarget-boundtarget.js {unsupported: [new.target]}
-    prototype/bind/instance-construct-newtarget-boundtarget-bound.js {unsupported: [new.target]}
-    prototype/bind/instance-construct-newtarget-self-new.js {unsupported: [new.target]}
-    prototype/bind/instance-construct-newtarget-self-reflect.js {unsupported: [new.target]}
     prototype/bind/instance-length-exceeds-int32.js
     prototype/bind/instance-length-tointeger.js
     prototype/bind/instance-name.js
@@ -951,27 +743,10 @@ built-ins/Function 128/509 (25.15%)
     prototype/bind/proto-from-ctor-realm.js
     prototype/caller-arguments/accessor-properties.js
     prototype/caller/prop-desc.js
-    prototype/call/15.3.4.4-1-s.js strict
-    prototype/call/15.3.4.4-2-s.js strict
-    prototype/call/15.3.4.4-3-s.js strict
+    prototype/call/15.3.4.4-1-s.js
+    prototype/call/15.3.4.4-2-s.js
+    prototype/call/15.3.4.4-3-s.js
     prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
-    prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
-    prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
-    prototype/toString/async-function-expression.js {unsupported: [async-functions]}
-    prototype/toString/async-generator-declaration.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-expression.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-class-expression.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-class-expression-static.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-class-statement.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-class-statement-static.js {unsupported: [async-iteration]}
-    prototype/toString/async-generator-method-object.js {unsupported: [async-iteration]}
-    prototype/toString/async-method-class-expression.js {unsupported: [async-functions]}
-    prototype/toString/async-method-class-expression-static.js {unsupported: [async-functions]}
-    prototype/toString/async-method-class-statement.js {unsupported: [async-functions]}
-    prototype/toString/async-method-class-statement-static.js {unsupported: [async-functions]}
-    prototype/toString/async-method-object.js {unsupported: [async-functions]}
-    prototype/toString/AsyncFunction.js {unsupported: [async-functions]}
-    prototype/toString/AsyncGenerator.js {unsupported: [async-iteration]}
     prototype/toString/bound-function.js
     prototype/toString/built-in-function-object.js
     prototype/toString/class-declaration-complex-heritage.js
@@ -998,12 +773,7 @@ built-ins/Function 128/509 (25.15%)
     prototype/toString/private-static-method-class-expression.js
     prototype/toString/private-static-method-class-statement.js
     prototype/toString/proxy-arrow-function.js
-    prototype/toString/proxy-async-function.js {unsupported: [async-functions]}
-    prototype/toString/proxy-async-generator-function.js {unsupported: [async-iteration]}
-    prototype/toString/proxy-async-generator-method-definition.js {unsupported: [async-iteration]}
-    prototype/toString/proxy-async-method-definition.js {unsupported: [async-functions]}
     prototype/toString/proxy-bound-function.js
-    prototype/toString/proxy-class.js {unsupported: [class]}
     prototype/toString/proxy-function-expression.js
     prototype/toString/proxy-generator-function.js
     prototype/toString/proxy-method-definition.js
@@ -1013,43 +783,42 @@ built-ins/Function 128/509 (25.15%)
     prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
-    15.3.2.1-10-6gs.js non-strict
-    15.3.2.1-11-1-s.js non-strict
-    15.3.2.1-11-3-s.js non-strict
-    15.3.2.1-11-5-s.js non-strict
-    15.3.5-1gs.js strict
-    15.3.5-2gs.js strict
-    15.3.5.4_2-11gs.js strict
-    15.3.5.4_2-13gs.js strict
-    15.3.5.4_2-15gs.js strict
-    15.3.5.4_2-17gs.js strict
-    15.3.5.4_2-19gs.js strict
-    15.3.5.4_2-1gs.js strict
-    15.3.5.4_2-21gs.js strict
-    15.3.5.4_2-22gs.js strict
-    15.3.5.4_2-23gs.js strict
-    15.3.5.4_2-24gs.js strict
-    15.3.5.4_2-25gs.js strict
-    15.3.5.4_2-26gs.js strict
-    15.3.5.4_2-27gs.js strict
-    15.3.5.4_2-28gs.js strict
-    15.3.5.4_2-29gs.js strict
-    15.3.5.4_2-3gs.js strict
-    15.3.5.4_2-48gs.js strict
-    15.3.5.4_2-50gs.js strict
-    15.3.5.4_2-52gs.js strict
-    15.3.5.4_2-54gs.js strict
-    15.3.5.4_2-5gs.js strict
-    15.3.5.4_2-7gs.js strict
-    15.3.5.4_2-9gs.js strict
+    15.3.2.1-10-6gs.js
+    15.3.2.1-11-1-s.js
+    15.3.2.1-11-3-s.js
+    15.3.2.1-11-5-s.js
+    15.3.5-1gs.js
+    15.3.5-2gs.js
+    15.3.5.4_2-11gs.js
+    15.3.5.4_2-13gs.js
+    15.3.5.4_2-15gs.js
+    15.3.5.4_2-17gs.js
+    15.3.5.4_2-19gs.js
+    15.3.5.4_2-1gs.js
+    15.3.5.4_2-21gs.js
+    15.3.5.4_2-22gs.js
+    15.3.5.4_2-23gs.js
+    15.3.5.4_2-24gs.js
+    15.3.5.4_2-25gs.js
+    15.3.5.4_2-26gs.js
+    15.3.5.4_2-27gs.js
+    15.3.5.4_2-28gs.js
+    15.3.5.4_2-29gs.js
+    15.3.5.4_2-3gs.js
+    15.3.5.4_2-48gs.js
+    15.3.5.4_2-50gs.js
+    15.3.5.4_2-52gs.js
+    15.3.5.4_2-54gs.js
+    15.3.5.4_2-5gs.js
+    15.3.5.4_2-7gs.js
+    15.3.5.4_2-9gs.js
     call-bind-this-realm-undef.js
     call-bind-this-realm-value.js
-    private-identifiers-not-empty.js {unsupported: [class-fields-private]}
     proto-from-ctor-realm.js
     proto-from-ctor-realm-prototype.js
-    StrictFunction_restricted-properties.js strict
+    StrictFunction_restricted-properties.js
 
-built-ins/GeneratorFunction 8/23 (34.78%)
+built-ins/GeneratorFunction
     prototype/constructor.js
     prototype/prototype.js
     prototype/Symbol.toStringTag.js
@@ -1059,7 +828,7 @@ built-ins/GeneratorFunction 8/23 (34.78%)
     name.js
     proto-from-ctor-realm-prototype.js
 
-built-ins/GeneratorPrototype 31/61 (50.82%)
+built-ins/GeneratorPrototype
     next/from-state-executing.js
     next/length.js
     next/not-a-constructor.js
@@ -1092,10 +861,15 @@ built-ins/GeneratorPrototype 31/61 (50.82%)
     constructor.js
     Symbol.toStringTag.js
 
-built-ins/Infinity 0/6 (0.0%)
+built-ins/Infinity
 
-built-ins/JSON 45/165 (27.27%)
-    isRawJSON 6/6 (100.0%)
+built-ins/JSON
+    isRawJSON/basic.js
+    isRawJSON/builtin.js
+    isRawJSON/length.js
+    isRawJSON/name.js
+    isRawJSON/not-a-constructor.js
+    isRawJSON/prop-desc.js
     parse/builtin.js
     parse/revived-proxy.js
     parse/reviver-array-define-prop-err.js
@@ -1111,9 +885,18 @@ built-ins/JSON 45/165 (27.27%)
     parse/reviver-object-define-prop-err.js
     parse/reviver-object-get-prop-from-prototype.js
     parse/reviver-object-non-configurable-prop-create.js
-    parse/reviver-object-non-configurable-prop-delete.js strict
+    parse/reviver-object-non-configurable-prop-delete.js
     parse/text-negative-zero.js
-    rawJSON 10/10 (100.0%)
+    rawJSON/basic.js
+    rawJSON/bigint-raw-json-can-be-stringified.js
+    rawJSON/builtin.js
+    rawJSON/illegal-empty-and-start-end-chars.js
+    rawJSON/invalid-JSON-text.js
+    rawJSON/length.js
+    rawJSON/name.js
+    rawJSON/not-a-constructor.js
+    rawJSON/prop-desc.js
+    rawJSON/returns-expected-object.js
     stringify/builtin.js
     stringify/replacer-array-abrupt.js
     stringify/replacer-array-proxy.js
@@ -1127,7 +910,7 @@ built-ins/JSON 45/165 (27.27%)
     stringify/value-bigint-tojson-receiver.js
     stringify/value-object-proxy.js
 
-built-ins/Map 12/185 (6.49%)
+built-ins/Map
     prototype/getOrInsert/append-new-values.js
     prototype/getOrInsert/append-new-values-normalizes-zero-key.js
     prototype/getOrInsert/append-value-if-key-is-not-present-different-key-types.js
@@ -1141,16 +924,29 @@ built-ins/Map 12/185 (6.49%)
     proto-from-ctor-realm.js
     valid-keys.js
 
-built-ins/MapIteratorPrototype 0/11 (0.0%)
+built-ins/MapIteratorPrototype
 
-built-ins/Math 16/327 (4.89%)
-    f16round 5/5 (100.0%)
+built-ins/Math
+    f16round/length.js
+    f16round/name.js
+    f16round/not-a-constructor.js
+    f16round/prop-desc.js
+    f16round/value-conversion.js
     log2/log2-basicTests.js calculation is not exact
-    sumPrecise 10/10 (100.0%)
+    sumPrecise/length.js
+    sumPrecise/name.js
+    sumPrecise/not-a-constructor.js
+    sumPrecise/prop-desc.js
+    sumPrecise/sum.js
+    sumPrecise/sum-is-infinite.js
+    sumPrecise/sum-is-minus-zero.js
+    sumPrecise/sum-is-NaN.js
+    sumPrecise/takes-iterable.js
+    sumPrecise/throws-on-non-number.js
 
-built-ins/NaN 0/6 (0.0%)
+built-ins/NaN
 
-built-ins/NativeErrors 36/139 (25.9%)
+built-ins/NativeErrors
     AggregateError/newtarget-proto-fallback.js
     AggregateError/proto-from-ctor-realm.js
     EvalError/prototype/not-error-object.js
@@ -1159,8 +955,28 @@ built-ins/NativeErrors 36/139 (25.9%)
     RangeError/proto-from-ctor-realm.js
     ReferenceError/prototype/not-error-object.js
     ReferenceError/proto-from-ctor-realm.js
-    SuppressedError/prototype 6/6 (100.0%)
-    SuppressedError 16/16 (100.0%)
+    SuppressedError/prototype/constructor.js
+    SuppressedError/prototype/errors-absent-on-prototype.js
+    SuppressedError/prototype/message.js
+    SuppressedError/prototype/name.js
+    SuppressedError/prototype/prop-desc.js
+    SuppressedError/prototype/proto.js
+    SuppressedError/is-a-constructor.js
+    SuppressedError/length.js
+    SuppressedError/message-method-prop.js
+    SuppressedError/message-method-prop-cast.js
+    SuppressedError/message-tostring-abrupt.js
+    SuppressedError/message-tostring-abrupt-symbol.js
+    SuppressedError/message-undefined-no-prop.js
+    SuppressedError/name.js
+    SuppressedError/newtarget-is-undefined.js
+    SuppressedError/newtarget-proto.js
+    SuppressedError/newtarget-proto-custom.js
+    SuppressedError/newtarget-proto-fallback.js
+    SuppressedError/order-of-args-evaluation.js
+    SuppressedError/prop-desc.js
+    SuppressedError/proto.js
+    SuppressedError/proto-from-ctor-realm.js
     SyntaxError/prototype/not-error-object.js
     SyntaxError/proto-from-ctor-realm.js
     TypeError/prototype/not-error-object.js
@@ -1168,30 +984,27 @@ built-ins/NativeErrors 36/139 (25.9%)
     URIError/prototype/not-error-object.js
     URIError/proto-from-ctor-realm.js
 
-built-ins/Number 8/335 (2.39%)
+built-ins/Number
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/undefined-fractiondigits.js
     prototype/toPrecision/nan.js
     proto-from-ctor-realm.js
-    S9.3.1_A2_U180E.js {unsupported: [u180e]}
-    S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
-    S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 120/3410 (3.52%)
+built-ins/Object
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order-proxy.js
-    defineProperties/15.2.3.7-6-a-112.js non-strict
-    defineProperties/15.2.3.7-6-a-113.js non-strict
+    defineProperties/15.2.3.7-6-a-112.js
+    defineProperties/15.2.3.7-6-a-113.js
     defineProperties/15.2.3.7-6-a-164.js
     defineProperties/15.2.3.7-6-a-165.js
-    defineProperties/15.2.3.7-6-a-166.js non-strict
-    defineProperties/15.2.3.7-6-a-168.js non-strict
-    defineProperties/15.2.3.7-6-a-169.js non-strict
-    defineProperties/15.2.3.7-6-a-170.js non-strict
-    defineProperties/15.2.3.7-6-a-172.js non-strict
-    defineProperties/15.2.3.7-6-a-173.js non-strict
+    defineProperties/15.2.3.7-6-a-166.js
+    defineProperties/15.2.3.7-6-a-168.js
+    defineProperties/15.2.3.7-6-a-169.js
+    defineProperties/15.2.3.7-6-a-170.js
+    defineProperties/15.2.3.7-6-a-172.js
+    defineProperties/15.2.3.7-6-a-173.js
     defineProperties/15.2.3.7-6-a-175.js
     defineProperties/15.2.3.7-6-a-176.js
     defineProperties/15.2.3.7-6-a-184.js
@@ -1199,32 +1012,27 @@ built-ins/Object 120/3410 (3.52%)
     defineProperties/15.2.3.7-6-a-282.js
     defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js
-    defineProperties/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    defineProperty/15.2.3.6-4-116.js non-strict
-    defineProperty/15.2.3.6-4-117.js non-strict
+    defineProperty/15.2.3.6-4-116.js
+    defineProperty/15.2.3.6-4-117.js
     defineProperty/15.2.3.6-4-168.js
     defineProperty/15.2.3.6-4-169.js
-    defineProperty/15.2.3.6-4-170.js non-strict
-    defineProperty/15.2.3.6-4-172.js non-strict
-    defineProperty/15.2.3.6-4-173.js non-strict
-    defineProperty/15.2.3.6-4-174.js non-strict
-    defineProperty/15.2.3.6-4-176.js non-strict
-    defineProperty/15.2.3.6-4-177.js non-strict
+    defineProperty/15.2.3.6-4-170.js
+    defineProperty/15.2.3.6-4-172.js
+    defineProperty/15.2.3.6-4-173.js
+    defineProperty/15.2.3.6-4-174.js
+    defineProperty/15.2.3.6-4-176.js
+    defineProperty/15.2.3.6-4-177.js
     defineProperty/15.2.3.6-4-188.js
     defineProperty/15.2.3.6-4-189.js
     defineProperty/15.2.3.6-4-254.js
     defineProperty/15.2.3.6-4-293-1.js
-    defineProperty/15.2.3.6-4-293-3.js non-strict
-    defineProperty/15.2.3.6-4-293-4.js strict
+    defineProperty/15.2.3.6-4-293-3.js
+    defineProperty/15.2.3.6-4-293-4.js
     defineProperty/15.2.3.6-4-336.js
-    defineProperty/coerced-P-grow.js {unsupported: [resizable-arraybuffer]}
-    defineProperty/coerced-P-shrink.js {unsupported: [resizable-arraybuffer]}
     defineProperty/property-description-must-be-an-object-not-symbol.js
-    defineProperty/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     entries/observable-operations.js
     freeze/proxy-no-ownkeys-returned-keys-order.js
     freeze/proxy-with-defineProperty-handler.js
-    freeze/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     getOwnPropertyDescriptors/order-after-define-property.js
     getOwnPropertyDescriptors/proxy-no-ownkeys-returned-keys-order.js
     getOwnPropertyDescriptors/proxy-undefined-descriptor.js
@@ -1268,17 +1076,14 @@ built-ins/Object 120/3410 (3.52%)
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    prototype/toLocaleString/primitive_this_value.js strict
-    prototype/toLocaleString/primitive_this_value_getter.js strict
-    prototype/toString/proxy-function.js {unsupported: [async-functions]}
-    prototype/toString/proxy-function-async.js {unsupported: [async-functions]}
+    prototype/toLocaleString/primitive_this_value.js
+    prototype/toLocaleString/primitive_this_value_getter.js
     prototype/toString/proxy-revoked-during-get-call.js
     prototype/toString/symbol-tag-array-builtin.js
     prototype/toString/symbol-tag-generators-builtin.js
     prototype/toString/symbol-tag-map-builtin.js
     prototype/toString/symbol-tag-non-str-bigint.js
     prototype/toString/symbol-tag-non-str-builtin.js
-    prototype/toString/symbol-tag-non-str-proxy-function.js {unsupported: [async-functions]}
     prototype/toString/symbol-tag-promise-builtin.js
     prototype/toString/symbol-tag-set-builtin.js
     prototype/toString/symbol-tag-string-builtin.js
@@ -1294,412 +1099,38 @@ built-ins/Object 120/3410 (3.52%)
     seal/seal-asyncfunction.js
     seal/seal-asyncgeneratorfunction.js
     seal/seal-finalizationregistry.js
-    seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     seal/seal-weakref.js
     values/observable-operations.js
     proto-from-ctor-realm.js
-    subclass-object-arg.js {unsupported: [class]}
 
-built-ins/Promise 375/631 (59.43%)
-    allSettled/capability-resolve-throws-reject.js {unsupported: [async]}
-    allSettled/ctx-ctor.js {unsupported: [class]}
-    allSettled/does-not-invoke-array-setters.js {unsupported: [async]}
-    allSettled/invoke-resolve-error-reject.js {unsupported: [async]}
-    allSettled/invoke-resolve-get-error.js {unsupported: [async]}
-    allSettled/invoke-resolve-get-error-reject.js {unsupported: [async]}
-    allSettled/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
-    allSettled/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
-    allSettled/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
-    allSettled/invoke-then-error-reject.js {unsupported: [async]}
-    allSettled/invoke-then-get-error-reject.js {unsupported: [async]}
-    allSettled/iter-arg-is-false-reject.js {unsupported: [async]}
-    allSettled/iter-arg-is-null-reject.js {unsupported: [async]}
-    allSettled/iter-arg-is-number-reject.js {unsupported: [async]}
-    allSettled/iter-arg-is-poisoned.js {unsupported: [async]}
-    allSettled/iter-arg-is-string-resolve.js {unsupported: [async]}
-    allSettled/iter-arg-is-symbol-reject.js {unsupported: [async]}
-    allSettled/iter-arg-is-true-reject.js {unsupported: [async]}
-    allSettled/iter-arg-is-undefined-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-false-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-null-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-number-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-string-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-symbol-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-true-reject.js {unsupported: [async]}
-    allSettled/iter-assigned-undefined-reject.js {unsupported: [async]}
-    allSettled/iter-next-err-reject.js {unsupported: [async]}
-    allSettled/iter-next-val-err-reject.js {unsupported: [async]}
-    allSettled/iter-returns-false-reject.js {unsupported: [async]}
-    allSettled/iter-returns-null-reject.js {unsupported: [async]}
-    allSettled/iter-returns-number-reject.js {unsupported: [async]}
-    allSettled/iter-returns-string-reject.js {unsupported: [async]}
-    allSettled/iter-returns-symbol-reject.js {unsupported: [async]}
-    allSettled/iter-returns-true-reject.js {unsupported: [async]}
-    allSettled/iter-returns-undefined-reject.js {unsupported: [async]}
-    allSettled/iter-step-err-reject.js {unsupported: [async]}
-    allSettled/reject-deferred.js {unsupported: [async]}
-    allSettled/reject-ignored-deferred.js {unsupported: [async]}
-    allSettled/reject-ignored-immed.js {unsupported: [async]}
-    allSettled/reject-immed.js {unsupported: [async]}
-    allSettled/resolve-ignores-late-rejection.js {unsupported: [async]}
-    allSettled/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
-    allSettled/resolve-non-callable.js {unsupported: [async]}
-    allSettled/resolve-non-thenable.js {unsupported: [async]}
-    allSettled/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
-    allSettled/resolve-poisoned-then.js {unsupported: [async]}
-    allSettled/resolve-thenable.js {unsupported: [async]}
-    allSettled/resolved-all-fulfilled.js {unsupported: [async]}
-    allSettled/resolved-all-mixed.js {unsupported: [async]}
-    allSettled/resolved-all-rejected.js {unsupported: [async]}
-    allSettled/resolved-immed.js {unsupported: [async]}
-    allSettled/resolved-sequence.js {unsupported: [async]}
-    allSettled/resolved-sequence-extra-ticks.js {unsupported: [async]}
-    allSettled/resolved-sequence-mixed.js {unsupported: [async]}
-    allSettled/resolved-sequence-with-rejections.js {unsupported: [async]}
-    allSettled/resolved-then-catch-finally.js {unsupported: [async]}
-    allSettled/resolves-empty-array.js {unsupported: [async]}
-    allSettled/resolves-to-array.js {unsupported: [async]}
-    all/capability-resolve-throws-reject.js {unsupported: [async]}
-    all/ctx-ctor.js {unsupported: [class]}
-    all/does-not-invoke-array-setters.js {unsupported: [async]}
-    all/invoke-resolve-error-reject.js {unsupported: [async]}
-    all/invoke-resolve-get-error.js {unsupported: [async]}
-    all/invoke-resolve-get-error-reject.js {unsupported: [async]}
-    all/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
-    all/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
-    all/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
-    all/invoke-then-error-reject.js {unsupported: [async]}
-    all/invoke-then-get-error-reject.js {unsupported: [async]}
-    all/iter-arg-is-false-reject.js {unsupported: [async]}
-    all/iter-arg-is-null-reject.js {unsupported: [async]}
-    all/iter-arg-is-number-reject.js {unsupported: [async]}
-    all/iter-arg-is-string-resolve.js {unsupported: [async]}
-    all/iter-arg-is-symbol-reject.js {unsupported: [async]}
-    all/iter-arg-is-true-reject.js {unsupported: [async]}
-    all/iter-arg-is-undefined-reject.js {unsupported: [async]}
-    all/iter-assigned-false-reject.js {unsupported: [async]}
-    all/iter-assigned-null-reject.js {unsupported: [async]}
-    all/iter-assigned-number-reject.js {unsupported: [async]}
-    all/iter-assigned-string-reject.js {unsupported: [async]}
-    all/iter-assigned-symbol-reject.js {unsupported: [async]}
-    all/iter-assigned-true-reject.js {unsupported: [async]}
-    all/iter-assigned-undefined-reject.js {unsupported: [async]}
-    all/iter-next-val-err-reject.js {unsupported: [async]}
-    all/iter-returns-false-reject.js {unsupported: [async]}
-    all/iter-returns-null-reject.js {unsupported: [async]}
-    all/iter-returns-number-reject.js {unsupported: [async]}
-    all/iter-returns-string-reject.js {unsupported: [async]}
-    all/iter-returns-symbol-reject.js {unsupported: [async]}
-    all/iter-returns-true-reject.js {unsupported: [async]}
-    all/iter-returns-undefined-reject.js {unsupported: [async]}
-    all/iter-step-err-reject.js {unsupported: [async]}
-    all/reject-deferred.js {unsupported: [async]}
-    all/reject-ignored-deferred.js {unsupported: [async]}
-    all/reject-ignored-immed.js {unsupported: [async]}
-    all/reject-immed.js {unsupported: [async]}
-    all/resolve-ignores-late-rejection.js {unsupported: [async]}
-    all/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
-    all/resolve-non-callable.js {unsupported: [async]}
-    all/resolve-non-thenable.js {unsupported: [async]}
-    all/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
-    all/resolve-poisoned-then.js {unsupported: [async]}
-    all/resolve-thenable.js {unsupported: [async]}
-    all/S25.4.4.1_A2.2_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A2.3_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A2.3_T2.js {unsupported: [async]}
-    all/S25.4.4.1_A2.3_T3.js {unsupported: [async]}
-    all/S25.4.4.1_A3.1_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A3.1_T2.js {unsupported: [async]}
-    all/S25.4.4.1_A3.1_T3.js {unsupported: [async]}
-    all/S25.4.4.1_A5.1_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A7.1_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A7.2_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A8.1_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A8.2_T1.js {unsupported: [async]}
-    all/S25.4.4.1_A8.2_T2.js {unsupported: [async]}
-    any/capability-reject-throws-no-close.js {unsupported: [async]}
-    any/capability-resolve-throws-no-close.js {unsupported: [async]}
-    any/capability-resolve-throws-reject.js {unsupported: [async]}
-    any/ctx-ctor.js {unsupported: [class]}
-    any/invoke-resolve.js {unsupported: [async]}
-    any/invoke-resolve-error-close.js {unsupported: [async]}
-    any/invoke-resolve-error-reject.js {unsupported: [async]}
-    any/invoke-resolve-get-error.js {unsupported: [async]}
-    any/invoke-resolve-get-error-reject.js {unsupported: [async]}
-    any/invoke-resolve-get-once-multiple-calls.js {unsupported: [async]}
-    any/invoke-resolve-get-once-no-calls.js {unsupported: [async]}
-    any/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
-    any/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
-    any/invoke-resolve-on-values-every-iteration-of-custom.js {unsupported: [class, async]}
-    any/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
-    any/invoke-then.js {unsupported: [async]}
-    any/invoke-then-error-close.js {unsupported: [async]}
-    any/invoke-then-error-reject.js {unsupported: [async]}
-    any/invoke-then-get-error-close.js {unsupported: [async]}
-    any/invoke-then-get-error-reject.js {unsupported: [async]}
-    any/invoke-then-on-promises-every-iteration.js {unsupported: [async]}
-    any/iter-arg-is-empty-iterable-reject.js {unsupported: [async]}
-    any/iter-arg-is-empty-string-reject.js {unsupported: [async]}
-    any/iter-arg-is-error-object-reject.js {unsupported: [async]}
-    any/iter-arg-is-false-reject.js {unsupported: [async]}
-    any/iter-arg-is-null-reject.js {unsupported: [async]}
-    any/iter-arg-is-number-reject.js {unsupported: [async]}
-    any/iter-arg-is-poisoned.js {unsupported: [async]}
-    any/iter-arg-is-string-resolve.js {unsupported: [async]}
-    any/iter-arg-is-symbol-reject.js {unsupported: [async]}
-    any/iter-arg-is-true-reject.js {unsupported: [async]}
-    any/iter-arg-is-undefined-reject.js {unsupported: [async]}
-    any/iter-assigned-false-reject.js {unsupported: [async]}
-    any/iter-assigned-null-reject.js {unsupported: [async]}
-    any/iter-assigned-number-reject.js {unsupported: [async]}
-    any/iter-assigned-string-reject.js {unsupported: [async]}
-    any/iter-assigned-symbol-reject.js {unsupported: [async]}
-    any/iter-assigned-true-reject.js {unsupported: [async]}
-    any/iter-assigned-undefined-reject.js {unsupported: [async]}
-    any/iter-next-val-err-no-close.js {unsupported: [async]}
-    any/iter-next-val-err-reject.js {unsupported: [async]}
-    any/iter-returns-false-reject.js {unsupported: [async]}
-    any/iter-returns-null-reject.js {unsupported: [async]}
-    any/iter-returns-number-reject.js {unsupported: [async]}
-    any/iter-returns-string-reject.js {unsupported: [async]}
-    any/iter-returns-symbol-reject.js {unsupported: [async]}
-    any/iter-returns-true-reject.js {unsupported: [async]}
-    any/iter-returns-undefined-reject.js {unsupported: [async]}
-    any/iter-step-err-no-close.js {unsupported: [async]}
-    any/iter-step-err-reject.js {unsupported: [async]}
-    any/reject-all-mixed.js {unsupported: [async]}
-    any/reject-deferred.js {unsupported: [async]}
-    any/reject-ignored-deferred.js {unsupported: [async]}
-    any/reject-ignored-immed.js {unsupported: [async]}
-    any/reject-immed.js {unsupported: [async]}
-    any/resolve-from-reject-catch.js {unsupported: [async]}
-    any/resolve-from-resolve-reject-catch.js {unsupported: [async]}
-    any/resolve-ignores-late-rejection.js {unsupported: [async]}
-    any/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
-    any/resolve-non-callable.js {unsupported: [async]}
-    any/resolve-non-thenable.js {unsupported: [async]}
-    any/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
-    any/resolved-sequence.js {unsupported: [async]}
-    any/resolved-sequence-extra-ticks.js {unsupported: [async]}
-    any/resolved-sequence-mixed.js {unsupported: [async]}
-    any/resolved-sequence-with-rejections.js {unsupported: [async]}
-    prototype/catch/S25.4.5.1_A3.1_T1.js {unsupported: [async]}
-    prototype/catch/S25.4.5.1_A3.1_T2.js {unsupported: [async]}
-    prototype/finally/rejected-observable-then-calls.js {unsupported: [async]}
-    prototype/finally/rejected-observable-then-calls-argument.js {unsupported: [class, async]}
-    prototype/finally/rejected-observable-then-calls-PromiseResolve.js {unsupported: [async]}
-    prototype/finally/rejection-reason-no-fulfill.js {unsupported: [async]}
-    prototype/finally/rejection-reason-override-with-throw.js {unsupported: [async]}
-    prototype/finally/resolution-value-no-override.js {unsupported: [async]}
-    prototype/finally/resolved-observable-then-calls.js {unsupported: [async]}
-    prototype/finally/resolved-observable-then-calls-argument.js {unsupported: [async]}
-    prototype/finally/resolved-observable-then-calls-PromiseResolve.js {unsupported: [async]}
-    prototype/finally/species-constructor.js {unsupported: [async]}
-    prototype/finally/subclass-reject-count.js {unsupported: [async]}
-    prototype/finally/subclass-resolve-count.js {unsupported: [async]}
+built-ins/Promise
     prototype/finally/subclass-species-constructor-reject-count.js
     prototype/finally/subclass-species-constructor-resolve-count.js
-    prototype/then/capability-executor-called-twice.js {unsupported: [class]}
-    prototype/then/capability-executor-not-callable.js {unsupported: [class]}
-    prototype/then/ctor-access-count.js {unsupported: [async]}
-    prototype/then/ctor-custom.js {unsupported: [class]}
-    prototype/then/deferred-is-resolved-value.js {unsupported: [class, async]}
-    prototype/then/prfm-fulfilled.js {unsupported: [async]}
-    prototype/then/prfm-pending-fulfulled.js {unsupported: [async]}
-    prototype/then/prfm-pending-rejected.js {unsupported: [async]}
-    prototype/then/prfm-rejected.js {unsupported: [async]}
-    prototype/then/reject-pending-fulfilled.js {unsupported: [async]}
-    prototype/then/reject-pending-rejected.js {unsupported: [async]}
-    prototype/then/reject-settled-fulfilled.js {unsupported: [async]}
-    prototype/then/reject-settled-rejected.js {unsupported: [async]}
-    prototype/then/resolve-pending-fulfilled-non-obj.js {unsupported: [async]}
-    prototype/then/resolve-pending-fulfilled-non-thenable.js {unsupported: [async]}
-    prototype/then/resolve-pending-fulfilled-poisoned-then.js {unsupported: [async]}
-    prototype/then/resolve-pending-fulfilled-prms-cstm-then.js {unsupported: [async]}
-    prototype/then/resolve-pending-fulfilled-self.js {unsupported: [async]}
-    prototype/then/resolve-pending-fulfilled-thenable.js {unsupported: [async]}
-    prototype/then/resolve-pending-rejected-non-obj.js {unsupported: [async]}
-    prototype/then/resolve-pending-rejected-non-thenable.js {unsupported: [async]}
-    prototype/then/resolve-pending-rejected-poisoned-then.js {unsupported: [async]}
-    prototype/then/resolve-pending-rejected-prms-cstm-then.js {unsupported: [async]}
-    prototype/then/resolve-pending-rejected-self.js {unsupported: [async]}
-    prototype/then/resolve-pending-rejected-thenable.js {unsupported: [async]}
-    prototype/then/resolve-settled-fulfilled-non-obj.js {unsupported: [async]}
-    prototype/then/resolve-settled-fulfilled-non-thenable.js {unsupported: [async]}
-    prototype/then/resolve-settled-fulfilled-poisoned-then.js {unsupported: [async]}
-    prototype/then/resolve-settled-fulfilled-prms-cstm-then.js {unsupported: [async]}
-    prototype/then/resolve-settled-fulfilled-self.js {unsupported: [async]}
-    prototype/then/resolve-settled-fulfilled-thenable.js {unsupported: [async]}
-    prototype/then/resolve-settled-rejected-non-obj.js {unsupported: [async]}
-    prototype/then/resolve-settled-rejected-non-thenable.js {unsupported: [async]}
-    prototype/then/resolve-settled-rejected-poisoned-then.js {unsupported: [async]}
-    prototype/then/resolve-settled-rejected-prms-cstm-then.js {unsupported: [async]}
-    prototype/then/resolve-settled-rejected-self.js {unsupported: [async]}
-    prototype/then/resolve-settled-rejected-thenable.js {unsupported: [async]}
-    prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js {unsupported: [async]}
-    prototype/then/rxn-handler-fulfilled-invoke-strict.js {unsupported: [async]}
-    prototype/then/rxn-handler-fulfilled-next.js {unsupported: [async]}
-    prototype/then/rxn-handler-fulfilled-next-abrupt.js {unsupported: [async]}
-    prototype/then/rxn-handler-fulfilled-return-abrupt.js {unsupported: [async]}
-    prototype/then/rxn-handler-fulfilled-return-normal.js {unsupported: [async]}
-    prototype/then/rxn-handler-identity.js {unsupported: [async]}
-    prototype/then/rxn-handler-rejected-invoke-nonstrict.js {unsupported: [async]}
-    prototype/then/rxn-handler-rejected-invoke-strict.js {unsupported: [async]}
-    prototype/then/rxn-handler-rejected-next.js {unsupported: [async]}
-    prototype/then/rxn-handler-rejected-next-abrupt.js {unsupported: [async]}
-    prototype/then/rxn-handler-rejected-return-abrupt.js {unsupported: [async]}
-    prototype/then/rxn-handler-rejected-return-normal.js {unsupported: [async]}
-    prototype/then/rxn-handler-thrower.js {unsupported: [async]}
-    prototype/then/S25.4.4_A1.1_T1.js {unsupported: [async]}
-    prototype/then/S25.4.4_A2.1_T1.js {unsupported: [async]}
-    prototype/then/S25.4.4_A2.1_T2.js {unsupported: [async]}
-    prototype/then/S25.4.4_A2.1_T3.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A4.1_T1.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A4.1_T2.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A4.2_T1.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A4.2_T2.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A5.1_T1.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A5.2_T1.js {unsupported: [async]}
-    prototype/then/S25.4.5.3_A5.3_T1.js {unsupported: [async]}
-    race/ctx-ctor.js {unsupported: [class]}
-    race/invoke-resolve-error-reject.js {unsupported: [async]}
-    race/invoke-resolve-get-error.js {unsupported: [async]}
-    race/invoke-resolve-get-error-reject.js {unsupported: [async]}
-    race/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
-    race/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
-    race/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
-    race/invoke-then-error-reject.js {unsupported: [async]}
-    race/invoke-then-get-error-reject.js {unsupported: [async]}
-    race/iter-arg-is-false-reject.js {unsupported: [async]}
-    race/iter-arg-is-null-reject.js {unsupported: [async]}
-    race/iter-arg-is-number-reject.js {unsupported: [async]}
-    race/iter-arg-is-string-resolve.js {unsupported: [async]}
-    race/iter-arg-is-symbol-reject.js {unsupported: [async]}
-    race/iter-arg-is-true-reject.js {unsupported: [async]}
-    race/iter-arg-is-undefined-reject.js {unsupported: [async]}
-    race/iter-assigned-false-reject.js {unsupported: [async]}
-    race/iter-assigned-null-reject.js {unsupported: [async]}
-    race/iter-assigned-number-reject.js {unsupported: [async]}
-    race/iter-assigned-string-reject.js {unsupported: [async]}
-    race/iter-assigned-symbol-reject.js {unsupported: [async]}
-    race/iter-assigned-true-reject.js {unsupported: [async]}
-    race/iter-assigned-undefined-reject.js {unsupported: [async]}
-    race/iter-next-val-err-reject.js {unsupported: [async]}
-    race/iter-returns-false-reject.js {unsupported: [async]}
-    race/iter-returns-null-reject.js {unsupported: [async]}
-    race/iter-returns-number-reject.js {unsupported: [async]}
-    race/iter-returns-string-reject.js {unsupported: [async]}
-    race/iter-returns-symbol-reject.js {unsupported: [async]}
-    race/iter-returns-true-reject.js {unsupported: [async]}
-    race/iter-returns-undefined-reject.js {unsupported: [async]}
-    race/iter-step-err-reject.js {unsupported: [async]}
-    race/reject-deferred.js {unsupported: [async]}
-    race/reject-ignored-deferred.js {unsupported: [async]}
-    race/reject-ignored-immed.js {unsupported: [async]}
-    race/reject-immed.js {unsupported: [async]}
-    race/resolve-ignores-late-rejection.js {unsupported: [async]}
-    race/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
-    race/resolve-non-callable.js {unsupported: [async]}
-    race/resolve-non-obj.js {unsupported: [async]}
-    race/resolve-non-thenable.js {unsupported: [async]}
-    race/resolve-poisoned-then.js {unsupported: [async]}
-    race/resolve-prms-cstm-then.js {unsupported: [async]}
-    race/resolve-self.js {unsupported: [async]}
-    race/resolve-thenable.js {unsupported: [async]}
-    race/resolved-sequence.js {unsupported: [async]}
-    race/resolved-sequence-extra-ticks.js {unsupported: [async]}
-    race/resolved-sequence-mixed.js {unsupported: [async]}
-    race/resolved-sequence-with-rejections.js {unsupported: [async]}
-    race/resolved-then-catch-finally.js {unsupported: [async]}
-    race/S25.4.4.3_A2.2_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A2.2_T2.js {unsupported: [async]}
-    race/S25.4.4.3_A2.2_T3.js {unsupported: [async]}
-    race/S25.4.4.3_A4.1_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A4.1_T2.js {unsupported: [async]}
-    race/S25.4.4.3_A5.1_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A6.1_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A6.2_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A7.1_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A7.1_T2.js {unsupported: [async]}
-    race/S25.4.4.3_A7.1_T3.js {unsupported: [async]}
-    race/S25.4.4.3_A7.2_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A7.3_T1.js {unsupported: [async]}
-    race/S25.4.4.3_A7.3_T2.js {unsupported: [async]}
     reject/capability-invocation.js
-    reject/ctx-ctor.js {unsupported: [class]}
-    reject/S25.4.4.4_A2.1_T1.js {unsupported: [async]}
-    resolve/arg-non-thenable.js {unsupported: [async]}
-    resolve/arg-poisoned-then.js {unsupported: [async]}
-    resolve/ctx-ctor.js {unsupported: [class]}
     resolve/resolve-from-promise-capability.js
-    resolve/resolve-non-obj.js {unsupported: [async]}
-    resolve/resolve-non-thenable.js {unsupported: [async]}
-    resolve/resolve-poisoned-then.js {unsupported: [async]}
-    resolve/resolve-self.js {unsupported: [async]}
-    resolve/resolve-thenable.js {unsupported: [async]}
-    resolve/S25.4.4.5_A2.2_T1.js {unsupported: [async]}
-    resolve/S25.4.4.5_A2.3_T1.js {unsupported: [async]}
-    resolve/S25.4.4.5_A3.1_T1.js {unsupported: [async]}
-    resolve/S25.4.4.5_A4.1_T1.js {unsupported: [async]}
-    resolve/S25.Promise_resolve_foreign_thenable_1.js {unsupported: [async]}
-    resolve/S25.Promise_resolve_foreign_thenable_2.js {unsupported: [async]}
-    try/args.js {unsupported: [async]}
-    try/ctx-ctor.js {unsupported: [class]}
-    try/return-value.js {unsupported: [async]}
-    try/throws.js {unsupported: [async]}
-    withResolvers/ctx-ctor.js {unsupported: [class]}
-    create-resolving-functions-reject.js {unsupported: [async]}
-    create-resolving-functions-resolve.js {unsupported: [async]}
-    exception-after-resolve-in-executor.js {unsupported: [async]}
-    exception-after-resolve-in-thenable-job.js {unsupported: [async]}
     get-prototype-abrupt.js
     proto-from-ctor-realm.js
-    reject-ignored-via-abrupt.js {unsupported: [async]}
-    reject-ignored-via-fn-deferred.js {unsupported: [async]}
-    reject-ignored-via-fn-immed.js {unsupported: [async]}
-    reject-via-abrupt.js {unsupported: [async]}
-    reject-via-abrupt-queue.js {unsupported: [async]}
-    reject-via-fn-deferred.js {unsupported: [async]}
-    reject-via-fn-deferred-queue.js {unsupported: [async]}
-    reject-via-fn-immed.js {unsupported: [async]}
-    reject-via-fn-immed-queue.js {unsupported: [async]}
-    resolve-ignored-via-fn-deferred.js {unsupported: [async]}
-    resolve-ignored-via-fn-immed.js {unsupported: [async]}
-    resolve-non-obj-deferred.js {unsupported: [async]}
-    resolve-non-obj-immed.js {unsupported: [async]}
-    resolve-non-thenable-deferred.js {unsupported: [async]}
-    resolve-non-thenable-immed.js {unsupported: [async]}
-    resolve-poisoned-then-deferred.js {unsupported: [async]}
-    resolve-poisoned-then-immed.js {unsupported: [async]}
-    resolve-prms-cstm-then-deferred.js {unsupported: [async]}
-    resolve-prms-cstm-then-immed.js {unsupported: [async]}
-    resolve-self.js {unsupported: [async]}
-    resolve-thenable-deferred.js {unsupported: [async]}
-    resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy 69/311 (22.19%)
+built-ins/Proxy
     construct/arguments-realm.js
     construct/call-parameters.js
     construct/call-parameters-new-target.js
-    construct/trap-is-missing-target-is-proxy.js {unsupported: [class]}
     construct/trap-is-null.js
-    construct/trap-is-null-target-is-proxy.js {unsupported: [class]}
     construct/trap-is-undefined.js
     construct/trap-is-undefined-no-property.js
     construct/trap-is-undefined-proto-from-newtarget-realm.js
-    construct/trap-is-undefined-target-is-proxy.js {unsupported: [class]}
     defineProperty/desc-realm.js
     defineProperty/targetdesc-not-configurable-writable-desc-not-writable.js
-    defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js non-strict
+    defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js
     defineProperty/trap-is-missing-target-is-proxy.js
     defineProperty/trap-is-undefined-target-is-proxy.js
     deleteProperty/boolean-trap-result-boolean-false.js
-    deleteProperty/return-false-not-strict.js non-strict
-    deleteProperty/return-false-strict.js strict
+    deleteProperty/return-false-not-strict.js
+    deleteProperty/return-false-strict.js
     deleteProperty/targetdesc-is-configurable-target-is-not-extensible.js
-    deleteProperty/trap-is-missing-target-is-proxy.js strict
+    deleteProperty/trap-is-missing-target-is-proxy.js
     deleteProperty/trap-is-null-target-is-proxy.js
-    deleteProperty/trap-is-undefined-strict.js strict
+    deleteProperty/trap-is-undefined-strict.js
     deleteProperty/trap-is-undefined-target-is-proxy.js
     getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined.js
     getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor.js
@@ -1711,17 +1142,15 @@ built-ins/Proxy 69/311 (22.19%)
     get/trap-is-undefined-receiver.js
     has/call-in-prototype.js
     has/call-in-prototype-index.js
-    has/call-with.js non-strict
-    has/return-false-target-not-extensible-using-with.js non-strict
-    has/return-false-target-prop-exists-using-with.js non-strict
-    has/return-false-targetdesc-not-configurable-using-with.js non-strict
-    has/return-is-abrupt-with.js non-strict
-    has/trap-is-not-callable-using-with.js non-strict
+    has/call-with.js
+    has/return-false-target-not-extensible-using-with.js
+    has/return-false-target-prop-exists-using-with.js
+    has/return-false-targetdesc-not-configurable-using-with.js
+    has/return-is-abrupt-with.js
+    has/trap-is-not-callable-using-with.js
     ownKeys/trap-is-undefined-target-is-proxy.js
-    preventExtensions/trap-is-undefined-target-is-proxy.js {unsupported: [module]}
     revocable/builtin.js
     revocable/revocation-function-not-a-constructor.js
-    revocable/tco-fn-realm.js {unsupported: [tail-call-optimization]}
     setPrototypeOf/internals-call-order.js
     setPrototypeOf/not-extensible-target-not-same-target-prototype.js
     setPrototypeOf/toboolean-trap-result-false.js
@@ -1748,11 +1177,11 @@ built-ins/Proxy 69/311 (22.19%)
     get-fn-realm.js
     get-fn-realm-recursive.js
 
-built-ins/Reflect 12/153 (7.84%)
+built-ins/Reflect
     construct/newtarget-is-not-constructor-throws.js
     defineProperty/return-abrupt-from-property-key.js
     deleteProperty/return-abrupt-from-result.js
-    deleteProperty/return-boolean.js strict
+    deleteProperty/return-boolean.js
     get/return-value-from-receiver.js
     ownKeys/return-on-corresponding-order-large-index.js
     set/call-prototype-property-set.js
@@ -1762,10 +1191,39 @@ built-ins/Reflect 12/153 (7.84%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 975/1868 (52.19%)
-    CharacterClassEscapes 12/12 (100.0%)
-    dotall 4/4 (100.0%)
-    escape 20/20 (100.0%)
+built-ins/RegExp
+    CharacterClassEscapes/character-class-digit-class-escape-negative-cases.js
+    CharacterClassEscapes/character-class-digit-class-escape-positive-cases.js
+    CharacterClassEscapes/character-class-non-digit-class-escape-negative-cases.js
+    CharacterClassEscapes/character-class-non-digit-class-escape-positive-cases.js
+    CharacterClassEscapes/character-class-non-whitespace-class-escape-negative-cases.js
+    CharacterClassEscapes/character-class-non-whitespace-class-escape-positive-cases.js
+    CharacterClassEscapes/character-class-non-word-class-escape-negative-cases.js
+    CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js
+    CharacterClassEscapes/character-class-whitespace-class-escape-negative-cases.js
+    CharacterClassEscapes/character-class-whitespace-class-escape-positive-cases.js
+    CharacterClassEscapes/character-class-word-class-escape-negative-cases.js
+    CharacterClassEscapes/character-class-word-class-escape-positive-cases.js
+    escape/cross-realm.js
+    escape/escaped-control-characters.js
+    escape/escaped-lineterminator.js
+    escape/escaped-otherpunctuators.js
+    escape/escaped-solidus-character-mixed.js
+    escape/escaped-solidus-character-simple.js
+    escape/escaped-surrogates.js
+    escape/escaped-syntax-characters-mixed.js
+    escape/escaped-syntax-characters-simple.js
+    escape/escaped-utf16encodecodepoint.js
+    escape/escaped-whitespace.js
+    escape/initial-char-escape.js
+    escape/is-function.js
+    escape/length.js
+    escape/name.js
+    escape/non-string-inputs.js
+    escape/not-a-constructor.js
+    escape/not-escaped.js
+    escape/not-escaped-underscore.js
+    escape/prop-desc.js
     match-indices/indices-array.js
     match-indices/indices-array-element.js
     match-indices/indices-array-matched.js
@@ -1782,30 +1240,20 @@ built-ins/RegExp 975/1868 (52.19%)
     named-groups/duplicate-names-match-indices.js
     named-groups/groups-object-subclass.js
     named-groups/groups-object-subclass-sans.js
-    property-escapes/generated/strings 28/28 (100.0%)
-    property-escapes/generated 431/431 (100.0%)
-    property-escapes 144/144 (100.0%)
-    prototype/dotAll 8/8 (100.0%)
     prototype/exec/duplicate-named-indices-groups-properties.js
     prototype/exec/failure-lastindex-access.js
     prototype/exec/not-a-constructor.js
-    prototype/exec/regexp-builtin-exec-v-u-flag.js {unsupported: [regexp-unicode-property-escapes]}
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
-    prototype/flags/coercion-dotall.js {unsupported: [regexp-dotall]}
     prototype/flags/coercion-global.js
     prototype/flags/coercion-hasIndices.js
     prototype/flags/coercion-ignoreCase.js
     prototype/flags/coercion-multiline.js
     prototype/flags/coercion-sticky.js
     prototype/flags/coercion-unicode.js
-    prototype/flags/get-order.js {unsupported: [regexp-dotall]}
     prototype/flags/length.js
     prototype/flags/name.js
     prototype/flags/prop-desc.js
-    prototype/flags/rethrow.js {unsupported: [regexp-dotall]}
-    prototype/flags/return-order.js {unsupported: [regexp-dotall]}
-    prototype/flags/this-val-regexp.js {unsupported: [regexp-dotall]}
     prototype/flags/this-val-regexp-prototype.js
     prototype/global/15.10.7.2-2.js
     prototype/global/cross-realm.js
@@ -1813,7 +1261,14 @@ built-ins/RegExp 975/1868 (52.19%)
     prototype/global/name.js
     prototype/global/S15.10.7.2_A9.js
     prototype/global/this-val-regexp-prototype.js
-    prototype/hasIndices 8/8 (100.0%)
+    prototype/hasIndices/cross-realm.js
+    prototype/hasIndices/length.js
+    prototype/hasIndices/name.js
+    prototype/hasIndices/prop-desc.js
+    prototype/hasIndices/this-val-invalid-obj.js
+    prototype/hasIndices/this-val-non-obj.js
+    prototype/hasIndices/this-val-regexp.js
+    prototype/hasIndices/this-val-regexp-prototype.js
     prototype/ignoreCase/15.10.7.3-2.js
     prototype/ignoreCase/cross-realm.js
     prototype/ignoreCase/length.js
@@ -1888,14 +1343,127 @@ built-ins/RegExp 975/1868 (52.19%)
     prototype/unicode/this-val-regexp-prototype.js
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
-    regexp-modifiers/syntax/valid 8/8 (100.0%)
-    regexp-modifiers 62/62 (100.0%)
-    unicodeSets/generated 113/113 (100.0%)
+    regexp-modifiers/syntax/valid/add-and-remove-modifiers.js
+    regexp-modifiers/syntax/valid/add-and-remove-modifiers-can-have-empty-remove-modifiers.js
+    regexp-modifiers/syntax/valid/add-modifiers-when-nested.js
+    regexp-modifiers/syntax/valid/add-modifiers-when-not-set-as-flags.js
+    regexp-modifiers/syntax/valid/add-modifiers-when-set-as-flags.js
+    regexp-modifiers/syntax/valid/remove-modifiers-when-nested.js
+    regexp-modifiers/syntax/valid/remove-modifiers-when-not-set-as-flags.js
+    regexp-modifiers/syntax/valid/remove-modifiers-when-set-as-flags.js
+    regexp-modifiers/add-dotAll.js
+    regexp-modifiers/add-dotAll-does-not-affect-alternatives-outside.js
+    regexp-modifiers/add-dotAll-does-not-affect-dotAll-property.js
+    regexp-modifiers/add-dotAll-does-not-affect-ignoreCase-flag.js
+    regexp-modifiers/add-dotAll-does-not-affect-multiline-flag.js
+    regexp-modifiers/add-ignoreCase.js
+    regexp-modifiers/add-ignoreCase-affects-backreferences.js
+    regexp-modifiers/add-ignoreCase-affects-characterClasses.js
+    regexp-modifiers/add-ignoreCase-affects-characterEscapes.js
+    regexp-modifiers/add-ignoreCase-affects-slash-lower-b.js
+    regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js
+    regexp-modifiers/add-ignoreCase-affects-slash-lower-w.js
+    regexp-modifiers/add-ignoreCase-affects-slash-upper-b.js
+    regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
+    regexp-modifiers/add-ignoreCase-affects-slash-upper-w.js
+    regexp-modifiers/add-ignoreCase-does-not-affect-alternatives-outside.js
+    regexp-modifiers/add-ignoreCase-does-not-affect-dotAll-flag.js
+    regexp-modifiers/add-ignoreCase-does-not-affect-ignoreCase-property.js
+    regexp-modifiers/add-ignoreCase-does-not-affect-multiline-flag.js
+    regexp-modifiers/add-multiline.js
+    regexp-modifiers/add-multiline-does-not-affect-alternatives-outside.js
+    regexp-modifiers/add-multiline-does-not-affect-dotAll-flag.js
+    regexp-modifiers/add-multiline-does-not-affect-ignoreCase-flag.js
+    regexp-modifiers/add-multiline-does-not-affect-multiline-property.js
+    regexp-modifiers/add-remove-modifiers.js
+    regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
+    regexp-modifiers/changing-ignoreCase-flag-does-not-affect-ignoreCase-modifier.js
+    regexp-modifiers/changing-multiline-flag-does-not-affect-multiline-modifier.js
+    regexp-modifiers/nested-add-remove-modifiers.js
+    regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
+    regexp-modifiers/nesting-add-ignoreCase-within-remove-ignoreCase.js
+    regexp-modifiers/nesting-add-multiline-within-remove-multiline.js
+    regexp-modifiers/nesting-dotAll-does-not-affect-alternatives-outside.js
+    regexp-modifiers/nesting-ignoreCase-does-not-affect-alternatives-outside.js
+    regexp-modifiers/nesting-multiline-does-not-affect-alternatives-outside.js
+    regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js
+    regexp-modifiers/nesting-remove-ignoreCase-within-add-ignoreCase.js
+    regexp-modifiers/nesting-remove-multiline-within-add-multiline.js
+    regexp-modifiers/remove-dotAll.js
+    regexp-modifiers/remove-dotAll-does-not-affect-alternatives-outside.js
+    regexp-modifiers/remove-dotAll-does-not-affect-dotAll-property.js
+    regexp-modifiers/remove-dotAll-does-not-affect-ignoreCase-flag.js
+    regexp-modifiers/remove-dotAll-does-not-affect-multiline-flag.js
+    regexp-modifiers/remove-ignoreCase.js
+    regexp-modifiers/remove-ignoreCase-affects-backreferences.js
+    regexp-modifiers/remove-ignoreCase-affects-characterClasses.js
+    regexp-modifiers/remove-ignoreCase-affects-characterEscapes.js
+    regexp-modifiers/remove-ignoreCase-affects-slash-lower-b.js
+    regexp-modifiers/remove-ignoreCase-affects-slash-lower-p.js
+    regexp-modifiers/remove-ignoreCase-affects-slash-lower-w.js
+    regexp-modifiers/remove-ignoreCase-affects-slash-upper-b.js
+    regexp-modifiers/remove-ignoreCase-affects-slash-upper-p.js
+    regexp-modifiers/remove-ignoreCase-affects-slash-upper-w.js
+    regexp-modifiers/remove-ignoreCase-does-not-affect-alternatives-outside.js
+    regexp-modifiers/remove-ignoreCase-does-not-affect-dotAll-flag.js
+    regexp-modifiers/remove-ignoreCase-does-not-affect-ignoreCase-property.js
+    regexp-modifiers/remove-ignoreCase-does-not-affect-multiline-flag.js
+    regexp-modifiers/remove-multiline.js
+    regexp-modifiers/remove-multiline-does-not-affect-alternatives-outside.js
+    regexp-modifiers/remove-multiline-does-not-affect-dotAll-flag.js
+    regexp-modifiers/remove-multiline-does-not-affect-ignoreCase-flag.js
+    regexp-modifiers/remove-multiline-does-not-affect-multiline-property.js
+    unicodeSets/generated/character-class-difference-character.js
+    unicodeSets/generated/character-class-difference-character-class.js
+    unicodeSets/generated/character-class-difference-character-class-escape.js
+    unicodeSets/generated/character-class-difference-string-literal.js
+    unicodeSets/generated/character-class-escape-difference-character.js
+    unicodeSets/generated/character-class-escape-difference-character-class.js
+    unicodeSets/generated/character-class-escape-difference-character-class-escape.js
+    unicodeSets/generated/character-class-escape-difference-string-literal.js
+    unicodeSets/generated/character-class-escape-intersection-character.js
+    unicodeSets/generated/character-class-escape-intersection-character-class.js
+    unicodeSets/generated/character-class-escape-intersection-character-class-escape.js
+    unicodeSets/generated/character-class-escape-intersection-string-literal.js
+    unicodeSets/generated/character-class-escape-union-character.js
+    unicodeSets/generated/character-class-escape-union-character-class.js
+    unicodeSets/generated/character-class-escape-union-character-class-escape.js
+    unicodeSets/generated/character-class-escape-union-string-literal.js
+    unicodeSets/generated/character-class-intersection-character.js
+    unicodeSets/generated/character-class-intersection-character-class.js
+    unicodeSets/generated/character-class-intersection-character-class-escape.js
+    unicodeSets/generated/character-class-intersection-string-literal.js
+    unicodeSets/generated/character-class-union-character.js
+    unicodeSets/generated/character-class-union-character-class.js
+    unicodeSets/generated/character-class-union-character-class-escape.js
+    unicodeSets/generated/character-class-union-string-literal.js
+    unicodeSets/generated/character-difference-character.js
+    unicodeSets/generated/character-difference-character-class.js
+    unicodeSets/generated/character-difference-character-class-escape.js
+    unicodeSets/generated/character-difference-string-literal.js
+    unicodeSets/generated/character-intersection-character.js
+    unicodeSets/generated/character-intersection-character-class.js
+    unicodeSets/generated/character-intersection-character-class-escape.js
+    unicodeSets/generated/character-intersection-string-literal.js
+    unicodeSets/generated/character-union-character.js
+    unicodeSets/generated/character-union-character-class.js
+    unicodeSets/generated/character-union-character-class-escape.js
+    unicodeSets/generated/character-union-string-literal.js
+    unicodeSets/generated/string-literal-difference-character.js
+    unicodeSets/generated/string-literal-difference-character-class.js
+    unicodeSets/generated/string-literal-difference-character-class-escape.js
+    unicodeSets/generated/string-literal-difference-string-literal.js
+    unicodeSets/generated/string-literal-intersection-character.js
+    unicodeSets/generated/string-literal-intersection-character-class.js
+    unicodeSets/generated/string-literal-intersection-character-class-escape.js
+    unicodeSets/generated/string-literal-intersection-string-literal.js
+    unicodeSets/generated/string-literal-union-character.js
+    unicodeSets/generated/string-literal-union-character-class.js
+    unicodeSets/generated/string-literal-union-character-class-escape.js
+    unicodeSets/generated/string-literal-union-string-literal.js
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
     call_with_regexp_not_same_constructor.js
-    character-class-escape-non-whitespace-u180e.js {unsupported: [u180e]}
-    duplicate-flags.js {unsupported: [regexp-dotall]}
     from-regexp-like.js
     from-regexp-like-flag-override.js
     from-regexp-like-get-ctor-err.js
@@ -1908,13 +1476,12 @@ built-ins/RegExp 975/1868 (52.19%)
     S15.10.1_A1_T14.js
     S15.10.1_A1_T15.js
     S15.10.1_A1_T16.js
-    u180e.js {unsupported: [u180e]}
     unicode_full_case_folding.js
     valid-flags-y.js
 
-built-ins/RegExpStringIteratorPrototype 0/17 (0.0%)
+built-ins/RegExpStringIteratorPrototype
 
-built-ins/Set 87/381 (22.83%)
+built-ins/Set
     prototype/difference/add-not-called.js
     prototype/difference/allows-set-like-class.js
     prototype/difference/allows-set-like-object.js
@@ -2003,11 +1570,11 @@ built-ins/Set 87/381 (22.83%)
     proto-from-ctor-realm.js
     valid-values.js
 
-built-ins/SetIteratorPrototype 0/11 (0.0%)
+built-ins/SetIteratorPrototype
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String 58/1212 (4.79%)
+built-ins/String
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -2021,7 +1588,6 @@ built-ins/String 58/1212 (4.79%)
     prototype/matchAll/flags-undefined-throws.js
     prototype/matchAll/regexp-matchAll-invocation.js
     prototype/matchAll/regexp-prototype-matchAll-invocation.js
-    prototype/matchAll/regexp-prototype-matchAll-v-u-flag.js {unsupported: [regexp-unicode-property-escapes]}
     prototype/match/cstm-matcher-invocation.js
     prototype/match/cstm-matcher-on-bigint-primitive.js
     prototype/match/cstm-matcher-on-boolean-primitive.js
@@ -2037,8 +1603,6 @@ built-ins/String 58/1212 (4.79%)
     prototype/replaceAll/replaceValue-call-matching-empty.js
     prototype/replaceAll/searchValue-flags-no-g-throws.js
     prototype/replaceAll/searchValue-replacer-method-abrupt.js
-    prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
-    prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
     prototype/replace/cstm-replace-on-bigint-primitive.js
     prototype/replace/cstm-replace-on-boolean-primitive.js
     prototype/replace/cstm-replace-on-number-primitive.js
@@ -2057,19 +1621,16 @@ built-ins/String 58/1212 (4.79%)
     prototype/split/cstm-split-on-string-primitive.js
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/substring/S15.5.4.15_A1_T5.js
-    prototype/toLocaleLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLocaleLowerCase/special_casing_conditional.js
-    prototype/toLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLowerCase/special_casing_conditional.js
     prototype/toString/non-generic-realm.js
     prototype/toWellFormed/to-string-primitive.js
-    prototype/trim/u180e.js {unsupported: [u180e]}
     prototype/valueOf/non-generic-realm.js
     proto-from-ctor-realm.js
 
-built-ins/StringIteratorPrototype 0/7 (0.0%)
+built-ins/StringIteratorPrototype
 
-built-ins/Symbol 19/94 (20.21%)
+built-ins/Symbol
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
     dispose/prop-desc.js
@@ -2090,7 +1651,7 @@ built-ins/Symbol 19/94 (20.21%)
     toStringTag/cross-realm.js
     unscopables/cross-realm.js
 
-built-ins/ThrowTypeError 8/14 (57.14%)
+built-ins/ThrowTypeError
     extensible.js
     frozen.js
     length.js
@@ -2100,290 +1661,54 @@ built-ins/ThrowTypeError 8/14 (57.14%)
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray 256/1434 (17.85%)
-    from/from-array-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    from/from-typedarray-into-itself-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    from/from-typedarray-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+built-ins/TypedArray
     from/iterated-array-changed-by-tonumber.js
-    of/resized-with-out-of-bounds-and-in-bounds-indices.js {unsupported: [resizable-arraybuffer]}
-    prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/at/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/at/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteLength/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/byteOffset/resized-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/coerced-target-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/coerced-target-start-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/entries/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/absent-indices-computed-from-initial-length.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/coerced-value-start-end-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/fill/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/BigInt/predicate-call-this-strict.js strict
-    prototype/find/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/BigInt/predicate-call-this-strict.js strict
-    prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/predicate-call-this-strict.js strict
-    prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/BigInt/predicate-call-this-strict.js strict
-    prototype/findLast/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/BigInt/predicate-call-this-strict.js strict
-    prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/predicate-call-this-strict.js strict
-    prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/predicate-call-this-strict.js strict
-    prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/predicate-call-this-strict.js strict
-    prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/forEach/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/index-compared-against-initial-length.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/index-compared-against-initial-length-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/search-undefined-after-shrinking-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/includes/search-undefined-after-shrinking-buffer-index-is-oob.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
-    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/join/separator-tostring-once-after-resized.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/keys/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/negative-index-and-resize-to-smaller.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
-    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
-    prototype/length/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/BigInt/predicate-call-this-strict.js
+    prototype/findIndex/BigInt/predicate-call-this-strict.js
+    prototype/findIndex/predicate-call-this-strict.js
+    prototype/findLast/BigInt/predicate-call-this-strict.js
+    prototype/findLastIndex/BigInt/predicate-call-this-strict.js
+    prototype/findLastIndex/predicate-call-this-strict.js
+    prototype/findLast/predicate-call-this-strict.js
+    prototype/find/predicate-call-this-strict.js
     prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
     prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/map/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/speciesctor-resizable-buffer-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/speciesctor-resizable-buffer-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reverse/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/reverse/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/set/BigInt/array-arg-primitive-toobject.js
     prototype/set/BigInt/bigint-tobiguint64.js
     prototype/set/BigInt/number-tobigint.js
-    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/BigInt/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/set/array-arg-primitive-toobject.js
-    prototype/set/array-arg-value-conversion-resizes-array-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/target-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/target-grow-source-length-getter.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/target-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/target-shrink-source-length-getter.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/this-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
-    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/set/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/slice/speciesctor-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/BigInt/infinity.js
-    prototype/subarray/coerced-begin-end-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/subarray/coerced-begin-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/infinity.js
-    prototype/subarray/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/subarray/result-byteOffset-from-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/Symbol.toStringTag/BigInt/name.js
     prototype/Symbol.toStringTag/name.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
-    prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/toReversed/this-value-invalid.js
     prototype/toSorted/this-value-invalid.js
-    prototype/values/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/make-in-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/make-out-of-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/values/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/with/BigInt/early-type-coercion-bigint.js
-    prototype/with/index-validated-against-current-length.js {unsupported: [resizable-arraybuffer]}
-    prototype/with/negative-index-resize-to-in-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/with/negative-index-resize-to-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    prototype/with/valid-typedarray-index-checked-after-coercions.js {unsupported: [resizable-arraybuffer]}
-    prototype/resizable-and-fixed-have-same-prototype.js {unsupported: [resizable-arraybuffer]}
     prototype/Symbol.iterator.js
     prototype/toString.js
-    Symbol.species 4/4 (100.0%)
-    out-of-bounds-behaves-like-detached.js {unsupported: [resizable-arraybuffer]}
-    out-of-bounds-get-and-set.js {unsupported: [resizable-arraybuffer]}
-    out-of-bounds-has.js {unsupported: [resizable-arraybuffer]}
+    Symbol.species/length.js
+    Symbol.species/name.js
+    Symbol.species/prop-desc.js
+    Symbol.species/result.js
     prototype.js
-    resizable-buffer-length-tracking-1.js {unsupported: [resizable-arraybuffer]}
-    resizable-buffer-length-tracking-2.js {unsupported: [resizable-arraybuffer]}
 
-built-ins/TypedArrayConstructors 198/736 (26.9%)
-    ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
+built-ins/TypedArrayConstructors
     ctors-bigint/buffer-arg/custom-proto-access-throws.js
-    ctors-bigint/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/proto-from-ctor-realm.js
-    ctors-bigint/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/use-custom-proto-if-object.js
-    ctors-bigint/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/length-arg/custom-proto-access-throws.js
     ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
     ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
@@ -2414,36 +1739,9 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     ctors-bigint/typedarray-arg/custom-proto-access-throws.js
     ctors-bigint/typedarray-arg/proto-from-ctor-realm.js
     ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
-    ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/custom-proto-access-throws.js
-    ctors/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/excessive-offset-throws-resizable-ab.js {unsupported: [resizable-arraybuffer]}
-    ctors/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/proto-from-ctor-realm.js
-    ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/resizable-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
-    ctors/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/use-custom-proto-if-object.js
-    ctors/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
-    ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/length-arg/custom-proto-access-throws.js
     ctors/length-arg/is-infinity-throws-rangeerror.js
     ctors/length-arg/is-negative-integer-throws-rangeerror.js
@@ -2474,12 +1772,11 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     ctors/object-arg/use-custom-proto-if-object.js
     ctors/typedarray-arg/custom-proto-access-throws.js
     ctors/typedarray-arg/proto-from-ctor-realm.js
-    ctors/typedarray-arg/src-typedarray-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js
     ctors/typedarray-arg/use-custom-proto-if-object.js
     ctors/no-species.js
-    from/BigInt/mapfn-this-without-thisarg-non-strict.js non-strict
-    from/mapfn-this-without-thisarg-non-strict.js non-strict
+    from/BigInt/mapfn-this-without-thisarg-non-strict.js
+    from/mapfn-this-without-thisarg-non-strict.js
     from/nan-conversion.js
     from/new-instance-from-sparse-array.js
     internals/DefineOwnProperty/BigInt/key-is-not-canonical-index.js
@@ -2496,23 +1793,17 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable-throws.js
     internals/DefineOwnProperty/key-is-numericindex-desc-not-writable-throws.js
     internals/DefineOwnProperty/non-extensible-redefine-key.js
-    internals/Delete/BigInt/indexed-value-ab-strict.js strict
-    internals/Delete/BigInt/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
-    internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
-    internals/Delete/indexed-value-ab-strict.js strict
-    internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/key-is-not-minus-zero-strict.js strict
-    internals/Delete/key-is-out-of-bounds-strict.js strict
-    internals/Get/BigInt/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/indexed-value-ab-strict.js
+    internals/Delete/BigInt/key-is-not-minus-zero-strict.js
+    internals/Delete/BigInt/key-is-out-of-bounds-strict.js
+    internals/Delete/indexed-value-ab-strict.js
+    internals/Delete/key-is-not-minus-zero-strict.js
+    internals/Delete/key-is-out-of-bounds-strict.js
     internals/Get/BigInt/key-is-not-integer.js
     internals/Get/BigInt/key-is-not-minus-zero.js
     internals/Get/BigInt/key-is-out-of-bounds.js
     internals/GetOwnProperty/BigInt/index-prop-desc.js
     internals/GetOwnProperty/index-prop-desc.js
-    internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/key-is-not-integer.js
     internals/Get/key-is-not-minus-zero.js
     internals/Get/key-is-out-of-bounds.js
@@ -2524,16 +1815,12 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/HasProperty/key-is-lower-than-zero.js
     internals/HasProperty/key-is-minus-zero.js
     internals/HasProperty/key-is-not-integer.js
-    internals/HasProperty/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    internals/HasProperty/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     internals/OwnPropertyKeys/BigInt/integer-indexes.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-keys.js
     internals/OwnPropertyKeys/integer-indexes.js
     internals/OwnPropertyKeys/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/integer-indexes-and-string-keys.js
-    internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
-    internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     internals/Set/BigInt/bigint-tobiguint64.js
     internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/BigInt/key-is-canonical-invalid-index-reflect-set.js
@@ -2552,10 +1839,9 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/Set/key-is-symbol.js
     internals/Set/key-is-valid-index-prototype-chain-set.js
     internals/Set/key-is-valid-index-reflect-set.js
-    internals/Set/resized-out-of-bounds-to-in-bounds-index.js {unsupported: [resizable-arraybuffer]}
     internals/Set/tonumber-value-throws.js
 
-built-ins/WeakMap 11/119 (9.24%)
+built-ins/WeakMap
     prototype/getOrInsert/adds-object-element.js
     prototype/getOrInsert/adds-symbol-element.js
     prototype/getOrInsert/getOrInsert.js
@@ -2570,112 +1856,74 @@ built-ins/WeakMap 11/119 (9.24%)
 
 ~built-ins/WeakRef
 
-built-ins/WeakSet 1/85 (1.18%)
+built-ins/WeakSet
     proto-from-ctor-realm.js
 
-built-ins/decodeURI 1/55 (1.82%)
+built-ins/decodeURI
     S15.1.3.1_A2.4_T1.js
 
-built-ins/decodeURIComponent 1/56 (1.79%)
+built-ins/decodeURIComponent
     S15.1.3.2_A2.4_T1.js
 
-built-ins/encodeURI 0/31 (0.0%)
+built-ins/encodeURI
 
-built-ins/encodeURIComponent 0/31 (0.0%)
+built-ins/encodeURIComponent
 
-built-ins/eval 1/10 (10.0%)
-    private-identifiers-not-empty.js {unsupported: [class-fields-private]}
+built-ins/eval
 
-built-ins/global 0/29 (0.0%)
+built-ins/global
 
-built-ins/isFinite 0/15 (0.0%)
+built-ins/isFinite
 
-built-ins/isNaN 0/15 (0.0%)
+built-ins/isNaN
 
-built-ins/parseFloat 1/54 (1.85%)
-    S15.1.2.3_A2_T10_U180E.js {unsupported: [u180e]}
+built-ins/parseFloat
 
-built-ins/parseInt 1/55 (1.82%)
-    S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
+built-ins/parseInt
 
-built-ins/undefined 0/8 (0.0%)
+built-ins/undefined
 
 ~intl402
 
-language/arguments-object 184/263 (69.96%)
-    mapped/mapped-arguments-nonconfigurable-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict
-    mapped/nonconfigurable-descriptors-basic.js non-strict
-    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict
-    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict
-    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict
-    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
-    unmapped/via-params-dstr.js non-strict
-    unmapped/via-params-rest.js non-strict
+language/arguments-object
+    mapped/mapped-arguments-nonconfigurable-3.js
+    mapped/mapped-arguments-nonconfigurable-delete-1.js
+    mapped/mapped-arguments-nonconfigurable-delete-2.js
+    mapped/mapped-arguments-nonconfigurable-delete-3.js
+    mapped/mapped-arguments-nonconfigurable-delete-4.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js
+    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js
+    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js
+    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js
+    mapped/nonconfigurable-descriptors-basic.js
+    mapped/nonconfigurable-descriptors-set-value-by-arguments.js
+    mapped/nonconfigurable-descriptors-set-value-with-define-property.js
+    mapped/nonconfigurable-descriptors-with-param-assign.js
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
+    mapped/nonconfigurable-nonwritable-descriptors-basic.js
+    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
+    mapped/nonwritable-nonconfigurable-descriptors-basic.js
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
+    unmapped/via-params-dstr.js
+    unmapped/via-params-rest.js
     arguments-caller.js
-    async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    async-gen-named-func-expr-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    async-gen-named-func-expr-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    async-gen-named-func-expr-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    async-gen-named-func-expr-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    async-gen-named-func-expr-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-func-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-func-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-func-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-func-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-func-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    cls-decl-async-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-decl-async-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
-    cls-decl-async-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
     cls-decl-gen-meth-args-trailing-comma-multiple.js
     cls-decl-gen-meth-args-trailing-comma-null.js
     cls-decl-gen-meth-args-trailing-comma-single-args.js
@@ -2696,51 +1944,6 @@ language/arguments-object 184/263 (69.96%)
     cls-decl-meth-static-args-trailing-comma-single-args.js
     cls-decl-meth-static-args-trailing-comma-spread-operator.js
     cls-decl-meth-static-args-trailing-comma-undefined.js
-    cls-decl-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-decl-private-gen-meth-args-trailing-comma-null.js {unsupported: [class]}
-    cls-decl-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-decl-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-decl-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-decl-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-decl-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [class]}
-    cls-decl-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-decl-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-decl-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-decl-private-meth-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-decl-private-meth-args-trailing-comma-null.js {unsupported: [class]}
-    cls-decl-private-meth-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-decl-private-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-decl-private-meth-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-decl-private-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-decl-private-meth-static-args-trailing-comma-null.js {unsupported: [class]}
-    cls-decl-private-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-decl-private-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-decl-private-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-expr-async-gen-func-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-func-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-func-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-func-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-func-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
-    cls-expr-async-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
-    cls-expr-async-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
-    cls-expr-async-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
     cls-expr-gen-meth-args-trailing-comma-multiple.js
     cls-expr-gen-meth-args-trailing-comma-null.js
     cls-expr-gen-meth-args-trailing-comma-single-args.js
@@ -2761,26 +1964,6 @@ language/arguments-object 184/263 (69.96%)
     cls-expr-meth-static-args-trailing-comma-single-args.js
     cls-expr-meth-static-args-trailing-comma-spread-operator.js
     cls-expr-meth-static-args-trailing-comma-undefined.js
-    cls-expr-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-expr-private-gen-meth-args-trailing-comma-null.js {unsupported: [class]}
-    cls-expr-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-expr-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-expr-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-expr-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-expr-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [class]}
-    cls-expr-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-expr-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-expr-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-expr-private-meth-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-expr-private-meth-args-trailing-comma-null.js {unsupported: [class]}
-    cls-expr-private-meth-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-expr-private-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-expr-private-meth-args-trailing-comma-undefined.js {unsupported: [class]}
-    cls-expr-private-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
-    cls-expr-private-meth-static-args-trailing-comma-null.js {unsupported: [class]}
-    cls-expr-private-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
-    cls-expr-private-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
-    cls-expr-private-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
     func-decl-args-trailing-comma-spread-operator.js
     func-expr-args-trailing-comma-spread-operator.js
     gen-func-decl-args-trailing-comma-spread-operator.js
@@ -2788,9 +1971,9 @@ language/arguments-object 184/263 (69.96%)
     gen-meth-args-trailing-comma-spread-operator.js
     meth-args-trailing-comma-spread-operator.js
 
-language/asi 0/102 (0.0%)
+language/asi
 
-language/block-scope 68/145 (46.9%)
+language/block-scope
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -2798,87 +1981,73 @@ language/block-scope 68/145 (46.9%)
     syntax/for-in/mixed-values-in-iteration.js
     syntax/function-declarations/in-statement-position-do-statement-while-expression.js
     syntax/function-declarations/in-statement-position-for-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement.js strict
-    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement.js
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
     syntax/function-declarations/in-statement-position-while-expression-statement.js
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-iteration, async-functions]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js {unsupported: [async-iteration]}
-    syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
-    syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
-    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
-    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
-    syntax/redeclaration/var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-redeclaration-attempt-after-function.js
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
 
-language/comments 9/52 (17.31%)
+language/comments
     hashbang/function-constructor.js
-    hashbang/module.js {unsupported: [module]}
-    mongolian-vowel-separator-multi.js {unsupported: [u180e]}
-    mongolian-vowel-separator-single.js {unsupported: [u180e]}
-    mongolian-vowel-separator-single-eval.js {unsupported: [u180e]}
     multi-line-asi-carriage-return.js
     multi-line-asi-line-feed.js
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
 
-language/computed-property-names 31/48 (64.58%)
-    class/accessor 4/4 (100.0%)
-    class/method 11/11 (100.0%)
-    class/static 14/14 (100.0%)
+language/computed-property-names
+    class/accessor/getter.js
+    class/accessor/getter-duplicates.js
+    class/accessor/setter.js
+    class/accessor/setter-duplicates.js
+    class/method/constructor.js
+    class/method/constructor-can-be-generator.js
+    class/method/constructor-can-be-getter.js
+    class/method/constructor-can-be-setter.js
+    class/method/constructor-duplicate-1.js
+    class/method/constructor-duplicate-2.js
+    class/method/constructor-duplicate-3.js
+    class/method/generator.js
+    class/method/number.js
+    class/method/string.js
+    class/method/symbol.js
+    class/static/generator-constructor.js
+    class/static/generator-prototype.js
+    class/static/getter-constructor.js
+    class/static/getter-prototype.js
+    class/static/method-constructor.js
+    class/static/method-number.js
+    class/static/method-number-order.js
+    class/static/method-prototype.js
+    class/static/method-string.js
+    class/static/method-string-order.js
+    class/static/method-symbol.js
+    class/static/method-symbol-order.js
+    class/static/setter-constructor.js
+    class/static/setter-prototype.js
     to-name-side-effects/class.js
     to-name-side-effects/numbers-class.js
 
-language/destructuring 9/19 (47.37%)
+language/destructuring
     binding/syntax/array-rest-elements.js
     binding/syntax/destructuring-array-parameters-function-arguments-length.js
     binding/syntax/destructuring-object-parameters-function-arguments-length.js
@@ -2886,248 +2055,187 @@ language/destructuring 9/19 (47.37%)
     binding/syntax/recursive-array-and-object-patterns.js
     binding/initialization-requires-object-coercible-null.js
     binding/initialization-requires-object-coercible-undefined.js
-    binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js non-strict
-    binding/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js
 
-language/directive-prologue 2/62 (3.23%)
-    14.1-4-s.js non-strict
-    14.1-5-s.js non-strict
+language/directive-prologue
+    14.1-4-s.js
+    14.1-5-s.js
 
-language/eval-code 241/347 (69.45%)
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
-    direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
-    direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
-    direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
-    direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
-    direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
-    direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
-    direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/block-decl-eval-source-is-strict-nostrict.js non-strict
-    direct/block-decl-eval-source-is-strict-onlystrict.js strict
-    direct/block-decl-onlystrict.js strict
-    direct/export.js {unsupported: [module]}
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/import.js {unsupported: [module]}
-    direct/lex-env-distinct-cls.js {unsupported: [class]}
+language/eval-code
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/block-decl-eval-source-is-strict-nostrict.js
+    direct/block-decl-eval-source-is-strict-onlystrict.js
+    direct/block-decl-onlystrict.js
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
     direct/lex-env-distinct-const.js
     direct/lex-env-distinct-let.js
-    direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/new.target.js {unsupported: [new.target]}
-    direct/new.target-arrow.js {unsupported: [new.target]}
-    direct/new.target-fn.js {unsupported: [new.target]}
-    direct/non-definable-global-var.js non-strict
-    direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
-    direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
-    direct/switch-case-decl-onlystrict.js strict
-    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js non-strict
-    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js strict
-    direct/switch-dflt-decl-onlystrict.js strict
-    direct/this-value-func-strict-caller.js strict
-    direct/var-env-func-init-global-update-configurable.js non-strict
-    direct/var-env-func-strict-caller.js strict
-    direct/var-env-func-strict-caller-2.js strict
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+    direct/non-definable-global-var.js
+    direct/switch-case-decl-eval-source-is-strict-nostrict.js
+    direct/switch-case-decl-eval-source-is-strict-onlystrict.js
+    direct/switch-case-decl-onlystrict.js
+    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js
+    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js
+    direct/switch-dflt-decl-onlystrict.js
+    direct/this-value-func-strict-caller.js
+    direct/var-env-func-init-global-update-configurable.js
+    direct/var-env-func-strict-caller.js
+    direct/var-env-func-strict-caller-2.js
     direct/var-env-func-strict-source.js
-    direct/var-env-global-lex-non-strict.js non-strict
-    direct/var-env-lower-lex-non-strict.js non-strict
-    direct/var-env-var-strict-caller.js strict
-    direct/var-env-var-strict-caller-2.js strict
-    direct/var-env-var-strict-caller-3.js strict
+    direct/var-env-global-lex-non-strict.js
+    direct/var-env-lower-lex-non-strict.js
+    direct/var-env-var-strict-caller.js
+    direct/var-env-var-strict-caller-2.js
+    direct/var-env-var-strict-caller-3.js
     direct/var-env-var-strict-source.js
-    indirect/always-non-strict.js strict
+    indirect/always-non-strict.js
     indirect/block-decl-strict.js
-    indirect/export.js {unsupported: [module]}
-    indirect/import.js {unsupported: [module]}
-    indirect/lex-env-distinct-cls.js {unsupported: [class]}
     indirect/lex-env-distinct-const.js
     indirect/lex-env-distinct-let.js
-    indirect/lex-env-no-init-cls.js {unsupported: [class]}
     indirect/lex-env-no-init-const.js
     indirect/lex-env-no-init-let.js
-    indirect/new.target.js {unsupported: [new.target]}
     indirect/non-definable-function-with-function.js
     indirect/non-definable-function-with-variable.js
-    indirect/non-definable-global-var.js non-strict
+    indirect/non-definable-global-var.js
     indirect/realm.js
     indirect/switch-case-decl-strict.js
     indirect/switch-dflt-decl-strict.js
@@ -3138,11 +2246,11 @@ language/eval-code 241/347 (69.45%)
 
 ~language/export
 
-language/expressions/addition 2/48 (4.17%)
+language/expressions/addition
     bigint-errors.js
     order-of-evaluation.js
 
-language/expressions/array 22/52 (42.31%)
+language/expressions/array
     spread-err-mult-err-expr-throws.js
     spread-err-mult-err-iter-get-value.js
     spread-err-mult-err-itr-get-call.js
@@ -3166,7 +2274,7 @@ language/expressions/array 22/52 (42.31%)
     spread-sngl-iter.js
     spread-sngl-literal.js
 
-language/expressions/arrow-function 151/343 (44.02%)
+language/expressions/arrow-function
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3254,9 +2362,6 @@ language/expressions/arrow-function 151/343 (44.02%)
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -3276,59 +2381,56 @@ language/expressions/arrow-function 151/343 (44.02%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    forbidden-ext/b1 2/2 (100.0%)
-    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
+    forbidden-ext/b1/arrow-function-forbidden-ext-direct-access-prop-arguments.js
+    forbidden-ext/b1/arrow-function-forbidden-ext-direct-access-prop-caller.js
+    syntax/early-errors/arrowparameters-cover-no-duplicates.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    syntax/arrowparameters-bindingidentifier-yield.js non-strict
-    syntax/arrowparameters-cover-formalparameters-yield.js non-strict
+    syntax/arrowparameters-bindingidentifier-yield.js
+    syntax/arrowparameters-cover-formalparameters-yield.js
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-initialize-2.js
     syntax/arrowparameters-cover-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
     array-destructuring-param-strict-body.js
     ArrowFunction_restricted-properties.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js
     length-dflt.js
-    lexical-new.target.js {unsupported: [new.target]}
-    lexical-new.target-closure-returned.js {unsupported: [new.target]}
     lexical-super-call-from-within-constructor.js
     lexical-super-property.js
     lexical-super-property-from-within-constructor.js
     lexical-supercall-from-immediately-invoked-arrow.js
     object-destructuring-param-strict-body.js
     param-dflt-yield-expr.js
-    param-dflt-yield-id-non-strict.js non-strict
-    params-duplicate.js non-strict
-    scope-body-lex-distinct.js non-strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    param-dflt-yield-id-non-strict.js
+    params-duplicate.js
+    scope-body-lex-distinct.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
     scope-paramsbody-var-open.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
+    unscopables-with.js
+    unscopables-with-in-nested-fn.js
 
-language/expressions/assignment 182/481 (37.84%)
-    destructuring 4/4 (100.0%)
+language/expressions/assignment
+    destructuring/iterator-destructuring-property-reference-target-evaluation-order.js
+    destructuring/keyed-destructuring-property-reference-target-evaluation-order.js
+    destructuring/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js
+    destructuring/obj-prop-__proto__dup.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
-    dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-cover.js
-    dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js non-strict
-    dstr/array-elem-init-yield-ident-valid.js non-strict
+    dstr/array-elem-init-simple-no-strict.js
+    dstr/array-elem-init-yield-ident-valid.js
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -3340,15 +2442,15 @@ language/expressions/assignment 182/481 (37.84%)
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
+    dstr/array-elem-nested-array-yield-ident-valid.js
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
-    dstr/array-elem-put-const.js non-strict
+    dstr/array-elem-nested-obj-yield-ident-valid.js
+    dstr/array-elem-put-const.js
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js strict
-    dstr/array-elem-target-yield-valid.js non-strict
+    dstr/array-elem-target-simple-strict.js
+    dstr/array-elem-target-yield-valid.js
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -3415,130 +2517,62 @@ language/expressions/assignment 182/481 (37.84%)
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-array-yield-ident-valid.js
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-obj-yield-ident-valid.js
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js non-strict
-    dstr/array-rest-put-unresolvable-strict.js strict
+    dstr/array-rest-put-unresolvable-no-strict.js
+    dstr/array-rest-put-unresolvable-strict.js
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js non-strict
+    dstr/array-rest-yield-ident-valid.js
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js non-strict
+    dstr/obj-id-identifier-yield-ident-valid.js
     dstr/obj-id-init-fn-name-arrow.js
-    dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
     dstr/obj-id-init-let.js
-    dstr/obj-id-init-simple-no-strict.js non-strict
-    dstr/obj-id-init-yield-ident-valid.js non-strict
-    dstr/obj-id-put-const.js non-strict
+    dstr/obj-id-init-simple-no-strict.js
+    dstr/obj-id-init-yield-ident-valid.js
+    dstr/obj-id-put-const.js
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
-    dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-init-yield-ident-valid.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-target-yield-ident-valid.js
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
+    dstr/obj-prop-nested-array-yield-ident-valid.js
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
-    dstr/obj-prop-put-const.js non-strict
+    dstr/obj-prop-nested-obj-yield-ident-valid.js
+    dstr/obj-prop-put-const.js
     dstr/obj-prop-put-let.js
-    dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
-    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
-    dstr/obj-rest-descriptors.js {unsupported: [object-rest]}
-    dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
-    dstr/obj-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1dot.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1dot0.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1e0.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-array-1.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-array-1e0.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-string-1.js {unsupported: [object-rest]}
-    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
-    dstr/obj-rest-number.js {unsupported: [object-rest]}
-    dstr/obj-rest-order.js {unsupported: [object-rest]}
-    dstr/obj-rest-put-const.js {unsupported: [object-rest]}
-    dstr/obj-rest-same-name.js {unsupported: [object-rest]}
-    dstr/obj-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-rest-str-val.js {unsupported: [object-rest]}
-    dstr/obj-rest-symbol-val.js {unsupported: [object-rest]}
-    dstr/obj-rest-to-property.js {unsupported: [object-rest]}
-    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
-    dstr/obj-rest-val-null.js {unsupported: [object-rest]}
-    dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
-    dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
-    11.13.1-2-s.js strict
-    assignment-operator-calls-putvalue-lref--rval-.js non-strict
-    assignment-operator-calls-putvalue-lref--rval--1.js non-strict
-    fn-name-class.js {unsupported: [class]}
-    target-cover-newtarget.js {unsupported: [new.target]}
-    target-newtarget.js {unsupported: [new.target]}
+    11.13.1-2-s.js
+    assignment-operator-calls-putvalue-lref--rval-.js
+    assignment-operator-calls-putvalue-lref--rval--1.js
     target-super-computed-reference.js
     target-super-computed-reference-null.js
     target-super-identifier-reference-null.js
 
-language/expressions/async-arrow-function 42/60 (70.0%)
-    forbidden-ext/b1 2/2 (100.0%)
-    forbidden-ext/b2 3/3 (100.0%)
-    arrow-returns-promise.js {unsupported: [async]}
-    await-as-binding-identifier.js {unsupported: [async-functions]}
-    await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
-    await-as-identifier-reference.js {unsupported: [async-functions]}
-    await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
-    await-as-label-identifier.js {unsupported: [async-functions]}
-    await-as-label-identifier-escaped.js {unsupported: [async-functions]}
-    await-as-param-ident-nested-arrow-parameter-position.js {unsupported: [async-functions]}
-    await-as-param-nested-arrow-body-position.js {unsupported: [async-functions]}
-    await-as-param-nested-arrow-parameter-position.js {unsupported: [async-functions]}
-    await-as-param-rest-nested-arrow-parameter-position.js {unsupported: [async-functions]}
-    dflt-params-abrupt.js {unsupported: [async-functions, async]}
-    dflt-params-arg-val-not-undefined.js {unsupported: [async-functions, async]}
-    dflt-params-arg-val-undefined.js {unsupported: [async-functions, async]}
-    dflt-params-ref-later.js {unsupported: [async-functions, async]}
-    dflt-params-ref-prior.js {unsupported: [async-functions, async]}
-    dflt-params-ref-self.js {unsupported: [async-functions, async]}
-    dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
-    early-errors-arrow-duplicate-parameters.js {unsupported: [async-functions]}
-    escaped-async.js {unsupported: [async-functions]}
-    escaped-async-line-terminator.js {unsupported: [async-functions]}
-    eval-var-scope-syntax-err.js {unsupported: [async-functions, async]}
+language/expressions/async-arrow-function
     name.js
-    params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
-    params-trailing-comma-single.js {unsupported: [async-functions, async]}
     prototype.js
-    try-reject-finally-reject.js {unsupported: [async]}
-    try-reject-finally-return.js {unsupported: [async]}
-    try-reject-finally-throw.js {unsupported: [async]}
-    try-return-finally-reject.js {unsupported: [async]}
-    try-return-finally-return.js {unsupported: [async]}
-    try-return-finally-throw.js {unsupported: [async]}
-    try-throw-finally-reject.js {unsupported: [async]}
-    try-throw-finally-return.js {unsupported: [async]}
-    try-throw-finally-throw.js {unsupported: [async]}
-    unscopables-with.js {unsupported: [async-functions, async]}
-    unscopables-with-in-nested-fn.js {unsupported: [async-functions, async]}
 
 ~language/expressions/async-function
 
@@ -3548,19 +2582,19 @@ language/expressions/async-arrow-function 42/60 (70.0%)
 
 ~language/expressions/await
 
-language/expressions/bitwise-and 1/30 (3.33%)
+language/expressions/bitwise-and
     order-of-evaluation.js
 
-language/expressions/bitwise-not 0/16 (0.0%)
+language/expressions/bitwise-not
 
-language/expressions/bitwise-or 1/30 (3.33%)
+language/expressions/bitwise-or
     order-of-evaluation.js
 
-language/expressions/bitwise-xor 1/30 (3.33%)
+language/expressions/bitwise-xor
     order-of-evaluation.js
 
-language/expressions/call 34/92 (36.96%)
-    eval-realm-indirect.js non-strict
+language/expressions/call
+    eval-realm-indirect.js
     eval-spread.js
     eval-spread-empty.js
     eval-spread-empty-leading.js
@@ -3587,112 +2621,55 @@ language/expressions/call 34/92 (36.96%)
     spread-sngl-expr.js
     spread-sngl-iter.js
     spread-sngl-literal.js
-    tco-call-args.js {unsupported: [tail-call-optimization]}
-    tco-member-args.js {unsupported: [tail-call-optimization]}
-    tco-non-eval-function.js {unsupported: [tail-call-optimization]}
-    tco-non-eval-function-dynamic.js {unsupported: [tail-call-optimization]}
-    tco-non-eval-global.js {unsupported: [tail-call-optimization]}
-    tco-non-eval-with.js {unsupported: [tail-call-optimization]}
     trailing-comma.js
 
 ~language/expressions/class
 
-language/expressions/coalesce 2/24 (8.33%)
-    tco-pos-null.js {unsupported: [tail-call-optimization]}
-    tco-pos-undefined.js {unsupported: [tail-call-optimization]}
+language/expressions/coalesce
 
-language/expressions/comma 1/6 (16.67%)
-    tco-final.js {unsupported: [tail-call-optimization]}
+language/expressions/comma
 
-language/expressions/compound-assignment 125/454 (27.53%)
-    11.13.2-34-s.js strict
-    11.13.2-35-s.js strict
-    11.13.2-36-s.js strict
-    11.13.2-37-s.js strict
-    11.13.2-38-s.js strict
-    11.13.2-39-s.js strict
-    11.13.2-40-s.js strict
-    11.13.2-41-s.js strict
-    11.13.2-42-s.js strict
-    11.13.2-43-s.js strict
-    11.13.2-44-s.js strict
-    add-arguments-strict.js strict
-    and-arguments-strict.js strict
-    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
-    div-arguments-strict.js strict
-    left-hand-side-private-reference-accessor-property-add.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-bitand.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-bitor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-bitxor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-div.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-exp.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-lshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-mod.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-mult.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-rshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-srshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-sub.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-add.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-bitand.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-bitor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-bitxor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-div.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-exp.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-lshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-mod.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-mult.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-rshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-srshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-sub.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-add.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-bitand.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-bitor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-bitxor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-div.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-exp.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-lshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-mod.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-mult.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-rshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-srshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-sub.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-add.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-bitand.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-bitor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-bitxor.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-div.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-exp.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-lshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-mod.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-mult.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-rshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-srshift.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-sub.js {unsupported: [class-fields-private]}
-    lshift-arguments-strict.js strict
-    mod-arguments-strict.js strict
-    mult-arguments-strict.js strict
-    or-arguments-strict.js strict
+language/expressions/compound-assignment
+    11.13.2-34-s.js
+    11.13.2-35-s.js
+    11.13.2-36-s.js
+    11.13.2-37-s.js
+    11.13.2-38-s.js
+    11.13.2-39-s.js
+    11.13.2-40-s.js
+    11.13.2-41-s.js
+    11.13.2-42-s.js
+    11.13.2-43-s.js
+    11.13.2-44-s.js
+    add-arguments-strict.js
+    and-arguments-strict.js
+    compound-assignment-operator-calls-putvalue-lref--v-.js
+    compound-assignment-operator-calls-putvalue-lref--v--1.js
+    compound-assignment-operator-calls-putvalue-lref--v--10.js
+    compound-assignment-operator-calls-putvalue-lref--v--11.js
+    compound-assignment-operator-calls-putvalue-lref--v--12.js
+    compound-assignment-operator-calls-putvalue-lref--v--13.js
+    compound-assignment-operator-calls-putvalue-lref--v--14.js
+    compound-assignment-operator-calls-putvalue-lref--v--15.js
+    compound-assignment-operator-calls-putvalue-lref--v--16.js
+    compound-assignment-operator-calls-putvalue-lref--v--17.js
+    compound-assignment-operator-calls-putvalue-lref--v--18.js
+    compound-assignment-operator-calls-putvalue-lref--v--19.js
+    compound-assignment-operator-calls-putvalue-lref--v--2.js
+    compound-assignment-operator-calls-putvalue-lref--v--20.js
+    compound-assignment-operator-calls-putvalue-lref--v--21.js
+    compound-assignment-operator-calls-putvalue-lref--v--3.js
+    compound-assignment-operator-calls-putvalue-lref--v--4.js
+    compound-assignment-operator-calls-putvalue-lref--v--5.js
+    compound-assignment-operator-calls-putvalue-lref--v--6.js
+    compound-assignment-operator-calls-putvalue-lref--v--7.js
+    compound-assignment-operator-calls-putvalue-lref--v--8.js
+    compound-assignment-operator-calls-putvalue-lref--v--9.js
+    div-arguments-strict.js
+    lshift-arguments-strict.js
+    mod-arguments-strict.js
+    mult-arguments-strict.js
+    or-arguments-strict.js
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
     S11.13.2_A7.10_T4.js
@@ -3726,38 +2703,33 @@ language/expressions/compound-assignment 125/454 (27.53%)
     S11.13.2_A7.9_T1.js
     S11.13.2_A7.9_T2.js
     S11.13.2_A7.9_T4.js
-    srshift-arguments-strict.js strict
-    sub-arguments-strict.js strict
-    urshift-arguments-strict.js strict
-    xor-arguments-strict.js strict
+    srshift-arguments-strict.js
+    sub-arguments-strict.js
+    urshift-arguments-strict.js
+    xor-arguments-strict.js
 
-language/expressions/concatenation 0/5 (0.0%)
+language/expressions/concatenation
 
-language/expressions/conditional 2/22 (9.09%)
-    tco-cond.js {unsupported: [tail-call-optimization]}
-    tco-pos.js {unsupported: [tail-call-optimization]}
+language/expressions/conditional
 
-language/expressions/delete 6/69 (8.7%)
-    identifier-strict.js strict
-    identifier-strict-recursive.js strict
-    super-property.js {unsupported: [class]}
-    super-property-method.js {unsupported: [class]}
-    super-property-null-base.js {unsupported: [class]}
+language/expressions/delete
+    identifier-strict.js
+    identifier-strict-recursive.js
     super-property-uninitialized-this.js
 
-language/expressions/division 1/45 (2.22%)
+language/expressions/division
     order-of-evaluation.js
 
-language/expressions/does-not-equals 0/38 (0.0%)
+language/expressions/does-not-equals
 
 ~language/expressions/dynamic-import
 
-language/expressions/equals 0/47 (0.0%)
+language/expressions/equals
 
-language/expressions/exponentiation 1/44 (2.27%)
+language/expressions/exponentiation
     order-of-evaluation.js
 
-language/expressions/function 149/264 (56.44%)
+language/expressions/function
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3845,9 +2817,6 @@ language/expressions/function 149/264 (56.44%)
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -3863,49 +2832,45 @@ language/expressions/function 149/264 (56.44%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    early-errors 4/4 (100.0%)
-    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict
-    arguments-with-arguments-lex.js non-strict
+    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js
+    arguments-with-arguments-fn.js
+    arguments-with-arguments-lex.js
     array-destructuring-param-strict-body.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js
     length-dflt.js
-    name-arguments-strict-body.js non-strict
-    named-no-strict-reassign-fn-name-in-body.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
-    named-strict-error-reassign-fn-name-in-body.js strict
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
-    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
+    name-arguments-strict-body.js
+    named-no-strict-reassign-fn-name-in-body.js
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js
+    named-no-strict-reassign-fn-name-in-body-in-eval.js
+    named-strict-error-reassign-fn-name-in-body.js
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js
+    named-strict-error-reassign-fn-name-in-body-in-eval.js
     object-destructuring-param-strict-body.js
-    param-dflt-yield-non-strict.js non-strict
-    param-dflt-yield-strict.js strict
-    param-duplicated-strict-body-1.js non-strict
-    param-duplicated-strict-body-2.js non-strict
-    param-duplicated-strict-body-3.js non-strict
-    param-eval-strict-body.js non-strict
+    param-dflt-yield-non-strict.js
+    param-dflt-yield-strict.js
+    param-duplicated-strict-body-1.js
+    param-duplicated-strict-body-2.js
+    param-duplicated-strict-body-3.js
+    param-eval-strict-body.js
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict
-    scope-name-var-open-non-strict.js non-strict
-    scope-name-var-open-strict.js strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js
+    scope-name-var-open-non-strict.js
+    scope-name-var-open-strict.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
+    unscopables-with.js
+    unscopables-with-in-nested-fn.js
 
-language/expressions/generators 182/290 (62.76%)
+language/expressions/generators
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4010,9 +2975,6 @@ language/expressions/generators 182/290 (62.76%)
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -4035,32 +2997,29 @@ language/expressions/generators 182/290 (62.76%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict
+    forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js
+    arguments-with-arguments-fn.js
     array-destructuring-param-strict-body.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
     eval-body-proto-realm.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
-    named-no-strict-reassign-fn-name-in-body.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
-    named-strict-error-reassign-fn-name-in-body.js strict
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
-    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
-    named-yield-identifier-non-strict.js non-strict
-    named-yield-identifier-spread-non-strict.js non-strict
+    named-no-strict-reassign-fn-name-in-body.js
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js
+    named-no-strict-reassign-fn-name-in-body-in-eval.js
+    named-strict-error-reassign-fn-name-in-body.js
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js
+    named-strict-error-reassign-fn-name-in-body-in-eval.js
+    named-yield-identifier-non-strict.js
+    named-yield-identifier-spread-non-strict.js
     named-yield-spread-arr-multiple.js
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
@@ -4068,128 +3027,90 @@ language/expressions/generators 182/290 (62.76%)
     prototype-own-properties.js
     prototype-value.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict
-    scope-name-var-close.js compiled
-    scope-name-var-open-non-strict.js non-strict
-    scope-name-var-open-strict.js strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js
+    scope-name-var-close.js
+    scope-name-var-open-non-strict.js
+    scope-name-var-open-strict.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
-    yield-as-function-expression-binding-identifier.js non-strict
-    yield-as-identifier-in-nested-function.js non-strict
-    yield-identifier-non-strict.js non-strict
-    yield-identifier-spread-non-strict.js non-strict
+    unscopables-with.js
+    unscopables-with-in-nested-fn.js
+    yield-as-function-expression-binding-identifier.js
+    yield-as-identifier-in-nested-function.js
+    yield-identifier-non-strict.js
+    yield-identifier-spread-non-strict.js
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/expressions/greater-than 0/49 (0.0%)
+language/expressions/greater-than
 
-language/expressions/greater-than-or-equal 0/43 (0.0%)
+language/expressions/greater-than-or-equal
 
-language/expressions/grouping 0/9 (0.0%)
+language/expressions/grouping
 
 ~language/expressions/import.meta
 
-language/expressions/in 20/36 (55.56%)
-    private-field-in.js {unsupported: [class-fields-private]}
-    private-field-in-nested.js {unsupported: [class-fields-private]}
-    private-field-invalid-assignment-reference.js {unsupported: [class-fields-private]}
-    private-field-invalid-assignment-target.js {unsupported: [class-fields-private]}
-    private-field-invalid-identifier-complex.js {unsupported: [class-fields-private]}
-    private-field-invalid-identifier-simple.js {unsupported: [class-fields-private]}
-    private-field-invalid-rhs.js {unsupported: [class-fields-private]}
+language/expressions/in
     private-field-presence-accessor.js
     private-field-presence-accessor-shadowed.js
-    private-field-presence-field.js {unsupported: [class-fields-private]}
-    private-field-presence-field-shadowed.js {unsupported: [class-fields-private]}
     private-field-presence-method.js
     private-field-presence-method-shadowed.js
-    private-field-rhs-await-absent.js {unsupported: [class-fields-private]}
-    private-field-rhs-await-present.js {unsupported: [class-fields-private, async]}
-    private-field-rhs-non-object.js {unsupported: [class-fields-private]}
-    private-field-rhs-unresolvable.js {unsupported: [class-fields-private]}
-    private-field-rhs-yield-absent.js {unsupported: [class-fields-private]}
-    private-field-rhs-yield-present.js {unsupported: [class-fields-private]}
-    rhs-yield-absent-non-strict.js non-strict
+    rhs-yield-absent-non-strict.js
 
-language/expressions/instanceof 5/43 (11.63%)
+language/expressions/instanceof
     S11.8.6_A6_T2.js
     symbol-hasinstance-get-err.js
     symbol-hasinstance-invocation.js
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift 1/45 (2.22%)
+language/expressions/left-shift
     order-of-evaluation.js
 
-language/expressions/less-than 0/45 (0.0%)
+language/expressions/less-than
 
-language/expressions/less-than-or-equal 0/47 (0.0%)
+language/expressions/less-than-or-equal
 
-language/expressions/logical-and 1/18 (5.56%)
-    tco-right.js {unsupported: [tail-call-optimization]}
+language/expressions/logical-and
 
-language/expressions/logical-assignment 40/78 (51.28%)
-    left-hand-side-private-reference-accessor-property-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-or.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-or.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-short-circuit-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-data-property-short-circuit-or.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-short-circuit-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-method-short-circuit-or.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-or.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
-    left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
-    lgcl-and-arguments-strict.js strict
+language/expressions/logical-assignment
+    lgcl-and-arguments-strict.js
     lgcl-and-assignment-operator-lhs-before-rhs.js
     lgcl-and-assignment-operator-namedevaluation-class-expression.js
-    lgcl-and-assignment-operator-no-set-put.js strict
-    lgcl-and-assignment-operator-non-extensible.js strict
+    lgcl-and-assignment-operator-no-set-put.js
+    lgcl-and-assignment-operator-non-extensible.js
     lgcl-and-assignment-operator-non-simple-lhs.js
-    lgcl-and-assignment-operator-non-writeable.js strict
-    lgcl-nullish-arguments-strict.js strict
+    lgcl-and-assignment-operator-non-writeable.js
+    lgcl-nullish-arguments-strict.js
     lgcl-nullish-assignment-operator-lhs-before-rhs.js
     lgcl-nullish-assignment-operator-namedevaluation-class-expression.js
-    lgcl-nullish-assignment-operator-no-set-put.js strict
+    lgcl-nullish-assignment-operator-no-set-put.js
     lgcl-nullish-assignment-operator-non-simple-lhs.js
-    lgcl-nullish-assignment-operator-non-writeable.js strict
-    lgcl-or-arguments-strict.js strict
+    lgcl-nullish-assignment-operator-non-writeable.js
+    lgcl-or-arguments-strict.js
     lgcl-or-assignment-operator-lhs-before-rhs.js
     lgcl-or-assignment-operator-namedevaluation-class-expression.js
-    lgcl-or-assignment-operator-no-set-put.js strict
+    lgcl-or-assignment-operator-no-set-put.js
     lgcl-or-assignment-operator-non-simple-lhs.js
-    lgcl-or-assignment-operator-non-writeable.js strict
+    lgcl-or-assignment-operator-non-writeable.js
 
-language/expressions/logical-not 0/19 (0.0%)
+language/expressions/logical-not
 
-language/expressions/logical-or 1/18 (5.56%)
-    tco-right.js {unsupported: [tail-call-optimization]}
+language/expressions/logical-or
 
-language/expressions/modulus 1/40 (2.5%)
+language/expressions/modulus
     order-of-evaluation.js
 
-language/expressions/multiplication 1/40 (2.5%)
+language/expressions/multiplication
     order-of-evaluation.js
 
-language/expressions/new 22/59 (37.29%)
+language/expressions/new
     spread-err-mult-err-expr-throws.js
     spread-err-mult-err-iter-get-value.js
     spread-err-mult-err-itr-get-call.js
@@ -4215,193 +3136,7 @@ language/expressions/new 22/59 (37.29%)
 
 ~language/expressions/new.target
 
-language/expressions/object 698/1170 (59.66%)
-    dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-name-iter-val.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-elem-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-elision-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-elision-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-empty-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-empty-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-rest-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-rest-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-ary-val-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-exhausted.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-hole.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-skipped.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-throws.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-undef.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-direct.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-init-id.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-init-iter-close.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-name-iter-val.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-init-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-init-undefined.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-empty.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
-    dstr/async-gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
-    dstr/async-gen-meth-obj-init-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-init-undefined.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-empty.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-get-value-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-init-skipped.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-id-init-throws.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-list-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
-    dstr/async-gen-meth-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
-    dstr/async-gen-meth-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
-    dstr/async-gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
-    dstr/async-gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
+language/expressions/object
     dstr/gen-meth-ary-init-iter-close.js
     dstr/gen-meth-ary-init-iter-get-err.js
     dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -4506,9 +3241,6 @@ language/expressions/object 698/1170 (59.66%)
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/gen-meth-obj-init-null.js
     dstr/gen-meth-obj-init-undefined.js
     dstr/gen-meth-obj-ptrn-id-get-value-err.js
@@ -4531,9 +3263,6 @@ language/expressions/object 698/1170 (59.66%)
     dstr/gen-meth-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-undef.js
-    dstr/gen-meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-ary-init-iter-close.js
     dstr/meth-ary-init-iter-get-err.js
     dstr/meth-ary-init-iter-get-err-array-prototype.js
@@ -4621,9 +3350,6 @@ language/expressions/object 698/1170 (59.66%)
     dstr/meth-dflt-obj-ptrn-prop-obj-init.js
     dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js
     dstr/meth-dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/meth-dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-obj-init-null.js
     dstr/meth-obj-init-undefined.js
     dstr/meth-obj-ptrn-id-init-fn-name-arrow.js
@@ -4639,160 +3365,9 @@ language/expressions/object 698/1170 (59.66%)
     dstr/meth-obj-ptrn-prop-obj-init.js
     dstr/meth-obj-ptrn-prop-obj-value-null.js
     dstr/meth-obj-ptrn-prop-obj-value-undef.js
-    dstr/meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    dstr/object-rest-proxy-get-not-called-on-dontenum-keys.js {unsupported: [object-rest]}
-    dstr/object-rest-proxy-gopd-not-called-on-excluded-keys.js {unsupported: [object-rest]}
-    dstr/object-rest-proxy-ownkeys-returned-keys-order.js {unsupported: [object-rest]}
-    method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-iteration, async]}
-    method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-iteration, async]}
-    method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-iteration, async]}
-    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-iteration, async]}
-    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-iteration, async]}
-    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-functions, async]}
-    method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
-    method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
-    method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
-    method-definition/async-await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
-    method-definition/async-await-as-label-identifier.js {unsupported: [async-functions]}
-    method-definition/async-await-as-label-identifier-escaped.js {unsupported: [async-functions]}
-    method-definition/async-gen-await-as-binding-identifier.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-identifier-reference.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-label-identifier.js {unsupported: [async-iteration]}
-    method-definition/async-gen-await-as-label-identifier-escaped.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-array-destructuring-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-abrupt.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-meth-dflt-params-arg-val-undefined.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-meth-dflt-params-duplicates.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-ref-later.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-ref-prior.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-meth-dflt-params-ref-self.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-rest.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-dflt-params-trailing-comma.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-meth-escaped-async.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-eval-var-scope-syntax-err.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-object-destructuring-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-params-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-meth-params-trailing-comma-single.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-meth-rest-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-gen-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-binding-identifier.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-identifier-reference.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-label-identifier.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-as-label-identifier-escaped.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-identifier-non-strict.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-identifier-spread-non-strict.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-identifier-spread-strict.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-identifier-strict.js {unsupported: [async-iteration]}
-    method-definition/async-gen-yield-promise-reject-next.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-promise-reject-next-catch.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-promise-reject-next-for-await-of-async-iterator.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-promise-reject-next-for-await-of-sync-iterator.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-promise-reject-next-yield-star-sync-iterator.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-spread-arr-multiple.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-spread-arr-single.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-spread-obj.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-async-next.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-async-return.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-async-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-expr-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-not-callable-number-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-not-callable-object-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-not-callable-string-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-null-sync-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-boolean-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-null-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-number-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-string-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-symbol-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-returns-undefined-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-async-undefined-sync-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-not-callable-number-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-not-callable-object-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-not-callable-string-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-boolean-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-null-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-number-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-string-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-symbol-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-getiter-sync-returns-undefined-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-call-done-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-call-returns-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-call-value-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-non-object-ignores-then.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-null-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-number-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-object-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-string-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-not-callable-undefined-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-get-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-boolean-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-null-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-number-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-object-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-string-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-symbol-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-non-callable-undefined-fulfillpromise.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-next-then-returns-abrupt.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-sync-next.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-sync-return.js {unsupported: [async-iteration, async]}
-    method-definition/async-gen-yield-star-sync-throw.js {unsupported: [async-iteration, async]}
-    method-definition/async-meth-array-destructuring-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-meth-dflt-params-abrupt.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-dflt-params-arg-val-not-undefined.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-dflt-params-arg-val-undefined.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-dflt-params-duplicates.js {unsupported: [async-iteration]}
-    method-definition/async-meth-dflt-params-ref-later.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-dflt-params-ref-prior.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-dflt-params-ref-self.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-dflt-params-rest.js {unsupported: [async-iteration]}
-    method-definition/async-meth-dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-escaped-async.js {unsupported: [async-functions]}
-    method-definition/async-meth-eval-var-scope-syntax-err.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-object-destructuring-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-meth-params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-params-trailing-comma-single.js {unsupported: [async-functions, async]}
-    method-definition/async-meth-rest-param-strict-body.js {unsupported: [async-iteration]}
-    method-definition/async-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
-    method-definition/async-returns-async-arrow.js {unsupported: [async-functions, async]}
-    method-definition/async-returns-async-arrow-returns-arguments-from-parent-function.js {unsupported: [async-functions, async]}
-    method-definition/async-returns-async-arrow-returns-newtarget.js {unsupported: [async-functions, async]}
-    method-definition/async-returns-async-function.js {unsupported: [async-functions, async]}
-    method-definition/async-returns-async-function-returns-arguments-from-own-function.js {unsupported: [async-functions, async]}
-    method-definition/async-returns-async-function-returns-newtarget.js {unsupported: [async-functions, async]}
-    method-definition/async-super-call-body.js {unsupported: [async]}
-    method-definition/async-super-call-param.js {unsupported: [async]}
-    method-definition/early-errors-object-method-arguments-in-formal-parameters.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-await-in-formals.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-await-in-formals-default.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-body-contains-super-call.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-duplicate-parameters.js non-strict
-    method-definition/early-errors-object-method-eval-in-formal-parameters.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-formals-body-duplicate.js {unsupported: [async-functions]}
+    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js
+    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js
+    method-definition/early-errors-object-method-duplicate-parameters.js
     method-definition/escaped-get.js
     method-definition/escaped-get-e.js
     method-definition/escaped-get-g.js
@@ -4803,52 +3378,43 @@ language/expressions/object 698/1170 (59.66%)
     method-definition/escaped-set-t.js
     method-definition/gen-meth-array-destructuring-param-strict-body.js
     method-definition/gen-meth-dflt-params-abrupt.js
-    method-definition/gen-meth-dflt-params-duplicates.js non-strict
+    method-definition/gen-meth-dflt-params-duplicates.js
     method-definition/gen-meth-dflt-params-ref-later.js
     method-definition/gen-meth-dflt-params-ref-self.js
     method-definition/gen-meth-dflt-params-rest.js
     method-definition/gen-meth-dflt-params-trailing-comma.js
-    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict
+    method-definition/gen-meth-eval-var-scope-syntax-err.js
     method-definition/gen-meth-object-destructuring-param-strict-body.js
     method-definition/gen-meth-rest-param-strict-body.js
-    method-definition/gen-yield-identifier-non-strict.js non-strict
-    method-definition/gen-yield-identifier-spread-non-strict.js non-strict
+    method-definition/gen-yield-identifier-non-strict.js
+    method-definition/gen-yield-identifier-spread-non-strict.js
     method-definition/gen-yield-spread-arr-multiple.js
     method-definition/gen-yield-spread-arr-single.js
     method-definition/gen-yield-spread-obj.js
-    method-definition/generator-invoke-fn-strict.js non-strict
+    method-definition/generator-invoke-fn-strict.js
     method-definition/generator-length-dflt.js
-    method-definition/generator-param-init-yield.js non-strict
+    method-definition/generator-param-init-yield.js
     method-definition/generator-param-redecl-let.js
-    method-definition/generator-prop-name-yield-expr.js non-strict
-    method-definition/generator-prop-name-yield-id.js non-strict
+    method-definition/generator-prop-name-yield-expr.js
+    method-definition/generator-prop-name-yield-id.js
     method-definition/generator-prototype-prop.js
     method-definition/meth-array-destructuring-param-strict-body.js
-    method-definition/meth-dflt-params-duplicates.js non-strict
+    method-definition/meth-dflt-params-duplicates.js
     method-definition/meth-dflt-params-ref-later.js
     method-definition/meth-dflt-params-ref-self.js
     method-definition/meth-dflt-params-rest.js
     method-definition/meth-dflt-params-trailing-comma.js
-    method-definition/meth-eval-var-scope-syntax-err.js non-strict
+    method-definition/meth-eval-var-scope-syntax-err.js
     method-definition/meth-object-destructuring-param-strict-body.js
     method-definition/meth-rest-param-strict-body.js
-    method-definition/name-invoke-fn-strict.js non-strict
+    method-definition/name-invoke-fn-strict.js
     method-definition/name-length-dflt.js
-    method-definition/name-param-id-yield.js non-strict
-    method-definition/name-param-init-yield.js non-strict
+    method-definition/name-param-id-yield.js
+    method-definition/name-param-init-yield.js
     method-definition/name-param-redecl.js
-    method-definition/name-prop-name-yield-expr.js non-strict
-    method-definition/name-prop-name-yield-id.js non-strict
-    method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
+    method-definition/name-prop-name-yield-expr.js
+    method-definition/name-prop-name-yield-id.js
     method-definition/params-dflt-meth-ref-arguments.js
-    method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
-    method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
-    method-definition/private-name-early-error-async-gen.js {unsupported: [async-iteration]}
-    method-definition/private-name-early-error-async-gen-inside-class.js {unsupported: [class-fields-public, async-iteration, class]}
-    method-definition/private-name-early-error-gen-inside-class.js {unsupported: [class-fields-public, class]}
-    method-definition/private-name-early-error-get-method-inside-class.js {unsupported: [class-fields-public, class]}
-    method-definition/private-name-early-error-method-inside-class.js {unsupported: [class-fields-public, class]}
-    method-definition/private-name-early-error-set-method-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/static-init-await-binding-accessor.js
     method-definition/static-init-await-binding-generator.js
     method-definition/static-init-await-binding-normal.js
@@ -4857,153 +3423,127 @@ language/expressions/object 698/1170 (59.66%)
     method-definition/static-init-await-reference-normal.js
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
-    method-definition/yield-as-function-expression-binding-identifier.js non-strict
-    method-definition/yield-as-identifier-in-nested-function.js non-strict
+    method-definition/yield-as-function-expression-binding-identifier.js
+    method-definition/yield-as-identifier-in-nested-function.js
     method-definition/yield-star-after-newline.js
     method-definition/yield-star-before-newline.js
-    11.1.5-2gs.js strict
-    11.1.5_4-4-a-3.js strict
-    11.1.5_4-4-b-1.js strict
-    __proto__-duplicate.js non-strict
+    11.1.5-2gs.js
+    11.1.5_4-4-a-3.js
+    11.1.5_4-4-b-1.js
+    __proto__-duplicate.js
     __proto__-duplicate-computed.js
-    __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-id.js non-strict
+    accessor-name-computed-yield-id.js
     computed-__proto__.js
     cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
-    cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
     cpn-obj-lit-computed-property-name-from-yield-expression.js
-    fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
-    getter-body-strict-inside.js non-strict
+    getter-body-strict-inside.js
     getter-param-dflt.js
     ident-name-prop-name-literal-await-static-init.js
-    identifier-shorthand-await-strict-mode.js non-strict
+    identifier-shorthand-await-strict-mode.js
     identifier-shorthand-static-init-await-valid.js
-    let-non-strict-access.js non-strict
-    let-non-strict-syntax.js non-strict
-    literal-property-name-bigint.js {unsupported: [class]}
+    let-non-strict-access.js
+    let-non-strict-syntax.js
     object-spread-proxy-get-not-called-on-dontenum-keys.js
     object-spread-proxy-no-excluded-keys.js
     object-spread-proxy-ownkeys-returned-keys-order.js
-    prop-def-id-eval-error.js non-strict
-    prop-def-id-eval-error-2.js non-strict
-    prop-dup-data-data.js strict
-    prop-dup-data-set.js strict
-    prop-dup-get-data.js strict
-    prop-dup-get-get.js strict
-    prop-dup-get-set-get.js strict
-    prop-dup-set-data.js strict
-    prop-dup-set-get-set.js strict
-    prop-dup-set-set.js strict
-    scope-gen-meth-body-lex-distinct.js non-strict
-    scope-gen-meth-param-rest-elem-var-close.js non-strict
-    scope-gen-meth-param-rest-elem-var-open.js non-strict
+    prop-def-id-eval-error.js
+    prop-def-id-eval-error-2.js
+    prop-dup-data-data.js
+    prop-dup-data-set.js
+    prop-dup-get-data.js
+    prop-dup-get-get.js
+    prop-dup-get-set-get.js
+    prop-dup-set-data.js
+    prop-dup-set-get-set.js
+    prop-dup-set-set.js
+    scope-gen-meth-body-lex-distinct.js
+    scope-gen-meth-param-rest-elem-var-close.js
+    scope-gen-meth-param-rest-elem-var-open.js
     scope-gen-meth-paramsbody-var-open.js
-    scope-getter-body-lex-distinc.js non-strict
-    scope-meth-body-lex-distinct.js non-strict
-    scope-meth-param-rest-elem-var-close.js non-strict
-    scope-meth-param-rest-elem-var-open.js non-strict
+    scope-getter-body-lex-distinc.js
+    scope-meth-body-lex-distinct.js
+    scope-meth-param-rest-elem-var-close.js
+    scope-meth-param-rest-elem-var-open.js
     scope-meth-paramsbody-var-open.js
-    scope-setter-body-lex-distinc.js non-strict
+    scope-setter-body-lex-distinc.js
     scope-setter-paramsbody-var-open.js
-    setter-body-strict-inside.js non-strict
+    setter-body-strict-inside.js
     setter-length-dflt.js
-    setter-param-arguments-strict-inside.js non-strict
-    setter-param-eval-strict-inside.js non-strict
-    yield-non-strict-access.js non-strict
-    yield-non-strict-syntax.js non-strict
+    setter-param-arguments-strict-inside.js
+    setter-param-eval-strict-inside.js
+    yield-non-strict-access.js
+    yield-non-strict-syntax.js
 
-language/expressions/optional-chaining 18/38 (47.37%)
+language/expressions/optional-chaining
     call-expression.js
     early-errors-tail-position-null-optchain-template-string.js
     early-errors-tail-position-null-optchain-template-string-esi.js
     early-errors-tail-position-optchain-template-string.js
     early-errors-tail-position-optchain-template-string-esi.js
     eval-optional-call.js
-    iteration-statement-for-await-of.js {unsupported: [async]}
     iteration-statement-for-in.js
     iteration-statement-for-of-type-error.js
     member-expression.js
-    member-expression-async-identifier.js {unsupported: [async]}
-    member-expression-async-literal.js {unsupported: [async]}
-    member-expression-async-this.js {unsupported: [async]}
     new-target-optional-call.js
-    optional-chain-async-optional-chain-square-brackets.js {unsupported: [async]}
-    optional-chain-async-square-brackets.js {unsupported: [async]}
     optional-chain-prod-arguments.js
     super-property-optional-call.js
 
-language/expressions/postfix-decrement 9/37 (24.32%)
-    arguments.js strict
-    eval.js strict
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict
+language/expressions/postfix-decrement
+    arguments.js
+    eval.js
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
-    target-cover-newtarget.js {unsupported: [new.target]}
-    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/postfix-increment 10/38 (26.32%)
-    11.3.1-2-1gs.js strict
-    arguments.js strict
-    eval.js strict
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict
+language/expressions/postfix-increment
+    11.3.1-2-1gs.js
+    arguments.js
+    eval.js
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
-    target-cover-newtarget.js {unsupported: [new.target]}
-    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-decrement 10/34 (29.41%)
-    11.4.5-2-2gs.js strict
-    arguments.js strict
-    eval.js strict
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict
+language/expressions/prefix-decrement
+    11.4.5-2-2gs.js
+    arguments.js
+    eval.js
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
-    target-cover-newtarget.js {unsupported: [new.target]}
-    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-increment 9/33 (27.27%)
-    arguments.js strict
-    eval.js strict
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict
+language/expressions/prefix-increment
+    arguments.js
+    eval.js
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
-    target-cover-newtarget.js {unsupported: [new.target]}
-    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/property-accessors 0/21 (0.0%)
+language/expressions/property-accessors
 
-language/expressions/relational 0/1 (0.0%)
+language/expressions/relational
 
-language/expressions/right-shift 1/37 (2.7%)
+language/expressions/right-shift
     order-of-evaluation.js
 
-language/expressions/strict-does-not-equals 0/30 (0.0%)
+language/expressions/strict-does-not-equals
 
-language/expressions/strict-equals 0/30 (0.0%)
+language/expressions/strict-equals
 
-language/expressions/subtraction 1/38 (2.63%)
+language/expressions/subtraction
     order-of-evaluation.js
 
-language/expressions/super 73/94 (77.66%)
-    call-arg-evaluation-err.js {unsupported: [class]}
-    call-bind-this-value.js {unsupported: [class]}
-    call-bind-this-value-twice.js {unsupported: [class]}
-    call-construct-error.js {unsupported: [class]}
-    call-construct-invocation.js {unsupported: [new.target, class]}
-    call-expr-value.js {unsupported: [class]}
-    call-poisoned-underscore-proto.js {unsupported: [class]}
-    call-proto-not-ctor.js {unsupported: [class]}
+language/expressions/super
     call-spread-err-mult-err-expr-throws.js
     call-spread-err-mult-err-iter-get-value.js
     call-spread-err-mult-err-itr-get-call.js
@@ -5045,132 +3585,112 @@ language/expressions/super 73/94 (77.66%)
     call-spread-sngl-iter.js
     call-spread-sngl-literal.js
     call-spread-sngl-obj-ident.js
-    prop-dot-cls-null-proto.js {unsupported: [class]}
-    prop-dot-cls-ref-strict.js {unsupported: [class]}
     prop-dot-cls-ref-this.js
-    prop-dot-cls-this-uninit.js {unsupported: [class]}
-    prop-dot-cls-val.js {unsupported: [class]}
-    prop-dot-cls-val-from-arrow.js {unsupported: [class]}
-    prop-dot-cls-val-from-eval.js {unsupported: [class]}
-    prop-expr-cls-err.js {unsupported: [class]}
-    prop-expr-cls-key-err.js {unsupported: [class]}
-    prop-expr-cls-null-proto.js {unsupported: [class]}
-    prop-expr-cls-ref-strict.js {unsupported: [class]}
     prop-expr-cls-ref-this.js
-    prop-expr-cls-this-uninit.js {unsupported: [class]}
-    prop-expr-cls-unresolvable.js {unsupported: [class]}
-    prop-expr-cls-val.js {unsupported: [class]}
-    prop-expr-cls-val-from-arrow.js {unsupported: [class]}
-    prop-expr-cls-val-from-eval.js {unsupported: [class]}
-    prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js interpreted
+    prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js
     prop-expr-uninitialized-this-getvalue.js
     prop-expr-uninitialized-this-putvalue.js
     prop-expr-uninitialized-this-putvalue-compound-assign.js
     prop-expr-uninitialized-this-putvalue-increment.js
     realm.js
-    super-reference-resolution.js {unsupported: [class]}
 
-language/expressions/tagged-template 3/27 (11.11%)
-    call-expression-context-strict.js strict
-    tco-call.js {unsupported: [tail-call-optimization]}
-    tco-member.js {unsupported: [tail-call-optimization]}
+language/expressions/tagged-template
+    call-expression-context-strict.js
 
-language/expressions/template-literal 2/57 (3.51%)
-    mongolian-vowel-separator.js {unsupported: [u180e]}
-    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+language/expressions/template-literal
 
-language/expressions/this 0/6 (0.0%)
+language/expressions/this
 
-language/expressions/typeof 0/16 (0.0%)
+language/expressions/typeof
 
-language/expressions/unary-minus 0/14 (0.0%)
+language/expressions/unary-minus
 
-language/expressions/unary-plus 0/17 (0.0%)
+language/expressions/unary-plus
 
-language/expressions/unsigned-right-shift 2/45 (4.44%)
+language/expressions/unsigned-right-shift
     bigint-toprimitive.js
     order-of-evaluation.js
 
-language/expressions/void 0/9 (0.0%)
+language/expressions/void
 
-language/expressions/yield 4/63 (6.35%)
+language/expressions/yield
     rhs-omitted.js
     rhs-primitive.js
     star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code 96/217 (44.24%)
-    10.4.3-1-1-s.js non-strict
-    10.4.3-1-10-s.js non-strict
-    10.4.3-1-104.js strict
-    10.4.3-1-106.js strict
-    10.4.3-1-10gs.js non-strict
-    10.4.3-1-11-s.js strict
-    10.4.3-1-11gs.js strict
-    10.4.3-1-12-s.js non-strict
-    10.4.3-1-12gs.js non-strict
-    10.4.3-1-14-s.js non-strict
-    10.4.3-1-14gs.js non-strict
-    10.4.3-1-16-s.js non-strict
-    10.4.3-1-16gs.js non-strict
-    10.4.3-1-17-s.js strict
-    10.4.3-1-2-s.js non-strict
-    10.4.3-1-27-s.js strict
-    10.4.3-1-27gs.js strict
-    10.4.3-1-28-s.js strict
-    10.4.3-1-28gs.js strict
-    10.4.3-1-29-s.js strict
-    10.4.3-1-29gs.js strict
-    10.4.3-1-3-s.js non-strict
-    10.4.3-1-30-s.js strict
-    10.4.3-1-30gs.js strict
-    10.4.3-1-31-s.js strict
-    10.4.3-1-31gs.js strict
-    10.4.3-1-32-s.js strict
-    10.4.3-1-32gs.js strict
-    10.4.3-1-33-s.js strict
-    10.4.3-1-33gs.js strict
-    10.4.3-1-34-s.js strict
-    10.4.3-1-34gs.js strict
-    10.4.3-1-35-s.js strict
-    10.4.3-1-35gs.js strict
-    10.4.3-1-36-s.js non-strict
-    10.4.3-1-36gs.js non-strict
-    10.4.3-1-37-s.js non-strict
-    10.4.3-1-37gs.js non-strict
-    10.4.3-1-38-s.js non-strict
-    10.4.3-1-38gs.js non-strict
-    10.4.3-1-39-s.js non-strict
-    10.4.3-1-39gs.js non-strict
-    10.4.3-1-4-s.js non-strict
-    10.4.3-1-40-s.js non-strict
-    10.4.3-1-40gs.js non-strict
-    10.4.3-1-41-s.js non-strict
-    10.4.3-1-41gs.js non-strict
-    10.4.3-1-42-s.js non-strict
-    10.4.3-1-42gs.js non-strict
-    10.4.3-1-43-s.js non-strict
-    10.4.3-1-43gs.js non-strict
-    10.4.3-1-44-s.js non-strict
-    10.4.3-1-44gs.js non-strict
-    10.4.3-1-45-s.js non-strict
-    10.4.3-1-45gs.js non-strict
-    10.4.3-1-46-s.js non-strict
-    10.4.3-1-46gs.js non-strict
-    10.4.3-1-47-s.js non-strict
-    10.4.3-1-47gs.js non-strict
-    10.4.3-1-48-s.js non-strict
-    10.4.3-1-48gs.js non-strict
-    10.4.3-1-49-s.js non-strict
-    10.4.3-1-49gs.js non-strict
-    10.4.3-1-50-s.js non-strict
-    10.4.3-1-50gs.js non-strict
-    10.4.3-1-51-s.js non-strict
-    10.4.3-1-51gs.js non-strict
-    10.4.3-1-52-s.js non-strict
-    10.4.3-1-52gs.js non-strict
-    10.4.3-1-53-s.js non-strict
-    10.4.3-1-53gs.js non-strict
+language/function-code
+    10.4.3-1-1-s.js
+    10.4.3-1-10-s.js
+    10.4.3-1-104.js
+    10.4.3-1-106.js
+    10.4.3-1-10gs.js
+    10.4.3-1-11-s.js
+    10.4.3-1-11gs.js
+    10.4.3-1-12-s.js
+    10.4.3-1-12gs.js
+    10.4.3-1-14-s.js
+    10.4.3-1-14gs.js
+    10.4.3-1-16-s.js
+    10.4.3-1-16gs.js
+    10.4.3-1-17-s.js
+    10.4.3-1-2-s.js
+    10.4.3-1-27-s.js
+    10.4.3-1-27gs.js
+    10.4.3-1-28-s.js
+    10.4.3-1-28gs.js
+    10.4.3-1-29-s.js
+    10.4.3-1-29gs.js
+    10.4.3-1-3-s.js
+    10.4.3-1-30-s.js
+    10.4.3-1-30gs.js
+    10.4.3-1-31-s.js
+    10.4.3-1-31gs.js
+    10.4.3-1-32-s.js
+    10.4.3-1-32gs.js
+    10.4.3-1-33-s.js
+    10.4.3-1-33gs.js
+    10.4.3-1-34-s.js
+    10.4.3-1-34gs.js
+    10.4.3-1-35-s.js
+    10.4.3-1-35gs.js
+    10.4.3-1-36-s.js
+    10.4.3-1-36gs.js
+    10.4.3-1-37-s.js
+    10.4.3-1-37gs.js
+    10.4.3-1-38-s.js
+    10.4.3-1-38gs.js
+    10.4.3-1-39-s.js
+    10.4.3-1-39gs.js
+    10.4.3-1-4-s.js
+    10.4.3-1-40-s.js
+    10.4.3-1-40gs.js
+    10.4.3-1-41-s.js
+    10.4.3-1-41gs.js
+    10.4.3-1-42-s.js
+    10.4.3-1-42gs.js
+    10.4.3-1-43-s.js
+    10.4.3-1-43gs.js
+    10.4.3-1-44-s.js
+    10.4.3-1-44gs.js
+    10.4.3-1-45-s.js
+    10.4.3-1-45gs.js
+    10.4.3-1-46-s.js
+    10.4.3-1-46gs.js
+    10.4.3-1-47-s.js
+    10.4.3-1-47gs.js
+    10.4.3-1-48-s.js
+    10.4.3-1-48gs.js
+    10.4.3-1-49-s.js
+    10.4.3-1-49gs.js
+    10.4.3-1-50-s.js
+    10.4.3-1-50gs.js
+    10.4.3-1-51-s.js
+    10.4.3-1-51gs.js
+    10.4.3-1-52-s.js
+    10.4.3-1-52gs.js
+    10.4.3-1-53-s.js
+    10.4.3-1-53gs.js
     10.4.3-1-62-s.js
     10.4.3-1-62gs.js
     10.4.3-1-63-s.js
@@ -5179,158 +3699,96 @@ language/function-code 96/217 (44.24%)
     10.4.3-1-64gs.js
     10.4.3-1-65-s.js
     10.4.3-1-65gs.js
-    10.4.3-1-7-s.js strict
+    10.4.3-1-7-s.js
     10.4.3-1-76-s.js
     10.4.3-1-76gs.js
     10.4.3-1-77-s.js
     10.4.3-1-77gs.js
     10.4.3-1-78-s.js
     10.4.3-1-78gs.js
-    10.4.3-1-7gs.js strict
-    10.4.3-1-8-s.js non-strict
-    10.4.3-1-8gs.js non-strict
-    10.4.3-1-9-s.js strict
-    10.4.3-1-9gs.js strict
-    block-decl-onlystrict.js strict
-    eval-param-env-with-computed-key.js non-strict
-    S10.4.3_A1.js strict
-    switch-case-decl-onlystrict.js strict
-    switch-dflt-decl-onlystrict.js strict
+    10.4.3-1-7gs.js
+    10.4.3-1-8-s.js
+    10.4.3-1-8gs.js
+    10.4.3-1-9-s.js
+    10.4.3-1-9gs.js
+    block-decl-onlystrict.js
+    eval-param-env-with-computed-key.js
+    S10.4.3_A1.js
+    switch-case-decl-onlystrict.js
+    switch-dflt-decl-onlystrict.js
 
-language/future-reserved-words 7/55 (12.73%)
-    implements.js non-strict
-    interface.js non-strict
-    package.js non-strict
-    private.js non-strict
-    protected.js non-strict
-    public.js non-strict
-    static.js non-strict
+language/future-reserved-words
+    implements.js
+    interface.js
+    package.js
+    private.js
+    protected.js
+    public.js
+    static.js
 
-language/global-code 26/42 (61.9%)
-    block-decl-strict.js strict
+language/global-code
+    block-decl-strict.js
     decl-lex.js
     decl-lex-configurable-global.js
-    decl-lex-deletion.js non-strict
+    decl-lex-deletion.js
     decl-lex-restricted-global.js
-    invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
-    invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
-    invalid-private-names-member-expression-bad-reference.js {unsupported: [class-fields-private]}
-    invalid-private-names-member-expression-this.js {unsupported: [class-fields-private]}
-    new.target.js {unsupported: [new.target]}
-    new.target-arrow.js {unsupported: [new.target]}
     script-decl-func.js
     script-decl-func-err-non-configurable.js
-    script-decl-func-err-non-extensible.js non-strict
+    script-decl-func-err-non-extensible.js
     script-decl-lex.js
-    script-decl-lex-deletion.js non-strict
+    script-decl-lex-deletion.js
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
     script-decl-lex-var-declared-via-eval.js
     script-decl-var.js
     script-decl-var-collision.js
-    script-decl-var-err.js non-strict
-    switch-case-decl-strict.js strict
-    switch-dflt-decl-strict.js strict
-    yield-non-strict.js non-strict
+    script-decl-var-err.js
+    switch-case-decl-strict.js
+    switch-dflt-decl-strict.js
+    yield-non-strict.js
 
-language/identifier-resolution 0/14 (0.0%)
+language/identifier-resolution
 
-language/identifiers 98/260 (37.69%)
+language/identifiers
     other_id_continue.js
     other_id_continue-escaped.js
     other_id_start.js
     other_id_start-escaped.js
-    part-unicode-10.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-10.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-11.0.0.js
-    part-unicode-11.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-11.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-11.0.0-escaped.js
     part-unicode-12.0.0.js
-    part-unicode-12.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-12.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-12.0.0-escaped.js
     part-unicode-13.0.0.js
-    part-unicode-13.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-13.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-13.0.0-escaped.js
     part-unicode-14.0.0.js
-    part-unicode-14.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-14.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-14.0.0-escaped.js
     part-unicode-15.0.0.js
-    part-unicode-15.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-15.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-15.0.0-escaped.js
     part-unicode-15.1.0.js
-    part-unicode-15.1.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-15.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-15.1.0-escaped.js
     part-unicode-16.0.0.js
-    part-unicode-16.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-16.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-16.0.0-escaped.js
     part-unicode-5.2.0.js
-    part-unicode-5.2.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-5.2.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-5.2.0-escaped.js
-    part-unicode-6.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-6.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    part-unicode-6.1.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-6.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    part-unicode-7.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-7.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    part-unicode-8.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-8.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    part-unicode-9.0.0-class.js {unsupported: [class-fields-private, class]}
-    part-unicode-9.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    start-unicode-10.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-10.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-11.0.0.js
-    start-unicode-11.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-11.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-11.0.0-escaped.js
     start-unicode-12.0.0.js
-    start-unicode-12.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-12.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-12.0.0-escaped.js
     start-unicode-13.0.0.js
-    start-unicode-13.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-13.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-13.0.0-escaped.js
     start-unicode-14.0.0.js
-    start-unicode-14.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-14.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-14.0.0-escaped.js
     start-unicode-15.0.0.js
-    start-unicode-15.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-15.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-15.0.0-escaped.js
     start-unicode-15.1.0.js
-    start-unicode-15.1.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-15.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-15.1.0-escaped.js
     start-unicode-16.0.0.js
-    start-unicode-16.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-16.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-16.0.0-escaped.js
     start-unicode-5.2.0.js
-    start-unicode-5.2.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-5.2.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    start-unicode-6.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-6.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-6.1.0.js
-    start-unicode-6.1.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-6.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-7.0.0.js
-    start-unicode-7.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-7.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-8.0.0.js
-    start-unicode-8.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-8.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
-    start-unicode-9.0.0-class.js {unsupported: [class-fields-private, class]}
-    start-unicode-9.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js
@@ -5338,93 +3796,68 @@ language/identifiers 98/260 (37.69%)
 
 ~language/import
 
-language/keywords 0/25 (0.0%)
+language/keywords
 
-language/line-terminators 0/41 (0.0%)
+language/line-terminators
 
-language/literals 43/534 (8.05%)
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
-    bigint/legacy-octal-like-invalid-00n.js non-strict
-    bigint/legacy-octal-like-invalid-01n.js non-strict
-    bigint/legacy-octal-like-invalid-07n.js non-strict
-    bigint/non-octal-like-invalid-0008n.js non-strict
-    bigint/non-octal-like-invalid-012348n.js non-strict
-    bigint/non-octal-like-invalid-08n.js non-strict
-    bigint/non-octal-like-invalid-09n.js non-strict
+language/literals
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
+    bigint/legacy-octal-like-invalid-00n.js
+    bigint/legacy-octal-like-invalid-01n.js
+    bigint/legacy-octal-like-invalid-07n.js
+    bigint/non-octal-like-invalid-0008n.js
+    bigint/non-octal-like-invalid-012348n.js
+    bigint/non-octal-like-invalid-08n.js
+    bigint/non-octal-like-invalid-09n.js
     boolean/false-with-unicode.js
     boolean/true-with-unicode.js
     null/null-with-unicode.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
     numeric/numeric-followed-by-ident.js
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
     regexp/invalid-braced-quantifier-range.js
-    regexp/mongolian-vowel-separator.js {unsupported: [u180e]}
-    regexp/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     regexp/S7.8.5_A1.1_T2.js
     regexp/S7.8.5_A1.4_T2.js
     regexp/S7.8.5_A2.1_T2.js
     regexp/S7.8.5_A2.4_T2.js
     regexp/u-case-mapping.js
-    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-8-strict.js strict
-    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-9-strict.js strict
-    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-strict.js strict
+    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-8-strict.js
+    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-9-strict.js
+    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js
+    string/legacy-non-octal-escape-sequence-strict.js
     string/legacy-octal-escape-sequence-prologue-strict.js
-    string/legacy-octal-escape-sequence-strict.js strict
-    string/mongolian-vowel-separator.js {unsupported: [u180e]}
-    string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
-    string/S7.8.4_A4.3_T1.js strict
-    string/S7.8.4_A4.3_T2.js strict
+    string/legacy-octal-escape-sequence-strict.js
+    string/S7.8.4_A4.3_T1.js
+    string/S7.8.4_A4.3_T2.js
 
 ~language/module-code
 
-language/punctuators 0/11 (0.0%)
+language/punctuators
 
-language/reserved-words 2/27 (7.41%)
-    await-module.js {unsupported: [module]}
+language/reserved-words
     await-script.js
 
-language/rest-parameters 5/11 (45.45%)
+language/rest-parameters
     array-pattern.js
     arrow-function.js
-    no-alias-arguments.js non-strict
+    no-alias-arguments.js
     object-pattern.js
     with-new-target.js
 
-language/source-text 0/1 (0.0%)
+language/source-text
 
-language/statementList 21/80 (26.25%)
-    class-array-literal.js {unsupported: [class]}
-    class-array-literal-with-item.js {unsupported: [class]}
-    class-arrow-function-assignment-expr.js {unsupported: [class]}
-    class-arrow-function-functionbody.js {unsupported: [class]}
-    class-block.js {unsupported: [class]}
-    class-block-with-labels.js {unsupported: [class]}
-    class-expr-arrow-function-boolean-literal.js {unsupported: [class]}
-    class-let-declaration.js {unsupported: [class]}
-    class-regexp-literal.js {unsupported: [class]}
-    class-regexp-literal-flags.js {unsupported: [class]}
-    eval-class-array-literal.js {unsupported: [class]}
-    eval-class-array-literal-with-item.js {unsupported: [class]}
-    eval-class-arrow-function-assignment-expr.js {unsupported: [class]}
-    eval-class-arrow-function-functionbody.js {unsupported: [class]}
-    eval-class-block.js {unsupported: [class]}
-    eval-class-block-with-labels.js {unsupported: [class]}
-    eval-class-expr-arrow-function-boolean-literal.js {unsupported: [class]}
-    eval-class-let-declaration.js {unsupported: [class]}
-    eval-class-regexp-literal.js {unsupported: [class]}
-    eval-class-regexp-literal-flags.js {unsupported: [class]}
+language/statementList
     eval-fn-block.js
 
 ~language/statements/async-function
@@ -5433,17 +3866,14 @@ language/statementList 21/80 (26.25%)
 
 ~language/statements/async-generator
 
-language/statements/block 7/21 (33.33%)
-    early-errors 4/4 (100.0%)
+language/statements/block
     labeled-continue.js
-    tco-stmt.js {unsupported: [tail-call-optimization]}
-    tco-stmt-list.js {unsupported: [tail-call-optimization]}
 
-language/statements/break 0/20 (0.0%)
+language/statements/break
 
 ~language/statements/class
 
-language/statements/const 87/136 (63.97%)
+language/statements/const
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5495,9 +3925,6 @@ language/statements/const 87/136 (63.97%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     syntax/block-scope-syntax-const-declarations-mixed-with-without-initialiser.js
     syntax/block-scope-syntax-const-declarations-mixed-without-with-initialiser.js
     syntax/block-scope-syntax-const-declarations-without-initialiser.js
@@ -5523,7 +3950,6 @@ language/statements/const 87/136 (63.97%)
     block-local-closure-get-before-initialization.js
     block-local-use-before-initialization-in-declaration-statement.js
     block-local-use-before-initialization-in-prior-statement.js
-    fn-name-class.js {unsupported: [class]}
     function-local-closure-get-before-initialization.js
     function-local-use-before-initialization-in-declaration-statement.js
     function-local-use-before-initialization-in-prior-statement.js
@@ -5532,27 +3958,24 @@ language/statements/const 87/136 (63.97%)
     global-use-before-initialization-in-prior-statement.js
     static-init-await-binding-valid.js
 
-language/statements/continue 0/24 (0.0%)
+language/statements/continue
 
-language/statements/debugger 0/2 (0.0%)
+language/statements/debugger
 
-language/statements/do-while 10/36 (27.78%)
+language/statements/do-while
     cptn-abrupt-empty.js
     cptn-normal.js
-    decl-async-fun.js {unsupported: [async-functions]}
-    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js non-strict
-    tco-body.js {unsupported: [tail-call-optimization]}
+    let-array-with-newline.js
 
-language/statements/empty 0/2 (0.0%)
+language/statements/empty
 
-language/statements/expression 0/3 (0.0%)
+language/statements/expression
 
-language/statements/for 230/385 (59.74%)
+language/statements/for
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -5639,9 +4062,6 @@ language/statements/for 230/385 (59.74%)
     dstr/const-obj-ptrn-prop-obj-init.js
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
-    dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
     dstr/let-ary-init-iter-get-err-array-prototype.js
@@ -5689,16 +4109,13 @@ language/statements/for 230/385 (59.74%)
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
-    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
+    dstr/let-obj-ptrn-prop-ary-trailing-comma.js
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
     dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
-    dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
     dstr/var-ary-init-iter-get-err-array-prototype.js
@@ -5752,15 +4169,10 @@ language/statements/for 230/385 (59.74%)
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
-    dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     cptn-decl-expr-iter.js
     cptn-decl-expr-no-iter.js
     cptn-expr-expr-iter.js
     cptn-expr-expr-no-iter.js
-    decl-async-fun.js {unsupported: [async-functions]}
-    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -5769,25 +4181,20 @@ language/statements/for 230/385 (59.74%)
     head-init-expr-check-empty-inc-empty-completion.js
     head-init-var-check-empty-inc-empty-completion.js
     head-let-bound-names-in-stmt.js
-    head-lhs-let.js non-strict
+    head-lhs-let.js
     labelled-fn-stmt-expr.js
     labelled-fn-stmt-let.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-open.js
-    tco-const-body.js {unsupported: [tail-call-optimization]}
-    tco-let-body.js {unsupported: [tail-call-optimization]}
-    tco-lhs-body.js {unsupported: [tail-call-optimization]}
-    tco-var-body.js {unsupported: [tail-call-optimization]}
 
 ~language/statements/for-await-of
 
-language/statements/for-in 40/115 (34.78%)
-    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
+language/statements/for-in
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
     cptn-decl-itr.js
@@ -5797,8 +4204,6 @@ language/statements/for-in 40/115 (34.78%)
     cptn-expr-itr.js
     cptn-expr-skip-itr.js
     cptn-expr-zero-itr.js
-    decl-async-fun.js {unsupported: [async-functions]}
-    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -5808,37 +4213,34 @@ language/statements/for-in 40/115 (34.78%)
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
     head-let-fresh-binding-per-iteration.js
-    head-lhs-let.js non-strict
+    head-lhs-let.js
     head-var-bound-names-dup.js
-    head-var-bound-names-let.js non-strict
-    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict
+    head-var-bound-names-let.js
+    identifier-let-allowed-as-lefthandside-expression-not-strict.js
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
     order-enumerable-shadowed.js
-    resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     scope-body-lex-boundary.js
     scope-body-lex-close.js
     scope-body-lex-open.js
     scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js non-strict
+    scope-head-var-none.js
 
-language/statements/for-of 438/751 (58.32%)
+language/statements/for-of
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
-    dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-cover.js
-    dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js non-strict
-    dstr/array-elem-init-yield-ident-valid.js non-strict
+    dstr/array-elem-init-simple-no-strict.js
+    dstr/array-elem-init-yield-ident-valid.js
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -5850,15 +4252,15 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
+    dstr/array-elem-nested-array-yield-ident-valid.js
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
-    dstr/array-elem-put-const.js non-strict
+    dstr/array-elem-nested-obj-yield-ident-valid.js
+    dstr/array-elem-put-const.js
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js strict
-    dstr/array-elem-target-yield-valid.js non-strict
+    dstr/array-elem-target-simple-strict.js
+    dstr/array-elem-target-yield-valid.js
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -5925,24 +4327,24 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-array-yield-ident-valid.js
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-obj-yield-ident-valid.js
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js non-strict
-    dstr/array-rest-put-unresolvable-strict.js strict
+    dstr/array-rest-put-unresolvable-no-strict.js
+    dstr/array-rest-put-unresolvable-strict.js
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js non-strict
+    dstr/array-rest-yield-ident-valid.js
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -6029,9 +4431,6 @@ language/statements/for-of 438/751 (58.32%)
     dstr/const-obj-ptrn-prop-obj-init.js
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
-    dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
     dstr/let-ary-ptrn-elem-ary-elem-init.js
@@ -6084,74 +4483,43 @@ language/statements/for-of 438/751 (58.32%)
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
-    dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js non-strict
+    dstr/obj-id-identifier-yield-ident-valid.js
     dstr/obj-id-init-assignment-missing.js
     dstr/obj-id-init-assignment-null.js
     dstr/obj-id-init-assignment-truthy.js
     dstr/obj-id-init-assignment-undef.js
     dstr/obj-id-init-evaluation.js
     dstr/obj-id-init-fn-name-arrow.js
-    dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
     dstr/obj-id-init-in.js
     dstr/obj-id-init-let.js
     dstr/obj-id-init-order.js
-    dstr/obj-id-init-simple-no-strict.js non-strict
+    dstr/obj-id-init-simple-no-strict.js
     dstr/obj-id-init-yield-expr.js
-    dstr/obj-id-init-yield-ident-valid.js non-strict
-    dstr/obj-id-put-const.js non-strict
+    dstr/obj-id-init-yield-ident-valid.js
+    dstr/obj-id-put-const.js
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
-    dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-init-yield-ident-valid.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-target-yield-ident-valid.js
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
+    dstr/obj-prop-nested-array-yield-ident-valid.js
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
-    dstr/obj-prop-put-const.js non-strict
+    dstr/obj-prop-nested-obj-yield-ident-valid.js
+    dstr/obj-prop-put-const.js
     dstr/obj-prop-put-let.js
-    dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
-    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
-    dstr/obj-rest-descriptors.js {unsupported: [object-rest]}
-    dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
-    dstr/obj-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1dot.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1dot0.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-1e0.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-array-1.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-array-1e0.js {unsupported: [object-rest]}
-    dstr/obj-rest-non-string-computed-property-string-1.js {unsupported: [object-rest]}
-    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
-    dstr/obj-rest-number.js {unsupported: [object-rest]}
-    dstr/obj-rest-order.js {unsupported: [object-rest]}
-    dstr/obj-rest-put-const.js {unsupported: [object-rest]}
-    dstr/obj-rest-same-name.js {unsupported: [object-rest]}
-    dstr/obj-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-rest-str-val.js {unsupported: [object-rest]}
-    dstr/obj-rest-symbol-val.js {unsupported: [object-rest]}
-    dstr/obj-rest-to-property.js {unsupported: [object-rest]}
-    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
-    dstr/obj-rest-val-null.js {unsupported: [object-rest]}
-    dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
-    dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
     dstr/var-ary-ptrn-elem-ary-elem-init.js
@@ -6204,9 +4572,6 @@ language/statements/for-of 438/751 (58.32%)
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
-    dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     body-dstr-assign-error.js
     body-put-error.js
     cptn-decl-abrupt-empty.js
@@ -6215,8 +4580,6 @@ language/statements/for-of 438/751 (58.32%)
     cptn-expr-abrupt-empty.js
     cptn-expr-itr.js
     cptn-expr-no-itr.js
-    decl-async-fun.js {unsupported: [async-functions]}
-    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -6225,9 +4588,6 @@ language/statements/for-of 438/751 (58.32%)
     generator-close-via-continue.js
     generator-close-via-return.js
     generator-close-via-throw.js
-    head-await-using-bound-names-fordecl-tdz.js {unsupported: [async]}
-    head-await-using-bound-names-in-stmt.js {unsupported: [module]}
-    head-await-using-fresh-binding-per-iteration.js {unsupported: [module]}
     head-const-bound-names-fordecl-tdz.js
     head-const-fresh-binding-per-iteration.js
     head-decl-no-expr.js
@@ -6239,7 +4599,7 @@ language/statements/for-of 438/751 (58.32%)
     head-lhs-async-invalid.js
     head-using-bound-names-fordecl-tdz.js
     head-using-fresh-binding-per-iteration.js
-    head-var-bound-names-let.js non-strict
+    head-var-bound-names-let.js
     head-var-init.js
     head-var-no-expr.js
     iterator-close-non-object.js
@@ -6255,20 +4615,15 @@ language/statements/for-of 438/751 (58.32%)
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    typedarray-backed-by-resizable-buffer-grow-before-end.js {unsupported: [resizable-arraybuffer]}
-    typedarray-backed-by-resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
-language/statements/function 162/451 (35.92%)
+language/statements/function
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6356,9 +4711,6 @@ language/statements/function 162/451 (35.92%)
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -6374,62 +4726,58 @@ language/statements/function 162/451 (35.92%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    early-errors 4/4 (100.0%)
-    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    13.0-13-s.js non-strict
-    13.0-14-s.js non-strict
-    13.1-22-s.js non-strict
+    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js
+    13.0-13-s.js
+    13.0-14-s.js
+    13.1-22-s.js
     13.2-10-s.js
     13.2-13-s.js
     13.2-14-s.js
     13.2-17-s.js
     13.2-18-s.js
-    13.2-19-b-3gs.js strict
-    13.2-2-s.js strict
-    13.2-21-s.js non-strict
-    13.2-22-s.js non-strict
-    13.2-25-s.js non-strict
-    13.2-26-s.js non-strict
+    13.2-19-b-3gs.js
+    13.2-2-s.js
+    13.2-21-s.js
+    13.2-22-s.js
+    13.2-25-s.js
+    13.2-26-s.js
     13.2-30-s.js
-    13.2-4-s.js strict
-    13.2-5-s.js non-strict
-    13.2-6-s.js non-strict
-    13.2-9-s.js non-strict
-    arguments-with-arguments-fn.js non-strict
-    arguments-with-arguments-lex.js non-strict
+    13.2-4-s.js
+    13.2-5-s.js
+    13.2-6-s.js
+    13.2-9-s.js
+    arguments-with-arguments-fn.js
+    arguments-with-arguments-lex.js
     array-destructuring-param-strict-body.js
     cptn-decl.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js
     length-dflt.js
-    name-arguments-strict-body.js non-strict
-    name-eval-strict-body.js non-strict
+    name-arguments-strict-body.js
+    name-eval-strict-body.js
     object-destructuring-param-strict-body.js
-    param-arguments-strict-body.js non-strict
-    param-dflt-yield-non-strict.js non-strict
-    param-dflt-yield-strict.js strict
-    param-duplicated-strict-body-1.js non-strict
-    param-duplicated-strict-body-2.js non-strict
-    param-duplicated-strict-body-3.js non-strict
-    param-eval-strict-body.js non-strict
+    param-arguments-strict-body.js
+    param-dflt-yield-non-strict.js
+    param-dflt-yield-strict.js
+    param-duplicated-strict-body-1.js
+    param-duplicated-strict-body-2.js
+    param-duplicated-strict-body-3.js
+    param-eval-strict-body.js
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
     scope-paramsbody-var-open.js
     static-init-await-binding-valid.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
+    unscopables-with.js
+    unscopables-with-in-nested-fn.js
 
-language/statements/generators 168/266 (63.16%)
+language/statements/generators
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6534,9 +4882,6 @@ language/statements/generators 168/266 (63.16%)
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
-    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -6559,21 +4904,18 @@ language/statements/generators 168/266 (63.16%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict
+    forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js
+    arguments-with-arguments-fn.js
     array-destructuring-param-strict-body.js
     cptn-decl.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
@@ -6582,24 +4924,24 @@ language/statements/generators 168/266 (63.16%)
     prototype-value.js
     rest-param-strict-body.js
     restricted-properties.js
-    scope-body-lex-distinct.js non-strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js
+    scope-param-rest-elem-var-close.js
+    scope-param-rest-elem-var-open.js
     scope-paramsbody-var-open.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
-    yield-as-function-expression-binding-identifier.js non-strict
-    yield-as-generator-declaration-binding-identifier.js non-strict
-    yield-as-identifier-in-nested-function.js non-strict
-    yield-identifier-non-strict.js non-strict
-    yield-identifier-spread-non-strict.js non-strict
+    unscopables-with.js
+    unscopables-with-in-nested-fn.js
+    yield-as-function-expression-binding-identifier.js
+    yield-as-generator-declaration-binding-identifier.js
+    yield-as-identifier-in-nested-function.js
+    yield-identifier-non-strict.js
+    yield-identifier-spread-non-strict.js
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/statements/if 42/69 (60.87%)
+language/statements/if
     cptn-else-false-abrupt-empty.js
     cptn-else-false-nrml.js
     cptn-else-true-abrupt-empty.js
@@ -6607,60 +4949,45 @@ language/statements/if 42/69 (60.87%)
     cptn-no-else-false.js
     cptn-no-else-true-abrupt-empty.js
     cptn-no-else-true-nrml.js
-    if-async-fun-else-async-fun.js {unsupported: [async-functions]}
-    if-async-fun-else-stmt.js {unsupported: [async-functions]}
-    if-async-fun-no-else.js {unsupported: [async-functions]}
-    if-async-gen-else-async-gen.js {unsupported: [async-iteration]}
-    if-async-gen-else-stmt.js {unsupported: [async-iteration]}
-    if-async-gen-no-else.js {unsupported: [async-iteration]}
     if-const-else-const.js
     if-const-else-stmt.js
     if-const-no-else.js
-    if-decl-else-decl-strict.js strict
-    if-decl-else-stmt-strict.js strict
-    if-decl-no-else-strict.js strict
-    if-fun-else-fun-strict.js strict
-    if-fun-else-stmt-strict.js strict
-    if-fun-no-else-strict.js strict
+    if-decl-else-decl-strict.js
+    if-decl-else-stmt-strict.js
+    if-decl-no-else-strict.js
+    if-fun-else-fun-strict.js
+    if-fun-else-stmt-strict.js
+    if-fun-no-else-strict.js
     if-gen-else-gen.js
     if-gen-else-stmt.js
     if-gen-no-else.js
     if-let-else-let.js
     if-let-else-stmt.js
     if-let-no-else.js
-    if-stmt-else-async-fun.js {unsupported: [async-functions]}
-    if-stmt-else-async-gen.js {unsupported: [async-iteration]}
     if-stmt-else-const.js
-    if-stmt-else-decl-strict.js strict
-    if-stmt-else-fun-strict.js strict
+    if-stmt-else-decl-strict.js
+    if-stmt-else-fun-strict.js
     if-stmt-else-gen.js
     if-stmt-else-let.js
     labelled-fn-stmt-first.js
     labelled-fn-stmt-lone.js
     labelled-fn-stmt-second.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    tco-else-body.js {unsupported: [tail-call-optimization]}
-    tco-if-body.js {unsupported: [tail-call-optimization]}
+    let-array-with-newline.js
+    let-block-with-newline.js
 
-language/statements/labeled 15/24 (62.5%)
-    decl-async-function.js {unsupported: [async-functions]}
-    decl-async-generator.js {unsupported: [async-iteration]}
+language/statements/labeled
     decl-const.js
-    decl-fun-strict.js strict
+    decl-fun-strict.js
     decl-gen.js
     decl-let.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    tco.js {unsupported: [tail-call-optimization]}
-    value-await-module.js {unsupported: [module]}
-    value-await-module-escaped.js {unsupported: [module]}
+    let-array-with-newline.js
+    let-block-with-newline.js
     value-await-non-module.js
     value-await-non-module-escaped.js
-    value-yield-non-strict.js non-strict
-    value-yield-non-strict-escaped.js non-strict
+    value-yield-non-strict.js
+    value-yield-non-strict-escaped.js
 
-language/statements/let 80/145 (55.17%)
+language/statements/let
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6712,10 +5039,7 @@ language/statements/let 80/145 (55.17%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    syntax/escaped-let.js non-strict
+    syntax/escaped-let.js
     syntax/let-closure-inside-condition.js
     syntax/let-closure-inside-initialization.js
     syntax/let-closure-inside-next-expression.js
@@ -6731,7 +5055,6 @@ language/statements/let 80/145 (55.17%)
     block-local-closure-set-before-initialization.js
     block-local-use-before-initialization-in-declaration-statement.js
     block-local-use-before-initialization-in-prior-statement.js
-    fn-name-class.js {unsupported: [class]}
     function-local-closure-get-before-initialization.js
     function-local-closure-set-before-initialization.js
     function-local-use-before-initialization-in-declaration-statement.js
@@ -6742,46 +5065,17 @@ language/statements/let 80/145 (55.17%)
     global-use-before-initialization-in-prior-statement.js
     static-init-await-binding-valid.js
 
-language/statements/return 1/16 (6.25%)
-    tco.js {unsupported: [tail-call-optimization]}
+language/statements/return
 
-language/statements/switch 62/111 (55.86%)
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js {unsupported: [async-functions]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-iteration, async-functions]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js {unsupported: [async-iteration]}
-    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js {unsupported: [async-iteration]}
-    syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
+language/statements/switch
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
-    syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
-    syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
@@ -6805,13 +5099,10 @@ language/statements/switch 62/111 (55.86%)
     scope-lex-generator.js
     scope-lex-open-case.js
     scope-lex-open-dflt.js
-    tco-case-body.js {unsupported: [tail-call-optimization]}
-    tco-case-body-dflt.js {unsupported: [tail-call-optimization]}
-    tco-dftl-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/throw 0/14 (0.0%)
+language/statements/throw
 
-language/statements/try 113/201 (56.22%)
+language/statements/try
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6896,15 +5187,12 @@ language/statements/try 113/201 (56.22%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    12.14-13.js non-strict
-    12.14-14.js non-strict
-    12.14-15.js non-strict
-    12.14-16.js non-strict
+    12.14-13.js
+    12.14-14.js
+    12.14-15.js
+    12.14-16.js
     completion-values.js
-    completion-values-fn-finally-abrupt.js compiled
+    completion-values-fn-finally-abrupt.js
     cptn-catch.js
     cptn-catch-empty-break.js
     cptn-catch-empty-continue.js
@@ -6920,13 +5208,10 @@ language/statements/try 113/201 (56.22%)
     early-catch-lex.js
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js
-    scope-catch-param-var-none.js non-strict
+    scope-catch-param-var-none.js
     static-init-await-binding-valid.js
-    tco-catch.js {unsupported: [tail-call-optimization]}
-    tco-catch-finally.js {unsupported: [tail-call-optimization]}
-    tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable 62/178 (34.83%)
+language/statements/variable
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6980,72 +5265,61 @@ language/statements/variable 62/178 (34.83%)
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
-    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    12.2.1-10-s.js strict
-    12.2.1-20-s.js strict
-    12.2.1-21-s.js strict
-    12.2.1-9-s.js strict
-    fn-name-class.js {unsupported: [class]}
+    12.2.1-10-s.js
+    12.2.1-20-s.js
+    12.2.1-21-s.js
+    12.2.1-9-s.js
     static-init-await-binding-valid.js
 
-language/statements/while 13/38 (34.21%)
+language/statements/while
     cptn-abrupt-empty.js
     cptn-iter.js
     cptn-no-iter.js
-    decl-async-fun.js {unsupported: [async-functions]}
-    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
-    tco-body.js {unsupported: [tail-call-optimization]}
+    let-array-with-newline.js
+    let-block-with-newline.js
+    let-identifier-with-newline.js
 
-language/statements/with 28/181 (15.47%)
-    binding-blocked-by-unscopables.js non-strict
-    cptn-abrupt-empty.js non-strict
-    cptn-nrml.js non-strict
-    decl-async-fun.js {unsupported: [async-functions]}
-    decl-async-gen.js {unsupported: [async-iteration]}
-    decl-const.js non-strict
-    decl-fun.js non-strict
-    decl-gen.js non-strict
-    decl-let.js non-strict
-    get-binding-value-call-with-proxy-env.js non-strict
-    get-binding-value-idref-with-proxy-env.js non-strict
-    get-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
-    get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
-    has-binding-call-with-proxy-env.js non-strict
-    has-binding-idref-with-proxy-env.js non-strict
-    has-property-err.js non-strict
-    labelled-fn-stmt.js non-strict
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    set-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
-    set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
-    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js non-strict
-    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js non-strict
-    set-mutable-binding-idref-compound-assign-with-proxy-env.js non-strict
-    set-mutable-binding-idref-with-proxy-env.js non-strict
-    unscopables-get-err.js non-strict
-    unscopables-inc-dec.js non-strict
-    unscopables-prop-get-err.js non-strict
+language/statements/with
+    binding-blocked-by-unscopables.js
+    cptn-abrupt-empty.js
+    cptn-nrml.js
+    decl-const.js
+    decl-fun.js
+    decl-gen.js
+    decl-let.js
+    get-binding-value-call-with-proxy-env.js
+    get-binding-value-idref-with-proxy-env.js
+    get-mutable-binding-binding-deleted-in-get-unscopables.js
+    get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js
+    has-binding-call-with-proxy-env.js
+    has-binding-idref-with-proxy-env.js
+    has-property-err.js
+    labelled-fn-stmt.js
+    let-array-with-newline.js
+    let-block-with-newline.js
+    set-mutable-binding-binding-deleted-in-get-unscopables.js
+    set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js
+    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js
+    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js
+    set-mutable-binding-idref-compound-assign-with-proxy-env.js
+    set-mutable-binding-idref-with-proxy-env.js
+    unscopables-get-err.js
+    unscopables-inc-dec.js
+    unscopables-prop-get-err.js
 
-language/types 9/113 (7.96%)
+language/types
     number/S8.5_A10_T1.js
-    number/S8.5_A10_T2.js non-strict
+    number/S8.5_A10_T2.js
     number/S8.5_A4_T1.js
-    number/S8.5_A4_T2.js non-strict
+    number/S8.5_A4_T2.js
     reference/get-value-prop-base-primitive-realm.js
     reference/put-value-prop-base-primitive.js
     reference/put-value-prop-base-primitive-realm.js
     undefined/S8.1_A3_T1.js
-    undefined/S8.1_A3_T2.js non-strict
+    undefined/S8.1_A3_T2.js
 
-language/white-space 2/67 (2.99%)
-    mongolian-vowel-separator.js {unsupported: [u180e]}
-    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+language/white-space

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1143,8 +1143,7 @@ built-ins/Map 12/185 (6.49%)
 
 built-ins/MapIteratorPrototype 0/11 (0.0%)
 
-built-ins/Math 12/327 (3.67%)
-    f16round/value-conversion.js
+built-ins/Math 11/327 (3.36%)
     log2/log2-basicTests.js calculation is not exact
     sumPrecise 10/10 (100.0%)
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1,6 +1,7 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-annexB/built-ins
+annexB/built-ins 58/241 (24.07%)
+    Array/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
     Date/prototype/getYear/not-a-constructor.js
     Date/prototype/setYear/not-a-constructor.js
     Date/prototype/setYear/year-number-relative.js
@@ -8,468 +9,578 @@ annexB/built-ins
     Function/createdynfn-html-close-comment-params.js
     Function/createdynfn-html-open-comment-params.js
     Function/createdynfn-no-line-terminator-html-close-comment-body.js
-    RegExp/legacy-accessors/index/prop-desc.js
-    RegExp/legacy-accessors/index/this-cross-realm-constructor.js
-    RegExp/legacy-accessors/index/this-not-regexp-constructor.js
-    RegExp/legacy-accessors/input/prop-desc.js
-    RegExp/legacy-accessors/input/this-cross-realm-constructor.js
-    RegExp/legacy-accessors/input/this-not-regexp-constructor.js
-    RegExp/legacy-accessors/lastMatch/prop-desc.js
-    RegExp/legacy-accessors/lastMatch/this-cross-realm-constructor.js
-    RegExp/legacy-accessors/lastMatch/this-not-regexp-constructor.js
-    RegExp/legacy-accessors/lastParen/prop-desc.js
-    RegExp/legacy-accessors/lastParen/this-cross-realm-constructor.js
-    RegExp/legacy-accessors/lastParen/this-not-regexp-constructor.js
-    RegExp/legacy-accessors/leftContext/prop-desc.js
-    RegExp/legacy-accessors/leftContext/this-cross-realm-constructor.js
-    RegExp/legacy-accessors/leftContext/this-not-regexp-constructor.js
-    RegExp/legacy-accessors/rightContext/prop-desc.js
-    RegExp/legacy-accessors/rightContext/this-cross-realm-constructor.js
-    RegExp/legacy-accessors/rightContext/this-not-regexp-constructor.js
+    Object/is/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    RegExp/legacy-accessors/index 4/4 (100.0%)
+    RegExp/legacy-accessors/input 4/4 (100.0%)
+    RegExp/legacy-accessors/lastMatch 4/4 (100.0%)
+    RegExp/legacy-accessors/lastParen 4/4 (100.0%)
+    RegExp/legacy-accessors/leftContext 4/4 (100.0%)
+    RegExp/legacy-accessors/rightContext 4/4 (100.0%)
     RegExp/prototype/compile/pattern-regexp-flags-defined.js
     RegExp/prototype/compile/this-cross-realm-instance.js
+    RegExp/prototype/compile/this-subclass-instance.js {unsupported: [class]}
+    RegExp/prototype/flags/order-after-compile.js {unsupported: [regexp-dotall]}
     RegExp/prototype/Symbol.split/Symbol.match-getter-recompiles-source.js
     RegExp/incomplete_hex_unicode_escape.js
-    RegExp/RegExp-control-escape-russian-letter.js
+    RegExp/RegExp-control-escape-russian-letter.js compiled
     RegExp/RegExp-leading-escape-BMP.js
     RegExp/RegExp-trailing-escape-BMP.js
     String/prototype/anchor/length.js
     String/prototype/fontcolor/length.js
     String/prototype/fontsize/length.js
     String/prototype/link/length.js
+    String/prototype/matchAll/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/match/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/replaceAll/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/replace/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/search/custom-searcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/split/custom-splitter-emulates-undefined.js {unsupported: [IsHTMLDDA]}
     String/prototype/substr/start-and-length-as-numbers.js
     String/prototype/trimLeft/name.js
     String/prototype/trimLeft/reference-trimStart.js
     String/prototype/trimRight/name.js
     String/prototype/trimRight/reference-trimEnd.js
+    TypedArrayConstructors/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
 
-annexB/language
+annexB/language 380/838 (45.35%)
     comments/multi-line-html-close.js
     comments/single-line-html-close.js
-    comments/single-line-html-close-first-line-3.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js
-    eval-code/direct/global-block-decl-eval-global-block-scoping.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
-    eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
-    eval-code/direct/global-switch-case-eval-global-block-scoping.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js
-    eval-code/direct/global-switch-dflt-eval-global-block-scoping.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js
-    eval-code/direct/var-env-lower-lex-catch-non-strict.js
-    eval-code/indirect/global-block-decl-eval-global-block-scoping.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-switch-case-eval-global-block-scoping.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js
-    eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js
-    expressions/template-literal/legacy-octal-escape-sequence-strict.js
-    function-code/block-decl-func-existing-block-fn-no-init.js
-    function-code/block-decl-func-init.js
-    function-code/block-decl-func-no-skip-try.js
-    function-code/block-decl-func-skip-arguments.js
-    function-code/block-decl-func-skip-dft-param.js
-    function-code/block-decl-func-skip-early-err.js
-    function-code/block-decl-func-skip-early-err-block.js
-    function-code/block-decl-func-skip-early-err-for.js
-    function-code/block-decl-func-skip-early-err-for-in.js
-    function-code/block-decl-func-skip-early-err-for-of.js
-    function-code/block-decl-func-skip-early-err-switch.js
-    function-code/block-decl-func-skip-early-err-try.js
-    function-code/block-decl-func-skip-param.js
-    function-code/block-decl-nested-blocks-with-fun-decl.js
-    function-code/block-decl-nostrict.js
-    function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js
-    function-code/if-decl-else-decl-a-func-skip-dft-param.js
-    function-code/if-decl-else-decl-a-func-skip-early-err.js
-    function-code/if-decl-else-decl-a-func-skip-early-err-block.js
-    function-code/if-decl-else-decl-a-func-skip-early-err-for.js
-    function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js
-    function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js
-    function-code/if-decl-else-decl-a-func-skip-early-err-switch.js
-    function-code/if-decl-else-decl-a-func-skip-early-err-try.js
-    function-code/if-decl-else-decl-a-func-skip-param.js
-    function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js
-    function-code/if-decl-else-decl-b-func-skip-dft-param.js
-    function-code/if-decl-else-decl-b-func-skip-early-err.js
-    function-code/if-decl-else-decl-b-func-skip-early-err-block.js
-    function-code/if-decl-else-decl-b-func-skip-early-err-for.js
-    function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js
-    function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js
-    function-code/if-decl-else-decl-b-func-skip-early-err-switch.js
-    function-code/if-decl-else-decl-b-func-skip-early-err-try.js
-    function-code/if-decl-else-decl-b-func-skip-param.js
-    function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js
-    function-code/if-decl-else-stmt-func-skip-dft-param.js
-    function-code/if-decl-else-stmt-func-skip-early-err.js
-    function-code/if-decl-else-stmt-func-skip-early-err-block.js
-    function-code/if-decl-else-stmt-func-skip-early-err-for.js
-    function-code/if-decl-else-stmt-func-skip-early-err-for-in.js
-    function-code/if-decl-else-stmt-func-skip-early-err-for-of.js
-    function-code/if-decl-else-stmt-func-skip-early-err-switch.js
-    function-code/if-decl-else-stmt-func-skip-early-err-try.js
-    function-code/if-decl-else-stmt-func-skip-param.js
-    function-code/if-decl-no-else-func-existing-block-fn-no-init.js
-    function-code/if-decl-no-else-func-skip-dft-param.js
-    function-code/if-decl-no-else-func-skip-early-err.js
-    function-code/if-decl-no-else-func-skip-early-err-block.js
-    function-code/if-decl-no-else-func-skip-early-err-for.js
-    function-code/if-decl-no-else-func-skip-early-err-for-in.js
-    function-code/if-decl-no-else-func-skip-early-err-for-of.js
-    function-code/if-decl-no-else-func-skip-early-err-switch.js
-    function-code/if-decl-no-else-func-skip-early-err-try.js
-    function-code/if-decl-no-else-func-skip-param.js
-    function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js
-    function-code/if-stmt-else-decl-func-skip-dft-param.js
-    function-code/if-stmt-else-decl-func-skip-early-err.js
-    function-code/if-stmt-else-decl-func-skip-early-err-block.js
-    function-code/if-stmt-else-decl-func-skip-early-err-for.js
-    function-code/if-stmt-else-decl-func-skip-early-err-for-in.js
-    function-code/if-stmt-else-decl-func-skip-early-err-for-of.js
-    function-code/if-stmt-else-decl-func-skip-early-err-switch.js
-    function-code/if-stmt-else-decl-func-skip-early-err-try.js
-    function-code/if-stmt-else-decl-func-skip-param.js
-    function-code/switch-case-func-existing-block-fn-no-init.js
-    function-code/switch-case-func-skip-dft-param.js
-    function-code/switch-case-func-skip-early-err.js
-    function-code/switch-case-func-skip-early-err-block.js
-    function-code/switch-case-func-skip-early-err-for.js
-    function-code/switch-case-func-skip-early-err-for-in.js
-    function-code/switch-case-func-skip-early-err-for-of.js
-    function-code/switch-case-func-skip-early-err-switch.js
-    function-code/switch-case-func-skip-early-err-try.js
-    function-code/switch-case-func-skip-param.js
-    function-code/switch-dflt-func-existing-block-fn-no-init.js
-    function-code/switch-dflt-func-skip-dft-param.js
-    function-code/switch-dflt-func-skip-early-err.js
-    function-code/switch-dflt-func-skip-early-err-block.js
-    function-code/switch-dflt-func-skip-early-err-for.js
-    function-code/switch-dflt-func-skip-early-err-for-in.js
-    function-code/switch-dflt-func-skip-early-err-for-of.js
-    function-code/switch-dflt-func-skip-early-err-switch.js
-    function-code/switch-dflt-func-skip-early-err-try.js
-    function-code/switch-dflt-func-skip-param.js
-    global-code/block-decl-global-block-scoping.js
-    global-code/block-decl-global-existing-block-fn-no-init.js
-    global-code/block-decl-global-init.js
-    global-code/block-decl-global-no-skip-try.js
-    global-code/block-decl-global-skip-early-err.js
-    global-code/block-decl-global-skip-early-err-block.js
-    global-code/block-decl-global-skip-early-err-for.js
-    global-code/block-decl-global-skip-early-err-for-in.js
-    global-code/block-decl-global-skip-early-err-for-of.js
-    global-code/block-decl-global-skip-early-err-switch.js
-    global-code/block-decl-global-skip-early-err-try.js
-    global-code/if-decl-else-decl-a-global-block-scoping.js
-    global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js
-    global-code/if-decl-else-decl-a-global-skip-early-err.js
-    global-code/if-decl-else-decl-a-global-skip-early-err-block.js
-    global-code/if-decl-else-decl-a-global-skip-early-err-for.js
-    global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js
-    global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js
-    global-code/if-decl-else-decl-a-global-skip-early-err-switch.js
-    global-code/if-decl-else-decl-a-global-skip-early-err-try.js
-    global-code/if-decl-else-decl-b-global-block-scoping.js
-    global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js
-    global-code/if-decl-else-decl-b-global-skip-early-err.js
-    global-code/if-decl-else-decl-b-global-skip-early-err-block.js
-    global-code/if-decl-else-decl-b-global-skip-early-err-for.js
-    global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js
-    global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js
-    global-code/if-decl-else-decl-b-global-skip-early-err-switch.js
-    global-code/if-decl-else-decl-b-global-skip-early-err-try.js
-    global-code/if-decl-else-stmt-global-block-scoping.js
-    global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js
-    global-code/if-decl-else-stmt-global-skip-early-err.js
-    global-code/if-decl-else-stmt-global-skip-early-err-block.js
-    global-code/if-decl-else-stmt-global-skip-early-err-for.js
-    global-code/if-decl-else-stmt-global-skip-early-err-for-in.js
-    global-code/if-decl-else-stmt-global-skip-early-err-for-of.js
-    global-code/if-decl-else-stmt-global-skip-early-err-switch.js
-    global-code/if-decl-else-stmt-global-skip-early-err-try.js
-    global-code/if-decl-no-else-global-block-scoping.js
-    global-code/if-decl-no-else-global-existing-block-fn-no-init.js
-    global-code/if-decl-no-else-global-skip-early-err.js
-    global-code/if-decl-no-else-global-skip-early-err-block.js
-    global-code/if-decl-no-else-global-skip-early-err-for.js
-    global-code/if-decl-no-else-global-skip-early-err-for-in.js
-    global-code/if-decl-no-else-global-skip-early-err-for-of.js
-    global-code/if-decl-no-else-global-skip-early-err-switch.js
-    global-code/if-decl-no-else-global-skip-early-err-try.js
-    global-code/if-stmt-else-decl-global-block-scoping.js
-    global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js
-    global-code/if-stmt-else-decl-global-skip-early-err.js
-    global-code/if-stmt-else-decl-global-skip-early-err-block.js
-    global-code/if-stmt-else-decl-global-skip-early-err-for.js
-    global-code/if-stmt-else-decl-global-skip-early-err-for-in.js
-    global-code/if-stmt-else-decl-global-skip-early-err-for-of.js
-    global-code/if-stmt-else-decl-global-skip-early-err-switch.js
-    global-code/if-stmt-else-decl-global-skip-early-err-try.js
-    global-code/script-decl-lex-collision.js
-    global-code/switch-case-global-block-scoping.js
-    global-code/switch-case-global-existing-block-fn-no-init.js
-    global-code/switch-case-global-skip-early-err.js
-    global-code/switch-case-global-skip-early-err-block.js
-    global-code/switch-case-global-skip-early-err-for.js
-    global-code/switch-case-global-skip-early-err-for-in.js
-    global-code/switch-case-global-skip-early-err-for-of.js
-    global-code/switch-case-global-skip-early-err-switch.js
-    global-code/switch-case-global-skip-early-err-try.js
-    global-code/switch-dflt-global-block-scoping.js
-    global-code/switch-dflt-global-existing-block-fn-no-init.js
-    global-code/switch-dflt-global-skip-early-err.js
-    global-code/switch-dflt-global-skip-early-err-block.js
-    global-code/switch-dflt-global-skip-early-err-for.js
-    global-code/switch-dflt-global-skip-early-err-for-in.js
-    global-code/switch-dflt-global-skip-early-err-for-of.js
-    global-code/switch-dflt-global-skip-early-err-switch.js
-    global-code/switch-dflt-global-skip-early-err-try.js
+    comments/single-line-html-close-first-line-3.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/global-block-decl-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-switch-case-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/var-env-lower-lex-catch-non-strict.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
+    expressions/assignment/dstr 2/2 (100.0%)
+    expressions/coalesce/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/conditional/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/logical-and/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/logical-assignment 3/3 (100.0%)
+    expressions/logical-not/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/logical-or/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/strict-does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/strict-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/template-literal/legacy-octal-escape-sequence-strict.js strict
+    expressions/typeof/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/yield 2/2 (100.0%)
+    function-code/block-decl-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/block-decl-func-init.js interpreted-non-strict
+    function-code/block-decl-func-no-skip-try.js interpreted-non-strict
+    function-code/block-decl-func-skip-arguments.js non-strict
+    function-code/block-decl-func-skip-dft-param.js non-strict
+    function-code/block-decl-func-skip-early-err.js non-strict
+    function-code/block-decl-func-skip-early-err-block.js non-strict
+    function-code/block-decl-func-skip-early-err-for.js non-strict
+    function-code/block-decl-func-skip-early-err-for-in.js non-strict
+    function-code/block-decl-func-skip-early-err-for-of.js non-strict
+    function-code/block-decl-func-skip-early-err-switch.js non-strict
+    function-code/block-decl-func-skip-early-err-try.js non-strict
+    function-code/block-decl-func-skip-param.js non-strict
+    function-code/block-decl-nested-blocks-with-fun-decl.js non-strict
+    function-code/block-decl-nostrict.js interpreted-non-strict
+    function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-else-decl-a-func-skip-dft-param.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-block.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-for.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-try.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-param.js non-strict
+    function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-else-decl-b-func-skip-dft-param.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-block.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-for.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-try.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-param.js non-strict
+    function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-else-stmt-func-skip-dft-param.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-block.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-for.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-try.js non-strict
+    function-code/if-decl-else-stmt-func-skip-param.js non-strict
+    function-code/if-decl-no-else-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-no-else-func-skip-dft-param.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-block.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-for.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-try.js non-strict
+    function-code/if-decl-no-else-func-skip-param.js non-strict
+    function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-stmt-else-decl-func-skip-dft-param.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-block.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-for.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-for-in.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-for-of.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-switch.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-try.js non-strict
+    function-code/if-stmt-else-decl-func-skip-param.js non-strict
+    function-code/switch-case-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/switch-case-func-skip-dft-param.js non-strict
+    function-code/switch-case-func-skip-early-err.js non-strict
+    function-code/switch-case-func-skip-early-err-block.js non-strict
+    function-code/switch-case-func-skip-early-err-for.js non-strict
+    function-code/switch-case-func-skip-early-err-for-in.js non-strict
+    function-code/switch-case-func-skip-early-err-for-of.js non-strict
+    function-code/switch-case-func-skip-early-err-switch.js non-strict
+    function-code/switch-case-func-skip-early-err-try.js non-strict
+    function-code/switch-case-func-skip-param.js non-strict
+    function-code/switch-dflt-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/switch-dflt-func-skip-dft-param.js non-strict
+    function-code/switch-dflt-func-skip-early-err.js non-strict
+    function-code/switch-dflt-func-skip-early-err-block.js non-strict
+    function-code/switch-dflt-func-skip-early-err-for.js non-strict
+    function-code/switch-dflt-func-skip-early-err-for-in.js non-strict
+    function-code/switch-dflt-func-skip-early-err-for-of.js non-strict
+    function-code/switch-dflt-func-skip-early-err-switch.js non-strict
+    function-code/switch-dflt-func-skip-early-err-try.js non-strict
+    function-code/switch-dflt-func-skip-param.js non-strict
+    global-code/block-decl-global-block-scoping.js non-strict
+    global-code/block-decl-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/block-decl-global-init.js interpreted-non-strict
+    global-code/block-decl-global-no-skip-try.js interpreted-non-strict
+    global-code/block-decl-global-skip-early-err.js non-strict
+    global-code/block-decl-global-skip-early-err-block.js non-strict
+    global-code/block-decl-global-skip-early-err-for.js non-strict
+    global-code/block-decl-global-skip-early-err-for-in.js non-strict
+    global-code/block-decl-global-skip-early-err-for-of.js non-strict
+    global-code/block-decl-global-skip-early-err-switch.js non-strict
+    global-code/block-decl-global-skip-early-err-try.js non-strict
+    global-code/if-decl-else-decl-a-global-block-scoping.js non-strict
+    global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-block.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-for.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-try.js non-strict
+    global-code/if-decl-else-decl-b-global-block-scoping.js non-strict
+    global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-block.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-for.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-try.js non-strict
+    global-code/if-decl-else-stmt-global-block-scoping.js non-strict
+    global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-block.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-for.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-try.js non-strict
+    global-code/if-decl-no-else-global-block-scoping.js non-strict
+    global-code/if-decl-no-else-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-no-else-global-skip-early-err.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-block.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-for.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-try.js non-strict
+    global-code/if-stmt-else-decl-global-block-scoping.js non-strict
+    global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-block.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-for.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-for-in.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-for-of.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-switch.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-try.js non-strict
+    global-code/script-decl-lex-collision.js non-strict
+    global-code/switch-case-global-block-scoping.js non-strict
+    global-code/switch-case-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/switch-case-global-skip-early-err.js non-strict
+    global-code/switch-case-global-skip-early-err-block.js non-strict
+    global-code/switch-case-global-skip-early-err-for.js non-strict
+    global-code/switch-case-global-skip-early-err-for-in.js non-strict
+    global-code/switch-case-global-skip-early-err-for-of.js non-strict
+    global-code/switch-case-global-skip-early-err-switch.js non-strict
+    global-code/switch-case-global-skip-early-err-try.js non-strict
+    global-code/switch-dflt-global-block-scoping.js non-strict
+    global-code/switch-dflt-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/switch-dflt-global-skip-early-err.js non-strict
+    global-code/switch-dflt-global-skip-early-err-block.js non-strict
+    global-code/switch-dflt-global-skip-early-err-for.js non-strict
+    global-code/switch-dflt-global-skip-early-err-for-in.js non-strict
+    global-code/switch-dflt-global-skip-early-err-for-of.js non-strict
+    global-code/switch-dflt-global-skip-early-err-switch.js non-strict
+    global-code/switch-dflt-global-skip-early-err-try.js non-strict
     literals/regexp/class-escape.js
     literals/regexp/identity-escape.js
     literals/regexp/legacy-octal-escape.js
+    statements/class/subclass 2/2 (100.0%)
+    statements/const/dstr 2/2 (100.0%)
+    statements/for-await-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [async-iteration, IsHTMLDDA, async]}
     statements/for-in/let-initializer.js
-    statements/for-in/strict-initializer.js
+    statements/for-in/strict-initializer.js strict
+    statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [IsHTMLDDA]}
+    statements/function/default-parameters-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    statements/if/emulated-undefined.js {unsupported: [IsHTMLDDA]}
+    statements/switch/emulates-undefined.js {unsupported: [IsHTMLDDA]}
 
-harness
+harness 23/116 (19.83%)
+    assert-notsamevalue-tostring.js {unsupported: [async-functions]}
+    assert-samevalue-tostring.js {unsupported: [async-functions]}
+    assert-tostring.js {unsupported: [async-functions]}
+    asyncHelpers-asyncTest-returns-undefined.js {unsupported: [async]}
+    asyncHelpers-asyncTest-then-rejects.js {unsupported: [async]}
+    asyncHelpers-asyncTest-then-resolves.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-custom.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-custom-typeerror.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-func-never-settles.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-func-throws-sync.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-incorrect-ctor.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-invalid-func.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-native.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-no-arg.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-no-error.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-null.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-primitive.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-resolved-error.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-same-realm.js {unsupported: [async]}
+    asyncHelpers-throwsAsync-single-arg.js {unsupported: [async]}
     compare-array-arguments.js
     isConstructor.js
     nativeFunctionMatcher.js
 
-built-ins/Array
-    fromAsync/builtin.js
-    fromAsync/length.js
-    fromAsync/name.js
-    fromAsync/not-a-constructor.js
-    fromAsync/prop-desc.js
+built-ins/Array 263/3077 (8.55%)
+    fromAsync 95/95 (100.0%)
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/proto-from-ctor-realm.js
     from/source-object-constructor.js Error propagation needs work in general
     length/define-own-prop-length-coercion-order-set.js
     of/proto-from-ctor-realm.js
+    prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/typed-array-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/concat/Array.prototype.concat_non-array.js
     prototype/concat/create-proto-from-ctor-realm-array.js
     prototype/concat/create-proxy.js
     prototype/concat/is-concat-spreadable-is-array-proxy-revoked.js
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
-    prototype/copyWithin/return-abrupt-from-delete-target.js Not throwing properly on unwritable
-    prototype/every/15.4.4.16-5-1-s.js
-    prototype/filter/15.4.4.20-5-1-s.js
+    prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
+    prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/15.4.4.16-5-1-s.js non-strict
+    prototype/every/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/typed-array-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/15.4.4.20-5-1-s.js non-strict
+    prototype/filter/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/create-proto-from-ctor-realm-array.js
     prototype/filter/create-proxy.js
-    prototype/findIndex/predicate-call-this-strict.js
-    prototype/findLastIndex/predicate-call-this-strict.js
-    prototype/findLast/predicate-call-this-strict.js
-    prototype/find/predicate-call-this-strict.js
+    prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/predicate-call-this-strict.js strict
+    prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/predicate-call-this-strict.js strict
+    prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/predicate-call-this-strict.js strict
+    prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/predicate-call-this-strict.js strict
+    prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/flatMap/proxy-access-count.js
     prototype/flatMap/this-value-ctor-non-object.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    prototype/flatMap/thisArg-argument.js
+    prototype/flatMap/thisArg-argument.js strict
     prototype/flat/proxy-access-count.js
-    prototype/forEach/15.4.4.18-5-1-s.js
+    prototype/forEach/15.4.4.18-5-1-s.js non-strict
+    prototype/forEach/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/calls-only-has-on-prototype-after-length-zeroed.js
+    prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/indexOf/length-zero-returns-minus-one.js
+    prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/calls-only-has-on-prototype-after-length-zeroed.js
+    prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/length-zero-returns-minus-one.js
-    prototype/map/15.4.4.19-5-1-s.js
+    prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/15.4.4.19-5-1-s.js non-strict
+    prototype/map/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/create-proto-from-ctor-realm-array.js
     prototype/map/create-proxy.js
+    prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/pop/set-length-array-is-frozen.js
     prototype/pop/set-length-array-length-is-non-writable.js
-    prototype/pop/set-length-zero-array-is-frozen.js
-    prototype/pop/set-length-zero-array-length-is-non-writable.js
-    prototype/pop/throws-with-string-receiver.js
-    prototype/push/length-near-integer-limit-set-failure.js
+    prototype/pop/set-length-zero-array-is-frozen.js non-strict
+    prototype/pop/set-length-zero-array-length-is-non-writable.js non-strict
+    prototype/pop/throws-with-string-receiver.js non-strict
+    prototype/push/length-near-integer-limit-set-failure.js non-strict
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/set-length-array-is-frozen.js
     prototype/push/set-length-array-length-is-non-writable.js
-    prototype/push/set-length-zero-array-is-frozen.js
+    prototype/push/set-length-zero-array-is-frozen.js non-strict
     prototype/push/set-length-zero-array-length-is-non-writable.js
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
-    prototype/push/throws-with-string-receiver.js
-    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js
-    prototype/reduce/15.4.4.21-9-c-ii-4-s.js
+    prototype/push/throws-with-string-receiver.js non-strict
+    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
+    prototype/reduceRight/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
+    prototype/reduce/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reverse/length-exceeding-integer-limit-with-proxy.js
+    prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/shift/set-length-array-is-frozen.js
     prototype/shift/set-length-array-length-is-non-writable.js
-    prototype/shift/set-length-zero-array-is-frozen.js
-    prototype/shift/set-length-zero-array-length-is-non-writable.js
-    prototype/shift/throws-when-this-value-length-is-writable-false.js
+    prototype/shift/set-length-zero-array-is-frozen.js non-strict
+    prototype/shift/set-length-zero-array-length-is-non-writable.js non-strict
+    prototype/shift/throws-when-this-value-length-is-writable-false.js non-strict
+    prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/create-proto-from-ctor-realm-array.js
     prototype/slice/create-proxy.js
     prototype/slice/create-species.js
-    prototype/some/15.4.4.17-5-1-s.js
-    prototype/sort/S15.4.4.11_A8.js
+    prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/15.4.4.17-5-1-s.js non-strict
+    prototype/some/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-proto-from-ctor-realm-array.js
     prototype/splice/create-proto-from-ctor-realm-non-array.js
@@ -479,34 +590,75 @@ built-ins/Array
     prototype/splice/create-species-length-exceeding-integer-limit.js
     prototype/splice/property-traps-order-with-species.js
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
-    prototype/splice/S15.4.4.12_A6.1_T3.js
+    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
     prototype/Symbol.unscopables/change-array-by-copy.js
     prototype/toLocaleString/invoke-element-tolocalestring.js
-    prototype/toLocaleString/primitive_this_value.js
-    prototype/toLocaleString/primitive_this_value_getter.js
+    prototype/toLocaleString/primitive_this_value.js strict
+    prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/toString/call-with-boolean.js
     prototype/toString/non-callable-join-string-tag.js
     prototype/unshift/set-length-array-is-frozen.js
     prototype/unshift/set-length-array-length-is-non-writable.js
-    prototype/unshift/set-length-zero-array-is-frozen.js
+    prototype/unshift/set-length-zero-array-is-frozen.js non-strict
     prototype/unshift/set-length-zero-array-length-is-non-writable.js
-    prototype/unshift/throws-with-string-receiver.js
+    prototype/unshift/throws-with-string-receiver.js non-strict
+    prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/methods-called-as-functions.js
     proto-from-ctor-realm-one.js
     proto-from-ctor-realm-two.js
     proto-from-ctor-realm-zero.js
 
-built-ins/ArrayBuffer
-    Symbol.species/length.js
-    Symbol.species/return-value.js
-    Symbol.species/symbol-species.js
-    Symbol.species/symbol-species-name.js
+built-ins/ArrayBuffer 84/192 (43.75%)
+    isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
+    isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
+    prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/detached/detached-buffer-resizable.js {unsupported: [resizable-arraybuffer]}
+    prototype/detached/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/detached/this-is-sharedarraybuffer-resizable.js {unsupported: [SharedArrayBuffer]}
+    prototype/maxByteLength 11/11 (100.0%)
+    prototype/resizable 10/10 (100.0%)
+    prototype/resize 21/21 (100.0%)
+    prototype/slice/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/transferToFixedLength/from-fixed-to-larger.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-fixed-to-same.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-fixed-to-smaller.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-fixed-to-zero.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-resizable-to-larger.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-resizable-to-same.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-resizable-to-smaller.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/from-resizable-to-zero.js {unsupported: [resizable-arraybuffer]}
+    prototype/transferToFixedLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    prototype/transfer/from-fixed-to-larger.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-fixed-to-same.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-fixed-to-smaller.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-fixed-to-zero.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-resizable-to-larger.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-resizable-to-same.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-resizable-to-smaller.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/from-resizable-to-zero.js {unsupported: [resizable-arraybuffer]}
+    prototype/transfer/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
+    Symbol.species 4/4 (100.0%)
     data-allocation-after-object-creation.js
+    options-maxbytelength-allocation-limit.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-compared-before-object-creation.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-data-allocation-after-object-creation.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-diminuitive.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-excessive.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-negative.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-object.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-poisoned.js {unsupported: [resizable-arraybuffer]}
+    options-maxbytelength-undefined.js {unsupported: [resizable-arraybuffer]}
+    options-non-object.js {unsupported: [resizable-arraybuffer]}
     proto-from-ctor-realm.js
     prototype-from-newtarget.js
 
-built-ins/ArrayIteratorPrototype
+built-ins/ArrayIteratorPrototype 0/27 (0.0%)
 
 ~built-ins/AsyncFromSyncIteratorPrototype
 
@@ -520,7 +672,7 @@ built-ins/ArrayIteratorPrototype
 
 ~built-ins/Atomics
 
-built-ins/BigInt
+built-ins/BigInt 7/75 (9.33%)
     asIntN/bigint-tobigint-errors.js
     asIntN/bits-toindex-errors.js
     asIntN/bits-toindex-wrapped-values.js
@@ -529,16 +681,27 @@ built-ins/BigInt
     asUintN/bits-toindex-wrapped-values.js
     wrapper-object-ordinary-toprimitive.js
 
-built-ins/Boolean
+built-ins/Boolean 1/51 (1.96%)
     proto-from-ctor-realm.js
 
-built-ins/DataView
+built-ins/DataView 150/550 (27.27%)
+    prototype/buffer/return-buffer-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/buffer/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/return-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/byteLength/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/return-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/byteOffset/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/getBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/getBigInt64/index-is-out-of-range.js
     prototype/getBigInt64/length.js
     prototype/getBigInt64/name.js
     prototype/getBigInt64/negative-byteoffset-throws.js
     prototype/getBigInt64/not-a-constructor.js
+    prototype/getBigInt64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigInt64/return-value-clean-arraybuffer.js
     prototype/getBigInt64/return-values.js
@@ -554,6 +717,7 @@ built-ins/DataView
     prototype/getBigUint64/name.js
     prototype/getBigUint64/negative-byteoffset-throws.js
     prototype/getBigUint64/not-a-constructor.js
+    prototype/getBigUint64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getBigUint64/return-abrupt-from-tonumber-byteoffset.js
     prototype/getBigUint64/return-value-clean-arraybuffer.js
     prototype/getBigUint64/return-values.js
@@ -570,6 +734,7 @@ built-ins/DataView
     prototype/getFloat16/name.js
     prototype/getFloat16/negative-byteoffset-throws.js
     prototype/getFloat16/not-a-constructor.js
+    prototype/getFloat16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/getFloat16/return-abrupt-from-tonumber-byteoffset.js
     prototype/getFloat16/return-infinity.js
     prototype/getFloat16/return-nan.js
@@ -578,6 +743,24 @@ built-ins/DataView
     prototype/getFloat16/return-values-custom-offset.js
     prototype/getFloat16/to-boolean-littleendian.js
     prototype/getFloat16/toindex-byteoffset.js
+    prototype/getFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getInt32/index-is-out-of-range-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getInt32/return-abrupt-from-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-abrupt-from-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-value-clean-arraybuffer-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-values-custom-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/return-values-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/this-has-no-dataview-internal-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/to-boolean-littleendian-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt32/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/getInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/getUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setBigInt64/detached-buffer-after-bigint-value.js
     prototype/setBigInt64/detached-buffer-after-toindex-byteoffset.js
     prototype/setBigInt64/index-check-before-value-conversion.js
@@ -587,13 +770,14 @@ built-ins/DataView
     prototype/setBigInt64/negative-byteoffset-throws.js
     prototype/setBigInt64/not-a-constructor.js
     prototype/setBigInt64/range-check-after-value-conversion.js
+    prototype/setBigInt64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setBigInt64/return-abrupt-from-tobigint-value.js
     prototype/setBigInt64/return-abrupt-from-tonumber-byteoffset.js
     prototype/setBigInt64/set-values-little-endian-order.js
     prototype/setBigInt64/set-values-return-undefined.js
     prototype/setBigInt64/to-boolean-littleendian.js
     prototype/setBigInt64/toindex-byteoffset.js
-    prototype/setBigUint64/not-a-constructor.js
+    prototype/setBigUint64 2/2 (100.0%)
     prototype/setFloat16/detached-buffer-after-number-value.js
     prototype/setFloat16/detached-buffer-after-toindex-byteoffset.js
     prototype/setFloat16/index-check-before-value-conversion.js
@@ -604,18 +788,54 @@ built-ins/DataView
     prototype/setFloat16/no-value-arg.js
     prototype/setFloat16/not-a-constructor.js
     prototype/setFloat16/range-check-after-value-conversion.js
+    prototype/setFloat16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/setFloat16/return-abrupt-from-tonumber-byteoffset.js
     prototype/setFloat16/return-abrupt-from-tonumber-value.js
     prototype/setFloat16/set-values-little-endian-order.js
     prototype/setFloat16/set-values-return-undefined.js
     prototype/setFloat16/to-boolean-littleendian.js
     prototype/setFloat16/toindex-byteoffset.js
+    prototype/setFloat32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setFloat64/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setInt16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setInt32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setInt8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setUint16/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setUint32/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/setUint8/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    buffer-does-not-have-arraybuffer-data-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    buffer-reference-sab.js {unsupported: [SharedArrayBuffer]}
+    byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     custom-proto-access-detaches-buffer.js
+    custom-proto-access-resizes-buffer-invalid-by-length.js {unsupported: [resizable-arraybuffer]}
+    custom-proto-access-resizes-buffer-invalid-by-offset.js {unsupported: [resizable-arraybuffer]}
+    custom-proto-access-resizes-buffer-valid-by-length.js {unsupported: [resizable-arraybuffer]}
+    custom-proto-access-resizes-buffer-valid-by-offset.js {unsupported: [resizable-arraybuffer]}
     custom-proto-access-throws.js
+    custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    custom-proto-if-not-object-fallbacks-to-default-prototype-sab.js {unsupported: [SharedArrayBuffer]}
     custom-proto-if-object-is-used.js
+    custom-proto-if-object-is-used-sab.js {unsupported: [SharedArrayBuffer]}
+    defined-bytelength-and-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    defined-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    defined-byteoffset-undefined-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    excessive-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    excessive-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
+    negative-bytelength-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    negative-byteoffset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    newtarget-undefined-throws-sab.js {unsupported: [SharedArrayBuffer]}
     proto-from-ctor-realm.js
+    proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-bytelength-symbol-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    return-abrupt-tonumber-byteoffset-symbol-sab.js {unsupported: [SharedArrayBuffer]}
+    return-instance-sab.js {unsupported: [SharedArrayBuffer]}
+    toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
 
-built-ins/Date
+built-ins/Date 85/594 (14.31%)
     now/not-a-constructor.js
     parse/not-a-constructor.js
     parse/year-zero.js
@@ -680,14 +900,7 @@ built-ins/Date
     prototype/toLocaleTimeString/not-a-constructor.js
     prototype/toString/non-date-receiver.js
     prototype/toString/not-a-constructor.js
-    prototype/toTemporalInstant/length.js
-    prototype/toTemporalInstant/name.js
-    prototype/toTemporalInstant/not-a-constructor.js
-    prototype/toTemporalInstant/prop-desc.js
-    prototype/toTemporalInstant/this-value-invalid-date.js
-    prototype/toTemporalInstant/this-value-non-date.js
-    prototype/toTemporalInstant/this-value-non-object.js
-    prototype/toTemporalInstant/this-value-valid-date.js
+    prototype/toTemporalInstant 8/8 (100.0%)
     prototype/toTimeString/not-a-constructor.js
     prototype/toUTCString/not-a-constructor.js
     prototype/valueOf/not-a-constructor.js
@@ -702,18 +915,8 @@ built-ins/Date
     proto-from-ctor-realm-zero.js
     year-zero.js
 
-built-ins/Error
-    isError/bigints.js
-    isError/errors.js
-    isError/errors-other-realm.js
-    isError/fake-errors.js
-    isError/is-a-constructor.js
-    isError/name.js
-    isError/non-error-objects.js
-    isError/non-error-objects-other-realm.js
-    isError/primitives.js
-    isError/prop-desc.js
-    isError/symbols.js
+built-ins/Error 17/53 (32.08%)
+    isError 12/12 (100.0%)
     prototype/toString/not-a-constructor.js
     prototype/no-error-data.js
     prototype/S15.11.4_A2.js
@@ -722,19 +925,24 @@ built-ins/Error
 
 ~built-ins/FinalizationRegistry
 
-built-ins/Function
-    internals/Construct/base-ctor-revoked-proxy.js
-    internals/Construct/base-ctor-revoked-proxy-realm.js
-    prototype/apply/15.3.4.3-1-s.js
-    prototype/apply/15.3.4.3-2-s.js
-    prototype/apply/15.3.4.3-3-s.js
+built-ins/Function 128/509 (25.15%)
+    internals/Call 2/2 (100.0%)
+    internals/Construct 6/6 (100.0%)
+    prototype/apply/15.3.4.3-1-s.js strict
+    prototype/apply/15.3.4.3-2-s.js strict
+    prototype/apply/15.3.4.3-3-s.js strict
     prototype/apply/argarray-not-object.js
     prototype/apply/argarray-not-object-realm.js
+    prototype/apply/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/apply/this-not-callable-realm.js
     prototype/arguments/prop-desc.js
     prototype/bind/BoundFunction_restricted-properties.js
     prototype/bind/get-fn-realm.js
     prototype/bind/get-fn-realm-recursive.js
+    prototype/bind/instance-construct-newtarget-boundtarget.js {unsupported: [new.target]}
+    prototype/bind/instance-construct-newtarget-boundtarget-bound.js {unsupported: [new.target]}
+    prototype/bind/instance-construct-newtarget-self-new.js {unsupported: [new.target]}
+    prototype/bind/instance-construct-newtarget-self-reflect.js {unsupported: [new.target]}
     prototype/bind/instance-length-exceeds-int32.js
     prototype/bind/instance-length-tointeger.js
     prototype/bind/instance-name.js
@@ -743,10 +951,27 @@ built-ins/Function
     prototype/bind/proto-from-ctor-realm.js
     prototype/caller-arguments/accessor-properties.js
     prototype/caller/prop-desc.js
-    prototype/call/15.3.4.4-1-s.js
-    prototype/call/15.3.4.4-2-s.js
-    prototype/call/15.3.4.4-3-s.js
+    prototype/call/15.3.4.4-1-s.js strict
+    prototype/call/15.3.4.4-2-s.js strict
+    prototype/call/15.3.4.4-3-s.js strict
     prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
+    prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
+    prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
+    prototype/toString/async-function-expression.js {unsupported: [async-functions]}
+    prototype/toString/async-generator-declaration.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-expression.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-expression.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-expression-static.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-statement.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-class-statement-static.js {unsupported: [async-iteration]}
+    prototype/toString/async-generator-method-object.js {unsupported: [async-iteration]}
+    prototype/toString/async-method-class-expression.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-expression-static.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-statement.js {unsupported: [async-functions]}
+    prototype/toString/async-method-class-statement-static.js {unsupported: [async-functions]}
+    prototype/toString/async-method-object.js {unsupported: [async-functions]}
+    prototype/toString/AsyncFunction.js {unsupported: [async-functions]}
+    prototype/toString/AsyncGenerator.js {unsupported: [async-iteration]}
     prototype/toString/bound-function.js
     prototype/toString/built-in-function-object.js
     prototype/toString/class-declaration-complex-heritage.js
@@ -773,7 +998,12 @@ built-ins/Function
     prototype/toString/private-static-method-class-expression.js
     prototype/toString/private-static-method-class-statement.js
     prototype/toString/proxy-arrow-function.js
+    prototype/toString/proxy-async-function.js {unsupported: [async-functions]}
+    prototype/toString/proxy-async-generator-function.js {unsupported: [async-iteration]}
+    prototype/toString/proxy-async-generator-method-definition.js {unsupported: [async-iteration]}
+    prototype/toString/proxy-async-method-definition.js {unsupported: [async-functions]}
     prototype/toString/proxy-bound-function.js
+    prototype/toString/proxy-class.js {unsupported: [class]}
     prototype/toString/proxy-function-expression.js
     prototype/toString/proxy-generator-function.js
     prototype/toString/proxy-method-definition.js
@@ -783,42 +1013,43 @@ built-ins/Function
     prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
-    15.3.2.1-10-6gs.js
-    15.3.2.1-11-1-s.js
-    15.3.2.1-11-3-s.js
-    15.3.2.1-11-5-s.js
-    15.3.5-1gs.js
-    15.3.5-2gs.js
-    15.3.5.4_2-11gs.js
-    15.3.5.4_2-13gs.js
-    15.3.5.4_2-15gs.js
-    15.3.5.4_2-17gs.js
-    15.3.5.4_2-19gs.js
-    15.3.5.4_2-1gs.js
-    15.3.5.4_2-21gs.js
-    15.3.5.4_2-22gs.js
-    15.3.5.4_2-23gs.js
-    15.3.5.4_2-24gs.js
-    15.3.5.4_2-25gs.js
-    15.3.5.4_2-26gs.js
-    15.3.5.4_2-27gs.js
-    15.3.5.4_2-28gs.js
-    15.3.5.4_2-29gs.js
-    15.3.5.4_2-3gs.js
-    15.3.5.4_2-48gs.js
-    15.3.5.4_2-50gs.js
-    15.3.5.4_2-52gs.js
-    15.3.5.4_2-54gs.js
-    15.3.5.4_2-5gs.js
-    15.3.5.4_2-7gs.js
-    15.3.5.4_2-9gs.js
+    15.3.2.1-10-6gs.js non-strict
+    15.3.2.1-11-1-s.js non-strict
+    15.3.2.1-11-3-s.js non-strict
+    15.3.2.1-11-5-s.js non-strict
+    15.3.5-1gs.js strict
+    15.3.5-2gs.js strict
+    15.3.5.4_2-11gs.js strict
+    15.3.5.4_2-13gs.js strict
+    15.3.5.4_2-15gs.js strict
+    15.3.5.4_2-17gs.js strict
+    15.3.5.4_2-19gs.js strict
+    15.3.5.4_2-1gs.js strict
+    15.3.5.4_2-21gs.js strict
+    15.3.5.4_2-22gs.js strict
+    15.3.5.4_2-23gs.js strict
+    15.3.5.4_2-24gs.js strict
+    15.3.5.4_2-25gs.js strict
+    15.3.5.4_2-26gs.js strict
+    15.3.5.4_2-27gs.js strict
+    15.3.5.4_2-28gs.js strict
+    15.3.5.4_2-29gs.js strict
+    15.3.5.4_2-3gs.js strict
+    15.3.5.4_2-48gs.js strict
+    15.3.5.4_2-50gs.js strict
+    15.3.5.4_2-52gs.js strict
+    15.3.5.4_2-54gs.js strict
+    15.3.5.4_2-5gs.js strict
+    15.3.5.4_2-7gs.js strict
+    15.3.5.4_2-9gs.js strict
     call-bind-this-realm-undef.js
     call-bind-this-realm-value.js
+    private-identifiers-not-empty.js {unsupported: [class-fields-private]}
     proto-from-ctor-realm.js
     proto-from-ctor-realm-prototype.js
-    StrictFunction_restricted-properties.js
+    StrictFunction_restricted-properties.js strict
 
-built-ins/GeneratorFunction
+built-ins/GeneratorFunction 8/23 (34.78%)
     prototype/constructor.js
     prototype/prototype.js
     prototype/Symbol.toStringTag.js
@@ -828,7 +1059,7 @@ built-ins/GeneratorFunction
     name.js
     proto-from-ctor-realm-prototype.js
 
-built-ins/GeneratorPrototype
+built-ins/GeneratorPrototype 31/61 (50.82%)
     next/from-state-executing.js
     next/length.js
     next/not-a-constructor.js
@@ -861,15 +1092,10 @@ built-ins/GeneratorPrototype
     constructor.js
     Symbol.toStringTag.js
 
-built-ins/Infinity
+built-ins/Infinity 0/6 (0.0%)
 
-built-ins/JSON
-    isRawJSON/basic.js
-    isRawJSON/builtin.js
-    isRawJSON/length.js
-    isRawJSON/name.js
-    isRawJSON/not-a-constructor.js
-    isRawJSON/prop-desc.js
+built-ins/JSON 45/165 (27.27%)
+    isRawJSON 6/6 (100.0%)
     parse/builtin.js
     parse/revived-proxy.js
     parse/reviver-array-define-prop-err.js
@@ -885,18 +1111,9 @@ built-ins/JSON
     parse/reviver-object-define-prop-err.js
     parse/reviver-object-get-prop-from-prototype.js
     parse/reviver-object-non-configurable-prop-create.js
-    parse/reviver-object-non-configurable-prop-delete.js
+    parse/reviver-object-non-configurable-prop-delete.js strict
     parse/text-negative-zero.js
-    rawJSON/basic.js
-    rawJSON/bigint-raw-json-can-be-stringified.js
-    rawJSON/builtin.js
-    rawJSON/illegal-empty-and-start-end-chars.js
-    rawJSON/invalid-JSON-text.js
-    rawJSON/length.js
-    rawJSON/name.js
-    rawJSON/not-a-constructor.js
-    rawJSON/prop-desc.js
-    rawJSON/returns-expected-object.js
+    rawJSON 10/10 (100.0%)
     stringify/builtin.js
     stringify/replacer-array-abrupt.js
     stringify/replacer-array-proxy.js
@@ -910,7 +1127,7 @@ built-ins/JSON
     stringify/value-bigint-tojson-receiver.js
     stringify/value-object-proxy.js
 
-built-ins/Map
+built-ins/Map 12/185 (6.49%)
     prototype/getOrInsert/append-new-values.js
     prototype/getOrInsert/append-new-values-normalizes-zero-key.js
     prototype/getOrInsert/append-value-if-key-is-not-present-different-key-types.js
@@ -924,29 +1141,16 @@ built-ins/Map
     proto-from-ctor-realm.js
     valid-keys.js
 
-built-ins/MapIteratorPrototype
+built-ins/MapIteratorPrototype 0/11 (0.0%)
 
-built-ins/Math
-    f16round/length.js
-    f16round/name.js
-    f16round/not-a-constructor.js
-    f16round/prop-desc.js
+built-ins/Math 12/327 (3.67%)
     f16round/value-conversion.js
     log2/log2-basicTests.js calculation is not exact
-    sumPrecise/length.js
-    sumPrecise/name.js
-    sumPrecise/not-a-constructor.js
-    sumPrecise/prop-desc.js
-    sumPrecise/sum.js
-    sumPrecise/sum-is-infinite.js
-    sumPrecise/sum-is-minus-zero.js
-    sumPrecise/sum-is-NaN.js
-    sumPrecise/takes-iterable.js
-    sumPrecise/throws-on-non-number.js
+    sumPrecise 10/10 (100.0%)
 
-built-ins/NaN
+built-ins/NaN 0/6 (0.0%)
 
-built-ins/NativeErrors
+built-ins/NativeErrors 36/139 (25.9%)
     AggregateError/newtarget-proto-fallback.js
     AggregateError/proto-from-ctor-realm.js
     EvalError/prototype/not-error-object.js
@@ -955,28 +1159,8 @@ built-ins/NativeErrors
     RangeError/proto-from-ctor-realm.js
     ReferenceError/prototype/not-error-object.js
     ReferenceError/proto-from-ctor-realm.js
-    SuppressedError/prototype/constructor.js
-    SuppressedError/prototype/errors-absent-on-prototype.js
-    SuppressedError/prototype/message.js
-    SuppressedError/prototype/name.js
-    SuppressedError/prototype/prop-desc.js
-    SuppressedError/prototype/proto.js
-    SuppressedError/is-a-constructor.js
-    SuppressedError/length.js
-    SuppressedError/message-method-prop.js
-    SuppressedError/message-method-prop-cast.js
-    SuppressedError/message-tostring-abrupt.js
-    SuppressedError/message-tostring-abrupt-symbol.js
-    SuppressedError/message-undefined-no-prop.js
-    SuppressedError/name.js
-    SuppressedError/newtarget-is-undefined.js
-    SuppressedError/newtarget-proto.js
-    SuppressedError/newtarget-proto-custom.js
-    SuppressedError/newtarget-proto-fallback.js
-    SuppressedError/order-of-args-evaluation.js
-    SuppressedError/prop-desc.js
-    SuppressedError/proto.js
-    SuppressedError/proto-from-ctor-realm.js
+    SuppressedError/prototype 6/6 (100.0%)
+    SuppressedError 16/16 (100.0%)
     SyntaxError/prototype/not-error-object.js
     SyntaxError/proto-from-ctor-realm.js
     TypeError/prototype/not-error-object.js
@@ -984,27 +1168,30 @@ built-ins/NativeErrors
     URIError/prototype/not-error-object.js
     URIError/proto-from-ctor-realm.js
 
-built-ins/Number
+built-ins/Number 8/335 (2.39%)
     prototype/toExponential/return-abrupt-tointeger-fractiondigits.js
     prototype/toExponential/return-abrupt-tointeger-fractiondigits-symbol.js
     prototype/toExponential/undefined-fractiondigits.js
     prototype/toPrecision/nan.js
     proto-from-ctor-realm.js
+    S9.3.1_A2_U180E.js {unsupported: [u180e]}
+    S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
+    S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object
+built-ins/Object 120/3410 (3.52%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order-proxy.js
-    defineProperties/15.2.3.7-6-a-112.js
-    defineProperties/15.2.3.7-6-a-113.js
+    defineProperties/15.2.3.7-6-a-112.js non-strict
+    defineProperties/15.2.3.7-6-a-113.js non-strict
     defineProperties/15.2.3.7-6-a-164.js
     defineProperties/15.2.3.7-6-a-165.js
-    defineProperties/15.2.3.7-6-a-166.js
-    defineProperties/15.2.3.7-6-a-168.js
-    defineProperties/15.2.3.7-6-a-169.js
-    defineProperties/15.2.3.7-6-a-170.js
-    defineProperties/15.2.3.7-6-a-172.js
-    defineProperties/15.2.3.7-6-a-173.js
+    defineProperties/15.2.3.7-6-a-166.js non-strict
+    defineProperties/15.2.3.7-6-a-168.js non-strict
+    defineProperties/15.2.3.7-6-a-169.js non-strict
+    defineProperties/15.2.3.7-6-a-170.js non-strict
+    defineProperties/15.2.3.7-6-a-172.js non-strict
+    defineProperties/15.2.3.7-6-a-173.js non-strict
     defineProperties/15.2.3.7-6-a-175.js
     defineProperties/15.2.3.7-6-a-176.js
     defineProperties/15.2.3.7-6-a-184.js
@@ -1012,27 +1199,32 @@ built-ins/Object
     defineProperties/15.2.3.7-6-a-282.js
     defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js
-    defineProperty/15.2.3.6-4-116.js
-    defineProperty/15.2.3.6-4-117.js
+    defineProperties/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    defineProperty/15.2.3.6-4-116.js non-strict
+    defineProperty/15.2.3.6-4-117.js non-strict
     defineProperty/15.2.3.6-4-168.js
     defineProperty/15.2.3.6-4-169.js
-    defineProperty/15.2.3.6-4-170.js
-    defineProperty/15.2.3.6-4-172.js
-    defineProperty/15.2.3.6-4-173.js
-    defineProperty/15.2.3.6-4-174.js
-    defineProperty/15.2.3.6-4-176.js
-    defineProperty/15.2.3.6-4-177.js
+    defineProperty/15.2.3.6-4-170.js non-strict
+    defineProperty/15.2.3.6-4-172.js non-strict
+    defineProperty/15.2.3.6-4-173.js non-strict
+    defineProperty/15.2.3.6-4-174.js non-strict
+    defineProperty/15.2.3.6-4-176.js non-strict
+    defineProperty/15.2.3.6-4-177.js non-strict
     defineProperty/15.2.3.6-4-188.js
     defineProperty/15.2.3.6-4-189.js
     defineProperty/15.2.3.6-4-254.js
     defineProperty/15.2.3.6-4-293-1.js
-    defineProperty/15.2.3.6-4-293-3.js
-    defineProperty/15.2.3.6-4-293-4.js
+    defineProperty/15.2.3.6-4-293-3.js non-strict
+    defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
+    defineProperty/coerced-P-grow.js {unsupported: [resizable-arraybuffer]}
+    defineProperty/coerced-P-shrink.js {unsupported: [resizable-arraybuffer]}
     defineProperty/property-description-must-be-an-object-not-symbol.js
+    defineProperty/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     entries/observable-operations.js
     freeze/proxy-no-ownkeys-returned-keys-order.js
     freeze/proxy-with-defineProperty-handler.js
+    freeze/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     getOwnPropertyDescriptors/order-after-define-property.js
     getOwnPropertyDescriptors/proxy-no-ownkeys-returned-keys-order.js
     getOwnPropertyDescriptors/proxy-undefined-descriptor.js
@@ -1076,14 +1268,17 @@ built-ins/Object
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    prototype/toLocaleString/primitive_this_value.js
-    prototype/toLocaleString/primitive_this_value_getter.js
+    prototype/toLocaleString/primitive_this_value.js strict
+    prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/toString/proxy-function.js {unsupported: [async-functions]}
+    prototype/toString/proxy-function-async.js {unsupported: [async-functions]}
     prototype/toString/proxy-revoked-during-get-call.js
     prototype/toString/symbol-tag-array-builtin.js
     prototype/toString/symbol-tag-generators-builtin.js
     prototype/toString/symbol-tag-map-builtin.js
     prototype/toString/symbol-tag-non-str-bigint.js
     prototype/toString/symbol-tag-non-str-builtin.js
+    prototype/toString/symbol-tag-non-str-proxy-function.js {unsupported: [async-functions]}
     prototype/toString/symbol-tag-promise-builtin.js
     prototype/toString/symbol-tag-set-builtin.js
     prototype/toString/symbol-tag-string-builtin.js
@@ -1099,38 +1294,412 @@ built-ins/Object
     seal/seal-asyncfunction.js
     seal/seal-asyncgeneratorfunction.js
     seal/seal-finalizationregistry.js
+    seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     seal/seal-weakref.js
     values/observable-operations.js
     proto-from-ctor-realm.js
+    subclass-object-arg.js {unsupported: [class]}
 
-built-ins/Promise
+built-ins/Promise 375/631 (59.43%)
+    allSettled/capability-resolve-throws-reject.js {unsupported: [async]}
+    allSettled/ctx-ctor.js {unsupported: [class]}
+    allSettled/does-not-invoke-array-setters.js {unsupported: [async]}
+    allSettled/invoke-resolve-error-reject.js {unsupported: [async]}
+    allSettled/invoke-resolve-get-error.js {unsupported: [async]}
+    allSettled/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    allSettled/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    allSettled/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    allSettled/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    allSettled/invoke-then-error-reject.js {unsupported: [async]}
+    allSettled/invoke-then-get-error-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-false-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-null-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-number-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-poisoned.js {unsupported: [async]}
+    allSettled/iter-arg-is-string-resolve.js {unsupported: [async]}
+    allSettled/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-true-reject.js {unsupported: [async]}
+    allSettled/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-false-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-null-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-number-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-string-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-symbol-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-true-reject.js {unsupported: [async]}
+    allSettled/iter-assigned-undefined-reject.js {unsupported: [async]}
+    allSettled/iter-next-err-reject.js {unsupported: [async]}
+    allSettled/iter-next-val-err-reject.js {unsupported: [async]}
+    allSettled/iter-returns-false-reject.js {unsupported: [async]}
+    allSettled/iter-returns-null-reject.js {unsupported: [async]}
+    allSettled/iter-returns-number-reject.js {unsupported: [async]}
+    allSettled/iter-returns-string-reject.js {unsupported: [async]}
+    allSettled/iter-returns-symbol-reject.js {unsupported: [async]}
+    allSettled/iter-returns-true-reject.js {unsupported: [async]}
+    allSettled/iter-returns-undefined-reject.js {unsupported: [async]}
+    allSettled/iter-step-err-reject.js {unsupported: [async]}
+    allSettled/reject-deferred.js {unsupported: [async]}
+    allSettled/reject-ignored-deferred.js {unsupported: [async]}
+    allSettled/reject-ignored-immed.js {unsupported: [async]}
+    allSettled/reject-immed.js {unsupported: [async]}
+    allSettled/resolve-ignores-late-rejection.js {unsupported: [async]}
+    allSettled/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    allSettled/resolve-non-callable.js {unsupported: [async]}
+    allSettled/resolve-non-thenable.js {unsupported: [async]}
+    allSettled/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
+    allSettled/resolve-poisoned-then.js {unsupported: [async]}
+    allSettled/resolve-thenable.js {unsupported: [async]}
+    allSettled/resolved-all-fulfilled.js {unsupported: [async]}
+    allSettled/resolved-all-mixed.js {unsupported: [async]}
+    allSettled/resolved-all-rejected.js {unsupported: [async]}
+    allSettled/resolved-immed.js {unsupported: [async]}
+    allSettled/resolved-sequence.js {unsupported: [async]}
+    allSettled/resolved-sequence-extra-ticks.js {unsupported: [async]}
+    allSettled/resolved-sequence-mixed.js {unsupported: [async]}
+    allSettled/resolved-sequence-with-rejections.js {unsupported: [async]}
+    allSettled/resolved-then-catch-finally.js {unsupported: [async]}
+    allSettled/resolves-empty-array.js {unsupported: [async]}
+    allSettled/resolves-to-array.js {unsupported: [async]}
+    all/capability-resolve-throws-reject.js {unsupported: [async]}
+    all/ctx-ctor.js {unsupported: [class]}
+    all/does-not-invoke-array-setters.js {unsupported: [async]}
+    all/invoke-resolve-error-reject.js {unsupported: [async]}
+    all/invoke-resolve-get-error.js {unsupported: [async]}
+    all/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    all/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    all/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    all/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    all/invoke-then-error-reject.js {unsupported: [async]}
+    all/invoke-then-get-error-reject.js {unsupported: [async]}
+    all/iter-arg-is-false-reject.js {unsupported: [async]}
+    all/iter-arg-is-null-reject.js {unsupported: [async]}
+    all/iter-arg-is-number-reject.js {unsupported: [async]}
+    all/iter-arg-is-string-resolve.js {unsupported: [async]}
+    all/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    all/iter-arg-is-true-reject.js {unsupported: [async]}
+    all/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    all/iter-assigned-false-reject.js {unsupported: [async]}
+    all/iter-assigned-null-reject.js {unsupported: [async]}
+    all/iter-assigned-number-reject.js {unsupported: [async]}
+    all/iter-assigned-string-reject.js {unsupported: [async]}
+    all/iter-assigned-symbol-reject.js {unsupported: [async]}
+    all/iter-assigned-true-reject.js {unsupported: [async]}
+    all/iter-assigned-undefined-reject.js {unsupported: [async]}
+    all/iter-next-val-err-reject.js {unsupported: [async]}
+    all/iter-returns-false-reject.js {unsupported: [async]}
+    all/iter-returns-null-reject.js {unsupported: [async]}
+    all/iter-returns-number-reject.js {unsupported: [async]}
+    all/iter-returns-string-reject.js {unsupported: [async]}
+    all/iter-returns-symbol-reject.js {unsupported: [async]}
+    all/iter-returns-true-reject.js {unsupported: [async]}
+    all/iter-returns-undefined-reject.js {unsupported: [async]}
+    all/iter-step-err-reject.js {unsupported: [async]}
+    all/reject-deferred.js {unsupported: [async]}
+    all/reject-ignored-deferred.js {unsupported: [async]}
+    all/reject-ignored-immed.js {unsupported: [async]}
+    all/reject-immed.js {unsupported: [async]}
+    all/resolve-ignores-late-rejection.js {unsupported: [async]}
+    all/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    all/resolve-non-callable.js {unsupported: [async]}
+    all/resolve-non-thenable.js {unsupported: [async]}
+    all/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
+    all/resolve-poisoned-then.js {unsupported: [async]}
+    all/resolve-thenable.js {unsupported: [async]}
+    all/S25.4.4.1_A2.2_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A2.3_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A2.3_T2.js {unsupported: [async]}
+    all/S25.4.4.1_A2.3_T3.js {unsupported: [async]}
+    all/S25.4.4.1_A3.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A3.1_T2.js {unsupported: [async]}
+    all/S25.4.4.1_A3.1_T3.js {unsupported: [async]}
+    all/S25.4.4.1_A5.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A7.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A7.2_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A8.1_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A8.2_T1.js {unsupported: [async]}
+    all/S25.4.4.1_A8.2_T2.js {unsupported: [async]}
+    any/capability-reject-throws-no-close.js {unsupported: [async]}
+    any/capability-resolve-throws-no-close.js {unsupported: [async]}
+    any/capability-resolve-throws-reject.js {unsupported: [async]}
+    any/ctx-ctor.js {unsupported: [class]}
+    any/invoke-resolve.js {unsupported: [async]}
+    any/invoke-resolve-error-close.js {unsupported: [async]}
+    any/invoke-resolve-error-reject.js {unsupported: [async]}
+    any/invoke-resolve-get-error.js {unsupported: [async]}
+    any/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    any/invoke-resolve-get-once-multiple-calls.js {unsupported: [async]}
+    any/invoke-resolve-get-once-no-calls.js {unsupported: [async]}
+    any/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    any/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    any/invoke-resolve-on-values-every-iteration-of-custom.js {unsupported: [class, async]}
+    any/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    any/invoke-then.js {unsupported: [async]}
+    any/invoke-then-error-close.js {unsupported: [async]}
+    any/invoke-then-error-reject.js {unsupported: [async]}
+    any/invoke-then-get-error-close.js {unsupported: [async]}
+    any/invoke-then-get-error-reject.js {unsupported: [async]}
+    any/invoke-then-on-promises-every-iteration.js {unsupported: [async]}
+    any/iter-arg-is-empty-iterable-reject.js {unsupported: [async]}
+    any/iter-arg-is-empty-string-reject.js {unsupported: [async]}
+    any/iter-arg-is-error-object-reject.js {unsupported: [async]}
+    any/iter-arg-is-false-reject.js {unsupported: [async]}
+    any/iter-arg-is-null-reject.js {unsupported: [async]}
+    any/iter-arg-is-number-reject.js {unsupported: [async]}
+    any/iter-arg-is-poisoned.js {unsupported: [async]}
+    any/iter-arg-is-string-resolve.js {unsupported: [async]}
+    any/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    any/iter-arg-is-true-reject.js {unsupported: [async]}
+    any/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    any/iter-assigned-false-reject.js {unsupported: [async]}
+    any/iter-assigned-null-reject.js {unsupported: [async]}
+    any/iter-assigned-number-reject.js {unsupported: [async]}
+    any/iter-assigned-string-reject.js {unsupported: [async]}
+    any/iter-assigned-symbol-reject.js {unsupported: [async]}
+    any/iter-assigned-true-reject.js {unsupported: [async]}
+    any/iter-assigned-undefined-reject.js {unsupported: [async]}
+    any/iter-next-val-err-no-close.js {unsupported: [async]}
+    any/iter-next-val-err-reject.js {unsupported: [async]}
+    any/iter-returns-false-reject.js {unsupported: [async]}
+    any/iter-returns-null-reject.js {unsupported: [async]}
+    any/iter-returns-number-reject.js {unsupported: [async]}
+    any/iter-returns-string-reject.js {unsupported: [async]}
+    any/iter-returns-symbol-reject.js {unsupported: [async]}
+    any/iter-returns-true-reject.js {unsupported: [async]}
+    any/iter-returns-undefined-reject.js {unsupported: [async]}
+    any/iter-step-err-no-close.js {unsupported: [async]}
+    any/iter-step-err-reject.js {unsupported: [async]}
+    any/reject-all-mixed.js {unsupported: [async]}
+    any/reject-deferred.js {unsupported: [async]}
+    any/reject-ignored-deferred.js {unsupported: [async]}
+    any/reject-ignored-immed.js {unsupported: [async]}
+    any/reject-immed.js {unsupported: [async]}
+    any/resolve-from-reject-catch.js {unsupported: [async]}
+    any/resolve-from-resolve-reject-catch.js {unsupported: [async]}
+    any/resolve-ignores-late-rejection.js {unsupported: [async]}
+    any/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    any/resolve-non-callable.js {unsupported: [async]}
+    any/resolve-non-thenable.js {unsupported: [async]}
+    any/resolve-not-callable-reject-with-typeerror.js {unsupported: [async]}
+    any/resolved-sequence.js {unsupported: [async]}
+    any/resolved-sequence-extra-ticks.js {unsupported: [async]}
+    any/resolved-sequence-mixed.js {unsupported: [async]}
+    any/resolved-sequence-with-rejections.js {unsupported: [async]}
+    prototype/catch/S25.4.5.1_A3.1_T1.js {unsupported: [async]}
+    prototype/catch/S25.4.5.1_A3.1_T2.js {unsupported: [async]}
+    prototype/finally/rejected-observable-then-calls.js {unsupported: [async]}
+    prototype/finally/rejected-observable-then-calls-argument.js {unsupported: [class, async]}
+    prototype/finally/rejected-observable-then-calls-PromiseResolve.js {unsupported: [async]}
+    prototype/finally/rejection-reason-no-fulfill.js {unsupported: [async]}
+    prototype/finally/rejection-reason-override-with-throw.js {unsupported: [async]}
+    prototype/finally/resolution-value-no-override.js {unsupported: [async]}
+    prototype/finally/resolved-observable-then-calls.js {unsupported: [async]}
+    prototype/finally/resolved-observable-then-calls-argument.js {unsupported: [async]}
+    prototype/finally/resolved-observable-then-calls-PromiseResolve.js {unsupported: [async]}
+    prototype/finally/species-constructor.js {unsupported: [async]}
+    prototype/finally/subclass-reject-count.js {unsupported: [async]}
+    prototype/finally/subclass-resolve-count.js {unsupported: [async]}
     prototype/finally/subclass-species-constructor-reject-count.js
     prototype/finally/subclass-species-constructor-resolve-count.js
+    prototype/then/capability-executor-called-twice.js {unsupported: [class]}
+    prototype/then/capability-executor-not-callable.js {unsupported: [class]}
+    prototype/then/ctor-access-count.js {unsupported: [async]}
+    prototype/then/ctor-custom.js {unsupported: [class]}
+    prototype/then/deferred-is-resolved-value.js {unsupported: [class, async]}
+    prototype/then/prfm-fulfilled.js {unsupported: [async]}
+    prototype/then/prfm-pending-fulfulled.js {unsupported: [async]}
+    prototype/then/prfm-pending-rejected.js {unsupported: [async]}
+    prototype/then/prfm-rejected.js {unsupported: [async]}
+    prototype/then/reject-pending-fulfilled.js {unsupported: [async]}
+    prototype/then/reject-pending-rejected.js {unsupported: [async]}
+    prototype/then/reject-settled-fulfilled.js {unsupported: [async]}
+    prototype/then/reject-settled-rejected.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-self.js {unsupported: [async]}
+    prototype/then/resolve-pending-fulfilled-thenable.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-self.js {unsupported: [async]}
+    prototype/then/resolve-pending-rejected-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-self.js {unsupported: [async]}
+    prototype/then/resolve-settled-fulfilled-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-non-obj.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-non-thenable.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-poisoned-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-prms-cstm-then.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-self.js {unsupported: [async]}
+    prototype/then/resolve-settled-rejected-thenable.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-invoke-nonstrict.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-invoke-strict.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-next.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-next-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-return-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-fulfilled-return-normal.js {unsupported: [async]}
+    prototype/then/rxn-handler-identity.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-invoke-nonstrict.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-invoke-strict.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-next.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-next-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-return-abrupt.js {unsupported: [async]}
+    prototype/then/rxn-handler-rejected-return-normal.js {unsupported: [async]}
+    prototype/then/rxn-handler-thrower.js {unsupported: [async]}
+    prototype/then/S25.4.4_A1.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.4_A2.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.4_A2.1_T2.js {unsupported: [async]}
+    prototype/then/S25.4.4_A2.1_T3.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.1_T2.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.2_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A4.2_T2.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A5.1_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A5.2_T1.js {unsupported: [async]}
+    prototype/then/S25.4.5.3_A5.3_T1.js {unsupported: [async]}
+    race/ctx-ctor.js {unsupported: [class]}
+    race/invoke-resolve-error-reject.js {unsupported: [async]}
+    race/invoke-resolve-get-error.js {unsupported: [async]}
+    race/invoke-resolve-get-error-reject.js {unsupported: [async]}
+    race/invoke-resolve-on-promises-every-iteration-of-custom.js {unsupported: [class, async]}
+    race/invoke-resolve-on-promises-every-iteration-of-promise.js {unsupported: [async]}
+    race/invoke-resolve-on-values-every-iteration-of-promise.js {unsupported: [async]}
+    race/invoke-then-error-reject.js {unsupported: [async]}
+    race/invoke-then-get-error-reject.js {unsupported: [async]}
+    race/iter-arg-is-false-reject.js {unsupported: [async]}
+    race/iter-arg-is-null-reject.js {unsupported: [async]}
+    race/iter-arg-is-number-reject.js {unsupported: [async]}
+    race/iter-arg-is-string-resolve.js {unsupported: [async]}
+    race/iter-arg-is-symbol-reject.js {unsupported: [async]}
+    race/iter-arg-is-true-reject.js {unsupported: [async]}
+    race/iter-arg-is-undefined-reject.js {unsupported: [async]}
+    race/iter-assigned-false-reject.js {unsupported: [async]}
+    race/iter-assigned-null-reject.js {unsupported: [async]}
+    race/iter-assigned-number-reject.js {unsupported: [async]}
+    race/iter-assigned-string-reject.js {unsupported: [async]}
+    race/iter-assigned-symbol-reject.js {unsupported: [async]}
+    race/iter-assigned-true-reject.js {unsupported: [async]}
+    race/iter-assigned-undefined-reject.js {unsupported: [async]}
+    race/iter-next-val-err-reject.js {unsupported: [async]}
+    race/iter-returns-false-reject.js {unsupported: [async]}
+    race/iter-returns-null-reject.js {unsupported: [async]}
+    race/iter-returns-number-reject.js {unsupported: [async]}
+    race/iter-returns-string-reject.js {unsupported: [async]}
+    race/iter-returns-symbol-reject.js {unsupported: [async]}
+    race/iter-returns-true-reject.js {unsupported: [async]}
+    race/iter-returns-undefined-reject.js {unsupported: [async]}
+    race/iter-step-err-reject.js {unsupported: [async]}
+    race/reject-deferred.js {unsupported: [async]}
+    race/reject-ignored-deferred.js {unsupported: [async]}
+    race/reject-ignored-immed.js {unsupported: [async]}
+    race/reject-immed.js {unsupported: [async]}
+    race/resolve-ignores-late-rejection.js {unsupported: [async]}
+    race/resolve-ignores-late-rejection-deferred.js {unsupported: [async]}
+    race/resolve-non-callable.js {unsupported: [async]}
+    race/resolve-non-obj.js {unsupported: [async]}
+    race/resolve-non-thenable.js {unsupported: [async]}
+    race/resolve-poisoned-then.js {unsupported: [async]}
+    race/resolve-prms-cstm-then.js {unsupported: [async]}
+    race/resolve-self.js {unsupported: [async]}
+    race/resolve-thenable.js {unsupported: [async]}
+    race/resolved-sequence.js {unsupported: [async]}
+    race/resolved-sequence-extra-ticks.js {unsupported: [async]}
+    race/resolved-sequence-mixed.js {unsupported: [async]}
+    race/resolved-sequence-with-rejections.js {unsupported: [async]}
+    race/resolved-then-catch-finally.js {unsupported: [async]}
+    race/S25.4.4.3_A2.2_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A2.2_T2.js {unsupported: [async]}
+    race/S25.4.4.3_A2.2_T3.js {unsupported: [async]}
+    race/S25.4.4.3_A4.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A4.1_T2.js {unsupported: [async]}
+    race/S25.4.4.3_A5.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A6.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A6.2_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.1_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.1_T2.js {unsupported: [async]}
+    race/S25.4.4.3_A7.1_T3.js {unsupported: [async]}
+    race/S25.4.4.3_A7.2_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.3_T1.js {unsupported: [async]}
+    race/S25.4.4.3_A7.3_T2.js {unsupported: [async]}
     reject/capability-invocation.js
+    reject/ctx-ctor.js {unsupported: [class]}
+    reject/S25.4.4.4_A2.1_T1.js {unsupported: [async]}
+    resolve/arg-non-thenable.js {unsupported: [async]}
+    resolve/arg-poisoned-then.js {unsupported: [async]}
+    resolve/ctx-ctor.js {unsupported: [class]}
     resolve/resolve-from-promise-capability.js
+    resolve/resolve-non-obj.js {unsupported: [async]}
+    resolve/resolve-non-thenable.js {unsupported: [async]}
+    resolve/resolve-poisoned-then.js {unsupported: [async]}
+    resolve/resolve-self.js {unsupported: [async]}
+    resolve/resolve-thenable.js {unsupported: [async]}
+    resolve/S25.4.4.5_A2.2_T1.js {unsupported: [async]}
+    resolve/S25.4.4.5_A2.3_T1.js {unsupported: [async]}
+    resolve/S25.4.4.5_A3.1_T1.js {unsupported: [async]}
+    resolve/S25.4.4.5_A4.1_T1.js {unsupported: [async]}
+    resolve/S25.Promise_resolve_foreign_thenable_1.js {unsupported: [async]}
+    resolve/S25.Promise_resolve_foreign_thenable_2.js {unsupported: [async]}
+    try/args.js {unsupported: [async]}
+    try/ctx-ctor.js {unsupported: [class]}
+    try/return-value.js {unsupported: [async]}
+    try/throws.js {unsupported: [async]}
+    withResolvers/ctx-ctor.js {unsupported: [class]}
+    create-resolving-functions-reject.js {unsupported: [async]}
+    create-resolving-functions-resolve.js {unsupported: [async]}
+    exception-after-resolve-in-executor.js {unsupported: [async]}
+    exception-after-resolve-in-thenable-job.js {unsupported: [async]}
     get-prototype-abrupt.js
     proto-from-ctor-realm.js
+    reject-ignored-via-abrupt.js {unsupported: [async]}
+    reject-ignored-via-fn-deferred.js {unsupported: [async]}
+    reject-ignored-via-fn-immed.js {unsupported: [async]}
+    reject-via-abrupt.js {unsupported: [async]}
+    reject-via-abrupt-queue.js {unsupported: [async]}
+    reject-via-fn-deferred.js {unsupported: [async]}
+    reject-via-fn-deferred-queue.js {unsupported: [async]}
+    reject-via-fn-immed.js {unsupported: [async]}
+    reject-via-fn-immed-queue.js {unsupported: [async]}
+    resolve-ignored-via-fn-deferred.js {unsupported: [async]}
+    resolve-ignored-via-fn-immed.js {unsupported: [async]}
+    resolve-non-obj-deferred.js {unsupported: [async]}
+    resolve-non-obj-immed.js {unsupported: [async]}
+    resolve-non-thenable-deferred.js {unsupported: [async]}
+    resolve-non-thenable-immed.js {unsupported: [async]}
+    resolve-poisoned-then-deferred.js {unsupported: [async]}
+    resolve-poisoned-then-immed.js {unsupported: [async]}
+    resolve-prms-cstm-then-deferred.js {unsupported: [async]}
+    resolve-prms-cstm-then-immed.js {unsupported: [async]}
+    resolve-self.js {unsupported: [async]}
+    resolve-thenable-deferred.js {unsupported: [async]}
+    resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy
+built-ins/Proxy 69/311 (22.19%)
     construct/arguments-realm.js
     construct/call-parameters.js
     construct/call-parameters-new-target.js
+    construct/trap-is-missing-target-is-proxy.js {unsupported: [class]}
     construct/trap-is-null.js
+    construct/trap-is-null-target-is-proxy.js {unsupported: [class]}
     construct/trap-is-undefined.js
     construct/trap-is-undefined-no-property.js
     construct/trap-is-undefined-proto-from-newtarget-realm.js
+    construct/trap-is-undefined-target-is-proxy.js {unsupported: [class]}
     defineProperty/desc-realm.js
     defineProperty/targetdesc-not-configurable-writable-desc-not-writable.js
-    defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js
+    defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js non-strict
     defineProperty/trap-is-missing-target-is-proxy.js
     defineProperty/trap-is-undefined-target-is-proxy.js
     deleteProperty/boolean-trap-result-boolean-false.js
-    deleteProperty/return-false-not-strict.js
-    deleteProperty/return-false-strict.js
+    deleteProperty/return-false-not-strict.js non-strict
+    deleteProperty/return-false-strict.js strict
     deleteProperty/targetdesc-is-configurable-target-is-not-extensible.js
-    deleteProperty/trap-is-missing-target-is-proxy.js
+    deleteProperty/trap-is-missing-target-is-proxy.js strict
     deleteProperty/trap-is-null-target-is-proxy.js
-    deleteProperty/trap-is-undefined-strict.js
+    deleteProperty/trap-is-undefined-strict.js strict
     deleteProperty/trap-is-undefined-target-is-proxy.js
     getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined.js
     getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor.js
@@ -1142,15 +1711,17 @@ built-ins/Proxy
     get/trap-is-undefined-receiver.js
     has/call-in-prototype.js
     has/call-in-prototype-index.js
-    has/call-with.js
-    has/return-false-target-not-extensible-using-with.js
-    has/return-false-target-prop-exists-using-with.js
-    has/return-false-targetdesc-not-configurable-using-with.js
-    has/return-is-abrupt-with.js
-    has/trap-is-not-callable-using-with.js
+    has/call-with.js non-strict
+    has/return-false-target-not-extensible-using-with.js non-strict
+    has/return-false-target-prop-exists-using-with.js non-strict
+    has/return-false-targetdesc-not-configurable-using-with.js non-strict
+    has/return-is-abrupt-with.js non-strict
+    has/trap-is-not-callable-using-with.js non-strict
     ownKeys/trap-is-undefined-target-is-proxy.js
+    preventExtensions/trap-is-undefined-target-is-proxy.js {unsupported: [module]}
     revocable/builtin.js
     revocable/revocation-function-not-a-constructor.js
+    revocable/tco-fn-realm.js {unsupported: [tail-call-optimization]}
     setPrototypeOf/internals-call-order.js
     setPrototypeOf/not-extensible-target-not-same-target-prototype.js
     setPrototypeOf/toboolean-trap-result-false.js
@@ -1177,11 +1748,11 @@ built-ins/Proxy
     get-fn-realm.js
     get-fn-realm-recursive.js
 
-built-ins/Reflect
+built-ins/Reflect 12/153 (7.84%)
     construct/newtarget-is-not-constructor-throws.js
     defineProperty/return-abrupt-from-property-key.js
     deleteProperty/return-abrupt-from-result.js
-    deleteProperty/return-boolean.js
+    deleteProperty/return-boolean.js strict
     get/return-value-from-receiver.js
     ownKeys/return-on-corresponding-order-large-index.js
     set/call-prototype-property-set.js
@@ -1191,39 +1762,10 @@ built-ins/Reflect
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp
-    CharacterClassEscapes/character-class-digit-class-escape-negative-cases.js
-    CharacterClassEscapes/character-class-digit-class-escape-positive-cases.js
-    CharacterClassEscapes/character-class-non-digit-class-escape-negative-cases.js
-    CharacterClassEscapes/character-class-non-digit-class-escape-positive-cases.js
-    CharacterClassEscapes/character-class-non-whitespace-class-escape-negative-cases.js
-    CharacterClassEscapes/character-class-non-whitespace-class-escape-positive-cases.js
-    CharacterClassEscapes/character-class-non-word-class-escape-negative-cases.js
-    CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js
-    CharacterClassEscapes/character-class-whitespace-class-escape-negative-cases.js
-    CharacterClassEscapes/character-class-whitespace-class-escape-positive-cases.js
-    CharacterClassEscapes/character-class-word-class-escape-negative-cases.js
-    CharacterClassEscapes/character-class-word-class-escape-positive-cases.js
-    escape/cross-realm.js
-    escape/escaped-control-characters.js
-    escape/escaped-lineterminator.js
-    escape/escaped-otherpunctuators.js
-    escape/escaped-solidus-character-mixed.js
-    escape/escaped-solidus-character-simple.js
-    escape/escaped-surrogates.js
-    escape/escaped-syntax-characters-mixed.js
-    escape/escaped-syntax-characters-simple.js
-    escape/escaped-utf16encodecodepoint.js
-    escape/escaped-whitespace.js
-    escape/initial-char-escape.js
-    escape/is-function.js
-    escape/length.js
-    escape/name.js
-    escape/non-string-inputs.js
-    escape/not-a-constructor.js
-    escape/not-escaped.js
-    escape/not-escaped-underscore.js
-    escape/prop-desc.js
+built-ins/RegExp 975/1868 (52.19%)
+    CharacterClassEscapes 12/12 (100.0%)
+    dotall 4/4 (100.0%)
+    escape 20/20 (100.0%)
     match-indices/indices-array.js
     match-indices/indices-array-element.js
     match-indices/indices-array-matched.js
@@ -1240,20 +1782,30 @@ built-ins/RegExp
     named-groups/duplicate-names-match-indices.js
     named-groups/groups-object-subclass.js
     named-groups/groups-object-subclass-sans.js
+    property-escapes/generated/strings 28/28 (100.0%)
+    property-escapes/generated 431/431 (100.0%)
+    property-escapes 144/144 (100.0%)
+    prototype/dotAll 8/8 (100.0%)
     prototype/exec/duplicate-named-indices-groups-properties.js
     prototype/exec/failure-lastindex-access.js
     prototype/exec/not-a-constructor.js
+    prototype/exec/regexp-builtin-exec-v-u-flag.js {unsupported: [regexp-unicode-property-escapes]}
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
+    prototype/flags/coercion-dotall.js {unsupported: [regexp-dotall]}
     prototype/flags/coercion-global.js
     prototype/flags/coercion-hasIndices.js
     prototype/flags/coercion-ignoreCase.js
     prototype/flags/coercion-multiline.js
     prototype/flags/coercion-sticky.js
     prototype/flags/coercion-unicode.js
+    prototype/flags/get-order.js {unsupported: [regexp-dotall]}
     prototype/flags/length.js
     prototype/flags/name.js
     prototype/flags/prop-desc.js
+    prototype/flags/rethrow.js {unsupported: [regexp-dotall]}
+    prototype/flags/return-order.js {unsupported: [regexp-dotall]}
+    prototype/flags/this-val-regexp.js {unsupported: [regexp-dotall]}
     prototype/flags/this-val-regexp-prototype.js
     prototype/global/15.10.7.2-2.js
     prototype/global/cross-realm.js
@@ -1261,14 +1813,7 @@ built-ins/RegExp
     prototype/global/name.js
     prototype/global/S15.10.7.2_A9.js
     prototype/global/this-val-regexp-prototype.js
-    prototype/hasIndices/cross-realm.js
-    prototype/hasIndices/length.js
-    prototype/hasIndices/name.js
-    prototype/hasIndices/prop-desc.js
-    prototype/hasIndices/this-val-invalid-obj.js
-    prototype/hasIndices/this-val-non-obj.js
-    prototype/hasIndices/this-val-regexp.js
-    prototype/hasIndices/this-val-regexp-prototype.js
+    prototype/hasIndices 8/8 (100.0%)
     prototype/ignoreCase/15.10.7.3-2.js
     prototype/ignoreCase/cross-realm.js
     prototype/ignoreCase/length.js
@@ -1343,127 +1888,14 @@ built-ins/RegExp
     prototype/unicode/this-val-regexp-prototype.js
     prototype/15.10.6.js
     prototype/no-regexp-matcher.js
-    regexp-modifiers/syntax/valid/add-and-remove-modifiers.js
-    regexp-modifiers/syntax/valid/add-and-remove-modifiers-can-have-empty-remove-modifiers.js
-    regexp-modifiers/syntax/valid/add-modifiers-when-nested.js
-    regexp-modifiers/syntax/valid/add-modifiers-when-not-set-as-flags.js
-    regexp-modifiers/syntax/valid/add-modifiers-when-set-as-flags.js
-    regexp-modifiers/syntax/valid/remove-modifiers-when-nested.js
-    regexp-modifiers/syntax/valid/remove-modifiers-when-not-set-as-flags.js
-    regexp-modifiers/syntax/valid/remove-modifiers-when-set-as-flags.js
-    regexp-modifiers/add-dotAll.js
-    regexp-modifiers/add-dotAll-does-not-affect-alternatives-outside.js
-    regexp-modifiers/add-dotAll-does-not-affect-dotAll-property.js
-    regexp-modifiers/add-dotAll-does-not-affect-ignoreCase-flag.js
-    regexp-modifiers/add-dotAll-does-not-affect-multiline-flag.js
-    regexp-modifiers/add-ignoreCase.js
-    regexp-modifiers/add-ignoreCase-affects-backreferences.js
-    regexp-modifiers/add-ignoreCase-affects-characterClasses.js
-    regexp-modifiers/add-ignoreCase-affects-characterEscapes.js
-    regexp-modifiers/add-ignoreCase-affects-slash-lower-b.js
-    regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js
-    regexp-modifiers/add-ignoreCase-affects-slash-lower-w.js
-    regexp-modifiers/add-ignoreCase-affects-slash-upper-b.js
-    regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
-    regexp-modifiers/add-ignoreCase-affects-slash-upper-w.js
-    regexp-modifiers/add-ignoreCase-does-not-affect-alternatives-outside.js
-    regexp-modifiers/add-ignoreCase-does-not-affect-dotAll-flag.js
-    regexp-modifiers/add-ignoreCase-does-not-affect-ignoreCase-property.js
-    regexp-modifiers/add-ignoreCase-does-not-affect-multiline-flag.js
-    regexp-modifiers/add-multiline.js
-    regexp-modifiers/add-multiline-does-not-affect-alternatives-outside.js
-    regexp-modifiers/add-multiline-does-not-affect-dotAll-flag.js
-    regexp-modifiers/add-multiline-does-not-affect-ignoreCase-flag.js
-    regexp-modifiers/add-multiline-does-not-affect-multiline-property.js
-    regexp-modifiers/add-remove-modifiers.js
-    regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
-    regexp-modifiers/changing-ignoreCase-flag-does-not-affect-ignoreCase-modifier.js
-    regexp-modifiers/changing-multiline-flag-does-not-affect-multiline-modifier.js
-    regexp-modifiers/nested-add-remove-modifiers.js
-    regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
-    regexp-modifiers/nesting-add-ignoreCase-within-remove-ignoreCase.js
-    regexp-modifiers/nesting-add-multiline-within-remove-multiline.js
-    regexp-modifiers/nesting-dotAll-does-not-affect-alternatives-outside.js
-    regexp-modifiers/nesting-ignoreCase-does-not-affect-alternatives-outside.js
-    regexp-modifiers/nesting-multiline-does-not-affect-alternatives-outside.js
-    regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js
-    regexp-modifiers/nesting-remove-ignoreCase-within-add-ignoreCase.js
-    regexp-modifiers/nesting-remove-multiline-within-add-multiline.js
-    regexp-modifiers/remove-dotAll.js
-    regexp-modifiers/remove-dotAll-does-not-affect-alternatives-outside.js
-    regexp-modifiers/remove-dotAll-does-not-affect-dotAll-property.js
-    regexp-modifiers/remove-dotAll-does-not-affect-ignoreCase-flag.js
-    regexp-modifiers/remove-dotAll-does-not-affect-multiline-flag.js
-    regexp-modifiers/remove-ignoreCase.js
-    regexp-modifiers/remove-ignoreCase-affects-backreferences.js
-    regexp-modifiers/remove-ignoreCase-affects-characterClasses.js
-    regexp-modifiers/remove-ignoreCase-affects-characterEscapes.js
-    regexp-modifiers/remove-ignoreCase-affects-slash-lower-b.js
-    regexp-modifiers/remove-ignoreCase-affects-slash-lower-p.js
-    regexp-modifiers/remove-ignoreCase-affects-slash-lower-w.js
-    regexp-modifiers/remove-ignoreCase-affects-slash-upper-b.js
-    regexp-modifiers/remove-ignoreCase-affects-slash-upper-p.js
-    regexp-modifiers/remove-ignoreCase-affects-slash-upper-w.js
-    regexp-modifiers/remove-ignoreCase-does-not-affect-alternatives-outside.js
-    regexp-modifiers/remove-ignoreCase-does-not-affect-dotAll-flag.js
-    regexp-modifiers/remove-ignoreCase-does-not-affect-ignoreCase-property.js
-    regexp-modifiers/remove-ignoreCase-does-not-affect-multiline-flag.js
-    regexp-modifiers/remove-multiline.js
-    regexp-modifiers/remove-multiline-does-not-affect-alternatives-outside.js
-    regexp-modifiers/remove-multiline-does-not-affect-dotAll-flag.js
-    regexp-modifiers/remove-multiline-does-not-affect-ignoreCase-flag.js
-    regexp-modifiers/remove-multiline-does-not-affect-multiline-property.js
-    unicodeSets/generated/character-class-difference-character.js
-    unicodeSets/generated/character-class-difference-character-class.js
-    unicodeSets/generated/character-class-difference-character-class-escape.js
-    unicodeSets/generated/character-class-difference-string-literal.js
-    unicodeSets/generated/character-class-escape-difference-character.js
-    unicodeSets/generated/character-class-escape-difference-character-class.js
-    unicodeSets/generated/character-class-escape-difference-character-class-escape.js
-    unicodeSets/generated/character-class-escape-difference-string-literal.js
-    unicodeSets/generated/character-class-escape-intersection-character.js
-    unicodeSets/generated/character-class-escape-intersection-character-class.js
-    unicodeSets/generated/character-class-escape-intersection-character-class-escape.js
-    unicodeSets/generated/character-class-escape-intersection-string-literal.js
-    unicodeSets/generated/character-class-escape-union-character.js
-    unicodeSets/generated/character-class-escape-union-character-class.js
-    unicodeSets/generated/character-class-escape-union-character-class-escape.js
-    unicodeSets/generated/character-class-escape-union-string-literal.js
-    unicodeSets/generated/character-class-intersection-character.js
-    unicodeSets/generated/character-class-intersection-character-class.js
-    unicodeSets/generated/character-class-intersection-character-class-escape.js
-    unicodeSets/generated/character-class-intersection-string-literal.js
-    unicodeSets/generated/character-class-union-character.js
-    unicodeSets/generated/character-class-union-character-class.js
-    unicodeSets/generated/character-class-union-character-class-escape.js
-    unicodeSets/generated/character-class-union-string-literal.js
-    unicodeSets/generated/character-difference-character.js
-    unicodeSets/generated/character-difference-character-class.js
-    unicodeSets/generated/character-difference-character-class-escape.js
-    unicodeSets/generated/character-difference-string-literal.js
-    unicodeSets/generated/character-intersection-character.js
-    unicodeSets/generated/character-intersection-character-class.js
-    unicodeSets/generated/character-intersection-character-class-escape.js
-    unicodeSets/generated/character-intersection-string-literal.js
-    unicodeSets/generated/character-union-character.js
-    unicodeSets/generated/character-union-character-class.js
-    unicodeSets/generated/character-union-character-class-escape.js
-    unicodeSets/generated/character-union-string-literal.js
-    unicodeSets/generated/string-literal-difference-character.js
-    unicodeSets/generated/string-literal-difference-character-class.js
-    unicodeSets/generated/string-literal-difference-character-class-escape.js
-    unicodeSets/generated/string-literal-difference-string-literal.js
-    unicodeSets/generated/string-literal-intersection-character.js
-    unicodeSets/generated/string-literal-intersection-character-class.js
-    unicodeSets/generated/string-literal-intersection-character-class-escape.js
-    unicodeSets/generated/string-literal-intersection-string-literal.js
-    unicodeSets/generated/string-literal-union-character.js
-    unicodeSets/generated/string-literal-union-character-class.js
-    unicodeSets/generated/string-literal-union-character-class-escape.js
-    unicodeSets/generated/string-literal-union-string-literal.js
+    regexp-modifiers/syntax/valid 8/8 (100.0%)
+    regexp-modifiers 62/62 (100.0%)
+    unicodeSets/generated 113/113 (100.0%)
     call_with_non_regexp_same_constructor.js
     call_with_regexp_match_falsy.js
     call_with_regexp_not_same_constructor.js
+    character-class-escape-non-whitespace-u180e.js {unsupported: [u180e]}
+    duplicate-flags.js {unsupported: [regexp-dotall]}
     from-regexp-like.js
     from-regexp-like-flag-override.js
     from-regexp-like-get-ctor-err.js
@@ -1476,12 +1908,13 @@ built-ins/RegExp
     S15.10.1_A1_T14.js
     S15.10.1_A1_T15.js
     S15.10.1_A1_T16.js
+    u180e.js {unsupported: [u180e]}
     unicode_full_case_folding.js
     valid-flags-y.js
 
-built-ins/RegExpStringIteratorPrototype
+built-ins/RegExpStringIteratorPrototype 0/17 (0.0%)
 
-built-ins/Set
+built-ins/Set 87/381 (22.83%)
     prototype/difference/add-not-called.js
     prototype/difference/allows-set-like-class.js
     prototype/difference/allows-set-like-object.js
@@ -1570,11 +2003,11 @@ built-ins/Set
     proto-from-ctor-realm.js
     valid-values.js
 
-built-ins/SetIteratorPrototype
+built-ins/SetIteratorPrototype 0/11 (0.0%)
 
 ~built-ins/SharedArrayBuffer
 
-built-ins/String
+built-ins/String 58/1212 (4.79%)
     prototype/endsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/includes/return-abrupt-from-searchstring-regexp-test.js
     prototype/indexOf/position-tointeger-errors.js
@@ -1588,6 +2021,7 @@ built-ins/String
     prototype/matchAll/flags-undefined-throws.js
     prototype/matchAll/regexp-matchAll-invocation.js
     prototype/matchAll/regexp-prototype-matchAll-invocation.js
+    prototype/matchAll/regexp-prototype-matchAll-v-u-flag.js {unsupported: [regexp-unicode-property-escapes]}
     prototype/match/cstm-matcher-invocation.js
     prototype/match/cstm-matcher-on-bigint-primitive.js
     prototype/match/cstm-matcher-on-boolean-primitive.js
@@ -1603,6 +2037,8 @@ built-ins/String
     prototype/replaceAll/replaceValue-call-matching-empty.js
     prototype/replaceAll/searchValue-flags-no-g-throws.js
     prototype/replaceAll/searchValue-replacer-method-abrupt.js
+    prototype/replaceAll/searchValue-replacer-RegExp-call.js {unsupported: [class]}
+    prototype/replaceAll/searchValue-replacer-RegExp-call-fn.js {unsupported: [class]}
     prototype/replace/cstm-replace-on-bigint-primitive.js
     prototype/replace/cstm-replace-on-boolean-primitive.js
     prototype/replace/cstm-replace-on-number-primitive.js
@@ -1621,16 +2057,19 @@ built-ins/String
     prototype/split/cstm-split-on-string-primitive.js
     prototype/startsWith/return-abrupt-from-searchstring-regexp-test.js
     prototype/substring/S15.5.4.15_A1_T5.js
+    prototype/toLocaleLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLocaleLowerCase/special_casing_conditional.js
+    prototype/toLowerCase/Final_Sigma_U180E.js {unsupported: [u180e]}
     prototype/toLowerCase/special_casing_conditional.js
     prototype/toString/non-generic-realm.js
     prototype/toWellFormed/to-string-primitive.js
+    prototype/trim/u180e.js {unsupported: [u180e]}
     prototype/valueOf/non-generic-realm.js
     proto-from-ctor-realm.js
 
-built-ins/StringIteratorPrototype
+built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-built-ins/Symbol
+built-ins/Symbol 19/94 (20.21%)
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
     dispose/prop-desc.js
@@ -1651,7 +2090,7 @@ built-ins/Symbol
     toStringTag/cross-realm.js
     unscopables/cross-realm.js
 
-built-ins/ThrowTypeError
+built-ins/ThrowTypeError 8/14 (57.14%)
     extensible.js
     frozen.js
     length.js
@@ -1661,54 +2100,290 @@ built-ins/ThrowTypeError
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js
 
-built-ins/TypedArray
+built-ins/TypedArray 256/1434 (17.85%)
+    from/from-array-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    from/from-typedarray-into-itself-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    from/from-typedarray-mapper-makes-result-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     from/iterated-array-changed-by-tonumber.js
+    of/resized-with-out-of-bounds-and-in-bounds-indices.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/at/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteLength/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/byteOffset/resized-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/coerced-target-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/coerced-target-start-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/entries/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/every/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/absent-indices-computed-from-initial-length.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/coerced-value-start-end-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/fill/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/filter/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
     prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/find/BigInt/predicate-call-this-strict.js
-    prototype/findIndex/BigInt/predicate-call-this-strict.js
-    prototype/findIndex/predicate-call-this-strict.js
-    prototype/findLast/BigInt/predicate-call-this-strict.js
-    prototype/findLastIndex/BigInt/predicate-call-this-strict.js
-    prototype/findLastIndex/predicate-call-this-strict.js
-    prototype/findLast/predicate-call-this-strict.js
-    prototype/find/predicate-call-this-strict.js
+    prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/BigInt/predicate-call-this-strict.js strict
+    prototype/find/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/BigInt/predicate-call-this-strict.js strict
+    prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/predicate-call-this-strict.js strict
+    prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/BigInt/predicate-call-this-strict.js strict
+    prototype/findLast/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/BigInt/predicate-call-this-strict.js strict
+    prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/predicate-call-this-strict.js strict
+    prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/predicate-call-this-strict.js strict
+    prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/findLast/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/predicate-call-this-strict.js strict
+    prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/find/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/forEach/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/coerced-searchelement-fromindex-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/index-compared-against-initial-length.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/index-compared-against-initial-length-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/search-undefined-after-shrinking-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/includes/search-undefined-after-shrinking-buffer-index-is-oob.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/coerced-searchelement-fromindex-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/coerced-searchelement-fromindex-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/coerced-separator-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/join/separator-tostring-once-after-resized.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/keys/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/coerced-position-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/negative-index-and-resize-to-smaller.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/resizable-buffer-special-float-values.js {unsupported: [resizable-arraybuffer]}
+    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/BigInt/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/BigInt/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resizable-buffer-assorted.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resized-out-of-bounds-1.js {unsupported: [resizable-arraybuffer]}
+    prototype/length/resized-out-of-bounds-2.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/map/BigInt/speciesctor-get-ctor-abrupt.js
     prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/map/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-get-ctor-abrupt.js
     prototype/map/speciesctor-get-species-custom-ctor-invocation.js
     prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/map/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
+    prototype/map/speciesctor-resizable-buffer-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/map/speciesctor-resizable-buffer-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/reduce/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/reverse/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/reverse/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/reverse/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/set/BigInt/array-arg-primitive-toobject.js
     prototype/set/BigInt/bigint-tobiguint64.js
     prototype/set/BigInt/number-tobigint.js
+    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/BigInt/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/set/array-arg-primitive-toobject.js
+    prototype/set/array-arg-value-conversion-resizes-array-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-grow-source-length-getter.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/target-shrink-source-length-getter.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/this-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
+    prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/set/typedarray-arg-target-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/BigInt/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/coerced-start-end-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/coerced-start-end-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/speciesctor-destination-resizable.js {unsupported: [resizable-arraybuffer]}
     prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
+    prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/slice/speciesctor-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/some/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
+    prototype/sort/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/BigInt/infinity.js
+    prototype/subarray/coerced-begin-end-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/subarray/coerced-begin-end-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/subarray/infinity.js
+    prototype/subarray/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/subarray/result-byteOffset-from-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/Symbol.toStringTag/BigInt/name.js
     prototype/Symbol.toStringTag/name.js
+    prototype/toLocaleString/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
+    prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/toReversed/this-value-invalid.js
     prototype/toSorted/this-value-invalid.js
+    prototype/values/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/make-in-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/make-out-of-bounds-after-exhausted.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    prototype/values/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/with/BigInt/early-type-coercion-bigint.js
+    prototype/with/index-validated-against-current-length.js {unsupported: [resizable-arraybuffer]}
+    prototype/with/negative-index-resize-to-in-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/with/negative-index-resize-to-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    prototype/with/valid-typedarray-index-checked-after-coercions.js {unsupported: [resizable-arraybuffer]}
+    prototype/resizable-and-fixed-have-same-prototype.js {unsupported: [resizable-arraybuffer]}
     prototype/Symbol.iterator.js
     prototype/toString.js
-    Symbol.species/length.js
-    Symbol.species/name.js
-    Symbol.species/prop-desc.js
-    Symbol.species/result.js
+    Symbol.species 4/4 (100.0%)
+    out-of-bounds-behaves-like-detached.js {unsupported: [resizable-arraybuffer]}
+    out-of-bounds-get-and-set.js {unsupported: [resizable-arraybuffer]}
+    out-of-bounds-has.js {unsupported: [resizable-arraybuffer]}
     prototype.js
+    resizable-buffer-length-tracking-1.js {unsupported: [resizable-arraybuffer]}
+    resizable-buffer-length-tracking-2.js {unsupported: [resizable-arraybuffer]}
 
-built-ins/TypedArrayConstructors
+built-ins/TypedArrayConstructors 198/736 (26.9%)
+    ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/custom-proto-access-throws.js
+    ctors-bigint/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/proto-from-ctor-realm.js
+    ctors-bigint/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/use-custom-proto-if-object.js
+    ctors-bigint/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/length-arg/custom-proto-access-throws.js
     ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
     ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
@@ -1739,9 +2414,36 @@ built-ins/TypedArrayConstructors
     ctors-bigint/typedarray-arg/custom-proto-access-throws.js
     ctors-bigint/typedarray-arg/proto-from-ctor-realm.js
     ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
+    ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/byteoffset-to-number-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/custom-proto-access-throws.js
+    ctors/buffer-arg/custom-proto-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/defined-length-and-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/defined-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/defined-negative-length-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/defined-offset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/excessive-length-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/excessive-offset-throws-resizable-ab.js {unsupported: [resizable-arraybuffer]}
+    ctors/buffer-arg/excessive-offset-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/invoked-with-undefined-newtarget-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/is-referenced-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/length-access-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/length-is-symbol-throws-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/new-instance-extensibility-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/proto-from-ctor-realm.js
+    ctors/buffer-arg/proto-from-ctor-realm-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/resizable-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
+    ctors/buffer-arg/returns-new-instance-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/use-custom-proto-if-object.js
+    ctors/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
+    ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/length-arg/custom-proto-access-throws.js
     ctors/length-arg/is-infinity-throws-rangeerror.js
     ctors/length-arg/is-negative-integer-throws-rangeerror.js
@@ -1772,11 +2474,12 @@ built-ins/TypedArrayConstructors
     ctors/object-arg/use-custom-proto-if-object.js
     ctors/typedarray-arg/custom-proto-access-throws.js
     ctors/typedarray-arg/proto-from-ctor-realm.js
+    ctors/typedarray-arg/src-typedarray-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js
     ctors/typedarray-arg/use-custom-proto-if-object.js
     ctors/no-species.js
-    from/BigInt/mapfn-this-without-thisarg-non-strict.js
-    from/mapfn-this-without-thisarg-non-strict.js
+    from/BigInt/mapfn-this-without-thisarg-non-strict.js non-strict
+    from/mapfn-this-without-thisarg-non-strict.js non-strict
     from/nan-conversion.js
     from/new-instance-from-sparse-array.js
     internals/DefineOwnProperty/BigInt/key-is-not-canonical-index.js
@@ -1793,17 +2496,23 @@ built-ins/TypedArrayConstructors
     internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable-throws.js
     internals/DefineOwnProperty/key-is-numericindex-desc-not-writable-throws.js
     internals/DefineOwnProperty/non-extensible-redefine-key.js
-    internals/Delete/BigInt/indexed-value-ab-strict.js
-    internals/Delete/BigInt/key-is-not-minus-zero-strict.js
-    internals/Delete/BigInt/key-is-out-of-bounds-strict.js
-    internals/Delete/indexed-value-ab-strict.js
-    internals/Delete/key-is-not-minus-zero-strict.js
-    internals/Delete/key-is-out-of-bounds-strict.js
+    internals/Delete/BigInt/indexed-value-ab-strict.js strict
+    internals/Delete/BigInt/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
+    internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
+    internals/Delete/indexed-value-ab-strict.js strict
+    internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
+    internals/Delete/key-is-not-minus-zero-strict.js strict
+    internals/Delete/key-is-out-of-bounds-strict.js strict
+    internals/Get/BigInt/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/BigInt/key-is-not-integer.js
     internals/Get/BigInt/key-is-not-minus-zero.js
     internals/Get/BigInt/key-is-out-of-bounds.js
     internals/GetOwnProperty/BigInt/index-prop-desc.js
     internals/GetOwnProperty/index-prop-desc.js
+    internals/Get/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/key-is-not-integer.js
     internals/Get/key-is-not-minus-zero.js
     internals/Get/key-is-out-of-bounds.js
@@ -1815,12 +2524,16 @@ built-ins/TypedArrayConstructors
     internals/HasProperty/key-is-lower-than-zero.js
     internals/HasProperty/key-is-minus-zero.js
     internals/HasProperty/key-is-not-integer.js
+    internals/HasProperty/resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    internals/HasProperty/resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     internals/OwnPropertyKeys/BigInt/integer-indexes.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-keys.js
     internals/OwnPropertyKeys/integer-indexes.js
     internals/OwnPropertyKeys/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/integer-indexes-and-string-keys.js
+    internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js {unsupported: [resizable-arraybuffer]}
+    internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js {unsupported: [resizable-arraybuffer]}
     internals/Set/BigInt/bigint-tobiguint64.js
     internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/BigInt/key-is-canonical-invalid-index-reflect-set.js
@@ -1839,9 +2552,10 @@ built-ins/TypedArrayConstructors
     internals/Set/key-is-symbol.js
     internals/Set/key-is-valid-index-prototype-chain-set.js
     internals/Set/key-is-valid-index-reflect-set.js
+    internals/Set/resized-out-of-bounds-to-in-bounds-index.js {unsupported: [resizable-arraybuffer]}
     internals/Set/tonumber-value-throws.js
 
-built-ins/WeakMap
+built-ins/WeakMap 11/119 (9.24%)
     prototype/getOrInsert/adds-object-element.js
     prototype/getOrInsert/adds-symbol-element.js
     prototype/getOrInsert/getOrInsert.js
@@ -1856,74 +2570,112 @@ built-ins/WeakMap
 
 ~built-ins/WeakRef
 
-built-ins/WeakSet
+built-ins/WeakSet 1/85 (1.18%)
     proto-from-ctor-realm.js
 
-built-ins/decodeURI
+built-ins/decodeURI 1/55 (1.82%)
     S15.1.3.1_A2.4_T1.js
 
-built-ins/decodeURIComponent
+built-ins/decodeURIComponent 1/56 (1.79%)
     S15.1.3.2_A2.4_T1.js
 
-built-ins/encodeURI
+built-ins/encodeURI 0/31 (0.0%)
 
-built-ins/encodeURIComponent
+built-ins/encodeURIComponent 0/31 (0.0%)
 
-built-ins/eval
+built-ins/eval 1/10 (10.0%)
+    private-identifiers-not-empty.js {unsupported: [class-fields-private]}
 
-built-ins/global
+built-ins/global 0/29 (0.0%)
 
-built-ins/isFinite
+built-ins/isFinite 0/15 (0.0%)
 
-built-ins/isNaN
+built-ins/isNaN 0/15 (0.0%)
 
-built-ins/parseFloat
+built-ins/parseFloat 1/54 (1.85%)
+    S15.1.2.3_A2_T10_U180E.js {unsupported: [u180e]}
 
-built-ins/parseInt
+built-ins/parseInt 1/55 (1.82%)
+    S15.1.2.2_A2_T10_U180E.js {unsupported: [u180e]}
 
-built-ins/undefined
+built-ins/undefined 0/8 (0.0%)
 
 ~intl402
 
-language/arguments-object
-    mapped/mapped-arguments-nonconfigurable-3.js
-    mapped/mapped-arguments-nonconfigurable-delete-1.js
-    mapped/mapped-arguments-nonconfigurable-delete-2.js
-    mapped/mapped-arguments-nonconfigurable-delete-3.js
-    mapped/mapped-arguments-nonconfigurable-delete-4.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js
-    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js
-    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js
-    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js
-    mapped/nonconfigurable-descriptors-basic.js
-    mapped/nonconfigurable-descriptors-set-value-by-arguments.js
-    mapped/nonconfigurable-descriptors-set-value-with-define-property.js
-    mapped/nonconfigurable-descriptors-with-param-assign.js
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js
-    mapped/nonconfigurable-nonwritable-descriptors-basic.js
-    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js
-    mapped/nonwritable-nonconfigurable-descriptors-basic.js
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js
-    unmapped/via-params-dstr.js
-    unmapped/via-params-rest.js
+language/arguments-object 184/263 (69.96%)
+    mapped/mapped-arguments-nonconfigurable-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict
+    mapped/nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict
+    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict
+    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
+    unmapped/via-params-dstr.js non-strict
+    unmapped/via-params-rest.js non-strict
     arguments-caller.js
+    async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    async-gen-named-func-expr-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-func-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-decl-async-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-decl-async-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
     cls-decl-gen-meth-args-trailing-comma-multiple.js
     cls-decl-gen-meth-args-trailing-comma-null.js
     cls-decl-gen-meth-args-trailing-comma-single-args.js
@@ -1944,6 +2696,51 @@ language/arguments-object
     cls-decl-meth-static-args-trailing-comma-single-args.js
     cls-decl-meth-static-args-trailing-comma-spread-operator.js
     cls-decl-meth-static-args-trailing-comma-undefined.js
+    cls-decl-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-decl-private-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-async-gen-func-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-func-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, async]}
+    cls-expr-async-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [async-iteration, class, async]}
+    cls-expr-async-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [async-iteration, class, async]}
     cls-expr-gen-meth-args-trailing-comma-multiple.js
     cls-expr-gen-meth-args-trailing-comma-null.js
     cls-expr-gen-meth-args-trailing-comma-single-args.js
@@ -1964,6 +2761,26 @@ language/arguments-object
     cls-expr-meth-static-args-trailing-comma-single-args.js
     cls-expr-meth-static-args-trailing-comma-spread-operator.js
     cls-expr-meth-static-args-trailing-comma-undefined.js
+    cls-expr-private-gen-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-gen-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-gen-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-meth-args-trailing-comma-undefined.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-multiple.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-null.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-single-args.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-spread-operator.js {unsupported: [class]}
+    cls-expr-private-meth-static-args-trailing-comma-undefined.js {unsupported: [class]}
     func-decl-args-trailing-comma-spread-operator.js
     func-expr-args-trailing-comma-spread-operator.js
     gen-func-decl-args-trailing-comma-spread-operator.js
@@ -1971,9 +2788,9 @@ language/arguments-object
     gen-meth-args-trailing-comma-spread-operator.js
     meth-args-trailing-comma-spread-operator.js
 
-language/asi
+language/asi 0/102 (0.0%)
 
-language/block-scope
+language/block-scope 68/145 (46.9%)
     shadowing/const-declaration-shadowing-catch-parameter.js
     shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables.js
     shadowing/let-declarations-shadowing-parameter-name-let-const-and-var.js
@@ -1981,73 +2798,87 @@ language/block-scope
     syntax/for-in/mixed-values-in-iteration.js
     syntax/function-declarations/in-statement-position-do-statement-while-expression.js
     syntax/function-declarations/in-statement-position-for-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js
+    syntax/function-declarations/in-statement-position-if-expression-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
     syntax/function-declarations/in-statement-position-while-expression-statement.js
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js {unsupported: [async-iteration]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/fn-scope-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js
     syntax/redeclaration/inner-block-var-redeclaration-attempt-after-let.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
+    syntax/redeclaration/var-redeclaration-attempt-after-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-redeclaration-attempt-after-function.js
     syntax/redeclaration/var-redeclaration-attempt-after-generator.js
 
-language/comments
+language/comments 9/52 (17.31%)
     hashbang/function-constructor.js
+    hashbang/module.js {unsupported: [module]}
+    mongolian-vowel-separator-multi.js {unsupported: [u180e]}
+    mongolian-vowel-separator-single.js {unsupported: [u180e]}
+    mongolian-vowel-separator-single-eval.js {unsupported: [u180e]}
     multi-line-asi-carriage-return.js
     multi-line-asi-line-feed.js
     multi-line-asi-line-separator.js
     multi-line-asi-paragraph-separator.js
 
-language/computed-property-names
-    class/accessor/getter.js
-    class/accessor/getter-duplicates.js
-    class/accessor/setter.js
-    class/accessor/setter-duplicates.js
-    class/method/constructor.js
-    class/method/constructor-can-be-generator.js
-    class/method/constructor-can-be-getter.js
-    class/method/constructor-can-be-setter.js
-    class/method/constructor-duplicate-1.js
-    class/method/constructor-duplicate-2.js
-    class/method/constructor-duplicate-3.js
-    class/method/generator.js
-    class/method/number.js
-    class/method/string.js
-    class/method/symbol.js
-    class/static/generator-constructor.js
-    class/static/generator-prototype.js
-    class/static/getter-constructor.js
-    class/static/getter-prototype.js
-    class/static/method-constructor.js
-    class/static/method-number.js
-    class/static/method-number-order.js
-    class/static/method-prototype.js
-    class/static/method-string.js
-    class/static/method-string-order.js
-    class/static/method-symbol.js
-    class/static/method-symbol-order.js
-    class/static/setter-constructor.js
-    class/static/setter-prototype.js
+language/computed-property-names 31/48 (64.58%)
+    class/accessor 4/4 (100.0%)
+    class/method 11/11 (100.0%)
+    class/static 14/14 (100.0%)
     to-name-side-effects/class.js
     to-name-side-effects/numbers-class.js
 
-language/destructuring
+language/destructuring 9/19 (47.37%)
     binding/syntax/array-rest-elements.js
     binding/syntax/destructuring-array-parameters-function-arguments-length.js
     binding/syntax/destructuring-object-parameters-function-arguments-length.js
@@ -2055,187 +2886,248 @@ language/destructuring
     binding/syntax/recursive-array-and-object-patterns.js
     binding/initialization-requires-object-coercible-null.js
     binding/initialization-requires-object-coercible-undefined.js
-    binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js
+    binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js non-strict
+    binding/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
 
-language/directive-prologue
-    14.1-4-s.js
-    14.1-5-s.js
+language/directive-prologue 2/62 (3.23%)
+    14.1-4-s.js non-strict
+    14.1-5-s.js non-strict
 
-language/eval-code
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
-    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
-    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/block-decl-eval-source-is-strict-nostrict.js
-    direct/block-decl-eval-source-is-strict-onlystrict.js
-    direct/block-decl-onlystrict.js
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+language/eval-code 241/347 (69.45%)
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
+    direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
+    direct/block-decl-eval-source-is-strict-nostrict.js non-strict
+    direct/block-decl-eval-source-is-strict-onlystrict.js strict
+    direct/block-decl-onlystrict.js strict
+    direct/export.js {unsupported: [module]}
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/import.js {unsupported: [module]}
+    direct/lex-env-distinct-cls.js {unsupported: [class]}
     direct/lex-env-distinct-const.js
     direct/lex-env-distinct-let.js
+    direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
-    direct/non-definable-global-var.js
-    direct/switch-case-decl-eval-source-is-strict-nostrict.js
-    direct/switch-case-decl-eval-source-is-strict-onlystrict.js
-    direct/switch-case-decl-onlystrict.js
-    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js
-    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js
-    direct/switch-dflt-decl-onlystrict.js
-    direct/this-value-func-strict-caller.js
-    direct/var-env-func-init-global-update-configurable.js
-    direct/var-env-func-strict-caller.js
-    direct/var-env-func-strict-caller-2.js
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/new.target.js {unsupported: [new.target]}
+    direct/new.target-arrow.js {unsupported: [new.target]}
+    direct/new.target-fn.js {unsupported: [new.target]}
+    direct/non-definable-global-var.js non-strict
+    direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
+    direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
+    direct/switch-case-decl-onlystrict.js strict
+    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js non-strict
+    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js strict
+    direct/switch-dflt-decl-onlystrict.js strict
+    direct/this-value-func-strict-caller.js strict
+    direct/var-env-func-init-global-update-configurable.js non-strict
+    direct/var-env-func-strict-caller.js strict
+    direct/var-env-func-strict-caller-2.js strict
     direct/var-env-func-strict-source.js
-    direct/var-env-global-lex-non-strict.js
-    direct/var-env-lower-lex-non-strict.js
-    direct/var-env-var-strict-caller.js
-    direct/var-env-var-strict-caller-2.js
-    direct/var-env-var-strict-caller-3.js
+    direct/var-env-global-lex-non-strict.js non-strict
+    direct/var-env-lower-lex-non-strict.js non-strict
+    direct/var-env-var-strict-caller.js strict
+    direct/var-env-var-strict-caller-2.js strict
+    direct/var-env-var-strict-caller-3.js strict
     direct/var-env-var-strict-source.js
-    indirect/always-non-strict.js
+    indirect/always-non-strict.js strict
     indirect/block-decl-strict.js
+    indirect/export.js {unsupported: [module]}
+    indirect/import.js {unsupported: [module]}
+    indirect/lex-env-distinct-cls.js {unsupported: [class]}
     indirect/lex-env-distinct-const.js
     indirect/lex-env-distinct-let.js
+    indirect/lex-env-no-init-cls.js {unsupported: [class]}
     indirect/lex-env-no-init-const.js
     indirect/lex-env-no-init-let.js
+    indirect/new.target.js {unsupported: [new.target]}
     indirect/non-definable-function-with-function.js
     indirect/non-definable-function-with-variable.js
-    indirect/non-definable-global-var.js
+    indirect/non-definable-global-var.js non-strict
     indirect/realm.js
     indirect/switch-case-decl-strict.js
     indirect/switch-dflt-decl-strict.js
@@ -2246,11 +3138,11 @@ language/eval-code
 
 ~language/export
 
-language/expressions/addition
+language/expressions/addition 2/48 (4.17%)
     bigint-errors.js
     order-of-evaluation.js
 
-language/expressions/array
+language/expressions/array 22/52 (42.31%)
     spread-err-mult-err-expr-throws.js
     spread-err-mult-err-iter-get-value.js
     spread-err-mult-err-itr-get-call.js
@@ -2274,7 +3166,7 @@ language/expressions/array
     spread-sngl-iter.js
     spread-sngl-literal.js
 
-language/expressions/arrow-function
+language/expressions/arrow-function 151/343 (44.02%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -2362,6 +3254,9 @@ language/expressions/arrow-function
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -2381,56 +3276,59 @@ language/expressions/arrow-function
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    forbidden-ext/b1/arrow-function-forbidden-ext-direct-access-prop-arguments.js
-    forbidden-ext/b1/arrow-function-forbidden-ext-direct-access-prop-caller.js
-    syntax/early-errors/arrowparameters-cover-no-duplicates.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    forbidden-ext/b1 2/2 (100.0%)
+    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    syntax/arrowparameters-bindingidentifier-yield.js
-    syntax/arrowparameters-cover-formalparameters-yield.js
+    syntax/arrowparameters-bindingidentifier-yield.js non-strict
+    syntax/arrowparameters-cover-formalparameters-yield.js non-strict
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-initialize-2.js
     syntax/arrowparameters-cover-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
     array-destructuring-param-strict-body.js
     ArrowFunction_restricted-properties.js
-    dflt-params-duplicates.js
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js
+    eval-var-scope-syntax-err.js non-strict
     length-dflt.js
+    lexical-new.target.js {unsupported: [new.target]}
+    lexical-new.target-closure-returned.js {unsupported: [new.target]}
     lexical-super-call-from-within-constructor.js
     lexical-super-property.js
     lexical-super-property-from-within-constructor.js
     lexical-supercall-from-immediately-invoked-arrow.js
     object-destructuring-param-strict-body.js
     param-dflt-yield-expr.js
-    param-dflt-yield-id-non-strict.js
-    params-duplicate.js
-    scope-body-lex-distinct.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    param-dflt-yield-id-non-strict.js non-strict
+    params-duplicate.js non-strict
+    scope-body-lex-distinct.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
-    unscopables-with.js
-    unscopables-with-in-nested-fn.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/assignment
-    destructuring/iterator-destructuring-property-reference-target-evaluation-order.js
-    destructuring/keyed-destructuring-property-reference-target-evaluation-order.js
-    destructuring/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js
-    destructuring/obj-prop-__proto__dup.js
+language/expressions/assignment 182/481 (37.84%)
+    destructuring 4/4 (100.0%)
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
+    dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-cover.js
+    dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js
-    dstr/array-elem-init-yield-ident-valid.js
+    dstr/array-elem-init-simple-no-strict.js non-strict
+    dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -2442,15 +3340,15 @@ language/expressions/assignment
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js
-    dstr/array-elem-put-const.js
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js
-    dstr/array-elem-target-yield-valid.js
+    dstr/array-elem-target-simple-strict.js strict
+    dstr/array-elem-target-yield-valid.js non-strict
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -2517,62 +3415,130 @@ language/expressions/assignment
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js
-    dstr/array-rest-put-unresolvable-strict.js
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict
+    dstr/array-rest-put-unresolvable-strict.js strict
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js
+    dstr/array-rest-yield-ident-valid.js non-strict
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict
     dstr/obj-id-init-fn-name-arrow.js
+    dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
     dstr/obj-id-init-let.js
-    dstr/obj-id-init-simple-no-strict.js
-    dstr/obj-id-init-yield-ident-valid.js
-    dstr/obj-id-put-const.js
+    dstr/obj-id-init-simple-no-strict.js non-strict
+    dstr/obj-id-init-yield-ident-valid.js non-strict
+    dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
+    dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js
-    dstr/obj-prop-put-const.js
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
+    dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
-    11.13.1-2-s.js
-    assignment-operator-calls-putvalue-lref--rval-.js
-    assignment-operator-calls-putvalue-lref--rval--1.js
+    dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
+    dstr/obj-rest-descriptors.js {unsupported: [object-rest]}
+    dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-string-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
+    dstr/obj-rest-number.js {unsupported: [object-rest]}
+    dstr/obj-rest-order.js {unsupported: [object-rest]}
+    dstr/obj-rest-put-const.js {unsupported: [object-rest]}
+    dstr/obj-rest-same-name.js {unsupported: [object-rest]}
+    dstr/obj-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-rest-str-val.js {unsupported: [object-rest]}
+    dstr/obj-rest-symbol-val.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
+    dstr/obj-rest-val-null.js {unsupported: [object-rest]}
+    dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
+    dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
+    11.13.1-2-s.js strict
+    assignment-operator-calls-putvalue-lref--rval-.js non-strict
+    assignment-operator-calls-putvalue-lref--rval--1.js non-strict
+    fn-name-class.js {unsupported: [class]}
+    target-cover-newtarget.js {unsupported: [new.target]}
+    target-newtarget.js {unsupported: [new.target]}
     target-super-computed-reference.js
     target-super-computed-reference-null.js
     target-super-identifier-reference-null.js
 
-language/expressions/async-arrow-function
+language/expressions/async-arrow-function 42/60 (70.0%)
+    forbidden-ext/b1 2/2 (100.0%)
+    forbidden-ext/b2 3/3 (100.0%)
+    arrow-returns-promise.js {unsupported: [async]}
+    await-as-binding-identifier.js {unsupported: [async-functions]}
+    await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
+    await-as-identifier-reference.js {unsupported: [async-functions]}
+    await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
+    await-as-label-identifier.js {unsupported: [async-functions]}
+    await-as-label-identifier-escaped.js {unsupported: [async-functions]}
+    await-as-param-ident-nested-arrow-parameter-position.js {unsupported: [async-functions]}
+    await-as-param-nested-arrow-body-position.js {unsupported: [async-functions]}
+    await-as-param-nested-arrow-parameter-position.js {unsupported: [async-functions]}
+    await-as-param-rest-nested-arrow-parameter-position.js {unsupported: [async-functions]}
+    dflt-params-abrupt.js {unsupported: [async-functions, async]}
+    dflt-params-arg-val-not-undefined.js {unsupported: [async-functions, async]}
+    dflt-params-arg-val-undefined.js {unsupported: [async-functions, async]}
+    dflt-params-ref-later.js {unsupported: [async-functions, async]}
+    dflt-params-ref-prior.js {unsupported: [async-functions, async]}
+    dflt-params-ref-self.js {unsupported: [async-functions, async]}
+    dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
+    early-errors-arrow-duplicate-parameters.js {unsupported: [async-functions]}
+    escaped-async.js {unsupported: [async-functions]}
+    escaped-async-line-terminator.js {unsupported: [async-functions]}
+    eval-var-scope-syntax-err.js {unsupported: [async-functions, async]}
     name.js
+    params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
+    params-trailing-comma-single.js {unsupported: [async-functions, async]}
     prototype.js
+    try-reject-finally-reject.js {unsupported: [async]}
+    try-reject-finally-return.js {unsupported: [async]}
+    try-reject-finally-throw.js {unsupported: [async]}
+    try-return-finally-reject.js {unsupported: [async]}
+    try-return-finally-return.js {unsupported: [async]}
+    try-return-finally-throw.js {unsupported: [async]}
+    try-throw-finally-reject.js {unsupported: [async]}
+    try-throw-finally-return.js {unsupported: [async]}
+    try-throw-finally-throw.js {unsupported: [async]}
+    unscopables-with.js {unsupported: [async-functions, async]}
+    unscopables-with-in-nested-fn.js {unsupported: [async-functions, async]}
 
 ~language/expressions/async-function
 
@@ -2582,19 +3548,19 @@ language/expressions/async-arrow-function
 
 ~language/expressions/await
 
-language/expressions/bitwise-and
+language/expressions/bitwise-and 1/30 (3.33%)
     order-of-evaluation.js
 
-language/expressions/bitwise-not
+language/expressions/bitwise-not 0/16 (0.0%)
 
-language/expressions/bitwise-or
+language/expressions/bitwise-or 1/30 (3.33%)
     order-of-evaluation.js
 
-language/expressions/bitwise-xor
+language/expressions/bitwise-xor 1/30 (3.33%)
     order-of-evaluation.js
 
-language/expressions/call
-    eval-realm-indirect.js
+language/expressions/call 34/92 (36.96%)
+    eval-realm-indirect.js non-strict
     eval-spread.js
     eval-spread-empty.js
     eval-spread-empty-leading.js
@@ -2621,55 +3587,112 @@ language/expressions/call
     spread-sngl-expr.js
     spread-sngl-iter.js
     spread-sngl-literal.js
+    tco-call-args.js {unsupported: [tail-call-optimization]}
+    tco-member-args.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-function.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-function-dynamic.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-global.js {unsupported: [tail-call-optimization]}
+    tco-non-eval-with.js {unsupported: [tail-call-optimization]}
     trailing-comma.js
 
 ~language/expressions/class
 
-language/expressions/coalesce
+language/expressions/coalesce 2/24 (8.33%)
+    tco-pos-null.js {unsupported: [tail-call-optimization]}
+    tco-pos-undefined.js {unsupported: [tail-call-optimization]}
 
-language/expressions/comma
+language/expressions/comma 1/6 (16.67%)
+    tco-final.js {unsupported: [tail-call-optimization]}
 
-language/expressions/compound-assignment
-    11.13.2-34-s.js
-    11.13.2-35-s.js
-    11.13.2-36-s.js
-    11.13.2-37-s.js
-    11.13.2-38-s.js
-    11.13.2-39-s.js
-    11.13.2-40-s.js
-    11.13.2-41-s.js
-    11.13.2-42-s.js
-    11.13.2-43-s.js
-    11.13.2-44-s.js
-    add-arguments-strict.js
-    and-arguments-strict.js
-    compound-assignment-operator-calls-putvalue-lref--v-.js
-    compound-assignment-operator-calls-putvalue-lref--v--1.js
-    compound-assignment-operator-calls-putvalue-lref--v--10.js
-    compound-assignment-operator-calls-putvalue-lref--v--11.js
-    compound-assignment-operator-calls-putvalue-lref--v--12.js
-    compound-assignment-operator-calls-putvalue-lref--v--13.js
-    compound-assignment-operator-calls-putvalue-lref--v--14.js
-    compound-assignment-operator-calls-putvalue-lref--v--15.js
-    compound-assignment-operator-calls-putvalue-lref--v--16.js
-    compound-assignment-operator-calls-putvalue-lref--v--17.js
-    compound-assignment-operator-calls-putvalue-lref--v--18.js
-    compound-assignment-operator-calls-putvalue-lref--v--19.js
-    compound-assignment-operator-calls-putvalue-lref--v--2.js
-    compound-assignment-operator-calls-putvalue-lref--v--20.js
-    compound-assignment-operator-calls-putvalue-lref--v--21.js
-    compound-assignment-operator-calls-putvalue-lref--v--3.js
-    compound-assignment-operator-calls-putvalue-lref--v--4.js
-    compound-assignment-operator-calls-putvalue-lref--v--5.js
-    compound-assignment-operator-calls-putvalue-lref--v--6.js
-    compound-assignment-operator-calls-putvalue-lref--v--7.js
-    compound-assignment-operator-calls-putvalue-lref--v--8.js
-    compound-assignment-operator-calls-putvalue-lref--v--9.js
-    div-arguments-strict.js
-    lshift-arguments-strict.js
-    mod-arguments-strict.js
-    mult-arguments-strict.js
-    or-arguments-strict.js
+language/expressions/compound-assignment 125/454 (27.53%)
+    11.13.2-34-s.js strict
+    11.13.2-35-s.js strict
+    11.13.2-36-s.js strict
+    11.13.2-37-s.js strict
+    11.13.2-38-s.js strict
+    11.13.2-39-s.js strict
+    11.13.2-40-s.js strict
+    11.13.2-41-s.js strict
+    11.13.2-42-s.js strict
+    11.13.2-43-s.js strict
+    11.13.2-44-s.js strict
+    add-arguments-strict.js strict
+    and-arguments-strict.js strict
+    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
+    div-arguments-strict.js strict
+    left-hand-side-private-reference-accessor-property-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-sub.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-sub.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-sub.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-add.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-bitand.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-bitor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-bitxor.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-div.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-exp.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-lshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-mod.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-mult.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-rshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-srshift.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-sub.js {unsupported: [class-fields-private]}
+    lshift-arguments-strict.js strict
+    mod-arguments-strict.js strict
+    mult-arguments-strict.js strict
+    or-arguments-strict.js strict
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
     S11.13.2_A7.10_T4.js
@@ -2703,33 +3726,38 @@ language/expressions/compound-assignment
     S11.13.2_A7.9_T1.js
     S11.13.2_A7.9_T2.js
     S11.13.2_A7.9_T4.js
-    srshift-arguments-strict.js
-    sub-arguments-strict.js
-    urshift-arguments-strict.js
-    xor-arguments-strict.js
+    srshift-arguments-strict.js strict
+    sub-arguments-strict.js strict
+    urshift-arguments-strict.js strict
+    xor-arguments-strict.js strict
 
-language/expressions/concatenation
+language/expressions/concatenation 0/5 (0.0%)
 
-language/expressions/conditional
+language/expressions/conditional 2/22 (9.09%)
+    tco-cond.js {unsupported: [tail-call-optimization]}
+    tco-pos.js {unsupported: [tail-call-optimization]}
 
-language/expressions/delete
-    identifier-strict.js
-    identifier-strict-recursive.js
+language/expressions/delete 6/69 (8.7%)
+    identifier-strict.js strict
+    identifier-strict-recursive.js strict
+    super-property.js {unsupported: [class]}
+    super-property-method.js {unsupported: [class]}
+    super-property-null-base.js {unsupported: [class]}
     super-property-uninitialized-this.js
 
-language/expressions/division
+language/expressions/division 1/45 (2.22%)
     order-of-evaluation.js
 
-language/expressions/does-not-equals
+language/expressions/does-not-equals 0/38 (0.0%)
 
 ~language/expressions/dynamic-import
 
-language/expressions/equals
+language/expressions/equals 0/47 (0.0%)
 
-language/expressions/exponentiation
+language/expressions/exponentiation 1/44 (2.27%)
     order-of-evaluation.js
 
-language/expressions/function
+language/expressions/function 149/264 (56.44%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -2817,6 +3845,9 @@ language/expressions/function
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -2832,45 +3863,49 @@ language/expressions/function
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js
-    arguments-with-arguments-fn.js
-    arguments-with-arguments-lex.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    early-errors 4/4 (100.0%)
+    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
-    dflt-params-duplicates.js
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js
+    eval-var-scope-syntax-err.js non-strict
     length-dflt.js
-    name-arguments-strict-body.js
-    named-no-strict-reassign-fn-name-in-body.js
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js
-    named-no-strict-reassign-fn-name-in-body-in-eval.js
-    named-strict-error-reassign-fn-name-in-body.js
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js
-    named-strict-error-reassign-fn-name-in-body-in-eval.js
+    name-arguments-strict-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
+    named-strict-error-reassign-fn-name-in-body.js strict
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
     object-destructuring-param-strict-body.js
-    param-dflt-yield-non-strict.js
-    param-dflt-yield-strict.js
-    param-duplicated-strict-body-1.js
-    param-duplicated-strict-body-2.js
-    param-duplicated-strict-body-3.js
-    param-eval-strict-body.js
+    param-dflt-yield-non-strict.js non-strict
+    param-dflt-yield-strict.js strict
+    param-duplicated-strict-body-1.js non-strict
+    param-duplicated-strict-body-2.js non-strict
+    param-duplicated-strict-body-3.js non-strict
+    param-eval-strict-body.js non-strict
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js
-    scope-name-var-open-non-strict.js
-    scope-name-var-open-strict.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-name-var-open-non-strict.js non-strict
+    scope-name-var-open-strict.js strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js
-    unscopables-with-in-nested-fn.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
-language/expressions/generators
+language/expressions/generators 182/290 (62.76%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -2975,6 +4010,9 @@ language/expressions/generators
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -2997,29 +4035,32 @@ language/expressions/generators
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js
-    arguments-with-arguments-fn.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js non-strict
+    arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
     eval-body-proto-realm.js
-    eval-var-scope-syntax-err.js
+    eval-var-scope-syntax-err.js non-strict
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
-    named-no-strict-reassign-fn-name-in-body.js
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js
-    named-no-strict-reassign-fn-name-in-body-in-eval.js
-    named-strict-error-reassign-fn-name-in-body.js
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js
-    named-strict-error-reassign-fn-name-in-body-in-eval.js
-    named-yield-identifier-non-strict.js
-    named-yield-identifier-spread-non-strict.js
+    named-no-strict-reassign-fn-name-in-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
+    named-strict-error-reassign-fn-name-in-body.js strict
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
+    named-yield-identifier-non-strict.js non-strict
+    named-yield-identifier-spread-non-strict.js non-strict
     named-yield-spread-arr-multiple.js
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
@@ -3027,90 +4068,128 @@ language/expressions/generators
     prototype-own-properties.js
     prototype-value.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js
-    scope-name-var-close.js
-    scope-name-var-open-non-strict.js
-    scope-name-var-open-strict.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-name-var-close.js compiled
+    scope-name-var-open-non-strict.js non-strict
+    scope-name-var-open-strict.js strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js
-    unscopables-with-in-nested-fn.js
-    yield-as-function-expression-binding-identifier.js
-    yield-as-identifier-in-nested-function.js
-    yield-identifier-non-strict.js
-    yield-identifier-spread-non-strict.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
+    yield-as-function-expression-binding-identifier.js non-strict
+    yield-as-identifier-in-nested-function.js non-strict
+    yield-identifier-non-strict.js non-strict
+    yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/expressions/greater-than
+language/expressions/greater-than 0/49 (0.0%)
 
-language/expressions/greater-than-or-equal
+language/expressions/greater-than-or-equal 0/43 (0.0%)
 
-language/expressions/grouping
+language/expressions/grouping 0/9 (0.0%)
 
 ~language/expressions/import.meta
 
-language/expressions/in
+language/expressions/in 20/36 (55.56%)
+    private-field-in.js {unsupported: [class-fields-private]}
+    private-field-in-nested.js {unsupported: [class-fields-private]}
+    private-field-invalid-assignment-reference.js {unsupported: [class-fields-private]}
+    private-field-invalid-assignment-target.js {unsupported: [class-fields-private]}
+    private-field-invalid-identifier-complex.js {unsupported: [class-fields-private]}
+    private-field-invalid-identifier-simple.js {unsupported: [class-fields-private]}
+    private-field-invalid-rhs.js {unsupported: [class-fields-private]}
     private-field-presence-accessor.js
     private-field-presence-accessor-shadowed.js
+    private-field-presence-field.js {unsupported: [class-fields-private]}
+    private-field-presence-field-shadowed.js {unsupported: [class-fields-private]}
     private-field-presence-method.js
     private-field-presence-method-shadowed.js
-    rhs-yield-absent-non-strict.js
+    private-field-rhs-await-absent.js {unsupported: [class-fields-private]}
+    private-field-rhs-await-present.js {unsupported: [class-fields-private, async]}
+    private-field-rhs-non-object.js {unsupported: [class-fields-private]}
+    private-field-rhs-unresolvable.js {unsupported: [class-fields-private]}
+    private-field-rhs-yield-absent.js {unsupported: [class-fields-private]}
+    private-field-rhs-yield-present.js {unsupported: [class-fields-private]}
+    rhs-yield-absent-non-strict.js non-strict
 
-language/expressions/instanceof
+language/expressions/instanceof 5/43 (11.63%)
     S11.8.6_A6_T2.js
     symbol-hasinstance-get-err.js
     symbol-hasinstance-invocation.js
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift
+language/expressions/left-shift 1/45 (2.22%)
     order-of-evaluation.js
 
-language/expressions/less-than
+language/expressions/less-than 0/45 (0.0%)
 
-language/expressions/less-than-or-equal
+language/expressions/less-than-or-equal 0/47 (0.0%)
 
-language/expressions/logical-and
+language/expressions/logical-and 1/18 (5.56%)
+    tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/logical-assignment
-    lgcl-and-arguments-strict.js
+language/expressions/logical-assignment 40/78 (51.28%)
+    left-hand-side-private-reference-accessor-property-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-short-circuit-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-data-property-short-circuit-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-method-short-circuit-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-or.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
+    left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
+    lgcl-and-arguments-strict.js strict
     lgcl-and-assignment-operator-lhs-before-rhs.js
     lgcl-and-assignment-operator-namedevaluation-class-expression.js
-    lgcl-and-assignment-operator-no-set-put.js
-    lgcl-and-assignment-operator-non-extensible.js
+    lgcl-and-assignment-operator-no-set-put.js strict
+    lgcl-and-assignment-operator-non-extensible.js strict
     lgcl-and-assignment-operator-non-simple-lhs.js
-    lgcl-and-assignment-operator-non-writeable.js
-    lgcl-nullish-arguments-strict.js
+    lgcl-and-assignment-operator-non-writeable.js strict
+    lgcl-nullish-arguments-strict.js strict
     lgcl-nullish-assignment-operator-lhs-before-rhs.js
     lgcl-nullish-assignment-operator-namedevaluation-class-expression.js
-    lgcl-nullish-assignment-operator-no-set-put.js
+    lgcl-nullish-assignment-operator-no-set-put.js strict
     lgcl-nullish-assignment-operator-non-simple-lhs.js
-    lgcl-nullish-assignment-operator-non-writeable.js
-    lgcl-or-arguments-strict.js
+    lgcl-nullish-assignment-operator-non-writeable.js strict
+    lgcl-or-arguments-strict.js strict
     lgcl-or-assignment-operator-lhs-before-rhs.js
     lgcl-or-assignment-operator-namedevaluation-class-expression.js
-    lgcl-or-assignment-operator-no-set-put.js
+    lgcl-or-assignment-operator-no-set-put.js strict
     lgcl-or-assignment-operator-non-simple-lhs.js
-    lgcl-or-assignment-operator-non-writeable.js
+    lgcl-or-assignment-operator-non-writeable.js strict
 
-language/expressions/logical-not
+language/expressions/logical-not 0/19 (0.0%)
 
-language/expressions/logical-or
+language/expressions/logical-or 1/18 (5.56%)
+    tco-right.js {unsupported: [tail-call-optimization]}
 
-language/expressions/modulus
+language/expressions/modulus 1/40 (2.5%)
     order-of-evaluation.js
 
-language/expressions/multiplication
+language/expressions/multiplication 1/40 (2.5%)
     order-of-evaluation.js
 
-language/expressions/new
+language/expressions/new 22/59 (37.29%)
     spread-err-mult-err-expr-throws.js
     spread-err-mult-err-iter-get-value.js
     spread-err-mult-err-itr-get-call.js
@@ -3136,7 +4215,193 @@ language/expressions/new
 
 ~language/expressions/new.target
 
-language/expressions/object
+language/expressions/object 698/1170 (59.66%)
+    dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-name-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elem-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elision-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-elision-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-empty-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-empty-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-rest-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-rest-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-ary-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-hole.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-undef.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-direct.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-init-iter-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-init-iter-get-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-init-iter-no-close.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-name-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elem-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elision-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-elision-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-empty-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-empty-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-rest-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-rest-iter.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-ary-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-hole.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-undef.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-complete.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-done.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-array-prototype.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elem-obj-val-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-elision-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elem.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-ary-rest.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-direct.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-exhausted.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-step-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-id-iter-val-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-ary.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-id.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-not-final-obj.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-ary-ptrn-rest-obj-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-init-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-init-undefined.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-list-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-obj-init-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-init-undefined.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-empty.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-arrow.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-cover.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-list-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-ary-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-eval-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-get-value-err.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init-skipped.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init-throws.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-init-unresolvable.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-id-trailing-comma.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj-init.js {unsupported: [async-iteration, async]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj-value-null.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-prop-obj-value-undef.js {unsupported: [async-iteration]}
+    dstr/async-gen-meth-obj-ptrn-rest-getter.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [async-iteration, object-rest, async]}
+    dstr/async-gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [async-iteration, object-rest, async]}
     dstr/gen-meth-ary-init-iter-close.js
     dstr/gen-meth-ary-init-iter-get-err.js
     dstr/gen-meth-ary-init-iter-get-err-array-prototype.js
@@ -3241,6 +4506,9 @@ language/expressions/object
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-null.js
     dstr/gen-meth-dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/gen-meth-dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/gen-meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/gen-meth-obj-init-null.js
     dstr/gen-meth-obj-init-undefined.js
     dstr/gen-meth-obj-ptrn-id-get-value-err.js
@@ -3263,6 +4531,9 @@ language/expressions/object
     dstr/gen-meth-obj-ptrn-prop-obj-init.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-null.js
     dstr/gen-meth-obj-ptrn-prop-obj-value-undef.js
+    dstr/gen-meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/gen-meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/gen-meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-ary-init-iter-close.js
     dstr/meth-ary-init-iter-get-err.js
     dstr/meth-ary-init-iter-get-err-array-prototype.js
@@ -3350,6 +4621,9 @@ language/expressions/object
     dstr/meth-dflt-obj-ptrn-prop-obj-init.js
     dstr/meth-dflt-obj-ptrn-prop-obj-value-null.js
     dstr/meth-dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/meth-dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/meth-dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/meth-dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/meth-obj-init-null.js
     dstr/meth-obj-init-undefined.js
     dstr/meth-obj-ptrn-id-init-fn-name-arrow.js
@@ -3365,9 +4639,160 @@ language/expressions/object
     dstr/meth-obj-ptrn-prop-obj-init.js
     dstr/meth-obj-ptrn-prop-obj-value-null.js
     dstr/meth-obj-ptrn-prop-obj-value-undef.js
-    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js
-    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js
-    method-definition/early-errors-object-method-duplicate-parameters.js
+    dstr/meth-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/meth-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/meth-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    dstr/object-rest-proxy-get-not-called-on-dontenum-keys.js {unsupported: [object-rest]}
+    dstr/object-rest-proxy-gopd-not-called-on-excluded-keys.js {unsupported: [object-rest]}
+    dstr/object-rest-proxy-ownkeys-returned-keys-order.js {unsupported: [object-rest]}
+    method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-iteration, async]}
+    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-functions, async]}
+    method-definition/forbidden-ext/b2/async-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-functions, async]}
+    method-definition/async-await-as-binding-identifier.js {unsupported: [async-functions]}
+    method-definition/async-await-as-binding-identifier-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-identifier-reference.js {unsupported: [async-functions]}
+    method-definition/async-await-as-identifier-reference-escaped.js {unsupported: [async-functions]}
+    method-definition/async-await-as-label-identifier.js {unsupported: [async-functions]}
+    method-definition/async-await-as-label-identifier-escaped.js {unsupported: [async-functions]}
+    method-definition/async-gen-await-as-binding-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-identifier-reference.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-label-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-await-as-label-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-array-destructuring-param-strict-body.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-abrupt.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-arg-val-not-undefined.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-arg-val-undefined.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-duplicates.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-ref-later.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-ref-prior.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-dflt-params-ref-self.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-rest.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-dflt-params-trailing-comma.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-escaped-async.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-eval-var-scope-syntax-err.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-object-destructuring-param-strict-body.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-params-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-params-trailing-comma-single.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-meth-rest-param-strict-body.js {unsupported: [async-iteration]}
+    method-definition/async-gen-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-binding-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-binding-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-identifier-reference.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-identifier-reference-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-label-identifier.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-as-label-identifier-escaped.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-identifier-non-strict.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-identifier-spread-non-strict.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-identifier-spread-strict.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-identifier-strict.js {unsupported: [async-iteration]}
+    method-definition/async-gen-yield-promise-reject-next.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-catch.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-for-await-of-async-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-for-await-of-sync-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-yield-star-async-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-promise-reject-next-yield-star-sync-iterator.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-spread-arr-multiple.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-spread-arr-single.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-spread-obj.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-async-next.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-async-return.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-async-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-expr-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-object-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-null-sync-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-null-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-returns-undefined-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-async-undefined-sync-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-object-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-null-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-getiter-sync-returns-undefined-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-call-done-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-call-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-call-value-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-non-object-ignores-then.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-boolean-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-null-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-number-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-object-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-string-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-symbol-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-not-callable-undefined-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-get-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-boolean-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-null-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-number-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-object-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-string-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-symbol-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-non-callable-undefined-fulfillpromise.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-next-then-returns-abrupt.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-sync-next.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-sync-return.js {unsupported: [async-iteration, async]}
+    method-definition/async-gen-yield-star-sync-throw.js {unsupported: [async-iteration, async]}
+    method-definition/async-meth-array-destructuring-param-strict-body.js {unsupported: [async-iteration]}
+    method-definition/async-meth-dflt-params-abrupt.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-arg-val-not-undefined.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-arg-val-undefined.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-duplicates.js {unsupported: [async-iteration]}
+    method-definition/async-meth-dflt-params-ref-later.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-ref-prior.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-ref-self.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-dflt-params-rest.js {unsupported: [async-iteration]}
+    method-definition/async-meth-dflt-params-trailing-comma.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-escaped-async.js {unsupported: [async-functions]}
+    method-definition/async-meth-eval-var-scope-syntax-err.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-object-destructuring-param-strict-body.js {unsupported: [async-iteration]}
+    method-definition/async-meth-params-trailing-comma-multiple.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-params-trailing-comma-single.js {unsupported: [async-functions, async]}
+    method-definition/async-meth-rest-param-strict-body.js {unsupported: [async-iteration]}
+    method-definition/async-meth-rest-params-trailing-comma-early-error.js {unsupported: [async-iteration]}
+    method-definition/async-returns-async-arrow.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-arrow-returns-arguments-from-parent-function.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-arrow-returns-newtarget.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-function.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-function-returns-arguments-from-own-function.js {unsupported: [async-functions, async]}
+    method-definition/async-returns-async-function-returns-newtarget.js {unsupported: [async-functions, async]}
+    method-definition/async-super-call-body.js {unsupported: [async]}
+    method-definition/async-super-call-param.js {unsupported: [async]}
+    method-definition/early-errors-object-method-arguments-in-formal-parameters.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-await-in-formals.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-await-in-formals-default.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-body-contains-super-call.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-duplicate-parameters.js non-strict
+    method-definition/early-errors-object-method-eval-in-formal-parameters.js {unsupported: [async-functions]}
+    method-definition/early-errors-object-method-formals-body-duplicate.js {unsupported: [async-functions]}
     method-definition/escaped-get.js
     method-definition/escaped-get-e.js
     method-definition/escaped-get-g.js
@@ -3378,43 +4803,52 @@ language/expressions/object
     method-definition/escaped-set-t.js
     method-definition/gen-meth-array-destructuring-param-strict-body.js
     method-definition/gen-meth-dflt-params-abrupt.js
-    method-definition/gen-meth-dflt-params-duplicates.js
+    method-definition/gen-meth-dflt-params-duplicates.js non-strict
     method-definition/gen-meth-dflt-params-ref-later.js
     method-definition/gen-meth-dflt-params-ref-self.js
     method-definition/gen-meth-dflt-params-rest.js
     method-definition/gen-meth-dflt-params-trailing-comma.js
-    method-definition/gen-meth-eval-var-scope-syntax-err.js
+    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict
     method-definition/gen-meth-object-destructuring-param-strict-body.js
     method-definition/gen-meth-rest-param-strict-body.js
-    method-definition/gen-yield-identifier-non-strict.js
-    method-definition/gen-yield-identifier-spread-non-strict.js
+    method-definition/gen-yield-identifier-non-strict.js non-strict
+    method-definition/gen-yield-identifier-spread-non-strict.js non-strict
     method-definition/gen-yield-spread-arr-multiple.js
     method-definition/gen-yield-spread-arr-single.js
     method-definition/gen-yield-spread-obj.js
-    method-definition/generator-invoke-fn-strict.js
+    method-definition/generator-invoke-fn-strict.js non-strict
     method-definition/generator-length-dflt.js
-    method-definition/generator-param-init-yield.js
+    method-definition/generator-param-init-yield.js non-strict
     method-definition/generator-param-redecl-let.js
-    method-definition/generator-prop-name-yield-expr.js
-    method-definition/generator-prop-name-yield-id.js
+    method-definition/generator-prop-name-yield-expr.js non-strict
+    method-definition/generator-prop-name-yield-id.js non-strict
     method-definition/generator-prototype-prop.js
     method-definition/meth-array-destructuring-param-strict-body.js
-    method-definition/meth-dflt-params-duplicates.js
+    method-definition/meth-dflt-params-duplicates.js non-strict
     method-definition/meth-dflt-params-ref-later.js
     method-definition/meth-dflt-params-ref-self.js
     method-definition/meth-dflt-params-rest.js
     method-definition/meth-dflt-params-trailing-comma.js
-    method-definition/meth-eval-var-scope-syntax-err.js
+    method-definition/meth-eval-var-scope-syntax-err.js non-strict
     method-definition/meth-object-destructuring-param-strict-body.js
     method-definition/meth-rest-param-strict-body.js
-    method-definition/name-invoke-fn-strict.js
+    method-definition/name-invoke-fn-strict.js non-strict
     method-definition/name-length-dflt.js
-    method-definition/name-param-id-yield.js
-    method-definition/name-param-init-yield.js
+    method-definition/name-param-id-yield.js non-strict
+    method-definition/name-param-init-yield.js non-strict
     method-definition/name-param-redecl.js
-    method-definition/name-prop-name-yield-expr.js
-    method-definition/name-prop-name-yield-id.js
+    method-definition/name-prop-name-yield-expr.js non-strict
+    method-definition/name-prop-name-yield-id.js non-strict
+    method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
     method-definition/params-dflt-meth-ref-arguments.js
+    method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
+    method-definition/private-name-early-error-async-fn-inside-class.js {unsupported: [class-fields-public, async-functions, class]}
+    method-definition/private-name-early-error-async-gen.js {unsupported: [async-iteration]}
+    method-definition/private-name-early-error-async-gen-inside-class.js {unsupported: [class-fields-public, async-iteration, class]}
+    method-definition/private-name-early-error-gen-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/private-name-early-error-get-method-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/private-name-early-error-method-inside-class.js {unsupported: [class-fields-public, class]}
+    method-definition/private-name-early-error-set-method-inside-class.js {unsupported: [class-fields-public, class]}
     method-definition/static-init-await-binding-accessor.js
     method-definition/static-init-await-binding-generator.js
     method-definition/static-init-await-binding-normal.js
@@ -3423,127 +4857,153 @@ language/expressions/object
     method-definition/static-init-await-reference-normal.js
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
-    method-definition/yield-as-function-expression-binding-identifier.js
-    method-definition/yield-as-identifier-in-nested-function.js
+    method-definition/yield-as-function-expression-binding-identifier.js non-strict
+    method-definition/yield-as-identifier-in-nested-function.js non-strict
     method-definition/yield-star-after-newline.js
     method-definition/yield-star-before-newline.js
-    11.1.5-2gs.js
-    11.1.5_4-4-a-3.js
-    11.1.5_4-4-b-1.js
-    __proto__-duplicate.js
+    11.1.5-2gs.js strict
+    11.1.5_4-4-a-3.js strict
+    11.1.5_4-4-b-1.js strict
+    __proto__-duplicate.js non-strict
     __proto__-duplicate-computed.js
+    __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-id.js
+    accessor-name-computed-yield-id.js non-strict
     computed-__proto__.js
     cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
+    cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
     cpn-obj-lit-computed-property-name-from-yield-expression.js
+    fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
-    getter-body-strict-inside.js
+    getter-body-strict-inside.js non-strict
     getter-param-dflt.js
     ident-name-prop-name-literal-await-static-init.js
-    identifier-shorthand-await-strict-mode.js
+    identifier-shorthand-await-strict-mode.js non-strict
     identifier-shorthand-static-init-await-valid.js
-    let-non-strict-access.js
-    let-non-strict-syntax.js
+    let-non-strict-access.js non-strict
+    let-non-strict-syntax.js non-strict
+    literal-property-name-bigint.js {unsupported: [class]}
     object-spread-proxy-get-not-called-on-dontenum-keys.js
     object-spread-proxy-no-excluded-keys.js
     object-spread-proxy-ownkeys-returned-keys-order.js
-    prop-def-id-eval-error.js
-    prop-def-id-eval-error-2.js
-    prop-dup-data-data.js
-    prop-dup-data-set.js
-    prop-dup-get-data.js
-    prop-dup-get-get.js
-    prop-dup-get-set-get.js
-    prop-dup-set-data.js
-    prop-dup-set-get-set.js
-    prop-dup-set-set.js
-    scope-gen-meth-body-lex-distinct.js
-    scope-gen-meth-param-rest-elem-var-close.js
-    scope-gen-meth-param-rest-elem-var-open.js
+    prop-def-id-eval-error.js non-strict
+    prop-def-id-eval-error-2.js non-strict
+    prop-dup-data-data.js strict
+    prop-dup-data-set.js strict
+    prop-dup-get-data.js strict
+    prop-dup-get-get.js strict
+    prop-dup-get-set-get.js strict
+    prop-dup-set-data.js strict
+    prop-dup-set-get-set.js strict
+    prop-dup-set-set.js strict
+    scope-gen-meth-body-lex-distinct.js non-strict
+    scope-gen-meth-param-rest-elem-var-close.js non-strict
+    scope-gen-meth-param-rest-elem-var-open.js non-strict
     scope-gen-meth-paramsbody-var-open.js
-    scope-getter-body-lex-distinc.js
-    scope-meth-body-lex-distinct.js
-    scope-meth-param-rest-elem-var-close.js
-    scope-meth-param-rest-elem-var-open.js
+    scope-getter-body-lex-distinc.js non-strict
+    scope-meth-body-lex-distinct.js non-strict
+    scope-meth-param-rest-elem-var-close.js non-strict
+    scope-meth-param-rest-elem-var-open.js non-strict
     scope-meth-paramsbody-var-open.js
-    scope-setter-body-lex-distinc.js
+    scope-setter-body-lex-distinc.js non-strict
     scope-setter-paramsbody-var-open.js
-    setter-body-strict-inside.js
+    setter-body-strict-inside.js non-strict
     setter-length-dflt.js
-    setter-param-arguments-strict-inside.js
-    setter-param-eval-strict-inside.js
-    yield-non-strict-access.js
-    yield-non-strict-syntax.js
+    setter-param-arguments-strict-inside.js non-strict
+    setter-param-eval-strict-inside.js non-strict
+    yield-non-strict-access.js non-strict
+    yield-non-strict-syntax.js non-strict
 
-language/expressions/optional-chaining
+language/expressions/optional-chaining 18/38 (47.37%)
     call-expression.js
     early-errors-tail-position-null-optchain-template-string.js
     early-errors-tail-position-null-optchain-template-string-esi.js
     early-errors-tail-position-optchain-template-string.js
     early-errors-tail-position-optchain-template-string-esi.js
     eval-optional-call.js
+    iteration-statement-for-await-of.js {unsupported: [async]}
     iteration-statement-for-in.js
     iteration-statement-for-of-type-error.js
     member-expression.js
+    member-expression-async-identifier.js {unsupported: [async]}
+    member-expression-async-literal.js {unsupported: [async]}
+    member-expression-async-this.js {unsupported: [async]}
     new-target-optional-call.js
+    optional-chain-async-optional-chain-square-brackets.js {unsupported: [async]}
+    optional-chain-async-square-brackets.js {unsupported: [async]}
     optional-chain-prod-arguments.js
     super-property-optional-call.js
 
-language/expressions/postfix-decrement
-    arguments.js
-    eval.js
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js
+language/expressions/postfix-decrement 9/37 (24.32%)
+    arguments.js strict
+    eval.js strict
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/postfix-increment
-    11.3.1-2-1gs.js
-    arguments.js
-    eval.js
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js
+language/expressions/postfix-increment 10/38 (26.32%)
+    11.3.1-2-1gs.js strict
+    arguments.js strict
+    eval.js strict
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-decrement
-    11.4.5-2-2gs.js
-    arguments.js
-    eval.js
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js
+language/expressions/prefix-decrement 10/34 (29.41%)
+    11.4.5-2-2gs.js strict
+    arguments.js strict
+    eval.js strict
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/prefix-increment
-    arguments.js
-    eval.js
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js
+language/expressions/prefix-increment 9/33 (27.27%)
+    arguments.js strict
+    eval.js strict
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
+    target-cover-newtarget.js {unsupported: [new.target]}
+    target-newtarget.js {unsupported: [new.target]}
 
-language/expressions/property-accessors
+language/expressions/property-accessors 0/21 (0.0%)
 
-language/expressions/relational
+language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift
+language/expressions/right-shift 1/37 (2.7%)
     order-of-evaluation.js
 
-language/expressions/strict-does-not-equals
+language/expressions/strict-does-not-equals 0/30 (0.0%)
 
-language/expressions/strict-equals
+language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction
+language/expressions/subtraction 1/38 (2.63%)
     order-of-evaluation.js
 
-language/expressions/super
+language/expressions/super 73/94 (77.66%)
+    call-arg-evaluation-err.js {unsupported: [class]}
+    call-bind-this-value.js {unsupported: [class]}
+    call-bind-this-value-twice.js {unsupported: [class]}
+    call-construct-error.js {unsupported: [class]}
+    call-construct-invocation.js {unsupported: [new.target, class]}
+    call-expr-value.js {unsupported: [class]}
+    call-poisoned-underscore-proto.js {unsupported: [class]}
+    call-proto-not-ctor.js {unsupported: [class]}
     call-spread-err-mult-err-expr-throws.js
     call-spread-err-mult-err-iter-get-value.js
     call-spread-err-mult-err-itr-get-call.js
@@ -3585,112 +5045,132 @@ language/expressions/super
     call-spread-sngl-iter.js
     call-spread-sngl-literal.js
     call-spread-sngl-obj-ident.js
+    prop-dot-cls-null-proto.js {unsupported: [class]}
+    prop-dot-cls-ref-strict.js {unsupported: [class]}
     prop-dot-cls-ref-this.js
+    prop-dot-cls-this-uninit.js {unsupported: [class]}
+    prop-dot-cls-val.js {unsupported: [class]}
+    prop-dot-cls-val-from-arrow.js {unsupported: [class]}
+    prop-dot-cls-val-from-eval.js {unsupported: [class]}
+    prop-expr-cls-err.js {unsupported: [class]}
+    prop-expr-cls-key-err.js {unsupported: [class]}
+    prop-expr-cls-null-proto.js {unsupported: [class]}
+    prop-expr-cls-ref-strict.js {unsupported: [class]}
     prop-expr-cls-ref-this.js
-    prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js
+    prop-expr-cls-this-uninit.js {unsupported: [class]}
+    prop-expr-cls-unresolvable.js {unsupported: [class]}
+    prop-expr-cls-val.js {unsupported: [class]}
+    prop-expr-cls-val-from-arrow.js {unsupported: [class]}
+    prop-expr-cls-val-from-eval.js {unsupported: [class]}
+    prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js interpreted
     prop-expr-uninitialized-this-getvalue.js
     prop-expr-uninitialized-this-putvalue.js
     prop-expr-uninitialized-this-putvalue-compound-assign.js
     prop-expr-uninitialized-this-putvalue-increment.js
     realm.js
+    super-reference-resolution.js {unsupported: [class]}
 
-language/expressions/tagged-template
-    call-expression-context-strict.js
+language/expressions/tagged-template 3/27 (11.11%)
+    call-expression-context-strict.js strict
+    tco-call.js {unsupported: [tail-call-optimization]}
+    tco-member.js {unsupported: [tail-call-optimization]}
 
-language/expressions/template-literal
+language/expressions/template-literal 2/57 (3.51%)
+    mongolian-vowel-separator.js {unsupported: [u180e]}
+    mongolian-vowel-separator-eval.js {unsupported: [u180e]}
 
-language/expressions/this
+language/expressions/this 0/6 (0.0%)
 
-language/expressions/typeof
+language/expressions/typeof 0/16 (0.0%)
 
-language/expressions/unary-minus
+language/expressions/unary-minus 0/14 (0.0%)
 
-language/expressions/unary-plus
+language/expressions/unary-plus 0/17 (0.0%)
 
-language/expressions/unsigned-right-shift
+language/expressions/unsigned-right-shift 2/45 (4.44%)
     bigint-toprimitive.js
     order-of-evaluation.js
 
-language/expressions/void
+language/expressions/void 0/9 (0.0%)
 
-language/expressions/yield
+language/expressions/yield 4/63 (6.35%)
     rhs-omitted.js
     rhs-primitive.js
     star-return-is-null.js
     star-rhs-iter-nrml-next-invoke.js
 
-language/function-code
-    10.4.3-1-1-s.js
-    10.4.3-1-10-s.js
-    10.4.3-1-104.js
-    10.4.3-1-106.js
-    10.4.3-1-10gs.js
-    10.4.3-1-11-s.js
-    10.4.3-1-11gs.js
-    10.4.3-1-12-s.js
-    10.4.3-1-12gs.js
-    10.4.3-1-14-s.js
-    10.4.3-1-14gs.js
-    10.4.3-1-16-s.js
-    10.4.3-1-16gs.js
-    10.4.3-1-17-s.js
-    10.4.3-1-2-s.js
-    10.4.3-1-27-s.js
-    10.4.3-1-27gs.js
-    10.4.3-1-28-s.js
-    10.4.3-1-28gs.js
-    10.4.3-1-29-s.js
-    10.4.3-1-29gs.js
-    10.4.3-1-3-s.js
-    10.4.3-1-30-s.js
-    10.4.3-1-30gs.js
-    10.4.3-1-31-s.js
-    10.4.3-1-31gs.js
-    10.4.3-1-32-s.js
-    10.4.3-1-32gs.js
-    10.4.3-1-33-s.js
-    10.4.3-1-33gs.js
-    10.4.3-1-34-s.js
-    10.4.3-1-34gs.js
-    10.4.3-1-35-s.js
-    10.4.3-1-35gs.js
-    10.4.3-1-36-s.js
-    10.4.3-1-36gs.js
-    10.4.3-1-37-s.js
-    10.4.3-1-37gs.js
-    10.4.3-1-38-s.js
-    10.4.3-1-38gs.js
-    10.4.3-1-39-s.js
-    10.4.3-1-39gs.js
-    10.4.3-1-4-s.js
-    10.4.3-1-40-s.js
-    10.4.3-1-40gs.js
-    10.4.3-1-41-s.js
-    10.4.3-1-41gs.js
-    10.4.3-1-42-s.js
-    10.4.3-1-42gs.js
-    10.4.3-1-43-s.js
-    10.4.3-1-43gs.js
-    10.4.3-1-44-s.js
-    10.4.3-1-44gs.js
-    10.4.3-1-45-s.js
-    10.4.3-1-45gs.js
-    10.4.3-1-46-s.js
-    10.4.3-1-46gs.js
-    10.4.3-1-47-s.js
-    10.4.3-1-47gs.js
-    10.4.3-1-48-s.js
-    10.4.3-1-48gs.js
-    10.4.3-1-49-s.js
-    10.4.3-1-49gs.js
-    10.4.3-1-50-s.js
-    10.4.3-1-50gs.js
-    10.4.3-1-51-s.js
-    10.4.3-1-51gs.js
-    10.4.3-1-52-s.js
-    10.4.3-1-52gs.js
-    10.4.3-1-53-s.js
-    10.4.3-1-53gs.js
+language/function-code 96/217 (44.24%)
+    10.4.3-1-1-s.js non-strict
+    10.4.3-1-10-s.js non-strict
+    10.4.3-1-104.js strict
+    10.4.3-1-106.js strict
+    10.4.3-1-10gs.js non-strict
+    10.4.3-1-11-s.js strict
+    10.4.3-1-11gs.js strict
+    10.4.3-1-12-s.js non-strict
+    10.4.3-1-12gs.js non-strict
+    10.4.3-1-14-s.js non-strict
+    10.4.3-1-14gs.js non-strict
+    10.4.3-1-16-s.js non-strict
+    10.4.3-1-16gs.js non-strict
+    10.4.3-1-17-s.js strict
+    10.4.3-1-2-s.js non-strict
+    10.4.3-1-27-s.js strict
+    10.4.3-1-27gs.js strict
+    10.4.3-1-28-s.js strict
+    10.4.3-1-28gs.js strict
+    10.4.3-1-29-s.js strict
+    10.4.3-1-29gs.js strict
+    10.4.3-1-3-s.js non-strict
+    10.4.3-1-30-s.js strict
+    10.4.3-1-30gs.js strict
+    10.4.3-1-31-s.js strict
+    10.4.3-1-31gs.js strict
+    10.4.3-1-32-s.js strict
+    10.4.3-1-32gs.js strict
+    10.4.3-1-33-s.js strict
+    10.4.3-1-33gs.js strict
+    10.4.3-1-34-s.js strict
+    10.4.3-1-34gs.js strict
+    10.4.3-1-35-s.js strict
+    10.4.3-1-35gs.js strict
+    10.4.3-1-36-s.js non-strict
+    10.4.3-1-36gs.js non-strict
+    10.4.3-1-37-s.js non-strict
+    10.4.3-1-37gs.js non-strict
+    10.4.3-1-38-s.js non-strict
+    10.4.3-1-38gs.js non-strict
+    10.4.3-1-39-s.js non-strict
+    10.4.3-1-39gs.js non-strict
+    10.4.3-1-4-s.js non-strict
+    10.4.3-1-40-s.js non-strict
+    10.4.3-1-40gs.js non-strict
+    10.4.3-1-41-s.js non-strict
+    10.4.3-1-41gs.js non-strict
+    10.4.3-1-42-s.js non-strict
+    10.4.3-1-42gs.js non-strict
+    10.4.3-1-43-s.js non-strict
+    10.4.3-1-43gs.js non-strict
+    10.4.3-1-44-s.js non-strict
+    10.4.3-1-44gs.js non-strict
+    10.4.3-1-45-s.js non-strict
+    10.4.3-1-45gs.js non-strict
+    10.4.3-1-46-s.js non-strict
+    10.4.3-1-46gs.js non-strict
+    10.4.3-1-47-s.js non-strict
+    10.4.3-1-47gs.js non-strict
+    10.4.3-1-48-s.js non-strict
+    10.4.3-1-48gs.js non-strict
+    10.4.3-1-49-s.js non-strict
+    10.4.3-1-49gs.js non-strict
+    10.4.3-1-50-s.js non-strict
+    10.4.3-1-50gs.js non-strict
+    10.4.3-1-51-s.js non-strict
+    10.4.3-1-51gs.js non-strict
+    10.4.3-1-52-s.js non-strict
+    10.4.3-1-52gs.js non-strict
+    10.4.3-1-53-s.js non-strict
+    10.4.3-1-53gs.js non-strict
     10.4.3-1-62-s.js
     10.4.3-1-62gs.js
     10.4.3-1-63-s.js
@@ -3699,96 +5179,158 @@ language/function-code
     10.4.3-1-64gs.js
     10.4.3-1-65-s.js
     10.4.3-1-65gs.js
-    10.4.3-1-7-s.js
+    10.4.3-1-7-s.js strict
     10.4.3-1-76-s.js
     10.4.3-1-76gs.js
     10.4.3-1-77-s.js
     10.4.3-1-77gs.js
     10.4.3-1-78-s.js
     10.4.3-1-78gs.js
-    10.4.3-1-7gs.js
-    10.4.3-1-8-s.js
-    10.4.3-1-8gs.js
-    10.4.3-1-9-s.js
-    10.4.3-1-9gs.js
-    block-decl-onlystrict.js
-    eval-param-env-with-computed-key.js
-    S10.4.3_A1.js
-    switch-case-decl-onlystrict.js
-    switch-dflt-decl-onlystrict.js
+    10.4.3-1-7gs.js strict
+    10.4.3-1-8-s.js non-strict
+    10.4.3-1-8gs.js non-strict
+    10.4.3-1-9-s.js strict
+    10.4.3-1-9gs.js strict
+    block-decl-onlystrict.js strict
+    eval-param-env-with-computed-key.js non-strict
+    S10.4.3_A1.js strict
+    switch-case-decl-onlystrict.js strict
+    switch-dflt-decl-onlystrict.js strict
 
-language/future-reserved-words
-    implements.js
-    interface.js
-    package.js
-    private.js
-    protected.js
-    public.js
-    static.js
+language/future-reserved-words 7/55 (12.73%)
+    implements.js non-strict
+    interface.js non-strict
+    package.js non-strict
+    private.js non-strict
+    protected.js non-strict
+    public.js non-strict
+    static.js non-strict
 
-language/global-code
-    block-decl-strict.js
+language/global-code 26/42 (61.9%)
+    block-decl-strict.js strict
     decl-lex.js
     decl-lex-configurable-global.js
-    decl-lex-deletion.js
+    decl-lex-deletion.js non-strict
     decl-lex-restricted-global.js
+    invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
+    invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
+    invalid-private-names-member-expression-bad-reference.js {unsupported: [class-fields-private]}
+    invalid-private-names-member-expression-this.js {unsupported: [class-fields-private]}
+    new.target.js {unsupported: [new.target]}
+    new.target-arrow.js {unsupported: [new.target]}
     script-decl-func.js
     script-decl-func-err-non-configurable.js
-    script-decl-func-err-non-extensible.js
+    script-decl-func-err-non-extensible.js non-strict
     script-decl-lex.js
-    script-decl-lex-deletion.js
+    script-decl-lex-deletion.js non-strict
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
     script-decl-lex-var-declared-via-eval.js
     script-decl-var.js
     script-decl-var-collision.js
-    script-decl-var-err.js
-    switch-case-decl-strict.js
-    switch-dflt-decl-strict.js
-    yield-non-strict.js
+    script-decl-var-err.js non-strict
+    switch-case-decl-strict.js strict
+    switch-dflt-decl-strict.js strict
+    yield-non-strict.js non-strict
 
-language/identifier-resolution
+language/identifier-resolution 0/14 (0.0%)
 
-language/identifiers
+language/identifiers 98/260 (37.69%)
     other_id_continue.js
     other_id_continue-escaped.js
     other_id_start.js
     other_id_start-escaped.js
+    part-unicode-10.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-10.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-11.0.0.js
+    part-unicode-11.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-11.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-11.0.0-escaped.js
     part-unicode-12.0.0.js
+    part-unicode-12.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-12.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-12.0.0-escaped.js
     part-unicode-13.0.0.js
+    part-unicode-13.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-13.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-13.0.0-escaped.js
     part-unicode-14.0.0.js
+    part-unicode-14.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-14.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-14.0.0-escaped.js
     part-unicode-15.0.0.js
+    part-unicode-15.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-15.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-15.0.0-escaped.js
     part-unicode-15.1.0.js
+    part-unicode-15.1.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-15.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-15.1.0-escaped.js
     part-unicode-16.0.0.js
+    part-unicode-16.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-16.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-16.0.0-escaped.js
     part-unicode-5.2.0.js
+    part-unicode-5.2.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-5.2.0-class-escaped.js {unsupported: [class-fields-private, class]}
     part-unicode-5.2.0-escaped.js
+    part-unicode-6.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-6.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-6.1.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-6.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-7.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-7.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-8.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-8.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    part-unicode-9.0.0-class.js {unsupported: [class-fields-private, class]}
+    part-unicode-9.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-10.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-10.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-11.0.0.js
+    start-unicode-11.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-11.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-11.0.0-escaped.js
     start-unicode-12.0.0.js
+    start-unicode-12.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-12.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-12.0.0-escaped.js
     start-unicode-13.0.0.js
+    start-unicode-13.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-13.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-13.0.0-escaped.js
     start-unicode-14.0.0.js
+    start-unicode-14.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-14.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-14.0.0-escaped.js
     start-unicode-15.0.0.js
+    start-unicode-15.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-15.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-15.0.0-escaped.js
     start-unicode-15.1.0.js
+    start-unicode-15.1.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-15.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-15.1.0-escaped.js
     start-unicode-16.0.0.js
+    start-unicode-16.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-16.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-16.0.0-escaped.js
     start-unicode-5.2.0.js
+    start-unicode-5.2.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-5.2.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-6.1.0.js
+    start-unicode-6.1.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-6.1.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-7.0.0.js
+    start-unicode-7.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-7.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     start-unicode-8.0.0.js
+    start-unicode-8.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-8.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
+    start-unicode-9.0.0-class.js {unsupported: [class-fields-private, class]}
+    start-unicode-9.0.0-class-escaped.js {unsupported: [class-fields-private, class]}
     vertical-tilde-continue.js
     vertical-tilde-continue-escaped.js
     vertical-tilde-start.js
@@ -3796,68 +5338,93 @@ language/identifiers
 
 ~language/import
 
-language/keywords
+language/keywords 0/25 (0.0%)
 
-language/line-terminators
+language/line-terminators 0/41 (0.0%)
 
-language/literals
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
-    bigint/legacy-octal-like-invalid-00n.js
-    bigint/legacy-octal-like-invalid-01n.js
-    bigint/legacy-octal-like-invalid-07n.js
-    bigint/non-octal-like-invalid-0008n.js
-    bigint/non-octal-like-invalid-012348n.js
-    bigint/non-octal-like-invalid-08n.js
-    bigint/non-octal-like-invalid-09n.js
+language/literals 43/534 (8.05%)
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
+    bigint/legacy-octal-like-invalid-00n.js non-strict
+    bigint/legacy-octal-like-invalid-01n.js non-strict
+    bigint/legacy-octal-like-invalid-07n.js non-strict
+    bigint/non-octal-like-invalid-0008n.js non-strict
+    bigint/non-octal-like-invalid-012348n.js non-strict
+    bigint/non-octal-like-invalid-08n.js non-strict
+    bigint/non-octal-like-invalid-09n.js non-strict
     boolean/false-with-unicode.js
     boolean/true-with-unicode.js
     null/null-with-unicode.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     numeric/numeric-followed-by-ident.js
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
     regexp/invalid-braced-quantifier-range.js
+    regexp/mongolian-vowel-separator.js {unsupported: [u180e]}
+    regexp/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
     regexp/S7.8.5_A1.1_T2.js
     regexp/S7.8.5_A1.4_T2.js
     regexp/S7.8.5_A2.1_T2.js
     regexp/S7.8.5_A2.4_T2.js
     regexp/u-case-mapping.js
-    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-8-strict.js
-    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-9-strict.js
-    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js
-    string/legacy-non-octal-escape-sequence-strict.js
+    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-8-strict.js strict
+    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-9-strict.js strict
+    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
-    string/legacy-octal-escape-sequence-strict.js
-    string/S7.8.4_A4.3_T1.js
-    string/S7.8.4_A4.3_T2.js
+    string/legacy-octal-escape-sequence-strict.js strict
+    string/mongolian-vowel-separator.js {unsupported: [u180e]}
+    string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
+    string/S7.8.4_A4.3_T1.js strict
+    string/S7.8.4_A4.3_T2.js strict
 
 ~language/module-code
 
-language/punctuators
+language/punctuators 0/11 (0.0%)
 
-language/reserved-words
+language/reserved-words 2/27 (7.41%)
+    await-module.js {unsupported: [module]}
     await-script.js
 
-language/rest-parameters
+language/rest-parameters 5/11 (45.45%)
     array-pattern.js
     arrow-function.js
-    no-alias-arguments.js
+    no-alias-arguments.js non-strict
     object-pattern.js
     with-new-target.js
 
-language/source-text
+language/source-text 0/1 (0.0%)
 
-language/statementList
+language/statementList 21/80 (26.25%)
+    class-array-literal.js {unsupported: [class]}
+    class-array-literal-with-item.js {unsupported: [class]}
+    class-arrow-function-assignment-expr.js {unsupported: [class]}
+    class-arrow-function-functionbody.js {unsupported: [class]}
+    class-block.js {unsupported: [class]}
+    class-block-with-labels.js {unsupported: [class]}
+    class-expr-arrow-function-boolean-literal.js {unsupported: [class]}
+    class-let-declaration.js {unsupported: [class]}
+    class-regexp-literal.js {unsupported: [class]}
+    class-regexp-literal-flags.js {unsupported: [class]}
+    eval-class-array-literal.js {unsupported: [class]}
+    eval-class-array-literal-with-item.js {unsupported: [class]}
+    eval-class-arrow-function-assignment-expr.js {unsupported: [class]}
+    eval-class-arrow-function-functionbody.js {unsupported: [class]}
+    eval-class-block.js {unsupported: [class]}
+    eval-class-block-with-labels.js {unsupported: [class]}
+    eval-class-expr-arrow-function-boolean-literal.js {unsupported: [class]}
+    eval-class-let-declaration.js {unsupported: [class]}
+    eval-class-regexp-literal.js {unsupported: [class]}
+    eval-class-regexp-literal-flags.js {unsupported: [class]}
     eval-fn-block.js
 
 ~language/statements/async-function
@@ -3866,14 +5433,17 @@ language/statementList
 
 ~language/statements/async-generator
 
-language/statements/block
+language/statements/block 7/21 (33.33%)
+    early-errors 4/4 (100.0%)
     labeled-continue.js
+    tco-stmt.js {unsupported: [tail-call-optimization]}
+    tco-stmt-list.js {unsupported: [tail-call-optimization]}
 
-language/statements/break
+language/statements/break 0/20 (0.0%)
 
 ~language/statements/class
 
-language/statements/const
+language/statements/const 87/136 (63.97%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -3925,6 +5495,9 @@ language/statements/const
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     syntax/block-scope-syntax-const-declarations-mixed-with-without-initialiser.js
     syntax/block-scope-syntax-const-declarations-mixed-without-with-initialiser.js
     syntax/block-scope-syntax-const-declarations-without-initialiser.js
@@ -3950,6 +5523,7 @@ language/statements/const
     block-local-closure-get-before-initialization.js
     block-local-use-before-initialization-in-declaration-statement.js
     block-local-use-before-initialization-in-prior-statement.js
+    fn-name-class.js {unsupported: [class]}
     function-local-closure-get-before-initialization.js
     function-local-use-before-initialization-in-declaration-statement.js
     function-local-use-before-initialization-in-prior-statement.js
@@ -3958,24 +5532,27 @@ language/statements/const
     global-use-before-initialization-in-prior-statement.js
     static-init-await-binding-valid.js
 
-language/statements/continue
+language/statements/continue 0/24 (0.0%)
 
-language/statements/debugger
+language/statements/debugger 0/2 (0.0%)
 
-language/statements/do-while
+language/statements/do-while 10/36 (27.78%)
     cptn-abrupt-empty.js
     cptn-normal.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js
+    let-array-with-newline.js non-strict
+    tco-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/empty
+language/statements/empty 0/2 (0.0%)
 
-language/statements/expression
+language/statements/expression 0/3 (0.0%)
 
-language/statements/for
+language/statements/for 230/385 (59.74%)
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -4062,6 +5639,9 @@ language/statements/for
     dstr/const-obj-ptrn-prop-obj-init.js
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
+    dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
     dstr/let-ary-init-iter-get-err-array-prototype.js
@@ -4109,13 +5689,16 @@ language/statements/for
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
-    dstr/let-obj-ptrn-prop-ary-trailing-comma.js
+    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
     dstr/let-obj-ptrn-prop-obj.js
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
+    dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
     dstr/var-ary-init-iter-get-err-array-prototype.js
@@ -4169,10 +5752,15 @@ language/statements/for
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
+    dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     cptn-decl-expr-iter.js
     cptn-decl-expr-no-iter.js
     cptn-expr-expr-iter.js
     cptn-expr-expr-no-iter.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -4181,20 +5769,25 @@ language/statements/for
     head-init-expr-check-empty-inc-empty-completion.js
     head-init-var-check-empty-inc-empty-completion.js
     head-let-bound-names-in-stmt.js
-    head-lhs-let.js
+    head-lhs-let.js non-strict
     labelled-fn-stmt-expr.js
     labelled-fn-stmt-let.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-open.js
+    tco-const-body.js {unsupported: [tail-call-optimization]}
+    tco-let-body.js {unsupported: [tail-call-optimization]}
+    tco-lhs-body.js {unsupported: [tail-call-optimization]}
+    tco-var-body.js {unsupported: [tail-call-optimization]}
 
 ~language/statements/for-await-of
 
-language/statements/for-in
+language/statements/for-in 40/115 (34.78%)
+    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
     12.6.4-2.js
     cptn-decl-abrupt-empty.js
     cptn-decl-itr.js
@@ -4204,6 +5797,8 @@ language/statements/for-in
     cptn-expr-itr.js
     cptn-expr-skip-itr.js
     cptn-expr-zero-itr.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -4213,34 +5808,37 @@ language/statements/for-in
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
     head-let-fresh-binding-per-iteration.js
-    head-lhs-let.js
+    head-lhs-let.js non-strict
     head-var-bound-names-dup.js
-    head-var-bound-names-let.js
-    identifier-let-allowed-as-lefthandside-expression-not-strict.js
+    head-var-bound-names-let.js non-strict
+    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     order-enumerable-shadowed.js
+    resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     scope-body-lex-boundary.js
     scope-body-lex-close.js
     scope-body-lex-open.js
     scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js
+    scope-head-var-none.js non-strict
 
-language/statements/for-of
+language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
+    dstr/array-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-cover.js
+    dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js
-    dstr/array-elem-init-yield-ident-valid.js
+    dstr/array-elem-init-simple-no-strict.js non-strict
+    dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -4252,15 +5850,15 @@ language/statements/for-of
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js
-    dstr/array-elem-put-const.js
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js
-    dstr/array-elem-target-yield-valid.js
+    dstr/array-elem-target-simple-strict.js strict
+    dstr/array-elem-target-yield-valid.js non-strict
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -4327,24 +5925,24 @@ language/statements/for-of
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js
-    dstr/array-rest-put-unresolvable-strict.js
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict
+    dstr/array-rest-put-unresolvable-strict.js strict
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js
+    dstr/array-rest-yield-ident-valid.js non-strict
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -4431,6 +6029,9 @@ language/statements/for-of
     dstr/const-obj-ptrn-prop-obj-init.js
     dstr/const-obj-ptrn-prop-obj-value-null.js
     dstr/const-obj-ptrn-prop-obj-value-undef.js
+    dstr/const-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/const-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/let-ary-init-iter-close.js
     dstr/let-ary-init-iter-get-err.js
     dstr/let-ary-ptrn-elem-ary-elem-init.js
@@ -4483,43 +6084,74 @@ language/statements/for-of
     dstr/let-obj-ptrn-prop-obj-init.js
     dstr/let-obj-ptrn-prop-obj-value-null.js
     dstr/let-obj-ptrn-prop-obj-value-undef.js
+    dstr/let-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict
     dstr/obj-id-init-assignment-missing.js
     dstr/obj-id-init-assignment-null.js
     dstr/obj-id-init-assignment-truthy.js
     dstr/obj-id-init-assignment-undef.js
     dstr/obj-id-init-evaluation.js
     dstr/obj-id-init-fn-name-arrow.js
+    dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
     dstr/obj-id-init-in.js
     dstr/obj-id-init-let.js
     dstr/obj-id-init-order.js
-    dstr/obj-id-init-simple-no-strict.js
+    dstr/obj-id-init-simple-no-strict.js non-strict
     dstr/obj-id-init-yield-expr.js
-    dstr/obj-id-init-yield-ident-valid.js
-    dstr/obj-id-put-const.js
+    dstr/obj-id-init-yield-ident-valid.js non-strict
+    dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
+    dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-prop-elem-init-fn-name-cover.js
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js
-    dstr/obj-prop-put-const.js
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
+    dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
+    dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
+    dstr/obj-rest-descriptors.js {unsupported: [object-rest]}
+    dstr/obj-rest-empty-obj.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-rest-getter-abrupt-get-error.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1dot0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-array-1e0.js {unsupported: [object-rest]}
+    dstr/obj-rest-non-string-computed-property-string-1.js {unsupported: [object-rest]}
+    dstr/obj-rest-not-last-element-invalid.js {unsupported: [object-rest]}
+    dstr/obj-rest-number.js {unsupported: [object-rest]}
+    dstr/obj-rest-order.js {unsupported: [object-rest]}
+    dstr/obj-rest-put-const.js {unsupported: [object-rest]}
+    dstr/obj-rest-same-name.js {unsupported: [object-rest]}
+    dstr/obj-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-rest-str-val.js {unsupported: [object-rest]}
+    dstr/obj-rest-symbol-val.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property.js {unsupported: [object-rest]}
+    dstr/obj-rest-to-property-with-setter.js {unsupported: [object-rest]}
+    dstr/obj-rest-val-null.js {unsupported: [object-rest]}
+    dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
+    dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
     dstr/var-ary-init-iter-close.js
     dstr/var-ary-init-iter-get-err.js
     dstr/var-ary-ptrn-elem-ary-elem-init.js
@@ -4572,6 +6204,9 @@ language/statements/for-of
     dstr/var-obj-ptrn-prop-obj-init.js
     dstr/var-obj-ptrn-prop-obj-value-null.js
     dstr/var-obj-ptrn-prop-obj-value-undef.js
+    dstr/var-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/var-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     body-dstr-assign-error.js
     body-put-error.js
     cptn-decl-abrupt-empty.js
@@ -4580,6 +6215,8 @@ language/statements/for-of
     cptn-expr-abrupt-empty.js
     cptn-expr-itr.js
     cptn-expr-no-itr.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
@@ -4588,6 +6225,9 @@ language/statements/for-of
     generator-close-via-continue.js
     generator-close-via-return.js
     generator-close-via-throw.js
+    head-await-using-bound-names-fordecl-tdz.js {unsupported: [async]}
+    head-await-using-bound-names-in-stmt.js {unsupported: [module]}
+    head-await-using-fresh-binding-per-iteration.js {unsupported: [module]}
     head-const-bound-names-fordecl-tdz.js
     head-const-fresh-binding-per-iteration.js
     head-decl-no-expr.js
@@ -4599,7 +6239,7 @@ language/statements/for-of
     head-lhs-async-invalid.js
     head-using-bound-names-fordecl-tdz.js
     head-using-fresh-binding-per-iteration.js
-    head-var-bound-names-let.js
+    head-var-bound-names-let.js non-strict
     head-var-init.js
     head-var-no-expr.js
     iterator-close-non-object.js
@@ -4615,15 +6255,20 @@ language/statements/for-of
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-close.js
     scope-head-lex-open.js
+    typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-grow-before-end.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
+    typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
-language/statements/function
+language/statements/function 162/451 (35.92%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4711,6 +6356,9 @@ language/statements/function
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
@@ -4726,58 +6374,62 @@ language/statements/function
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js
-    13.0-13-s.js
-    13.0-14-s.js
-    13.1-22-s.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    early-errors 4/4 (100.0%)
+    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    13.0-13-s.js non-strict
+    13.0-14-s.js non-strict
+    13.1-22-s.js non-strict
     13.2-10-s.js
     13.2-13-s.js
     13.2-14-s.js
     13.2-17-s.js
     13.2-18-s.js
-    13.2-19-b-3gs.js
-    13.2-2-s.js
-    13.2-21-s.js
-    13.2-22-s.js
-    13.2-25-s.js
-    13.2-26-s.js
+    13.2-19-b-3gs.js strict
+    13.2-2-s.js strict
+    13.2-21-s.js non-strict
+    13.2-22-s.js non-strict
+    13.2-25-s.js non-strict
+    13.2-26-s.js non-strict
     13.2-30-s.js
-    13.2-4-s.js
-    13.2-5-s.js
-    13.2-6-s.js
-    13.2-9-s.js
-    arguments-with-arguments-fn.js
-    arguments-with-arguments-lex.js
+    13.2-4-s.js strict
+    13.2-5-s.js non-strict
+    13.2-6-s.js non-strict
+    13.2-9-s.js non-strict
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
-    dflt-params-duplicates.js
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js
+    eval-var-scope-syntax-err.js non-strict
     length-dflt.js
-    name-arguments-strict-body.js
-    name-eval-strict-body.js
+    name-arguments-strict-body.js non-strict
+    name-eval-strict-body.js non-strict
     object-destructuring-param-strict-body.js
-    param-arguments-strict-body.js
-    param-dflt-yield-non-strict.js
-    param-dflt-yield-strict.js
-    param-duplicated-strict-body-1.js
-    param-duplicated-strict-body-2.js
-    param-duplicated-strict-body-3.js
-    param-eval-strict-body.js
+    param-arguments-strict-body.js non-strict
+    param-dflt-yield-non-strict.js non-strict
+    param-dflt-yield-strict.js strict
+    param-duplicated-strict-body-1.js non-strict
+    param-duplicated-strict-body-2.js non-strict
+    param-duplicated-strict-body-3.js non-strict
+    param-eval-strict-body.js non-strict
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
     static-init-await-binding-valid.js
-    unscopables-with.js
-    unscopables-with-in-nested-fn.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators
+language/statements/generators 168/266 (63.16%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -4882,6 +6534,9 @@ language/statements/generators
     dstr/dflt-obj-ptrn-prop-obj-init.js
     dstr/dflt-obj-ptrn-prop-obj-value-null.js
     dstr/dflt-obj-ptrn-prop-obj-value-undef.js
+    dstr/dflt-obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/dflt-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
     dstr/obj-ptrn-id-get-value-err.js
@@ -4904,18 +6559,21 @@ language/statements/generators
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js
-    arguments-with-arguments-fn.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js non-strict
+    arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js
+    eval-var-scope-syntax-err.js non-strict
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
@@ -4924,24 +6582,24 @@ language/statements/generators
     prototype-value.js
     rest-param-strict-body.js
     restricted-properties.js
-    scope-body-lex-distinct.js
-    scope-param-rest-elem-var-close.js
-    scope-param-rest-elem-var-open.js
+    scope-body-lex-distinct.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
-    unscopables-with.js
-    unscopables-with-in-nested-fn.js
-    yield-as-function-expression-binding-identifier.js
-    yield-as-generator-declaration-binding-identifier.js
-    yield-as-identifier-in-nested-function.js
-    yield-identifier-non-strict.js
-    yield-identifier-spread-non-strict.js
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
+    yield-as-function-expression-binding-identifier.js non-strict
+    yield-as-generator-declaration-binding-identifier.js non-strict
+    yield-as-identifier-in-nested-function.js non-strict
+    yield-identifier-non-strict.js non-strict
+    yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
     yield-star-after-newline.js
     yield-star-before-newline.js
 
-language/statements/if
+language/statements/if 42/69 (60.87%)
     cptn-else-false-abrupt-empty.js
     cptn-else-false-nrml.js
     cptn-else-true-abrupt-empty.js
@@ -4949,45 +6607,60 @@ language/statements/if
     cptn-no-else-false.js
     cptn-no-else-true-abrupt-empty.js
     cptn-no-else-true-nrml.js
+    if-async-fun-else-async-fun.js {unsupported: [async-functions]}
+    if-async-fun-else-stmt.js {unsupported: [async-functions]}
+    if-async-fun-no-else.js {unsupported: [async-functions]}
+    if-async-gen-else-async-gen.js {unsupported: [async-iteration]}
+    if-async-gen-else-stmt.js {unsupported: [async-iteration]}
+    if-async-gen-no-else.js {unsupported: [async-iteration]}
     if-const-else-const.js
     if-const-else-stmt.js
     if-const-no-else.js
-    if-decl-else-decl-strict.js
-    if-decl-else-stmt-strict.js
-    if-decl-no-else-strict.js
-    if-fun-else-fun-strict.js
-    if-fun-else-stmt-strict.js
-    if-fun-no-else-strict.js
+    if-decl-else-decl-strict.js strict
+    if-decl-else-stmt-strict.js strict
+    if-decl-no-else-strict.js strict
+    if-fun-else-fun-strict.js strict
+    if-fun-else-stmt-strict.js strict
+    if-fun-no-else-strict.js strict
     if-gen-else-gen.js
     if-gen-else-stmt.js
     if-gen-no-else.js
     if-let-else-let.js
     if-let-else-stmt.js
     if-let-no-else.js
+    if-stmt-else-async-fun.js {unsupported: [async-functions]}
+    if-stmt-else-async-gen.js {unsupported: [async-iteration]}
     if-stmt-else-const.js
-    if-stmt-else-decl-strict.js
-    if-stmt-else-fun-strict.js
+    if-stmt-else-decl-strict.js strict
+    if-stmt-else-fun-strict.js strict
     if-stmt-else-gen.js
     if-stmt-else-let.js
     labelled-fn-stmt-first.js
     labelled-fn-stmt-lone.js
     labelled-fn-stmt-second.js
-    let-array-with-newline.js
-    let-block-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    tco-else-body.js {unsupported: [tail-call-optimization]}
+    tco-if-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/labeled
+language/statements/labeled 15/24 (62.5%)
+    decl-async-function.js {unsupported: [async-functions]}
+    decl-async-generator.js {unsupported: [async-iteration]}
     decl-const.js
-    decl-fun-strict.js
+    decl-fun-strict.js strict
     decl-gen.js
     decl-let.js
-    let-array-with-newline.js
-    let-block-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    tco.js {unsupported: [tail-call-optimization]}
+    value-await-module.js {unsupported: [module]}
+    value-await-module-escaped.js {unsupported: [module]}
     value-await-non-module.js
     value-await-non-module-escaped.js
-    value-yield-non-strict.js
-    value-yield-non-strict-escaped.js
+    value-yield-non-strict.js non-strict
+    value-yield-non-strict-escaped.js non-strict
 
-language/statements/let
+language/statements/let 80/145 (55.17%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5039,7 +6712,10 @@ language/statements/let
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    syntax/escaped-let.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    syntax/escaped-let.js non-strict
     syntax/let-closure-inside-condition.js
     syntax/let-closure-inside-initialization.js
     syntax/let-closure-inside-next-expression.js
@@ -5055,6 +6731,7 @@ language/statements/let
     block-local-closure-set-before-initialization.js
     block-local-use-before-initialization-in-declaration-statement.js
     block-local-use-before-initialization-in-prior-statement.js
+    fn-name-class.js {unsupported: [class]}
     function-local-closure-get-before-initialization.js
     function-local-closure-set-before-initialization.js
     function-local-use-before-initialization-in-declaration-statement.js
@@ -5065,17 +6742,46 @@ language/statements/let
     global-use-before-initialization-in-prior-statement.js
     static-init-await-binding-valid.js
 
-language/statements/return
+language/statements/return 1/16 (6.25%)
+    tco.js {unsupported: [tail-call-optimization]}
 
-language/statements/switch
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js
+language/statements/switch 62/111 (55.86%)
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js {unsupported: [async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-iteration, async-functions]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js {unsupported: [async-iteration]}
+    syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js {unsupported: [async-iteration]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
+    syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/var-name-redeclaration-attempt-with-function.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/var-name-redeclaration-attempt-with-let.js
@@ -5099,10 +6805,13 @@ language/statements/switch
     scope-lex-generator.js
     scope-lex-open-case.js
     scope-lex-open-dflt.js
+    tco-case-body.js {unsupported: [tail-call-optimization]}
+    tco-case-body-dflt.js {unsupported: [tail-call-optimization]}
+    tco-dftl-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/throw
+language/statements/throw 0/14 (0.0%)
 
-language/statements/try
+language/statements/try 113/201 (56.22%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5187,12 +6896,15 @@ language/statements/try
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    12.14-13.js
-    12.14-14.js
-    12.14-15.js
-    12.14-16.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    12.14-13.js non-strict
+    12.14-14.js non-strict
+    12.14-15.js non-strict
+    12.14-16.js non-strict
     completion-values.js
-    completion-values-fn-finally-abrupt.js
+    completion-values-fn-finally-abrupt.js compiled
     cptn-catch.js
     cptn-catch-empty-break.js
     cptn-catch-empty-continue.js
@@ -5208,10 +6920,13 @@ language/statements/try
     early-catch-lex.js
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js
-    scope-catch-param-var-none.js
+    scope-catch-param-var-none.js non-strict
     static-init-await-binding-valid.js
+    tco-catch.js {unsupported: [tail-call-optimization]}
+    tco-catch-finally.js {unsupported: [tail-call-optimization]}
+    tco-finally.js {unsupported: [tail-call-optimization]}
 
-language/statements/variable
+language/statements/variable 62/178 (34.83%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -5265,61 +6980,72 @@ language/statements/variable
     dstr/obj-ptrn-prop-obj-init.js
     dstr/obj-ptrn-prop-obj-value-null.js
     dstr/obj-ptrn-prop-obj-value-undef.js
-    12.2.1-10-s.js
-    12.2.1-20-s.js
-    12.2.1-21-s.js
-    12.2.1-9-s.js
+    dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
+    dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
+    12.2.1-10-s.js strict
+    12.2.1-20-s.js strict
+    12.2.1-21-s.js strict
+    12.2.1-9-s.js strict
+    fn-name-class.js {unsupported: [class]}
     static-init-await-binding-valid.js
 
-language/statements/while
+language/statements/while 13/38 (34.21%)
     cptn-abrupt-empty.js
     cptn-iter.js
     cptn-no-iter.js
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
     decl-const.js
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    let-identifier-with-newline.js
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
+    tco-body.js {unsupported: [tail-call-optimization]}
 
-language/statements/with
-    binding-blocked-by-unscopables.js
-    cptn-abrupt-empty.js
-    cptn-nrml.js
-    decl-const.js
-    decl-fun.js
-    decl-gen.js
-    decl-let.js
-    get-binding-value-call-with-proxy-env.js
-    get-binding-value-idref-with-proxy-env.js
-    get-mutable-binding-binding-deleted-in-get-unscopables.js
-    get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js
-    has-binding-call-with-proxy-env.js
-    has-binding-idref-with-proxy-env.js
-    has-property-err.js
-    labelled-fn-stmt.js
-    let-array-with-newline.js
-    let-block-with-newline.js
-    set-mutable-binding-binding-deleted-in-get-unscopables.js
-    set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js
-    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js
-    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js
-    set-mutable-binding-idref-compound-assign-with-proxy-env.js
-    set-mutable-binding-idref-with-proxy-env.js
-    unscopables-get-err.js
-    unscopables-inc-dec.js
-    unscopables-prop-get-err.js
+language/statements/with 28/181 (15.47%)
+    binding-blocked-by-unscopables.js non-strict
+    cptn-abrupt-empty.js non-strict
+    cptn-nrml.js non-strict
+    decl-async-fun.js {unsupported: [async-functions]}
+    decl-async-gen.js {unsupported: [async-iteration]}
+    decl-const.js non-strict
+    decl-fun.js non-strict
+    decl-gen.js non-strict
+    decl-let.js non-strict
+    get-binding-value-call-with-proxy-env.js non-strict
+    get-binding-value-idref-with-proxy-env.js non-strict
+    get-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
+    get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
+    has-binding-call-with-proxy-env.js non-strict
+    has-binding-idref-with-proxy-env.js non-strict
+    has-property-err.js non-strict
+    labelled-fn-stmt.js non-strict
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    set-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
+    set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
+    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js non-strict
+    set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js non-strict
+    set-mutable-binding-idref-compound-assign-with-proxy-env.js non-strict
+    set-mutable-binding-idref-with-proxy-env.js non-strict
+    unscopables-get-err.js non-strict
+    unscopables-inc-dec.js non-strict
+    unscopables-prop-get-err.js non-strict
 
-language/types
+language/types 9/113 (7.96%)
     number/S8.5_A10_T1.js
-    number/S8.5_A10_T2.js
+    number/S8.5_A10_T2.js non-strict
     number/S8.5_A4_T1.js
-    number/S8.5_A4_T2.js
+    number/S8.5_A4_T2.js non-strict
     reference/get-value-prop-base-primitive-realm.js
     reference/put-value-prop-base-primitive.js
     reference/put-value-prop-base-primitive-realm.js
     undefined/S8.1_A3_T1.js
-    undefined/S8.1_A3_T2.js
+    undefined/S8.1_A3_T2.js non-strict
 
-language/white-space
+language/white-space 2/67 (2.99%)
+    mongolian-vowel-separator.js {unsupported: [u180e]}
+    mongolian-vowel-separator-eval.js {unsupported: [u180e]}


### PR DESCRIPTION
Implements ES2025 Math.f16round method with IEEE 754 binary16 conversion. Handles special values, overflow/underflow, and proper rounding. Includes comprehensive tests and updates test262.properties (1,686 additional tests now passing). Part of ES2025 series with PRs #2025, #2029, #2030, #2048.