### PR TITLE
Fix `rhino-all` shadow jar task to avoid stack overflow.

### DIFF
--- a/rhino-all/build.gradle
+++ b/rhino-all/build.gradle
@@ -22,9 +22,6 @@ shadowJar {
     // Ensure that the "jar" from this step is the shadowed one that we want to 
     // publish in Maven.
     archiveClassifier.set('')
-    manifest {
-      inheritFrom(project.tasks.jar.manifest)
-    }
 }
 
 startScripts {


### PR DESCRIPTION
@gbrail this should solve the issue with shadower 9.2.2, at least according to https://github.com/GradleUp/shadow/issues/1781. It appears to work locally for me.