### PR TITLE
Duplicate properties in object literal should be allowed

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -3911,6 +3911,9 @@ public class Parser {
                     && !(pname instanceof ComputedPropertyKey)) {
                 switch (entryKind) {
                     case PROP_ENTRY:
+                        if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
+                            break;
+                        }
                     case METHOD_ENTRY:
                         if (getterNames.contains(propertyName)
                                 || setterNames.contains(propertyName)) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DuplicateProperties.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DuplicateProperties.java
@@ -4,16 +4,18 @@ import org.junit.Test;
 import org.mozilla.javascript.testutils.Utils;
 
 public class DuplicateProperties {
-	@Test
-	public void unterminatedCharacterClass() {
-		String script = "(function() {\n" +
-				"'use strict';\n" +
-				"const o = {foo: 1, foo: 2};\n" +
-				"return o.foo\n" +
-				"})();";
+    @Test
+    public void unterminatedCharacterClass() {
+        String script =
+                "(function() {\n"
+                        + "'use strict';\n"
+                        + "const o = {foo: 1, foo: 2};\n"
+                        + "return o.foo\n"
+                        + "})();";
 
-		Utils.assertEvaluatorException_1_8("Property \"foo\" already defined in this object literal", script);
+        Utils.assertEvaluatorException_1_8(
+                "Property \"foo\" already defined in this object literal", script);
 
-		Utils.assertWithAllModes_ES6(2, script);
-	}
+        Utils.assertWithAllModes_ES6(2, script);
+    }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DuplicateProperties.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DuplicateProperties.java
@@ -1,0 +1,19 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+public class DuplicateProperties {
+	@Test
+	public void unterminatedCharacterClass() {
+		String script = "(function() {\n" +
+				"'use strict';\n" +
+				"const o = {foo: 1, foo: 2};\n" +
+				"return o.foo\n" +
+				"})();";
+
+		Utils.assertEvaluatorException_1_8("Property \"foo\" already defined in this object literal", script);
+
+		Utils.assertWithAllModes_ES6(2, script);
+	}
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1,428 +1,6 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-annexB/built-ins 58/241 (24.07%)
-    Array/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    Date/prototype/getYear/not-a-constructor.js
-    Date/prototype/setYear/not-a-constructor.js
-    Date/prototype/setYear/year-number-relative.js
-    Date/prototype/toGMTString/not-a-constructor.js
-    Function/createdynfn-html-close-comment-params.js
-    Function/createdynfn-html-open-comment-params.js
-    Function/createdynfn-no-line-terminator-html-close-comment-body.js
-    Object/is/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    RegExp/legacy-accessors/index 4/4 (100.0%)
-    RegExp/legacy-accessors/input 4/4 (100.0%)
-    RegExp/legacy-accessors/lastMatch 4/4 (100.0%)
-    RegExp/legacy-accessors/lastParen 4/4 (100.0%)
-    RegExp/legacy-accessors/leftContext 4/4 (100.0%)
-    RegExp/legacy-accessors/rightContext 4/4 (100.0%)
-    RegExp/prototype/compile/pattern-regexp-flags-defined.js
-    RegExp/prototype/compile/this-cross-realm-instance.js
-    RegExp/prototype/compile/this-subclass-instance.js {unsupported: [class]}
-    RegExp/prototype/flags/order-after-compile.js {unsupported: [regexp-dotall]}
-    RegExp/prototype/Symbol.split/Symbol.match-getter-recompiles-source.js
-    RegExp/incomplete_hex_unicode_escape.js
-    RegExp/RegExp-control-escape-russian-letter.js compiled
-    RegExp/RegExp-leading-escape-BMP.js
-    RegExp/RegExp-trailing-escape-BMP.js
-    String/prototype/anchor/length.js
-    String/prototype/fontcolor/length.js
-    String/prototype/fontsize/length.js
-    String/prototype/link/length.js
-    String/prototype/matchAll/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/match/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/replaceAll/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/replace/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/search/custom-searcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/split/custom-splitter-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    String/prototype/substr/start-and-length-as-numbers.js
-    String/prototype/trimLeft/name.js
-    String/prototype/trimLeft/reference-trimStart.js
-    String/prototype/trimRight/name.js
-    String/prototype/trimRight/reference-trimEnd.js
-    TypedArrayConstructors/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-
-annexB/language 386/845 (45.68%)
-    comments/multi-line-html-close.js
-    comments/single-line-html-close.js
-    comments/single-line-html-close-first-line-3.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js non-strict
-    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js non-strict
-    eval-code/direct/global-block-decl-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-switch-case-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-block-scoping.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
-    eval-code/direct/var-env-lower-lex-catch-non-strict.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
-    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
-    expressions/assignment/dstr 2/2 (100.0%)
-    expressions/assignmenttargettype/callexpression.js non-strict
-    expressions/assignmenttargettype/callexpression-as-for-in-lhs.js non-strict
-    expressions/assignmenttargettype/callexpression-as-for-of-lhs.js non-strict
-    expressions/assignmenttargettype/callexpression-in-compound-assignment.js non-strict
-    expressions/assignmenttargettype/callexpression-in-postfix-update.js non-strict
-    expressions/assignmenttargettype/callexpression-in-prefix-update.js non-strict
-    expressions/coalesce/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/conditional/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/logical-and/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/logical-assignment 3/3 (100.0%)
-    expressions/logical-not/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/logical-or/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/strict-does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/strict-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/template-literal/legacy-octal-escape-sequence-strict.js strict
-    expressions/typeof/emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    expressions/yield 2/2 (100.0%)
-    function-code/block-decl-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/block-decl-func-init.js interpreted-non-strict
-    function-code/block-decl-func-no-skip-try.js interpreted-non-strict
-    function-code/block-decl-func-skip-arguments.js non-strict
-    function-code/block-decl-func-skip-dft-param.js non-strict
-    function-code/block-decl-func-skip-early-err.js non-strict
-    function-code/block-decl-func-skip-early-err-block.js non-strict
-    function-code/block-decl-func-skip-early-err-for.js non-strict
-    function-code/block-decl-func-skip-early-err-for-in.js non-strict
-    function-code/block-decl-func-skip-early-err-for-of.js non-strict
-    function-code/block-decl-func-skip-early-err-switch.js non-strict
-    function-code/block-decl-func-skip-early-err-try.js non-strict
-    function-code/block-decl-func-skip-param.js non-strict
-    function-code/block-decl-nested-blocks-with-fun-decl.js non-strict
-    function-code/block-decl-nostrict.js interpreted-non-strict
-    function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-else-decl-a-func-skip-dft-param.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-block.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-for.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-early-err-try.js non-strict
-    function-code/if-decl-else-decl-a-func-skip-param.js non-strict
-    function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-else-decl-b-func-skip-dft-param.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-block.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-for.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-early-err-try.js non-strict
-    function-code/if-decl-else-decl-b-func-skip-param.js non-strict
-    function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-else-stmt-func-skip-dft-param.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-block.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-for.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-else-stmt-func-skip-early-err-try.js non-strict
-    function-code/if-decl-else-stmt-func-skip-param.js non-strict
-    function-code/if-decl-no-else-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-decl-no-else-func-skip-dft-param.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-block.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-for.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-for-in.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-for-of.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-switch.js non-strict
-    function-code/if-decl-no-else-func-skip-early-err-try.js non-strict
-    function-code/if-decl-no-else-func-skip-param.js non-strict
-    function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/if-stmt-else-decl-func-skip-dft-param.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-block.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-for.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-for-in.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-for-of.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-switch.js non-strict
-    function-code/if-stmt-else-decl-func-skip-early-err-try.js non-strict
-    function-code/if-stmt-else-decl-func-skip-param.js non-strict
-    function-code/switch-case-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/switch-case-func-skip-dft-param.js non-strict
-    function-code/switch-case-func-skip-early-err.js non-strict
-    function-code/switch-case-func-skip-early-err-block.js non-strict
-    function-code/switch-case-func-skip-early-err-for.js non-strict
-    function-code/switch-case-func-skip-early-err-for-in.js non-strict
-    function-code/switch-case-func-skip-early-err-for-of.js non-strict
-    function-code/switch-case-func-skip-early-err-switch.js non-strict
-    function-code/switch-case-func-skip-early-err-try.js non-strict
-    function-code/switch-case-func-skip-param.js non-strict
-    function-code/switch-dflt-func-existing-block-fn-no-init.js interpreted-non-strict
-    function-code/switch-dflt-func-skip-dft-param.js non-strict
-    function-code/switch-dflt-func-skip-early-err.js non-strict
-    function-code/switch-dflt-func-skip-early-err-block.js non-strict
-    function-code/switch-dflt-func-skip-early-err-for.js non-strict
-    function-code/switch-dflt-func-skip-early-err-for-in.js non-strict
-    function-code/switch-dflt-func-skip-early-err-for-of.js non-strict
-    function-code/switch-dflt-func-skip-early-err-switch.js non-strict
-    function-code/switch-dflt-func-skip-early-err-try.js non-strict
-    function-code/switch-dflt-func-skip-param.js non-strict
-    global-code/block-decl-global-block-scoping.js non-strict
-    global-code/block-decl-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/block-decl-global-init.js interpreted-non-strict
-    global-code/block-decl-global-no-skip-try.js interpreted-non-strict
-    global-code/block-decl-global-skip-early-err.js non-strict
-    global-code/block-decl-global-skip-early-err-block.js non-strict
-    global-code/block-decl-global-skip-early-err-for.js non-strict
-    global-code/block-decl-global-skip-early-err-for-in.js non-strict
-    global-code/block-decl-global-skip-early-err-for-of.js non-strict
-    global-code/block-decl-global-skip-early-err-switch.js non-strict
-    global-code/block-decl-global-skip-early-err-try.js non-strict
-    global-code/if-decl-else-decl-a-global-block-scoping.js non-strict
-    global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-block.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-for.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-else-decl-a-global-skip-early-err-try.js non-strict
-    global-code/if-decl-else-decl-b-global-block-scoping.js non-strict
-    global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-block.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-for.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-else-decl-b-global-skip-early-err-try.js non-strict
-    global-code/if-decl-else-stmt-global-block-scoping.js non-strict
-    global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-block.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-for.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-else-stmt-global-skip-early-err-try.js non-strict
-    global-code/if-decl-no-else-global-block-scoping.js non-strict
-    global-code/if-decl-no-else-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-decl-no-else-global-skip-early-err.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-block.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-for.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-for-in.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-for-of.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-switch.js non-strict
-    global-code/if-decl-no-else-global-skip-early-err-try.js non-strict
-    global-code/if-stmt-else-decl-global-block-scoping.js non-strict
-    global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-block.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-for.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-for-in.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-for-of.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-switch.js non-strict
-    global-code/if-stmt-else-decl-global-skip-early-err-try.js non-strict
-    global-code/script-decl-lex-collision.js non-strict
-    global-code/switch-case-global-block-scoping.js non-strict
-    global-code/switch-case-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/switch-case-global-skip-early-err.js non-strict
-    global-code/switch-case-global-skip-early-err-block.js non-strict
-    global-code/switch-case-global-skip-early-err-for.js non-strict
-    global-code/switch-case-global-skip-early-err-for-in.js non-strict
-    global-code/switch-case-global-skip-early-err-for-of.js non-strict
-    global-code/switch-case-global-skip-early-err-switch.js non-strict
-    global-code/switch-case-global-skip-early-err-try.js non-strict
-    global-code/switch-dflt-global-block-scoping.js non-strict
-    global-code/switch-dflt-global-existing-block-fn-no-init.js interpreted-non-strict
-    global-code/switch-dflt-global-skip-early-err.js non-strict
-    global-code/switch-dflt-global-skip-early-err-block.js non-strict
-    global-code/switch-dflt-global-skip-early-err-for.js non-strict
-    global-code/switch-dflt-global-skip-early-err-for-in.js non-strict
-    global-code/switch-dflt-global-skip-early-err-for-of.js non-strict
-    global-code/switch-dflt-global-skip-early-err-switch.js non-strict
-    global-code/switch-dflt-global-skip-early-err-try.js non-strict
-    literals/regexp/class-escape.js
-    literals/regexp/identity-escape.js
-    literals/regexp/legacy-octal-escape.js
-    statements/class/subclass 2/2 (100.0%)
-    statements/const/dstr 2/2 (100.0%)
-    statements/for-await-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [async-iteration, IsHTMLDDA, async]}
-    statements/for-in/let-initializer.js
-    statements/for-in/strict-initializer.js strict
-    statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [IsHTMLDDA]}
-    statements/function/default-parameters-emulates-undefined.js {unsupported: [IsHTMLDDA]}
-    statements/if/emulated-undefined.js {unsupported: [IsHTMLDDA]}
-    statements/switch/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+~annexB
 
 harness 23/116 (19.83%)
     assert-notsamevalue-tostring.js {unsupported: [async-functions]}
@@ -449,8 +27,6 @@ harness 23/116 (19.83%)
     isConstructor.js
     nativeFunctionMatcher.js
 
-built-ins/AggregateError 25/25 (100.0%)
-
 built-ins/Array 263/3077 (8.55%)
     fromAsync 95/95 (100.0%)
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -467,18 +43,18 @@ built-ins/Array 263/3077 (8.55%)
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
     prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
+    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict {compiled-non-strict,interpreted-non-strict} Not throwing properly on unwritable
     prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/15.4.4.16-5-1-s.js non-strict
+    prototype/every/15.4.4.16-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/every/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/typed-array-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/15.4.4.20-5-1-s.js non-strict
+    prototype/filter/15.4.4.20-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/filter/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/create-proto-from-ctor-realm-array.js
     prototype/filter/create-proxy.js
@@ -486,22 +62,22 @@ built-ins/Array 263/3077 (8.55%)
     prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/predicate-call-this-strict.js strict
+    prototype/findIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/predicate-call-this-strict.js strict
+    prototype/findLastIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/predicate-call-this-strict.js strict
+    prototype/findLast/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/predicate-call-this-strict.js strict
+    prototype/find/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -509,9 +85,9 @@ built-ins/Array 263/3077 (8.55%)
     prototype/flatMap/this-value-ctor-non-object.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    prototype/flatMap/thisArg-argument.js strict
+    prototype/flatMap/thisArg-argument.js strict {compiled-strict,interpreted-strict}
     prototype/flat/proxy-access-count.js
-    prototype/forEach/15.4.4.18-5-1-s.js non-strict
+    prototype/forEach/15.4.4.18-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/forEach/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -536,7 +112,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/15.4.4.19-5-1-s.js non-strict
+    prototype/map/15.4.4.19-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/map/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/create-proto-from-ctor-realm-array.js
     prototype/map/create-proxy.js
@@ -548,7 +124,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/pop/set-length-zero-array-is-frozen.js non-strict
     prototype/pop/set-length-zero-array-length-is-non-writable.js non-strict
     prototype/pop/throws-with-string-receiver.js non-strict
-    prototype/push/length-near-integer-limit-set-failure.js non-strict
+    prototype/push/length-near-integer-limit-set-failure.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/set-length-array-is-frozen.js
     prototype/push/set-length-array-length-is-non-writable.js
@@ -556,12 +132,12 @@ built-ins/Array 263/3077 (8.55%)
     prototype/push/set-length-zero-array-length-is-non-writable.js
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
     prototype/push/throws-with-string-receiver.js non-strict
-    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
+    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/reduceRight/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
+    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/reduce/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -579,7 +155,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/slice/create-proxy.js
     prototype/slice/create-species.js
     prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/15.4.4.17-5-1-s.js non-strict
+    prototype/some/15.4.4.17-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/some/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -588,7 +164,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/S15.4.4.11_A8.js non-strict
+    prototype/sort/S15.4.4.11_A8.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-proto-from-ctor-realm-array.js
     prototype/splice/create-proto-from-ctor-realm-non-array.js
@@ -598,12 +174,12 @@ built-ins/Array 263/3077 (8.55%)
     prototype/splice/create-species-length-exceeding-integer-limit.js
     prototype/splice/property-traps-order-with-species.js
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
-    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
+    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict {compiled-non-strict,interpreted-non-strict}
     prototype/splice/set_length_no_args.js
     prototype/Symbol.unscopables/change-array-by-copy.js
     prototype/toLocaleString/invoke-element-tolocalestring.js
-    prototype/toLocaleString/primitive_this_value.js strict
-    prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/toLocaleString/primitive_this_value.js strict {compiled-strict,interpreted-strict}
+    prototype/toLocaleString/primitive_this_value_getter.js strict {compiled-strict,interpreted-strict}
     prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
@@ -669,8 +245,6 @@ built-ins/ArrayBuffer 87/196 (44.39%)
     prototype-from-newtarget.js
 
 built-ins/ArrayIteratorPrototype 0/27 (0.0%)
-
-~built-ins/AsyncDisposableStack
 
 ~built-ins/AsyncFromSyncIteratorPrototype
 
@@ -937,8 +511,6 @@ built-ins/Date 85/594 (14.31%)
     proto-from-ctor-realm-zero.js
     year-zero.js
 
-~built-ins/DisposableStack
-
 built-ins/Error 7/53 (13.21%)
     isError/error-subclass.js {unsupported: [class]}
     isError/is-a-constructor.js
@@ -953,9 +525,9 @@ built-ins/Error 7/53 (13.21%)
 built-ins/Function 128/509 (25.15%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
-    prototype/apply/15.3.4.3-1-s.js strict
-    prototype/apply/15.3.4.3-2-s.js strict
-    prototype/apply/15.3.4.3-3-s.js strict
+    prototype/apply/15.3.4.3-1-s.js strict {compiled-strict,interpreted-strict}
+    prototype/apply/15.3.4.3-2-s.js strict {compiled-strict,interpreted-strict}
+    prototype/apply/15.3.4.3-3-s.js strict {compiled-strict,interpreted-strict}
     prototype/apply/argarray-not-object.js
     prototype/apply/argarray-not-object-realm.js
     prototype/apply/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
@@ -976,9 +548,9 @@ built-ins/Function 128/509 (25.15%)
     prototype/bind/proto-from-ctor-realm.js
     prototype/caller-arguments/accessor-properties.js
     prototype/caller/prop-desc.js
-    prototype/call/15.3.4.4-1-s.js strict
-    prototype/call/15.3.4.4-2-s.js strict
-    prototype/call/15.3.4.4-3-s.js strict
+    prototype/call/15.3.4.4-1-s.js strict {compiled-strict,interpreted-strict}
+    prototype/call/15.3.4.4-2-s.js strict {compiled-strict,interpreted-strict}
+    prototype/call/15.3.4.4-3-s.js strict {compiled-strict,interpreted-strict}
     prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
     prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
     prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
@@ -1038,54 +610,46 @@ built-ins/Function 128/509 (25.15%)
     prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
-    15.3.2.1-10-6gs.js non-strict
-    15.3.2.1-11-1-s.js non-strict
-    15.3.2.1-11-3-s.js non-strict
-    15.3.2.1-11-5-s.js non-strict
-    15.3.5-1gs.js strict
-    15.3.5-2gs.js strict
-    15.3.5.4_2-11gs.js strict
-    15.3.5.4_2-13gs.js strict
-    15.3.5.4_2-15gs.js strict
-    15.3.5.4_2-17gs.js strict
-    15.3.5.4_2-19gs.js strict
-    15.3.5.4_2-1gs.js strict
-    15.3.5.4_2-21gs.js strict
-    15.3.5.4_2-22gs.js strict
-    15.3.5.4_2-23gs.js strict
-    15.3.5.4_2-24gs.js strict
-    15.3.5.4_2-25gs.js strict
-    15.3.5.4_2-26gs.js strict
-    15.3.5.4_2-27gs.js strict
-    15.3.5.4_2-28gs.js strict
-    15.3.5.4_2-29gs.js strict
-    15.3.5.4_2-3gs.js strict
-    15.3.5.4_2-48gs.js strict
-    15.3.5.4_2-50gs.js strict
-    15.3.5.4_2-52gs.js strict
-    15.3.5.4_2-54gs.js strict
-    15.3.5.4_2-5gs.js strict
-    15.3.5.4_2-7gs.js strict
-    15.3.5.4_2-9gs.js strict
+    15.3.2.1-10-6gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    15.3.2.1-11-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    15.3.2.1-11-3-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    15.3.2.1-11-5-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    15.3.5-1gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5-2gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-11gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-13gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-15gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-17gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-19gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-1gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-21gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-22gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-23gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-24gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-25gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-26gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-27gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-28gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-29gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-3gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-48gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-50gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-52gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-54gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-5gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-7gs.js strict {compiled-strict,interpreted-strict}
+    15.3.5.4_2-9gs.js strict {compiled-strict,interpreted-strict}
     call-bind-this-realm-undef.js
     call-bind-this-realm-value.js
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
     proto-from-ctor-realm.js
     proto-from-ctor-realm-prototype.js
-    StrictFunction_restricted-properties.js strict
+    StrictFunction_restricted-properties.js strict {compiled-strict,interpreted-strict}
 
-built-ins/GeneratorFunction 8/23 (34.78%)
-    prototype/constructor.js
-    prototype/prototype.js
-    prototype/Symbol.toStringTag.js
-    instance-construct-throws.js
-    instance-prototype.js
-    instance-restricted-properties.js
-    name.js
-    proto-from-ctor-realm-prototype.js
+~built-ins/GeneratorFunction
 
 built-ins/GeneratorPrototype 31/61 (50.82%)
-    next/from-state-executing.js
+    next/from-state-executing.js {compiled-strict,compiled-non-strict}
     next/length.js
     next/not-a-constructor.js
     next/property-descriptor.js
@@ -1109,7 +673,7 @@ built-ins/GeneratorPrototype 31/61 (50.82%)
     return/try-finally-nested-try-catch-within-outer-try-before-nested.js
     return/try-finally-within-finally.js
     return/try-finally-within-try.js
-    throw/from-state-executing.js
+    throw/from-state-executing.js {compiled-strict,compiled-non-strict}
     throw/length.js
     throw/name.js
     throw/not-a-constructor.js
@@ -1118,371 +682,6 @@ built-ins/GeneratorPrototype 31/61 (50.82%)
     Symbol.toStringTag.js
 
 built-ins/Infinity 0/6 (0.0%)
-
-built-ins/Iterator 392/432 (90.74%)
-    concat/arguments-checked-in-order.js
-    concat/fresh-iterator-result.js
-    concat/get-iterator-method-only-once.js
-    concat/get-iterator-method-throws.js
-    concat/get-value-after-done.js
-    concat/inner-iterator-created-in-order.js
-    concat/is-function.js
-    concat/iterable-primitive-wrapper-objects.js
-    concat/length.js
-    concat/many-arguments.js
-    concat/name.js
-    concat/next-method-called-with-zero-arguments.js
-    concat/next-method-returns-non-object.js
-    concat/next-method-returns-throwing-done.js
-    concat/next-method-returns-throwing-value.js
-    concat/next-method-returns-throwing-value-done.js
-    concat/next-method-throws.js
-    concat/prop-desc.js
-    concat/proto.js
-    concat/result-is-iterator.js
-    concat/return-is-forwarded.js
-    concat/return-is-not-forwarded-after-exhaustion.js
-    concat/return-is-not-forwarded-before-initial-start.js
-    concat/return-method-called-with-zero-arguments.js
-    concat/single-argument.js
-    concat/throws-typeerror-when-generator-is-running-next.js
-    concat/throws-typeerror-when-generator-is-running-return.js
-    concat/throws-typeerror-when-iterator-not-an-object.js
-    concat/zero-arguments.js
-    from 19/19 (100.0%)
-    prototype/constructor 2/2 (100.0%)
-    prototype/drop/argument-effect-order.js
-    prototype/drop/argument-validation-failure-closes-underlying.js
-    prototype/drop/callable.js
-    prototype/drop/exhaustion-does-not-call-return.js
-    prototype/drop/get-next-method-only-once.js
-    prototype/drop/get-next-method-throws.js
-    prototype/drop/get-return-method-throws.js
-    prototype/drop/is-function.js
-    prototype/drop/length.js
-    prototype/drop/limit-equals-total.js
-    prototype/drop/limit-greater-than-total.js
-    prototype/drop/limit-less-than-total.js
-    prototype/drop/limit-rangeerror.js
-    prototype/drop/limit-tonumber.js
-    prototype/drop/limit-tonumber-throws.js
-    prototype/drop/name.js
-    prototype/drop/next-method-returns-non-object.js
-    prototype/drop/next-method-returns-throwing-done.js
-    prototype/drop/next-method-returns-throwing-value.js
-    prototype/drop/next-method-returns-throwing-value-done.js
-    prototype/drop/next-method-throws.js
-    prototype/drop/non-constructible.js
-    prototype/drop/prop-desc.js
-    prototype/drop/proto.js
-    prototype/drop/result-is-iterator.js
-    prototype/drop/return-is-forwarded.js
-    prototype/drop/return-is-not-forwarded-after-exhaustion.js
-    prototype/drop/this-non-callable-next.js
-    prototype/drop/this-plain-iterator.js
-    prototype/drop/throws-typeerror-when-generator-is-running.js
-    prototype/drop/underlying-iterator-advanced-in-parallel.js
-    prototype/drop/underlying-iterator-closed.js
-    prototype/drop/underlying-iterator-closed-in-parallel.js
-    prototype/every/argument-validation-failure-closes-underlying.js
-    prototype/every/callable.js
-    prototype/every/get-next-method-only-once.js
-    prototype/every/get-next-method-throws.js
-    prototype/every/get-return-method-throws.js
-    prototype/every/is-function.js
-    prototype/every/iterator-already-exhausted.js
-    prototype/every/iterator-has-no-return.js
-    prototype/every/iterator-return-method-throws.js
-    prototype/every/length.js
-    prototype/every/name.js
-    prototype/every/next-method-returns-non-object.js
-    prototype/every/next-method-returns-throwing-done.js
-    prototype/every/next-method-returns-throwing-value.js
-    prototype/every/next-method-returns-throwing-value-done.js
-    prototype/every/next-method-throws.js
-    prototype/every/non-constructible.js
-    prototype/every/predicate-args.js
-    prototype/every/predicate-returns-falsey.js
-    prototype/every/predicate-returns-non-boolean.js
-    prototype/every/predicate-returns-truthy.js
-    prototype/every/predicate-returns-truthy-then-falsey.js
-    prototype/every/predicate-this.js
-    prototype/every/predicate-throws.js
-    prototype/every/predicate-throws-then-closing-iterator-also-throws.js
-    prototype/every/prop-desc.js
-    prototype/every/proto.js
-    prototype/every/result-is-boolean.js
-    prototype/every/this-plain-iterator.js
-    prototype/filter/argument-validation-failure-closes-underlying.js
-    prototype/filter/callable.js
-    prototype/filter/exhaustion-does-not-call-return.js
-    prototype/filter/get-next-method-only-once.js
-    prototype/filter/get-next-method-throws.js
-    prototype/filter/get-return-method-throws.js
-    prototype/filter/is-function.js
-    prototype/filter/iterator-already-exhausted.js
-    prototype/filter/iterator-return-method-throws.js
-    prototype/filter/length.js
-    prototype/filter/name.js
-    prototype/filter/next-method-returns-non-object.js
-    prototype/filter/next-method-returns-throwing-done.js
-    prototype/filter/next-method-returns-throwing-value.js
-    prototype/filter/next-method-returns-throwing-value-done.js
-    prototype/filter/next-method-throws.js
-    prototype/filter/non-constructible.js
-    prototype/filter/predicate-args.js
-    prototype/filter/predicate-filters.js
-    prototype/filter/predicate-returns-non-boolean.js
-    prototype/filter/predicate-this.js
-    prototype/filter/predicate-throws.js
-    prototype/filter/predicate-throws-then-closing-iterator-also-throws.js
-    prototype/filter/prop-desc.js
-    prototype/filter/proto.js
-    prototype/filter/result-is-iterator.js
-    prototype/filter/return-is-forwarded.js
-    prototype/filter/return-is-not-forwarded-after-exhaustion.js
-    prototype/filter/this-non-callable-next.js
-    prototype/filter/this-plain-iterator.js
-    prototype/filter/throws-typeerror-when-generator-is-running.js
-    prototype/filter/underlying-iterator-advanced-in-parallel.js
-    prototype/filter/underlying-iterator-closed.js
-    prototype/filter/underlying-iterator-closed-in-parallel.js
-    prototype/find/argument-validation-failure-closes-underlying.js
-    prototype/find/callable.js
-    prototype/find/get-next-method-only-once.js
-    prototype/find/get-next-method-throws.js
-    prototype/find/get-return-method-throws.js
-    prototype/find/is-function.js
-    prototype/find/iterator-already-exhausted.js
-    prototype/find/iterator-has-no-return.js
-    prototype/find/iterator-return-method-throws.js
-    prototype/find/length.js
-    prototype/find/name.js
-    prototype/find/next-method-returns-non-object.js
-    prototype/find/next-method-returns-throwing-done.js
-    prototype/find/next-method-returns-throwing-value.js
-    prototype/find/next-method-returns-throwing-value-done.js
-    prototype/find/next-method-throws.js
-    prototype/find/non-constructible.js
-    prototype/find/predicate-args.js
-    prototype/find/predicate-returns-falsey.js
-    prototype/find/predicate-returns-falsey-then-truthy.js
-    prototype/find/predicate-returns-non-boolean.js
-    prototype/find/predicate-returns-truthy.js
-    prototype/find/predicate-this.js
-    prototype/find/predicate-throws.js
-    prototype/find/predicate-throws-then-closing-iterator-also-throws.js
-    prototype/find/prop-desc.js
-    prototype/find/proto.js
-    prototype/find/this-plain-iterator.js
-    prototype/flatMap/argument-validation-failure-closes-underlying.js
-    prototype/flatMap/callable.js
-    prototype/flatMap/exhaustion-does-not-call-return.js
-    prototype/flatMap/flattens-iterable.js
-    prototype/flatMap/flattens-iterator.js
-    prototype/flatMap/flattens-only-depth-1.js
-    prototype/flatMap/get-next-method-only-once.js
-    prototype/flatMap/get-next-method-throws.js
-    prototype/flatMap/get-return-method-throws.js
-    prototype/flatMap/is-function.js
-    prototype/flatMap/iterable-primitives-are-not-flattened.js
-    prototype/flatMap/iterable-to-iterator-fallback.js
-    prototype/flatMap/iterator-already-exhausted.js
-    prototype/flatMap/iterator-return-method-throws.js
-    prototype/flatMap/length.js
-    prototype/flatMap/mapper-args.js
-    prototype/flatMap/mapper-returns-closed-iterator.js
-    prototype/flatMap/mapper-returns-non-object.js
-    prototype/flatMap/mapper-this.js
-    prototype/flatMap/mapper-throws.js
-    prototype/flatMap/mapper-throws-then-closing-iterator-also-throws.js
-    prototype/flatMap/name.js
-    prototype/flatMap/next-method-returns-non-object.js
-    prototype/flatMap/next-method-returns-throwing-done.js
-    prototype/flatMap/next-method-returns-throwing-value.js
-    prototype/flatMap/next-method-returns-throwing-value-done.js
-    prototype/flatMap/next-method-throws.js
-    prototype/flatMap/non-constructible.js
-    prototype/flatMap/prop-desc.js
-    prototype/flatMap/proto.js
-    prototype/flatMap/result-is-iterator.js
-    prototype/flatMap/return-is-forwarded-to-mapper-result.js
-    prototype/flatMap/return-is-forwarded-to-underlying-iterator.js
-    prototype/flatMap/return-is-not-forwarded-after-exhaustion.js
-    prototype/flatMap/strings-are-not-flattened.js
-    prototype/flatMap/this-non-callable-next.js
-    prototype/flatMap/this-plain-iterator.js
-    prototype/flatMap/throws-typeerror-when-generator-is-running.js
-    prototype/flatMap/underlying-iterator-advanced-in-parallel.js
-    prototype/flatMap/underlying-iterator-closed.js
-    prototype/flatMap/underlying-iterator-closed-in-parallel.js
-    prototype/forEach/argument-validation-failure-closes-underlying.js
-    prototype/forEach/callable.js
-    prototype/forEach/fn-args.js
-    prototype/forEach/fn-called-for-each-yielded-value.js
-    prototype/forEach/fn-this.js
-    prototype/forEach/fn-throws.js
-    prototype/forEach/fn-throws-then-closing-iterator-also-throws.js
-    prototype/forEach/get-next-method-only-once.js
-    prototype/forEach/get-next-method-throws.js
-    prototype/forEach/is-function.js
-    prototype/forEach/iterator-already-exhausted.js
-    prototype/forEach/length.js
-    prototype/forEach/name.js
-    prototype/forEach/next-method-returns-non-object.js
-    prototype/forEach/next-method-returns-throwing-done.js
-    prototype/forEach/next-method-returns-throwing-value.js
-    prototype/forEach/next-method-returns-throwing-value-done.js
-    prototype/forEach/next-method-throws.js
-    prototype/forEach/non-constructible.js
-    prototype/forEach/prop-desc.js
-    prototype/forEach/proto.js
-    prototype/forEach/result-is-undefined.js
-    prototype/forEach/this-plain-iterator.js
-    prototype/map/argument-validation-failure-closes-underlying.js
-    prototype/map/callable.js
-    prototype/map/exhaustion-does-not-call-return.js
-    prototype/map/get-next-method-only-once.js
-    prototype/map/get-next-method-throws.js
-    prototype/map/get-return-method-throws.js
-    prototype/map/is-function.js
-    prototype/map/iterator-already-exhausted.js
-    prototype/map/iterator-return-method-throws.js
-    prototype/map/length.js
-    prototype/map/mapper-args.js
-    prototype/map/mapper-this.js
-    prototype/map/mapper-throws.js
-    prototype/map/mapper-throws-then-closing-iterator-also-throws.js
-    prototype/map/name.js
-    prototype/map/next-method-returns-non-object.js
-    prototype/map/next-method-returns-throwing-done.js
-    prototype/map/next-method-returns-throwing-value.js
-    prototype/map/next-method-returns-throwing-value-done.js
-    prototype/map/next-method-throws.js
-    prototype/map/non-constructible.js
-    prototype/map/prop-desc.js
-    prototype/map/proto.js
-    prototype/map/result-is-iterator.js
-    prototype/map/return-is-forwarded-to-underlying-iterator.js
-    prototype/map/return-is-not-forwarded-after-exhaustion.js
-    prototype/map/returned-iterator-yields-mapper-return-values.js
-    prototype/map/this-non-callable-next.js
-    prototype/map/this-plain-iterator.js
-    prototype/map/throws-typeerror-when-generator-is-running.js
-    prototype/map/underlying-iterator-advanced-in-parallel.js
-    prototype/map/underlying-iterator-closed.js
-    prototype/map/underlying-iterator-closed-in-parallel.js
-    prototype/reduce/argument-effect-order.js
-    prototype/reduce/argument-validation-failure-closes-underlying.js
-    prototype/reduce/callable.js
-    prototype/reduce/get-next-method-only-once.js
-    prototype/reduce/get-next-method-throws.js
-    prototype/reduce/is-function.js
-    prototype/reduce/iterator-already-exhausted-initial-value.js
-    prototype/reduce/iterator-already-exhausted-no-initial-value.js
-    prototype/reduce/iterator-yields-once-initial-value.js
-    prototype/reduce/iterator-yields-once-no-initial-value.js
-    prototype/reduce/length.js
-    prototype/reduce/name.js
-    prototype/reduce/next-method-returns-non-object.js
-    prototype/reduce/next-method-returns-throwing-done.js
-    prototype/reduce/next-method-returns-throwing-value.js
-    prototype/reduce/next-method-returns-throwing-value-done.js
-    prototype/reduce/next-method-throws.js
-    prototype/reduce/non-callable-reducer.js
-    prototype/reduce/non-constructible.js
-    prototype/reduce/prop-desc.js
-    prototype/reduce/proto.js
-    prototype/reduce/reducer-args-initial-value.js
-    prototype/reduce/reducer-args-no-initial-value.js
-    prototype/reduce/reducer-memo-can-be-any-type.js
-    prototype/reduce/reducer-this.js
-    prototype/reduce/reducer-throws.js
-    prototype/reduce/reducer-throws-then-closing-iterator-also-throws.js
-    prototype/reduce/this-plain-iterator.js
-    prototype/some/argument-validation-failure-closes-underlying.js
-    prototype/some/callable.js
-    prototype/some/get-next-method-only-once.js
-    prototype/some/get-next-method-throws.js
-    prototype/some/get-return-method-throws.js
-    prototype/some/is-function.js
-    prototype/some/iterator-already-exhausted.js
-    prototype/some/iterator-has-no-return.js
-    prototype/some/iterator-return-method-throws.js
-    prototype/some/length.js
-    prototype/some/name.js
-    prototype/some/next-method-returns-non-object.js
-    prototype/some/next-method-returns-throwing-done.js
-    prototype/some/next-method-returns-throwing-value.js
-    prototype/some/next-method-returns-throwing-value-done.js
-    prototype/some/next-method-throws.js
-    prototype/some/non-constructible.js
-    prototype/some/predicate-args.js
-    prototype/some/predicate-returns-falsey.js
-    prototype/some/predicate-returns-falsey-then-truthy.js
-    prototype/some/predicate-returns-non-boolean.js
-    prototype/some/predicate-returns-truthy.js
-    prototype/some/predicate-this.js
-    prototype/some/predicate-throws.js
-    prototype/some/predicate-throws-then-closing-iterator-also-throws.js
-    prototype/some/prop-desc.js
-    prototype/some/proto.js
-    prototype/some/result-is-boolean.js
-    prototype/some/this-plain-iterator.js
-    prototype/Symbol.dispose 6/6 (100.0%)
-    prototype/Symbol.iterator 5/5 (100.0%)
-    prototype/Symbol.toStringTag 2/2 (100.0%)
-    prototype/take/argument-effect-order.js
-    prototype/take/argument-validation-failure-closes-underlying.js
-    prototype/take/callable.js
-    prototype/take/exhaustion-calls-return.js
-    prototype/take/get-next-method-only-once.js
-    prototype/take/get-next-method-throws.js
-    prototype/take/get-return-method-throws.js
-    prototype/take/is-function.js
-    prototype/take/length.js
-    prototype/take/limit-greater-than-or-equal-to-total.js
-    prototype/take/limit-less-than-total.js
-    prototype/take/limit-rangeerror.js
-    prototype/take/limit-tonumber.js
-    prototype/take/limit-tonumber-throws.js
-    prototype/take/name.js
-    prototype/take/next-method-returns-non-object.js
-    prototype/take/next-method-returns-throwing-done.js
-    prototype/take/next-method-returns-throwing-value.js
-    prototype/take/next-method-returns-throwing-value-done.js
-    prototype/take/next-method-throws.js
-    prototype/take/non-constructible.js
-    prototype/take/prop-desc.js
-    prototype/take/proto.js
-    prototype/take/result-is-iterator.js
-    prototype/take/return-is-forwarded.js
-    prototype/take/return-is-not-forwarded-after-exhaustion.js
-    prototype/take/this-non-callable-next.js
-    prototype/take/this-plain-iterator.js
-    prototype/take/throws-typeerror-when-generator-is-running.js
-    prototype/take/underlying-iterator-advanced-in-parallel.js
-    prototype/take/underlying-iterator-closed.js
-    prototype/take/underlying-iterator-closed-in-parallel.js
-    prototype/toArray/callable.js
-    prototype/toArray/get-next-method-only-once.js
-    prototype/toArray/get-next-method-throws.js
-    prototype/toArray/is-function.js
-    prototype/toArray/iterator-already-exhausted.js
-    prototype/toArray/length.js
-    prototype/toArray/name.js
-    prototype/toArray/next-method-returns-non-object.js
-    prototype/toArray/next-method-returns-throwing-done.js
-    prototype/toArray/next-method-returns-throwing-value.js
-    prototype/toArray/next-method-returns-throwing-value-done.js
-    prototype/toArray/next-method-throws.js
-    prototype/toArray/non-constructible.js
-    prototype/toArray/prop-desc.js
-    prototype/toArray/proto.js
-    prototype/toArray/this-plain-iterator.js
-    length.js
-    proto-from-ctor-realm.js
-    subclassable.js
 
 built-ins/JSON 45/165 (27.27%)
     isRawJSON 6/6 (100.0%)
@@ -1501,7 +700,7 @@ built-ins/JSON 45/165 (27.27%)
     parse/reviver-object-define-prop-err.js
     parse/reviver-object-get-prop-from-prototype.js
     parse/reviver-object-non-configurable-prop-create.js
-    parse/reviver-object-non-configurable-prop-delete.js strict
+    parse/reviver-object-non-configurable-prop-delete.js strict {compiled-strict,interpreted-strict}
     parse/text-negative-zero.js
     rawJSON 10/10 (100.0%)
     stringify/builtin.js
@@ -1559,16 +758,16 @@ built-ins/Object 121/3410 (3.55%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order-proxy.js
-    defineProperties/15.2.3.7-6-a-112.js non-strict
-    defineProperties/15.2.3.7-6-a-113.js non-strict
+    defineProperties/15.2.3.7-6-a-112.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-113.js non-strict {compiled-non-strict,interpreted-non-strict}
     defineProperties/15.2.3.7-6-a-164.js
     defineProperties/15.2.3.7-6-a-165.js
-    defineProperties/15.2.3.7-6-a-166.js non-strict
-    defineProperties/15.2.3.7-6-a-168.js non-strict
-    defineProperties/15.2.3.7-6-a-169.js non-strict
-    defineProperties/15.2.3.7-6-a-170.js non-strict
-    defineProperties/15.2.3.7-6-a-172.js non-strict
-    defineProperties/15.2.3.7-6-a-173.js non-strict
+    defineProperties/15.2.3.7-6-a-166.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-168.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-169.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-170.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-172.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-173.js non-strict {compiled-non-strict,interpreted-non-strict}
     defineProperties/15.2.3.7-6-a-175.js
     defineProperties/15.2.3.7-6-a-176.js
     defineProperties/15.2.3.7-6-a-184.js
@@ -1577,22 +776,22 @@ built-ins/Object 121/3410 (3.55%)
     defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js
     defineProperties/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    defineProperty/15.2.3.6-4-116.js non-strict
-    defineProperty/15.2.3.6-4-117.js non-strict
+    defineProperty/15.2.3.6-4-116.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-117.js non-strict {compiled-non-strict,interpreted-non-strict}
     defineProperty/15.2.3.6-4-168.js
     defineProperty/15.2.3.6-4-169.js
-    defineProperty/15.2.3.6-4-170.js non-strict
-    defineProperty/15.2.3.6-4-172.js non-strict
-    defineProperty/15.2.3.6-4-173.js non-strict
-    defineProperty/15.2.3.6-4-174.js non-strict
-    defineProperty/15.2.3.6-4-176.js non-strict
-    defineProperty/15.2.3.6-4-177.js non-strict
+    defineProperty/15.2.3.6-4-170.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-172.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-173.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-174.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-176.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-177.js non-strict {compiled-non-strict,interpreted-non-strict}
     defineProperty/15.2.3.6-4-188.js
     defineProperty/15.2.3.6-4-189.js
     defineProperty/15.2.3.6-4-254.js
     defineProperty/15.2.3.6-4-293-1.js
-    defineProperty/15.2.3.6-4-293-3.js non-strict
-    defineProperty/15.2.3.6-4-293-4.js strict
+    defineProperty/15.2.3.6-4-293-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-293-4.js strict {compiled-strict,interpreted-strict}
     defineProperty/15.2.3.6-4-336.js
     defineProperty/coerced-P-grow.js {unsupported: [resizable-arraybuffer]}
     defineProperty/coerced-P-shrink.js {unsupported: [resizable-arraybuffer]}
@@ -1645,8 +844,8 @@ built-ins/Object 121/3410 (3.55%)
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    prototype/toLocaleString/primitive_this_value.js strict
-    prototype/toLocaleString/primitive_this_value_getter.js strict
+    prototype/toLocaleString/primitive_this_value.js strict {compiled-strict,interpreted-strict}
+    prototype/toLocaleString/primitive_this_value_getter.js strict {compiled-strict,interpreted-strict}
     prototype/toString/proxy-function.js {unsupported: [async-functions]}
     prototype/toString/proxy-function-async.js {unsupported: [async-functions]}
     prototype/toString/proxy-revoked-during-get-call.js
@@ -2063,90 +1262,9 @@ built-ins/Promise 383/639 (59.94%)
     resolve-thenable-deferred.js {unsupported: [async]}
     resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy 69/311 (22.19%)
-    construct/arguments-realm.js
-    construct/call-parameters.js
-    construct/call-parameters-new-target.js
-    construct/trap-is-missing-target-is-proxy.js {unsupported: [class]}
-    construct/trap-is-null.js
-    construct/trap-is-null-target-is-proxy.js {unsupported: [class]}
-    construct/trap-is-undefined.js
-    construct/trap-is-undefined-no-property.js
-    construct/trap-is-undefined-proto-from-newtarget-realm.js
-    construct/trap-is-undefined-target-is-proxy.js {unsupported: [class]}
-    defineProperty/desc-realm.js
-    defineProperty/targetdesc-not-configurable-writable-desc-not-writable.js
-    defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js non-strict
-    defineProperty/trap-is-missing-target-is-proxy.js
-    defineProperty/trap-is-undefined-target-is-proxy.js
-    deleteProperty/boolean-trap-result-boolean-false.js
-    deleteProperty/return-false-not-strict.js non-strict
-    deleteProperty/return-false-strict.js strict
-    deleteProperty/targetdesc-is-configurable-target-is-not-extensible.js
-    deleteProperty/trap-is-missing-target-is-proxy.js strict
-    deleteProperty/trap-is-null-target-is-proxy.js
-    deleteProperty/trap-is-undefined-strict.js strict
-    deleteProperty/trap-is-undefined-target-is-proxy.js
-    getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined.js
-    getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor.js
-    getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable.js
-    getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-configurable.js
-    getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-undefined.js
-    getOwnPropertyDescriptor/trap-is-null-target-is-proxy.js
-    get/accessor-get-is-undefined-throws.js
-    get/trap-is-undefined-receiver.js
-    has/call-in-prototype.js
-    has/call-in-prototype-index.js
-    has/call-with.js non-strict
-    has/return-false-target-not-extensible-using-with.js non-strict
-    has/return-false-target-prop-exists-using-with.js non-strict
-    has/return-false-targetdesc-not-configurable-using-with.js non-strict
-    has/return-is-abrupt-with.js non-strict
-    has/trap-is-not-callable-using-with.js non-strict
-    ownKeys/trap-is-undefined-target-is-proxy.js
-    preventExtensions/trap-is-undefined-target-is-proxy.js {unsupported: [module]}
-    revocable/builtin.js
-    revocable/revocation-function-not-a-constructor.js
-    revocable/tco-fn-realm.js {unsupported: [tail-call-optimization]}
-    setPrototypeOf/internals-call-order.js
-    setPrototypeOf/not-extensible-target-not-same-target-prototype.js
-    setPrototypeOf/toboolean-trap-result-false.js
-    setPrototypeOf/toboolean-trap-result-true-target-is-extensible.js
-    setPrototypeOf/trap-is-missing-target-is-proxy.js
-    setPrototypeOf/trap-is-null-target-is-proxy.js
-    set/boolean-trap-result-is-false-boolean-return-false.js
-    set/boolean-trap-result-is-false-null-return-false.js
-    set/boolean-trap-result-is-false-number-return-false.js
-    set/boolean-trap-result-is-false-string-return-false.js
-    set/boolean-trap-result-is-false-undefined-return-false.js
-    set/call-parameters.js
-    set/call-parameters-prototype.js
-    set/call-parameters-prototype-dunder-proto.js
-    set/call-parameters-prototype-index.js
-    set/target-property-is-accessor-not-configurable-set-is-undefined.js
-    set/trap-is-missing-receiver-multiple-calls.js
-    set/trap-is-missing-receiver-multiple-calls-index.js
-    set/trap-is-missing-target-is-proxy.js
-    set/trap-is-null-receiver.js
-    set/trap-is-null-target-is-proxy.js
-    set/trap-is-undefined-target-is-proxy.js
-    create-target-is-not-a-constructor.js
-    get-fn-realm.js
-    get-fn-realm-recursive.js
+~built-ins/Proxy
 
-built-ins/Reflect 12/153 (7.84%)
-    construct/newtarget-is-not-constructor-throws.js
-    defineProperty/return-abrupt-from-property-key.js
-    deleteProperty/return-abrupt-from-result.js
-    deleteProperty/return-boolean.js strict
-    get/return-value-from-receiver.js
-    ownKeys/return-on-corresponding-order-large-index.js
-    set/call-prototype-property-set.js
-    set/different-property-descriptors.js
-    set/receiver-is-not-object.js
-    set/return-abrupt-from-result.js
-    set/return-false-if-receiver-is-not-writable.js
-    set/return-false-if-target-is-not-writable.js
+~built-ins/Reflect
 
 built-ins/RegExp 975/1868 (52.19%)
     CharacterClassEscapes 12/12 (100.0%)
@@ -2391,8 +1509,6 @@ built-ins/Set 87/381 (22.83%)
 
 built-ins/SetIteratorPrototype 0/11 (0.0%)
 
-~built-ins/ShadowRealm
-
 ~built-ins/SharedArrayBuffer
 
 built-ins/String 58/1212 (4.79%)
@@ -2457,8 +1573,6 @@ built-ins/String 58/1212 (4.79%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
-~built-ins/SuppressedError 22/22 (100.0%)
-
 built-ins/Symbol 19/94 (20.21%)
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
@@ -2479,8 +1593,6 @@ built-ins/Symbol 19/94 (20.21%)
     toPrimitive/cross-realm.js
     toStringTag/cross-realm.js
     unscopables/cross-realm.js
-
-built-ins/Temporal 4255/4255 (100.0%)
 
 built-ins/ThrowTypeError 8/14 (57.14%)
     extensible.js
@@ -2554,7 +1666,7 @@ built-ins/TypedArray 256/1434 (17.85%)
     prototype/findIndex/BigInt/predicate-call-this-strict.js strict
     prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/predicate-call-this-strict.js strict
+    prototype/findIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2564,19 +1676,19 @@ built-ins/TypedArray 256/1434 (17.85%)
     prototype/findLastIndex/BigInt/predicate-call-this-strict.js strict
     prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/predicate-call-this-strict.js strict
+    prototype/findLastIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/predicate-call-this-strict.js strict
+    prototype/findLast/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/predicate-call-this-strict.js strict
+    prototype/find/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -2871,7 +1983,7 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     ctors/typedarray-arg/use-custom-proto-if-object.js
     ctors/no-species.js
     from/BigInt/mapfn-this-without-thisarg-non-strict.js non-strict
-    from/mapfn-this-without-thisarg-non-strict.js non-strict
+    from/mapfn-this-without-thisarg-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     from/nan-conversion.js
     from/new-instance-from-sparse-array.js
     internals/DefineOwnProperty/BigInt/key-is-not-canonical-index.js
@@ -2893,11 +2005,11 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
     internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
-    internals/Delete/indexed-value-ab-strict.js strict
+    internals/Delete/indexed-value-ab-strict.js strict {compiled-strict,interpreted-strict}
     internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/key-is-not-minus-zero-strict.js strict
-    internals/Delete/key-is-out-of-bounds-strict.js strict
+    internals/Delete/key-is-not-minus-zero-strict.js strict {compiled-strict,interpreted-strict}
+    internals/Delete/key-is-out-of-bounds-strict.js strict {compiled-strict,interpreted-strict}
     internals/Get/BigInt/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/BigInt/key-is-not-integer.js
     internals/Get/BigInt/key-is-not-minus-zero.js
@@ -2947,66 +2059,6 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/Set/resized-out-of-bounds-to-in-bounds-index.js {unsupported: [resizable-arraybuffer]}
     internals/Set/tonumber-value-throws.js
 
-built-ins/Uint8Array 58/66 (87.88%)
-    fromBase64/alphabet.js
-    fromBase64/descriptor.js
-    fromBase64/ignores-receiver.js
-    fromBase64/illegal-characters.js
-    fromBase64/last-chunk-handling.js
-    fromBase64/last-chunk-invalid.js
-    fromBase64/length.js
-    fromBase64/name.js
-    fromBase64/nonconstructor.js
-    fromBase64/option-coercion.js
-    fromBase64/results.js
-    fromBase64/whitespace.js
-    fromHex/descriptor.js
-    fromHex/ignores-receiver.js
-    fromHex/illegal-characters.js
-    fromHex/length.js
-    fromHex/name.js
-    fromHex/nonconstructor.js
-    fromHex/odd-length-input.js
-    fromHex/results.js
-    prototype/setFromBase64/alphabet.js
-    prototype/setFromBase64/descriptor.js
-    prototype/setFromBase64/detached-buffer.js
-    prototype/setFromBase64/illegal-characters.js
-    prototype/setFromBase64/last-chunk-handling.js
-    prototype/setFromBase64/length.js
-    prototype/setFromBase64/name.js
-    prototype/setFromBase64/nonconstructor.js
-    prototype/setFromBase64/option-coercion.js
-    prototype/setFromBase64/results.js
-    prototype/setFromBase64/subarray.js
-    prototype/setFromBase64/target-size.js
-    prototype/setFromBase64/whitespace.js
-    prototype/setFromBase64/writes-up-to-error.js
-    prototype/setFromHex/descriptor.js
-    prototype/setFromHex/illegal-characters.js
-    prototype/setFromHex/length.js
-    prototype/setFromHex/name.js
-    prototype/setFromHex/nonconstructor.js
-    prototype/setFromHex/results.js
-    prototype/setFromHex/subarray.js
-    prototype/setFromHex/target-size.js
-    prototype/setFromHex/throws-when-string-length-is-odd.js
-    prototype/setFromHex/writes-up-to-error.js
-    prototype/toBase64/alphabet.js
-    prototype/toBase64/descriptor.js
-    prototype/toBase64/detached-buffer.js
-    prototype/toBase64/length.js
-    prototype/toBase64/name.js
-    prototype/toBase64/nonconstructor.js
-    prototype/toBase64/omit-padding.js
-    prototype/toBase64/option-coercion.js
-    prototype/toBase64/results.js
-    prototype/toHex/descriptor.js
-    prototype/toHex/length.js
-    prototype/toHex/name.js
-    prototype/toHex/nonconstructor.js
-    prototype/toHex/results.js
-
 built-ins/WeakMap 40/141 (28.37%)
     prototype/getOrInsertComputed 22/22 (100.0%)
     prototype/getOrInsert 17/17 (100.0%)
@@ -3047,43 +2099,43 @@ built-ins/undefined 0/8 (0.0%)
 ~intl402
 
 language/arguments-object 184/263 (69.96%)
-    mapped/mapped-arguments-nonconfigurable-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict
-    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict
-    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict
-    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict
-    mapped/nonconfigurable-descriptors-basic.js non-strict
-    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict
-    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict
-    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict
-    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
-    unmapped/via-params-dstr.js non-strict
-    unmapped/via-params-rest.js non-strict
+    mapped/mapped-arguments-nonconfigurable-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unmapped/via-params-dstr.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unmapped/via-params-rest.js non-strict {compiled-non-strict,interpreted-non-strict}
     arguments-caller.js
     async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
     async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
@@ -3242,8 +2294,8 @@ language/block-scope 68/145 (46.9%)
     syntax/for-in/mixed-values-in-iteration.js
     syntax/function-declarations/in-statement-position-do-statement-while-expression.js
     syntax/function-declarations/in-statement-position-for-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement.js strict
-    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement.js strict {compiled-strict,interpreted-strict}
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict {compiled-strict,interpreted-strict}
     syntax/function-declarations/in-statement-position-while-expression-statement.js
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
@@ -3272,7 +2324,7 @@ language/block-scope 68/145 (46.9%)
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict {compiled-strict,interpreted-strict}
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
@@ -3335,17 +2387,17 @@ language/destructuring 9/19 (47.37%)
 
 language/directive-prologue 2/62 (3.23%)
     14.1-4-s.js non-strict
-    14.1-5-s.js non-strict
+    14.1-5-s.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/eval-code 241/347 (69.45%)
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
-    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
     direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
@@ -3382,54 +2434,54 @@ language/eval-code 241/347 (69.45%)
     direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
     direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
     direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
@@ -3446,131 +2498,131 @@ language/eval-code 241/347 (69.45%)
     direct/block-decl-eval-source-is-strict-onlystrict.js strict
     direct/block-decl-onlystrict.js strict
     direct/export.js {unsupported: [module]}
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/import.js {unsupported: [module]}
     direct/lex-env-distinct-cls.js {unsupported: [class]}
     direct/lex-env-distinct-const.js
-    direct/lex-env-distinct-let.js
+    direct/lex-env-distinct-let.js {compiled-non-strict,interpreted-non-strict}
     direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/new.target.js {unsupported: [new.target]}
     direct/new.target-arrow.js {unsupported: [new.target]}
     direct/new.target-fn.js {unsupported: [new.target]}
-    direct/non-definable-global-var.js non-strict
+    direct/non-definable-global-var.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
     direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
     direct/switch-case-decl-onlystrict.js strict
     direct/switch-dflt-decl-eval-source-is-strict-nostrict.js non-strict
     direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js strict
     direct/switch-dflt-decl-onlystrict.js strict
-    direct/this-value-func-strict-caller.js strict
-    direct/var-env-func-init-global-update-configurable.js non-strict
+    direct/this-value-func-strict-caller.js strict {compiled-strict,interpreted-strict}
+    direct/var-env-func-init-global-update-configurable.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/var-env-func-strict-caller.js strict
     direct/var-env-func-strict-caller-2.js strict
     direct/var-env-func-strict-source.js
-    direct/var-env-global-lex-non-strict.js non-strict
-    direct/var-env-lower-lex-non-strict.js non-strict
+    direct/var-env-global-lex-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/var-env-lower-lex-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     direct/var-env-var-strict-caller.js strict
     direct/var-env-var-strict-caller-2.js strict
     direct/var-env-var-strict-caller-3.js strict
     direct/var-env-var-strict-source.js
-    indirect/always-non-strict.js strict
+    indirect/always-non-strict.js strict {compiled-strict,interpreted-strict}
     indirect/block-decl-strict.js
     indirect/export.js {unsupported: [module]}
     indirect/import.js {unsupported: [module]}
     indirect/lex-env-distinct-cls.js {unsupported: [class]}
     indirect/lex-env-distinct-const.js
-    indirect/lex-env-distinct-let.js
+    indirect/lex-env-distinct-let.js {compiled-non-strict,interpreted-non-strict}
     indirect/lex-env-no-init-cls.js {unsupported: [class]}
     indirect/lex-env-no-init-const.js
     indirect/lex-env-no-init-let.js
     indirect/new.target.js {unsupported: [new.target]}
-    indirect/non-definable-function-with-function.js
-    indirect/non-definable-function-with-variable.js
+    indirect/non-definable-function-with-function.js {compiled-non-strict,interpreted-non-strict}
+    indirect/non-definable-function-with-variable.js {compiled-non-strict,interpreted-non-strict}
     indirect/non-definable-global-var.js non-strict
     indirect/realm.js
     indirect/switch-case-decl-strict.js
@@ -3724,26 +2776,26 @@ language/expressions/arrow-function 151/343 (44.02%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1 2/2 (100.0%)
-    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
+    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    syntax/arrowparameters-bindingidentifier-yield.js non-strict
-    syntax/arrowparameters-cover-formalparameters-yield.js non-strict
+    syntax/arrowparameters-bindingidentifier-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
+    syntax/arrowparameters-cover-formalparameters-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-initialize-2.js
     syntax/arrowparameters-cover-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
     array-destructuring-param-strict-body.js
     ArrowFunction_restricted-properties.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     length-dflt.js
     lexical-new.target.js {unsupported: [new.target]}
     lexical-new.target-closure-returned.js {unsupported: [new.target]}
@@ -3753,21 +2805,20 @@ language/expressions/arrow-function 151/343 (44.02%)
     lexical-supercall-from-immediately-invoked-arrow.js
     object-destructuring-param-strict-body.js
     param-dflt-yield-expr.js
-    param-dflt-yield-id-non-strict.js non-strict
-    params-duplicate.js non-strict
-    scope-body-lex-distinct.js non-strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    param-dflt-yield-id-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    params-duplicate.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-paramsbody-var-open.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
+    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
 
-language/expressions/assignment 184/485 (37.94%)
+language/expressions/assignment 183/485 (37.73%)
     destructuring/default-expr-throws-iterator-return-get-throws.js
     destructuring/iterator-destructuring-property-reference-target-evaluation-order.js
     destructuring/keyed-destructuring-property-reference-target-evaluation-order.js
     destructuring/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js non-strict
-    destructuring/obj-prop-__proto__dup.js strict
     destructuring/target-assign-throws-iterator-return-get-throws.js
     dstr/array-elem-init-evaluation.js
     dstr/array-elem-init-fn-name-arrow.js
@@ -3776,8 +2827,8 @@ language/expressions/assignment 184/485 (37.94%)
     dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js non-strict
-    dstr/array-elem-init-yield-ident-valid.js non-strict
+    dstr/array-elem-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -3789,15 +2840,15 @@ language/expressions/assignment 184/485 (37.94%)
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
-    dstr/array-elem-put-const.js non-strict
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js strict
-    dstr/array-elem-target-yield-valid.js non-strict
+    dstr/array-elem-target-simple-strict.js strict {compiled-strict,interpreted-strict}
+    dstr/array-elem-target-yield-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -3864,36 +2915,36 @@ language/expressions/assignment 184/485 (37.94%)
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js non-strict
-    dstr/array-rest-put-unresolvable-strict.js strict
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-put-unresolvable-strict.js strict {compiled-strict,interpreted-strict}
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js non-strict
+    dstr/array-rest-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js non-strict
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-id-init-fn-name-arrow.js
     dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
     dstr/obj-id-init-let.js
-    dstr/obj-id-init-simple-no-strict.js non-strict
-    dstr/obj-id-init-yield-ident-valid.js non-strict
-    dstr/obj-id-put-const.js non-strict
+    dstr/obj-id-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
@@ -3901,16 +2952,16 @@ language/expressions/assignment 184/485 (37.94%)
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
-    dstr/obj-prop-put-const.js non-strict
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-put-let.js
     dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
     dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
@@ -3938,42 +2989,15 @@ language/expressions/assignment 184/485 (37.94%)
     dstr/obj-rest-val-null.js {unsupported: [object-rest]}
     dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
     dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
-    11.13.1-2-s.js strict
-    assignment-operator-calls-putvalue-lref--rval-.js non-strict
-    assignment-operator-calls-putvalue-lref--rval--1.js non-strict
+    11.13.1-2-s.js strict {compiled-strict,interpreted-strict}
+    assignment-operator-calls-putvalue-lref--rval-.js non-strict {compiled-non-strict,interpreted-non-strict}
+    assignment-operator-calls-putvalue-lref--rval--1.js non-strict {compiled-non-strict,interpreted-non-strict}
     fn-name-class.js {unsupported: [class]}
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
     target-super-computed-reference.js
     target-super-computed-reference-null.js
     target-super-identifier-reference-null.js
-
-language/expressions/assignmenttargettype 25/324 (7.72%)
-    direct-arrowfunction-1.js
-    direct-callexpression.js strict
-    direct-callexpression-as-for-in-lhs.js strict
-    direct-callexpression-as-for-of-lhs.js strict
-    direct-callexpression-in-compound-assignment.js strict
-    direct-callexpression-in-logical-assignment.js
-    direct-callexpression-in-postfix-update.js strict
-    direct-callexpression-in-prefix-update.js strict
-    direct-callexpression-templateliteral.js
-    direct-importcall.js {unsupported: [module]}
-    direct-importcall-defer.js {unsupported: [module]}
-    direct-importcall-source.js {unsupported: [module]}
-    direct-memberexpression-templateliteral.js
-    parenthesized-callexpression.js strict
-    parenthesized-callexpression-in-compound-assignment.js strict
-    parenthesized-callexpression-in-logical-assignment.js
-    parenthesized-callexpression-templateliteral.js
-    parenthesized-importcall.js {unsupported: [module]}
-    parenthesized-importcall-defer.js {unsupported: [module]}
-    parenthesized-importcall-source.js {unsupported: [module]}
-    parenthesized-memberexpression-templateliteral.js
-    parenthesized-optionalexpression.js
-    parenthesized-primaryexpression-objectliteral.js
-    simple-basic-identifierreference-await.js
-    simple-basic-identifierreference-yield.js non-strict
 
 language/expressions/async-arrow-function 42/60 (70.0%)
     forbidden-ext/b1 2/2 (100.0%)
@@ -4020,6 +3044,8 @@ language/expressions/async-arrow-function 42/60 (70.0%)
 
 ~language/expressions/async-generator
 
+~language/expressions/async-generator
+
 ~language/expressions/await
 
 language/expressions/bitwise-and 1/30 (3.33%)
@@ -4034,7 +3060,7 @@ language/expressions/bitwise-xor 1/30 (3.33%)
     order-of-evaluation.js
 
 language/expressions/call 34/92 (36.96%)
-    eval-realm-indirect.js non-strict
+    eval-realm-indirect.js non-strict {compiled-non-strict,interpreted-non-strict}
     eval-spread.js
     eval-spread-empty.js
     eval-spread-empty-leading.js
@@ -4079,42 +3105,42 @@ language/expressions/comma 1/6 (16.67%)
     tco-final.js {unsupported: [tail-call-optimization]}
 
 language/expressions/compound-assignment 125/454 (27.53%)
-    11.13.2-34-s.js strict
-    11.13.2-35-s.js strict
-    11.13.2-36-s.js strict
-    11.13.2-37-s.js strict
-    11.13.2-38-s.js strict
-    11.13.2-39-s.js strict
-    11.13.2-40-s.js strict
-    11.13.2-41-s.js strict
-    11.13.2-42-s.js strict
-    11.13.2-43-s.js strict
-    11.13.2-44-s.js strict
-    add-arguments-strict.js strict
-    and-arguments-strict.js strict
-    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict
-    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
-    div-arguments-strict.js strict
+    11.13.2-34-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-35-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-36-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-37-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-38-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-39-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-40-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-41-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-42-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-43-s.js strict {compiled-strict,interpreted-strict}
+    11.13.2-44-s.js strict {compiled-strict,interpreted-strict}
+    add-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    and-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict {compiled-non-strict,interpreted-non-strict}
+    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict {compiled-non-strict,interpreted-non-strict}
+    div-arguments-strict.js strict {compiled-strict,interpreted-strict}
     left-hand-side-private-reference-accessor-property-add.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-bitand.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-bitor.js {unsupported: [class-fields-private]}
@@ -4163,10 +3189,10 @@ language/expressions/compound-assignment 125/454 (27.53%)
     left-hand-side-private-reference-readonly-accessor-property-rshift.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-srshift.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-sub.js {unsupported: [class-fields-private]}
-    lshift-arguments-strict.js strict
-    mod-arguments-strict.js strict
-    mult-arguments-strict.js strict
-    or-arguments-strict.js strict
+    lshift-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    mod-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    mult-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    or-arguments-strict.js strict {compiled-strict,interpreted-strict}
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
     S11.13.2_A7.10_T4.js
@@ -4200,10 +3226,10 @@ language/expressions/compound-assignment 125/454 (27.53%)
     S11.13.2_A7.9_T1.js
     S11.13.2_A7.9_T2.js
     S11.13.2_A7.9_T4.js
-    srshift-arguments-strict.js strict
-    sub-arguments-strict.js strict
-    urshift-arguments-strict.js strict
-    xor-arguments-strict.js strict
+    srshift-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    sub-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    urshift-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    xor-arguments-strict.js strict {compiled-strict,interpreted-strict}
 
 language/expressions/concatenation 0/5 (0.0%)
 
@@ -4212,8 +3238,8 @@ language/expressions/conditional 2/22 (9.09%)
     tco-pos.js {unsupported: [tail-call-optimization]}
 
 language/expressions/delete 6/69 (8.7%)
-    identifier-strict.js strict
-    identifier-strict-recursive.js strict
+    identifier-strict.js strict {compiled-strict,interpreted-strict}
+    identifier-strict-recursive.js strict {compiled-strict,interpreted-strict}
     super-property.js {unsupported: [class]}
     super-property-method.js {unsupported: [class]}
     super-property-null-base.js {unsupported: [class]}
@@ -4341,43 +3367,43 @@ language/expressions/function 149/264 (56.44%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
-    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict
-    arguments-with-arguments-lex.js non-strict
+    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments-with-arguments-lex.js non-strict {compiled-non-strict,interpreted-non-strict}
     array-destructuring-param-strict-body.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     length-dflt.js
-    name-arguments-strict-body.js non-strict
-    named-no-strict-reassign-fn-name-in-body.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
-    named-strict-error-reassign-fn-name-in-body.js strict
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
-    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
+    name-arguments-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-no-strict-reassign-fn-name-in-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-strict-error-reassign-fn-name-in-body.js strict {compiled-strict,interpreted-strict}
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict {compiled-strict,interpreted-strict}
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict {compiled-strict,interpreted-strict}
     object-destructuring-param-strict-body.js
-    param-dflt-yield-non-strict.js non-strict
-    param-dflt-yield-strict.js strict
-    param-duplicated-strict-body-1.js non-strict
-    param-duplicated-strict-body-2.js non-strict
-    param-duplicated-strict-body-3.js non-strict
-    param-eval-strict-body.js non-strict
+    param-dflt-yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-dflt-yield-strict.js strict {compiled-strict,interpreted-strict}
+    param-duplicated-strict-body-1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-duplicated-strict-body-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-duplicated-strict-body-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-eval-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict
-    scope-name-var-open-non-strict.js non-strict
-    scope-name-var-open-strict.js strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-name-var-open-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-name-var-open-strict.js strict {compiled-strict,interpreted-strict}
+    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
+    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/expressions/generators 182/290 (62.76%)
     dstr/ary-init-iter-close.js
@@ -4513,28 +3539,28 @@ language/expressions/generators 182/290 (62.76%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
     array-destructuring-param-strict-body.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
     eval-body-proto-realm.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
-    named-no-strict-reassign-fn-name-in-body.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
-    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
-    named-strict-error-reassign-fn-name-in-body.js strict
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
-    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
-    named-yield-identifier-non-strict.js non-strict
-    named-yield-identifier-spread-non-strict.js non-strict
+    named-no-strict-reassign-fn-name-in-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-strict-error-reassign-fn-name-in-body.js strict {compiled-strict,interpreted-strict}
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict {compiled-strict,interpreted-strict}
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict {compiled-strict,interpreted-strict}
+    named-yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     named-yield-spread-arr-multiple.js
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
@@ -4542,21 +3568,21 @@ language/expressions/generators 182/290 (62.76%)
     prototype-own-properties.js
     prototype-value.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict
-    scope-name-var-close.js compiled
-    scope-name-var-open-non-strict.js non-strict
-    scope-name-var-open-strict.js strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-name-var-close.js compiled {compiled-strict,compiled-non-strict}
+    scope-name-var-open-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-name-var-open-strict.js strict {compiled-strict,interpreted-strict}
+    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
-    yield-as-function-expression-binding-identifier.js non-strict
-    yield-as-identifier-in-nested-function.js non-strict
-    yield-identifier-non-strict.js non-strict
-    yield-identifier-spread-non-strict.js non-strict
+    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-as-function-expression-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-as-identifier-in-nested-function.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
@@ -4591,7 +3617,7 @@ language/expressions/in 20/36 (55.56%)
     private-field-rhs-unresolvable.js {unsupported: [class-fields-private]}
     private-field-rhs-yield-absent.js {unsupported: [class-fields-private]}
     private-field-rhs-yield-present.js {unsupported: [class-fields-private]}
-    rhs-yield-absent-non-strict.js non-strict
+    rhs-yield-absent-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/expressions/instanceof 5/43 (11.63%)
     S11.8.6_A6_T2.js
@@ -4632,32 +3658,30 @@ language/expressions/logical-assignment 40/78 (51.28%)
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
-    lgcl-and-arguments-strict.js strict
+    lgcl-and-arguments-strict.js strict {compiled-strict,interpreted-strict}
     lgcl-and-assignment-operator-lhs-before-rhs.js
     lgcl-and-assignment-operator-namedevaluation-class-expression.js
-    lgcl-and-assignment-operator-no-set-put.js strict
-    lgcl-and-assignment-operator-non-extensible.js strict
+    lgcl-and-assignment-operator-no-set-put.js strict {compiled-strict,interpreted-strict}
+    lgcl-and-assignment-operator-non-extensible.js strict {compiled-strict,interpreted-strict}
     lgcl-and-assignment-operator-non-simple-lhs.js
-    lgcl-and-assignment-operator-non-writeable.js strict
-    lgcl-nullish-arguments-strict.js strict
+    lgcl-and-assignment-operator-non-writeable.js strict {compiled-strict,interpreted-strict}
+    lgcl-nullish-arguments-strict.js strict {compiled-strict,interpreted-strict}
     lgcl-nullish-assignment-operator-lhs-before-rhs.js
     lgcl-nullish-assignment-operator-namedevaluation-class-expression.js
-    lgcl-nullish-assignment-operator-no-set-put.js strict
+    lgcl-nullish-assignment-operator-no-set-put.js strict {compiled-strict,interpreted-strict}
     lgcl-nullish-assignment-operator-non-simple-lhs.js
-    lgcl-nullish-assignment-operator-non-writeable.js strict
-    lgcl-or-arguments-strict.js strict
+    lgcl-nullish-assignment-operator-non-writeable.js strict {compiled-strict,interpreted-strict}
+    lgcl-or-arguments-strict.js strict {compiled-strict,interpreted-strict}
     lgcl-or-assignment-operator-lhs-before-rhs.js
     lgcl-or-assignment-operator-namedevaluation-class-expression.js
-    lgcl-or-assignment-operator-no-set-put.js strict
+    lgcl-or-assignment-operator-no-set-put.js strict {compiled-strict,interpreted-strict}
     lgcl-or-assignment-operator-non-simple-lhs.js
-    lgcl-or-assignment-operator-non-writeable.js strict
+    lgcl-or-assignment-operator-non-writeable.js strict {compiled-strict,interpreted-strict}
 
 language/expressions/logical-not 0/19 (0.0%)
 
 language/expressions/logical-or 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
-
-~language/expressions/member-expression 1/1 (100.0%)
 
 language/expressions/modulus 1/40 (2.5%)
     order-of-evaluation.js
@@ -4691,7 +3715,7 @@ language/expressions/new 22/59 (37.29%)
 
 ~language/expressions/new.target
 
-language/expressions/object 698/1170 (59.66%)
+language/expressions/object 692/1170 (59.15%)
     dstr/async-gen-meth-ary-init-iter-close.js {unsupported: [async-iteration, async]}
     dstr/async-gen-meth-ary-init-iter-get-err.js {unsupported: [async-iteration]}
     dstr/async-gen-meth-ary-init-iter-get-err-array-prototype.js {unsupported: [async-iteration]}
@@ -5125,8 +4149,8 @@ language/expressions/object 698/1170 (59.66%)
     method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-functions, async]}
     method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-iteration, async]}
@@ -5266,7 +4290,7 @@ language/expressions/object 698/1170 (59.66%)
     method-definition/early-errors-object-method-await-in-formals.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-await-in-formals-default.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-body-contains-super-call.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-duplicate-parameters.js non-strict
+    method-definition/early-errors-object-method-duplicate-parameters.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/early-errors-object-method-eval-in-formal-parameters.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-formals-body-duplicate.js {unsupported: [async-functions]}
     method-definition/escaped-get.js
@@ -5284,37 +4308,37 @@ language/expressions/object 698/1170 (59.66%)
     method-definition/gen-meth-dflt-params-ref-self.js
     method-definition/gen-meth-dflt-params-rest.js
     method-definition/gen-meth-dflt-params-trailing-comma.js
-    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict
+    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/gen-meth-object-destructuring-param-strict-body.js
     method-definition/gen-meth-rest-param-strict-body.js
-    method-definition/gen-yield-identifier-non-strict.js non-strict
-    method-definition/gen-yield-identifier-spread-non-strict.js non-strict
+    method-definition/gen-yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/gen-yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/gen-yield-spread-arr-multiple.js
     method-definition/gen-yield-spread-arr-single.js
     method-definition/gen-yield-spread-obj.js
-    method-definition/generator-invoke-fn-strict.js non-strict
+    method-definition/generator-invoke-fn-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/generator-length-dflt.js
     method-definition/generator-param-init-yield.js non-strict
     method-definition/generator-param-redecl-let.js
-    method-definition/generator-prop-name-yield-expr.js non-strict
-    method-definition/generator-prop-name-yield-id.js non-strict
+    method-definition/generator-prop-name-yield-expr.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/generator-prop-name-yield-id.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/generator-prototype-prop.js
     method-definition/meth-array-destructuring-param-strict-body.js
-    method-definition/meth-dflt-params-duplicates.js non-strict
+    method-definition/meth-dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/meth-dflt-params-ref-later.js
     method-definition/meth-dflt-params-ref-self.js
     method-definition/meth-dflt-params-rest.js
     method-definition/meth-dflt-params-trailing-comma.js
-    method-definition/meth-eval-var-scope-syntax-err.js non-strict
+    method-definition/meth-eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/meth-object-destructuring-param-strict-body.js
     method-definition/meth-rest-param-strict-body.js
-    method-definition/name-invoke-fn-strict.js non-strict
+    method-definition/name-invoke-fn-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/name-length-dflt.js
-    method-definition/name-param-id-yield.js non-strict
-    method-definition/name-param-init-yield.js non-strict
+    method-definition/name-param-id-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/name-param-init-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/name-param-redecl.js
-    method-definition/name-prop-name-yield-expr.js non-strict
-    method-definition/name-prop-name-yield-id.js non-strict
+    method-definition/name-prop-name-yield-expr.js non-strict {compiled-non-strict}
+    method-definition/name-prop-name-yield-id.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
     method-definition/params-dflt-meth-ref-arguments.js
     method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
@@ -5333,63 +4357,57 @@ language/expressions/object 698/1170 (59.66%)
     method-definition/static-init-await-reference-normal.js
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
-    method-definition/yield-as-function-expression-binding-identifier.js non-strict
-    method-definition/yield-as-identifier-in-nested-function.js non-strict
+    method-definition/yield-as-function-expression-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/yield-as-identifier-in-nested-function.js non-strict {compiled-non-strict,interpreted-non-strict}
     method-definition/yield-star-after-newline.js
     method-definition/yield-star-before-newline.js
-    11.1.5-2gs.js strict
-    11.1.5_4-4-a-3.js strict
-    11.1.5_4-4-b-1.js strict
-    __proto__-duplicate.js non-strict
+    __proto__-duplicate.js {compiled-non-strict,interpreted-non-strict}
     __proto__-duplicate-computed.js
     __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-id.js non-strict
+    accessor-name-computed-yield-id.js non-strict {compiled-non-strict,interpreted-non-strict}
     computed-__proto__.js
     cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
     cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
     cpn-obj-lit-computed-property-name-from-yield-expression.js
     fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
-    getter-body-strict-inside.js non-strict
+    getter-body-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
     getter-param-dflt.js
     ident-name-prop-name-literal-await-static-init.js
-    identifier-shorthand-await-strict-mode.js non-strict
+    identifier-shorthand-await-strict-mode.js non-strict {compiled-non-strict,interpreted-non-strict}
     identifier-shorthand-static-init-await-valid.js
-    let-non-strict-access.js non-strict
-    let-non-strict-syntax.js non-strict
+    let-non-strict-access.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-non-strict-syntax.js non-strict {compiled-non-strict,interpreted-non-strict}
     literal-property-name-bigint.js {unsupported: [class]}
     object-spread-proxy-get-not-called-on-dontenum-keys.js
     object-spread-proxy-no-excluded-keys.js
     object-spread-proxy-ownkeys-returned-keys-order.js
-    prop-def-id-eval-error.js non-strict
-    prop-def-id-eval-error-2.js non-strict
-    prop-dup-data-data.js strict
-    prop-dup-data-set.js strict
-    prop-dup-get-data.js strict
-    prop-dup-get-get.js strict
-    prop-dup-get-set-get.js strict
-    prop-dup-set-data.js strict
-    prop-dup-set-get-set.js strict
-    prop-dup-set-set.js strict
-    scope-gen-meth-body-lex-distinct.js non-strict
-    scope-gen-meth-param-rest-elem-var-close.js non-strict
-    scope-gen-meth-param-rest-elem-var-open.js non-strict
+    prop-def-id-eval-error.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prop-def-id-eval-error-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prop-dup-get-data.js strict {compiled-strict,interpreted-strict}
+    prop-dup-get-get.js strict {compiled-strict,interpreted-strict}
+    prop-dup-get-set-get.js strict {compiled-strict,interpreted-strict}
+    prop-dup-set-get-set.js strict {compiled-strict,interpreted-strict}
+    prop-dup-set-set.js strict {compiled-strict,interpreted-strict}
+    scope-gen-meth-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-gen-meth-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-gen-meth-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-gen-meth-paramsbody-var-open.js
-    scope-getter-body-lex-distinc.js non-strict
-    scope-meth-body-lex-distinct.js non-strict
-    scope-meth-param-rest-elem-var-close.js non-strict
-    scope-meth-param-rest-elem-var-open.js non-strict
+    scope-getter-body-lex-distinc.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-meth-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-meth-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-meth-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-meth-paramsbody-var-open.js
-    scope-setter-body-lex-distinc.js non-strict
+    scope-setter-body-lex-distinc.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-setter-paramsbody-var-open.js
-    setter-body-strict-inside.js non-strict
+    setter-body-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
     setter-length-dflt.js
-    setter-param-arguments-strict-inside.js non-strict
-    setter-param-eval-strict-inside.js non-strict
-    yield-non-strict-access.js non-strict
-    yield-non-strict-syntax.js non-strict
+    setter-param-arguments-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
+    setter-param-eval-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-non-strict-access.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-non-strict-syntax.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/expressions/optional-chaining 18/38 (47.37%)
     call-expression.js
@@ -5412,10 +4430,10 @@ language/expressions/optional-chaining 18/38 (47.37%)
     super-property-optional-call.js
 
 language/expressions/postfix-decrement 9/37 (24.32%)
-    arguments.js strict
-    eval.js strict
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict
+    arguments.js strict {compiled-strict,interpreted-strict}
+    eval.js strict {compiled-strict,interpreted-strict}
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
@@ -5423,11 +4441,11 @@ language/expressions/postfix-decrement 9/37 (24.32%)
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/postfix-increment 10/38 (26.32%)
-    11.3.1-2-1gs.js strict
-    arguments.js strict
-    eval.js strict
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict
+    11.3.1-2-1gs.js strict {compiled-strict,interpreted-strict}
+    arguments.js strict {compiled-strict,interpreted-strict}
+    eval.js strict {compiled-strict,interpreted-strict}
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
@@ -5435,11 +4453,11 @@ language/expressions/postfix-increment 10/38 (26.32%)
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/prefix-decrement 10/34 (29.41%)
-    11.4.5-2-2gs.js strict
-    arguments.js strict
-    eval.js strict
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict
+    11.4.5-2-2gs.js strict {compiled-strict,interpreted-strict}
+    arguments.js strict {compiled-strict,interpreted-strict}
+    eval.js strict {compiled-strict,interpreted-strict}
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
@@ -5447,10 +4465,10 @@ language/expressions/prefix-decrement 10/34 (29.41%)
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/prefix-increment 9/33 (27.27%)
-    arguments.js strict
-    eval.js strict
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict
+    arguments.js strict {compiled-strict,interpreted-strict}
+    eval.js strict {compiled-strict,interpreted-strict}
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
@@ -5471,83 +4489,10 @@ language/expressions/strict-equals 0/30 (0.0%)
 language/expressions/subtraction 1/38 (2.63%)
     order-of-evaluation.js
 
-language/expressions/super 73/94 (77.66%)
-    call-arg-evaluation-err.js {unsupported: [class]}
-    call-bind-this-value.js {unsupported: [class]}
-    call-bind-this-value-twice.js {unsupported: [class]}
-    call-construct-error.js {unsupported: [class]}
-    call-construct-invocation.js {unsupported: [new.target, class]}
-    call-expr-value.js {unsupported: [class]}
-    call-poisoned-underscore-proto.js {unsupported: [class]}
-    call-proto-not-ctor.js {unsupported: [class]}
-    call-spread-err-mult-err-expr-throws.js
-    call-spread-err-mult-err-iter-get-value.js
-    call-spread-err-mult-err-itr-get-call.js
-    call-spread-err-mult-err-itr-get-get.js
-    call-spread-err-mult-err-itr-step.js
-    call-spread-err-mult-err-itr-value.js
-    call-spread-err-mult-err-obj-unresolvable.js
-    call-spread-err-mult-err-unresolvable.js
-    call-spread-err-sngl-err-expr-throws.js
-    call-spread-err-sngl-err-itr-get-call.js
-    call-spread-err-sngl-err-itr-get-get.js
-    call-spread-err-sngl-err-itr-get-value.js
-    call-spread-err-sngl-err-itr-step.js
-    call-spread-err-sngl-err-itr-value.js
-    call-spread-err-sngl-err-obj-unresolvable.js
-    call-spread-err-sngl-err-unresolvable.js
-    call-spread-mult-empty.js
-    call-spread-mult-expr.js
-    call-spread-mult-iter.js
-    call-spread-mult-literal.js
-    call-spread-mult-obj-ident.js
-    call-spread-mult-obj-null.js
-    call-spread-mult-obj-undefined.js
-    call-spread-obj-getter-descriptor.js
-    call-spread-obj-getter-init.js
-    call-spread-obj-manipulate-outter-obj-in-getter.js
-    call-spread-obj-mult-spread.js
-    call-spread-obj-mult-spread-getter.js
-    call-spread-obj-null.js
-    call-spread-obj-override-immutable.js
-    call-spread-obj-overrides-prev-properties.js
-    call-spread-obj-skip-non-enumerable.js
-    call-spread-obj-spread-order.js
-    call-spread-obj-symbol-property.js
-    call-spread-obj-undefined.js
-    call-spread-obj-with-overrides.js
-    call-spread-sngl-empty.js
-    call-spread-sngl-expr.js
-    call-spread-sngl-iter.js
-    call-spread-sngl-literal.js
-    call-spread-sngl-obj-ident.js
-    prop-dot-cls-null-proto.js {unsupported: [class]}
-    prop-dot-cls-ref-strict.js {unsupported: [class]}
-    prop-dot-cls-ref-this.js
-    prop-dot-cls-this-uninit.js {unsupported: [class]}
-    prop-dot-cls-val.js {unsupported: [class]}
-    prop-dot-cls-val-from-arrow.js {unsupported: [class]}
-    prop-dot-cls-val-from-eval.js {unsupported: [class]}
-    prop-expr-cls-err.js {unsupported: [class]}
-    prop-expr-cls-key-err.js {unsupported: [class]}
-    prop-expr-cls-null-proto.js {unsupported: [class]}
-    prop-expr-cls-ref-strict.js {unsupported: [class]}
-    prop-expr-cls-ref-this.js
-    prop-expr-cls-this-uninit.js {unsupported: [class]}
-    prop-expr-cls-unresolvable.js {unsupported: [class]}
-    prop-expr-cls-val.js {unsupported: [class]}
-    prop-expr-cls-val-from-arrow.js {unsupported: [class]}
-    prop-expr-cls-val-from-eval.js {unsupported: [class]}
-    prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js interpreted
-    prop-expr-uninitialized-this-getvalue.js
-    prop-expr-uninitialized-this-putvalue.js
-    prop-expr-uninitialized-this-putvalue-compound-assign.js
-    prop-expr-uninitialized-this-putvalue-increment.js
-    realm.js
-    super-reference-resolution.js {unsupported: [class]}
+~language/expressions/super
 
 language/expressions/tagged-template 3/27 (11.11%)
-    call-expression-context-strict.js strict
+    call-expression-context-strict.js strict {compiled-strict,interpreted-strict}
     tco-call.js {unsupported: [tail-call-optimization]}
     tco-member.js {unsupported: [tail-call-optimization]}
 
@@ -5576,77 +4521,77 @@ language/expressions/yield 4/63 (6.35%)
     star-rhs-iter-nrml-next-invoke.js
 
 language/function-code 96/217 (44.24%)
-    10.4.3-1-1-s.js non-strict
-    10.4.3-1-10-s.js non-strict
-    10.4.3-1-104.js strict
-    10.4.3-1-106.js strict
-    10.4.3-1-10gs.js non-strict
-    10.4.3-1-11-s.js strict
-    10.4.3-1-11gs.js strict
-    10.4.3-1-12-s.js non-strict
-    10.4.3-1-12gs.js non-strict
-    10.4.3-1-14-s.js non-strict
-    10.4.3-1-14gs.js non-strict
-    10.4.3-1-16-s.js non-strict
-    10.4.3-1-16gs.js non-strict
-    10.4.3-1-17-s.js strict
-    10.4.3-1-2-s.js non-strict
-    10.4.3-1-27-s.js strict
-    10.4.3-1-27gs.js strict
-    10.4.3-1-28-s.js strict
-    10.4.3-1-28gs.js strict
-    10.4.3-1-29-s.js strict
-    10.4.3-1-29gs.js strict
-    10.4.3-1-3-s.js non-strict
-    10.4.3-1-30-s.js strict
-    10.4.3-1-30gs.js strict
-    10.4.3-1-31-s.js strict
-    10.4.3-1-31gs.js strict
-    10.4.3-1-32-s.js strict
-    10.4.3-1-32gs.js strict
-    10.4.3-1-33-s.js strict
-    10.4.3-1-33gs.js strict
-    10.4.3-1-34-s.js strict
-    10.4.3-1-34gs.js strict
-    10.4.3-1-35-s.js strict
-    10.4.3-1-35gs.js strict
-    10.4.3-1-36-s.js non-strict
-    10.4.3-1-36gs.js non-strict
-    10.4.3-1-37-s.js non-strict
-    10.4.3-1-37gs.js non-strict
-    10.4.3-1-38-s.js non-strict
-    10.4.3-1-38gs.js non-strict
-    10.4.3-1-39-s.js non-strict
-    10.4.3-1-39gs.js non-strict
-    10.4.3-1-4-s.js non-strict
-    10.4.3-1-40-s.js non-strict
-    10.4.3-1-40gs.js non-strict
-    10.4.3-1-41-s.js non-strict
-    10.4.3-1-41gs.js non-strict
-    10.4.3-1-42-s.js non-strict
-    10.4.3-1-42gs.js non-strict
-    10.4.3-1-43-s.js non-strict
-    10.4.3-1-43gs.js non-strict
-    10.4.3-1-44-s.js non-strict
-    10.4.3-1-44gs.js non-strict
-    10.4.3-1-45-s.js non-strict
-    10.4.3-1-45gs.js non-strict
-    10.4.3-1-46-s.js non-strict
-    10.4.3-1-46gs.js non-strict
-    10.4.3-1-47-s.js non-strict
-    10.4.3-1-47gs.js non-strict
-    10.4.3-1-48-s.js non-strict
-    10.4.3-1-48gs.js non-strict
-    10.4.3-1-49-s.js non-strict
-    10.4.3-1-49gs.js non-strict
-    10.4.3-1-50-s.js non-strict
-    10.4.3-1-50gs.js non-strict
-    10.4.3-1-51-s.js non-strict
-    10.4.3-1-51gs.js non-strict
-    10.4.3-1-52-s.js non-strict
-    10.4.3-1-52gs.js non-strict
-    10.4.3-1-53-s.js non-strict
-    10.4.3-1-53gs.js non-strict
+    10.4.3-1-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-10-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-104.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-106.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-10gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-11-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-11gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-12-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-12gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-14-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-14gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-16-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-16gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-17-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-2-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-27-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-27gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-28-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-28gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-29-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-29gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-3-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-30-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-30gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-31-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-31gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-32-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-32gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-33-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-33gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-34-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-34gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-35-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-35gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-36-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-36gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-37-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-37gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-38-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-38gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-39-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-39gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-4-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-40-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-40gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-41-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-41gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-42-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-42gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-43-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-43gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-44-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-44gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-45-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-45gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-46-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-46gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-47-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-47gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-48-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-48gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-49-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-49gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-50-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-50gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-51-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-51gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-52-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-52gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-53-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-53gs.js non-strict {compiled-non-strict,interpreted-non-strict}
     10.4.3-1-62-s.js
     10.4.3-1-62gs.js
     10.4.3-1-63-s.js
@@ -5655,38 +4600,38 @@ language/function-code 96/217 (44.24%)
     10.4.3-1-64gs.js
     10.4.3-1-65-s.js
     10.4.3-1-65gs.js
-    10.4.3-1-7-s.js strict
+    10.4.3-1-7-s.js strict {compiled-strict,interpreted-strict}
     10.4.3-1-76-s.js
     10.4.3-1-76gs.js
     10.4.3-1-77-s.js
     10.4.3-1-77gs.js
     10.4.3-1-78-s.js
     10.4.3-1-78gs.js
-    10.4.3-1-7gs.js strict
-    10.4.3-1-8-s.js non-strict
-    10.4.3-1-8gs.js non-strict
-    10.4.3-1-9-s.js strict
-    10.4.3-1-9gs.js strict
-    block-decl-onlystrict.js strict
-    eval-param-env-with-computed-key.js non-strict
-    S10.4.3_A1.js strict
-    switch-case-decl-onlystrict.js strict
-    switch-dflt-decl-onlystrict.js strict
+    10.4.3-1-7gs.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-8-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-8gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-9-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-9gs.js strict {compiled-strict,interpreted-strict}
+    block-decl-onlystrict.js strict {compiled-strict,interpreted-strict}
+    eval-param-env-with-computed-key.js non-strict {compiled-non-strict,interpreted-non-strict}
+    S10.4.3_A1.js strict {compiled-strict,interpreted-strict}
+    switch-case-decl-onlystrict.js strict {compiled-strict,interpreted-strict}
+    switch-dflt-decl-onlystrict.js strict {compiled-strict,interpreted-strict}
 
 language/future-reserved-words 7/55 (12.73%)
-    implements.js non-strict
-    interface.js non-strict
-    package.js non-strict
-    private.js non-strict
-    protected.js non-strict
-    public.js non-strict
-    static.js non-strict
+    implements.js non-strict {compiled-non-strict,interpreted-non-strict}
+    interface.js non-strict {compiled-non-strict,interpreted-non-strict}
+    package.js non-strict {compiled-non-strict,interpreted-non-strict}
+    private.js non-strict {compiled-non-strict,interpreted-non-strict}
+    protected.js non-strict {compiled-non-strict,interpreted-non-strict}
+    public.js non-strict {compiled-non-strict,interpreted-non-strict}
+    static.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/global-code 26/42 (61.9%)
-    block-decl-strict.js strict
+    block-decl-strict.js strict {compiled-strict,interpreted-strict}
     decl-lex.js
     decl-lex-configurable-global.js
-    decl-lex-deletion.js non-strict
+    decl-lex-deletion.js non-strict {compiled-non-strict,interpreted-non-strict}
     decl-lex-restricted-global.js
     invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
     invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
@@ -5696,19 +4641,19 @@ language/global-code 26/42 (61.9%)
     new.target-arrow.js {unsupported: [new.target]}
     script-decl-func.js
     script-decl-func-err-non-configurable.js
-    script-decl-func-err-non-extensible.js non-strict
+    script-decl-func-err-non-extensible.js non-strict {compiled-non-strict,interpreted-non-strict}
     script-decl-lex.js
-    script-decl-lex-deletion.js non-strict
+    script-decl-lex-deletion.js non-strict {compiled-non-strict,interpreted-non-strict}
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
-    script-decl-lex-var-declared-via-eval.js
+    script-decl-lex-var-declared-via-eval.js {compiled-non-strict,interpreted-non-strict}
     script-decl-var.js
     script-decl-var-collision.js
-    script-decl-var-err.js non-strict
-    switch-case-decl-strict.js strict
-    switch-dflt-decl-strict.js strict
-    yield-non-strict.js non-strict
+    script-decl-var-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    switch-case-decl-strict.js strict {compiled-strict,interpreted-strict}
+    switch-dflt-decl-strict.js strict {compiled-strict,interpreted-strict}
+    yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/identifier-resolution 0/14 (0.0%)
 
@@ -5819,20 +4764,20 @@ language/keywords 0/25 (0.0%)
 language/line-terminators 0/41 (0.0%)
 
 language/literals 43/534 (8.05%)
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
-    bigint/legacy-octal-like-invalid-00n.js non-strict
-    bigint/legacy-octal-like-invalid-01n.js non-strict
-    bigint/legacy-octal-like-invalid-07n.js non-strict
-    bigint/non-octal-like-invalid-0008n.js non-strict
-    bigint/non-octal-like-invalid-012348n.js non-strict
-    bigint/non-octal-like-invalid-08n.js non-strict
-    bigint/non-octal-like-invalid-09n.js non-strict
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/legacy-octal-like-invalid-00n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/legacy-octal-like-invalid-01n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/legacy-octal-like-invalid-07n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/non-octal-like-invalid-0008n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/non-octal-like-invalid-012348n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/non-octal-like-invalid-08n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/non-octal-like-invalid-09n.js non-strict {compiled-non-strict,interpreted-non-strict}
     boolean/false-with-unicode.js
     boolean/true-with-unicode.js
     null/null-with-unicode.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     numeric/numeric-followed-by-ident.js
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
@@ -5844,24 +4789,24 @@ language/literals 43/534 (8.05%)
     regexp/S7.8.5_A2.1_T2.js
     regexp/S7.8.5_A2.4_T2.js
     regexp/u-case-mapping.js
-    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-8-strict.js strict
-    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-9-strict.js strict
-    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict
-    string/legacy-non-octal-escape-sequence-strict.js strict
+    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-8-strict.js strict {compiled-strict,interpreted-strict}
+    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-9-strict.js strict {compiled-strict,interpreted-strict}
+    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
+    string/legacy-non-octal-escape-sequence-strict.js strict {compiled-strict,interpreted-strict}
     string/legacy-octal-escape-sequence-prologue-strict.js
-    string/legacy-octal-escape-sequence-strict.js strict
+    string/legacy-octal-escape-sequence-strict.js strict {compiled-strict,interpreted-strict}
     string/mongolian-vowel-separator.js {unsupported: [u180e]}
     string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
-    string/S7.8.4_A4.3_T1.js strict
-    string/S7.8.4_A4.3_T2.js strict
+    string/S7.8.4_A4.3_T1.js strict {compiled-strict,interpreted-strict}
+    string/S7.8.4_A4.3_T2.js strict {compiled-strict,interpreted-strict}
 
 ~language/module-code
 
@@ -5874,7 +4819,7 @@ language/reserved-words 2/27 (7.41%)
 language/rest-parameters 5/11 (45.45%)
     array-pattern.js
     arrow-function.js
-    no-alias-arguments.js non-strict
+    no-alias-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
     object-pattern.js
     with-new-target.js
 
@@ -5907,7 +4852,7 @@ language/statementList 21/80 (26.25%)
 
 ~language/statements/async-generator
 
-~language/statements/await-using
+~language/statements/async-generator
 
 language/statements/block 7/21 (33.33%)
     early-errors 4/4 (100.0%)
@@ -6021,7 +4966,7 @@ language/statements/do-while 10/36 (27.78%)
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     tco-body.js {unsupported: [tail-call-optimization]}
 
 language/statements/empty 0/2 (0.0%)
@@ -6165,7 +5110,7 @@ language/statements/for 230/385 (59.74%)
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
-    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
+    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict {compiled-strict,interpreted-strict}
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
     dstr/let-obj-ptrn-prop-obj.js
@@ -6245,13 +5190,13 @@ language/statements/for 230/385 (59.74%)
     head-init-expr-check-empty-inc-empty-completion.js
     head-init-var-check-empty-inc-empty-completion.js
     head-let-bound-names-in-stmt.js
-    head-lhs-let.js non-strict
+    head-lhs-let.js non-strict {compiled-non-strict,interpreted-non-strict}
     labelled-fn-stmt-expr.js
     labelled-fn-stmt-let.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-open.js
@@ -6284,16 +5229,16 @@ language/statements/for-in 40/115 (34.78%)
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
     head-let-fresh-binding-per-iteration.js
-    head-lhs-let.js non-strict
+    head-lhs-let.js non-strict {compiled-non-strict,interpreted-non-strict}
     head-var-bound-names-dup.js
-    head-var-bound-names-let.js non-strict
-    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict
+    head-var-bound-names-let.js non-strict {compiled-non-strict,interpreted-non-strict}
+    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     order-enumerable-shadowed.js
     resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     scope-body-lex-boundary.js
@@ -6302,7 +5247,7 @@ language/statements/for-in 40/115 (34.78%)
     scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js non-strict
+    scope-head-var-none.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-init-evaluation.js
@@ -6313,8 +5258,8 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js non-strict
-    dstr/array-elem-init-yield-ident-valid.js non-strict
+    dstr/array-elem-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -6326,15 +5271,15 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
-    dstr/array-elem-put-const.js non-strict
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js strict
-    dstr/array-elem-target-yield-valid.js non-strict
+    dstr/array-elem-target-simple-strict.js strict {compiled-strict,interpreted-strict}
+    dstr/array-elem-target-yield-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -6401,24 +5346,24 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js non-strict
-    dstr/array-rest-put-unresolvable-strict.js strict
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-put-unresolvable-strict.js strict {compiled-strict,interpreted-strict}
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js non-strict
+    dstr/array-rest-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -6565,7 +5510,7 @@ language/statements/for-of 438/751 (58.32%)
     dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js non-strict
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-id-init-assignment-missing.js
     dstr/obj-id-init-assignment-null.js
     dstr/obj-id-init-assignment-truthy.js
@@ -6579,10 +5524,10 @@ language/statements/for-of 438/751 (58.32%)
     dstr/obj-id-init-in.js
     dstr/obj-id-init-let.js
     dstr/obj-id-init-order.js
-    dstr/obj-id-init-simple-no-strict.js non-strict
+    dstr/obj-id-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-id-init-yield-expr.js
-    dstr/obj-id-init-yield-ident-valid.js non-strict
-    dstr/obj-id-put-const.js non-strict
+    dstr/obj-id-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
@@ -6591,16 +5536,16 @@ language/statements/for-of 438/751 (58.32%)
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
-    dstr/obj-prop-put-const.js non-strict
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
     dstr/obj-prop-put-let.js
     dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
     dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
@@ -6715,7 +5660,7 @@ language/statements/for-of 438/751 (58.32%)
     head-lhs-async-invalid.js
     head-using-bound-names-fordecl-tdz.js
     head-using-fresh-binding-per-iteration.js
-    head-var-bound-names-let.js non-strict
+    head-var-bound-names-let.js non-strict {compiled-non-strict,interpreted-non-strict}
     head-var-init.js
     head-var-no-expr.js
     iterator-close-non-object.js
@@ -6731,9 +5676,9 @@ language/statements/for-of 438/751 (58.32%)
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-close.js
@@ -6854,56 +5799,56 @@ language/statements/function 162/451 (35.92%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
-    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
-    13.0-13-s.js non-strict
-    13.0-14-s.js non-strict
-    13.1-22-s.js non-strict
+    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.0-13-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.0-14-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.1-22-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     13.2-10-s.js
     13.2-13-s.js
     13.2-14-s.js
     13.2-17-s.js
     13.2-18-s.js
-    13.2-19-b-3gs.js strict
-    13.2-2-s.js strict
-    13.2-21-s.js non-strict
-    13.2-22-s.js non-strict
-    13.2-25-s.js non-strict
-    13.2-26-s.js non-strict
+    13.2-19-b-3gs.js strict {compiled-strict,interpreted-strict}
+    13.2-2-s.js strict {compiled-strict,interpreted-strict}
+    13.2-21-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-22-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-25-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-26-s.js non-strict {compiled-non-strict,interpreted-non-strict}
     13.2-30-s.js
-    13.2-4-s.js strict
-    13.2-5-s.js non-strict
-    13.2-6-s.js non-strict
-    13.2-9-s.js non-strict
-    arguments-with-arguments-fn.js non-strict
-    arguments-with-arguments-lex.js non-strict
+    13.2-4-s.js strict {compiled-strict,interpreted-strict}
+    13.2-5-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-6-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-9-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments-with-arguments-lex.js non-strict {compiled-non-strict,interpreted-non-strict}
     array-destructuring-param-strict-body.js
     cptn-decl.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     length-dflt.js
-    name-arguments-strict-body.js non-strict
-    name-eval-strict-body.js non-strict
+    name-arguments-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    name-eval-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
     object-destructuring-param-strict-body.js
-    param-arguments-strict-body.js non-strict
-    param-dflt-yield-non-strict.js non-strict
-    param-dflt-yield-strict.js strict
-    param-duplicated-strict-body-1.js non-strict
-    param-duplicated-strict-body-2.js non-strict
-    param-duplicated-strict-body-3.js non-strict
-    param-eval-strict-body.js non-strict
+    param-arguments-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-dflt-yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-dflt-yield-strict.js strict {compiled-strict,interpreted-strict}
+    param-duplicated-strict-body-1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-duplicated-strict-body-2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-duplicated-strict-body-3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-eval-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-paramsbody-var-open.js
     static-init-await-binding-valid.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
+    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/statements/generators 168/266 (63.16%)
     dstr/ary-init-iter-close.js
@@ -7039,17 +5984,17 @@ language/statements/generators 168/266 (63.16%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
     array-destructuring-param-strict-body.js
     cptn-decl.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js non-strict
+    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict
+    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
@@ -7058,17 +6003,17 @@ language/statements/generators 168/266 (63.16%)
     prototype-value.js
     rest-param-strict-body.js
     restricted-properties.js
-    scope-body-lex-distinct.js non-strict
-    scope-param-rest-elem-var-close.js non-strict
-    scope-param-rest-elem-var-open.js non-strict
+    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
     scope-paramsbody-var-open.js
-    unscopables-with.js non-strict
-    unscopables-with-in-nested-fn.js non-strict
-    yield-as-function-expression-binding-identifier.js non-strict
-    yield-as-generator-declaration-binding-identifier.js non-strict
-    yield-as-identifier-in-nested-function.js non-strict
-    yield-identifier-non-strict.js non-strict
-    yield-identifier-spread-non-strict.js non-strict
+    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-as-function-expression-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-as-generator-declaration-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-as-identifier-in-nested-function.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
@@ -7092,12 +6037,12 @@ language/statements/if 42/69 (60.87%)
     if-const-else-const.js
     if-const-else-stmt.js
     if-const-no-else.js
-    if-decl-else-decl-strict.js strict
-    if-decl-else-stmt-strict.js strict
-    if-decl-no-else-strict.js strict
-    if-fun-else-fun-strict.js strict
-    if-fun-else-stmt-strict.js strict
-    if-fun-no-else-strict.js strict
+    if-decl-else-decl-strict.js strict {compiled-strict,interpreted-strict}
+    if-decl-else-stmt-strict.js strict {compiled-strict,interpreted-strict}
+    if-decl-no-else-strict.js strict {compiled-strict,interpreted-strict}
+    if-fun-else-fun-strict.js strict {compiled-strict,interpreted-strict}
+    if-fun-else-stmt-strict.js strict {compiled-strict,interpreted-strict}
+    if-fun-no-else-strict.js strict {compiled-strict,interpreted-strict}
     if-gen-else-gen.js
     if-gen-else-stmt.js
     if-gen-no-else.js
@@ -7107,15 +6052,15 @@ language/statements/if 42/69 (60.87%)
     if-stmt-else-async-fun.js {unsupported: [async-functions]}
     if-stmt-else-async-gen.js {unsupported: [async-iteration]}
     if-stmt-else-const.js
-    if-stmt-else-decl-strict.js strict
-    if-stmt-else-fun-strict.js strict
+    if-stmt-else-decl-strict.js strict {compiled-strict,interpreted-strict}
+    if-stmt-else-fun-strict.js strict {compiled-strict,interpreted-strict}
     if-stmt-else-gen.js
     if-stmt-else-let.js
     labelled-fn-stmt-first.js
     labelled-fn-stmt-lone.js
     labelled-fn-stmt-second.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     tco-else-body.js {unsupported: [tail-call-optimization]}
     tco-if-body.js {unsupported: [tail-call-optimization]}
 
@@ -7123,18 +6068,18 @@ language/statements/labeled 15/24 (62.5%)
     decl-async-function.js {unsupported: [async-functions]}
     decl-async-generator.js {unsupported: [async-iteration]}
     decl-const.js
-    decl-fun-strict.js strict
+    decl-fun-strict.js strict {compiled-strict,interpreted-strict}
     decl-gen.js
     decl-let.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     tco.js {unsupported: [tail-call-optimization]}
     value-await-module.js {unsupported: [module]}
     value-await-module-escaped.js {unsupported: [module]}
     value-await-non-module.js
     value-await-non-module-escaped.js
-    value-yield-non-strict.js non-strict
-    value-yield-non-strict-escaped.js non-strict
+    value-yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    value-yield-non-strict-escaped.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/statements/let 80/145 (55.17%)
     dstr/ary-init-iter-close.js
@@ -7191,7 +6136,7 @@ language/statements/let 80/145 (55.17%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    syntax/escaped-let.js non-strict
+    syntax/escaped-let.js non-strict {compiled-non-strict,interpreted-non-strict}
     syntax/let-closure-inside-condition.js
     syntax/let-closure-inside-initialization.js
     syntax/let-closure-inside-next-expression.js
@@ -7244,7 +6189,7 @@ language/statements/switch 62/111 (55.86%)
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict {compiled-strict,interpreted-strict}
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
@@ -7375,12 +6320,12 @@ language/statements/try 113/201 (56.22%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    12.14-13.js non-strict
-    12.14-14.js non-strict
-    12.14-15.js non-strict
-    12.14-16.js non-strict
+    12.14-13.js non-strict {compiled-non-strict,interpreted-non-strict}
+    12.14-14.js non-strict {compiled-non-strict,interpreted-non-strict}
+    12.14-15.js non-strict {compiled-non-strict,interpreted-non-strict}
+    12.14-16.js non-strict {compiled-non-strict,interpreted-non-strict}
     completion-values.js
-    completion-values-fn-finally-abrupt.js compiled
+    completion-values-fn-finally-abrupt.js compiled {compiled-strict,compiled-non-strict}
     cptn-catch.js
     cptn-catch-empty-break.js
     cptn-catch-empty-continue.js
@@ -7396,13 +6341,11 @@ language/statements/try 113/201 (56.22%)
     early-catch-lex.js
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js
-    scope-catch-param-var-none.js non-strict
+    scope-catch-param-var-none.js non-strict {compiled-non-strict,interpreted-non-strict}
     static-init-await-binding-valid.js
     tco-catch.js {unsupported: [tail-call-optimization]}
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
-
-~language/statements/using 1/1 (100.0%)
 
 language/statements/variable 62/178 (34.83%)
     dstr/ary-init-iter-close.js
@@ -7461,10 +6404,10 @@ language/statements/variable 62/178 (34.83%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    12.2.1-10-s.js strict
-    12.2.1-20-s.js strict
-    12.2.1-21-s.js strict
-    12.2.1-9-s.js strict
+    12.2.1-10-s.js strict {compiled-strict,interpreted-strict}
+    12.2.1-20-s.js strict {compiled-strict,interpreted-strict}
+    12.2.1-21-s.js strict {compiled-strict,interpreted-strict}
+    12.2.1-9-s.js strict {compiled-strict,interpreted-strict}
     fn-name-class.js {unsupported: [class]}
     static-init-await-binding-valid.js
 
@@ -7478,51 +6421,51 @@ language/statements/while 13/38 (34.21%)
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
-    let-identifier-with-newline.js non-strict
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     tco-body.js {unsupported: [tail-call-optimization]}
 
 language/statements/with 28/181 (15.47%)
-    binding-blocked-by-unscopables.js non-strict
-    cptn-abrupt-empty.js non-strict
-    cptn-nrml.js non-strict
+    binding-blocked-by-unscopables.js non-strict {compiled-non-strict,interpreted-non-strict}
+    cptn-abrupt-empty.js non-strict {compiled-non-strict,interpreted-non-strict}
+    cptn-nrml.js non-strict {compiled-non-strict,interpreted-non-strict}
     decl-async-fun.js {unsupported: [async-functions]}
     decl-async-gen.js {unsupported: [async-iteration]}
-    decl-const.js non-strict
-    decl-fun.js non-strict
-    decl-gen.js non-strict
-    decl-let.js non-strict
+    decl-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    decl-fun.js non-strict {compiled-non-strict,interpreted-non-strict}
+    decl-gen.js non-strict {compiled-non-strict,interpreted-non-strict}
+    decl-let.js non-strict {compiled-non-strict,interpreted-non-strict}
     get-binding-value-call-with-proxy-env.js non-strict
     get-binding-value-idref-with-proxy-env.js non-strict
     get-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
     get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
     has-binding-call-with-proxy-env.js non-strict
     has-binding-idref-with-proxy-env.js non-strict
-    has-property-err.js non-strict
-    labelled-fn-stmt.js non-strict
-    let-array-with-newline.js non-strict
-    let-block-with-newline.js non-strict
+    has-property-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    labelled-fn-stmt.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
     set-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
     set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
     set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js non-strict
     set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js non-strict
     set-mutable-binding-idref-compound-assign-with-proxy-env.js non-strict
     set-mutable-binding-idref-with-proxy-env.js non-strict
-    unscopables-get-err.js non-strict
-    unscopables-inc-dec.js non-strict
-    unscopables-prop-get-err.js non-strict
+    unscopables-get-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-inc-dec.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-prop-get-err.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/types 9/113 (7.96%)
     number/S8.5_A10_T1.js
-    number/S8.5_A10_T2.js non-strict
+    number/S8.5_A10_T2.js non-strict {compiled-non-strict,interpreted-non-strict}
     number/S8.5_A4_T1.js
-    number/S8.5_A4_T2.js non-strict
+    number/S8.5_A4_T2.js non-strict {compiled-non-strict,interpreted-non-strict}
     reference/get-value-prop-base-primitive-realm.js
     reference/put-value-prop-base-primitive.js
     reference/put-value-prop-base-primitive-realm.js
     undefined/S8.1_A3_T1.js
-    undefined/S8.1_A3_T2.js non-strict
+    undefined/S8.1_A3_T2.js non-strict {compiled-non-strict,interpreted-non-strict}
 
 language/white-space 2/67 (2.99%)
     mongolian-vowel-separator.js {unsupported: [u180e]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1,6 +1,428 @@
 # This is a configuration file for Test262SuiteTest.java. See ./README.md for more info about this file
 
-~annexB
+annexB/built-ins 58/241 (24.07%)
+    Array/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    Date/prototype/getYear/not-a-constructor.js
+    Date/prototype/setYear/not-a-constructor.js
+    Date/prototype/setYear/year-number-relative.js
+    Date/prototype/toGMTString/not-a-constructor.js
+    Function/createdynfn-html-close-comment-params.js
+    Function/createdynfn-html-open-comment-params.js
+    Function/createdynfn-no-line-terminator-html-close-comment-body.js
+    Object/is/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    RegExp/legacy-accessors/index 4/4 (100.0%)
+    RegExp/legacy-accessors/input 4/4 (100.0%)
+    RegExp/legacy-accessors/lastMatch 4/4 (100.0%)
+    RegExp/legacy-accessors/lastParen 4/4 (100.0%)
+    RegExp/legacy-accessors/leftContext 4/4 (100.0%)
+    RegExp/legacy-accessors/rightContext 4/4 (100.0%)
+    RegExp/prototype/compile/pattern-regexp-flags-defined.js
+    RegExp/prototype/compile/this-cross-realm-instance.js
+    RegExp/prototype/compile/this-subclass-instance.js {unsupported: [class]}
+    RegExp/prototype/flags/order-after-compile.js {unsupported: [regexp-dotall]}
+    RegExp/prototype/Symbol.split/Symbol.match-getter-recompiles-source.js
+    RegExp/incomplete_hex_unicode_escape.js
+    RegExp/RegExp-control-escape-russian-letter.js compiled
+    RegExp/RegExp-leading-escape-BMP.js
+    RegExp/RegExp-trailing-escape-BMP.js
+    String/prototype/anchor/length.js
+    String/prototype/fontcolor/length.js
+    String/prototype/fontsize/length.js
+    String/prototype/link/length.js
+    String/prototype/matchAll/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/match/custom-matcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/replaceAll/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/replace/custom-replacer-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/search/custom-searcher-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/split/custom-splitter-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    String/prototype/substr/start-and-length-as-numbers.js
+    String/prototype/trimLeft/name.js
+    String/prototype/trimLeft/reference-trimStart.js
+    String/prototype/trimRight/name.js
+    String/prototype/trimRight/reference-trimEnd.js
+    TypedArrayConstructors/from/iterator-method-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+
+annexB/language 386/845 (45.68%)
+    comments/multi-line-html-close.js
+    comments/single-line-html-close.js
+    comments/single-line-html-close-first-line-3.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-block-decl-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-else-decl-b-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-else-stmt-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-decl-no-else-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-if-stmt-else-decl-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-switch-case-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-block.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-in.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-for-of.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-switch.js non-strict
+    eval-code/direct/func-switch-dflt-eval-func-skip-early-err-try.js non-strict
+    eval-code/direct/global-block-decl-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-block-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-switch-case-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-switch-case-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-block-scoping.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
+    eval-code/direct/var-env-lower-lex-catch-non-strict.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-block-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-a-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-else-decl-b-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-else-stmt-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-decl-no-else-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-if-stmt-else-decl-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-switch-case-eval-global-skip-early-err-try.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-block-scoping.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-block.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-in.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-for-of.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-switch.js non-strict
+    eval-code/indirect/global-switch-dflt-eval-global-skip-early-err-try.js non-strict
+    expressions/assignment/dstr 2/2 (100.0%)
+    expressions/assignmenttargettype/callexpression.js non-strict
+    expressions/assignmenttargettype/callexpression-as-for-in-lhs.js non-strict
+    expressions/assignmenttargettype/callexpression-as-for-of-lhs.js non-strict
+    expressions/assignmenttargettype/callexpression-in-compound-assignment.js non-strict
+    expressions/assignmenttargettype/callexpression-in-postfix-update.js non-strict
+    expressions/assignmenttargettype/callexpression-in-prefix-update.js non-strict
+    expressions/coalesce/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/conditional/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/logical-and/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/logical-assignment 3/3 (100.0%)
+    expressions/logical-not/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/logical-or/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/strict-does-not-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/strict-equals/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/template-literal/legacy-octal-escape-sequence-strict.js strict
+    expressions/typeof/emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    expressions/yield 2/2 (100.0%)
+    function-code/block-decl-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/block-decl-func-init.js interpreted-non-strict
+    function-code/block-decl-func-no-skip-try.js interpreted-non-strict
+    function-code/block-decl-func-skip-arguments.js non-strict
+    function-code/block-decl-func-skip-dft-param.js non-strict
+    function-code/block-decl-func-skip-early-err.js non-strict
+    function-code/block-decl-func-skip-early-err-block.js non-strict
+    function-code/block-decl-func-skip-early-err-for.js non-strict
+    function-code/block-decl-func-skip-early-err-for-in.js non-strict
+    function-code/block-decl-func-skip-early-err-for-of.js non-strict
+    function-code/block-decl-func-skip-early-err-switch.js non-strict
+    function-code/block-decl-func-skip-early-err-try.js non-strict
+    function-code/block-decl-func-skip-param.js non-strict
+    function-code/block-decl-nested-blocks-with-fun-decl.js non-strict
+    function-code/block-decl-nostrict.js interpreted-non-strict
+    function-code/if-decl-else-decl-a-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-else-decl-a-func-skip-dft-param.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-block.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-for.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-early-err-try.js non-strict
+    function-code/if-decl-else-decl-a-func-skip-param.js non-strict
+    function-code/if-decl-else-decl-b-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-else-decl-b-func-skip-dft-param.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-block.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-for.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-early-err-try.js non-strict
+    function-code/if-decl-else-decl-b-func-skip-param.js non-strict
+    function-code/if-decl-else-stmt-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-else-stmt-func-skip-dft-param.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-block.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-for.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-else-stmt-func-skip-early-err-try.js non-strict
+    function-code/if-decl-else-stmt-func-skip-param.js non-strict
+    function-code/if-decl-no-else-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-decl-no-else-func-skip-dft-param.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-block.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-for.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-for-in.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-for-of.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-switch.js non-strict
+    function-code/if-decl-no-else-func-skip-early-err-try.js non-strict
+    function-code/if-decl-no-else-func-skip-param.js non-strict
+    function-code/if-stmt-else-decl-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/if-stmt-else-decl-func-skip-dft-param.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-block.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-for.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-for-in.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-for-of.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-switch.js non-strict
+    function-code/if-stmt-else-decl-func-skip-early-err-try.js non-strict
+    function-code/if-stmt-else-decl-func-skip-param.js non-strict
+    function-code/switch-case-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/switch-case-func-skip-dft-param.js non-strict
+    function-code/switch-case-func-skip-early-err.js non-strict
+    function-code/switch-case-func-skip-early-err-block.js non-strict
+    function-code/switch-case-func-skip-early-err-for.js non-strict
+    function-code/switch-case-func-skip-early-err-for-in.js non-strict
+    function-code/switch-case-func-skip-early-err-for-of.js non-strict
+    function-code/switch-case-func-skip-early-err-switch.js non-strict
+    function-code/switch-case-func-skip-early-err-try.js non-strict
+    function-code/switch-case-func-skip-param.js non-strict
+    function-code/switch-dflt-func-existing-block-fn-no-init.js interpreted-non-strict
+    function-code/switch-dflt-func-skip-dft-param.js non-strict
+    function-code/switch-dflt-func-skip-early-err.js non-strict
+    function-code/switch-dflt-func-skip-early-err-block.js non-strict
+    function-code/switch-dflt-func-skip-early-err-for.js non-strict
+    function-code/switch-dflt-func-skip-early-err-for-in.js non-strict
+    function-code/switch-dflt-func-skip-early-err-for-of.js non-strict
+    function-code/switch-dflt-func-skip-early-err-switch.js non-strict
+    function-code/switch-dflt-func-skip-early-err-try.js non-strict
+    function-code/switch-dflt-func-skip-param.js non-strict
+    global-code/block-decl-global-block-scoping.js non-strict
+    global-code/block-decl-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/block-decl-global-init.js interpreted-non-strict
+    global-code/block-decl-global-no-skip-try.js interpreted-non-strict
+    global-code/block-decl-global-skip-early-err.js non-strict
+    global-code/block-decl-global-skip-early-err-block.js non-strict
+    global-code/block-decl-global-skip-early-err-for.js non-strict
+    global-code/block-decl-global-skip-early-err-for-in.js non-strict
+    global-code/block-decl-global-skip-early-err-for-of.js non-strict
+    global-code/block-decl-global-skip-early-err-switch.js non-strict
+    global-code/block-decl-global-skip-early-err-try.js non-strict
+    global-code/if-decl-else-decl-a-global-block-scoping.js non-strict
+    global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-block.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-for.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-else-decl-a-global-skip-early-err-try.js non-strict
+    global-code/if-decl-else-decl-b-global-block-scoping.js non-strict
+    global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-block.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-for.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-else-decl-b-global-skip-early-err-try.js non-strict
+    global-code/if-decl-else-stmt-global-block-scoping.js non-strict
+    global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-block.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-for.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-else-stmt-global-skip-early-err-try.js non-strict
+    global-code/if-decl-no-else-global-block-scoping.js non-strict
+    global-code/if-decl-no-else-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-decl-no-else-global-skip-early-err.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-block.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-for.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-for-in.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-for-of.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-switch.js non-strict
+    global-code/if-decl-no-else-global-skip-early-err-try.js non-strict
+    global-code/if-stmt-else-decl-global-block-scoping.js non-strict
+    global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-block.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-for.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-for-in.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-for-of.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-switch.js non-strict
+    global-code/if-stmt-else-decl-global-skip-early-err-try.js non-strict
+    global-code/script-decl-lex-collision.js non-strict
+    global-code/switch-case-global-block-scoping.js non-strict
+    global-code/switch-case-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/switch-case-global-skip-early-err.js non-strict
+    global-code/switch-case-global-skip-early-err-block.js non-strict
+    global-code/switch-case-global-skip-early-err-for.js non-strict
+    global-code/switch-case-global-skip-early-err-for-in.js non-strict
+    global-code/switch-case-global-skip-early-err-for-of.js non-strict
+    global-code/switch-case-global-skip-early-err-switch.js non-strict
+    global-code/switch-case-global-skip-early-err-try.js non-strict
+    global-code/switch-dflt-global-block-scoping.js non-strict
+    global-code/switch-dflt-global-existing-block-fn-no-init.js interpreted-non-strict
+    global-code/switch-dflt-global-skip-early-err.js non-strict
+    global-code/switch-dflt-global-skip-early-err-block.js non-strict
+    global-code/switch-dflt-global-skip-early-err-for.js non-strict
+    global-code/switch-dflt-global-skip-early-err-for-in.js non-strict
+    global-code/switch-dflt-global-skip-early-err-for-of.js non-strict
+    global-code/switch-dflt-global-skip-early-err-switch.js non-strict
+    global-code/switch-dflt-global-skip-early-err-try.js non-strict
+    literals/regexp/class-escape.js
+    literals/regexp/identity-escape.js
+    literals/regexp/legacy-octal-escape.js
+    statements/class/subclass 2/2 (100.0%)
+    statements/const/dstr 2/2 (100.0%)
+    statements/for-await-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [async-iteration, IsHTMLDDA, async]}
+    statements/for-in/let-initializer.js
+    statements/for-in/strict-initializer.js strict
+    statements/for-of/iterator-close-return-emulates-undefined-throws-when-called.js {unsupported: [IsHTMLDDA]}
+    statements/function/default-parameters-emulates-undefined.js {unsupported: [IsHTMLDDA]}
+    statements/if/emulated-undefined.js {unsupported: [IsHTMLDDA]}
+    statements/switch/emulates-undefined.js {unsupported: [IsHTMLDDA]}
 
 harness 23/116 (19.83%)
     assert-notsamevalue-tostring.js {unsupported: [async-functions]}
@@ -27,6 +449,8 @@ harness 23/116 (19.83%)
     isConstructor.js
     nativeFunctionMatcher.js
 
+built-ins/AggregateError 25/25 (100.0%)
+
 built-ins/Array 263/3077 (8.55%)
     fromAsync 95/95 (100.0%)
     from/elements-deleted-after.js Checking to see if length changed, but spec says it should not
@@ -43,18 +467,18 @@ built-ins/Array 263/3077 (8.55%)
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
     prototype/copyWithin/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict {compiled-non-strict,interpreted-non-strict} Not throwing properly on unwritable
+    prototype/copyWithin/return-abrupt-from-delete-target.js non-strict Not throwing properly on unwritable
     prototype/entries/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/entries/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/every/15.4.4.16-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/every/15.4.4.16-5-1-s.js non-strict
     prototype/every/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/every/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/fill/typed-array-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/filter/15.4.4.20-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/filter/15.4.4.20-5-1-s.js non-strict
     prototype/filter/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/create-proto-from-ctor-realm-array.js
     prototype/filter/create-proxy.js
@@ -62,22 +486,22 @@ built-ins/Array 263/3077 (8.55%)
     prototype/filter/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/filter/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/findLastIndex/predicate-call-this-strict.js strict
     prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/findLast/predicate-call-this-strict.js strict
     prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/find/predicate-call-this-strict.js strict
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -85,9 +509,9 @@ built-ins/Array 263/3077 (8.55%)
     prototype/flatMap/this-value-ctor-non-object.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor.js
     prototype/flatMap/this-value-ctor-object-species-custom-ctor-poisoned-throws.js
-    prototype/flatMap/thisArg-argument.js strict {compiled-strict,interpreted-strict}
+    prototype/flatMap/thisArg-argument.js strict
     prototype/flat/proxy-access-count.js
-    prototype/forEach/15.4.4.18-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/forEach/15.4.4.18-5-1-s.js non-strict
     prototype/forEach/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/forEach/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -112,7 +536,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/lastIndexOf/coerced-position-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/map/15.4.4.19-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/map/15.4.4.19-5-1-s.js non-strict
     prototype/map/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/map/create-proto-from-ctor-realm-array.js
     prototype/map/create-proxy.js
@@ -124,7 +548,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/pop/set-length-zero-array-is-frozen.js non-strict
     prototype/pop/set-length-zero-array-length-is-non-writable.js non-strict
     prototype/pop/throws-with-string-receiver.js non-strict
-    prototype/push/length-near-integer-limit-set-failure.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/push/length-near-integer-limit-set-failure.js non-strict
     prototype/push/S15.4.4.7_A2_T2.js incorrect length handling
     prototype/push/set-length-array-is-frozen.js
     prototype/push/set-length-array-length-is-non-writable.js
@@ -132,12 +556,12 @@ built-ins/Array 263/3077 (8.55%)
     prototype/push/set-length-zero-array-length-is-non-writable.js
     prototype/push/throws-if-integer-limit-exceeded.js incorrect length handling
     prototype/push/throws-with-string-receiver.js non-strict
-    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/reduceRight/15.4.4.22-9-c-ii-4-s.js non-strict
     prototype/reduceRight/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
-    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/reduce/15.4.4.21-9-c-ii-4-s.js non-strict
     prototype/reduce/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/reduce/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -155,7 +579,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/slice/create-proxy.js
     prototype/slice/create-species.js
     prototype/slice/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    prototype/some/15.4.4.17-5-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/some/15.4.4.17-5-1-s.js non-strict
     prototype/some/callbackfn-resize-arraybuffer.js {unsupported: [resizable-arraybuffer]}
     prototype/some/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/some/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -164,7 +588,7 @@ built-ins/Array 263/3077 (8.55%)
     prototype/sort/comparefn-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/comparefn-shrink.js {unsupported: [resizable-arraybuffer]}
     prototype/sort/resizable-buffer-default-comparator.js {unsupported: [resizable-arraybuffer]}
-    prototype/sort/S15.4.4.11_A8.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/sort/S15.4.4.11_A8.js non-strict
     prototype/splice/clamps-length-to-integer-limit.js
     prototype/splice/create-proto-from-ctor-realm-array.js
     prototype/splice/create-proto-from-ctor-realm-non-array.js
@@ -174,12 +598,12 @@ built-ins/Array 263/3077 (8.55%)
     prototype/splice/create-species-length-exceeding-integer-limit.js
     prototype/splice/property-traps-order-with-species.js
     prototype/splice/S15.4.4.12_A6.1_T2.js incorrect length handling
-    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prototype/splice/S15.4.4.12_A6.1_T3.js non-strict
     prototype/splice/set_length_no_args.js
     prototype/Symbol.unscopables/change-array-by-copy.js
     prototype/toLocaleString/invoke-element-tolocalestring.js
-    prototype/toLocaleString/primitive_this_value.js strict {compiled-strict,interpreted-strict}
-    prototype/toLocaleString/primitive_this_value_getter.js strict {compiled-strict,interpreted-strict}
+    prototype/toLocaleString/primitive_this_value.js strict
+    prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/toLocaleString/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/user-provided-tolocalestring-grow.js {unsupported: [resizable-arraybuffer]}
     prototype/toLocaleString/user-provided-tolocalestring-shrink.js {unsupported: [resizable-arraybuffer]}
@@ -245,6 +669,8 @@ built-ins/ArrayBuffer 87/196 (44.39%)
     prototype-from-newtarget.js
 
 built-ins/ArrayIteratorPrototype 0/27 (0.0%)
+
+~built-ins/AsyncDisposableStack
 
 ~built-ins/AsyncFromSyncIteratorPrototype
 
@@ -511,6 +937,8 @@ built-ins/Date 85/594 (14.31%)
     proto-from-ctor-realm-zero.js
     year-zero.js
 
+~built-ins/DisposableStack
+
 built-ins/Error 7/53 (13.21%)
     isError/error-subclass.js {unsupported: [class]}
     isError/is-a-constructor.js
@@ -525,9 +953,9 @@ built-ins/Error 7/53 (13.21%)
 built-ins/Function 128/509 (25.15%)
     internals/Call 2/2 (100.0%)
     internals/Construct 6/6 (100.0%)
-    prototype/apply/15.3.4.3-1-s.js strict {compiled-strict,interpreted-strict}
-    prototype/apply/15.3.4.3-2-s.js strict {compiled-strict,interpreted-strict}
-    prototype/apply/15.3.4.3-3-s.js strict {compiled-strict,interpreted-strict}
+    prototype/apply/15.3.4.3-1-s.js strict
+    prototype/apply/15.3.4.3-2-s.js strict
+    prototype/apply/15.3.4.3-3-s.js strict
     prototype/apply/argarray-not-object.js
     prototype/apply/argarray-not-object-realm.js
     prototype/apply/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
@@ -548,9 +976,9 @@ built-ins/Function 128/509 (25.15%)
     prototype/bind/proto-from-ctor-realm.js
     prototype/caller-arguments/accessor-properties.js
     prototype/caller/prop-desc.js
-    prototype/call/15.3.4.4-1-s.js strict {compiled-strict,interpreted-strict}
-    prototype/call/15.3.4.4-2-s.js strict {compiled-strict,interpreted-strict}
-    prototype/call/15.3.4.4-3-s.js strict {compiled-strict,interpreted-strict}
+    prototype/call/15.3.4.4-1-s.js strict
+    prototype/call/15.3.4.4-2-s.js strict
+    prototype/call/15.3.4.4-3-s.js strict
     prototype/Symbol.hasInstance/this-val-poisoned-prototype.js
     prototype/toString/async-arrow-function.js {unsupported: [async-functions]}
     prototype/toString/async-function-declaration.js {unsupported: [async-functions]}
@@ -610,46 +1038,54 @@ built-ins/Function 128/509 (25.15%)
     prototype/toString/setter-class-statement-static.js
     prototype/toString/setter-object.js
     prototype/toString/symbol-named-builtins.js
-    15.3.2.1-10-6gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    15.3.2.1-11-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    15.3.2.1-11-3-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    15.3.2.1-11-5-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    15.3.5-1gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5-2gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-11gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-13gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-15gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-17gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-19gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-1gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-21gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-22gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-23gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-24gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-25gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-26gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-27gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-28gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-29gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-3gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-48gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-50gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-52gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-54gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-5gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-7gs.js strict {compiled-strict,interpreted-strict}
-    15.3.5.4_2-9gs.js strict {compiled-strict,interpreted-strict}
+    15.3.2.1-10-6gs.js non-strict
+    15.3.2.1-11-1-s.js non-strict
+    15.3.2.1-11-3-s.js non-strict
+    15.3.2.1-11-5-s.js non-strict
+    15.3.5-1gs.js strict
+    15.3.5-2gs.js strict
+    15.3.5.4_2-11gs.js strict
+    15.3.5.4_2-13gs.js strict
+    15.3.5.4_2-15gs.js strict
+    15.3.5.4_2-17gs.js strict
+    15.3.5.4_2-19gs.js strict
+    15.3.5.4_2-1gs.js strict
+    15.3.5.4_2-21gs.js strict
+    15.3.5.4_2-22gs.js strict
+    15.3.5.4_2-23gs.js strict
+    15.3.5.4_2-24gs.js strict
+    15.3.5.4_2-25gs.js strict
+    15.3.5.4_2-26gs.js strict
+    15.3.5.4_2-27gs.js strict
+    15.3.5.4_2-28gs.js strict
+    15.3.5.4_2-29gs.js strict
+    15.3.5.4_2-3gs.js strict
+    15.3.5.4_2-48gs.js strict
+    15.3.5.4_2-50gs.js strict
+    15.3.5.4_2-52gs.js strict
+    15.3.5.4_2-54gs.js strict
+    15.3.5.4_2-5gs.js strict
+    15.3.5.4_2-7gs.js strict
+    15.3.5.4_2-9gs.js strict
     call-bind-this-realm-undef.js
     call-bind-this-realm-value.js
     private-identifiers-not-empty.js {unsupported: [class-fields-private]}
     proto-from-ctor-realm.js
     proto-from-ctor-realm-prototype.js
-    StrictFunction_restricted-properties.js strict {compiled-strict,interpreted-strict}
+    StrictFunction_restricted-properties.js strict
 
-~built-ins/GeneratorFunction
+built-ins/GeneratorFunction 8/23 (34.78%)
+    prototype/constructor.js
+    prototype/prototype.js
+    prototype/Symbol.toStringTag.js
+    instance-construct-throws.js
+    instance-prototype.js
+    instance-restricted-properties.js
+    name.js
+    proto-from-ctor-realm-prototype.js
 
 built-ins/GeneratorPrototype 31/61 (50.82%)
-    next/from-state-executing.js {compiled-strict,compiled-non-strict}
+    next/from-state-executing.js
     next/length.js
     next/not-a-constructor.js
     next/property-descriptor.js
@@ -673,7 +1109,7 @@ built-ins/GeneratorPrototype 31/61 (50.82%)
     return/try-finally-nested-try-catch-within-outer-try-before-nested.js
     return/try-finally-within-finally.js
     return/try-finally-within-try.js
-    throw/from-state-executing.js {compiled-strict,compiled-non-strict}
+    throw/from-state-executing.js
     throw/length.js
     throw/name.js
     throw/not-a-constructor.js
@@ -682,6 +1118,371 @@ built-ins/GeneratorPrototype 31/61 (50.82%)
     Symbol.toStringTag.js
 
 built-ins/Infinity 0/6 (0.0%)
+
+built-ins/Iterator 392/432 (90.74%)
+    concat/arguments-checked-in-order.js
+    concat/fresh-iterator-result.js
+    concat/get-iterator-method-only-once.js
+    concat/get-iterator-method-throws.js
+    concat/get-value-after-done.js
+    concat/inner-iterator-created-in-order.js
+    concat/is-function.js
+    concat/iterable-primitive-wrapper-objects.js
+    concat/length.js
+    concat/many-arguments.js
+    concat/name.js
+    concat/next-method-called-with-zero-arguments.js
+    concat/next-method-returns-non-object.js
+    concat/next-method-returns-throwing-done.js
+    concat/next-method-returns-throwing-value.js
+    concat/next-method-returns-throwing-value-done.js
+    concat/next-method-throws.js
+    concat/prop-desc.js
+    concat/proto.js
+    concat/result-is-iterator.js
+    concat/return-is-forwarded.js
+    concat/return-is-not-forwarded-after-exhaustion.js
+    concat/return-is-not-forwarded-before-initial-start.js
+    concat/return-method-called-with-zero-arguments.js
+    concat/single-argument.js
+    concat/throws-typeerror-when-generator-is-running-next.js
+    concat/throws-typeerror-when-generator-is-running-return.js
+    concat/throws-typeerror-when-iterator-not-an-object.js
+    concat/zero-arguments.js
+    from 19/19 (100.0%)
+    prototype/constructor 2/2 (100.0%)
+    prototype/drop/argument-effect-order.js
+    prototype/drop/argument-validation-failure-closes-underlying.js
+    prototype/drop/callable.js
+    prototype/drop/exhaustion-does-not-call-return.js
+    prototype/drop/get-next-method-only-once.js
+    prototype/drop/get-next-method-throws.js
+    prototype/drop/get-return-method-throws.js
+    prototype/drop/is-function.js
+    prototype/drop/length.js
+    prototype/drop/limit-equals-total.js
+    prototype/drop/limit-greater-than-total.js
+    prototype/drop/limit-less-than-total.js
+    prototype/drop/limit-rangeerror.js
+    prototype/drop/limit-tonumber.js
+    prototype/drop/limit-tonumber-throws.js
+    prototype/drop/name.js
+    prototype/drop/next-method-returns-non-object.js
+    prototype/drop/next-method-returns-throwing-done.js
+    prototype/drop/next-method-returns-throwing-value.js
+    prototype/drop/next-method-returns-throwing-value-done.js
+    prototype/drop/next-method-throws.js
+    prototype/drop/non-constructible.js
+    prototype/drop/prop-desc.js
+    prototype/drop/proto.js
+    prototype/drop/result-is-iterator.js
+    prototype/drop/return-is-forwarded.js
+    prototype/drop/return-is-not-forwarded-after-exhaustion.js
+    prototype/drop/this-non-callable-next.js
+    prototype/drop/this-plain-iterator.js
+    prototype/drop/throws-typeerror-when-generator-is-running.js
+    prototype/drop/underlying-iterator-advanced-in-parallel.js
+    prototype/drop/underlying-iterator-closed.js
+    prototype/drop/underlying-iterator-closed-in-parallel.js
+    prototype/every/argument-validation-failure-closes-underlying.js
+    prototype/every/callable.js
+    prototype/every/get-next-method-only-once.js
+    prototype/every/get-next-method-throws.js
+    prototype/every/get-return-method-throws.js
+    prototype/every/is-function.js
+    prototype/every/iterator-already-exhausted.js
+    prototype/every/iterator-has-no-return.js
+    prototype/every/iterator-return-method-throws.js
+    prototype/every/length.js
+    prototype/every/name.js
+    prototype/every/next-method-returns-non-object.js
+    prototype/every/next-method-returns-throwing-done.js
+    prototype/every/next-method-returns-throwing-value.js
+    prototype/every/next-method-returns-throwing-value-done.js
+    prototype/every/next-method-throws.js
+    prototype/every/non-constructible.js
+    prototype/every/predicate-args.js
+    prototype/every/predicate-returns-falsey.js
+    prototype/every/predicate-returns-non-boolean.js
+    prototype/every/predicate-returns-truthy.js
+    prototype/every/predicate-returns-truthy-then-falsey.js
+    prototype/every/predicate-this.js
+    prototype/every/predicate-throws.js
+    prototype/every/predicate-throws-then-closing-iterator-also-throws.js
+    prototype/every/prop-desc.js
+    prototype/every/proto.js
+    prototype/every/result-is-boolean.js
+    prototype/every/this-plain-iterator.js
+    prototype/filter/argument-validation-failure-closes-underlying.js
+    prototype/filter/callable.js
+    prototype/filter/exhaustion-does-not-call-return.js
+    prototype/filter/get-next-method-only-once.js
+    prototype/filter/get-next-method-throws.js
+    prototype/filter/get-return-method-throws.js
+    prototype/filter/is-function.js
+    prototype/filter/iterator-already-exhausted.js
+    prototype/filter/iterator-return-method-throws.js
+    prototype/filter/length.js
+    prototype/filter/name.js
+    prototype/filter/next-method-returns-non-object.js
+    prototype/filter/next-method-returns-throwing-done.js
+    prototype/filter/next-method-returns-throwing-value.js
+    prototype/filter/next-method-returns-throwing-value-done.js
+    prototype/filter/next-method-throws.js
+    prototype/filter/non-constructible.js
+    prototype/filter/predicate-args.js
+    prototype/filter/predicate-filters.js
+    prototype/filter/predicate-returns-non-boolean.js
+    prototype/filter/predicate-this.js
+    prototype/filter/predicate-throws.js
+    prototype/filter/predicate-throws-then-closing-iterator-also-throws.js
+    prototype/filter/prop-desc.js
+    prototype/filter/proto.js
+    prototype/filter/result-is-iterator.js
+    prototype/filter/return-is-forwarded.js
+    prototype/filter/return-is-not-forwarded-after-exhaustion.js
+    prototype/filter/this-non-callable-next.js
+    prototype/filter/this-plain-iterator.js
+    prototype/filter/throws-typeerror-when-generator-is-running.js
+    prototype/filter/underlying-iterator-advanced-in-parallel.js
+    prototype/filter/underlying-iterator-closed.js
+    prototype/filter/underlying-iterator-closed-in-parallel.js
+    prototype/find/argument-validation-failure-closes-underlying.js
+    prototype/find/callable.js
+    prototype/find/get-next-method-only-once.js
+    prototype/find/get-next-method-throws.js
+    prototype/find/get-return-method-throws.js
+    prototype/find/is-function.js
+    prototype/find/iterator-already-exhausted.js
+    prototype/find/iterator-has-no-return.js
+    prototype/find/iterator-return-method-throws.js
+    prototype/find/length.js
+    prototype/find/name.js
+    prototype/find/next-method-returns-non-object.js
+    prototype/find/next-method-returns-throwing-done.js
+    prototype/find/next-method-returns-throwing-value.js
+    prototype/find/next-method-returns-throwing-value-done.js
+    prototype/find/next-method-throws.js
+    prototype/find/non-constructible.js
+    prototype/find/predicate-args.js
+    prototype/find/predicate-returns-falsey.js
+    prototype/find/predicate-returns-falsey-then-truthy.js
+    prototype/find/predicate-returns-non-boolean.js
+    prototype/find/predicate-returns-truthy.js
+    prototype/find/predicate-this.js
+    prototype/find/predicate-throws.js
+    prototype/find/predicate-throws-then-closing-iterator-also-throws.js
+    prototype/find/prop-desc.js
+    prototype/find/proto.js
+    prototype/find/this-plain-iterator.js
+    prototype/flatMap/argument-validation-failure-closes-underlying.js
+    prototype/flatMap/callable.js
+    prototype/flatMap/exhaustion-does-not-call-return.js
+    prototype/flatMap/flattens-iterable.js
+    prototype/flatMap/flattens-iterator.js
+    prototype/flatMap/flattens-only-depth-1.js
+    prototype/flatMap/get-next-method-only-once.js
+    prototype/flatMap/get-next-method-throws.js
+    prototype/flatMap/get-return-method-throws.js
+    prototype/flatMap/is-function.js
+    prototype/flatMap/iterable-primitives-are-not-flattened.js
+    prototype/flatMap/iterable-to-iterator-fallback.js
+    prototype/flatMap/iterator-already-exhausted.js
+    prototype/flatMap/iterator-return-method-throws.js
+    prototype/flatMap/length.js
+    prototype/flatMap/mapper-args.js
+    prototype/flatMap/mapper-returns-closed-iterator.js
+    prototype/flatMap/mapper-returns-non-object.js
+    prototype/flatMap/mapper-this.js
+    prototype/flatMap/mapper-throws.js
+    prototype/flatMap/mapper-throws-then-closing-iterator-also-throws.js
+    prototype/flatMap/name.js
+    prototype/flatMap/next-method-returns-non-object.js
+    prototype/flatMap/next-method-returns-throwing-done.js
+    prototype/flatMap/next-method-returns-throwing-value.js
+    prototype/flatMap/next-method-returns-throwing-value-done.js
+    prototype/flatMap/next-method-throws.js
+    prototype/flatMap/non-constructible.js
+    prototype/flatMap/prop-desc.js
+    prototype/flatMap/proto.js
+    prototype/flatMap/result-is-iterator.js
+    prototype/flatMap/return-is-forwarded-to-mapper-result.js
+    prototype/flatMap/return-is-forwarded-to-underlying-iterator.js
+    prototype/flatMap/return-is-not-forwarded-after-exhaustion.js
+    prototype/flatMap/strings-are-not-flattened.js
+    prototype/flatMap/this-non-callable-next.js
+    prototype/flatMap/this-plain-iterator.js
+    prototype/flatMap/throws-typeerror-when-generator-is-running.js
+    prototype/flatMap/underlying-iterator-advanced-in-parallel.js
+    prototype/flatMap/underlying-iterator-closed.js
+    prototype/flatMap/underlying-iterator-closed-in-parallel.js
+    prototype/forEach/argument-validation-failure-closes-underlying.js
+    prototype/forEach/callable.js
+    prototype/forEach/fn-args.js
+    prototype/forEach/fn-called-for-each-yielded-value.js
+    prototype/forEach/fn-this.js
+    prototype/forEach/fn-throws.js
+    prototype/forEach/fn-throws-then-closing-iterator-also-throws.js
+    prototype/forEach/get-next-method-only-once.js
+    prototype/forEach/get-next-method-throws.js
+    prototype/forEach/is-function.js
+    prototype/forEach/iterator-already-exhausted.js
+    prototype/forEach/length.js
+    prototype/forEach/name.js
+    prototype/forEach/next-method-returns-non-object.js
+    prototype/forEach/next-method-returns-throwing-done.js
+    prototype/forEach/next-method-returns-throwing-value.js
+    prototype/forEach/next-method-returns-throwing-value-done.js
+    prototype/forEach/next-method-throws.js
+    prototype/forEach/non-constructible.js
+    prototype/forEach/prop-desc.js
+    prototype/forEach/proto.js
+    prototype/forEach/result-is-undefined.js
+    prototype/forEach/this-plain-iterator.js
+    prototype/map/argument-validation-failure-closes-underlying.js
+    prototype/map/callable.js
+    prototype/map/exhaustion-does-not-call-return.js
+    prototype/map/get-next-method-only-once.js
+    prototype/map/get-next-method-throws.js
+    prototype/map/get-return-method-throws.js
+    prototype/map/is-function.js
+    prototype/map/iterator-already-exhausted.js
+    prototype/map/iterator-return-method-throws.js
+    prototype/map/length.js
+    prototype/map/mapper-args.js
+    prototype/map/mapper-this.js
+    prototype/map/mapper-throws.js
+    prototype/map/mapper-throws-then-closing-iterator-also-throws.js
+    prototype/map/name.js
+    prototype/map/next-method-returns-non-object.js
+    prototype/map/next-method-returns-throwing-done.js
+    prototype/map/next-method-returns-throwing-value.js
+    prototype/map/next-method-returns-throwing-value-done.js
+    prototype/map/next-method-throws.js
+    prototype/map/non-constructible.js
+    prototype/map/prop-desc.js
+    prototype/map/proto.js
+    prototype/map/result-is-iterator.js
+    prototype/map/return-is-forwarded-to-underlying-iterator.js
+    prototype/map/return-is-not-forwarded-after-exhaustion.js
+    prototype/map/returned-iterator-yields-mapper-return-values.js
+    prototype/map/this-non-callable-next.js
+    prototype/map/this-plain-iterator.js
+    prototype/map/throws-typeerror-when-generator-is-running.js
+    prototype/map/underlying-iterator-advanced-in-parallel.js
+    prototype/map/underlying-iterator-closed.js
+    prototype/map/underlying-iterator-closed-in-parallel.js
+    prototype/reduce/argument-effect-order.js
+    prototype/reduce/argument-validation-failure-closes-underlying.js
+    prototype/reduce/callable.js
+    prototype/reduce/get-next-method-only-once.js
+    prototype/reduce/get-next-method-throws.js
+    prototype/reduce/is-function.js
+    prototype/reduce/iterator-already-exhausted-initial-value.js
+    prototype/reduce/iterator-already-exhausted-no-initial-value.js
+    prototype/reduce/iterator-yields-once-initial-value.js
+    prototype/reduce/iterator-yields-once-no-initial-value.js
+    prototype/reduce/length.js
+    prototype/reduce/name.js
+    prototype/reduce/next-method-returns-non-object.js
+    prototype/reduce/next-method-returns-throwing-done.js
+    prototype/reduce/next-method-returns-throwing-value.js
+    prototype/reduce/next-method-returns-throwing-value-done.js
+    prototype/reduce/next-method-throws.js
+    prototype/reduce/non-callable-reducer.js
+    prototype/reduce/non-constructible.js
+    prototype/reduce/prop-desc.js
+    prototype/reduce/proto.js
+    prototype/reduce/reducer-args-initial-value.js
+    prototype/reduce/reducer-args-no-initial-value.js
+    prototype/reduce/reducer-memo-can-be-any-type.js
+    prototype/reduce/reducer-this.js
+    prototype/reduce/reducer-throws.js
+    prototype/reduce/reducer-throws-then-closing-iterator-also-throws.js
+    prototype/reduce/this-plain-iterator.js
+    prototype/some/argument-validation-failure-closes-underlying.js
+    prototype/some/callable.js
+    prototype/some/get-next-method-only-once.js
+    prototype/some/get-next-method-throws.js
+    prototype/some/get-return-method-throws.js
+    prototype/some/is-function.js
+    prototype/some/iterator-already-exhausted.js
+    prototype/some/iterator-has-no-return.js
+    prototype/some/iterator-return-method-throws.js
+    prototype/some/length.js
+    prototype/some/name.js
+    prototype/some/next-method-returns-non-object.js
+    prototype/some/next-method-returns-throwing-done.js
+    prototype/some/next-method-returns-throwing-value.js
+    prototype/some/next-method-returns-throwing-value-done.js
+    prototype/some/next-method-throws.js
+    prototype/some/non-constructible.js
+    prototype/some/predicate-args.js
+    prototype/some/predicate-returns-falsey.js
+    prototype/some/predicate-returns-falsey-then-truthy.js
+    prototype/some/predicate-returns-non-boolean.js
+    prototype/some/predicate-returns-truthy.js
+    prototype/some/predicate-this.js
+    prototype/some/predicate-throws.js
+    prototype/some/predicate-throws-then-closing-iterator-also-throws.js
+    prototype/some/prop-desc.js
+    prototype/some/proto.js
+    prototype/some/result-is-boolean.js
+    prototype/some/this-plain-iterator.js
+    prototype/Symbol.dispose 6/6 (100.0%)
+    prototype/Symbol.iterator 5/5 (100.0%)
+    prototype/Symbol.toStringTag 2/2 (100.0%)
+    prototype/take/argument-effect-order.js
+    prototype/take/argument-validation-failure-closes-underlying.js
+    prototype/take/callable.js
+    prototype/take/exhaustion-calls-return.js
+    prototype/take/get-next-method-only-once.js
+    prototype/take/get-next-method-throws.js
+    prototype/take/get-return-method-throws.js
+    prototype/take/is-function.js
+    prototype/take/length.js
+    prototype/take/limit-greater-than-or-equal-to-total.js
+    prototype/take/limit-less-than-total.js
+    prototype/take/limit-rangeerror.js
+    prototype/take/limit-tonumber.js
+    prototype/take/limit-tonumber-throws.js
+    prototype/take/name.js
+    prototype/take/next-method-returns-non-object.js
+    prototype/take/next-method-returns-throwing-done.js
+    prototype/take/next-method-returns-throwing-value.js
+    prototype/take/next-method-returns-throwing-value-done.js
+    prototype/take/next-method-throws.js
+    prototype/take/non-constructible.js
+    prototype/take/prop-desc.js
+    prototype/take/proto.js
+    prototype/take/result-is-iterator.js
+    prototype/take/return-is-forwarded.js
+    prototype/take/return-is-not-forwarded-after-exhaustion.js
+    prototype/take/this-non-callable-next.js
+    prototype/take/this-plain-iterator.js
+    prototype/take/throws-typeerror-when-generator-is-running.js
+    prototype/take/underlying-iterator-advanced-in-parallel.js
+    prototype/take/underlying-iterator-closed.js
+    prototype/take/underlying-iterator-closed-in-parallel.js
+    prototype/toArray/callable.js
+    prototype/toArray/get-next-method-only-once.js
+    prototype/toArray/get-next-method-throws.js
+    prototype/toArray/is-function.js
+    prototype/toArray/iterator-already-exhausted.js
+    prototype/toArray/length.js
+    prototype/toArray/name.js
+    prototype/toArray/next-method-returns-non-object.js
+    prototype/toArray/next-method-returns-throwing-done.js
+    prototype/toArray/next-method-returns-throwing-value.js
+    prototype/toArray/next-method-returns-throwing-value-done.js
+    prototype/toArray/next-method-throws.js
+    prototype/toArray/non-constructible.js
+    prototype/toArray/prop-desc.js
+    prototype/toArray/proto.js
+    prototype/toArray/this-plain-iterator.js
+    length.js
+    proto-from-ctor-realm.js
+    subclassable.js
 
 built-ins/JSON 45/165 (27.27%)
     isRawJSON 6/6 (100.0%)
@@ -700,7 +1501,7 @@ built-ins/JSON 45/165 (27.27%)
     parse/reviver-object-define-prop-err.js
     parse/reviver-object-get-prop-from-prototype.js
     parse/reviver-object-non-configurable-prop-create.js
-    parse/reviver-object-non-configurable-prop-delete.js strict {compiled-strict,interpreted-strict}
+    parse/reviver-object-non-configurable-prop-delete.js strict
     parse/text-negative-zero.js
     rawJSON 10/10 (100.0%)
     stringify/builtin.js
@@ -758,16 +1559,16 @@ built-ins/Object 121/3410 (3.55%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order-proxy.js
-    defineProperties/15.2.3.7-6-a-112.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperties/15.2.3.7-6-a-113.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-112.js non-strict
+    defineProperties/15.2.3.7-6-a-113.js non-strict
     defineProperties/15.2.3.7-6-a-164.js
     defineProperties/15.2.3.7-6-a-165.js
-    defineProperties/15.2.3.7-6-a-166.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperties/15.2.3.7-6-a-168.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperties/15.2.3.7-6-a-169.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperties/15.2.3.7-6-a-170.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperties/15.2.3.7-6-a-172.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperties/15.2.3.7-6-a-173.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperties/15.2.3.7-6-a-166.js non-strict
+    defineProperties/15.2.3.7-6-a-168.js non-strict
+    defineProperties/15.2.3.7-6-a-169.js non-strict
+    defineProperties/15.2.3.7-6-a-170.js non-strict
+    defineProperties/15.2.3.7-6-a-172.js non-strict
+    defineProperties/15.2.3.7-6-a-173.js non-strict
     defineProperties/15.2.3.7-6-a-175.js
     defineProperties/15.2.3.7-6-a-176.js
     defineProperties/15.2.3.7-6-a-184.js
@@ -776,22 +1577,22 @@ built-ins/Object 121/3410 (3.55%)
     defineProperties/property-description-must-be-an-object-not-symbol.js
     defineProperties/proxy-no-ownkeys-returned-keys-order.js
     defineProperties/typedarray-backed-by-resizable-buffer.js {unsupported: [resizable-arraybuffer]}
-    defineProperty/15.2.3.6-4-116.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-117.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-116.js non-strict
+    defineProperty/15.2.3.6-4-117.js non-strict
     defineProperty/15.2.3.6-4-168.js
     defineProperty/15.2.3.6-4-169.js
-    defineProperty/15.2.3.6-4-170.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-172.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-173.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-174.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-176.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-177.js non-strict {compiled-non-strict,interpreted-non-strict}
+    defineProperty/15.2.3.6-4-170.js non-strict
+    defineProperty/15.2.3.6-4-172.js non-strict
+    defineProperty/15.2.3.6-4-173.js non-strict
+    defineProperty/15.2.3.6-4-174.js non-strict
+    defineProperty/15.2.3.6-4-176.js non-strict
+    defineProperty/15.2.3.6-4-177.js non-strict
     defineProperty/15.2.3.6-4-188.js
     defineProperty/15.2.3.6-4-189.js
     defineProperty/15.2.3.6-4-254.js
     defineProperty/15.2.3.6-4-293-1.js
-    defineProperty/15.2.3.6-4-293-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    defineProperty/15.2.3.6-4-293-4.js strict {compiled-strict,interpreted-strict}
+    defineProperty/15.2.3.6-4-293-3.js non-strict
+    defineProperty/15.2.3.6-4-293-4.js strict
     defineProperty/15.2.3.6-4-336.js
     defineProperty/coerced-P-grow.js {unsupported: [resizable-arraybuffer]}
     defineProperty/coerced-P-shrink.js {unsupported: [resizable-arraybuffer]}
@@ -844,8 +1645,8 @@ built-ins/Object 121/3410 (3.55%)
     prototype/propertyIsEnumerable/symbol_property_toPrimitive.js
     prototype/propertyIsEnumerable/symbol_property_toString.js
     prototype/propertyIsEnumerable/symbol_property_valueOf.js
-    prototype/toLocaleString/primitive_this_value.js strict {compiled-strict,interpreted-strict}
-    prototype/toLocaleString/primitive_this_value_getter.js strict {compiled-strict,interpreted-strict}
+    prototype/toLocaleString/primitive_this_value.js strict
+    prototype/toLocaleString/primitive_this_value_getter.js strict
     prototype/toString/proxy-function.js {unsupported: [async-functions]}
     prototype/toString/proxy-function-async.js {unsupported: [async-functions]}
     prototype/toString/proxy-revoked-during-get-call.js
@@ -1262,9 +2063,90 @@ built-ins/Promise 383/639 (59.94%)
     resolve-thenable-deferred.js {unsupported: [async]}
     resolve-thenable-immed.js {unsupported: [async]}
 
-~built-ins/Proxy
+built-ins/Proxy 69/311 (22.19%)
+    construct/arguments-realm.js
+    construct/call-parameters.js
+    construct/call-parameters-new-target.js
+    construct/trap-is-missing-target-is-proxy.js {unsupported: [class]}
+    construct/trap-is-null.js
+    construct/trap-is-null-target-is-proxy.js {unsupported: [class]}
+    construct/trap-is-undefined.js
+    construct/trap-is-undefined-no-property.js
+    construct/trap-is-undefined-proto-from-newtarget-realm.js
+    construct/trap-is-undefined-target-is-proxy.js {unsupported: [class]}
+    defineProperty/desc-realm.js
+    defineProperty/targetdesc-not-configurable-writable-desc-not-writable.js
+    defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js non-strict
+    defineProperty/trap-is-missing-target-is-proxy.js
+    defineProperty/trap-is-undefined-target-is-proxy.js
+    deleteProperty/boolean-trap-result-boolean-false.js
+    deleteProperty/return-false-not-strict.js non-strict
+    deleteProperty/return-false-strict.js strict
+    deleteProperty/targetdesc-is-configurable-target-is-not-extensible.js
+    deleteProperty/trap-is-missing-target-is-proxy.js strict
+    deleteProperty/trap-is-null-target-is-proxy.js
+    deleteProperty/trap-is-undefined-strict.js strict
+    deleteProperty/trap-is-undefined-target-is-proxy.js
+    getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined.js
+    getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor.js
+    getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable.js
+    getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-configurable.js
+    getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-undefined.js
+    getOwnPropertyDescriptor/trap-is-null-target-is-proxy.js
+    get/accessor-get-is-undefined-throws.js
+    get/trap-is-undefined-receiver.js
+    has/call-in-prototype.js
+    has/call-in-prototype-index.js
+    has/call-with.js non-strict
+    has/return-false-target-not-extensible-using-with.js non-strict
+    has/return-false-target-prop-exists-using-with.js non-strict
+    has/return-false-targetdesc-not-configurable-using-with.js non-strict
+    has/return-is-abrupt-with.js non-strict
+    has/trap-is-not-callable-using-with.js non-strict
+    ownKeys/trap-is-undefined-target-is-proxy.js
+    preventExtensions/trap-is-undefined-target-is-proxy.js {unsupported: [module]}
+    revocable/builtin.js
+    revocable/revocation-function-not-a-constructor.js
+    revocable/tco-fn-realm.js {unsupported: [tail-call-optimization]}
+    setPrototypeOf/internals-call-order.js
+    setPrototypeOf/not-extensible-target-not-same-target-prototype.js
+    setPrototypeOf/toboolean-trap-result-false.js
+    setPrototypeOf/toboolean-trap-result-true-target-is-extensible.js
+    setPrototypeOf/trap-is-missing-target-is-proxy.js
+    setPrototypeOf/trap-is-null-target-is-proxy.js
+    set/boolean-trap-result-is-false-boolean-return-false.js
+    set/boolean-trap-result-is-false-null-return-false.js
+    set/boolean-trap-result-is-false-number-return-false.js
+    set/boolean-trap-result-is-false-string-return-false.js
+    set/boolean-trap-result-is-false-undefined-return-false.js
+    set/call-parameters.js
+    set/call-parameters-prototype.js
+    set/call-parameters-prototype-dunder-proto.js
+    set/call-parameters-prototype-index.js
+    set/target-property-is-accessor-not-configurable-set-is-undefined.js
+    set/trap-is-missing-receiver-multiple-calls.js
+    set/trap-is-missing-receiver-multiple-calls-index.js
+    set/trap-is-missing-target-is-proxy.js
+    set/trap-is-null-receiver.js
+    set/trap-is-null-target-is-proxy.js
+    set/trap-is-undefined-target-is-proxy.js
+    create-target-is-not-a-constructor.js
+    get-fn-realm.js
+    get-fn-realm-recursive.js
 
-~built-ins/Reflect
+built-ins/Reflect 12/153 (7.84%)
+    construct/newtarget-is-not-constructor-throws.js
+    defineProperty/return-abrupt-from-property-key.js
+    deleteProperty/return-abrupt-from-result.js
+    deleteProperty/return-boolean.js strict
+    get/return-value-from-receiver.js
+    ownKeys/return-on-corresponding-order-large-index.js
+    set/call-prototype-property-set.js
+    set/different-property-descriptors.js
+    set/receiver-is-not-object.js
+    set/return-abrupt-from-result.js
+    set/return-false-if-receiver-is-not-writable.js
+    set/return-false-if-target-is-not-writable.js
 
 built-ins/RegExp 975/1868 (52.19%)
     CharacterClassEscapes 12/12 (100.0%)
@@ -1509,6 +2391,8 @@ built-ins/Set 87/381 (22.83%)
 
 built-ins/SetIteratorPrototype 0/11 (0.0%)
 
+~built-ins/ShadowRealm
+
 ~built-ins/SharedArrayBuffer
 
 built-ins/String 58/1212 (4.79%)
@@ -1573,6 +2457,8 @@ built-ins/String 58/1212 (4.79%)
 
 built-ins/StringIteratorPrototype 0/7 (0.0%)
 
+~built-ins/SuppressedError 22/22 (100.0%)
+
 built-ins/Symbol 19/94 (20.21%)
     asyncDispose/prop-desc.js
     asyncIterator/prop-desc.js
@@ -1593,6 +2479,8 @@ built-ins/Symbol 19/94 (20.21%)
     toPrimitive/cross-realm.js
     toStringTag/cross-realm.js
     unscopables/cross-realm.js
+
+built-ins/Temporal 4255/4255 (100.0%)
 
 built-ins/ThrowTypeError 8/14 (57.14%)
     extensible.js
@@ -1666,7 +2554,7 @@ built-ins/TypedArray 256/1434 (17.85%)
     prototype/findIndex/BigInt/predicate-call-this-strict.js strict
     prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -1676,19 +2564,19 @@ built-ins/TypedArray 256/1434 (17.85%)
     prototype/findLastIndex/BigInt/predicate-call-this-strict.js strict
     prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLastIndex/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/findLastIndex/predicate-call-this-strict.js strict
     prototype/findLastIndex/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/findLast/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/findLast/predicate-call-this-strict.js strict
     prototype/findLast/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/findLast/return-abrupt-from-this-out-of-bounds.js {unsupported: [resizable-arraybuffer]}
     prototype/find/callbackfn-resize.js {unsupported: [resizable-arraybuffer]}
-    prototype/find/predicate-call-this-strict.js strict {compiled-strict,interpreted-strict}
+    prototype/find/predicate-call-this-strict.js strict
     prototype/find/resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-grow-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     prototype/find/resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
@@ -1983,7 +2871,7 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     ctors/typedarray-arg/use-custom-proto-if-object.js
     ctors/no-species.js
     from/BigInt/mapfn-this-without-thisarg-non-strict.js non-strict
-    from/mapfn-this-without-thisarg-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    from/mapfn-this-without-thisarg-non-strict.js non-strict
     from/nan-conversion.js
     from/new-instance-from-sparse-array.js
     internals/DefineOwnProperty/BigInt/key-is-not-canonical-index.js
@@ -2005,11 +2893,11 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
     internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
-    internals/Delete/indexed-value-ab-strict.js strict {compiled-strict,interpreted-strict}
+    internals/Delete/indexed-value-ab-strict.js strict
     internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
-    internals/Delete/key-is-not-minus-zero-strict.js strict {compiled-strict,interpreted-strict}
-    internals/Delete/key-is-out-of-bounds-strict.js strict {compiled-strict,interpreted-strict}
+    internals/Delete/key-is-not-minus-zero-strict.js strict
+    internals/Delete/key-is-out-of-bounds-strict.js strict
     internals/Get/BigInt/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/BigInt/key-is-not-integer.js
     internals/Get/BigInt/key-is-not-minus-zero.js
@@ -2059,6 +2947,66 @@ built-ins/TypedArrayConstructors 198/736 (26.9%)
     internals/Set/resized-out-of-bounds-to-in-bounds-index.js {unsupported: [resizable-arraybuffer]}
     internals/Set/tonumber-value-throws.js
 
+built-ins/Uint8Array 58/66 (87.88%)
+    fromBase64/alphabet.js
+    fromBase64/descriptor.js
+    fromBase64/ignores-receiver.js
+    fromBase64/illegal-characters.js
+    fromBase64/last-chunk-handling.js
+    fromBase64/last-chunk-invalid.js
+    fromBase64/length.js
+    fromBase64/name.js
+    fromBase64/nonconstructor.js
+    fromBase64/option-coercion.js
+    fromBase64/results.js
+    fromBase64/whitespace.js
+    fromHex/descriptor.js
+    fromHex/ignores-receiver.js
+    fromHex/illegal-characters.js
+    fromHex/length.js
+    fromHex/name.js
+    fromHex/nonconstructor.js
+    fromHex/odd-length-input.js
+    fromHex/results.js
+    prototype/setFromBase64/alphabet.js
+    prototype/setFromBase64/descriptor.js
+    prototype/setFromBase64/detached-buffer.js
+    prototype/setFromBase64/illegal-characters.js
+    prototype/setFromBase64/last-chunk-handling.js
+    prototype/setFromBase64/length.js
+    prototype/setFromBase64/name.js
+    prototype/setFromBase64/nonconstructor.js
+    prototype/setFromBase64/option-coercion.js
+    prototype/setFromBase64/results.js
+    prototype/setFromBase64/subarray.js
+    prototype/setFromBase64/target-size.js
+    prototype/setFromBase64/whitespace.js
+    prototype/setFromBase64/writes-up-to-error.js
+    prototype/setFromHex/descriptor.js
+    prototype/setFromHex/illegal-characters.js
+    prototype/setFromHex/length.js
+    prototype/setFromHex/name.js
+    prototype/setFromHex/nonconstructor.js
+    prototype/setFromHex/results.js
+    prototype/setFromHex/subarray.js
+    prototype/setFromHex/target-size.js
+    prototype/setFromHex/throws-when-string-length-is-odd.js
+    prototype/setFromHex/writes-up-to-error.js
+    prototype/toBase64/alphabet.js
+    prototype/toBase64/descriptor.js
+    prototype/toBase64/detached-buffer.js
+    prototype/toBase64/length.js
+    prototype/toBase64/name.js
+    prototype/toBase64/nonconstructor.js
+    prototype/toBase64/omit-padding.js
+    prototype/toBase64/option-coercion.js
+    prototype/toBase64/results.js
+    prototype/toHex/descriptor.js
+    prototype/toHex/length.js
+    prototype/toHex/name.js
+    prototype/toHex/nonconstructor.js
+    prototype/toHex/results.js
+
 built-ins/WeakMap 40/141 (28.37%)
     prototype/getOrInsertComputed 22/22 (100.0%)
     prototype/getOrInsert 17/17 (100.0%)
@@ -2099,43 +3047,43 @@ built-ins/undefined 0/8 (0.0%)
 ~intl402
 
 language/arguments-object 184/263 (69.96%)
-    mapped/mapped-arguments-nonconfigurable-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unmapped/via-params-dstr.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unmapped/via-params-rest.js non-strict {compiled-non-strict,interpreted-non-strict}
+    mapped/mapped-arguments-nonconfigurable-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-delete-4.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-4.js non-strict
+    mapped/mapped-arguments-nonconfigurable-nonwritable-5.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-1.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-2.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-3.js non-strict
+    mapped/mapped-arguments-nonconfigurable-strict-delete-4.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-1.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-2.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-3.js non-strict
+    mapped/mapped-arguments-nonwritable-nonconfigurable-4.js non-strict
+    mapped/nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-descriptors-set-value-by-arguments.js non-strict
+    mapped/nonconfigurable-descriptors-set-value-with-define-property.js non-strict
+    mapped/nonconfigurable-descriptors-with-param-assign.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-arguments.js non-strict
+    mapped/nonconfigurable-nonenumerable-nonwritable-descriptors-set-by-param.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-basic.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-define-property-consecutive.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-arguments.js non-strict
+    mapped/nonconfigurable-nonwritable-descriptors-set-by-param.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-arguments.js non-strict
+    mapped/nonwritable-nonconfigurable-descriptors-set-by-param.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-basic.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-arguments.js non-strict
+    mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-param.js non-strict
+    unmapped/via-params-dstr.js non-strict
+    unmapped/via-params-rest.js non-strict
     arguments-caller.js
     async-gen-meth-args-trailing-comma-multiple.js {unsupported: [async-iteration, async]}
     async-gen-meth-args-trailing-comma-null.js {unsupported: [async-iteration, async]}
@@ -2294,8 +3242,8 @@ language/block-scope 68/145 (46.9%)
     syntax/for-in/mixed-values-in-iteration.js
     syntax/function-declarations/in-statement-position-do-statement-while-expression.js
     syntax/function-declarations/in-statement-position-for-statement.js
-    syntax/function-declarations/in-statement-position-if-expression-statement.js strict {compiled-strict,interpreted-strict}
-    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict {compiled-strict,interpreted-strict}
+    syntax/function-declarations/in-statement-position-if-expression-statement.js strict
+    syntax/function-declarations/in-statement-position-if-expression-statement-else-statement.js strict
     syntax/function-declarations/in-statement-position-while-expression-statement.js
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration, async-functions]}
@@ -2324,7 +3272,7 @@ language/block-scope 68/145 (46.9%)
     syntax/redeclaration/function-declaration-attempt-to-redeclare-with-var-declaration-nested-in-function.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict {compiled-strict,interpreted-strict}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
@@ -2387,17 +3335,17 @@ language/destructuring 9/19 (47.37%)
 
 language/directive-prologue 2/62 (3.23%)
     14.1-4-s.js non-strict
-    14.1-5-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    14.1-5-s.js non-strict
 
 language/eval-code 241/347 (69.45%)
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js non-strict
+    direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-lex-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
+    direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
     direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
@@ -2434,54 +3382,54 @@ language/eval-code 241/347 (69.45%)
     direct/async-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
     direct/async-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
     direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
     direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js {unsupported: [async]}
@@ -2498,131 +3446,131 @@ language/eval-code 241/347 (69.45%)
     direct/block-decl-eval-source-is-strict-onlystrict.js strict
     direct/block-decl-onlystrict.js strict
     direct/export.js {unsupported: [module]}
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
     direct/import.js {unsupported: [module]}
     direct/lex-env-distinct-cls.js {unsupported: [class]}
     direct/lex-env-distinct-const.js
-    direct/lex-env-distinct-let.js {compiled-non-strict,interpreted-non-strict}
+    direct/lex-env-distinct-let.js
     direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js non-strict
+    direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js non-strict
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js non-strict
+    direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js non-strict
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js non-strict
+    direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
     direct/new.target.js {unsupported: [new.target]}
     direct/new.target-arrow.js {unsupported: [new.target]}
     direct/new.target-fn.js {unsupported: [new.target]}
-    direct/non-definable-global-var.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/non-definable-global-var.js non-strict
     direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
     direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
     direct/switch-case-decl-onlystrict.js strict
     direct/switch-dflt-decl-eval-source-is-strict-nostrict.js non-strict
     direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js strict
     direct/switch-dflt-decl-onlystrict.js strict
-    direct/this-value-func-strict-caller.js strict {compiled-strict,interpreted-strict}
-    direct/var-env-func-init-global-update-configurable.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/this-value-func-strict-caller.js strict
+    direct/var-env-func-init-global-update-configurable.js non-strict
     direct/var-env-func-strict-caller.js strict
     direct/var-env-func-strict-caller-2.js strict
     direct/var-env-func-strict-source.js
-    direct/var-env-global-lex-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    direct/var-env-lower-lex-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    direct/var-env-global-lex-non-strict.js non-strict
+    direct/var-env-lower-lex-non-strict.js non-strict
     direct/var-env-var-strict-caller.js strict
     direct/var-env-var-strict-caller-2.js strict
     direct/var-env-var-strict-caller-3.js strict
     direct/var-env-var-strict-source.js
-    indirect/always-non-strict.js strict {compiled-strict,interpreted-strict}
+    indirect/always-non-strict.js strict
     indirect/block-decl-strict.js
     indirect/export.js {unsupported: [module]}
     indirect/import.js {unsupported: [module]}
     indirect/lex-env-distinct-cls.js {unsupported: [class]}
     indirect/lex-env-distinct-const.js
-    indirect/lex-env-distinct-let.js {compiled-non-strict,interpreted-non-strict}
+    indirect/lex-env-distinct-let.js
     indirect/lex-env-no-init-cls.js {unsupported: [class]}
     indirect/lex-env-no-init-const.js
     indirect/lex-env-no-init-let.js
     indirect/new.target.js {unsupported: [new.target]}
-    indirect/non-definable-function-with-function.js {compiled-non-strict,interpreted-non-strict}
-    indirect/non-definable-function-with-variable.js {compiled-non-strict,interpreted-non-strict}
+    indirect/non-definable-function-with-function.js
+    indirect/non-definable-function-with-variable.js
     indirect/non-definable-global-var.js non-strict
     indirect/realm.js
     indirect/switch-case-decl-strict.js
@@ -2776,26 +3724,26 @@ language/expressions/arrow-function 151/343 (44.02%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1 2/2 (100.0%)
-    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    syntax/early-errors/arrowparameters-cover-no-duplicates.js non-strict
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-1.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-2.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-3.js
     syntax/early-errors/arrowparameters-cover-no-duplicates-binding-object-6.js
-    syntax/arrowparameters-bindingidentifier-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
-    syntax/arrowparameters-cover-formalparameters-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
+    syntax/arrowparameters-bindingidentifier-yield.js non-strict
+    syntax/arrowparameters-cover-formalparameters-yield.js non-strict
     syntax/arrowparameters-cover-includes-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-initialize-2.js
     syntax/arrowparameters-cover-rest-concisebody-functionbody.js
     syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody.js
     array-destructuring-param-strict-body.js
     ArrowFunction_restricted-properties.js
-    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    eval-var-scope-syntax-err.js non-strict
     length-dflt.js
     lexical-new.target.js {unsupported: [new.target]}
     lexical-new.target-closure-returned.js {unsupported: [new.target]}
@@ -2805,14 +3753,14 @@ language/expressions/arrow-function 151/343 (44.02%)
     lexical-supercall-from-immediately-invoked-arrow.js
     object-destructuring-param-strict-body.js
     param-dflt-yield-expr.js
-    param-dflt-yield-id-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    params-duplicate.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-dflt-yield-id-non-strict.js non-strict
+    params-duplicate.js non-strict
+    scope-body-lex-distinct.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
-    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
 language/expressions/assignment 183/485 (37.73%)
     destructuring/default-expr-throws-iterator-return-get-throws.js
@@ -2827,8 +3775,8 @@ language/expressions/assignment 183/485 (37.73%)
     dstr/array-elem-init-fn-name-fn.js {unsupported: [class]}
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/array-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-init-simple-no-strict.js non-strict
+    dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -2840,15 +3788,15 @@ language/expressions/assignment 183/485 (37.73%)
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/array-elem-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js strict {compiled-strict,interpreted-strict}
-    dstr/array-elem-target-yield-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-target-simple-strict.js strict
+    dstr/array-elem-target-yield-valid.js non-strict
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -2915,36 +3863,36 @@ language/expressions/assignment 183/485 (37.73%)
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/array-rest-put-unresolvable-strict.js strict {compiled-strict,interpreted-strict}
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict
+    dstr/array-rest-put-unresolvable-strict.js strict
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-yield-ident-valid.js non-strict
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict
     dstr/obj-id-init-fn-name-arrow.js
     dstr/obj-id-init-fn-name-class.js {unsupported: [class]}
     dstr/obj-id-init-fn-name-cover.js
     dstr/obj-id-init-fn-name-fn.js
     dstr/obj-id-init-fn-name-gen.js
     dstr/obj-id-init-let.js
-    dstr/obj-id-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/obj-id-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/obj-id-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-init-simple-no-strict.js non-strict
+    dstr/obj-id-init-yield-ident-valid.js non-strict
+    dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
@@ -2952,16 +3900,16 @@ language/expressions/assignment 183/485 (37.73%)
     dstr/obj-prop-elem-init-fn-name-fn.js
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/obj-prop-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
+    dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
     dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
     dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
@@ -2989,15 +3937,42 @@ language/expressions/assignment 183/485 (37.73%)
     dstr/obj-rest-val-null.js {unsupported: [object-rest]}
     dstr/obj-rest-val-undefined.js {unsupported: [object-rest]}
     dstr/obj-rest-valid-object.js {unsupported: [object-rest]}
-    11.13.1-2-s.js strict {compiled-strict,interpreted-strict}
-    assignment-operator-calls-putvalue-lref--rval-.js non-strict {compiled-non-strict,interpreted-non-strict}
-    assignment-operator-calls-putvalue-lref--rval--1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    11.13.1-2-s.js strict
+    assignment-operator-calls-putvalue-lref--rval-.js non-strict
+    assignment-operator-calls-putvalue-lref--rval--1.js non-strict
     fn-name-class.js {unsupported: [class]}
     target-cover-newtarget.js {unsupported: [new.target]}
     target-newtarget.js {unsupported: [new.target]}
     target-super-computed-reference.js
     target-super-computed-reference-null.js
     target-super-identifier-reference-null.js
+
+language/expressions/assignmenttargettype 25/324 (7.72%)
+    direct-arrowfunction-1.js
+    direct-callexpression.js strict
+    direct-callexpression-as-for-in-lhs.js strict
+    direct-callexpression-as-for-of-lhs.js strict
+    direct-callexpression-in-compound-assignment.js strict
+    direct-callexpression-in-logical-assignment.js
+    direct-callexpression-in-postfix-update.js strict
+    direct-callexpression-in-prefix-update.js strict
+    direct-callexpression-templateliteral.js
+    direct-importcall.js {unsupported: [module]}
+    direct-importcall-defer.js {unsupported: [module]}
+    direct-importcall-source.js {unsupported: [module]}
+    direct-memberexpression-templateliteral.js
+    parenthesized-callexpression.js strict
+    parenthesized-callexpression-in-compound-assignment.js strict
+    parenthesized-callexpression-in-logical-assignment.js
+    parenthesized-callexpression-templateliteral.js
+    parenthesized-importcall.js {unsupported: [module]}
+    parenthesized-importcall-defer.js {unsupported: [module]}
+    parenthesized-importcall-source.js {unsupported: [module]}
+    parenthesized-memberexpression-templateliteral.js
+    parenthesized-optionalexpression.js
+    parenthesized-primaryexpression-objectliteral.js
+    simple-basic-identifierreference-await.js
+    simple-basic-identifierreference-yield.js non-strict
 
 language/expressions/async-arrow-function 42/60 (70.0%)
     forbidden-ext/b1 2/2 (100.0%)
@@ -3044,8 +4019,6 @@ language/expressions/async-arrow-function 42/60 (70.0%)
 
 ~language/expressions/async-generator
 
-~language/expressions/async-generator
-
 ~language/expressions/await
 
 language/expressions/bitwise-and 1/30 (3.33%)
@@ -3060,7 +4033,7 @@ language/expressions/bitwise-xor 1/30 (3.33%)
     order-of-evaluation.js
 
 language/expressions/call 34/92 (36.96%)
-    eval-realm-indirect.js non-strict {compiled-non-strict,interpreted-non-strict}
+    eval-realm-indirect.js non-strict
     eval-spread.js
     eval-spread-empty.js
     eval-spread-empty-leading.js
@@ -3105,42 +4078,42 @@ language/expressions/comma 1/6 (16.67%)
     tco-final.js {unsupported: [tail-call-optimization]}
 
 language/expressions/compound-assignment 125/454 (27.53%)
-    11.13.2-34-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-35-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-36-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-37-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-38-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-39-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-40-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-41-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-42-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-43-s.js strict {compiled-strict,interpreted-strict}
-    11.13.2-44-s.js strict {compiled-strict,interpreted-strict}
-    add-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    and-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict {compiled-non-strict,interpreted-non-strict}
-    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict {compiled-non-strict,interpreted-non-strict}
-    div-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    11.13.2-34-s.js strict
+    11.13.2-35-s.js strict
+    11.13.2-36-s.js strict
+    11.13.2-37-s.js strict
+    11.13.2-38-s.js strict
+    11.13.2-39-s.js strict
+    11.13.2-40-s.js strict
+    11.13.2-41-s.js strict
+    11.13.2-42-s.js strict
+    11.13.2-43-s.js strict
+    11.13.2-44-s.js strict
+    add-arguments-strict.js strict
+    and-arguments-strict.js strict
+    compound-assignment-operator-calls-putvalue-lref--v-.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--1.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--10.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--11.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--12.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--13.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--14.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--15.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--16.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--17.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--18.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--19.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--2.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--20.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--21.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--3.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--4.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--5.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--6.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--7.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--8.js non-strict
+    compound-assignment-operator-calls-putvalue-lref--v--9.js non-strict
+    div-arguments-strict.js strict
     left-hand-side-private-reference-accessor-property-add.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-bitand.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-accessor-property-bitor.js {unsupported: [class-fields-private]}
@@ -3189,10 +4162,10 @@ language/expressions/compound-assignment 125/454 (27.53%)
     left-hand-side-private-reference-readonly-accessor-property-rshift.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-srshift.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-sub.js {unsupported: [class-fields-private]}
-    lshift-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    mod-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    mult-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    or-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    lshift-arguments-strict.js strict
+    mod-arguments-strict.js strict
+    mult-arguments-strict.js strict
+    or-arguments-strict.js strict
     S11.13.2_A7.10_T1.js
     S11.13.2_A7.10_T2.js
     S11.13.2_A7.10_T4.js
@@ -3226,10 +4199,10 @@ language/expressions/compound-assignment 125/454 (27.53%)
     S11.13.2_A7.9_T1.js
     S11.13.2_A7.9_T2.js
     S11.13.2_A7.9_T4.js
-    srshift-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    sub-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    urshift-arguments-strict.js strict {compiled-strict,interpreted-strict}
-    xor-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    srshift-arguments-strict.js strict
+    sub-arguments-strict.js strict
+    urshift-arguments-strict.js strict
+    xor-arguments-strict.js strict
 
 language/expressions/concatenation 0/5 (0.0%)
 
@@ -3238,8 +4211,8 @@ language/expressions/conditional 2/22 (9.09%)
     tco-pos.js {unsupported: [tail-call-optimization]}
 
 language/expressions/delete 6/69 (8.7%)
-    identifier-strict.js strict {compiled-strict,interpreted-strict}
-    identifier-strict-recursive.js strict {compiled-strict,interpreted-strict}
+    identifier-strict.js strict
+    identifier-strict-recursive.js strict
     super-property.js {unsupported: [class]}
     super-property-method.js {unsupported: [class]}
     super-property-null-base.js {unsupported: [class]}
@@ -3367,43 +4340,43 @@ language/expressions/function 149/264 (56.44%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
-    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
-    arguments-with-arguments-lex.js non-strict {compiled-non-strict,interpreted-non-strict}
+    forbidden-ext/b1/func-expr-strict-forbidden-ext-direct-access-prop-arguments.js non-strict
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
-    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    eval-var-scope-syntax-err.js non-strict
     length-dflt.js
-    name-arguments-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-no-strict-reassign-fn-name-in-body.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-strict-error-reassign-fn-name-in-body.js strict {compiled-strict,interpreted-strict}
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict {compiled-strict,interpreted-strict}
-    named-strict-error-reassign-fn-name-in-body-in-eval.js strict {compiled-strict,interpreted-strict}
+    name-arguments-strict-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
+    named-strict-error-reassign-fn-name-in-body.js strict
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
     object-destructuring-param-strict-body.js
-    param-dflt-yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-dflt-yield-strict.js strict {compiled-strict,interpreted-strict}
-    param-duplicated-strict-body-1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-duplicated-strict-body-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-duplicated-strict-body-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-eval-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-dflt-yield-non-strict.js non-strict
+    param-dflt-yield-strict.js strict
+    param-duplicated-strict-body-1.js non-strict
+    param-duplicated-strict-body-2.js non-strict
+    param-duplicated-strict-body-3.js non-strict
+    param-eval-strict-body.js non-strict
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-name-var-open-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-name-var-open-strict.js strict {compiled-strict,interpreted-strict}
-    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-body-lex-distinct.js non-strict
+    scope-name-var-open-non-strict.js non-strict
+    scope-name-var-open-strict.js strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
 language/expressions/generators 182/290 (62.76%)
     dstr/ary-init-iter-close.js
@@ -3539,28 +4512,28 @@ language/expressions/generators 182/290 (62.76%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1/gen-func-expr-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
     eval-body-proto-realm.js
-    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    eval-var-scope-syntax-err.js non-strict
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
-    named-no-strict-reassign-fn-name-in-body.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-strict-error-reassign-fn-name-in-body.js strict {compiled-strict,interpreted-strict}
-    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict {compiled-strict,interpreted-strict}
-    named-strict-error-reassign-fn-name-in-body-in-eval.js strict {compiled-strict,interpreted-strict}
-    named-yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    named-yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    named-no-strict-reassign-fn-name-in-body.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-arrow.js non-strict
+    named-no-strict-reassign-fn-name-in-body-in-eval.js non-strict
+    named-strict-error-reassign-fn-name-in-body.js strict
+    named-strict-error-reassign-fn-name-in-body-in-arrow.js strict
+    named-strict-error-reassign-fn-name-in-body-in-eval.js strict
+    named-yield-identifier-non-strict.js non-strict
+    named-yield-identifier-spread-non-strict.js non-strict
     named-yield-spread-arr-multiple.js
     named-yield-spread-arr-single.js
     named-yield-spread-obj.js
@@ -3568,21 +4541,21 @@ language/expressions/generators 182/290 (62.76%)
     prototype-own-properties.js
     prototype-value.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-name-var-close.js compiled {compiled-strict,compiled-non-strict}
-    scope-name-var-open-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-name-var-open-strict.js strict {compiled-strict,interpreted-strict}
-    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-body-lex-distinct.js non-strict
+    scope-name-var-close.js compiled
+    scope-name-var-open-non-strict.js non-strict
+    scope-name-var-open-strict.js strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
     static-init-await-binding.js
     static-init-await-reference.js
-    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-as-function-expression-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-as-identifier-in-nested-function.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
+    yield-as-function-expression-binding-identifier.js non-strict
+    yield-as-identifier-in-nested-function.js non-strict
+    yield-identifier-non-strict.js non-strict
+    yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
@@ -3617,7 +4590,7 @@ language/expressions/in 20/36 (55.56%)
     private-field-rhs-unresolvable.js {unsupported: [class-fields-private]}
     private-field-rhs-yield-absent.js {unsupported: [class-fields-private]}
     private-field-rhs-yield-present.js {unsupported: [class-fields-private]}
-    rhs-yield-absent-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    rhs-yield-absent-non-strict.js non-strict
 
 language/expressions/instanceof 5/43 (11.63%)
     S11.8.6_A6_T2.js
@@ -3658,30 +4631,32 @@ language/expressions/logical-assignment 40/78 (51.28%)
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-and.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-nullish.js {unsupported: [class-fields-private]}
     left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js {unsupported: [class-fields-private]}
-    lgcl-and-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    lgcl-and-arguments-strict.js strict
     lgcl-and-assignment-operator-lhs-before-rhs.js
     lgcl-and-assignment-operator-namedevaluation-class-expression.js
-    lgcl-and-assignment-operator-no-set-put.js strict {compiled-strict,interpreted-strict}
-    lgcl-and-assignment-operator-non-extensible.js strict {compiled-strict,interpreted-strict}
+    lgcl-and-assignment-operator-no-set-put.js strict
+    lgcl-and-assignment-operator-non-extensible.js strict
     lgcl-and-assignment-operator-non-simple-lhs.js
-    lgcl-and-assignment-operator-non-writeable.js strict {compiled-strict,interpreted-strict}
-    lgcl-nullish-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    lgcl-and-assignment-operator-non-writeable.js strict
+    lgcl-nullish-arguments-strict.js strict
     lgcl-nullish-assignment-operator-lhs-before-rhs.js
     lgcl-nullish-assignment-operator-namedevaluation-class-expression.js
-    lgcl-nullish-assignment-operator-no-set-put.js strict {compiled-strict,interpreted-strict}
+    lgcl-nullish-assignment-operator-no-set-put.js strict
     lgcl-nullish-assignment-operator-non-simple-lhs.js
-    lgcl-nullish-assignment-operator-non-writeable.js strict {compiled-strict,interpreted-strict}
-    lgcl-or-arguments-strict.js strict {compiled-strict,interpreted-strict}
+    lgcl-nullish-assignment-operator-non-writeable.js strict
+    lgcl-or-arguments-strict.js strict
     lgcl-or-assignment-operator-lhs-before-rhs.js
     lgcl-or-assignment-operator-namedevaluation-class-expression.js
-    lgcl-or-assignment-operator-no-set-put.js strict {compiled-strict,interpreted-strict}
+    lgcl-or-assignment-operator-no-set-put.js strict
     lgcl-or-assignment-operator-non-simple-lhs.js
-    lgcl-or-assignment-operator-non-writeable.js strict {compiled-strict,interpreted-strict}
+    lgcl-or-assignment-operator-non-writeable.js strict
 
 language/expressions/logical-not 0/19 (0.0%)
 
 language/expressions/logical-or 1/18 (5.56%)
     tco-right.js {unsupported: [tail-call-optimization]}
+
+~language/expressions/member-expression 1/1 (100.0%)
 
 language/expressions/modulus 1/40 (2.5%)
     order-of-evaluation.js
@@ -4149,8 +5124,8 @@ language/expressions/object 692/1170 (59.15%)
     method-definition/forbidden-ext/b1/async-gen-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-arguments.js {unsupported: [async-functions, async]}
     method-definition/forbidden-ext/b1/async-meth-forbidden-ext-direct-access-prop-caller.js {unsupported: [async-functions, async]}
-    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/forbidden-ext/b1/gen-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    method-definition/forbidden-ext/b1/meth-forbidden-ext-direct-access-prop-arguments.js non-strict
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-get.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-own-prop-caller-value.js {unsupported: [async-iteration, async]}
     method-definition/forbidden-ext/b2/async-gen-meth-forbidden-ext-indirect-access-prop-caller.js {unsupported: [async-iteration, async]}
@@ -4290,7 +5265,7 @@ language/expressions/object 692/1170 (59.15%)
     method-definition/early-errors-object-method-await-in-formals.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-await-in-formals-default.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-body-contains-super-call.js {unsupported: [async-functions]}
-    method-definition/early-errors-object-method-duplicate-parameters.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/early-errors-object-method-duplicate-parameters.js non-strict
     method-definition/early-errors-object-method-eval-in-formal-parameters.js {unsupported: [async-functions]}
     method-definition/early-errors-object-method-formals-body-duplicate.js {unsupported: [async-functions]}
     method-definition/escaped-get.js
@@ -4308,37 +5283,37 @@ language/expressions/object 692/1170 (59.15%)
     method-definition/gen-meth-dflt-params-ref-self.js
     method-definition/gen-meth-dflt-params-rest.js
     method-definition/gen-meth-dflt-params-trailing-comma.js
-    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/gen-meth-eval-var-scope-syntax-err.js non-strict
     method-definition/gen-meth-object-destructuring-param-strict-body.js
     method-definition/gen-meth-rest-param-strict-body.js
-    method-definition/gen-yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    method-definition/gen-yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/gen-yield-identifier-non-strict.js non-strict
+    method-definition/gen-yield-identifier-spread-non-strict.js non-strict
     method-definition/gen-yield-spread-arr-multiple.js
     method-definition/gen-yield-spread-arr-single.js
     method-definition/gen-yield-spread-obj.js
-    method-definition/generator-invoke-fn-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/generator-invoke-fn-strict.js non-strict
     method-definition/generator-length-dflt.js
     method-definition/generator-param-init-yield.js non-strict
     method-definition/generator-param-redecl-let.js
-    method-definition/generator-prop-name-yield-expr.js non-strict {compiled-non-strict,interpreted-non-strict}
-    method-definition/generator-prop-name-yield-id.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/generator-prop-name-yield-expr.js non-strict
+    method-definition/generator-prop-name-yield-id.js non-strict
     method-definition/generator-prototype-prop.js
     method-definition/meth-array-destructuring-param-strict-body.js
-    method-definition/meth-dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/meth-dflt-params-duplicates.js non-strict
     method-definition/meth-dflt-params-ref-later.js
     method-definition/meth-dflt-params-ref-self.js
     method-definition/meth-dflt-params-rest.js
     method-definition/meth-dflt-params-trailing-comma.js
-    method-definition/meth-eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/meth-eval-var-scope-syntax-err.js non-strict
     method-definition/meth-object-destructuring-param-strict-body.js
     method-definition/meth-rest-param-strict-body.js
-    method-definition/name-invoke-fn-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/name-invoke-fn-strict.js non-strict
     method-definition/name-length-dflt.js
-    method-definition/name-param-id-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
-    method-definition/name-param-init-yield.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/name-param-id-yield.js non-strict
+    method-definition/name-param-init-yield.js non-strict
     method-definition/name-param-redecl.js
-    method-definition/name-prop-name-yield-expr.js non-strict {compiled-non-strict}
-    method-definition/name-prop-name-yield-id.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/name-prop-name-yield-expr.js non-strict
+    method-definition/name-prop-name-yield-id.js non-strict
     method-definition/object-method-returns-promise.js {unsupported: [async-functions]}
     method-definition/params-dflt-meth-ref-arguments.js
     method-definition/private-name-early-error-async-fn.js {unsupported: [async-functions]}
@@ -4357,57 +5332,57 @@ language/expressions/object 692/1170 (59.15%)
     method-definition/static-init-await-reference-normal.js
     method-definition/yield-as-expression-with-rhs.js
     method-definition/yield-as-expression-without-rhs.js
-    method-definition/yield-as-function-expression-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
-    method-definition/yield-as-identifier-in-nested-function.js non-strict {compiled-non-strict,interpreted-non-strict}
+    method-definition/yield-as-function-expression-binding-identifier.js non-strict
+    method-definition/yield-as-identifier-in-nested-function.js non-strict
     method-definition/yield-star-after-newline.js
     method-definition/yield-star-before-newline.js
-    __proto__-duplicate.js {compiled-non-strict,interpreted-non-strict}
+    __proto__-duplicate.js
     __proto__-duplicate-computed.js
     __proto__-permitted-dup.js {unsupported: [async-iteration, async-functions]}
     __proto__-permitted-dup-shorthand.js
     accessor-name-computed-in.js
-    accessor-name-computed-yield-id.js non-strict {compiled-non-strict,interpreted-non-strict}
+    accessor-name-computed-yield-id.js non-strict
     computed-__proto__.js
     cpn-obj-lit-computed-property-name-from-async-arrow-function-expression.js
     cpn-obj-lit-computed-property-name-from-await-expression.js {unsupported: [module, async]}
     cpn-obj-lit-computed-property-name-from-yield-expression.js
     fn-name-class.js {unsupported: [class]}
     fn-name-cover.js
-    getter-body-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
+    getter-body-strict-inside.js non-strict
     getter-param-dflt.js
     ident-name-prop-name-literal-await-static-init.js
-    identifier-shorthand-await-strict-mode.js non-strict {compiled-non-strict,interpreted-non-strict}
+    identifier-shorthand-await-strict-mode.js non-strict
     identifier-shorthand-static-init-await-valid.js
-    let-non-strict-access.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-non-strict-syntax.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-non-strict-access.js non-strict
+    let-non-strict-syntax.js non-strict
     literal-property-name-bigint.js {unsupported: [class]}
     object-spread-proxy-get-not-called-on-dontenum-keys.js
     object-spread-proxy-no-excluded-keys.js
     object-spread-proxy-ownkeys-returned-keys-order.js
-    prop-def-id-eval-error.js non-strict {compiled-non-strict,interpreted-non-strict}
-    prop-def-id-eval-error-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    prop-dup-get-data.js strict {compiled-strict,interpreted-strict}
-    prop-dup-get-get.js strict {compiled-strict,interpreted-strict}
-    prop-dup-get-set-get.js strict {compiled-strict,interpreted-strict}
-    prop-dup-set-get-set.js strict {compiled-strict,interpreted-strict}
-    prop-dup-set-set.js strict {compiled-strict,interpreted-strict}
-    scope-gen-meth-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-gen-meth-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-gen-meth-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    prop-def-id-eval-error.js non-strict
+    prop-def-id-eval-error-2.js non-strict
+    prop-dup-get-data.js strict
+    prop-dup-get-get.js strict
+    prop-dup-get-set-get.js strict
+    prop-dup-set-get-set.js strict
+    prop-dup-set-set.js strict
+    scope-gen-meth-body-lex-distinct.js non-strict
+    scope-gen-meth-param-rest-elem-var-close.js non-strict
+    scope-gen-meth-param-rest-elem-var-open.js non-strict
     scope-gen-meth-paramsbody-var-open.js
-    scope-getter-body-lex-distinc.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-meth-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-meth-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-meth-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-getter-body-lex-distinc.js non-strict
+    scope-meth-body-lex-distinct.js non-strict
+    scope-meth-param-rest-elem-var-close.js non-strict
+    scope-meth-param-rest-elem-var-open.js non-strict
     scope-meth-paramsbody-var-open.js
-    scope-setter-body-lex-distinc.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-setter-body-lex-distinc.js non-strict
     scope-setter-paramsbody-var-open.js
-    setter-body-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
+    setter-body-strict-inside.js non-strict
     setter-length-dflt.js
-    setter-param-arguments-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
-    setter-param-eval-strict-inside.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-non-strict-access.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-non-strict-syntax.js non-strict {compiled-non-strict,interpreted-non-strict}
+    setter-param-arguments-strict-inside.js non-strict
+    setter-param-eval-strict-inside.js non-strict
+    yield-non-strict-access.js non-strict
+    yield-non-strict-syntax.js non-strict
 
 language/expressions/optional-chaining 18/38 (47.37%)
     call-expression.js
@@ -4430,10 +5405,10 @@ language/expressions/optional-chaining 18/38 (47.37%)
     super-property-optional-call.js
 
 language/expressions/postfix-decrement 9/37 (24.32%)
-    arguments.js strict {compiled-strict,interpreted-strict}
-    eval.js strict {compiled-strict,interpreted-strict}
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
-    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments.js strict
+    eval.js strict
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-x-postfix-decrement-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.3.2_A6_T1.js
     S11.3.2_A6_T2.js
     S11.3.2_A6_T3.js
@@ -4441,11 +5416,11 @@ language/expressions/postfix-decrement 9/37 (24.32%)
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/postfix-increment 10/38 (26.32%)
-    11.3.1-2-1gs.js strict {compiled-strict,interpreted-strict}
-    arguments.js strict {compiled-strict,interpreted-strict}
-    eval.js strict {compiled-strict,interpreted-strict}
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
-    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    11.3.1-2-1gs.js strict
+    arguments.js strict
+    eval.js strict
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-x-postfix-increment-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.3.1_A6_T1.js
     S11.3.1_A6_T2.js
     S11.3.1_A6_T3.js
@@ -4453,11 +5428,11 @@ language/expressions/postfix-increment 10/38 (26.32%)
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/prefix-decrement 10/34 (29.41%)
-    11.4.5-2-2gs.js strict {compiled-strict,interpreted-strict}
-    arguments.js strict {compiled-strict,interpreted-strict}
-    eval.js strict {compiled-strict,interpreted-strict}
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
-    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    11.4.5-2-2gs.js strict
+    arguments.js strict
+    eval.js strict
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-prefix-decrement-x-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.4.5_A6_T1.js
     S11.4.5_A6_T2.js
     S11.4.5_A6_T3.js
@@ -4465,10 +5440,10 @@ language/expressions/prefix-decrement 10/34 (29.41%)
     target-newtarget.js {unsupported: [new.target]}
 
 language/expressions/prefix-increment 9/33 (27.27%)
-    arguments.js strict {compiled-strict,interpreted-strict}
-    eval.js strict {compiled-strict,interpreted-strict}
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict {compiled-non-strict,interpreted-non-strict}
-    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments.js strict
+    eval.js strict
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue-.js non-strict
+    operator-prefix-increment-x-calls-putvalue-lhs-newvalue--1.js non-strict
     S11.4.4_A6_T1.js
     S11.4.4_A6_T2.js
     S11.4.4_A6_T3.js
@@ -4489,10 +5464,83 @@ language/expressions/strict-equals 0/30 (0.0%)
 language/expressions/subtraction 1/38 (2.63%)
     order-of-evaluation.js
 
-~language/expressions/super
+language/expressions/super 73/94 (77.66%)
+    call-arg-evaluation-err.js {unsupported: [class]}
+    call-bind-this-value.js {unsupported: [class]}
+    call-bind-this-value-twice.js {unsupported: [class]}
+    call-construct-error.js {unsupported: [class]}
+    call-construct-invocation.js {unsupported: [new.target, class]}
+    call-expr-value.js {unsupported: [class]}
+    call-poisoned-underscore-proto.js {unsupported: [class]}
+    call-proto-not-ctor.js {unsupported: [class]}
+    call-spread-err-mult-err-expr-throws.js
+    call-spread-err-mult-err-iter-get-value.js
+    call-spread-err-mult-err-itr-get-call.js
+    call-spread-err-mult-err-itr-get-get.js
+    call-spread-err-mult-err-itr-step.js
+    call-spread-err-mult-err-itr-value.js
+    call-spread-err-mult-err-obj-unresolvable.js
+    call-spread-err-mult-err-unresolvable.js
+    call-spread-err-sngl-err-expr-throws.js
+    call-spread-err-sngl-err-itr-get-call.js
+    call-spread-err-sngl-err-itr-get-get.js
+    call-spread-err-sngl-err-itr-get-value.js
+    call-spread-err-sngl-err-itr-step.js
+    call-spread-err-sngl-err-itr-value.js
+    call-spread-err-sngl-err-obj-unresolvable.js
+    call-spread-err-sngl-err-unresolvable.js
+    call-spread-mult-empty.js
+    call-spread-mult-expr.js
+    call-spread-mult-iter.js
+    call-spread-mult-literal.js
+    call-spread-mult-obj-ident.js
+    call-spread-mult-obj-null.js
+    call-spread-mult-obj-undefined.js
+    call-spread-obj-getter-descriptor.js
+    call-spread-obj-getter-init.js
+    call-spread-obj-manipulate-outter-obj-in-getter.js
+    call-spread-obj-mult-spread.js
+    call-spread-obj-mult-spread-getter.js
+    call-spread-obj-null.js
+    call-spread-obj-override-immutable.js
+    call-spread-obj-overrides-prev-properties.js
+    call-spread-obj-skip-non-enumerable.js
+    call-spread-obj-spread-order.js
+    call-spread-obj-symbol-property.js
+    call-spread-obj-undefined.js
+    call-spread-obj-with-overrides.js
+    call-spread-sngl-empty.js
+    call-spread-sngl-expr.js
+    call-spread-sngl-iter.js
+    call-spread-sngl-literal.js
+    call-spread-sngl-obj-ident.js
+    prop-dot-cls-null-proto.js {unsupported: [class]}
+    prop-dot-cls-ref-strict.js {unsupported: [class]}
+    prop-dot-cls-ref-this.js
+    prop-dot-cls-this-uninit.js {unsupported: [class]}
+    prop-dot-cls-val.js {unsupported: [class]}
+    prop-dot-cls-val-from-arrow.js {unsupported: [class]}
+    prop-dot-cls-val-from-eval.js {unsupported: [class]}
+    prop-expr-cls-err.js {unsupported: [class]}
+    prop-expr-cls-key-err.js {unsupported: [class]}
+    prop-expr-cls-null-proto.js {unsupported: [class]}
+    prop-expr-cls-ref-strict.js {unsupported: [class]}
+    prop-expr-cls-ref-this.js
+    prop-expr-cls-this-uninit.js {unsupported: [class]}
+    prop-expr-cls-unresolvable.js {unsupported: [class]}
+    prop-expr-cls-val.js {unsupported: [class]}
+    prop-expr-cls-val-from-arrow.js {unsupported: [class]}
+    prop-expr-cls-val-from-eval.js {unsupported: [class]}
+    prop-expr-getsuperbase-before-topropertykey-putvalue-increment.js interpreted
+    prop-expr-uninitialized-this-getvalue.js
+    prop-expr-uninitialized-this-putvalue.js
+    prop-expr-uninitialized-this-putvalue-compound-assign.js
+    prop-expr-uninitialized-this-putvalue-increment.js
+    realm.js
+    super-reference-resolution.js {unsupported: [class]}
 
 language/expressions/tagged-template 3/27 (11.11%)
-    call-expression-context-strict.js strict {compiled-strict,interpreted-strict}
+    call-expression-context-strict.js strict
     tco-call.js {unsupported: [tail-call-optimization]}
     tco-member.js {unsupported: [tail-call-optimization]}
 
@@ -4521,77 +5569,77 @@ language/expressions/yield 4/63 (6.35%)
     star-rhs-iter-nrml-next-invoke.js
 
 language/function-code 96/217 (44.24%)
-    10.4.3-1-1-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-10-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-104.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-106.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-10gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-11-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-11gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-12-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-12gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-14-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-14gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-16-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-16gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-17-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-2-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-27-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-27gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-28-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-28gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-29-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-29gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-3-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-30-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-30gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-31-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-31gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-32-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-32gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-33-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-33gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-34-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-34gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-35-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-35gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-36-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-36gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-37-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-37gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-38-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-38gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-39-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-39gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-4-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-40-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-40gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-41-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-41gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-42-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-42gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-43-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-43gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-44-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-44gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-45-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-45gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-46-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-46gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-47-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-47gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-48-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-48gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-49-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-49gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-50-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-50gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-51-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-51gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-52-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-52gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-53-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-53gs.js non-strict {compiled-non-strict,interpreted-non-strict}
+    10.4.3-1-1-s.js non-strict
+    10.4.3-1-10-s.js non-strict
+    10.4.3-1-104.js strict
+    10.4.3-1-106.js strict
+    10.4.3-1-10gs.js non-strict
+    10.4.3-1-11-s.js strict
+    10.4.3-1-11gs.js strict
+    10.4.3-1-12-s.js non-strict
+    10.4.3-1-12gs.js non-strict
+    10.4.3-1-14-s.js non-strict
+    10.4.3-1-14gs.js non-strict
+    10.4.3-1-16-s.js non-strict
+    10.4.3-1-16gs.js non-strict
+    10.4.3-1-17-s.js strict
+    10.4.3-1-2-s.js non-strict
+    10.4.3-1-27-s.js strict
+    10.4.3-1-27gs.js strict
+    10.4.3-1-28-s.js strict
+    10.4.3-1-28gs.js strict
+    10.4.3-1-29-s.js strict
+    10.4.3-1-29gs.js strict
+    10.4.3-1-3-s.js non-strict
+    10.4.3-1-30-s.js strict
+    10.4.3-1-30gs.js strict
+    10.4.3-1-31-s.js strict
+    10.4.3-1-31gs.js strict
+    10.4.3-1-32-s.js strict
+    10.4.3-1-32gs.js strict
+    10.4.3-1-33-s.js strict
+    10.4.3-1-33gs.js strict
+    10.4.3-1-34-s.js strict
+    10.4.3-1-34gs.js strict
+    10.4.3-1-35-s.js strict
+    10.4.3-1-35gs.js strict
+    10.4.3-1-36-s.js non-strict
+    10.4.3-1-36gs.js non-strict
+    10.4.3-1-37-s.js non-strict
+    10.4.3-1-37gs.js non-strict
+    10.4.3-1-38-s.js non-strict
+    10.4.3-1-38gs.js non-strict
+    10.4.3-1-39-s.js non-strict
+    10.4.3-1-39gs.js non-strict
+    10.4.3-1-4-s.js non-strict
+    10.4.3-1-40-s.js non-strict
+    10.4.3-1-40gs.js non-strict
+    10.4.3-1-41-s.js non-strict
+    10.4.3-1-41gs.js non-strict
+    10.4.3-1-42-s.js non-strict
+    10.4.3-1-42gs.js non-strict
+    10.4.3-1-43-s.js non-strict
+    10.4.3-1-43gs.js non-strict
+    10.4.3-1-44-s.js non-strict
+    10.4.3-1-44gs.js non-strict
+    10.4.3-1-45-s.js non-strict
+    10.4.3-1-45gs.js non-strict
+    10.4.3-1-46-s.js non-strict
+    10.4.3-1-46gs.js non-strict
+    10.4.3-1-47-s.js non-strict
+    10.4.3-1-47gs.js non-strict
+    10.4.3-1-48-s.js non-strict
+    10.4.3-1-48gs.js non-strict
+    10.4.3-1-49-s.js non-strict
+    10.4.3-1-49gs.js non-strict
+    10.4.3-1-50-s.js non-strict
+    10.4.3-1-50gs.js non-strict
+    10.4.3-1-51-s.js non-strict
+    10.4.3-1-51gs.js non-strict
+    10.4.3-1-52-s.js non-strict
+    10.4.3-1-52gs.js non-strict
+    10.4.3-1-53-s.js non-strict
+    10.4.3-1-53gs.js non-strict
     10.4.3-1-62-s.js
     10.4.3-1-62gs.js
     10.4.3-1-63-s.js
@@ -4600,38 +5648,38 @@ language/function-code 96/217 (44.24%)
     10.4.3-1-64gs.js
     10.4.3-1-65-s.js
     10.4.3-1-65gs.js
-    10.4.3-1-7-s.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-7-s.js strict
     10.4.3-1-76-s.js
     10.4.3-1-76gs.js
     10.4.3-1-77-s.js
     10.4.3-1-77gs.js
     10.4.3-1-78-s.js
     10.4.3-1-78gs.js
-    10.4.3-1-7gs.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-8-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-8gs.js non-strict {compiled-non-strict,interpreted-non-strict}
-    10.4.3-1-9-s.js strict {compiled-strict,interpreted-strict}
-    10.4.3-1-9gs.js strict {compiled-strict,interpreted-strict}
-    block-decl-onlystrict.js strict {compiled-strict,interpreted-strict}
-    eval-param-env-with-computed-key.js non-strict {compiled-non-strict,interpreted-non-strict}
-    S10.4.3_A1.js strict {compiled-strict,interpreted-strict}
-    switch-case-decl-onlystrict.js strict {compiled-strict,interpreted-strict}
-    switch-dflt-decl-onlystrict.js strict {compiled-strict,interpreted-strict}
+    10.4.3-1-7gs.js strict
+    10.4.3-1-8-s.js non-strict
+    10.4.3-1-8gs.js non-strict
+    10.4.3-1-9-s.js strict
+    10.4.3-1-9gs.js strict
+    block-decl-onlystrict.js strict
+    eval-param-env-with-computed-key.js non-strict
+    S10.4.3_A1.js strict
+    switch-case-decl-onlystrict.js strict
+    switch-dflt-decl-onlystrict.js strict
 
 language/future-reserved-words 7/55 (12.73%)
-    implements.js non-strict {compiled-non-strict,interpreted-non-strict}
-    interface.js non-strict {compiled-non-strict,interpreted-non-strict}
-    package.js non-strict {compiled-non-strict,interpreted-non-strict}
-    private.js non-strict {compiled-non-strict,interpreted-non-strict}
-    protected.js non-strict {compiled-non-strict,interpreted-non-strict}
-    public.js non-strict {compiled-non-strict,interpreted-non-strict}
-    static.js non-strict {compiled-non-strict,interpreted-non-strict}
+    implements.js non-strict
+    interface.js non-strict
+    package.js non-strict
+    private.js non-strict
+    protected.js non-strict
+    public.js non-strict
+    static.js non-strict
 
 language/global-code 26/42 (61.9%)
-    block-decl-strict.js strict {compiled-strict,interpreted-strict}
+    block-decl-strict.js strict
     decl-lex.js
     decl-lex-configurable-global.js
-    decl-lex-deletion.js non-strict {compiled-non-strict,interpreted-non-strict}
+    decl-lex-deletion.js non-strict
     decl-lex-restricted-global.js
     invalid-private-names-call-expression-bad-reference.js {unsupported: [class-fields-private]}
     invalid-private-names-call-expression-this.js {unsupported: [class-fields-private]}
@@ -4641,19 +5689,19 @@ language/global-code 26/42 (61.9%)
     new.target-arrow.js {unsupported: [new.target]}
     script-decl-func.js
     script-decl-func-err-non-configurable.js
-    script-decl-func-err-non-extensible.js non-strict {compiled-non-strict,interpreted-non-strict}
+    script-decl-func-err-non-extensible.js non-strict
     script-decl-lex.js
-    script-decl-lex-deletion.js non-strict {compiled-non-strict,interpreted-non-strict}
+    script-decl-lex-deletion.js non-strict
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
-    script-decl-lex-var-declared-via-eval.js {compiled-non-strict,interpreted-non-strict}
+    script-decl-lex-var-declared-via-eval.js
     script-decl-var.js
     script-decl-var-collision.js
-    script-decl-var-err.js non-strict {compiled-non-strict,interpreted-non-strict}
-    switch-case-decl-strict.js strict {compiled-strict,interpreted-strict}
-    switch-dflt-decl-strict.js strict {compiled-strict,interpreted-strict}
-    yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    script-decl-var-err.js non-strict
+    switch-case-decl-strict.js strict
+    switch-dflt-decl-strict.js strict
+    yield-non-strict.js non-strict
 
 language/identifier-resolution 0/14 (0.0%)
 
@@ -4764,20 +5812,20 @@ language/keywords 0/25 (0.0%)
 language/line-terminators 0/41 (0.0%)
 
 language/literals 43/534 (8.05%)
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/legacy-octal-like-invalid-00n.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/legacy-octal-like-invalid-01n.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/legacy-octal-like-invalid-07n.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/non-octal-like-invalid-0008n.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/non-octal-like-invalid-012348n.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/non-octal-like-invalid-08n.js non-strict {compiled-non-strict,interpreted-non-strict}
-    bigint/non-octal-like-invalid-09n.js non-strict {compiled-non-strict,interpreted-non-strict}
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
+    bigint/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
+    bigint/legacy-octal-like-invalid-00n.js non-strict
+    bigint/legacy-octal-like-invalid-01n.js non-strict
+    bigint/legacy-octal-like-invalid-07n.js non-strict
+    bigint/non-octal-like-invalid-0008n.js non-strict
+    bigint/non-octal-like-invalid-012348n.js non-strict
+    bigint/non-octal-like-invalid-08n.js non-strict
+    bigint/non-octal-like-invalid-09n.js non-strict
     boolean/false-with-unicode.js
     boolean/true-with-unicode.js
     null/null-with-unicode.js
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict {compiled-non-strict,interpreted-non-strict}
-    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-08-err.js non-strict
+    numeric/numeric-separators/numeric-separator-literal-nonoctal-09-err.js non-strict
     numeric/numeric-followed-by-ident.js
     regexp/invalid-braced-quantifier-exact.js
     regexp/invalid-braced-quantifier-lower.js
@@ -4789,24 +5837,24 @@ language/literals 43/534 (8.05%)
     regexp/S7.8.5_A2.1_T2.js
     regexp/S7.8.5_A2.4_T2.js
     regexp/u-case-mapping.js
-    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-8-strict.js strict {compiled-strict,interpreted-strict}
-    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-9-strict.js strict {compiled-strict,interpreted-strict}
-    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict {compiled-non-strict,interpreted-non-strict}
-    string/legacy-non-octal-escape-sequence-strict.js strict {compiled-strict,interpreted-strict}
+    string/legacy-non-octal-escape-sequence-1-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-2-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-3-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-4-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-5-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-6-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-7-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-8-strict.js strict
+    string/legacy-non-octal-escape-sequence-8-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-9-strict.js strict
+    string/legacy-non-octal-escape-sequence-9-strict-explicit-pragma.js non-strict
+    string/legacy-non-octal-escape-sequence-strict.js strict
     string/legacy-octal-escape-sequence-prologue-strict.js
-    string/legacy-octal-escape-sequence-strict.js strict {compiled-strict,interpreted-strict}
+    string/legacy-octal-escape-sequence-strict.js strict
     string/mongolian-vowel-separator.js {unsupported: [u180e]}
     string/mongolian-vowel-separator-eval.js {unsupported: [u180e]}
-    string/S7.8.4_A4.3_T1.js strict {compiled-strict,interpreted-strict}
-    string/S7.8.4_A4.3_T2.js strict {compiled-strict,interpreted-strict}
+    string/S7.8.4_A4.3_T1.js strict
+    string/S7.8.4_A4.3_T2.js strict
 
 ~language/module-code
 
@@ -4819,7 +5867,7 @@ language/reserved-words 2/27 (7.41%)
 language/rest-parameters 5/11 (45.45%)
     array-pattern.js
     arrow-function.js
-    no-alias-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
+    no-alias-arguments.js non-strict
     object-pattern.js
     with-new-target.js
 
@@ -4852,7 +5900,7 @@ language/statementList 21/80 (26.25%)
 
 ~language/statements/async-generator
 
-~language/statements/async-generator
+~language/statements/await-using
 
 language/statements/block 7/21 (33.33%)
     early-errors 4/4 (100.0%)
@@ -4966,7 +6014,7 @@ language/statements/do-while 10/36 (27.78%)
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
     tco-body.js {unsupported: [tail-call-optimization]}
 
 language/statements/empty 0/2 (0.0%)
@@ -5110,7 +6158,7 @@ language/statements/for 230/385 (59.74%)
     dstr/let-obj-ptrn-id-init-fn-name-gen.js
     dstr/let-obj-ptrn-prop-ary.js
     dstr/let-obj-ptrn-prop-ary-init.js
-    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict {compiled-strict,interpreted-strict}
+    dstr/let-obj-ptrn-prop-ary-trailing-comma.js strict
     dstr/let-obj-ptrn-prop-ary-value-null.js
     dstr/let-obj-ptrn-prop-eval-err.js
     dstr/let-obj-ptrn-prop-obj.js
@@ -5190,13 +6238,13 @@ language/statements/for 230/385 (59.74%)
     head-init-expr-check-empty-inc-empty-completion.js
     head-init-var-check-empty-inc-empty-completion.js
     head-let-bound-names-in-stmt.js
-    head-lhs-let.js non-strict {compiled-non-strict,interpreted-non-strict}
+    head-lhs-let.js non-strict
     labelled-fn-stmt-expr.js
     labelled-fn-stmt-let.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-open.js
@@ -5229,16 +6277,16 @@ language/statements/for-in 40/115 (34.78%)
     head-let-bound-names-in-stmt.js
     head-let-destructuring.js
     head-let-fresh-binding-per-iteration.js
-    head-lhs-let.js non-strict {compiled-non-strict,interpreted-non-strict}
+    head-lhs-let.js non-strict
     head-var-bound-names-dup.js
-    head-var-bound-names-let.js non-strict {compiled-non-strict,interpreted-non-strict}
-    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    head-var-bound-names-let.js non-strict
+    identifier-let-allowed-as-lefthandside-expression-not-strict.js non-strict
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     order-enumerable-shadowed.js
     resizable-buffer.js {unsupported: [resizable-arraybuffer]}
     scope-body-lex-boundary.js
@@ -5247,7 +6295,7 @@ language/statements/for-in 40/115 (34.78%)
     scope-body-var-none.js
     scope-head-lex-close.js
     scope-head-lex-open.js
-    scope-head-var-none.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-head-var-none.js non-strict
 
 language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-init-evaluation.js
@@ -5258,8 +6306,8 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-init-fn-name-gen.js
     dstr/array-elem-init-in.js
     dstr/array-elem-init-let.js
-    dstr/array-elem-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/array-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-init-simple-no-strict.js non-strict
+    dstr/array-elem-init-yield-ident-valid.js non-strict
     dstr/array-elem-iter-get-err.js
     dstr/array-elem-iter-nrml-close.js
     dstr/array-elem-iter-nrml-close-err.js
@@ -5271,15 +6319,15 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-elem-iter-thrw-close.js
     dstr/array-elem-iter-thrw-close-err.js
     dstr/array-elem-iter-thrw-close-skip.js
-    dstr/array-elem-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-nested-array-yield-ident-valid.js non-strict
     dstr/array-elem-nested-obj-yield-expr.js
-    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/array-elem-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-nested-obj-yield-ident-valid.js non-strict
+    dstr/array-elem-put-const.js non-strict
     dstr/array-elem-put-let.js
     dstr/array-elem-put-obj-literal-prop-ref-init.js
     dstr/array-elem-put-obj-literal-prop-ref-init-active.js
-    dstr/array-elem-target-simple-strict.js strict {compiled-strict,interpreted-strict}
-    dstr/array-elem-target-yield-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-elem-target-simple-strict.js strict
+    dstr/array-elem-target-yield-valid.js non-strict
     dstr/array-elem-trlg-iter-elision-iter-abpt.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close.js
     dstr/array-elem-trlg-iter-elision-iter-nrml-close-err.js
@@ -5346,24 +6394,24 @@ language/statements/for-of 438/751 (58.32%)
     dstr/array-rest-nested-array-undefined-hole.js
     dstr/array-rest-nested-array-undefined-own.js
     dstr/array-rest-nested-array-yield-expr.js
-    dstr/array-rest-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-nested-array-yield-ident-valid.js non-strict
     dstr/array-rest-nested-obj.js
     dstr/array-rest-nested-obj-null.js
     dstr/array-rest-nested-obj-undefined.js
     dstr/array-rest-nested-obj-undefined-hole.js
     dstr/array-rest-nested-obj-undefined-own.js
     dstr/array-rest-nested-obj-yield-expr.js
-    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-nested-obj-yield-ident-valid.js non-strict
     dstr/array-rest-put-const.js
     dstr/array-rest-put-let.js
     dstr/array-rest-put-prop-ref.js
     dstr/array-rest-put-prop-ref-no-get.js
     dstr/array-rest-put-prop-ref-user-err.js
     dstr/array-rest-put-prop-ref-user-err-iter-close-skip.js
-    dstr/array-rest-put-unresolvable-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/array-rest-put-unresolvable-strict.js strict {compiled-strict,interpreted-strict}
+    dstr/array-rest-put-unresolvable-no-strict.js non-strict
+    dstr/array-rest-put-unresolvable-strict.js strict
     dstr/array-rest-yield-expr.js
-    dstr/array-rest-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/array-rest-yield-ident-valid.js non-strict
     dstr/const-ary-init-iter-close.js
     dstr/const-ary-init-iter-get-err.js
     dstr/const-ary-init-iter-get-err-array-prototype.js
@@ -5510,7 +6558,7 @@ language/statements/for-of 438/751 (58.32%)
     dstr/let-obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     dstr/obj-empty-null.js
     dstr/obj-empty-undef.js
-    dstr/obj-id-identifier-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-identifier-yield-ident-valid.js non-strict
     dstr/obj-id-init-assignment-missing.js
     dstr/obj-id-init-assignment-null.js
     dstr/obj-id-init-assignment-truthy.js
@@ -5524,10 +6572,10 @@ language/statements/for-of 438/751 (58.32%)
     dstr/obj-id-init-in.js
     dstr/obj-id-init-let.js
     dstr/obj-id-init-order.js
-    dstr/obj-id-init-simple-no-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-init-simple-no-strict.js non-strict
     dstr/obj-id-init-yield-expr.js
-    dstr/obj-id-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/obj-id-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-id-init-yield-ident-valid.js non-strict
+    dstr/obj-id-put-const.js non-strict
     dstr/obj-id-put-let.js
     dstr/obj-prop-elem-init-fn-name-arrow.js
     dstr/obj-prop-elem-init-fn-name-class.js {unsupported: [class]}
@@ -5536,16 +6584,16 @@ language/statements/for-of 438/751 (58.32%)
     dstr/obj-prop-elem-init-fn-name-gen.js
     dstr/obj-prop-elem-init-in.js
     dstr/obj-prop-elem-init-let.js
-    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-elem-init-yield-ident-valid.js non-strict
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init.js
     dstr/obj-prop-elem-target-obj-literal-prop-ref-init-active.js
-    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-elem-target-yield-ident-valid.js non-strict
     dstr/obj-prop-name-evaluation.js
     dstr/obj-prop-name-evaluation-error.js
-    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-nested-array-yield-ident-valid.js non-strict
     dstr/obj-prop-nested-obj-yield-expr.js
-    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict {compiled-non-strict,interpreted-non-strict}
-    dstr/obj-prop-put-const.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dstr/obj-prop-nested-obj-yield-ident-valid.js non-strict
+    dstr/obj-prop-put-const.js non-strict
     dstr/obj-prop-put-let.js
     dstr/obj-rest-computed-property.js {unsupported: [object-rest]}
     dstr/obj-rest-computed-property-no-strict.js {unsupported: [object-rest]}
@@ -5660,7 +6708,7 @@ language/statements/for-of 438/751 (58.32%)
     head-lhs-async-invalid.js
     head-using-bound-names-fordecl-tdz.js
     head-using-fresh-binding-per-iteration.js
-    head-var-bound-names-let.js non-strict {compiled-non-strict,interpreted-non-strict}
+    head-var-bound-names-let.js non-strict
     head-var-init.js
     head-var-no-expr.js
     iterator-close-non-object.js
@@ -5676,9 +6724,9 @@ language/statements/for-of 438/751 (58.32%)
     labelled-fn-stmt-let.js
     labelled-fn-stmt-lhs.js
     labelled-fn-stmt-var.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     scope-body-lex-boundary.js
     scope-body-lex-open.js
     scope-head-lex-close.js
@@ -5799,56 +6847,56 @@ language/statements/function 162/451 (35.92%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     early-errors 4/4 (100.0%)
-    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.0-13-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.0-14-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.1-22-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    forbidden-ext/b1/cls-expr-meth-forbidden-ext-direct-access-prop-arguments.js non-strict
+    13.0-13-s.js non-strict
+    13.0-14-s.js non-strict
+    13.1-22-s.js non-strict
     13.2-10-s.js
     13.2-13-s.js
     13.2-14-s.js
     13.2-17-s.js
     13.2-18-s.js
-    13.2-19-b-3gs.js strict {compiled-strict,interpreted-strict}
-    13.2-2-s.js strict {compiled-strict,interpreted-strict}
-    13.2-21-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.2-22-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.2-25-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.2-26-s.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-19-b-3gs.js strict
+    13.2-2-s.js strict
+    13.2-21-s.js non-strict
+    13.2-22-s.js non-strict
+    13.2-25-s.js non-strict
+    13.2-26-s.js non-strict
     13.2-30-s.js
-    13.2-4-s.js strict {compiled-strict,interpreted-strict}
-    13.2-5-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.2-6-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    13.2-9-s.js non-strict {compiled-non-strict,interpreted-non-strict}
-    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
-    arguments-with-arguments-lex.js non-strict {compiled-non-strict,interpreted-non-strict}
+    13.2-4-s.js strict
+    13.2-5-s.js non-strict
+    13.2-6-s.js non-strict
+    13.2-9-s.js non-strict
+    arguments-with-arguments-fn.js non-strict
+    arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
-    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    eval-var-scope-syntax-err.js non-strict
     length-dflt.js
-    name-arguments-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
-    name-eval-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    name-arguments-strict-body.js non-strict
+    name-eval-strict-body.js non-strict
     object-destructuring-param-strict-body.js
-    param-arguments-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-dflt-yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-dflt-yield-strict.js strict {compiled-strict,interpreted-strict}
-    param-duplicated-strict-body-1.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-duplicated-strict-body-2.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-duplicated-strict-body-3.js non-strict {compiled-non-strict,interpreted-non-strict}
-    param-eval-strict-body.js non-strict {compiled-non-strict,interpreted-non-strict}
+    param-arguments-strict-body.js non-strict
+    param-dflt-yield-non-strict.js non-strict
+    param-dflt-yield-strict.js strict
+    param-duplicated-strict-body-1.js non-strict
+    param-duplicated-strict-body-2.js non-strict
+    param-duplicated-strict-body-3.js non-strict
+    param-eval-strict-body.js non-strict
     params-dflt-ref-arguments.js
     rest-param-strict-body.js
-    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-body-lex-distinct.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
     static-init-await-binding-valid.js
-    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
 
 language/statements/generators 168/266 (63.16%)
     dstr/ary-init-iter-close.js
@@ -5984,17 +7032,17 @@ language/statements/generators 168/266 (63.16%)
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
     forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js non-strict
-    arguments-with-arguments-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
+    arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
     cptn-decl.js
     default-proto.js
     dflt-params-abrupt.js
-    dflt-params-duplicates.js non-strict {compiled-non-strict,interpreted-non-strict}
+    dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
     dflt-params-rest.js
     dflt-params-trailing-comma.js
-    eval-var-scope-syntax-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    eval-var-scope-syntax-err.js non-strict
     has-instance.js
     invoke-as-constructor.js
     length-dflt.js
@@ -6003,17 +7051,17 @@ language/statements/generators 168/266 (63.16%)
     prototype-value.js
     rest-param-strict-body.js
     restricted-properties.js
-    scope-body-lex-distinct.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-close.js non-strict {compiled-non-strict,interpreted-non-strict}
-    scope-param-rest-elem-var-open.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-body-lex-distinct.js non-strict
+    scope-param-rest-elem-var-close.js non-strict
+    scope-param-rest-elem-var-open.js non-strict
     scope-paramsbody-var-open.js
-    unscopables-with.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-with-in-nested-fn.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-as-function-expression-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-as-generator-declaration-binding-identifier.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-as-identifier-in-nested-function.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-identifier-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    yield-identifier-spread-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-with.js non-strict
+    unscopables-with-in-nested-fn.js non-strict
+    yield-as-function-expression-binding-identifier.js non-strict
+    yield-as-generator-declaration-binding-identifier.js non-strict
+    yield-as-identifier-in-nested-function.js non-strict
+    yield-identifier-non-strict.js non-strict
+    yield-identifier-spread-non-strict.js non-strict
     yield-spread-arr-multiple.js
     yield-spread-arr-single.js
     yield-spread-obj.js
@@ -6037,12 +7085,12 @@ language/statements/if 42/69 (60.87%)
     if-const-else-const.js
     if-const-else-stmt.js
     if-const-no-else.js
-    if-decl-else-decl-strict.js strict {compiled-strict,interpreted-strict}
-    if-decl-else-stmt-strict.js strict {compiled-strict,interpreted-strict}
-    if-decl-no-else-strict.js strict {compiled-strict,interpreted-strict}
-    if-fun-else-fun-strict.js strict {compiled-strict,interpreted-strict}
-    if-fun-else-stmt-strict.js strict {compiled-strict,interpreted-strict}
-    if-fun-no-else-strict.js strict {compiled-strict,interpreted-strict}
+    if-decl-else-decl-strict.js strict
+    if-decl-else-stmt-strict.js strict
+    if-decl-no-else-strict.js strict
+    if-fun-else-fun-strict.js strict
+    if-fun-else-stmt-strict.js strict
+    if-fun-no-else-strict.js strict
     if-gen-else-gen.js
     if-gen-else-stmt.js
     if-gen-no-else.js
@@ -6052,15 +7100,15 @@ language/statements/if 42/69 (60.87%)
     if-stmt-else-async-fun.js {unsupported: [async-functions]}
     if-stmt-else-async-gen.js {unsupported: [async-iteration]}
     if-stmt-else-const.js
-    if-stmt-else-decl-strict.js strict {compiled-strict,interpreted-strict}
-    if-stmt-else-fun-strict.js strict {compiled-strict,interpreted-strict}
+    if-stmt-else-decl-strict.js strict
+    if-stmt-else-fun-strict.js strict
     if-stmt-else-gen.js
     if-stmt-else-let.js
     labelled-fn-stmt-first.js
     labelled-fn-stmt-lone.js
     labelled-fn-stmt-second.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
     tco-else-body.js {unsupported: [tail-call-optimization]}
     tco-if-body.js {unsupported: [tail-call-optimization]}
 
@@ -6068,18 +7116,18 @@ language/statements/labeled 15/24 (62.5%)
     decl-async-function.js {unsupported: [async-functions]}
     decl-async-generator.js {unsupported: [async-iteration]}
     decl-const.js
-    decl-fun-strict.js strict {compiled-strict,interpreted-strict}
+    decl-fun-strict.js strict
     decl-gen.js
     decl-let.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
     tco.js {unsupported: [tail-call-optimization]}
     value-await-module.js {unsupported: [module]}
     value-await-module-escaped.js {unsupported: [module]}
     value-await-non-module.js
     value-await-non-module-escaped.js
-    value-yield-non-strict.js non-strict {compiled-non-strict,interpreted-non-strict}
-    value-yield-non-strict-escaped.js non-strict {compiled-non-strict,interpreted-non-strict}
+    value-yield-non-strict.js non-strict
+    value-yield-non-strict-escaped.js non-strict
 
 language/statements/let 80/145 (55.17%)
     dstr/ary-init-iter-close.js
@@ -6136,7 +7184,7 @@ language/statements/let 80/145 (55.17%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    syntax/escaped-let.js non-strict {compiled-non-strict,interpreted-non-strict}
+    syntax/escaped-let.js non-strict
     syntax/let-closure-inside-condition.js
     syntax/let-closure-inside-initialization.js
     syntax/let-closure-inside-next-expression.js
@@ -6189,7 +7237,7 @@ language/statements/switch 62/111 (55.86%)
     syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js {unsupported: [async-functions]}
     syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js {unsupported: [async-iteration]}
-    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict {compiled-strict,interpreted-strict}
+    syntax/redeclaration/function-name-redeclaration-attempt-with-function.js strict
     syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-let.js
     syntax/redeclaration/function-name-redeclaration-attempt-with-var.js
@@ -6320,12 +7368,12 @@ language/statements/try 113/201 (56.22%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    12.14-13.js non-strict {compiled-non-strict,interpreted-non-strict}
-    12.14-14.js non-strict {compiled-non-strict,interpreted-non-strict}
-    12.14-15.js non-strict {compiled-non-strict,interpreted-non-strict}
-    12.14-16.js non-strict {compiled-non-strict,interpreted-non-strict}
+    12.14-13.js non-strict
+    12.14-14.js non-strict
+    12.14-15.js non-strict
+    12.14-16.js non-strict
     completion-values.js
-    completion-values-fn-finally-abrupt.js compiled {compiled-strict,compiled-non-strict}
+    completion-values-fn-finally-abrupt.js compiled
     cptn-catch.js
     cptn-catch-empty-break.js
     cptn-catch-empty-continue.js
@@ -6341,11 +7389,13 @@ language/statements/try 113/201 (56.22%)
     early-catch-lex.js
     scope-catch-block-lex-open.js
     scope-catch-param-lex-open.js
-    scope-catch-param-var-none.js non-strict {compiled-non-strict,interpreted-non-strict}
+    scope-catch-param-var-none.js non-strict
     static-init-await-binding-valid.js
     tco-catch.js {unsupported: [tail-call-optimization]}
     tco-catch-finally.js {unsupported: [tail-call-optimization]}
     tco-finally.js {unsupported: [tail-call-optimization]}
+
+~language/statements/using 1/1 (100.0%)
 
 language/statements/variable 62/178 (34.83%)
     dstr/ary-init-iter-close.js
@@ -6404,10 +7454,10 @@ language/statements/variable 62/178 (34.83%)
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
-    12.2.1-10-s.js strict {compiled-strict,interpreted-strict}
-    12.2.1-20-s.js strict {compiled-strict,interpreted-strict}
-    12.2.1-21-s.js strict {compiled-strict,interpreted-strict}
-    12.2.1-9-s.js strict {compiled-strict,interpreted-strict}
+    12.2.1-10-s.js strict
+    12.2.1-20-s.js strict
+    12.2.1-21-s.js strict
+    12.2.1-9-s.js strict
     fn-name-class.js {unsupported: [class]}
     static-init-await-binding-valid.js
 
@@ -6421,51 +7471,51 @@ language/statements/while 13/38 (34.21%)
     decl-fun.js
     decl-gen.js
     labelled-fn-stmt.js
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-identifier-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
+    let-identifier-with-newline.js non-strict
     tco-body.js {unsupported: [tail-call-optimization]}
 
 language/statements/with 28/181 (15.47%)
-    binding-blocked-by-unscopables.js non-strict {compiled-non-strict,interpreted-non-strict}
-    cptn-abrupt-empty.js non-strict {compiled-non-strict,interpreted-non-strict}
-    cptn-nrml.js non-strict {compiled-non-strict,interpreted-non-strict}
+    binding-blocked-by-unscopables.js non-strict
+    cptn-abrupt-empty.js non-strict
+    cptn-nrml.js non-strict
     decl-async-fun.js {unsupported: [async-functions]}
     decl-async-gen.js {unsupported: [async-iteration]}
-    decl-const.js non-strict {compiled-non-strict,interpreted-non-strict}
-    decl-fun.js non-strict {compiled-non-strict,interpreted-non-strict}
-    decl-gen.js non-strict {compiled-non-strict,interpreted-non-strict}
-    decl-let.js non-strict {compiled-non-strict,interpreted-non-strict}
+    decl-const.js non-strict
+    decl-fun.js non-strict
+    decl-gen.js non-strict
+    decl-let.js non-strict
     get-binding-value-call-with-proxy-env.js non-strict
     get-binding-value-idref-with-proxy-env.js non-strict
     get-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
     get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
     has-binding-call-with-proxy-env.js non-strict
     has-binding-idref-with-proxy-env.js non-strict
-    has-property-err.js non-strict {compiled-non-strict,interpreted-non-strict}
-    labelled-fn-stmt.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-array-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
-    let-block-with-newline.js non-strict {compiled-non-strict,interpreted-non-strict}
+    has-property-err.js non-strict
+    labelled-fn-stmt.js non-strict
+    let-array-with-newline.js non-strict
+    let-block-with-newline.js non-strict
     set-mutable-binding-binding-deleted-in-get-unscopables.js non-strict
     set-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js non-strict
     set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain.js non-strict
     set-mutable-binding-binding-deleted-with-typed-array-in-proto-chain-strict-mode.js non-strict
     set-mutable-binding-idref-compound-assign-with-proxy-env.js non-strict
     set-mutable-binding-idref-with-proxy-env.js non-strict
-    unscopables-get-err.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-inc-dec.js non-strict {compiled-non-strict,interpreted-non-strict}
-    unscopables-prop-get-err.js non-strict {compiled-non-strict,interpreted-non-strict}
+    unscopables-get-err.js non-strict
+    unscopables-inc-dec.js non-strict
+    unscopables-prop-get-err.js non-strict
 
 language/types 9/113 (7.96%)
     number/S8.5_A10_T1.js
-    number/S8.5_A10_T2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    number/S8.5_A10_T2.js non-strict
     number/S8.5_A4_T1.js
-    number/S8.5_A4_T2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    number/S8.5_A4_T2.js non-strict
     reference/get-value-prop-base-primitive-realm.js
     reference/put-value-prop-base-primitive.js
     reference/put-value-prop-base-primitive-realm.js
     undefined/S8.1_A3_T1.js
-    undefined/S8.1_A3_T2.js non-strict {compiled-non-strict,interpreted-non-strict}
+    undefined/S8.1_A3_T2.js non-strict
 
 language/white-space 2/67 (2.99%)
     mongolian-vowel-separator.js {unsupported: [u180e]}


### PR DESCRIPTION
The following should work in > ES6 mode, and throw a SyntaxError: Property "foo" already defined in this object literal. in pre-es6 mode:

(function() {
	'use strict';
	o = {foo: 1, foo: 2};
	o.foo
})();