### PR TITLE
cleanup `JavaAdapter`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -33,6 +33,10 @@ public final class JavaAdapter {
     /**
      * Provides a key with which to distinguish previously generated adapter classes stored in a
      * hash table.
+     *
+     * <p>JavaAdapter should cache the adapter class when input classes are the same, and
+     * implementation object are of "same shape", which means having same number of function
+     * properties, and same length for each function
      */
     static class JavaAdapterSignature {
         Class<?> superClass;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/JavaAdapterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/JavaAdapterTest.java
@@ -97,4 +97,20 @@ public class JavaAdapterTest {
         Assert.assertFalse(adapted.test(null));
         Assert.assertFalse(adapted.test(42));
     }
+
+    /**
+     * @see org.mozilla.javascript.JavaAdapter.JavaAdapterSignature
+     */
+    @Test
+    public void adapterCache() {
+        String testCode =
+                String.format(
+                        "JavaAdapter(Packages.%s,%s)",
+                        Predicate.class.getName(),
+                        "{ test: function(obj) { return 'rhino' == obj; } }");
+
+        var adapterObject1 = (NativeJavaObject) eval(testCode);
+        var adapterObject2 = (NativeJavaObject) eval(testCode);
+        Assert.assertSame(adapterObject1.unwrap().getClass(), adapterObject2.unwrap().getClass());
+    }
 }


### PR DESCRIPTION
- migrate `JavaAdapter` away from `IdFunctionCall`
- expand `JavaAdapterTest`
- some other cleanup for `JavaAdapter` and `JavaAdapterSignature`