### PR TITLE
Fix: `eval` of a function should be undefined

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -296,17 +296,6 @@ class CodeGenerator extends Icode {
                             throw Kit.codeBug();
                         }
                     }
-                    // For function statements or function expression statements
-                    // in scripts, we need to ensure that the result of the script
-                    // is the function if it is the last statement in the script.
-                    // For example, eval("function () {}") should return a
-                    // function, not undefined.
-                    if (!itsInFunctionFlag) {
-                        addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
-                        stackChange(1);
-                        addIcode(Icode_POP_RESULT);
-                        stackChange(-1);
-                    }
                 }
                 break;
 

--- a/rhino/src/test/java/org/mozilla/javascript/EvalTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/EvalTest.java
@@ -1,0 +1,20 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+class EvalTest {
+    @Test
+    void evalFunctionIsUndefined() {
+        Utils.runWithAllModes(
+                cx -> {
+                    var scope = cx.initStandardObjects(new TopLevel());
+                    Object result =
+                            cx.evaluateString(scope, "eval('function f(){}')", "test", 1, null);
+                    assertTrue(Undefined.isUndefined(result));
+                    return null;
+                });
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -5880,7 +5880,7 @@ language/rest-parameters 5/11 (45.45%)
 
 language/source-text 0/1 (0.0%)
 
-language/statementList 21/80 (26.25%)
+language/statementList 20/80 (25.0%)
     class-array-literal.js {unsupported: [class]}
     class-array-literal-with-item.js {unsupported: [class]}
     class-arrow-function-assignment-expr.js {unsupported: [class]}
@@ -5901,7 +5901,6 @@ language/statementList 21/80 (26.25%)
     eval-class-let-declaration.js {unsupported: [class]}
     eval-class-regexp-literal.js {unsupported: [class]}
     eval-class-regexp-literal-flags.js {unsupported: [class]}
-    eval-fn-block.js
 
 ~language/statements/async-function
 
@@ -6744,7 +6743,7 @@ language/statements/for-of 438/751 (58.32%)
     typedarray-backed-by-resizable-buffer-shrink-mid-iteration.js {unsupported: [resizable-arraybuffer]}
     typedarray-backed-by-resizable-buffer-shrink-to-zero-mid-iteration.js {unsupported: [resizable-arraybuffer]}
 
-language/statements/function 162/451 (35.92%)
+language/statements/function 161/451 (35.7%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -6877,7 +6876,6 @@ language/statements/function 162/451 (35.92%)
     arguments-with-arguments-fn.js non-strict
     arguments-with-arguments-lex.js non-strict
     array-destructuring-param-strict-body.js
-    cptn-decl.js
     dflt-params-duplicates.js non-strict
     dflt-params-ref-later.js
     dflt-params-ref-self.js
@@ -6905,7 +6903,7 @@ language/statements/function 162/451 (35.92%)
     unscopables-with.js non-strict
     unscopables-with-in-nested-fn.js non-strict
 
-language/statements/generators 168/266 (63.16%)
+language/statements/generators 167/266 (62.78%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
@@ -7041,7 +7039,6 @@ language/statements/generators 168/266 (63.16%)
     forbidden-ext/b1/gen-func-decl-forbidden-ext-direct-access-prop-arguments.js non-strict
     arguments-with-arguments-fn.js non-strict
     array-destructuring-param-strict-body.js
-    cptn-decl.js
     default-proto.js
     dflt-params-abrupt.js
     dflt-params-duplicates.js non-strict

--- a/tests/testsrc/tests/js1_5/decompilation/regress-406555.js
+++ b/tests/testsrc/tests/js1_5/decompilation/regress-406555.js
@@ -23,7 +23,7 @@ function test()
  
   var f = (function() {return "\uD800\uD800";});
   var g = uneval(f);
-  var h = eval(g);
+  var h = eval('(' + g + ')');
 
   expect = "\uD800\uD800";
   actual = h();

--- a/tests/testsrc/tests/js1_5/extensions/regress-352261.js
+++ b/tests/testsrc/tests/js1_5/extensions/regress-352261.js
@@ -28,7 +28,7 @@ function test()
   actual = g + '';
   compareSource(expect, actual, summary);
 
-  h = eval(uneval(g));
+  h = eval('(' + uneval(g) + ')');
   expect = g(1, 10, 100);
   actual = h(1, 10, 100);
   reportCompare(expect, actual, summary);
@@ -40,7 +40,7 @@ function test()
   actual = p + '';
   compareSource(expect, actual, summary);
 
-  q = eval(uneval(p));
+  q = eval('(' + uneval(p) + ')');
   expect = p(3, "4", "5");
   actual = q(3, "4", "5");
   reportCompare(expect, actual, summary);

--- a/tests/testsrc/tests/js1_5/extensions/regress-96284-001.js
+++ b/tests/testsrc/tests/js1_5/extensions/regress-96284-001.js
@@ -99,7 +99,7 @@ addThis();
 
 status = inSection(10);
 obj1 = function(x) {function g(y){return y+1;} return g(x);};
-obj2 = eval(obj1.toSource());
+obj2 = eval('(' + obj1.toSource() + ')');
 actual = obj2.toSource();
 expect = obj1.toSource();
 addThis();

--- a/tests/testsrc/tests/js1_5/extensions/regress-96284-002.js
+++ b/tests/testsrc/tests/js1_5/extensions/regress-96284-002.js
@@ -99,7 +99,7 @@ addThis();
 
 status = inSection(10);
 obj1 = function(x) {function g(y){return y+1;} return g(x);};
-obj2 = eval(uneval(obj1));
+obj2 = eval('(' + uneval(obj1) + ')');
 actual = obj2.toSource();
 expect = obj1.toSource();
 addThis();


### PR DESCRIPTION
Calling:

```js
eval('function f(){})'
```

should be `undefined`. Before this change, it was the function, but the spec says that parenthesis are required around the function to return it, i.e.

```js
eval('(function f(){})')
```

should return a function.

Note: this is a backward-incompatible change, but a correct one in the sense that it fixes a bug. If needed, we could add a context flag to preserve the old behavior, but I haven't done that yet. I did have to update some old tests executed by `MozillaSuiteTest` though.