### PR TITLE
Fix the order of evaluation of various operations in compiled mode.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -3944,8 +3944,10 @@ class BodyCodegen {
             return;
         }
         if (childNumberFlag == -1) {
-            addObjectToNumeric();
             generateExpression(child.getNext(), node);
+            cfw.add(ByteCode.SWAP);
+            addObjectToNumeric();
+            cfw.add(ByteCode.SWAP);
             addObjectToNumeric();
 
             switch (type) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -3860,8 +3860,12 @@ class BodyCodegen {
             }
         } else {
             generateExpression(child, node);
-            if (!isArithmeticNode(child)) addObjectToNumeric();
             generateExpression(child.getNext(), node);
+            if (!isArithmeticNode(child)) {
+                cfw.add(ByteCode.SWAP);
+                addObjectToNumeric();
+                cfw.add(ByteCode.SWAP);
+            }
             if (!isArithmeticNode(child.getNext())) addObjectToNumeric();
 
             switch (type) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -3935,8 +3935,11 @@ class BodyCodegen {
         // that we can return a 32-bit unsigned value, and call
         // toUint32 instead of toInt32.
         if (type == Token.URSH) {
-            addDynamicInvoke("MATH:TOUINT32", Signatures.MATH_TO_UINT32);
             generateExpression(child.getNext(), node);
+            cfw.add(ByteCode.SWAP);
+            addDynamicInvoke("MATH:TOUINT32", Signatures.MATH_TO_UINT32);
+            cfw.add(ByteCode.DUP2_X1);
+            cfw.add(ByteCode.POP2);
             addDynamicInvoke("MATH:TOINT32", Signatures.MATH_TO_INT32);
             // Looks like we need to explicitly mask the shift to 5 bits -
             // LUSHR takes 6 bits.

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -3994,16 +3994,13 @@ language/expressions/async-arrow-function 42/60 (70.0%)
 
 ~language/expressions/await
 
-language/expressions/bitwise-and 1/30 (3.33%)
-    order-of-evaluation.js compiled
+language/expressions/bitwise-and 0/30 (0.0%)
 
 language/expressions/bitwise-not 0/16 (0.0%)
 
-language/expressions/bitwise-or 1/30 (3.33%)
-    order-of-evaluation.js compiled
+language/expressions/bitwise-or 0/30 (0.0%)
 
-language/expressions/bitwise-xor 1/30 (3.33%)
-    order-of-evaluation.js compiled
+language/expressions/bitwise-xor 0/30 (0.0%)
 
 language/expressions/call 34/92 (36.96%)
     eval-realm-indirect.js non-strict
@@ -4571,8 +4568,7 @@ language/expressions/instanceof 5/43 (11.63%)
     symbol-hasinstance-not-callable.js
     symbol-hasinstance-to-boolean.js
 
-language/expressions/left-shift 1/45 (2.22%)
-    order-of-evaluation.js compiled
+language/expressions/left-shift 0/45 (0.0%)
 
 language/expressions/less-than 0/45 (0.0%)
 
@@ -5422,8 +5418,7 @@ language/expressions/property-accessors 0/21 (0.0%)
 
 language/expressions/relational 0/1 (0.0%)
 
-language/expressions/right-shift 1/37 (2.7%)
-    order-of-evaluation.js compiled
+language/expressions/right-shift 0/37 (0.0%)
 
 language/expressions/strict-does-not-equals 0/30 (0.0%)
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -4188,8 +4188,7 @@ language/expressions/delete 6/69 (8.7%)
     super-property-null-base.js {unsupported: [class]}
     super-property-uninitialized-this.js
 
-language/expressions/division 1/45 (2.22%)
-    order-of-evaluation.js compiled
+language/expressions/division 0/45 (0.0%)
 
 language/expressions/does-not-equals 0/38 (0.0%)
 
@@ -4626,11 +4625,9 @@ language/expressions/logical-or 1/18 (5.56%)
 
 ~language/expressions/member-expression 1/1 (100.0%)
 
-language/expressions/modulus 1/40 (2.5%)
-    order-of-evaluation.js compiled
+language/expressions/modulus 0/40 (0.0%)
 
-language/expressions/multiplication 1/40 (2.5%)
-    order-of-evaluation.js compiled
+language/expressions/multiplication 0/40 (0.0%)
 
 language/expressions/new 22/59 (37.29%)
     spread-err-mult-err-expr-throws.js
@@ -5424,8 +5421,7 @@ language/expressions/strict-does-not-equals 0/30 (0.0%)
 
 language/expressions/strict-equals 0/30 (0.0%)
 
-language/expressions/subtraction 1/38 (2.63%)
-    order-of-evaluation.js compiled
+language/expressions/subtraction 0/38 (0.0%)
 
 language/expressions/super 73/94 (77.66%)
     call-arg-evaluation-err.js {unsupported: [class]}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -5515,9 +5515,8 @@ language/expressions/unary-minus 0/14 (0.0%)
 
 language/expressions/unary-plus 0/17 (0.0%)
 
-language/expressions/unsigned-right-shift 2/45 (4.44%)
+language/expressions/unsigned-right-shift 1/45 (2.22%)
     bigint-toprimitive.js
-    order-of-evaluation.js compiled
 
 language/expressions/void 0/9 (0.0%)
 


### PR DESCRIPTION
Now all that symbols behave better we can resolve all the order of evaluation issues and get some more tests passing.