### PR TITLE
Rewrite `Symbol.keyFor` to avoid iterator.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -136,12 +136,10 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
             throw ScriptRuntime.throwCustomError(cx, scope, "TypeError", "Not a Symbol");
         }
 
-        Map<String, SymbolKey> table = getGlobalMap();
-        for (var e : table.entrySet()) {
-            if (e.getValue() == sym) {
-                return e.getKey();
-            }
+        if (getGlobalMap().get(sym.getName()) == sym) {
+            return sym.getName();
         }
+
         return Undefined.instance;
     }
 


### PR DESCRIPTION
I've seen a rare concurrent modification exception due to one thread manipulating the global symbol table while the iterator in `js_keyfor` was traversing it. Apparently the synchronised map could not completely protect against this. I've rewritten that code since it can now use the `SymbolKey`' s internal name to retrieve the symbol and check its identity. This avoids the iterator and should be more performant.