### PR TITLE
Prefer 'get' getter over 'is' getter in Java beaning

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -615,10 +615,14 @@ class JavaMembers {
                 var candidate = extractGetMethod(method.methods, isStatic);
                 if (candidate != null) {
                     var bean = beans.computeIfAbsent(beanName, BeanProperty::new);
-                    if (method.methods.length == 1) {
-                        bean.getter = method;
-                    } else {
-                        bean.getter = new NativeJavaMethod(new MemberBox[] {candidate});
+                    if (bean.getter == null
+                            // prefer 'get' over 'is'
+                            || bean.getter.getFunctionName().startsWith("is")) {
+                        if (method.methods.length == 1) {
+                            bean.getter = method;
+                        } else {
+                            bean.getter = new NativeJavaMethod(new MemberBox[] {candidate});
+                        }
                     }
                 }
             } else { // isSetBeaning

--- a/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
@@ -59,6 +59,15 @@ public class JavaBeaningTest {
                 SCRIPT_INIT + "obj.elementAt = 42");
     }
 
+    /**
+     * 'get' should be preferred over 'is'
+     */
+    @Test
+    public void testGetterPreference() {
+        expect("obj.getInParent", "getGetInParent");
+        expect("obj.isInParent", "getIsInParent");
+    }
+
     private static void expect(String script, Object expected) {
         expect(false, script, expected);
         expect(true, script, expected);
@@ -81,7 +90,7 @@ public class JavaBeaningTest {
         }
     }
 
-    public static class BeaningTestObject<N extends Number> {
+    public static class BeaningTestObject<N extends Number> extends BeaningTestObjectBase {
         private String maskedValue = "";
         public Integer value = 42;
 
@@ -116,6 +125,25 @@ public class JavaBeaningTest {
         public void setElementAt(int value) {
             throw new IllegalStateException(
                     "There's an existed method 'elementAt', no beaning should be applied");
+        }
+
+        public String isGetInParent() {
+            throw new IllegalStateException("'get' getter should be preferred over 'is'");
+        }
+
+        public String getIsInParent() {
+            return "getIsInParent";
+        }
+    }
+
+    public static class BeaningTestObjectBase {
+
+        public String getGetInParent() {
+            return "getGetInParent";
+        }
+
+        public String isIsInParent() {
+            throw new IllegalStateException("'get' getter should be preferred over 'is'");
         }
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/lc/JavaBeaningTest.java
@@ -59,9 +59,7 @@ public class JavaBeaningTest {
                 SCRIPT_INIT + "obj.elementAt = 42");
     }
 
-    /**
-     * 'get' should be preferred over 'is'
-     */
+    /** 'get' should be preferred over 'is' */
     @Test
     public void testGetterPreference() {
         expect("obj.getInParent", "getGetInParent");
@@ -136,6 +134,10 @@ public class JavaBeaningTest {
         }
     }
 
+    /**
+     * Methods in parent will be scanned later than those in subclass. We can utilize this to create
+     * test cases for order-dependent action
+     */
     public static class BeaningTestObjectBase {
 
         public String getGetInParent() {


### PR DESCRIPTION
This behaviour change is introduced in #2095 . I didn't realize this until I encountered some `member not found` error when interacting with this class (class name obfuscated):

```java
interface A {
    Lazy<B> getDeferred();
    boolean isDeferred() { return this instanceof DeferredA; }
}
```