### PR TITLE
Fix InterpreterByteCodeDumpTest for Windows.

### DIFF
--- a/rhino/src/test/java/org/mozilla/javascript/InterpreterBytecodeDumpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/InterpreterBytecodeDumpTest.java
@@ -11,85 +11,90 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
 
 // Simple smoke tests for dumping of the bytecode generated in interpreter mode
 class InterpreterBytecodeDumpTest {
     @Test
     void basicSmokeTest() throws IOException {
         assertEquals(
-                ""
-                        + "ICode dump, for null, length = 8\n"
-                        + "MaxStack = 1\n"
-                        + " [0] LINE : 1\n"
-                        + " [3] SHORTNUMBER 42\n"
-                        + " [6] POP_RESULT\n"
-                        + " [7] RETURN_RESULT\n",
+                Utils.portableLines(
+                        "ICode dump, for null, length = 8",
+                        "MaxStack = 1",
+                        " [0] LINE : 1",
+                        " [3] SHORTNUMBER 42",
+                        " [6] POP_RESULT",
+                        " [7] RETURN_RESULT",
+                        ""),
                 getByteCodeFrom("42"));
     }
 
     @Test
     void functionNamesArePrinted() throws IOException {
         assertEquals(
-                ""
-                        + "ICode dump, for f, length = 4\n"
-                        + "MaxStack = 0\n"
-                        + " [0] LINE : 1\n"
-                        + " [3] RETUNDEF\n"
-                        + "ICode dump, for null, length = 1\n"
-                        + "MaxStack = 0\n"
-                        + " [0] RETURN_RESULT\n",
+                Utils.portableLines(
+                        "ICode dump, for f, length = 4",
+                        "MaxStack = 0",
+                        " [0] LINE : 1",
+                        " [3] RETUNDEF",
+                        "ICode dump, for null, length = 1",
+                        "MaxStack = 0",
+                        " [0] RETURN_RESULT",
+                        ""),
                 getByteCodeFrom("function f() {}"));
     }
 
     @Test
     void methodsArePrinted() throws IOException {
         assertEquals(
-                ""
-                        + "ICode dump, for f, length = 4\n"
-                        + "MaxStack = 0\n"
-                        + " [0] LINE : 1\n"
-                        + " [3] RETUNDEF\n"
-                        + "ICode dump, for null, length = 16\n"
-                        + "MaxStack = 4\n"
-                        + " [0] LINE : 1\n"
-                        + " [3] REG_STR_C0 \"o\"\n"
-                        + " [4] BINDNAME\n"
-                        + " [5] REG_IND_C0\n"
-                        + " [6] LITERAL_NEW_OBJECT [f] false\n"
-                        + " [8] REG_IND_C0\n"
-                        + " [9] METHOD_EXPR #0\n"
-                        + " [10] LITERAL_SET\n"
-                        + " [11] OBJECTLIT\n"
-                        + " [12] REG_STR_C0 \"o\"\n"
-                        + " [13] SETNAME\n"
-                        + " [14] POP_RESULT\n"
-                        + " [15] RETURN_RESULT\n",
+                Utils.portableLines(
+                        "ICode dump, for f, length = 4",
+                        "MaxStack = 0",
+                        " [0] LINE : 1",
+                        " [3] RETUNDEF",
+                        "ICode dump, for null, length = 16",
+                        "MaxStack = 4",
+                        " [0] LINE : 1",
+                        " [3] REG_STR_C0 \"o\"",
+                        " [4] BINDNAME",
+                        " [5] REG_IND_C0",
+                        " [6] LITERAL_NEW_OBJECT [f] false",
+                        " [8] REG_IND_C0",
+                        " [9] METHOD_EXPR #0",
+                        " [10] LITERAL_SET",
+                        " [11] OBJECTLIT",
+                        " [12] REG_STR_C0 \"o\"",
+                        " [13] SETNAME",
+                        " [14] POP_RESULT",
+                        " [15] RETURN_RESULT",
+                        ""),
                 getByteCodeFrom("o = { f() {} }"));
     }
 
     @Test
     void bigIntsArePrinted() throws IOException {
         assertEquals(
-                ""
-                        + "ICode dump, for null, length = 20\n"
-                        + "MaxStack = 2\n"
-                        + " [0] LINE : 1\n"
-                        + " [3] REG_BIGINT_C0 1n\n"
-                        + " [4] BIGINT\n"
-                        + " [5] REG_BIGINT_C1 2n\n"
-                        + " [6] BIGINT\n"
-                        + " [7] ADD\n"
-                        + " [8] REG_BIGINT_C2 3n\n"
-                        + " [9] BIGINT\n"
-                        + " [10] ADD\n"
-                        + " [11] REG_BIGINT_C3 4n\n"
-                        + " [12] BIGINT\n"
-                        + " [13] ADD\n"
-                        + " [14] LOAD_BIGINT1 5n\n"
-                        + " [16] BIGINT\n"
-                        + " [17] ADD\n"
-                        + " [18] POP_RESULT\n"
-                        + " [19] RETURN_RESULT\n",
+                Utils.portableLines(
+                        "ICode dump, for null, length = 20",
+                        "MaxStack = 2",
+                        " [0] LINE : 1",
+                        " [3] REG_BIGINT_C0 1n",
+                        " [4] BIGINT",
+                        " [5] REG_BIGINT_C1 2n",
+                        " [6] BIGINT",
+                        " [7] ADD",
+                        " [8] REG_BIGINT_C2 3n",
+                        " [9] BIGINT",
+                        " [10] ADD",
+                        " [11] REG_BIGINT_C3 4n",
+                        " [12] BIGINT",
+                        " [13] ADD",
+                        " [14] LOAD_BIGINT1 5n",
+                        " [16] BIGINT",
+                        " [17] ADD",
+                        " [18] POP_RESULT",
+                        " [19] RETURN_RESULT",
+                        ""),
                 getByteCodeFrom("1n + 2n + 3n + 4n + 5n"));
     }
 

--- a/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
+++ b/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
@@ -30,13 +30,27 @@ public class Utils {
 
     /**
      * helper for joining multiple lines into one string, so that you don't need to do {@code
-     * "line1\n" + "line2\n" + "line3"} by yourself
+     * "line1\n" + "line2\n" + "line3"} by yourself. This should be used when creating strings to
+     * compare against output that has explicit "\n" separators.
      *
      * @param lines the lines to join
      * @return the joined lines
      */
     public static String lines(String... lines) {
         return String.join("\n", lines);
+    }
+
+    /**
+     * helper for joining multiple lines into one string, so that you don't need to do {@code
+     * "line1\n" + "line2\n" + "line3"} by yourself, that uses the system line break so that it will
+     * work across platforms. This must be used when comparing output written using "println" or
+     * other methods that use the system line separator rather than a constant "\n".
+     *
+     * @param lines the lines to join
+     * @return the joined lines
+     */
+    public static String portableLines(String... lines) {
+        return String.join(System.lineSeparator(), lines);
     }
 
     /** Make the ctor private; this is a utility classe. */


### PR DESCRIPTION
Make sure that is uses the proper newline separator for Windows.

This broken in the current master branch, but only when testing on Windows.
Since we don't have CI on Windows, we didn't catch this.
