### PR TITLE
Run tests on the CI with thread-safe mode on

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -62,6 +62,18 @@ jobs:
       with:
         name: reports-java-11
         path: '*/build/reports'
+    - name: Build and test Java 21 - Multithread
+      timeout-minutes: 30
+      env:
+        "rhino.useThreadSafeObjectsByDefault": true
+      run: >-
+        ./gradlew check
+    - name: Upload results Java 21 - Multithread
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      if: ${{ always() }}
+      with:
+        name: reports-java-21-multithread
+        path: '*/build/reports'
     - name: Check current state of test262.properties
       id: hashBefore
       run: echo "hash=${{ hashFiles('./tests/testsrc/test262.properties') }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -64,10 +64,8 @@ jobs:
         path: '*/build/reports'
     - name: Build and test Java 21 - Multithread
       timeout-minutes: 30
-      env:
-        "rhino.useThreadSafeObjectsByDefault": true
       run: >-
-        ./gradlew check
+        ./gradlew check -Drhino.useThreadSafeObjectsByDefault=true
     - name: Upload results Java 21 - Multithread
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: ${{ always() }}

--- a/rhino/src/main/java/org/mozilla/javascript/ContextFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ContextFactory.java
@@ -10,6 +10,7 @@ package org.mozilla.javascript;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import org.mozilla.javascript.config.RhinoConfig;
 
 /**
  * Factory class that Rhino runtime uses to create new {@link Context} instances. A <code>
@@ -105,6 +106,9 @@ import java.security.PrivilegedAction;
  * </pre>
  */
 public class ContextFactory {
+    private static final boolean useThreadSafeObjectsByDefault =
+            RhinoConfig.get("rhino.useThreadSafeObjectsByDefault", false);
+
     private static volatile boolean hasCustomGlobal;
     private static ContextFactory global = new ContextFactory();
 
@@ -274,7 +278,7 @@ public class ContextFactory {
                 return cx.getLanguageVersion() >= Context.VERSION_ES6;
 
             case Context.FEATURE_THREAD_SAFE_OBJECTS:
-                return false;
+                return useThreadSafeObjectsByDefault;
 
             case Context.FEATURE_INTEGER_WITHOUT_DECIMAL_PLACE:
                 return false;


### PR DESCRIPTION
In this PR, I've done two things:

- modify the default `ContextFactory` to allow configuration of the default value for `Context.FEATURE_THREAD_SAFE_OBJECTS` via the `RhinoConfig` mechanism
- added a new step in the CI to run all the tests once more with the flag set to true. I've not done it for all the JDK versions we support because it seems unnecessary. There is a 30 minutes timeout for the step. Verified via https://github.com/mozilla/rhino/pull/2062.

See the discussion in https://github.com/mozilla/rhino/issues/1968