### PR TITLE
first step of migrating the Arguments impl to lambda and fix some issue

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -17,7 +17,27 @@ package org.mozilla.javascript;
 final class Arguments extends IdScriptableObject {
     private static final long serialVersionUID = 4275508002492040609L;
 
-    private static final String FTAG = "Arguments";
+    private static final String CLASS_NAME = "Arguments";
+
+    // Fields to hold caller, callee and length properties,
+    // where NOT_FOUND value tags deleted properties.
+    // In addition if callerObj == NULL_VALUE, it tags null for scripts, as
+    // initial callerObj == null means access to caller arguments available
+    // only in JS <= 1.3 scripts
+    private Object callerObj;
+    private Object calleeObj;
+    private Object lengthObj;
+
+    private int callerAttr = DONTENUM;
+    private int calleeAttr = DONTENUM;
+    private int lengthAttr = DONTENUM;
+
+    private NativeCall activation;
+
+    // Initially args holds activation.getOriginalArgs(), but any modification
+    // of its elements triggers creation of a copy. If its element holds NOT_FOUND,
+    // it indicates deleted index, in which case super class is queried.
+    private Object[] args;
 
     public Arguments(NativeCall activation) {
         this.activation = activation;
@@ -45,11 +65,30 @@ final class Arguments extends IdScriptableObject {
                                 ScriptableObject.getTopLevelScope(parent), TopLevel.Builtins.Array)
                         .get("values", parent),
                 ScriptableObject.DONTENUM);
+
+        if (activation.isStrict) {
+            // ECMAScript2015
+            // 9.4.4.6 CreateUnmappedArgumentsObject(argumentsList)
+            //   8. Perform DefinePropertyOrThrow(obj, "caller", PropertyDescriptor {[[Get]]:
+            // %ThrowTypeError%,
+            //      [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false}).
+            //   9. Perform DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {[[Get]]:
+            // %ThrowTypeError%,
+            //      [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false}).
+            setGetterOrSetter("caller", 0, new ThrowTypeError(parent, "caller"), true);
+            setGetterOrSetter("caller", 0, new ThrowTypeError(parent, "caller"), false);
+            setGetterOrSetter("callee", 0, new ThrowTypeError(parent, "callee"), true);
+            setGetterOrSetter("callee", 0, new ThrowTypeError(parent, "callee"), false);
+            setAttributes("caller", DONTENUM | PERMANENT);
+            setAttributes("callee", DONTENUM | PERMANENT);
+            callerObj = null;
+            calleeObj = null;
+        }
     }
 
     @Override
     public String getClassName() {
-        return FTAG;
+        return CLASS_NAME;
     }
 
     private Object arg(int index) {
@@ -389,35 +428,23 @@ final class Arguments extends IdScriptableObject {
         return true;
     }
 
-    // ECMAScript2015
-    // 9.4.4.6 CreateUnmappedArgumentsObject(argumentsList)
-    //   8. Perform DefinePropertyOrThrow(obj, "caller", PropertyDescriptor {[[Get]]:
-    // %ThrowTypeError%,
-    //      [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false}).
-    //   9. Perform DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {[[Get]]:
-    // %ThrowTypeError%,
-    //      [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false}).
-    void defineAttributesForStrictMode() {
-        Context cx = Context.getContext();
-        if (!cx.isStrictMode()) {
-            return;
-        }
-        setGetterOrSetter("caller", 0, new ThrowTypeError("caller"), true);
-        setGetterOrSetter("caller", 0, new ThrowTypeError("caller"), false);
-        setGetterOrSetter("callee", 0, new ThrowTypeError("callee"), true);
-        setGetterOrSetter("callee", 0, new ThrowTypeError("callee"), false);
-        setAttributes("caller", DONTENUM | PERMANENT);
-        setAttributes("callee", DONTENUM | PERMANENT);
-        callerObj = null;
-        calleeObj = null;
-    }
-
-    private static class ThrowTypeError extends BaseFunction {
+    private static final class ThrowTypeError extends BaseFunction {
         private static final long serialVersionUID = -744615873947395749L;
         private String propertyName;
 
-        ThrowTypeError(String propertyName) {
+        ThrowTypeError(Scriptable scope, String propertyName) {
             this.propertyName = propertyName;
+            setPrototype(ScriptableObject.getFunctionPrototype(scope));
+
+            setAttributes("length", DONTENUM | PERMANENT | READONLY);
+            setAttributes("name", DONTENUM | PERMANENT | READONLY);
+
+            setAttributes("arity", DONTENUM);
+            delete("arity");
+            setAttributes("arguments", DONTENUM);
+            delete("arguments");
+
+            preventExtensions();
         }
 
         @Override
@@ -425,24 +452,4 @@ final class Arguments extends IdScriptableObject {
             throw ScriptRuntime.typeErrorById("msg.arguments.not.access.strict", propertyName);
         }
     }
-
-    // Fields to hold caller, callee and length properties,
-    // where NOT_FOUND value tags deleted properties.
-    // In addition if callerObj == NULL_VALUE, it tags null for scripts, as
-    // initial callerObj == null means access to caller arguments available
-    // only in JS <= 1.3 scripts
-    private Object callerObj;
-    private Object calleeObj;
-    private Object lengthObj;
-
-    private int callerAttr = DONTENUM;
-    private int calleeAttr = DONTENUM;
-    private int lengthAttr = DONTENUM;
-
-    private NativeCall activation;
-
-    // Initially args holds activation.getOriginalArgs(), but any modification
-    // of its elements triggers creation of a copy. If its element holds NOT_FOUND,
-    // it indicates deleted index, in which case super class is queried.
-    private Object[] args;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
@@ -140,12 +140,6 @@ public final class NativeCall extends IdScriptableObject {
         throw new IllegalArgumentException(String.valueOf(id));
     }
 
-    public void defineAttributesForArguments() {
-        if (arguments != null) {
-            arguments.defineAttributesForStrictMode();
-        }
-    }
-
     public Scriptable getHomeObject() {
         return function.getHomeObject();
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4995,7 +4995,6 @@ public class ScriptRuntime {
         NativeCall call = (NativeCall) scope;
         call.parentActivationCall = cx.currentActivationCall;
         cx.currentActivationCall = call;
-        call.defineAttributesForArguments();
     }
 
     public static void exitActivationFunction(Context cx) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ThrowTypeErrorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ThrowTypeErrorTest.java
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es6;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/** Tests for ThrowTypeError support. */
+public class ThrowTypeErrorTest {
+
+    @Test
+    public void isFunction() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let desc = Object.getOwnPropertyDescriptor(args, 'callee');"
+                        + "let ThrowTypeError = desc.get"
+                        + "'' + typeof ThrowTypeError";
+
+        Utils.assertWithAllModes_ES6("function", code);
+    }
+
+    @Test
+    public void isExtensible() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "Object.isExtensible(ThrowTypeError)";
+
+        Utils.assertWithAllModes_ES6(false, code);
+    }
+
+    @Test
+    public void isSealed() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "Object.isSealed(ThrowTypeError)";
+
+        Utils.assertWithAllModes_ES6(true, code);
+    }
+
+    @Test
+    public void isFrozen() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "Object.isFrozen(ThrowTypeError)";
+
+        Utils.assertWithAllModes_ES6(true, code);
+    }
+
+    @Test
+    public void length() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "  let res = '';"
+                        + "  let desc = Object.getOwnPropertyDescriptor(ThrowTypeError, 'length');"
+                        + "  res += desc.value;\n"
+                        + "  res += ' W-' + desc.writable;\n"
+                        + "  res += ' E-' + desc.enumerable;\n"
+                        + "  res += ' C-' + desc.configurable;\n"
+                        + "res";
+
+        Utils.assertWithAllModes_ES6("0 W-false E-false C-false", code);
+    }
+
+    @Test
+    public void name() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "  let res = '';"
+                        + "  let desc = Object.getOwnPropertyDescriptor(ThrowTypeError, 'name');"
+                        + "  res += '#' + desc.value + '#';\n"
+                        + "  res += ' W-' + desc.writable;\n"
+                        + "  res += ' E-' + desc.enumerable;\n"
+                        + "  res += ' C-' + desc.configurable;\n"
+                        + "res";
+
+        Utils.assertWithAllModes_ES6("## W-false E-false C-false", code);
+    }
+
+    @Test
+    public void prototype() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "Function.prototype === Object.getPrototypeOf(ThrowTypeError)";
+
+        Utils.assertWithAllModes_ES6(true, code);
+    }
+
+    @Test
+    public void ownPropertyNames() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "'' + Object.getOwnPropertyNames(ThrowTypeError)";
+
+        Utils.assertWithAllModes_ES6("length,name", code);
+    }
+
+    @Test
+    public void noCaller() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "Object.prototype.hasOwnProperty.call(ThrowTypeError, 'caller')";
+
+        Utils.assertWithAllModes_ES6(false, code);
+    }
+
+    @Test
+    public void noArguments() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "Object.prototype.hasOwnProperty.call(ThrowTypeError, 'arguments')";
+
+        Utils.assertWithAllModes_ES6(false, code);
+    }
+
+    @Test
+    public void toStringCall() {
+        String code =
+                "let args = function() { 'use strict'; return arguments; }();"
+                        + "let ThrowTypeError = Object.getOwnPropertyDescriptor(args, 'callee').get;"
+                        + "ThrowTypeError.toString()";
+
+        Utils.assertWithAllModes_ES6("function () {\n\t[native code]\n}\n", code);
+    }
+}

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2430,12 +2430,8 @@ built-ins/Symbol 5/94 (5.32%)
 
 built-ins/Temporal 4255/4255 (100.0%)
 
-built-ins/ThrowTypeError 8/14 (57.14%)
-    extensible.js
-    frozen.js
-    length.js
-    name.js
-    prototype.js
+built-ins/ThrowTypeError 4/14 (28.57%)
+    distinct-cross-realm.js strict
     unique-per-realm-function-proto.js
     unique-per-realm-non-simple.js
     unique-per-realm-unmapped-args.js


### PR DESCRIPTION
* a bit of cleanup for the Arguments implementation itself (preparation for the migration to lambda that will be another pr)
* fix a bunch of issues with ThrowTypeError
* add some tests for ThrowTypeError

The 'new' test262 problem ThrowTypeError/distinct-cross-realm.js is something that worked so far by chance. With the fixes it now fails because we have no real realm and the ThrowTypeError is reused.

Fun fact, the test itself is also wrong - i will open an issue aganst the test262 project later.

Started this effort because the HtmlUnit brach still has some patches for arguments handling, and i like to get rid of them. Looks like the Rhino impl is already good and only minor things required to make some progress here. Already working on the next PR, but I like to have this first merged to make the steps and the impact clear.