### PR TITLE
Fixed exception in the interpreter when using many literal bigint

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -1041,6 +1041,18 @@ public final class Interpreter extends Icode implements Evaluator {
             case Icode_LITERAL_NEW_OBJECT:
                 // make a copy or not flag
                 return 1 + 1;
+
+            case Icode_REG_BIGINT1:
+                // ubyte bigint index
+                return 1 + 1;
+
+            case Icode_REG_BIGINT2:
+                // ushort bigint index
+                return 1 + 2;
+
+            case Icode_REG_BIGINT4:
+                // uint bigint index
+                return 1 + 4;
         }
         if (!validBytecode(bytecode)) throw Kit.codeBug();
         return 1;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/BigIntTest.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript.tests;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import org.junit.Test;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
@@ -90,5 +91,21 @@ public class BigIntTest {
 
         // Test zero bits edge case
         Utils.assertWithAllModes_ES6("0", "BigInt.asIntN(0, 123n).toString()");
+    }
+
+    @Test
+    public void manyBigIntLiteral() {
+        // We want to ensure we use all the icode, so we need to have a bigint literal that doesn't
+        // fit in an ushort
+        final long n = 0xFFFF + 1;
+
+        // Generate 0n + 1n + 2n + ...
+        StringBuilder src = new StringBuilder("var sum = 0n;\n");
+        for (long i = 1; i <= n; ++i) {
+            src.append("sum += ").append(i).append("n;\n");
+        }
+        src.append("sum");
+
+        Utils.assertWithAllModes_ES6(BigInteger.valueOf((n * (n + 1)) / 2), src.toString());
     }
 }


### PR DESCRIPTION
The interpreter has various special icode for big int literals, but the ones to access the 5th onward literal were broken. I've fixed it and added a test.