### PR TITLE
Don't propagate strict flag when compiling scripts

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2615,9 +2615,6 @@ public class Context implements Closeable {
         if (returnFunction) {
             p.calledByCompileFunction = true;
         }
-        if (isStrictMode()) {
-            p.setDefaultUseStrictDirective(true);
-        }
 
         AstRoot ast = p.parse(sourceString, sourceName, lineno);
         if (returnFunction) {

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -162,8 +162,6 @@ public class Parser {
     private int lastTokenLineno = -1;
     private int lastTokenColumn = -1;
 
-    private boolean defaultUseStrictDirective;
-
     // Exception to unwind
     public static class ParserException extends RuntimeException {
         private static final long serialVersionUID = 5882582646773765630L;
@@ -606,7 +604,7 @@ public class Parser {
         boolean inDirectivePrologue = true;
         boolean savedStrictMode = inUseStrictDirective;
 
-        inUseStrictDirective = defaultUseStrictDirective;
+        inUseStrictDirective = compilerEnv.isStrictMode();
         if (inUseStrictDirective) {
             root.setInStrictMode(true);
         }
@@ -4860,10 +4858,6 @@ public class Parser {
                         + ts.tokenBeg
                         + ", currentToken="
                         + currentToken);
-    }
-
-    public void setDefaultUseStrictDirective(boolean useStrict) {
-        defaultUseStrictDirective = useStrict;
     }
 
     public boolean inUseStrictDirective() {

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3526,6 +3526,9 @@ public class ScriptRuntime {
         // mode.
         Consumer<CompilerEnvirons> compilerEnvironsProcessor =
                 compilerEnvs -> {
+                    // `eval` propagates strict mode
+                    compilerEnvs.setStrictMode(cx.isStrictMode());
+
                     // If we are inside a method, we need to allow super. Methods have the home
                     // object set and propagated via the activation (i.e. the NativeCall),
                     // but non-methods will have the home object set to null.

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/StrictPropagationTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/StrictPropagationTest.java
@@ -1,0 +1,40 @@
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.LambdaFunction;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.SerializableCallable;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.testutils.Utils;
+
+public class StrictPropagationTest {
+
+    @Test
+    public void strictIsNotPropagatedWhenLoadingDynamically() {
+        final String outer = "function outer() { 'use strict'; includeDynamic() } outer(); x";
+        // This works in non-strict mode, and is a ReferenceError in strict mode
+        final String nested = "(function() { x = 'x'; })()";
+
+        Utils.runWithAllModes(
+                cx -> {
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    Scriptable scope = cx.initStandardObjects(new TopLevel());
+
+                    SerializableCallable includeDynamic =
+                            (cx2, scope2, thisObj, args) ->
+                                    cx2.evaluateString(scope2, nested, "nested", 1, null);
+                    scope.put(
+                            "includeDynamic",
+                            scope,
+                            new LambdaFunction(scope, "includeDynamic", 0, includeDynamic));
+
+                    Object res = cx.evaluateString(scope, outer, "outer", 1, null);
+                    assertEquals("x", res);
+
+                    return null;
+                });
+    }
+}

--- a/tests/testsrc/jstests/inside-strict-mode.js
+++ b/tests/testsrc/jstests/inside-strict-mode.js
@@ -27,4 +27,9 @@ assertThrows(function() {
   delete Math.LN2;
 }, TypeError);
 
+assertThrows(function evalInStrict() {
+	'use strict';
+	eval("arguments = 10");
+}, SyntaxError);
+
 "success";


### PR DESCRIPTION
Before this change, if we compiled dynamically a script while we already had an active context in strict mode, we would have propagated the strict flag, which is incorrect. I've modified the code to not do so.

`eval` required some special handling; I have added a test to verify that we have not broken it (and I've double-checked with node). The `Function` constructor does not suffer from this problem, because it _always_ parses the code in non-strict mode (i.e. it does not propagate the flag, whereas `eval` should), per the spec.

Nothing in test262 breaks, which is encouraging.