### PR TITLE
Convert `TopLevel` from `IdScriptableObject` to being lambda based.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -29,7 +29,7 @@ import java.util.EnumMap;
  * dynamic scopes) embeddings should explicitly call {@link #cacheBuiltins(Scriptable, boolean)} to
  * initialize the class cache for each top-level scope.
  */
-public class TopLevel extends IdScriptableObject {
+public class TopLevel extends ScriptableObject {
 
     private static final long serialVersionUID = -4648046356662472260L;
 


### PR DESCRIPTION
This is another PR in the long road to separating scopes and scriptable objects, but it's a draft for now because it cast light on a really tricky corner of Rhino's API around `ImporterTopLevel`, and I don't have a good answer for how to square this circle.

`ImporterTopLevel` stores additional information against scopes when Java packages are imported, and then uses that to resolve class names at a later time. If two packages are imported with identically named classes then when those classes are looked up this will raise an error. As a top level scope, or an explicitly created scope this is fine if a little tricky, but it also allows for extremely sneaky additional behaviour as tested for in `SealedSharedScopeTest` which sets up scopes as follows:

```java
        try (Context tmpCtx = Context.enter()) {
            sharedScope = new ImporterTopLevel(tmpCtx, true);
            sharedScope.sealObject();
        }

        ctx = Context.enter();
        ctx.setLanguageVersion(Context.VERSION_DEFAULT);
        scope1 = ctx.newObject(sharedScope);
        scope1.setPrototype(sharedScope);
        scope1.setParentScope(null);
        scope2 = ctx.newObject(sharedScope);
        scope2.setPrototype(sharedScope);
        scope2.setParentScope(null);
```

and these are then tested like this:

```java
        evaluateString(scope1, "importPackage(javax.naming);");
        evaluateString(scope2, "importPackage(javax.xml.soap);");
        o = evaluateString(scope1, "Name");
```

For this to work `importPackage()` has to execute with the caller's scope, not it's own declaration scope, in order to store data against `scope1` or `scope2` rather than the sealed `sharedScope`, _and_ it requires `scope1` and `scope2` to have the `sharedScope` set as their prototype because only prototype chain look ups pass in the target as the starting scope.

This test / API does not survive the separation of scopes and objects (scopes no longer have prototypes), and also either requires special handling of scopes, or special handling of `this`. It can _barely_ even survive the change to lambdas.

Looking through the users of `ImporterTopLevel` on GH I think almost all of them are just using it as a top level scope and are not relying on the creating child scopes, at least not explicitly,  but I thought this warranted discussion before breaking an API, especially when we have tests for it, and we even have had bug reports against (#1463).

I wonder if we should deprecate `ImporterTopLevel` except as a top level scope, (maybe even as that) and strongly push people to using `Pacakges` for this sort of thing like
```javascript
var {Integer, String:JString} = Packages.java.lang;
```

@gbrail , @rPraml , @rbri, and @p-bakker I'm guessing you'll all have opinions on this. I've checked our internal GHE and we don't use `importClass` and or `importPackage` anywhere outside a few tests as far as I can tell.