### PR TITLE
Fix variable resolution in switch statements with let declarations

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1167,8 +1167,15 @@ public final class IRFactory {
         Scope block = Scope.splitScope(node);
         block.setLineColumnNumber(node.getLineno(), node.getColumn());
         block.addChildToBack(node);
+        node.setParentScope(block);
 
-        parser.pushScope(node);
+        // Can't use pushScope/popScope here since splitScope moves the symbol table
+        // We set currentScope to 'node' (not 'block') so nested scopes can be pushed,
+        // since their parent pointers were set to 'node' during parsing. Variable resolution
+        // works correctly because it walks up the parentScope chain, where node.parentScope =
+        // block.
+        Scope savedScope = parser.currentScope;
+        parser.currentScope = node;
         try {
             Node switchExpr = transform(node.getExpression());
             node.addChildToBack(switchExpr);
@@ -1193,7 +1200,7 @@ public final class IRFactory {
             closeSwitch(block);
             return block;
         } finally {
-            parser.popScope();
+            parser.currentScope = savedScope;
         }
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/LetTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/LetTest.java
@@ -94,4 +94,35 @@ class LetTest {
                         + "})()\n";
         Utils.assertWithAllModes_ES6(1, script);
     }
+
+    @Test
+    void letInsideFunctionSwitchIf() {
+        String script =
+                "(function () {\n"
+                        + "    switch (0) {\n"
+                        + "        default:\n"
+                        + "            let a = 0;\n"
+                        + "            if (a == 0) {\n"
+                        + "                a++;\n"
+                        + "            }\n"
+                        + "            return a;\n"
+                        + "    }\n"
+                        + "})();\n";
+        Utils.assertWithAllModes_1_8(1, script);
+    }
+
+    @Test
+    void letInsideFunctionWhileIf() {
+        String script =
+                "(function () {\n"
+                        + "    while (true) {\n"
+                        + "            let a = 0;\n"
+                        + "            if (a == 0) {\n"
+                        + "                a++;\n"
+                        + "            }\n"
+                        + "            return a;\n"
+                        + "    }\n"
+                        + "})();\n";
+        Utils.assertWithAllModes_1_8(1, script);
+    }
 }


### PR DESCRIPTION
Fixed the regression introduced by 2ba6e57, which made `switch` a proper `Scope`.

The issue was that `Scope.splitScope()` creates an outer block scope and moves the symbol table from the switch to the block, but doesn't update the switch's `parentScope` pointer. This breaks the scope chain used for variable resolution, causing it to skip the block where symbols are stored.

Fixed by manually fixing the scope chain, and follow the same pattern as `transformForLoop()` for manually managing `currentScope` instead of using `pushScope`/`popScope`, since the scope hierarchy is modified after parsing.

Fixes https://github.com/mozilla/rhino/issues/2180