### PR TITLE
Migrated `NativeIterator` away from `IdScriptableObject`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -198,7 +198,7 @@ public final class NativeIterator extends ScriptableObject {
 
     private Object next(Context cx, Scriptable scope) {
         Boolean b = ScriptRuntime.enumNext(this.objectIterator, cx);
-        if (!b.booleanValue()) {
+        if (!b) {
             // Out of values. Throw StopIteration.
             throw new JavaScriptException(NativeIterator.getStopIterationObject(scope), null, 0);
         }


### PR DESCRIPTION
I've had an LLM do most of the changes, but I've reviewed them carefully and it looks good.

Doesn't seem to have an impact on test262.