### PR TITLE
fix for the parser to allow let in switch statement if the switch is the only statement in a for loop

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -1485,8 +1485,16 @@ public class Parser {
 
         AstNode discriminant = expr(false);
         pn.setExpression(discriminant);
-        enterSwitch(pn);
 
+        // a bit of a hack, but there is no separate scope for the switch statement
+        // therefore the check done in defineSymbol(int, java.lang.String, boolean)
+        // still thinks we are in a for loop if the 'switch' directly follow the 'for'
+        // without brackets
+        // therefore we (miss-)use the inForInit var to disable the check for the
+        // 'switch' body
+        boolean wasInForInit = inForInit;
+        inForInit = true;
+        enterSwitch(pn);
         try {
             if (mustMatchToken(Token.RP, "msg.no.paren.after.switch", true))
                 pn.setRp(ts.tokenBeg - pos);
@@ -1553,6 +1561,7 @@ public class Parser {
                 pn.addCase(caseNode);
             }
         } finally {
+            inForInit = wasInForInit;
             exitSwitch();
         }
         return pn;

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/LetTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/LetTest.java
@@ -1,0 +1,66 @@
+package org.mozilla.javascript.tests.es5;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/** Test for let. */
+public class LetTest {
+
+    @Test
+    public void simple() throws Exception {
+        String script =
+                "function f(a,b,c) {\n"
+                        + " let sum = a + b + c;\n"
+                        + " return sum;\n"
+                        + "}\n"
+                        + "f(1, 2, 3);";
+        Utils.assertWithAllModes_1_8(6, script);
+    }
+
+    @Test
+    public void switchLet() throws Exception {
+        String script =
+                "var sum = 0;\n"
+                        + "var t = 1;\n"
+                        + "switch(t) {\n"
+                        + "  case 1:\n"
+                        + "    let s = t + 2;\n"
+                        + "    sum += s + 3;\n"
+                        + "    break;\n"
+                        + "  default:\n"
+                        + "    sum = 7;\n"
+                        + "}\n"
+                        + "sum;";
+        Utils.assertWithAllModes_1_8(6, script);
+    }
+
+    @Test
+    public void forSwitchLet() throws Exception {
+        String script =
+                "  var sum = 0;\n"
+                        + "for (let i = 0; i < 1; i++)\n"
+                        + "  switch (i) {\n"
+                        + "    case 0:\n"
+                        + "      let test = 7;\n"
+                        + "      sum += 4;\n"
+                        + "      break;\n"
+                        + "    }"
+                        + "sum;";
+        Utils.assertWithAllModes_1_8(4, script);
+    }
+
+    @Test
+    public void ifSwitchLet() throws Exception {
+        String script =
+                "var sum = 0;\n"
+                        + "if (sum == 0)\n"
+                        + "  switch (sum) {\n"
+                        + "    case 0:\n"
+                        + "      let test = 7;\n"
+                        + "      sum += 4;\n"
+                        + "      break;\n"
+                        + "    }"
+                        + "sum;";
+        Utils.assertWithAllModes_1_8(4, script);
+    }
+}


### PR DESCRIPTION
found by an HtmlUnit user https://github.com/HtmlUnit/htmlunit/issues/1040

    for (let i = 0; i < 1; i++)
        switch (i) {
            case 0:
                let test = 7;
                break;
    }

Currently the code above is not accepted by rhino but it is valid.

The fix is a bit of a hack but solves the problem without introducing much more pain.