### PR TITLE
Removed a test case about dates that uses the current instant

### DIFF
--- a/tests/testsrc/tests/ecma/Date/15.9.5.8.js
+++ b/tests/testsrc/tests/ecma/Date/15.9.5.8.js
@@ -25,7 +25,7 @@ var TITLE   = "Date.prototype.getMonth()";
 
 writeHeaderToLog( SECTION + " "+ TITLE);
 
-addTestCase( TIME_NOW );
+// Flaky: addTestCase( TIME_NOW );
 addTestCase( TIME_0000 );
 addTestCase( TIME_1970 );
 addTestCase( TIME_1900 );


### PR DESCRIPTION
It's an inconsistent behavior that has caused a flaky test failure [in the CI](https://github.com/mozilla/rhino/actions/runs/19851039740/job/56877721100#step:5:278).

I've only removed the test case with the "current instant", not the whole test, although really all of these seem kinda obsolete and superset by test262, frankly. They also contain JS implementation of date methods, like this [LocalTime](
https://github.com/mozilla/rhino/blob/e3d6b16aa233e0a427bf1dfe6b4ba3645213b924/tests/testsrc/tests/ecma/shell.js#L304) function, which are pretty complex.
According to Claude at least, there's likely a discrepancy between the daylight savings time behavior, but I didn't investigate much further.

Fixes https://github.com/mozilla/rhino/issues/2187