### PR TITLE
delegate Java getter/setter calling to `NativeJavaMethod` instead of `MemberBox`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -555,26 +555,26 @@ class JavaMembers {
     private static boolean maskingExistedMember(
             boolean includePrivate, Map<String, Object> members, String beanName) {
         var existed = members.get(beanName);
-        if (existed == null) {
-            return false;
-        }
-        // A private field shouldn't block a public getter/setter
+        // A private field shouldn't mask a public getter/setter
         // true <-> there's a non-private field
         return existed instanceof Member
-                && !(includePrivate && Modifier.isPrivate(((Member) existed).getModifiers()));
+                && (!includePrivate || !Modifier.isPrivate(((Member) existed).getModifiers()));
     }
 
+    /**
+     * @param nameComponent method name without prefix. E.g. "Value" in "getValue", and "X" in
+     *     "getX"
+     * @return bean property name. E.g. "value" if provided "Value", "X" if provided "X"
+     */
     private static String getBeaningName(String nameComponent) {
-        // Make the bean property name.
         char ch0 = nameComponent.charAt(0);
         if (Character.isUpperCase(ch0)) {
             if (nameComponent.length() == 1) {
-                nameComponent = nameComponent.toLowerCase(Locale.ROOT);
-            } else {
-                char ch1 = nameComponent.charAt(1);
-                if (!Character.isUpperCase(ch1)) {
-                    nameComponent = Character.toLowerCase(ch0) + nameComponent.substring(1);
-                }
+                return nameComponent.toLowerCase(Locale.ROOT);
+            }
+            char ch1 = nameComponent.charAt(1);
+            if (!Character.isUpperCase(ch1)) {
+                return Character.toLowerCase(ch0) + nameComponent.substring(1);
             }
         }
         return nameComponent;

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -97,19 +97,21 @@ class JavaMembers {
             return member;
         }
         Context cx = Context.getContext();
+
+        if (member instanceof BeanProperty) {
+            var bean = (BeanProperty) member;
+            if (bean.getter == null) {
+                return Scriptable.NOT_FOUND;
+            }
+            return bean.getter.call(cx, scope, scope, ScriptRuntime.emptyArgs);
+        }
+
         Object rval;
         Class<?> type;
         try {
-            if (member instanceof BeanProperty) {
-                BeanProperty bp = (BeanProperty) member;
-                if (bp.getter == null) return Scriptable.NOT_FOUND;
-                rval = bp.getter.invoke(javaObject, ScriptRuntime.emptyArgs);
-                type = bp.getter.getReturnType().asClass();
-            } else {
-                Field field = (Field) member;
-                rval = field.get(isStatic ? null : javaObject);
-                type = field.getType();
-            }
+            var field = (Field) member;
+            rval = field.get(isStatic ? null : javaObject);
+            type = field.getType();
         } catch (Exception ex) {
             throw Context.throwAsScriptRuntimeEx(ex);
         }
@@ -137,25 +139,11 @@ class JavaMembers {
             if (bp.setter == null) {
                 throw reportMemberNotFound(name);
             }
-            // If there's only one setter or if the value is null, use the
-            // main setter. Otherwise, let the NativeJavaMethod decide which
-            // setter to use:
-            if (bp.setters == null || value == null) {
-                var setType = bp.setter.getArgTypes().get(0);
-                Object[] args = {Context.jsToJava(value, setType)};
-                try {
-                    bp.setter.invoke(javaObject, args);
-                } catch (Exception ex) {
-                    throw Context.throwAsScriptRuntimeEx(ex);
-                }
-            } else {
-                Object[] args = {value};
-                bp.setters.call(
-                        Context.getContext(),
-                        ScriptableObject.getTopLevelScope(scope),
-                        scope,
-                        args);
-            }
+            bp.setter.call(
+                    Context.getContext(),
+                    ScriptableObject.getTopLevelScope(scope),
+                    scope,
+                    new Object[] {value});
         } else {
             if (!(member instanceof Field)) {
                 String str =
@@ -551,87 +539,8 @@ class JavaMembers {
             boolean isStatic = (tableCursor == 0);
             Map<String, Object> ht = isStatic ? staticMembers : members;
 
-            Map<String, BeanProperty> toAdd = new HashMap<>();
-
-            // Now, For each member, make "bean" properties.
-            for (String name : ht.keySet()) {
-                // Is this a getter?
-                boolean memberIsGetMethod = name.startsWith("get");
-                boolean memberIsSetMethod = name.startsWith("set");
-                boolean memberIsIsMethod = name.startsWith("is");
-                if (memberIsGetMethod || memberIsIsMethod || memberIsSetMethod) {
-                    // Double check name component.
-                    String nameComponent = name.substring(memberIsIsMethod ? 2 : 3);
-                    if (nameComponent.length() == 0) continue;
-
-                    // Make the bean property name.
-                    String beanPropertyName = nameComponent;
-                    char ch0 = nameComponent.charAt(0);
-                    if (Character.isUpperCase(ch0)) {
-                        if (nameComponent.length() == 1) {
-                            beanPropertyName = nameComponent.toLowerCase(Locale.ROOT);
-                        } else {
-                            char ch1 = nameComponent.charAt(1);
-                            if (!Character.isUpperCase(ch1)) {
-                                beanPropertyName =
-                                        Character.toLowerCase(ch0) + nameComponent.substring(1);
-                            }
-                        }
-                    }
-
-                    // If we already have a member by this name, don't do this
-                    // property.
-                    if (toAdd.containsKey(beanPropertyName)) continue;
-                    Object v = ht.get(beanPropertyName);
-                    if (v != null) {
-                        // A private field shouldn't mask a public getter/setter
-                        if (!includePrivate
-                                || !(v instanceof Member)
-                                || !Modifier.isPrivate(((Member) v).getModifiers())) {
-
-                            continue;
-                        }
-                    }
-
-                    // Find the getter method, or if there is none, the is-
-                    // method.
-                    MemberBox getter = null;
-                    getter = findGetter(isStatic, ht, "get", nameComponent);
-                    // If there was no valid getter, check for an is- method.
-                    if (getter == null) {
-                        getter = findGetter(isStatic, ht, "is", nameComponent);
-                    }
-
-                    // setter
-                    MemberBox setter = null;
-                    NativeJavaMethod setters = null;
-                    String setterName = "set".concat(nameComponent);
-
-                    // Is this value a method?
-                    Object member = ht.get(setterName);
-                    if (member instanceof NativeJavaMethod) {
-                        NativeJavaMethod njmSet = (NativeJavaMethod) member;
-                        if (getter != null) {
-                            // We have a getter. Now, do we have a matching
-                            // setter?
-                            var type = getter.getReturnType();
-                            setter = extractSetMethod(type, njmSet.methods, isStatic);
-                        } else {
-                            // No getter, find any set method
-                            setter = extractSetMethod(njmSet.methods, isStatic);
-                        }
-                        if (njmSet.methods.length > 1) {
-                            setters = njmSet;
-                        }
-                    }
-                    // Make the property.
-                    BeanProperty bp = new BeanProperty(getter, setter, setters);
-                    toAdd.put(beanPropertyName, bp);
-                }
-            }
-
             // Add the new bean properties.
-            ht.putAll(toAdd);
+            ht.putAll(extractBeaning(ht, isStatic, includePrivate));
         }
 
         // Reflect constructors
@@ -641,6 +550,110 @@ class JavaMembers {
             ctorMembers[i] = new MemberBox(constructors[i], typeFactory);
         }
         ctors = new NativeJavaMethod(ctorMembers, cl.getSimpleName());
+    }
+
+    private static boolean maskingExistedMember(
+            boolean includePrivate, Map<String, Object> members, String beanName) {
+        // A private field shouldn't block a public getter/setter
+        if (!includePrivate) {
+            return false; // no field
+        }
+
+        var existed = members.get(beanName);
+        // true <-> there's a non-private field
+        return existed instanceof Member && !Modifier.isPrivate(((Member) existed).getModifiers());
+    }
+
+    private static String getBeaningName(String nameComponent) {
+        // Make the bean property name.
+        char ch0 = nameComponent.charAt(0);
+        if (Character.isUpperCase(ch0)) {
+            if (nameComponent.length() == 1) {
+                nameComponent = nameComponent.toLowerCase(Locale.ROOT);
+            } else {
+                char ch1 = nameComponent.charAt(1);
+                if (!Character.isUpperCase(ch1)) {
+                    nameComponent = Character.toLowerCase(ch0) + nameComponent.substring(1);
+                }
+            }
+        }
+        return nameComponent;
+    }
+
+    /** at this stage, {@code members} includes {@link NativeJavaMethod} and {@link Field} */
+    private Map<String, BeanProperty> extractBeaning(
+            Map<String, Object> members, boolean isStatic, boolean includePrivate) {
+        var beans = new HashMap<String, BeanProperty>();
+        for (var entry : members.entrySet()) {
+            var name = entry.getKey();
+
+            var isGetBeaning = name.startsWith("get");
+            var isIsBeaning = name.startsWith("is");
+            var isSetBeaning = name.startsWith("set");
+            if (!isGetBeaning && !isIsBeaning && !isSetBeaning) {
+                continue;
+            }
+
+            var nameComponent = name.substring(isIsBeaning ? 2 : 3);
+            if (nameComponent.isEmpty() || !(entry.getValue() instanceof NativeJavaMethod)) {
+                continue;
+            }
+
+            var beaningName = getBeaningName(nameComponent);
+            if (maskingExistedMember(includePrivate, members, beaningName)) {
+                continue;
+            }
+
+            if (isGetBeaning || isIsBeaning) { // getter
+                var method = (NativeJavaMethod) entry.getValue();
+
+                var candidate = extractGetMethod(method.methods, isStatic);
+                if (candidate != null) {
+                    var bean = beans.computeIfAbsent(beaningName, BeanProperty::new);
+                    if (method.methods.length == 1) {
+                        bean.getter = method;
+                    } else {
+                        bean.getter = new NativeJavaMethod(new MemberBox[] {candidate});
+                    }
+                }
+            } else { // isSetBeaning
+                var bean = beans.computeIfAbsent(beaningName, BeanProperty::new);
+                // capture all possible setters for now, actual setter will be searched later
+                bean.setter = (NativeJavaMethod) entry.getValue();
+            }
+        }
+
+        // process setter candidates
+        for (var bean : beans.values()) {
+            var setterCandidates = bean.setter;
+            if (setterCandidates == null) {
+                continue;
+            }
+
+            MemberBox match;
+            var getter = bean.getter;
+            if (getter != null) {
+                var type = getter.methods[0].getReturnType();
+                // We have a getter. Now, do we have a setter with matching type?
+                match = extractSetMethod(type, setterCandidates.methods, isStatic);
+                if (match != null) {
+                    bean.setter = new NativeJavaMethod(match, match.getName());
+                    continue;
+                }
+            }
+
+            // search for any valid setter
+            match = extractSetMethod(setterCandidates.methods, isStatic);
+            if (match == null) {
+                // no valid setter st all
+                bean.setter = null;
+            }
+
+            // at this stage we know there's at least one valid setter. We will let NativeJavaMethod
+            // itself to pick the best one.
+        }
+
+        return beans;
     }
 
     private Constructor<?>[] getAccessibleConstructors(boolean includePrivate) {
@@ -695,18 +708,6 @@ class JavaMembers {
         return cl.getFields();
     }
 
-    private static MemberBox findGetter(
-            boolean isStatic, Map<String, Object> ht, String prefix, String propertyName) {
-        String getterName = prefix.concat(propertyName);
-        // Check that the getter is a method.
-        Object member = ht.get(getterName);
-        if (member instanceof NativeJavaMethod) {
-            NativeJavaMethod njmGet = (NativeJavaMethod) member;
-            return extractGetMethod(njmGet.methods, isStatic);
-        }
-        return null;
-    }
-
     private static MemberBox extractGetMethod(MemberBox[] methods, boolean isStatic) {
         // Inspect the list of all MemberBox for the only one having no
         // parameters
@@ -715,7 +716,7 @@ class JavaMembers {
             // value (eg. a getSomething() or isSomething())?
             if (method.getArgTypes().isEmpty() && (!isStatic || method.isStatic())) {
                 var type = method.getReturnType();
-                if (!type.isVoid()) {
+                if (type != TypeInfo.PRIMITIVE_VOID) {
                     return method;
                 }
                 break;
@@ -875,16 +876,14 @@ class JavaMembers {
     NativeJavaMethod ctors; // we use NativeJavaMethod for ctor overload resolution
 }
 
-class BeanProperty {
-    BeanProperty(MemberBox getter, MemberBox setter, NativeJavaMethod setters) {
-        this.getter = getter;
-        this.setter = setter;
-        this.setters = setters;
+final class BeanProperty {
+    BeanProperty(String name) {
+        this.name = name;
     }
 
-    MemberBox getter;
-    MemberBox setter;
-    NativeJavaMethod setters;
+    final String name;
+    NativeJavaMethod getter;
+    NativeJavaMethod setter;
 }
 
 class FieldAndMethods extends NativeJavaMethod {

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -554,14 +554,14 @@ class JavaMembers {
 
     private static boolean maskingExistedMember(
             boolean includePrivate, Map<String, Object> members, String beanName) {
-        // A private field shouldn't block a public getter/setter
-        if (!includePrivate) {
-            return false; // no field
-        }
-
         var existed = members.get(beanName);
+        if (existed == null) {
+            return false;
+        }
+        // A private field shouldn't block a public getter/setter
         // true <-> there's a non-private field
-        return existed instanceof Member && !Modifier.isPrivate(((Member) existed).getModifiers());
+        return existed instanceof Member
+                && !(includePrivate && Modifier.isPrivate(((Member) existed).getModifiers()));
     }
 
     private static String getBeaningName(String nameComponent) {
@@ -581,7 +581,7 @@ class JavaMembers {
     }
 
     /** at this stage, {@code members} includes {@link NativeJavaMethod} and {@link Field} */
-    private Map<String, BeanProperty> extractBeaning(
+    private static Map<String, BeanProperty> extractBeaning(
             Map<String, Object> members, boolean isStatic, boolean includePrivate) {
         var beans = new HashMap<String, BeanProperty>();
         for (var entry : members.entrySet()) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
@@ -55,7 +55,8 @@ public class JavaBeaningTest {
     public void testMaskingMethod() {
         // method should not be masked
         Utils.assertEvaluatorExceptionES6(
-                "Java method \"elementAt\" cannot be assigned to", SCRIPT_INIT + "obj.elementAt = 42");
+                "Java method \"elementAt\" cannot be assigned to",
+                SCRIPT_INIT + "obj.elementAt = 42");
     }
 
     private static void expect(String script, Object expected) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
@@ -1,0 +1,89 @@
+package org.mozilla.javascript.tests.lc;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Wrapper;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * @author ZZZank
+ */
+public class JavaBeaningTest {
+
+    @Test
+    public void testMasked() {
+        // 'maskedValue' is private, with getter/setter
+
+        // get
+        expect("obj.maskedValue", "_getter");
+
+        // set & get
+        expect(Utils.lines("obj.maskedValue = '42'", "obj.maskedValue"), "42_setter_getter");
+    }
+
+    @Test
+    public void testPublic() {
+        // 'value' is public. In this case, no getter/setter should be used
+        expect("obj.value", 42);
+        expect("obj.value = 123; obj.value", 123);
+    }
+
+    @Test
+    public void testOverload() {
+        // for 'maskedValue', the return type of getter is String, so a setter with type 'String'
+        // should be preferred
+
+        // Here there's a setter that accepts number, but the setter that accepts String should be
+        // preferred instead. And 42 should be auto-wrapped into string
+        expect("obj.maskedValue = 42; obj.maskedValue", "42_setter_getter");
+    }
+
+    private static void expect(String script, Object expected) {
+        for (int i = 0; i < 2; i++) {
+            try (var cx = ContextFactory.getGlobal().enterContext()) {
+                cx.setInterpretedMode(i == 0);
+
+                var scope = cx.initStandardObjects();
+
+                var testObject = new BeaningTestObject<>();
+                scope.put("obj", scope, testObject);
+
+                var result = cx.evaluateString(scope, script, "test.js", 1, null);
+                while (result instanceof Wrapper) {
+                    result = ((Wrapper) result).unwrap();
+                }
+                Assertions.assertEquals(expected, result);
+            }
+        }
+    }
+
+    public static class BeaningTestObject<N extends Number> {
+        private String maskedValue = "";
+        public Integer value = 42;
+
+        public String getMaskedValue() {
+            return maskedValue + "_getter";
+        }
+
+        public void setMaskedValue(String maskedValue) {
+            this.maskedValue = maskedValue + "_setter";
+        }
+
+        public void setMaskedValue(Integer value) {
+            throw new IllegalStateException("This setter is not the preferred setter");
+        }
+
+        public void setMaskedValue() {
+            throw new IllegalStateException("This is not setter");
+        }
+
+        public String getValue() {
+            throw new IllegalStateException("'value' is public, field access should be preferred");
+        }
+
+        public void setValue(Number value) {
+            throw new IllegalStateException("'value' is public, field access should be preferred");
+        }
+    }
+}


### PR DESCRIPTION
This PR rewrites Java beaning handling in JS-Java interop, using `NativeJavaMethod` instead of `MemberBox` to handle getter/setter. There's also a new test: `JavaBeaningTest`.

There should be no behaviour change caused by this PR, because the main purpose of this PR is to allow getter/setter to reuse code infrastructure in `NativeJavaMethod`, to make implementing Java Generic Support (#2080 ) for beaning easier.