### PR TITLE
Separate top level scope and `globalThis`.

### DIFF
--- a/examples/src/main/java/Shell.java
+++ b/examples/src/main/java/Shell.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.Function;
 import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.WrappedException;
 
 /**
@@ -49,7 +50,8 @@ public class Shell extends ScriptableObject {
             // Initialize the standard objects (Object, Function, etc.)
             // This must be done before scripts can be executed.
             Shell shell = new Shell();
-            cx.initStandardObjects(shell);
+            TopLevel topLevel = new TopLevel(shell);
+            cx.initStandardObjects(topLevel);
 
             // Define some global functions particular to the shell. Note
             // that these functions are not part of ECMA.
@@ -202,7 +204,7 @@ public class Shell extends ScriptableObject {
      * @param funObj the function object of the invoked JavaScript function
      */
     public static void load(Context cx, Scriptable thisObj, Object[] args, Function funObj) {
-        Shell shell = (Shell) getTopLevelScope(thisObj);
+        Shell shell = (Shell) getTopLevelScope(thisObj).getGlobalThis();
         for (int i = 0; i < args.length; i++) {
             shell.processSource(cx, Context.toString(args[i]));
         }

--- a/examples/src/main/java/Shell.java
+++ b/examples/src/main/java/Shell.java
@@ -56,7 +56,7 @@ public class Shell extends ScriptableObject {
             // Define some global functions particular to the shell. Note
             // that these functions are not part of ECMA.
             String[] names = {"print", "quit", "version", "load", "help"};
-            shell.defineFunctionProperties(names, Shell.class, ScriptableObject.DONTENUM);
+            shell.defineFunctionProperties(topLevel, names, Shell.class, ScriptableObject.DONTENUM);
 
             args = processOptions(cx, args);
 

--- a/it-android/src/main/java/org/mozilla/javascript/android/TestCase.java
+++ b/it-android/src/main/java/org/mozilla/javascript/android/TestCase.java
@@ -13,7 +13,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 
 /**
  * Utility class, that search for testcases in "assets/tests".

--- a/it-android/src/main/java/org/mozilla/javascript/android/TestCase.java
+++ b/it-android/src/main/java/org/mozilla/javascript/android/TestCase.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Utility class, that search for testcases in "assets/tests".
@@ -24,7 +25,7 @@ import org.mozilla.javascript.Scriptable;
 public abstract class TestCase {
 
     protected final String name;
-    protected final Scriptable global;
+    protected final TopLevel global;
 
     private static final ContextFactory factory =
             new ContextFactory() {
@@ -46,7 +47,7 @@ public abstract class TestCase {
                 }
             };
 
-    public TestCase(String name, Scriptable global) {
+    public TestCase(String name, TopLevel global) {
         this.name = name;
         this.global = global;
     }
@@ -54,9 +55,7 @@ public abstract class TestCase {
     public String run() {
         Context cx = factory.enterContext();
         try {
-            Scriptable scope = cx.newObject(global);
-            scope.setPrototype(global);
-            scope.setParentScope(null);
+            Scriptable scope = TopLevel.createIsolate(global);
             return ScriptRuntime.toString(runTest(cx, scope));
         } finally {
             Context.exit();
@@ -73,7 +72,7 @@ public abstract class TestCase {
     public static class AssetScript extends TestCase {
         protected final AssetManager assetManager;
 
-        public AssetScript(String name, Scriptable global, AssetManager assetManager) {
+        public AssetScript(String name, TopLevel global, AssetManager assetManager) {
             super(name, global);
             this.assetManager = assetManager;
         }
@@ -93,7 +92,7 @@ public abstract class TestCase {
 
         AssetManager assetManager = context.getAssets();
         // define assert object
-        ScriptableObject global;
+        TopLevel global;
         Context cx = factory.enterContext();
         try (InputStream in = assetManager.open("assert.js");
                 Reader rdr = new InputStreamReader(in, StandardCharsets.UTF_8)) {

--- a/it-android/src/main/java/org/mozilla/javascript/android/TypeInfoFactoryTestCase.java
+++ b/it-android/src/main/java/org/mozilla/javascript/android/TypeInfoFactoryTestCase.java
@@ -2,6 +2,7 @@ package org.mozilla.javascript.android;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
 import org.mozilla.javascript.lc.type.impl.factory.ClassValueCacheFactory;
 
@@ -9,7 +10,7 @@ import org.mozilla.javascript.lc.type.impl.factory.ClassValueCacheFactory;
  * @author ZZZank
  */
 public class TypeInfoFactoryTestCase extends TestCase {
-    public TypeInfoFactoryTestCase(String name, Scriptable global) {
+    public TypeInfoFactoryTestCase(String name, TopLevel global) {
         super(name, global);
     }
 

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
@@ -47,7 +47,7 @@ public class Builtins {
 
     private static Object print(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         try {
-            Builtins self = getSelf(thisObj);
+            Builtins self = getSelf(scope);
             for (Object arg : args) {
                 self.stdout.write(ScriptRuntime.toString(arg));
             }

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
@@ -25,6 +25,7 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * This is the implementation of the standard ScriptEngine interface for Rhino.
@@ -76,7 +77,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
 
     private final RhinoScriptEngineFactory factory;
     private final Builtins builtins;
-    private ScriptableObject topLevelScope = null;
+    private TopLevel topLevelScope = null;
 
     RhinoScriptEngine(RhinoScriptEngineFactory factory) {
         this.factory = factory;
@@ -94,18 +95,16 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
             builtins.register(cx, topLevelScope, sc);
         }
 
-        Scriptable engineScope = new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE));
-        engineScope.setParentScope(null);
-        engineScope.setPrototype(topLevelScope);
-
         if (sc.getBindings(ScriptContext.GLOBAL_SCOPE) != null) {
-            Scriptable globalScope = new BindingsObject(sc.getBindings(ScriptContext.GLOBAL_SCOPE));
-            globalScope.setParentScope(null);
-            globalScope.setPrototype(topLevelScope);
-            engineScope.setPrototype(globalScope);
+            var globalScope =
+                    topLevelScope.createIsolate(
+                            new BindingsObject(sc.getBindings(ScriptContext.GLOBAL_SCOPE)));
+            return globalScope.createIsolate(
+                    new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
+        } else {
+            return topLevelScope.createIsolate(
+                    new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
         }
-
-        return engineScope;
     }
 
     @Override

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
@@ -97,13 +97,14 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
 
         if (sc.getBindings(ScriptContext.GLOBAL_SCOPE) != null) {
             var globalScope =
-                    topLevelScope.createIsolate(
+                    TopLevel.createIsolate(
+                            topLevelScope,
                             new BindingsObject(sc.getBindings(ScriptContext.GLOBAL_SCOPE)));
-            return globalScope.createIsolate(
-                    new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
+            return TopLevel.createIsolate(
+                    globalScope, new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
         } else {
-            return topLevelScope.createIsolate(
-                    new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
+            return TopLevel.createIsolate(
+                    topLevelScope, new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
         }
     }
 

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.commonjs.module.ModuleScope;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -180,7 +181,7 @@ public class Main {
             global.installRequire(cx, List.of(), false);
 
             URI uri = new File(System.getProperty("user.dir")).toURI();
-            ModuleScope scope = new ModuleScope(global, uri, null);
+            ScriptableObject scope = ModuleScope.createModuleScope(global, uri, null);
 
             main.setScope(scope);
 

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
@@ -131,7 +131,7 @@ public class Global extends ImporterTopLevel {
         // that these functions are not part of ECMA.
         initStandardObjects(cx, sealedStdLib);
         NativeConsole.init(this, sealedStdLib, new ShellConsolePrinter());
-        defineFunctionProperties(TOP_COMMANDS, Global.class, ScriptableObject.DONTENUM);
+        defineFunctionProperties(this, TOP_COMMANDS, Global.class, ScriptableObject.DONTENUM);
 
         // Set up "environment" in the global scope to provide access to the
         // System environment variables.
@@ -298,7 +298,8 @@ public class Global extends ImporterTopLevel {
         if (!Scriptable.class.isAssignableFrom(clazz)) {
             throw reportRuntimeError("msg.must.implement.Scriptable");
         }
-        ScriptableObject.defineClass(thisObj, (Class<? extends Scriptable>) clazz);
+        ScriptableObject.defineClass(
+                funObj.getDeclarationScope(), (Class<? extends Scriptable>) clazz);
     }
 
     /**
@@ -364,7 +365,7 @@ public class Global extends ImporterTopLevel {
         }
         String filename = Context.toString(args[0]);
         try (FileInputStream fis = new FileInputStream(filename)) {
-            Scriptable scope = ScriptableObject.getTopLevelScope(thisObj);
+            Scriptable scope = ScriptableObject.getTopLevelScope(funObj.getDeclarationScope());
             try (ObjectInputStream in = new ScriptableInputStream(fis, scope)) {
                 Object deserialized = in.readObject();
                 return Context.toObject(deserialized, scope);

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
@@ -97,9 +97,12 @@ public class Global extends ImporterTopLevel {
     private static final String[] prompts = {"js> ", "  > "};
     private HashMap<String, String> doctestCanonicalizations;
 
-    public Global() {}
+    public Global() {
+        super(true);
+    }
 
     public Global(Context cx) {
+        super(true);
         init(cx);
     }
 
@@ -261,7 +264,7 @@ public class Global extends ImporterTopLevel {
         for (Object arg : args) {
             String file = Context.toString(arg);
             try {
-                Main.processFile(cx, thisObj, file);
+                Main.processFile(cx, funObj.getDeclarationScope(), file);
             } catch (IOException ioex) {
                 String msg =
                         ToolErrorReporter.getMessage(
@@ -348,7 +351,7 @@ public class Global extends ImporterTopLevel {
         Object obj = args[0];
         String filename = Context.toString(args[1]);
         FileOutputStream fos = new FileOutputStream(filename);
-        Scriptable scope = ScriptableObject.getTopLevelScope(thisObj);
+        Scriptable scope = ScriptableObject.getTopLevelScope(funObj.getDeclarationScope());
         try (ScriptableOutputStream out = new ScriptableOutputStream(fos, scope)) {
             out.writeObject(obj);
         }

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Main.java
@@ -251,7 +251,7 @@ public class Main {
                     uri = new File(path).toURI();
                 }
             }
-            return new ModuleScope(global, uri, null);
+            return ModuleScope.createModuleScope(global, uri, null);
         }
         return global;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -169,7 +169,7 @@ public class AccessorSlot extends Slot {
 
         @Override
         public Function asGetterFunction(String name, Scriptable scope) {
-            return member.asGetterFunction(name, scope);
+            return member.asGetterFunction(name);
         }
 
         @Override
@@ -246,7 +246,7 @@ public class AccessorSlot extends Slot {
 
         @Override
         public Function asSetterFunction(String name, Scriptable scope) {
-            return member.asSetterFunction(name, scope);
+            return member.asSetterFunction(name);
         }
 
         @Override

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -144,6 +144,9 @@ public class ArrayLikeAbstractOperations {
         } else {
             thisArg = ScriptRuntime.toObject(cx, scope, args[1]);
         }
+        if (thisArg instanceof TopLevel) {
+            thisArg = ((TopLevel) thisArg).getGlobalThis();
+        }
 
         Scriptable array = null;
         if (operation == IterativeOperation.FILTER || operation == IterativeOperation.MAP) {
@@ -340,6 +343,8 @@ public class ArrayLikeAbstractOperations {
         }
         Function f = (Function) callbackArg;
         Scriptable parent = ScriptableObject.getTopLevelScope(f);
+        Scriptable globalThis =
+                parent instanceof TopLevel ? ((TopLevel) parent).getGlobalThis() : parent;
         // hack to serve both reduce and reduceRight with the same loop
         boolean movingLeft = operation == ReduceOperation.REDUCE;
         Object value = args.length > 1 ? args[1] : NOT_FOUND;
@@ -354,7 +359,7 @@ public class ArrayLikeAbstractOperations {
                 value = elem;
             } else {
                 Object[] innerArgs = {value, elem, index, o};
-                value = f.call(cx, parent, parent, innerArgs);
+                value = f.call(cx, parent, globalThis, innerArgs);
             }
         }
         if (value == NOT_FOUND) {

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -137,15 +137,12 @@ public class ArrayLikeAbstractOperations {
         Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
 
         Function f = getCallbackArg(cx, callbackArg);
-        Scriptable parent = ScriptableObject.getTopLevelScope(f);
+        TopLevel parent = ScriptableObject.getTopLevelScope(f);
         Scriptable thisArg;
         if (args.length < 2 || args[1] == null || args[1] == Undefined.instance) {
-            thisArg = parent;
+            thisArg = parent.getGlobalThis();
         } else {
             thisArg = ScriptRuntime.toObject(cx, scope, args[1]);
-        }
-        if (thisArg instanceof TopLevel) {
-            thisArg = ((TopLevel) thisArg).getGlobalThis();
         }
 
         Scriptable array = null;
@@ -342,9 +339,8 @@ public class ArrayLikeAbstractOperations {
             throw ScriptRuntime.notFunctionError(callbackArg);
         }
         Function f = (Function) callbackArg;
-        Scriptable parent = ScriptableObject.getTopLevelScope(f);
-        Scriptable globalThis =
-                parent instanceof TopLevel ? ((TopLevel) parent).getGlobalThis() : parent;
+        TopLevel parent = ScriptableObject.getTopLevelScope(f);
+        Scriptable globalThis = parent.getGlobalThis();
         // hack to serve both reduce and reduceRight with the same loop
         boolean movingLeft = operation == ReduceOperation.REDUCE;
         Object value = args.length > 1 ? args[1] : NOT_FOUND;

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -115,6 +115,9 @@ public class BoundFunction extends BaseFunction {
         if (callThis == null) {
             callThis = getTopLevelScope(scope);
         }
+        if (callThis instanceof TopLevel) {
+            callThis = ((TopLevel) callThis).getGlobalThis();
+        }
         return callThis;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -109,14 +109,12 @@ public class BoundFunction extends BaseFunction {
 
     Scriptable getCallThis(Context cx, Scriptable scope) {
         Scriptable callThis = boundThis;
-        if (callThis == null && ScriptRuntime.hasTopCall(cx)) {
-            callThis = ScriptRuntime.getTopCallScope(cx);
-        }
         if (callThis == null) {
-            callThis = getTopLevelScope(scope);
-        }
-        if (callThis instanceof TopLevel) {
-            callThis = ((TopLevel) callThis).getGlobalThis();
+            if (ScriptRuntime.hasTopCall(cx)) {
+                callThis = ScriptRuntime.getTopCallScope(cx).getGlobalThis();
+            } else {
+                callThis = getTopLevelScope(scope).getGlobalThis();
+            }
         }
         return callThis;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -77,12 +77,6 @@ public class ClassCache implements Serializable {
         if (cache == null) {
             // we expect this to not happen frequently, so computing top scope twice is acceptable
             var topScope = ScriptableObject.getTopLevelScope(scope);
-            if (!(topScope instanceof ScriptableObject)) {
-                // Note: it's originally a RuntimeException, the super class of
-                // IllegalArgumentException, so this will not break error catching
-                throw new IllegalArgumentException(
-                        "top scope have no associated ClassCache and cannot have ClassCache associated due to not being a ScriptableObject");
-            }
             cache = new ClassCache();
             cache.associate(((ScriptableObject) topScope));
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
@@ -107,9 +107,9 @@ public class ClassDescriptor {
         @Override
         void makeProp(Context cx, Scriptable scope, ScriptableObject obj) {
             if (name instanceof String) {
-                obj.defineProperty(cx, (String) name, getter, setter, attributes);
+                obj.defineProperty(cx, scope, (String) name, getter, setter, attributes);
             } else {
-                obj.defineProperty(cx, (SymbolKey) name, getter, setter, attributes);
+                obj.defineProperty(cx, scope, (SymbolKey) name, getter, setter, attributes);
             }
         }
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1210,7 +1210,8 @@ public class Context implements Closeable {
             Scriptable scope, String source, String sourceName, int lineno, Object securityDomain) {
         Script script = compileString(source, sourceName, lineno, securityDomain);
         if (script != null) {
-            return script.exec(this, scope, scope);
+            return script.exec(
+                    this, scope, ScriptableObject.getTopLevelScope(scope).getGlobalThis());
         }
         return null;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1052,7 +1052,7 @@ public class Context implements Closeable {
      *
      * @return the initialized scope
      */
-    public final ScriptableObject initStandardObjects() {
+    public final TopLevel initStandardObjects() {
         return initStandardObjects(null, false);
     }
 
@@ -1095,7 +1095,7 @@ public class Context implements Closeable {
      * @return the initialized scope. The method returns the value of the scope argument if it is
      *     not null or newly allocated scope object which is an instance {@link ScriptableObject}.
      */
-    public final Scriptable initStandardObjects(ScriptableObject scope) {
+    public final TopLevel initStandardObjects(TopLevel scope) {
         return initStandardObjects(scope, false);
     }
 
@@ -1121,7 +1121,7 @@ public class Context implements Closeable {
      * @return the initialized scope. The method returns the value of the scope argument if it is
      *     not null or newly allocated scope object which is an instance {@link ScriptableObject}.
      */
-    public final Scriptable initSafeStandardObjects(ScriptableObject scope) {
+    public final TopLevel initSafeStandardObjects(TopLevel scope) {
         return initSafeStandardObjects(scope, false);
     }
 
@@ -1148,7 +1148,7 @@ public class Context implements Closeable {
      *     not null or newly allocated scope object.
      * @since 1.4R3
      */
-    public ScriptableObject initStandardObjects(ScriptableObject scope, boolean sealed) {
+    public TopLevel initStandardObjects(TopLevel scope, boolean sealed) {
         return ScriptRuntime.initStandardObjects(this, scope, sealed);
     }
 
@@ -1181,7 +1181,7 @@ public class Context implements Closeable {
      *     not null or newly allocated scope object.
      * @since 1.7.6
      */
-    public ScriptableObject initSafeStandardObjects(ScriptableObject scope, boolean sealed) {
+    public TopLevel initSafeStandardObjects(TopLevel scope, boolean sealed) {
         return ScriptRuntime.initSafeStandardObjects(this, scope, sealed);
     }
 
@@ -2790,7 +2790,7 @@ public class Context implements Closeable {
     private boolean sealed;
     private Object sealKey;
 
-    Scriptable topCallScope;
+    TopLevel topCallScope;
     boolean isContinuationsTopCall;
     NativeCall currentActivationCall;
     private boolean isStrict;

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -18,7 +18,7 @@ public final class ES6Generator extends ScriptableObject {
     private State state = State.SUSPENDED_START;
     private Object delegee;
 
-    static ES6Generator init(ScriptableObject scope, boolean sealed) {
+    static ES6Generator init(TopLevel scope, boolean sealed) {
 
         ES6Generator prototype = new ES6Generator();
         if (scope != null) {

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
@@ -17,7 +17,7 @@ public abstract class ES6Iterator extends ScriptableObject {
     public static final String RETURN_METHOD = "return";
 
     protected static void init(
-            ScriptableObject scope, boolean sealed, ScriptableObject prototype, String tag) {
+            TopLevel scope, boolean sealed, ScriptableObject prototype, String tag) {
         if (scope != null) {
             prototype.setParentScope(scope);
             prototype.setPrototype(getObjectPrototype(scope));

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -14,7 +14,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import org.mozilla.javascript.commonjs.module.ModuleScope;
 
 public class FunctionObject extends BaseFunction {
     private static final long serialVersionUID = -5332312783643935019L;
@@ -387,22 +386,8 @@ public class FunctionObject extends BaseFunction {
                     thisObj = ((Delegator) thisObj).getDelegee();
                 }
                 if (!clazz.isInstance(thisObj)) {
-                    boolean compatible = false;
-                    if (thisObj == scope || thisObj instanceof ModuleScope) {
-                        Scriptable parentScope = getDeclarationScope();
-                        if (scope != parentScope) {
-                            // Call with dynamic scope for standalone function,
-                            // use parentScope as thisObj
-                            compatible = clazz.isInstance(parentScope);
-                            if (compatible) {
-                                thisObj = parentScope;
-                            }
-                        }
-                    }
-                    if (!compatible) {
-                        // Couldn't find an object to call this on.
-                        throw ScriptRuntime.typeErrorById("msg.incompat.call", functionName);
-                    }
+                    // Couldn't find an object to call this on.
+                    throw ScriptRuntime.typeErrorById("msg.incompat.call", functionName);
                 }
             }
 

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -79,10 +79,10 @@ public class FunctionObject extends BaseFunction {
      */
     public FunctionObject(String name, Member methodOrConstructor, Scriptable scope) {
         if (methodOrConstructor instanceof Constructor) {
-            member = new MemberBox((Constructor<?>) methodOrConstructor);
+            member = new MemberBox(getDeclarationScope(), (Constructor<?>) methodOrConstructor);
             isStatic = true; // well, doesn't take a 'this'
         } else {
-            member = new MemberBox((Method) methodOrConstructor);
+            member = new MemberBox(getDeclarationScope(), (Method) methodOrConstructor);
             isStatic = member.isStatic();
         }
         String methodName = member.getName();

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -78,10 +78,10 @@ public class FunctionObject extends BaseFunction {
      */
     public FunctionObject(String name, Member methodOrConstructor, Scriptable scope) {
         if (methodOrConstructor instanceof Constructor) {
-            member = new MemberBox(getDeclarationScope(), (Constructor<?>) methodOrConstructor);
+            member = new MemberBox(scope, (Constructor<?>) methodOrConstructor);
             isStatic = true; // well, doesn't take a 'this'
         } else {
-            member = new MemberBox(getDeclarationScope(), (Method) methodOrConstructor);
+            member = new MemberBox(scope, (Method) methodOrConstructor);
             isStatic = member.isStatic();
         }
         String methodName = member.getName();

--- a/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
@@ -74,9 +74,6 @@ public class ImporterTopLevel extends TopLevel {
         private Object getPackageProperty(String name, Scriptable start) {
             Object result = NOT_FOUND;
             Scriptable scope = start;
-            if (topScopeFlag) {
-                scope = ScriptableObject.getTopLevelScope(scope);
-            }
             Object[] elements = getNativeJavaPackages(scope);
             if (elements == null) {
                 return result;

--- a/rhino/src/main/java/org/mozilla/javascript/JSScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSScript.java
@@ -31,6 +31,9 @@ public class JSScript implements Script, ScriptOrFn<JSScript> {
     @Override
     public Object exec(Context cx, Scriptable scope, Scriptable thisObj) {
         Object ret;
+        if (thisObj instanceof TopLevel) {
+            thisObj = ((TopLevel) thisObj).getGlobalThis();
+        }
         if (!ScriptRuntime.hasTopCall(cx)) {
             // It will go through "call" path. but they are equivalent
             ret = ScriptRuntime.doTopCall(this, cx, scope, thisObj, descriptor.isStrict());

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -302,7 +302,12 @@ public class LambdaConstructor extends LambdaFunction {
     public void definePrototypeProperty(
             Context cx, String name, ScriptableObject.LambdaGetterFunction getter, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
-        proto.defineProperty(cx, name, getter, null, attributes);
+        proto.defineProperty(cx, getDeclarationScope(), name, getter, null, attributes);
+    }
+
+    public void defineProperty(
+            Context cx, String name, LambdaGetterFunction getter, int attributes) {
+        defineProperty(cx, name, getter, null, attributes);
     }
 
     public void definePrototypeProperty(
@@ -313,7 +318,7 @@ public class LambdaConstructor extends LambdaFunction {
     public void definePrototypeProperty(
             Context cx, Symbol key, ScriptableObject.LambdaGetterFunction getter, int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
-        proto.defineProperty(cx, key, getter, null, attributes);
+        proto.defineProperty(cx, getDeclarationScope(), key, getter, null, attributes);
     }
 
     /**
@@ -328,7 +333,7 @@ public class LambdaConstructor extends LambdaFunction {
             ScriptableObject.LambdaSetterFunction setter,
             int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
-        proto.defineProperty(cx, name, getter, setter, attributes);
+        proto.defineProperty(cx, getDeclarationScope(), name, getter, setter, attributes);
     }
 
     public void definePrototypeProperty(
@@ -346,7 +351,7 @@ public class LambdaConstructor extends LambdaFunction {
             ScriptableObject.LambdaSetterFunction setter,
             int attributes) {
         ScriptableObject proto = getPrototypeScriptable();
-        proto.defineProperty(cx, key, getter, setter, attributes);
+        proto.defineProperty(cx, getDeclarationScope(), key, getter, setter, attributes);
     }
 
     public void definePrototypeProperty(
@@ -369,6 +374,15 @@ public class LambdaConstructor extends LambdaFunction {
         ScriptableObject proto = getPrototypeScriptable();
         Object val = proto.get(name, proto);
         proto.defineProperty(alias, val, attributes);
+    }
+
+    public void defineProperty(
+            Context cx,
+            String name,
+            LambdaGetterFunction getter,
+            LambdaSetterFunction setter,
+            int attributes) {
+        defineProperty(cx, getDeclarationScope(), name, getter, setter, attributes);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -36,14 +36,18 @@ final class MemberBox implements Serializable {
     transient Function asSetterFunction;
     transient Object delegateTo;
 
+    private final Scriptable scope;
+
     private static final NullabilityDetector nullDetector =
             ScriptRuntime.loadOneServiceImplementation(NullabilityDetector.class);
 
-    MemberBox(Method method) {
+    MemberBox(Scriptable scope, Method method) {
+        this.scope = scope;
         init(method);
     }
 
-    MemberBox(Constructor<?> constructor) {
+    MemberBox(Scriptable scope, Constructor<?> constructor) {
+        this.scope = scope;
         init(constructor);
     }
 
@@ -156,7 +160,7 @@ final class MemberBox implements Serializable {
     }
 
     /** Function returned by calls to __lookupGetter__ */
-    Function asGetterFunction(final String name, final Scriptable scope) {
+    Function asGetterFunction(final String name) {
         // Note: scope is the scriptable this function is related to; therefore this function
         // is constant for this member box.
         // Because of this we can cache the function in the attribute
@@ -188,7 +192,7 @@ final class MemberBox implements Serializable {
     }
 
     /** Function returned by calls to __lookupSetter__ */
-    Function asSetterFunction(final String name, final Scriptable scope) {
+    Function asSetterFunction(final String name) {
         // Note: scope is the scriptable this function is related to; therefore this function
         // is constant for this member box.
         // Because of this we can cache the function in the attribute

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
@@ -20,7 +20,7 @@ public final class NativeArrayIterator extends ES6Iterator {
 
     private ARRAY_ITERATOR_TYPE type;
 
-    static void init(ScriptableObject scope, boolean sealed) {
+    static void init(TopLevel scope, boolean sealed) {
         ES6Iterator.init(scope, sealed, new NativeArrayIterator(), ITERATOR_TAG);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
@@ -18,7 +18,7 @@ public class NativeCollectionIterator extends ES6Iterator {
         BOTH
     }
 
-    static void init(ScriptableObject scope, String tag, boolean sealed) {
+    static void init(TopLevel scope, String tag, boolean sealed) {
         ES6Iterator.init(scope, sealed, new NativeCollectionIterator(tag), tag);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
@@ -17,7 +17,7 @@ public final class NativeGenerator extends IdScriptableObject {
 
     private static final Object GENERATOR_TAG = "Generator";
 
-    static NativeGenerator init(ScriptableObject scope, boolean sealed) {
+    static NativeGenerator init(TopLevel scope, boolean sealed) {
         // Generator
         // Can't use "NativeGenerator().exportAsJSClass" since we don't want
         // to define "Generator" as a constructor in the top-level scope.

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -23,7 +23,7 @@ import org.mozilla.javascript.xml.XMLLib;
 public class NativeGlobal implements Serializable {
     static final long serialVersionUID = 6080442165748707530L;
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static void init(Context cx, TopLevel scope, boolean sealed) {
         defineGlobalFunction(scope, sealed, "decodeURI", 1, NativeGlobal::js_decodeURI);
         defineGlobalFunction(
                 scope, sealed, "decodeURIComponent", 1, NativeGlobal::js_decodeURIComponent);
@@ -46,7 +46,7 @@ public class NativeGlobal implements Serializable {
                 scope, "Infinity", Double.POSITIVE_INFINITY, READONLY | DONTENUM | PERMANENT);
         ScriptableObject.defineProperty(
                 scope, "undefined", Undefined.instance, READONLY | DONTENUM | PERMANENT);
-        var globalThis = scope instanceof TopLevel ? ((TopLevel) scope).getGlobalThis() : scope;
+        var globalThis = scope.getGlobalThis();
 
         var obj = (Scriptable) scope.get("Object", scope);
         var objProto = (Scriptable) obj.get("prototype", obj);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -46,7 +46,13 @@ public class NativeGlobal implements Serializable {
                 scope, "Infinity", Double.POSITIVE_INFINITY, READONLY | DONTENUM | PERMANENT);
         ScriptableObject.defineProperty(
                 scope, "undefined", Undefined.instance, READONLY | DONTENUM | PERMANENT);
-        ScriptableObject.defineProperty(scope, "globalThis", scope, DONTENUM);
+        var globalThis = scope instanceof TopLevel ? ((TopLevel) scope).getGlobalThis() : scope;
+
+        var obj = (Scriptable) scope.get("Object", scope);
+        var objProto = (Scriptable) obj.get("prototype", obj);
+        globalThis.setPrototype(objProto);
+
+        ScriptableObject.defineProperty(scope, "globalThis", globalThis, DONTENUM);
 
         /*
             Each error constructor gets its own Error object as a prototype,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -21,7 +21,7 @@ public final class NativeIterator extends ScriptableObject {
 
     private Object objectIterator;
 
-    static void init(Context cx, ScriptableObject scope, boolean sealed) {
+    static void init(Context cx, TopLevel scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -63,6 +63,7 @@ public final class NativeIterator extends ScriptableObject {
         // throw StopIteration even if the property of the global
         // scope is replaced or deleted.
         scope.associateValue(ITERATOR_TAG, obj);
+        scope.getGlobalThis().associateValue(ITERATOR_TAG, obj);
     }
 
     /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -63,7 +63,6 @@ public final class NativeIterator extends ScriptableObject {
         // throw StopIteration even if the property of the global
         // scope is replaced or deleted.
         scope.associateValue(ITERATOR_TAG, obj);
-        scope.getGlobalThis().associateValue(ITERATOR_TAG, obj);
     }
 
     /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -30,7 +30,7 @@ public class NativeJavaMap extends NativeJavaObject {
     private final TypeInfo keyType;
     private final TypeInfo valueType;
 
-    static void init(ScriptableObject scope, boolean sealed) {
+    static void init(TopLevel scope, boolean sealed) {
         NativeJavaMapIterator.init(scope, sealed);
     }
 
@@ -171,7 +171,7 @@ public class NativeJavaMap extends NativeJavaObject {
         private static final long serialVersionUID = 1L;
         private static final String ITERATOR_TAG = "JavaMapIterator";
 
-        static void init(ScriptableObject scope, boolean sealed) {
+        static void init(TopLevel scope, boolean sealed) {
             ES6Iterator.init(scope, sealed, new NativeJavaMapIterator(), ITERATOR_TAG);
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -53,7 +53,7 @@ public class NativeJavaMethod extends BaseFunction {
     }
 
     @Deprecated
-    public NativeJavaMethod(Method method, String name) {
+    public NativeJavaMethod(Scriptable scope, Method method, String name) {
         this(new ExecutableBox(method, TypeInfoFactory.GLOBAL, method.getDeclaringClass()), name);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -35,7 +35,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     private static final long serialVersionUID = -6948590651130498591L;
 
-    static void init(ScriptableObject scope, boolean sealed) {
+    static void init(TopLevel scope, boolean sealed) {
         JavaIterableIterator.init(scope, sealed);
     }
 
@@ -923,7 +923,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         private static final long serialVersionUID = 1L;
         private static final String ITERATOR_TAG = "JavaIterableIterator";
 
-        static void init(ScriptableObject scope, boolean sealed) {
+        static void init(TopLevel scope, boolean sealed) {
             ES6Iterator.init(scope, sealed, new JavaIterableIterator(), ITERATOR_TAG);
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -208,7 +208,7 @@ public class NativeMap extends ScriptableObject {
             Scriptable thisObj = ScriptRuntime.toObjectOrNull(cx, arg2, scope);
 
             if (thisObj == null && !isStrict) {
-                thisObj = scope;
+                thisObj = scope instanceof TopLevel ? ((TopLevel) scope).getGlobalThis() : scope;
             }
             if (thisObj == null) {
                 thisObj = Undefined.SCRIPTABLE_UNDEFINED;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -208,7 +208,7 @@ public class NativeMap extends ScriptableObject {
             Scriptable thisObj = ScriptRuntime.toObjectOrNull(cx, arg2, scope);
 
             if (thisObj == null && !isStrict) {
-                thisObj = scope instanceof TopLevel ? ((TopLevel) scope).getGlobalThis() : scope;
+                thisObj = ScriptableObject.getTopLevelScope(scope).getGlobalThis();
             }
             if (thisObj == null) {
                 thisObj = Undefined.SCRIPTABLE_UNDEFINED;

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -72,9 +72,9 @@ public class NativePromise extends ScriptableObject {
 
         Scriptable thisObj = Undefined.SCRIPTABLE_UNDEFINED;
         if (!cx.isStrictMode()) {
-            Scriptable tcs = cx.topCallScope;
+            TopLevel tcs = cx.topCallScope;
             if (tcs != null) {
-                thisObj = tcs instanceof TopLevel ? ((TopLevel) tcs).getGlobalThis() : tcs;
+                thisObj = tcs.getGlobalThis();
             }
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -74,7 +74,7 @@ public class NativePromise extends ScriptableObject {
         if (!cx.isStrictMode()) {
             Scriptable tcs = cx.topCallScope;
             if (tcs != null) {
-                thisObj = tcs;
+                thisObj = tcs instanceof TopLevel ? ((TopLevel) tcs).getGlobalThis() : tcs;
             }
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -202,7 +202,7 @@ public class NativeSet extends ScriptableObject {
             Scriptable thisObj = ScriptRuntime.toObjectOrNull(cx, arg2, scope);
 
             if (thisObj == null && !isStrict) {
-                thisObj = scope;
+                thisObj = scope instanceof TopLevel ? ((TopLevel) scope).getGlobalThis() : scope;
             }
             if (thisObj == null) {
                 thisObj = Undefined.SCRIPTABLE_UNDEFINED;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -202,7 +202,7 @@ public class NativeSet extends ScriptableObject {
             Scriptable thisObj = ScriptRuntime.toObjectOrNull(cx, arg2, scope);
 
             if (thisObj == null && !isStrict) {
-                thisObj = scope instanceof TopLevel ? ((TopLevel) scope).getGlobalThis() : scope;
+                thisObj = ScriptableObject.getTopLevelScope(scope).getGlobalThis();
             }
             if (thisObj == null) {
                 thisObj = Undefined.SCRIPTABLE_UNDEFINED;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
@@ -10,7 +10,7 @@ public final class NativeStringIterator extends ES6Iterator {
     private static final long serialVersionUID = 1L;
     private static final String ITERATOR_TAG = "StringIterator";
 
-    static void init(ScriptableObject scope, boolean sealed) {
+    static void init(TopLevel scope, boolean sealed) {
         ES6Iterator.init(scope, sealed, new NativeStringIterator(), ITERATOR_TAG);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
@@ -18,7 +18,7 @@ public interface RegExpProxy {
     public static final int RA_REPLACE_ALL = 3;
     public static final int RA_SEARCH = 4;
 
-    public void register(ScriptableObject scope, boolean sealed);
+    public void register(TopLevel scope, boolean sealed);
 
     public boolean isRegExp(Scriptable obj);
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -5381,9 +5381,9 @@ public class ScriptRuntime {
 
     public static void setBuiltinProtoAndParent(
             ScriptableObject object, Scriptable scope, TopLevel.Builtins type) {
-        scope = ScriptableObject.getTopLevelScope(scope);
-        object.setParentScope(scope);
-        object.setPrototype(TopLevel.getBuiltinPrototype(scope, type));
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
+        object.setParentScope(top);
+        object.setPrototype(TopLevel.getBuiltinPrototype(top, type));
     }
 
     public static void setBuiltinProtoAndParent(

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -194,7 +194,7 @@ public class ScriptRuntime {
             scope = new TopLevel();
         }
 
-        scope.put("global", scope, scope);
+        scope.put("global", scope, scope.getGlobalThis());
 
         scope.clearCache();
         scope.associateValue(LIBRARY_SCOPE_KEY, scope);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3355,6 +3355,7 @@ public class ScriptRuntime {
             // nested functions should have top scope as their thisObj
             thisObj = ScriptableObject.getTopLevelScope(thisObj);
         }
+
         storeScriptable(cx, thisObj);
         return f;
     }
@@ -3396,6 +3397,7 @@ public class ScriptRuntime {
             // nested functions should have top scope as their thisObj
             thisObj = ScriptableObject.getTopLevelScope(thisObj);
         }
+
         return new LookupResult(f, thisObj, value);
     }
 
@@ -3564,6 +3566,10 @@ public class ScriptRuntime {
             if (missingCallThis && !isFunctionStrict) {
                 callThis = getTopCallScope(cx);
             }
+        }
+
+        if (callThis instanceof TopLevel) {
+            callThis = ((TopLevel) callThis).getGlobalThis();
         }
 
         return callThis;
@@ -6197,7 +6203,8 @@ public class ScriptRuntime {
 
         LookupResult(Object result, Scriptable thisObj, Object name) {
             this.result = result;
-            this.thisObj = thisObj;
+            this.thisObj =
+                    thisObj instanceof TopLevel ? ((TopLevel) thisObj).getGlobalThis() : thisObj;
             this.name = name;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -189,17 +189,16 @@ public class ScriptRuntime {
                 || ScriptableClass.isAssignableFrom(cl));
     }
 
-    public static ScriptableObject initSafeStandardObjects(
-            Context cx, ScriptableObject scope, boolean sealed) {
+    public static TopLevel initSafeStandardObjects(Context cx, TopLevel scope, boolean sealed) {
         if (scope == null) {
-            scope = new NativeObject();
-        } else if (scope instanceof TopLevel) {
-            ((TopLevel) scope).clearCache();
+            scope = new TopLevel();
         }
 
         scope.put("global", scope, scope);
 
+        scope.clearCache();
         scope.associateValue(LIBRARY_SCOPE_KEY, scope);
+
         new ClassCache().associate(scope);
         var typeFactory =
                 (androidApi >= 34 || androidApi < 0)
@@ -298,23 +297,20 @@ public class ScriptRuntime {
             new LazilyLoadedCtor(scope, "Reflect", sealed, true, NativeReflect::init);
         }
 
-        if (scope instanceof TopLevel) {
-            ((TopLevel) scope).cacheBuiltins(scope, sealed);
-        }
+        scope.cacheBuiltins(sealed);
 
         return scope;
     }
 
-    private static void registerRegExp(Context cx, ScriptableObject scope, boolean sealed) {
+    private static void registerRegExp(Context cx, TopLevel scope, boolean sealed) {
         RegExpProxy regExpProxy = getRegExpProxy(cx);
         if (regExpProxy != null) {
             regExpProxy.register(scope, sealed);
         }
     }
 
-    public static ScriptableObject initStandardObjects(
-            Context cx, ScriptableObject scope, boolean sealed) {
-        ScriptableObject s = initSafeStandardObjects(cx, scope, sealed);
+    public static TopLevel initStandardObjects(Context cx, TopLevel scope, boolean sealed) {
+        TopLevel s = initSafeStandardObjects(cx, scope, sealed);
 
         // These depend on the legacy initialization behavior of the lazy loading mechanism
         new LazilyLoadedCtor(
@@ -3545,7 +3541,7 @@ public class ScriptRuntime {
             }
             if (callThis == null) {
                 // This covers the case of args[0] == (null|undefined) as well.
-                callThis = getTopCallScope(cx);
+                callThis = getTopCallScope(cx).getGlobalThis();
             }
         } else {
             // Spec-compliant behavior
@@ -3564,12 +3560,8 @@ public class ScriptRuntime {
             boolean isFunctionStrict =
                     !(target instanceof JSFunction) || ((JSFunction) target).isStrict();
             if (missingCallThis && !isFunctionStrict) {
-                callThis = getTopCallScope(cx);
+                callThis = getTopCallScope(cx).getGlobalThis();
             }
-        }
-
-        if (callThis instanceof TopLevel) {
-            callThis = ((TopLevel) callThis).getGlobalThis();
         }
 
         return callThis;
@@ -4874,8 +4866,8 @@ public class ScriptRuntime {
         return (cx.topCallScope != null);
     }
 
-    public static Scriptable getTopCallScope(Context cx) {
-        Scriptable scope = cx.topCallScope;
+    public static TopLevel getTopCallScope(Context cx) {
+        var scope = cx.topCallScope;
         if (scope == null) {
             throw new IllegalStateException();
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2398,11 +2398,11 @@ public abstract class ScriptableObject extends SlotMapOwner
      * @param obj a JavaScript object
      * @return the corresponding global scope
      */
-    public static Scriptable getTopLevelScope(Scriptable obj) {
+    public static TopLevel getTopLevelScope(Scriptable obj) {
         for (; ; ) {
             Scriptable parent = obj.getParentScope();
             if (parent == null) {
-                return obj;
+                return (TopLevel) obj;
             }
             obj = parent;
         }
@@ -2950,20 +2950,8 @@ public abstract class ScriptableObject extends SlotMapOwner
      * @see #getAssociatedValue(Object key)
      */
     public static Object getTopScopeValue(Scriptable scope, Object key) {
-        scope = ScriptableObject.getTopLevelScope(scope);
-        for (; ; ) {
-            if (scope instanceof ScriptableObject) {
-                ScriptableObject so = (ScriptableObject) scope;
-                Object value = so.getAssociatedValue(key);
-                if (value != null) {
-                    return value;
-                }
-            }
-            scope = scope.getPrototype();
-            if (scope == null) {
-                return null;
-            }
-        }
+        var topScope = ScriptableObject.getTopLevelScope(scope);
+        return topScope.getAssociatedValue(key);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2331,6 +2331,7 @@ public abstract class ScriptableObject extends SlotMapOwner
      * constructed from the methods found, and are added to this object as properties with the given
      * names.
      *
+     * @param scope the declaration scope for the created function.
      * @param names the names of the Methods to add as function properties
      * @param clazz the class to search for the Methods
      * @param attributes the attributes of the new properties

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -332,7 +332,7 @@ public abstract class SlotMapOwner {
         }
     }
 
-    final SlotMap getMap() {
+    SlotMap getMap() {
         return slotMap;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -119,6 +119,23 @@ public class TopLevel extends ScriptableObject {
         globalThis = customGlobal;
     }
 
+    public TopLevel createIsolate() {
+        var newGlobal = new NativeObject();
+        newGlobal.setPrototype(getGlobalThis());
+        newGlobal.setParentScope(null);
+        var isolate = new TopLevel(newGlobal);
+        isolate.cacheBuiltins(newGlobal, false);
+        return isolate;
+    }
+
+    public TopLevel createIsolate(ScriptableObject customGlobal) {
+        customGlobal.setParentScope(null);
+        customGlobal.setPrototype(getGlobalThis());
+        var isolate = new TopLevel(customGlobal);
+        isolate.cacheBuiltins(customGlobal, false);
+        return isolate;
+    }
+
     @Override
     public String getClassName() {
         return "topLevel";

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -109,7 +109,15 @@ public class TopLevel extends ScriptableObject {
 
     private EnumMap<Builtins, BaseFunction> ctors;
     private EnumMap<NativeErrors, BaseFunction> errors;
-    private final ScriptableObject globalThis = new GlobalThis();
+    private final ScriptableObject globalThis;
+
+    public TopLevel() {
+        this(new GlobalThis());
+    }
+
+    public TopLevel(ScriptableObject customGlobal) {
+        globalThis = customGlobal;
+    }
 
     @Override
     public String getClassName() {
@@ -284,17 +292,17 @@ public class TopLevel extends ScriptableObject {
         if (res != NOT_FOUND) {
             return res;
         }
-        return globalThis.get(name, globalThis);
+        return ScriptableObject.getProperty(globalThis, name);
     }
 
     @Override
     public void put(String name, Scriptable start, Object value) {
-        globalThis.put(name, globalThis, value);
+        ScriptableObject.putProperty(globalThis, name, value);
     }
 
     @Override
     public boolean has(String name, Scriptable start) {
-        return super.has(name, start) || globalThis.has(name, globalThis);
+        return super.has(name, start) || ScriptableObject.hasProperty(globalThis, name);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -124,6 +124,7 @@ public class TopLevel extends ScriptableObject {
         newGlobal.setPrototype(getGlobalThis());
         newGlobal.setParentScope(null);
         var isolate = new TopLevel(newGlobal);
+        isolate.copyAssociatedValue(this);
         isolate.copyBuiltins(this, false);
         return isolate;
     }
@@ -132,6 +133,7 @@ public class TopLevel extends ScriptableObject {
         customGlobal.setParentScope(null);
         customGlobal.setPrototype(getGlobalThis());
         var isolate = new TopLevel(customGlobal);
+        isolate.copyAssociatedValue(this);
         isolate.copyBuiltins(this, false);
         return isolate;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -151,6 +151,19 @@ public class TopLevel extends ScriptableObject {
         return isolate;
     }
 
+    /**
+     * Only use this function if you have already set the customGlobal's prototype chain to point to
+     * this top level's global object. This should only be done if you know for certain that no
+     * other use will be made of this prototype chain.
+     */
+    public TopLevel createIsolateCustomPrototypeChain(ScriptableObject customGlobal) {
+        customGlobal.setParentScope(null);
+        var isolate = new TopLevel(customGlobal);
+        isolate.copyAssociatedValue(this);
+        isolate.copyBuiltins(this, false);
+        return isolate;
+    }
+
     @Override
     public String getClassName() {
         return "topLevel";

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -132,22 +132,22 @@ public class TopLevel extends ScriptableObject {
         globalThis = customGlobal;
     }
 
-    public TopLevel createIsolate() {
+    public static TopLevel createIsolate(TopLevel parent) {
         var newGlobal = new NativeObject();
-        newGlobal.setPrototype(getGlobalThis());
+        newGlobal.setPrototype(parent.getGlobalThis());
         newGlobal.setParentScope(null);
         var isolate = new TopLevel(newGlobal);
-        isolate.copyAssociatedValue(this);
-        isolate.copyBuiltins(this, false);
+        isolate.copyAssociatedValue(parent);
+        isolate.copyBuiltins(parent, false);
         return isolate;
     }
 
-    public TopLevel createIsolate(ScriptableObject customGlobal) {
+    public static TopLevel createIsolate(TopLevel parent, ScriptableObject customGlobal) {
         customGlobal.setParentScope(null);
-        customGlobal.setPrototype(getGlobalThis());
+        customGlobal.setPrototype(parent.getGlobalThis());
         var isolate = new TopLevel(customGlobal);
-        isolate.copyAssociatedValue(this);
-        isolate.copyBuiltins(this, false);
+        isolate.copyAssociatedValue(parent);
+        isolate.copyBuiltins(parent, false);
         return isolate;
     }
 
@@ -156,11 +156,12 @@ public class TopLevel extends ScriptableObject {
      * this top level's global object. This should only be done if you know for certain that no
      * other use will be made of this prototype chain.
      */
-    public TopLevel createIsolateCustomPrototypeChain(ScriptableObject customGlobal) {
+    public static TopLevel createIsolateCustomPrototypeChain(
+            TopLevel parent, ScriptableObject customGlobal) {
         customGlobal.setParentScope(null);
         var isolate = new TopLevel(customGlobal);
-        isolate.copyAssociatedValue(this);
-        isolate.copyBuiltins(this, false);
+        isolate.copyAssociatedValue(parent);
+        isolate.copyBuiltins(parent, false);
         return isolate;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -30,7 +30,7 @@ public class ModuleScope extends TopLevel.GlobalThis {
         }
         var global = new ModuleScope(prototype, uri, base);
         var scope = new TopLevel(global);
-        scope.cacheBuiltins(global, false);
+        scope.cacheBuiltins(false);
         return scope;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -6,22 +6,32 @@ package org.mozilla.javascript.commonjs.module;
 
 import java.net.URI;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 
 /**
  * A top-level module scope. This class provides methods to retrieve the module's source and base
  * URIs in order to resolve relative module IDs and check sandbox constraints.
  */
-public class ModuleScope extends TopLevel {
+public class ModuleScope extends TopLevel.GlobalThis {
     private static final long serialVersionUID = 1L;
     private final URI uri;
     private final URI base;
 
-    public ModuleScope(Scriptable prototype, URI uri, URI base) {
+    private ModuleScope(Scriptable prototype, URI uri, URI base) {
         this.uri = uri;
         this.base = base;
         setPrototype(prototype);
-        cacheBuiltins(prototype, false);
+    }
+
+    public static ScriptableObject createModuleScope(Scriptable prototype, URI uri, URI base) {
+        if (prototype instanceof TopLevel) {
+            prototype = ((TopLevel) prototype).getGlobalThis();
+        }
+        var global = new ModuleScope(prototype, uri, base);
+        var scope = new TopLevel(global);
+        scope.cacheBuiltins(global, false);
+        return scope;
     }
 
     public URI getUri() {

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -5,7 +5,6 @@
 package org.mozilla.javascript.commonjs.module;
 
 import java.net.URI;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 
@@ -18,19 +17,14 @@ public class ModuleScope extends TopLevel.GlobalThis {
     private final URI uri;
     private final URI base;
 
-    private ModuleScope(Scriptable prototype, URI uri, URI base) {
+    private ModuleScope(URI uri, URI base) {
         this.uri = uri;
         this.base = base;
-        setPrototype(prototype);
     }
 
-    public static ScriptableObject createModuleScope(Scriptable prototype, URI uri, URI base) {
-        if (prototype instanceof TopLevel) {
-            prototype = ((TopLevel) prototype).getGlobalThis();
-        }
-        var global = new ModuleScope(prototype, uri, base);
-        var scope = new TopLevel(global);
-        scope.cacheBuiltins(false);
+    public static ScriptableObject createModuleScope(TopLevel global, URI uri, URI base) {
+        var moduleScope = new ModuleScope(uri, base);
+        var scope = global.createIsolate(moduleScope);
         return scope;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -5,6 +5,7 @@
 package org.mozilla.javascript.commonjs.module;
 
 import java.net.URI;
+import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 
@@ -12,7 +13,7 @@ import org.mozilla.javascript.TopLevel;
  * A top-level module scope. This class provides methods to retrieve the module's source and base
  * URIs in order to resolve relative module IDs and check sandbox constraints.
  */
-public class ModuleScope extends TopLevel.GlobalThis {
+public class ModuleScope extends ScriptableObject {
     private static final long serialVersionUID = 1L;
     private final URI uri;
     private final URI base;
@@ -24,8 +25,8 @@ public class ModuleScope extends TopLevel.GlobalThis {
 
     public static ScriptableObject createModuleScope(TopLevel global, URI uri, URI base) {
         var moduleScope = new ModuleScope(uri, base);
-        var scope = global.createIsolate(moduleScope);
-        return scope;
+        moduleScope.setParentScope(global);
+        return moduleScope;
     }
 
     public URI getUri() {
@@ -34,5 +35,22 @@ public class ModuleScope extends TopLevel.GlobalThis {
 
     public URI getBase() {
         return base;
+    }
+
+    @Override
+    public String getClassName() {
+        return "module";
+    }
+
+    /** Search up the chain of scopes to find a module scope. */
+    public static ModuleScope findModuleScope(Scriptable scope) {
+        Scriptable current = scope;
+        while (current != null) {
+            if (current instanceof ModuleScope) {
+                return (ModuleScope) current;
+            }
+            current = current.getParentScope();
+        }
+        return null;
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
@@ -17,6 +17,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.Undefined;
 
 /**
  * Implements the require() function as defined by <a
@@ -176,12 +177,18 @@ public class Require extends BaseFunction {
         if (args == null || args.length < 1) {
             throw ScriptRuntime.throwError(cx, scope, "require() needs one argument");
         }
+        // Top scope from the point of view of the callee
+        TopLevel topScope = ScriptableObject.getTopLevelScope(scope);
+        if (thisObj == null || Undefined.isUndefined(thisObj)) {
+            thisObj = topScope.getGlobalThis();
+        }
+        ModuleScope moduleScope = ModuleScope.findModuleScope(scope);
 
         String id = (String) Context.jsToJava(args[0], String.class);
         URI uri = null;
         URI base = null;
         if (id.startsWith("./") || id.startsWith("../")) {
-            if (!(thisObj instanceof ModuleScope)) {
+            if (moduleScope == null) {
                 throw ScriptRuntime.throwError(
                         cx,
                         scope,
@@ -190,7 +197,6 @@ public class Require extends BaseFunction {
                                 + "\" when require() is used outside of a module");
             }
 
-            ModuleScope moduleScope = (ModuleScope) thisObj;
             base = moduleScope.getBase();
             URI current = moduleScope.getUri();
             uri = current.resolve(id);

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
@@ -313,7 +313,7 @@ public class Require extends BaseFunction {
         if (!sandboxed) {
             defineReadOnlyProperty(moduleObject, "uri", uri.toString());
         }
-        final Scriptable executionScope = new ModuleScope(nativeScope, uri, base);
+        final Scriptable executionScope = ModuleScope.createModuleScope(nativeScope, uri, base);
         // Set this so it can access the global JS environment objects.
         // This means we're currently using the "MGN" approach (ModuleScript
         // with Global Natives) as specified here:

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Implements the require() function as defined by <a
@@ -44,7 +45,7 @@ import org.mozilla.javascript.ScriptableObject;
 public class Require extends BaseFunction {
     private static final long serialVersionUID = 1L;
     private final ModuleScriptProvider moduleScriptProvider;
-    private final Scriptable nativeScope;
+    private final TopLevel nativeScope;
     private final Scriptable paths;
     private final boolean sandboxed;
     private final Script preExec;
@@ -79,7 +80,7 @@ public class Require extends BaseFunction {
      */
     public Require(
             Context cx,
-            Scriptable nativeScope,
+            TopLevel nativeScope,
             ModuleScriptProvider moduleScriptProvider,
             Script preExec,
             Script postExec,

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/RequireBuilder.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/RequireBuilder.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * A builder for {@link Require} instances. Useful when you're creating many instances of {@link
@@ -85,7 +86,7 @@ public class RequireBuilder implements Serializable {
      * @param globalScope the global scope containing the JS standard natives.
      * @return a new Require instance.
      */
-    public Require createRequire(Context cx, Scriptable globalScope) {
+    public Require createRequire(Context cx, TopLevel globalScope) {
         return new Require(cx, globalScope, moduleScriptProvider, preExec, postExec, sandboxed);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
@@ -353,7 +353,7 @@ public interface TypeInfoFactory extends Serializable {
         if (topScope.getParentScope() != null) {
             throw new IllegalArgumentException("provided scope not top scope");
         }
-        return (TypeInfoFactory) topScope.getGlobalThis().associateValue("TypeInfoFactory", this);
+        return (TypeInfoFactory) topScope.associateValue("TypeInfoFactory", this);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.lc.type.impl.factory.ClassValueCacheFactory;
 import org.mozilla.javascript.lc.type.impl.factory.LegacyCacheFactory;
 
@@ -348,11 +349,11 @@ public interface TypeInfoFactory extends Serializable {
      * @throws IllegalArgumentException if provided scope is not top scope
      * @see #get(Scriptable scope)
      */
-    default TypeInfoFactory associate(ScriptableObject topScope) {
+    default TypeInfoFactory associate(TopLevel topScope) {
         if (topScope.getParentScope() != null) {
             throw new IllegalArgumentException("provided scope not top scope");
         }
-        return (TypeInfoFactory) topScope.associateValue("TypeInfoFactory", this);
+        return (TypeInfoFactory) topScope.getGlobalThis().associateValue("TypeInfoFactory", this);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -10,7 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ES6Iterator;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 
 // See ECMAScript spec 22.2.9.1
@@ -25,7 +25,7 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     private boolean nextDone;
     private Object next = null;
 
-    public static void init(ScriptableObject scope, boolean sealed) {
+    public static void init(TopLevel scope, boolean sealed) {
         ES6Iterator.init(scope, sealed, new NativeRegExpStringIterator(), ITERATOR_TAG);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -14,13 +14,14 @@ import org.mozilla.javascript.RegExpProxy;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 
 /** */
 public class RegExpImpl implements RegExpProxy {
 
     @Override
-    public void register(ScriptableObject scope, boolean sealed) {
+    public void register(TopLevel scope, boolean sealed) {
         NativeRegExpStringIterator.init(scope, sealed);
         new LazilyLoadedCtor(scope, "RegExp", sealed, true, NativeRegExp::init);
     }

--- a/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullabilityDetectorTest.java
@@ -11,37 +11,43 @@ import org.mozilla.javascript.NullabilityDetector.NullabilityAccessor;
 public class NullabilityDetectorTest {
     @Test
     public void testNullableDetectorForMethodWithoutArgs() {
-        MemberBox memberBox = new MemberBox(getTestClassMethod("function1"));
+        var scope = new TopLevel();
+        MemberBox memberBox = new MemberBox(scope, getTestClassMethod("function1"));
         assertNullabilityMatch(memberBox.getArgNullability());
     }
 
     @Test
     public void testNullableDetectorForMethodWithOneArg() {
-        MemberBox memberBox = new MemberBox(getTestClassMethod("function2"));
+        var scope = new TopLevel();
+        MemberBox memberBox = new MemberBox(scope, getTestClassMethod("function2"));
         assertNullabilityMatch(memberBox.getArgNullability(), true);
     }
 
     @Test
     public void testNullableDetectorForMethodWithSeveralArgs() {
-        MemberBox memberBox = new MemberBox(getTestClassMethod("function3"));
+        var scope = new TopLevel();
+        MemberBox memberBox = new MemberBox(scope, getTestClassMethod("function3"));
         assertNullabilityMatch(memberBox.getArgNullability(), true, true, true, true);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithoutArgs() {
-        MemberBox memberBox = new MemberBox(getTestClassConstructor(0));
+        var scope = new TopLevel();
+        MemberBox memberBox = new MemberBox(scope, getTestClassConstructor(0));
         assertNullabilityMatch(memberBox.getArgNullability());
     }
 
     @Test
     public void testNullableDetectorForConstructorWithOneArg() {
-        MemberBox memberBox = new MemberBox(getTestClassConstructor(1));
+        var scope = new TopLevel();
+        MemberBox memberBox = new MemberBox(scope, getTestClassConstructor(1));
         assertNullabilityMatch(memberBox.getArgNullability(), true);
     }
 
     @Test
     public void testNullableDetectorForConstructorWithSeveralArgs() {
-        MemberBox memberBox = new MemberBox(getTestClassConstructor(4));
+        var scope = new TopLevel();
+        MemberBox memberBox = new MemberBox(scope, getTestClassConstructor(4));
         assertNullabilityMatch(memberBox.getArgNullability(), true, false, true, false);
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
@@ -372,7 +372,10 @@ class SuperTest {
                                             int line,
                                             String lineSource,
                                             int lineOffset) {
-                                        fail("should not have been called");
+                                        fail(
+                                                String.format(
+                                                        "should not have been called but was with %s",
+                                                        message));
                                     }
 
                                     @Override
@@ -382,7 +385,10 @@ class SuperTest {
                                             int line,
                                             String lineSource,
                                             int lineOffset) {
-                                        fail("should not have been called");
+                                        fail(
+                                                String.format(
+                                                        "should not have been called but was with %s",
+                                                        message));
                                         return null;
                                     }
                                 });

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug685403Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug685403Test.java
@@ -53,7 +53,8 @@ public class Bug685403Test {
         source += "state";
 
         String[] functions = new String[] {"continuation"};
-        scope.defineFunctionProperties(functions, Bug685403Test.class, ScriptableObject.DONTENUM);
+        scope.defineFunctionProperties(
+                scope, functions, Bug685403Test.class, ScriptableObject.DONTENUM);
 
         Object state = null;
         Script script = cx.compileString(source, "", 1, null);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * @author André Bargull
@@ -513,13 +514,15 @@ public class Bug783797Test {
                             @Override
                             public void run(
                                     Context cx, ScriptableObject scope1, ScriptableObject scope2) {
-                                assertSame(scope2, eval(cx, scope2, "test()"));
-                                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
-                                assertSame(scope2, eval(cx, scope1, "scope2.test()"));
-                                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
-                                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
+                                var globalThis1 = ((TopLevel) scope1).getGlobalThis();
+                                var globalThis2 = ((TopLevel) scope2).getGlobalThis();
+                                assertSame(globalThis2, eval(cx, scope2, "test()"));
+                                assertSame(globalThis2, eval(cx, scope2, "test.call(null)"));
+                                assertSame(globalThis2, eval(cx, scope1, "scope2.test()"));
+                                assertSame(globalThis1, eval(cx, scope1, "scope2.test.call(null)"));
+                                assertSame(globalThis1, eval(cx, scope1, "var t=scope2.test; t()"));
                                 assertSame(
-                                        scope1,
+                                        globalThis1,
                                         eval(cx, scope1, "var t=scope2.test; t.call(null)"));
                             }
                         }));
@@ -535,13 +538,14 @@ public class Bug783797Test {
                             @Override
                             public void run(
                                     Context cx, ScriptableObject scope1, ScriptableObject scope2) {
-                                assertSame(scope2, eval(cx, scope2, "test()"));
-                                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
-                                assertSame(scope2, eval(cx, scope1, "scope2.test()"));
-                                assertSame(scope2, eval(cx, scope1, "scope2.test.call(null)"));
-                                assertSame(scope2, eval(cx, scope1, "var t=scope2.test; t()"));
+                                var globalThis = ((TopLevel) scope2).getGlobalThis();
+                                assertSame(globalThis, eval(cx, scope2, "test()"));
+                                assertSame(globalThis, eval(cx, scope2, "test.call(null)"));
+                                assertSame(globalThis, eval(cx, scope1, "scope2.test()"));
+                                assertSame(globalThis, eval(cx, scope1, "scope2.test.call(null)"));
+                                assertSame(globalThis, eval(cx, scope1, "var t=scope2.test; t()"));
                                 assertSame(
-                                        scope2,
+                                        globalThis,
                                         eval(cx, scope1, "var t=scope2.test; t.call(null)"));
                             }
                         }));
@@ -557,24 +561,29 @@ public class Bug783797Test {
                             @Override
                             public void run(
                                     Context cx, ScriptableObject scope1, ScriptableObject scope2) {
-                                assertSame(scope2, eval(cx, scope2, "test()"));
-                                assertSame(scope2, eval(cx, scope2, "test(null)"));
-                                assertSame(scope2, eval(cx, scope2, "test.call(null)"));
-                                assertSame(scope2, eval(cx, scope2, "test.call(null, null)"));
+                                var globalThis1 = ((TopLevel) scope1).getGlobalThis();
+                                var globalThis2 = ((TopLevel) scope2).getGlobalThis();
+                                assertSame(globalThis2, eval(cx, scope2, "test()"));
+                                assertSame(globalThis2, eval(cx, scope2, "test(null)"));
+                                assertSame(globalThis2, eval(cx, scope2, "test.call(null)"));
+                                assertSame(globalThis2, eval(cx, scope2, "test.call(null, null)"));
 
-                                assertSame(scope1, eval(cx, scope1, "scope2.test()"));
-                                assertSame(scope1, eval(cx, scope1, "scope2.test(null)"));
-                                assertSame(scope1, eval(cx, scope1, "scope2.test.call(null)"));
+                                assertSame(globalThis1, eval(cx, scope1, "scope2.test()"));
+                                assertSame(globalThis1, eval(cx, scope1, "scope2.test(null)"));
+                                assertSame(globalThis1, eval(cx, scope1, "scope2.test.call(null)"));
                                 assertSame(
-                                        scope1, eval(cx, scope1, "scope2.test.call(null, null)"));
+                                        globalThis1,
+                                        eval(cx, scope1, "scope2.test.call(null, null)"));
 
-                                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t()"));
-                                assertSame(scope1, eval(cx, scope1, "var t=scope2.test; t(null)"));
+                                assertSame(globalThis1, eval(cx, scope1, "var t=scope2.test; t()"));
                                 assertSame(
-                                        scope1,
+                                        globalThis1,
+                                        eval(cx, scope1, "var t=scope2.test; t(null)"));
+                                assertSame(
+                                        globalThis1,
                                         eval(cx, scope1, "var t=scope2.test; t.call(null)"));
                                 assertSame(
-                                        scope1,
+                                        globalThis1,
                                         eval(cx, scope1, "var t=scope2.test; t.call(null, null)"));
                             }
                         }));

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ConsStringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ConsStringTest.java
@@ -63,7 +63,8 @@ public class ConsStringTest {
             // define custom getter method
             final Method getter = MyHostObject.class.getMethod("getFoo");
             final Method setter = MyHostObject.class.getMethod("setFoo", Object.class);
-            myHostObject.defineProperty("foo", null, getter, setter, ScriptableObject.EMPTY);
+            myHostObject.defineProperty(
+                    topScope, "foo", null, getter, setter, ScriptableObject.EMPTY);
             topScope.put("MyHostObject", topScope, myHostObject);
 
             final String script =

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CustomSetterAcceptNullScriptableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CustomSetterAcceptNullScriptableTest.java
@@ -52,7 +52,8 @@ public class CustomSetterAcceptNullScriptableTest {
 
             // define custom setter method
             final Method setMyPropMethod = Foo.class.getMethod("setMyProp", Foo2.class);
-            foo.defineProperty("myProp", null, null, setMyPropMethod, ScriptableObject.EMPTY);
+            foo.defineProperty(
+                    topScope, "myProp", null, null, setMyPropMethod, ScriptableObject.EMPTY);
 
             topScope.put("foo", topScope, foo);
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DefineFunctionPropertiesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DefineFunctionPropertiesTest.java
@@ -35,7 +35,7 @@ public class DefineFunctionPropertiesTest {
             global = (TopLevel) cx.initStandardObjects();
             String[] names = {"f", "g"};
             global.defineFunctionProperties(
-                    names, DefineFunctionPropertiesTest.class, ScriptableObject.DONTENUM);
+                    global, names, DefineFunctionPropertiesTest.class, ScriptableObject.DONTENUM);
         }
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DefineFunctionPropertiesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DefineFunctionPropertiesTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -21,7 +22,7 @@ import org.mozilla.javascript.Undefined;
  */
 public class DefineFunctionPropertiesTest {
 
-    ScriptableObject global;
+    TopLevel global;
     static Object key = "DefineFunctionPropertiesTest";
 
     /**
@@ -31,7 +32,7 @@ public class DefineFunctionPropertiesTest {
     @Before
     public void setUp() {
         try (Context cx = Context.enter()) {
-            global = cx.initStandardObjects();
+            global = (TopLevel) cx.initStandardObjects();
             String[] names = {"f", "g"};
             global.defineFunctionProperties(
                     names, DefineFunctionPropertiesTest.class, ScriptableObject.DONTENUM);
@@ -71,7 +72,7 @@ public class DefineFunctionPropertiesTest {
     @Test
     public void privateData() {
         try (Context cx = Context.enter()) {
-            global.associateValue(key, "bar");
+            global.getGlobalThis().associateValue(key, "bar");
             Object result = cx.evaluateString(global, "g('foo');", "test source", 1, null);
             assertEquals("foobar", result);
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
@@ -99,7 +99,7 @@ public class DynamicScopeTest {
 
             // Used to fail with org.mozilla.javascript.EvaluatorException: Cannot modify a property
             // of a sealed object: iterator.
-            final ScriptableObject someScope = cx.initStandardObjects();
+            final TopLevel someScope = cx.initStandardObjects();
 
             Scriptable someObj =
                     (Scriptable)
@@ -113,12 +113,12 @@ public class DynamicScopeTest {
                                     "source2",
                                     1,
                                     null);
-            subScope.setParentScope(null);
+            var newTopLevel = someScope.createIsolate((ScriptableObject) subScope);
 
             Scriptable subObj =
                     (Scriptable)
                             cx.evaluateString(
-                                    subScope,
+                                    newTopLevel,
                                     "var subObj = Object.create(obj); subObj;",
                                     "source3",
                                     1,

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
@@ -113,7 +113,7 @@ public class DynamicScopeTest {
                                     "source2",
                                     1,
                                     null);
-            var newTopLevel = someScope.createIsolate((ScriptableObject) subScope);
+            var newTopLevel = TopLevel.createIsolate(someScope, (ScriptableObject) subScope);
 
             Scriptable subObj =
                     (Scriptable)

--- a/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
@@ -28,14 +28,14 @@ public class IterableTest {
 
     public static final class FooWithoutSymbols extends FooBoilerplate {
 
-        public FooWithoutSymbols(final Scriptable scope) {
+        public FooWithoutSymbols(TopLevel scope) {
             super(scope);
         }
     }
 
     public static final class FooWithSymbols extends SymbolFooBoilerplate {
 
-        public FooWithSymbols(final Scriptable scope) {
+        public FooWithSymbols(TopLevel scope) {
             super(scope);
         }
 
@@ -47,7 +47,7 @@ public class IterableTest {
 
     public static final class FooWithArrayIterator extends SymbolFooBoilerplate {
 
-        public FooWithArrayIterator(final Scriptable scope) {
+        public FooWithArrayIterator(TopLevel scope) {
             super(scope);
         }
 
@@ -97,7 +97,7 @@ public class IterableTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Scriptable foo = new FooWithoutSymbols(scope);
                     ScriptableObject.putProperty(scope, "foo", foo);
@@ -131,7 +131,7 @@ public class IterableTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Scriptable foo = new FooWithSymbols(scope);
                     ScriptableObject.putProperty(scope, "foo", foo);
@@ -161,7 +161,7 @@ public class IterableTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Scriptable foo = new FooWithArrayIterator(scope);
                     ScriptableObject.putProperty(scope, "foo", foo);
@@ -191,9 +191,9 @@ public class IterableTest {
     // Explicitly not a ScriptableObject
     public static class FooBoilerplate implements Scriptable {
 
-        protected final Scriptable scope;
+        protected final TopLevel scope;
 
-        public FooBoilerplate(final Scriptable scope) {
+        public FooBoilerplate(TopLevel scope) {
             this.scope = scope;
         }
 
@@ -283,7 +283,7 @@ public class IterableTest {
 
     public static class SymbolFooBoilerplate extends FooBoilerplate implements SymbolScriptable {
 
-        public SymbolFooBoilerplate(final Scriptable scope) {
+        public SymbolFooBoilerplate(TopLevel scope) {
             super(scope);
         }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class LookupSetterTest {
@@ -149,7 +150,7 @@ public class LookupSetterTest {
         }
     }
 
-    public static class TopScope extends ScriptableObject {
+    public static class TopScope extends TopLevel {
         @Override
         public String getClassName() {
             return "TopScope";

--- a/rhino/src/test/java/org/mozilla/javascript/tests/PrimitiveTypeScopeResolutionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/PrimitiveTypeScopeResolutionTest.java
@@ -125,7 +125,6 @@ public class PrimitiveTypeScopeResolutionTest {
         // define object with custom method
         final MyObject myObject = new MyObject();
         final String[] functionNames = {"readPropFoo"};
-        myObject.defineFunctionProperties(functionNames, MyObject.class, ScriptableObject.EMPTY);
 
         final String scriptScope1 = "String.prototype.foo = 'from 1'; scope2.f()";
 
@@ -136,6 +135,8 @@ public class PrimitiveTypeScopeResolutionTest {
                     final TopLevel scope2 = new TopLevel(new MySimpleScriptableObject("scope2"));
                     cx.initStandardObjects(scope2);
 
+                    myObject.defineFunctionProperties(
+                            scope2, functionNames, MyObject.class, ScriptableObject.EMPTY);
                     scope2.put("myObject", scope2, myObject);
                     cx.evaluateString(scope2, scriptScope2, "source2", 1, null);
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/PrimitiveTypeScopeResolutionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/PrimitiveTypeScopeResolutionTest.java
@@ -7,6 +7,7 @@ package org.mozilla.javascript.tests;
 import org.junit.Test;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -62,13 +63,14 @@ public class PrimitiveTypeScopeResolutionTest {
     private void testWithTwoScopes(final String scriptScope1, final String scriptScope2) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope1 =
-                            cx.initStandardObjects(new MySimpleScriptableObject("scope1"));
-                    final Scriptable scope2 =
-                            cx.initStandardObjects(new MySimpleScriptableObject("scope2"));
+                    final TopLevel scope1 = new TopLevel(new MySimpleScriptableObject("scope1"));
+                    cx.initStandardObjects(scope1);
+                    final TopLevel scope2 = new TopLevel(new MySimpleScriptableObject("scope2"));
+                    cx.initStandardObjects(scope2);
+
                     cx.evaluateString(scope2, scriptScope2, "source2", 1, null);
 
-                    scope1.put("scope2", scope1, scope2);
+                    scope1.put("scope2", scope1, scope2.getGlobalThis());
 
                     return cx.evaluateString(scope1, scriptScope1, "source1", 1, null);
                 });
@@ -129,10 +131,10 @@ public class PrimitiveTypeScopeResolutionTest {
 
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope1 =
-                            cx.initStandardObjects(new MySimpleScriptableObject("scope1"));
-                    final Scriptable scope2 =
-                            cx.initStandardObjects(new MySimpleScriptableObject("scope2"));
+                    final TopLevel scope1 = new TopLevel(new MySimpleScriptableObject("scope1"));
+                    cx.initStandardObjects(scope1);
+                    final TopLevel scope2 = new TopLevel(new MySimpleScriptableObject("scope2"));
+                    cx.initStandardObjects(scope2);
 
                     scope2.put("myObject", scope2, myObject);
                     cx.evaluateString(scope2, scriptScope2, "source2", 1, null);

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -24,6 +24,7 @@ import org.mozilla.javascript.LambdaFunction;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -71,7 +72,7 @@ public abstract class ScriptTestsBase {
             Global global = new Global(cx);
             loadNatives(global);
 
-            var scope = global.createIsolate();
+            var scope = TopLevel.createIsolate(global);
 
             return cx.evaluateReader(scope, script, suiteName, 1, null);
         } catch (JavaScriptException ex) {

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -71,9 +71,7 @@ public abstract class ScriptTestsBase {
             Global global = new Global(cx);
             loadNatives(global);
 
-            Scriptable scope = cx.newObject(global);
-            scope.setPrototype(global);
-            scope.setParentScope(null);
+            var scope = global.createIsolate();
 
             return cx.evaluateReader(scope, script, suiteName, 1, null);
         } catch (JavaScriptException ex) {

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -320,6 +320,7 @@ public class ShellTest {
                                 // invoke after init(...) to make sure ClassCache is available for
                                 // FunctionObject
                                 global.defineFunctionProperties(
+                                        global,
                                         new String[] {"options"},
                                         ShellTest.class,
                                         ScriptableObject.DONTENUM
@@ -429,6 +430,7 @@ public class ShellTest {
 
             // invoke after init(...) to make sure ClassCache is available for FunctionObject
             global.defineFunctionProperties(
+                    global,
                     new String[] {"options"},
                     ShellTest.class,
                     ScriptableObject.DONTENUM

--- a/tests/src/test/java/org/mozilla/javascript/tests/ExternalArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ExternalArrayTest.java
@@ -48,7 +48,7 @@ public class ExternalArrayTest {
     public void intArray() {
         ScriptableObject a = (ScriptableObject) cx.newObject(root);
         TestIntArray l = new TestIntArray(10);
-        a.setExternalArrayData(l);
+        a.setExternalArrayData(root, l);
         for (int i = 0; i < 10; i++) {
             l.setArrayElement(i, i);
         }
@@ -63,7 +63,7 @@ public class ExternalArrayTest {
         ScriptableObject a = (ScriptableObject) cx.newObject(root);
         // Set the external array data
         TestIntArray l = new TestIntArray(10);
-        a.setExternalArrayData(l);
+        a.setExternalArrayData(root, l);
         for (int i = 0; i < 10; i++) {
             l.setArrayElement(i, i);
         }
@@ -76,7 +76,7 @@ public class ExternalArrayTest {
         // regular JavaScript object.
         a.delete("stringField");
         a.delete("intField");
-        a.setExternalArrayData(null);
+        a.setExternalArrayData(root, null);
         for (int i = 0; i < 10; i++) {
             a.put(i, a, i);
         }
@@ -89,7 +89,7 @@ public class ExternalArrayTest {
     public void nativeIntArray() {
         ScriptableObject a = (ScriptableObject) cx.newObject(root);
         NativeInt32Array l = new NativeInt32Array(10);
-        a.setExternalArrayData(l);
+        a.setExternalArrayData(root, l);
 
         root.put("testArray", root, a);
         root.put("testArrayLength", root, 10);
@@ -101,7 +101,7 @@ public class ExternalArrayTest {
     public void nativeShortArray() {
         ScriptableObject a = (ScriptableObject) cx.newObject(root);
         NativeInt16Array l = new NativeInt16Array(10);
-        a.setExternalArrayData(l);
+        a.setExternalArrayData(root, l);
 
         root.put("testArray", root, a);
         root.put("testArrayLength", root, 10);
@@ -113,7 +113,7 @@ public class ExternalArrayTest {
     public void nativeDoubleArray() {
         ScriptableObject a = (ScriptableObject) cx.newObject(root);
         NativeFloat64Array l = new NativeFloat64Array(10);
-        a.setExternalArrayData(l);
+        a.setExternalArrayData(root, l);
 
         root.put("testArray", root, a);
         root.put("testArrayLength", root, 10);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ImportClassTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ImportClassTest.java
@@ -17,8 +17,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.NativeJavaClass;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.UniqueTag;
 import org.mozilla.javascript.drivers.TestUtils;
 import org.mozilla.javascript.testutils.Utils;
@@ -80,7 +79,7 @@ public class ImportClassTest {
     public void importMultipleTimes() {
         Utils.runWithAllModes(
                 cx -> {
-                    ScriptableObject sharedScope = cx.initStandardObjects();
+                    TopLevel sharedScope = cx.initStandardObjects();
                     // sharedScope.sealObject(); // code below will try to modify sealed object
 
                     Script script =
@@ -88,10 +87,8 @@ public class ImportClassTest {
                                     "importClass(java.util.UUID);true", "TestScript", 1, null);
 
                     for (int i = 0; i < 3; i++) {
-                        Scriptable scope = new ImporterTopLevel(cx);
-                        scope.setPrototype(sharedScope);
-                        scope.setParentScope(null);
-                        script.exec(cx, scope, scope);
+                        var scope = ImporterTopLevel.createIsolate(cx, sharedScope);
+                        script.exec(cx, scope, scope.getGlobalThis());
                         assertEquals(UniqueTag.NOT_FOUND, sharedScope.get("UUID", sharedScope));
                         assertTrue(scope.get("UUID", scope) instanceof NativeJavaClass);
                     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
@@ -127,12 +127,14 @@ public class LambdaAccessorSlotTest {
 
                     sh.defineProperty("value", "oldValueOfValue", DONTENUM);
 
-                    sh.defineProperty(cx, "value", (thisObj) -> "valueOfValue", null, DONTENUM);
+                    sh.defineProperty(
+                            cx, scope, "value", (thisObj) -> "valueOfValue", null, DONTENUM);
 
-                    sh.defineProperty(cx, "status", (thisObj) -> 42, null, DONTENUM);
+                    sh.defineProperty(cx, scope, "status", (thisObj) -> 42, null, DONTENUM);
 
                     sh.defineProperty(
                             cx,
+                            scope,
                             "status",
                             (thisObj) -> self(thisObj).getStatus(),
                             (thisObj, value) -> self(thisObj).setStatus(value),
@@ -398,6 +400,7 @@ public class LambdaAccessorSlotTest {
                                     () ->
                                             sh.defineProperty(
                                                     cx,
+                                                    scope,
                                                     "status",
                                                     (thisObj) -> self(thisObj).getStatus(),
                                                     (thisObj, value) ->
@@ -434,6 +437,7 @@ public class LambdaAccessorSlotTest {
                                     () ->
                                             sh.defineProperty(
                                                     cx,
+                                                    scope,
                                                     "status",
                                                     (thisObj) -> self(thisObj).getStatus(),
                                                     (thisObj, value) ->

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
@@ -86,7 +86,7 @@ public class NativeWrappedArrayTest {
     public void customArray() throws IOException {
         ((ScriptableObject) global)
                 .defineFunctionProperties(
-                        new String[] {"makeCustomArray"}, NativeWrappedArrayTest.class, 0);
+                        global, new String[] {"makeCustomArray"}, NativeWrappedArrayTest.class, 0);
 
         final String setFunc = "function makeTestArray() { return makeCustomArray(); }";
         cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
@@ -108,7 +108,7 @@ public class NativeWrappedArrayTest {
         a.add("two");
         a.add("three");
         a.add("four");
-        return new WrappedArray(thisObj, a);
+        return new WrappedArray(fn.getDeclarationScope(), a);
     }
 
     static class WrappedArray extends ScriptableObject {

--- a/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
@@ -106,7 +106,7 @@ public class NestedContextPrototypeTest {
                                     scope = context.newObject(global);
                                     break;
                                 case SEALED:
-                                    scope = global.createIsolate();
+                                    scope = TopLevel.createIsolate(global);
                                     break;
                                 case SEALED_OWN_OBJECTS:
                                     scope = context.initStandardObjects(new TopLevel());

--- a/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
@@ -106,16 +106,13 @@ public class NestedContextPrototypeTest {
                                     scope = context.newObject(global);
                                     break;
                                 case SEALED:
-                                    scope = context.newObject(global);
-                                    scope.setPrototype(global);
-                                    scope.setParentScope(null);
+                                    scope = global.createIsolate();
                                     break;
                                 case SEALED_OWN_OBJECTS:
                                     scope = context.initStandardObjects(new TopLevel());
                                     ((TopLevel) scope)
                                             .getGlobalThis()
                                             .setPrototype(((TopLevel) global).getGlobalThis());
-                                    scope.setParentScope(null);
                                     break;
                                 default:
                                     throw new UnsupportedOperationException();

--- a/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
@@ -19,6 +19,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
@@ -110,8 +111,10 @@ public class NestedContextPrototypeTest {
                                     scope.setParentScope(null);
                                     break;
                                 case SEALED_OWN_OBJECTS:
-                                    scope = context.initStandardObjects(null);
-                                    scope.setPrototype(global);
+                                    scope = context.initStandardObjects(new TopLevel());
+                                    ((TopLevel) scope)
+                                            .getGlobalThis()
+                                            .setPrototype(((TopLevel) global).getGlobalThis());
                                     scope.setParentScope(null);
                                     break;
                                 default:

--- a/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -21,7 +21,6 @@ import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.JSFunction;
-import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Wrapper;

--- a/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -21,7 +21,9 @@ import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.JSFunction;
+import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Wrapper;
 
 @RunWith(BlockJUnit4ClassRunner.class)
@@ -41,12 +43,12 @@ public class SealedSharedScopeTest {
 
         ctx = Context.enter();
         ctx.setLanguageVersion(Context.VERSION_DEFAULT);
-        scope1 = ctx.newObject(sharedScope);
-        scope1.setPrototype(sharedScope);
-        scope1.setParentScope(null);
-        scope2 = ctx.newObject(sharedScope);
-        scope2.setPrototype(sharedScope);
-        scope2.setParentScope(null);
+        var scope1Global = new NativeObject();
+        scope1Global.setPrototype(sharedScope.getGlobalThis());
+        scope1 = new TopLevel(scope1Global);
+        var scope2Global = new NativeObject();
+        scope2Global.setPrototype(sharedScope.getGlobalThis());
+        scope2 = new TopLevel(scope2Global);
     }
 
     @After

--- a/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -23,6 +23,7 @@ import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Wrapper;
 
 @RunWith(BlockJUnit4ClassRunner.class)
@@ -42,8 +43,8 @@ public class SealedSharedScopeTest {
 
         ctx = Context.enter();
         ctx.setLanguageVersion(Context.VERSION_DEFAULT);
-        scope1 = sharedScope.createIsolate();
-        scope2 = sharedScope.createIsolate();
+        scope1 = TopLevel.createIsolate(sharedScope);
+        scope2 = TopLevel.createIsolate(sharedScope);
     }
 
     @After

--- a/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SealedSharedScopeTest.java
@@ -23,7 +23,6 @@ import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Wrapper;
 
 @RunWith(BlockJUnit4ClassRunner.class)
@@ -43,12 +42,8 @@ public class SealedSharedScopeTest {
 
         ctx = Context.enter();
         ctx.setLanguageVersion(Context.VERSION_DEFAULT);
-        var scope1Global = new NativeObject();
-        scope1Global.setPrototype(sharedScope.getGlobalThis());
-        scope1 = new TopLevel(scope1Global);
-        var scope2Global = new NativeObject();
-        scope2Global.setPrototype(sharedScope.getGlobalThis());
-        scope2 = new TopLevel(scope2Global);
+        scope1 = sharedScope.createIsolate();
+        scope2 = sharedScope.createIsolate();
     }
 
     @After

--- a/tests/src/test/java/org/mozilla/javascript/tests/StrictModeApiTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StrictModeApiTest.java
@@ -49,7 +49,12 @@ public class StrictModeApiTest {
                         ScriptableObject.defineClass(scope, MyHostObject.class);
                         final Method readMethod = MyHostObject.class.getMethod("jsxGet_x");
                         prototype.defineProperty(
-                                "readonlyProp", null, readMethod, null, ScriptableObject.EMPTY);
+                                scope,
+                                "readonlyProp",
+                                null,
+                                readMethod,
+                                null,
+                                ScriptableObject.EMPTY);
 
                         ScriptableObject.defineProperty(
                                 scope, "o", prototype, ScriptableObject.DONTENUM);

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -223,8 +223,8 @@ public class Test262SuiteTest {
             proto.defineProperty(scope, "evalScript", 1, $262::evalScript);
             proto.defineProperty(scope, "detachArrayBuffer", 0, $262::detachArrayBuffer);
 
-            proto.defineProperty(cx, "global", $262::getGlobal, null, DONTENUM | READONLY);
-            proto.defineProperty(cx, "agent", $262::getAgent, null, DONTENUM | READONLY);
+            proto.defineProperty(cx, scope, "global", $262::getGlobal, null, DONTENUM | READONLY);
+            proto.defineProperty(cx, scope, "agent", $262::getAgent, null, DONTENUM | READONLY);
 
             proto.defineProperty(SymbolKey.TO_STRING_TAG, "__262__", DONTENUM | READONLY);
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -256,7 +256,7 @@ public class Test262SuiteTest {
         }
 
         public static Object getGlobal(Scriptable scriptable) {
-            return scriptable.getParentScope();
+            return ((TopLevel) scriptable.getParentScope()).getGlobalThis();
         }
 
         public static $262 createRealm(

--- a/tests/src/test/java/org/mozilla/javascript/tests/WriteReadOnlyPropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/WriteReadOnlyPropertyTest.java
@@ -49,8 +49,6 @@ public class WriteReadOnlyPropertyTest {
 
     void testWriteReadOnly(final boolean acceptWriteReadOnly) throws Exception {
         final Method readMethod = Foo.class.getMethod("getMyProp", (Class[]) null);
-        final Foo foo = new Foo("hello");
-        foo.defineProperty("myProp", null, readMethod, null, ScriptableObject.EMPTY);
 
         final String script = "foo.myProp = 123; foo.myProp";
 
@@ -67,6 +65,9 @@ public class WriteReadOnlyPropertyTest {
         contextFactory.call(
                 cx -> {
                     final ScriptableObject top = cx.initStandardObjects();
+                    final Foo foo = new Foo("hello");
+                    foo.defineProperty(
+                            top, "myProp", null, readMethod, null, ScriptableObject.EMPTY);
                     ScriptableObject.putProperty(top, "foo", foo);
 
                     cx.evaluateString(top, script, "script", 0, null);

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
@@ -17,6 +17,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
@@ -45,7 +46,7 @@ public class ComplianceTest {
         return retval;
     }
 
-    private static Require createRequire(File dir, Context cx, Scriptable scope)
+    private static Require createRequire(File dir, Context cx, TopLevel scope)
             throws URISyntaxException {
         return new Require(
                 cx,
@@ -68,7 +69,7 @@ public class ComplianceTest {
     public void require() throws Throwable {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    final TopLevel scope = cx.initStandardObjects();
                     ScriptableObject.putProperty(scope, "print", new Print(scope));
                     try {
                         createRequire(testDir, cx, scope).requireMain(cx, "program");

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -81,7 +81,8 @@ public class RequireTest {
 
             var obj = cx.newObject(scope, "CustomGlobal", null);
             obj.getPrototype().setPrototype(scope.getGlobalThis());
-            final TopLevel global = scope.createIsolateCustomPrototypeChain((ScriptableObject) obj);
+            final TopLevel global =
+                    TopLevel.createIsolateCustomPrototypeChain(scope, (ScriptableObject) obj);
 
             final Require require =
                     new Require(

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.ScriptStackElement;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
@@ -75,13 +76,12 @@ public class RequireTest {
     @Test
     public void customGlobal() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            final TopLevel scope = cx.initStandardObjects();
             ScriptableObject.defineClass(scope, CustomGlobal.class);
 
-            final Scriptable global = cx.newObject(scope, "CustomGlobal", null);
-
-            global.getPrototype().setPrototype(scope);
-            global.setParentScope(null);
+            var obj = cx.newObject(scope, "CustomGlobal", null);
+            obj.getPrototype().setPrototype(scope.getGlobalThis());
+            final TopLevel global = scope.createIsolateCustomPrototypeChain((ScriptableObject) obj);
 
             final Require require =
                     new Require(

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
@@ -38,6 +38,7 @@ public class FunctionNullSetTest {
                             final Method setterMethod =
                                     MyHostObject.class.getMethod("jsxSet_onclick", Object.class);
                             prototype.defineProperty(
+                                    scope,
                                     "onclick",
                                     null,
                                     getterMethod,

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ParentPropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ParentPropertyTest.java
@@ -18,7 +18,7 @@ public class ParentPropertyTest {
         // https://whereswalden.com/2010/05/07/spidermonkey-change-du-jour-the-special-__parent__-property-has-been-removed/
         String script = "var a = {};" + "'' + a.__parent__;";
 
-        Utils.assertWithAllModes_1_8("[object Object]", script);
+        Utils.assertWithAllModes_1_8("[object topLevel]", script);
         Utils.assertWithAllModes_ES6("undefined", script);
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
@@ -33,7 +33,7 @@ public class PropertyTest {
                         final Method getter = MyHostObject.class.getMethod("getFoo");
                         final Method setter = MyHostObject.class.getMethod("setFoo", String.class);
                         myHostObject.defineProperty(
-                                "foo", null, getter, setter, ScriptableObject.EMPTY);
+                                scope, "foo", null, getter, setter, ScriptableObject.EMPTY);
                         scope.put("MyHostObject", scope, myHostObject);
                     } catch (Exception e) {
                     }
@@ -70,7 +70,7 @@ public class PropertyTest {
                         final Method getter = MyHostObject.class.getMethod("getFoo");
                         final Method setter = MyHostObject.class.getMethod("setFoo", String.class);
                         myHostObject.defineProperty(
-                                "foo", null, getter, setter, ScriptableObject.EMPTY);
+                                scope, "foo", null, getter, setter, ScriptableObject.EMPTY);
                         scope.put("MyHostObject", scope, myHostObject);
                     } catch (Exception e) {
                     }
@@ -107,7 +107,7 @@ public class PropertyTest {
                         Method getter = MyHostObject.class.getMethod("getFoo");
                         final Method setter = MyHostObject.class.getMethod("setFoo", String.class);
                         myHostObject.defineProperty(
-                                "foo", null, getter, setter, ScriptableObject.EMPTY);
+                                scope, "foo", null, getter, setter, ScriptableObject.EMPTY);
                         scope.put("MyHostObject", scope, myHostObject);
                     } catch (Exception e) {
                     }
@@ -146,7 +146,8 @@ public class PropertyTest {
                 // define custom getter method
                 final Method getter = MyHostObject.class.getMethod("getFoo");
                 final Method setter = MyHostObject.class.getMethod("setFoo", String.class);
-                myHostObject.defineProperty("foo", null, getter, setter, ScriptableObject.EMPTY);
+                myHostObject.defineProperty(
+                        scope, "foo", null, getter, setter, ScriptableObject.EMPTY);
                 scope.put("MyHostObject", scope, myHostObject);
             } catch (Exception e) {
             }

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/CustomTypeInfoFactoryTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/CustomTypeInfoFactoryTest.java
@@ -31,7 +31,7 @@ public class CustomTypeInfoFactoryTest {
         var contextFactory = new ContextFactory();
 
         try (var cx = contextFactory.enterContext()) {
-            var scope = new NativeObject();
+            var scope = new TopLevel();
             new NoGenericNoCacheFactory().associate(scope);
             cx.initStandardObjects(scope);
 
@@ -59,7 +59,7 @@ public class CustomTypeInfoFactoryTest {
         var contextFactory = new ContextFactory();
         byte[] data;
         try (var cx = contextFactory.enterContext()) {
-            var scope = new NativeObject();
+            var scope = new TopLevel();
             new NoGenericNoCacheFactory().associate(scope);
             cx.initStandardObjects(scope);
 
@@ -79,7 +79,7 @@ public class CustomTypeInfoFactoryTest {
         var contextFactory = new ContextFactory();
         byte[] data;
         try (var cx = contextFactory.enterContext()) {
-            var scope = new NativeObject();
+            var scope = new TopLevel();
             TypeInfoFactory.GLOBAL.associate(scope);
             cx.initStandardObjects(scope);
 

--- a/tests/testsrc/doctests/xmlOptions.doctest
+++ b/tests/testsrc/doctests/xmlOptions.doctest
@@ -9,7 +9,7 @@ js> x
     <baz>1</baz>
   </bar>
 </foo>
-js> var xmlLib = org.mozilla.javascript.xml.XMLLib.extractFromScope(this);
+js> var xmlLib = __xml_lib__;
 js> xmlLib.isPrettyPrinting();
 true
 js> xmlLib.setPrettyPrinting(false);


### PR DESCRIPTION
Another draft PR on the road to separating scopes and scriptable objects (#2163). I've put the rationale for doing this in a separate issue(#2164) 

The global scope in EcmaScript is a a little subtle in that it consists of a declaration environment record and an object environment record for the global object (`globalThis`). The global object contains variable declarations, function declarations, generator function declarations, async function declarations, and async generator function declarations. Everything else (`const` declarations, `let` declarations, `class` declarations, etc.) goes on declaration environment and is *not* added to `globalThis`. This change could make that full separation, but currently there is one test in `MozillaSuiteTest` which depends on a `const` declaration being added to the global `this`. I wonder if we should gate that on a language version.

This is working well apart from a couple of edge cases that I think it's worth talking through:

1. `ImporterTopLevel` is mostly working, but I don't think I have a great model of how it should work. Currently The behaviour for package lookup is living on the scope half, but I'm wondering if `ImporterTopLevel` should really put all the behaviour on a custom `GlobalThis`.
2. One doc test is using a java method to get the XML implementation associated with the current global scope. Currently that is not part of `globalThis`, but maybe like java imports it should live on that half.
3. Module scopes. These have some existing awkward special handling on `FunctionObject` (which is currently the only way the existing `customGlobal` test works). The existing `ModuleScope` model also doesn't match `require` in node or common-js.

Let me expand on that last point slightly. If I have a file `blah.js` containing
```javascript
function thing() { return this; }
exports.thing = thing;
exports.thing2 = thing();
```
and from node REPL I do
```javascript
e = require("./blah.js");
thing = e.thing
thing2 = e.thing2
function thing3() { return this; }
thing4 = thing3();
```

Then we find `thing2 === globalThis` and `thing2 === thing4`. `require` simply introduces a new scope (just like a function does) rather than what we do with a module scope (a new top level scope that happens to have another top level scope as the prototype). What we have doesn't match that, but it also doesn't match the behaviour of `import` which should have an entirely separate realm (top level scope).

I think I can see two possible ways to resolve this:
1. If you want custom function provided by a java class on your scope then that java object has to be your `globalThis`, and the module scope becomes a normal child scope. This would be closest to node as far as I can tell. We might well want to keep the `ModuleScope` as a special class to mark that we are in a module for relative requires etc.
2. We keep module scope as a top level scope, but with a `globalThis` of whatever custom type provided. To avoid mutating the main `globalThis` when executing code in a module we'd need to ensure all modules execute on child scopes of this main module scope (but those need not themselves be `ModuleScope`s, and we'd need to find all `instanceof ModuleScope` checks which currently look at the `thisObj` and change them to appropriate top scope checks.

I don't know if @youngj is still around, still has their use case, and has an opinion on this. I can't tell how well covered this area really is because our Jacoco reports in `rhino` only cover the tests in `rhino`, while the coverage report in `tests` doesn't seem to be configured to show the core runtime classes.