### PR TITLE
Revert "Bump com.gradleup.shadow from 9.1.0 to 9.2.2"

### DIFF
--- a/rhino-all/build.gradle
+++ b/rhino-all/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'rhino.library-conventions'
-    id 'com.gradleup.shadow' version '9.2.2'
+    id 'com.gradleup.shadow' version '9.1.0'
     id 'application'
 }
 


### PR DESCRIPTION
This reverts commit a120c1943bf4bf759c69ba2bedc77c6486bb9d11.

I have been getting a stack overflow when building the shadow JAR
with this change.
