### PR TITLE
Fix Decycle plugin compatibility with Gradle 8.12.1

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:7.2.1'
     implementation 'net.ltgt.gradle:gradle-errorprone-plugin:4.0.0'
-    implementation 'de.obqo.decycle:de.obqo.decycle.gradle.plugin:1.2.3'
+    implementation 'de.obqo.decycle:decycle-gradle-plugin:0.11.0'
 }


### PR DESCRIPTION
Fixes CI Stream closed error by updating Decycle plugin to 0.11.0