### PR TITLE
Fix Array.from to prioritize iterable over array-like objects

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -709,9 +709,7 @@ public class NativeArray extends ScriptableObject implements List {
         }
 
         Object iteratorProp = ScriptableObject.getProperty(items, SymbolKey.ITERATOR);
-        if (!(items instanceof NativeArray)
-                && (iteratorProp != Scriptable.NOT_FOUND)
-                && !Undefined.isUndefined(iteratorProp)) {
+        if ((iteratorProp != Scriptable.NOT_FOUND) && !Undefined.isUndefined(iteratorProp)) {
             final Object iterator = ScriptRuntime.callIterator(items, cx, scope);
             if (!Undefined.isUndefined(iterator)) {
                 final Scriptable result =

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2015/ArrayFromTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2015/ArrayFromTest.java
@@ -1,0 +1,97 @@
+package org.mozilla.javascript.tests.es2015;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * Tests for Array.from spec compliance, particularly prioritizing iterable over array-like. See
+ * issue #1518
+ */
+public class ArrayFromTest {
+
+    @Test
+    public void testArrayFromPrioritizesIterableOverArrayLike() {
+        // Test that Array.from uses Symbol.iterator even on native arrays
+        String script =
+                "let counter = 0;"
+                        + "Array.prototype[Symbol.iterator] = function* () {"
+                        + "    for (let i = 0; i < this.length; i++) {"
+                        + "        counter++;"
+                        + "        yield this[i];"
+                        + "    }"
+                        + "};"
+                        + "Array.from(['a','b','c']);"
+                        + "counter;";
+
+        Utils.assertWithAllModes_ES6(3, script);
+    }
+
+    @Test
+    public void testArrayFromUsesCustomIterator() {
+        // Test that custom iterator is used over array-like behavior
+        String script =
+                "const obj = {"
+                        + "    length: 3,"
+                        + "    0: 'a',"
+                        + "    1: 'b',"
+                        + "    2: 'c',"
+                        + "    [Symbol.iterator]: function* () {"
+                        + "        yield 'x';"
+                        + "        yield 'y';"
+                        + "    }"
+                        + "};"
+                        + "JSON.stringify(Array.from(obj));";
+
+        Utils.assertWithAllModes_ES6("[\"x\",\"y\"]", script);
+    }
+
+    @Test
+    public void testArrayFromWithMapFunction() {
+        // Test that map function works with custom iterator
+        String script =
+                "const obj = {"
+                        + "    length: 2,"
+                        + "    0: 'ignored',"
+                        + "    1: 'ignored',"
+                        + "    [Symbol.iterator]: function* () {"
+                        + "        yield 'a';"
+                        + "        yield 'b';"
+                        + "    }"
+                        + "};"
+                        + "const result = Array.from(obj, function(x, i) {"
+                        + "    return x.toUpperCase();"
+                        + "});"
+                        + "JSON.stringify(result);";
+
+        Utils.assertWithAllModes_ES6("[\"A\",\"B\"]", script);
+    }
+
+    @Test
+    public void testArrayFromFallsBackToArrayLike() {
+        // Test that array-like behavior still works when no iterator
+        String script =
+                "const obj = {"
+                        + "    length: 2,"
+                        + "    0: 'a',"
+                        + "    1: 'b'"
+                        + "};"
+                        + "JSON.stringify(Array.from(obj));";
+
+        Utils.assertWithAllModes_ES6("[\"a\",\"b\"]", script);
+    }
+
+    @Test
+    public void testArrayFromWithEmptyIterator() {
+        // Test that empty iterator takes precedence over array-like properties
+        String script =
+                "const obj = {"
+                        + "    length: 2,"
+                        + "    0: 'a',"
+                        + "    1: 'b',"
+                        + "    [Symbol.iterator]: function* () {}"
+                        + "};"
+                        + "JSON.stringify(Array.from(obj));";
+
+        Utils.assertWithAllModes_ES6("[]", script);
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -451,11 +451,9 @@ harness 23/116 (19.83%)
 
 built-ins/AggregateError 25/25 (100.0%)
 
-built-ins/Array 263/3077 (8.55%)
+built-ins/Array 261/3077 (8.48%)
     fromAsync 95/95 (100.0%)
-    from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
     from/proto-from-ctor-realm.js
-    from/source-object-constructor.js Error propagation needs work in general
     length/define-own-prop-length-coercion-order-set.js
     of/proto-from-ctor-realm.js
     prototype/at/coerced-index-resize.js {unsupported: [resizable-arraybuffer]}


### PR DESCRIPTION
Fixes Array.from to follow ES2015 spec by checking Symbol.iterator first, even on native arrays.

Previously Array.from skipped iterator check for NativeArray instances. Now follows spec correctly.

Closes #1518