### PR TITLE
Convert Chinese characters to Unicode escapes to ensure ResourceBundle compatibility

### DIFF
--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages_zh_CN.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages_zh_CN.properties
@@ -29,851 +29,851 @@ implementation.version = @IMPLEMENTATION.VERSION@
 params.omit.non.js.object.warning = true
 
 msg.non.js.object.warning =\
-    Rhino用法警告：缺少 Context.javaToJS() 转换：Rhino 运行时检测到类 “{1}” 的对象 “{0}”，它需要字符串、数字、布尔值或可编写脚本的实例。请检查您的代码是否缺少 Context.javaToJS() 调用。
+    Rhino\u7528\u6CD5\u8B66\u544A\uFF1A\u7F3A\u5C11 Context.javaToJS() \u8F6C\u6362\uFF1ARhino \u8FD0\u884C\u65F6\u68C0\u6D4B\u5230\u7C7B \u201C{1}\u201D \u7684\u5BF9\u8C61 \u201C{0}\u201D\uFF0C\u5B83\u9700\u8981\u5B57\u7B26\u4E32\u3001\u6570\u5B57\u3001\u5E03\u5C14\u503C\u6216\u53EF\u7F16\u5199\u811A\u672C\u7684\u5B9E\u4F8B\u3002\u8BF7\u68C0\u67E5\u60A8\u7684\u4EE3\u7801\u662F\u5426\u7F3A\u5C11 Context.javaToJS() \u8C03\u7528\u3002
 
 # Codegen
 msg.dup.parms =\
-    参数名称 “{0}” 已存在。
+    \u53C2\u6570\u540D\u79F0 \u201C{0}\u201D \u5DF2\u5B58\u5728\u3002
 
 msg.too.big.jump =\
-    程序太复杂：跳转偏移量太大。
+    \u7A0B\u5E8F\u592A\u590D\u6742\uFF1A\u8DF3\u8F6C\u504F\u79FB\u91CF\u592A\u5927\u3002
 
 msg.too.big.index =\
-    程序太复杂：内部索引超过 64KB 限制。
+    \u7A0B\u5E8F\u592A\u590D\u6742\uFF1A\u5185\u90E8\u7D22\u5F15\u8D85\u8FC7 64KB \u9650\u5236\u3002
 
 msg.while.compiling.fn =\
-    编译函数 “{0}” 时遇到代码生成错误：{1}
+    \u7F16\u8BD1\u51FD\u6570 \u201C{0}\u201D \u65F6\u9047\u5230\u4EE3\u7801\u751F\u6210\u9519\u8BEF\uFF1A{1}
 
 msg.while.compiling.script =\
-    编译脚本时遇到代码生成错误：{0}
+    \u7F16\u8BD1\u811A\u672C\u65F6\u9047\u5230\u4EE3\u7801\u751F\u6210\u9519\u8BEF\uFF1A{0}
 
 # Context
 msg.ctor.not.found =\
-    未找到 “{0}” 的构造函数。
+    \u672A\u627E\u5230 \u201C{0}\u201D \u7684\u6784\u9020\u51FD\u6570\u3002
 
 msg.not.ctor =\
-    “{0}” 不是构造函数。
+    \u201C{0}\u201D \u4E0D\u662F\u6784\u9020\u51FD\u6570\u3002
 
 # FunctionObject
 msg.varargs.ctor =\
-    方法或构造函数 “{0}” 必须是带有签名的静态 \
-    “(Context cx, Object[] args, Function ctorObj, boolean inNewExpr)” \
-    以定义可变参数的构造函数。
+    \u65B9\u6CD5\u6216\u6784\u9020\u51FD\u6570 \u201C{0}\u201D \u5FC5\u987B\u662F\u5E26\u6709\u7B7E\u540D\u7684\u9759\u6001 \
+    \u201C(Context cx, Object[] args, Function ctorObj, boolean inNewExpr)\u201D \
+    \u4EE5\u5B9A\u4E49\u53EF\u53D8\u53C2\u6570\u7684\u6784\u9020\u51FD\u6570\u3002
 
 msg.varargs.fun =\
-    方法 “{0}” 必须是带有签名的静态 \
-    “(Context cx, Scriptable thisObj, Object[] args, Function funObj)” \
-    以定义可变参数的函数。
+    \u65B9\u6CD5 \u201C{0}\u201D \u5FC5\u987B\u662F\u5E26\u6709\u7B7E\u540D\u7684\u9759\u6001 \
+    \u201C(Context cx, Scriptable thisObj, Object[] args, Function funObj)\u201D \
+    \u4EE5\u5B9A\u4E49\u53EF\u53D8\u53C2\u6570\u7684\u51FD\u6570\u3002
 
 msg.incompat.call =\
-    在不兼容的对象中调用了方法 “{0}”。
+    \u5728\u4E0D\u517C\u5BB9\u7684\u5BF9\u8C61\u4E2D\u8C03\u7528\u4E86\u65B9\u6CD5 \u201C{0}\u201D\u3002
 
 msg.incompat.call.details =\
-    对不兼容对象调用的方法 “{0}”（{1} 不是 {2} 的实例）。
+    \u5BF9\u4E0D\u517C\u5BB9\u5BF9\u8C61\u8C03\u7528\u7684\u65B9\u6CD5 \u201C{0}\u201D\uFF08{1} \u4E0D\u662F {2} \u7684\u5B9E\u4F8B\uFF09\u3002
 
 msg.bad.parms =\
-    方法 “{1}” 中不支持参数类型 “{0}”。
+    \u65B9\u6CD5 \u201C{1}\u201D \u4E2D\u4E0D\u652F\u6301\u53C2\u6570\u7C7B\u578B \u201C{0}\u201D\u3002
 
 msg.bad.method.return =\
-    方法 “{1}” 中不支持返回类型 “{0}”。
+    \u65B9\u6CD5 \u201C{1}\u201D \u4E2D\u4E0D\u652F\u6301\u8FD4\u56DE\u7C7B\u578B \u201C{0}\u201D\u3002
 
 msg.bad.ctor.return =\
-    无法构造 “{0}” 类型的对象。
+    \u65E0\u6CD5\u6784\u9020 \u201C{0}\u201D \u7C7B\u578B\u7684\u5BF9\u8C61\u3002
 
 msg.no.overload =\
-    方法 “{0}” 在类 “{1}” 中出现多次。
+    \u65B9\u6CD5 \u201C{0}\u201D \u5728\u7C7B \u201C{1}\u201D \u4E2D\u51FA\u73B0\u591A\u6B21\u3002
 
 msg.method.not.found =\
-    在 “{1}” 中找不到方法 “{0}” 。
+    \u5728 \u201C{1}\u201D \u4E2D\u627E\u4E0D\u5230\u65B9\u6CD5 \u201C{0}\u201D \u3002
 
 msg.method.missing.parameter =\
-    {0}：至少需要 {1} 个参数，但仅通过了 {2} 个
+    {0}\uFF1A\u81F3\u5C11\u9700\u8981 {1} \u4E2A\u53C2\u6570\uFF0C\u4F46\u4EC5\u901A\u8FC7\u4E86 {2} \u4E2A
 
 # IRFactory
 
 msg.bad.for.in.lhs =\
-    for..in 循环的左边部分不正确。
+    for..in \u5FAA\u73AF\u7684\u5DE6\u8FB9\u90E8\u5206\u4E0D\u6B63\u786E\u3002
 
 msg.mult.index =\
-    for..in 循环中只允许有一个变量
+    for..in \u5FAA\u73AF\u4E2D\u53EA\u5141\u8BB8\u6709\u4E00\u4E2A\u53D8\u91CF
 
 msg.bad.for.in.destruct =\
-    for..in 循环的左侧必须是一个长度为 2 的数组才能接受一个键值对。
+    for..in \u5FAA\u73AF\u7684\u5DE6\u4FA7\u5FC5\u987B\u662F\u4E00\u4E2A\u957F\u5EA6\u4E3A 2 \u7684\u6570\u7EC4\u624D\u80FD\u63A5\u53D7\u4E00\u4E2A\u952E\u503C\u5BF9\u3002
 
 msg.cant.convert =\
-    无法转换为类型 “{0}”。
+    \u65E0\u6CD5\u8F6C\u6362\u4E3A\u7C7B\u578B \u201C{0}\u201D\u3002
 
 msg.bad.assign.left =\
-    左侧分配无效。
+    \u5DE6\u4FA7\u5206\u914D\u65E0\u6548\u3002
 
 msg.bad.decr =\
-    递减的操作数无效。
+    \u9012\u51CF\u7684\u64CD\u4F5C\u6570\u65E0\u6548\u3002
 
 msg.bad.incr =\
-    递增的操作数无效。
+    \u9012\u589E\u7684\u64CD\u4F5C\u6570\u65E0\u6548\u3002
 
 msg.bad.yield =\
-    yield 必须在函数内部。
+    yield \u5FC5\u987B\u5728\u51FD\u6570\u5185\u90E8\u3002
 
 msg.yield.parenthesized =\
-    yield 后面的表达式必须放在括号中。
+    yield \u540E\u9762\u7684\u8868\u8FBE\u5F0F\u5FC5\u987B\u653E\u5728\u62EC\u53F7\u4E2D\u3002
 
 # NativeGlobal
 msg.cant.call.indirect =\
-    必须直接调用函数 “{0}”，而不是通过具有其他名称的函数。
+    \u5FC5\u987B\u76F4\u63A5\u8C03\u7528\u51FD\u6570 \u201C{0}\u201D\uFF0C\u800C\u4E0D\u662F\u901A\u8FC7\u5177\u6709\u5176\u4ED6\u540D\u79F0\u7684\u51FD\u6570\u3002
 
 msg.eval.nonstring =\
-    如果您使用不是原始字符串的值调用 eval() 函数，\
-    则返回有问题的值。那是你的意图吗？
+    \u5982\u679C\u60A8\u4F7F\u7528\u4E0D\u662F\u539F\u59CB\u5B57\u7B26\u4E32\u7684\u503C\u8C03\u7528 eval() \u51FD\u6570\uFF0C\
+    \u5219\u8FD4\u56DE\u6709\u95EE\u9898\u7684\u503C\u3002\u90A3\u662F\u4F60\u7684\u610F\u56FE\u5417\uFF1F
 
 msg.eval.nonstring.strict =\
-    在严格模式下，不能使用原始字符串以外的值调用 eval() 函数。
+    \u5728\u4E25\u683C\u6A21\u5F0F\u4E0B\uFF0C\u4E0D\u80FD\u4F7F\u7528\u539F\u59CB\u5B57\u7B26\u4E32\u4EE5\u5916\u7684\u503C\u8C03\u7528 eval() \u51FD\u6570\u3002
 
 msg.bad.destruct.op =\
-    无效的解构赋值运算符
+    \u65E0\u6548\u7684\u89E3\u6784\u8D4B\u503C\u8FD0\u7B97\u7B26
 
 # NativeCall
 msg.only.from.new =\
-    “构造函数 {0}”只能从 “new” 表达式调用。
+    \u201C\u6784\u9020\u51FD\u6570 {0}\u201D\u53EA\u80FD\u4ECE \u201Cnew\u201D \u8868\u8FBE\u5F0F\u8C03\u7528\u3002
 
 msg.deprec.ctor =\
-    “{0}” 构造函数已弃用。
+    \u201C{0}\u201D \u6784\u9020\u51FD\u6570\u5DF2\u5F03\u7528\u3002
 
 # NativeFunction
 msg.no.function.ref.found =\
-    未找到反编译函数引用 {0} 的源
+    \u672A\u627E\u5230\u53CD\u7F16\u8BD1\u51FD\u6570\u5F15\u7528 {0} \u7684\u6E90
 
 msg.arg.isnt.array =\
-    Function.prototype.apply 方法的第二个参数必须是一个数组
+    Function.prototype.apply \u65B9\u6CD5\u7684\u7B2C\u4E8C\u4E2A\u53C2\u6570\u5FC5\u987B\u662F\u4E00\u4E2A\u6570\u7EC4
 
 # NativeGlobal
 msg.bad.esc.mask =\
-    字符串转义掩码不正确
+    \u5B57\u7B26\u4E32\u8F6C\u4E49\u63A9\u7801\u4E0D\u6B63\u786E
 
 # NativeJavaClass
 msg.cant.instantiate =\
-    实例化错误 ({0})：类 {1} 是接口或抽象类
+    \u5B9E\u4F8B\u5316\u9519\u8BEF ({0})\uFF1A\u7C7B {1} \u662F\u63A5\u53E3\u6216\u62BD\u8C61\u7C7B
 
 msg.bad.ctor.sig =\
-    检测到具有不正确签名的构造函数：\
-    {0} 调用带有签名 {2} 的 {1}
+    \u68C0\u6D4B\u5230\u5177\u6709\u4E0D\u6B63\u786E\u7B7E\u540D\u7684\u6784\u9020\u51FD\u6570\uFF1A\
+    {0} \u8C03\u7528\u5E26\u6709\u7B7E\u540D {2} \u7684 {1}
 
 msg.not.java.obj =\
-    getClass() 函数的预期参数必须是 Java 对象。
+    getClass() \u51FD\u6570\u7684\u9884\u671F\u53C2\u6570\u5FC5\u987B\u662F Java \u5BF9\u8C61\u3002
 
 msg.no.java.ctor =\
-    未找到带有参数 “{1}” 的 “{0}” 的 Java 构造函数。
+    \u672A\u627E\u5230\u5E26\u6709\u53C2\u6570 \u201C{1}\u201D \u7684 \u201C{0}\u201D \u7684 Java \u6784\u9020\u51FD\u6570\u3002
 
 # NativeJavaMethod
 msg.method.ambiguous =\
-    对应于 JavaScript 参数类型 ({2}) 的 Java 方法 {0}.{1} 的选择不明确。 \
-    建议的方法是：{3}
+    \u5BF9\u5E94\u4E8E JavaScript \u53C2\u6570\u7C7B\u578B ({2}) \u7684 Java \u65B9\u6CD5 {0}.{1} \u7684\u9009\u62E9\u4E0D\u660E\u786E\u3002 \
+    \u5EFA\u8BAE\u7684\u65B9\u6CD5\u662F\uFF1A{3}
 
 msg.constructor.ambiguous =\
-    对应于 JavaScript 参数类型 ({1}) 的 Java 构造函数 {0} 的选择不明确。 \
-    建议的构造函数是：{2}
+    \u5BF9\u5E94\u4E8E JavaScript \u53C2\u6570\u7C7B\u578B ({1}) \u7684 Java \u6784\u9020\u51FD\u6570 {0} \u7684\u9009\u62E9\u4E0D\u660E\u786E\u3002 \
+    \u5EFA\u8BAE\u7684\u6784\u9020\u51FD\u6570\u662F\uFF1A{2}
 
 # NativeJavaObject
 msg.conversion.not.allowed =\
-    无法将 {0} 转换为 {1}
+    \u65E0\u6CD5\u5C06 {0} \u8F6C\u6362\u4E3A {1}
 
 msg.no.empty.interface.conversion =\
-    无法在没有任何方法的情况下将函数转换为接口 {0}
+    \u65E0\u6CD5\u5728\u6CA1\u6709\u4EFB\u4F55\u65B9\u6CD5\u7684\u60C5\u51B5\u4E0B\u5C06\u51FD\u6570\u8F6C\u6362\u4E3A\u63A5\u53E3 {0}
 
 msg.no.function.interface.conversion =\
-    无法将函数 {0} 转换为接口，因为它包含具有不同名称的方法
+    \u65E0\u6CD5\u5C06\u51FD\u6570 {0} \u8F6C\u6362\u4E3A\u63A5\u53E3\uFF0C\u56E0\u4E3A\u5B83\u5305\u542B\u5177\u6709\u4E0D\u540C\u540D\u79F0\u7684\u65B9\u6CD5
 
 msg.undefined.function.interface =\
-    接口适配器中未设置属性“{0}”
+    \u63A5\u53E3\u9002\u914D\u5668\u4E2D\u672A\u8BBE\u7F6E\u5C5E\u6027\u201C{0}\u201D
 
 msg.not.function.interface =\
-    属性 “{0}” 不是接口适配器中的函数
+    \u5C5E\u6027 \u201C{0}\u201D \u4E0D\u662F\u63A5\u53E3\u9002\u914D\u5668\u4E2D\u7684\u51FD\u6570
 
 # NativeJavaPackage
 msg.not.classloader =\
-    “Packages” 的构造函数需要 java.lang.Classloader 类型的参数
+    \u201CPackages\u201D \u7684\u6784\u9020\u51FD\u6570\u9700\u8981 java.lang.Classloader \u7C7B\u578B\u7684\u53C2\u6570
 
 # NativeRegExp
 msg.bad.quant =\
-    量词 {0} 不正确
+    \u91CF\u8BCD {0} \u4E0D\u6B63\u786E
 
 msg.overlarge.backref =\
-    过大的反向引用 {0}
+    \u8FC7\u5927\u7684\u53CD\u5411\u5F15\u7528 {0}
 
 msg.overlarge.min =\
-    最小值 {0} 太大
+    \u6700\u5C0F\u503C {0} \u592A\u5927
 
 msg.overlarge.max =\
-    最大值 {0} 太大
+    \u6700\u5927\u503C {0} \u592A\u5927
 
 msg.zero.quant =\
-    量词 {0} 为空
+    \u91CF\u8BCD {0} \u4E3A\u7A7A
 
 msg.max.lt.min =\
-    最大值 {0} 小于最小值
+    \u6700\u5927\u503C {0} \u5C0F\u4E8E\u6700\u5C0F\u503C
 
 msg.unterm.quant =\
-    量词 {0} 没有限制
+    \u91CF\u8BCD {0} \u6CA1\u6709\u9650\u5236
 
 msg.unterm.paren =\
-    {0} 括号没有限制
+    {0} \u62EC\u53F7\u6CA1\u6709\u9650\u5236
 
 msg.unterm.class =\
-    字符类 {0} 没有限制
+    \u5B57\u7B26\u7C7B {0} \u6CA1\u6709\u9650\u5236
 
 msg.bad.range =\
-    字符类包含不正确的值范围。
+    \u5B57\u7B26\u7C7B\u5305\u542B\u4E0D\u6B63\u786E\u7684\u503C\u8303\u56F4\u3002
 
 msg.trail.backslash =\
-    “\\” 在正则表达式的末尾。
+    \u201C\\\u201D \u5728\u6B63\u5219\u8868\u8FBE\u5F0F\u7684\u672B\u5C3E\u3002
 
 msg.re.unmatched.right.paren =\
-    只有一个 “)” 在正则表达式中。
+    \u53EA\u6709\u4E00\u4E2A \u201C)\u201D \u5728\u6B63\u5219\u8868\u8FBE\u5F0F\u4E2D\u3002
 
 msg.no.regexp =\
-    正则表达式不可用。
+    \u6B63\u5219\u8868\u8FBE\u5F0F\u4E0D\u53EF\u7528\u3002
 
 msg.bad.backref =\
-    反向引用超过了捕获括号的数量。
+    \u53CD\u5411\u5F15\u7528\u8D85\u8FC7\u4E86\u6355\u83B7\u62EC\u53F7\u7684\u6570\u91CF\u3002
 
 msg.bad.regexp.compile =\
-    如果 RegExp.prototype.compile 的第一个参数是 RegExp 类型的对象，则只能指定一个参数。
+    \u5982\u679C RegExp.prototype.compile \u7684\u7B2C\u4E00\u4E2A\u53C2\u6570\u662F RegExp \u7C7B\u578B\u7684\u5BF9\u8C61\uFF0C\u5219\u53EA\u80FD\u6307\u5B9A\u4E00\u4E2A\u53C2\u6570\u3002
 
 msg.arg.not.object =\
-    预期参数的类型是 “object” 而不是 “{0}”
+    \u9884\u671F\u53C2\u6570\u7684\u7C7B\u578B\u662F \u201Cobject\u201D \u800C\u4E0D\u662F \u201C{0}\u201D
 
 # NativeDate
 msg.invalid.date =\
-    日期不正确。
+    \u65E5\u671F\u4E0D\u6B63\u786E\u3002
 
 msg.toisostring.must.return.primitive =\
-    toISOString 应该返回一个原始值，而不是返回 “{0}”
+    toISOString \u5E94\u8BE5\u8FD4\u56DE\u4E00\u4E2A\u539F\u59CB\u503C\uFF0C\u800C\u4E0D\u662F\u8FD4\u56DE \u201C{0}\u201D
 
 # NativeJSON
 msg.json.cant.serialize =\
-    不知道如何序列化 {0}
+    \u4E0D\u77E5\u9053\u5982\u4F55\u5E8F\u5217\u5316 {0}
 
 # Parser
 msg.got.syntax.errors = \
-    编译产生 {0} 个语法错误。
+    \u7F16\u8BD1\u4EA7\u751F {0} \u4E2A\u8BED\u6CD5\u9519\u8BEF\u3002
 
 msg.var.redecl =\
-    类型错误：变量 {0} 被重新声明。
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u53D8\u91CF {0} \u88AB\u91CD\u65B0\u58F0\u660E\u3002
 
 msg.const.redecl =\
-    类型错误：重新声明了常量 {0}。
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u91CD\u65B0\u58F0\u660E\u4E86\u5E38\u91CF {0}\u3002
 
 msg.let.redecl =\
-    类型错误：变量 {0} 被重新声明。
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u53D8\u91CF {0} \u88AB\u91CD\u65B0\u58F0\u660E\u3002
 
 msg.parm.redecl =\
-    类型错误：重新声明了形式参数 {0} 。
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u91CD\u65B0\u58F0\u660E\u4E86\u5F62\u5F0F\u53C2\u6570 {0} \u3002
 
 msg.fn.redecl =\
-    类型错误：重新声明了函数 {0}。
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u91CD\u65B0\u58F0\u660E\u4E86\u51FD\u6570 {0}\u3002
 
 msg.let.decl.not.in.block =\
-    语法错误：let 语句不能直接在块中
+    \u8BED\u6CD5\u9519\u8BEF\uFF1Alet \u8BED\u53E5\u4E0D\u80FD\u76F4\u63A5\u5728\u5757\u4E2D
 
 msg.bad.object.init =\
-    语法错误：无效的对象初始化程序
+    \u8BED\u6CD5\u9519\u8BEF\uFF1A\u65E0\u6548\u7684\u5BF9\u8C61\u521D\u59CB\u5316\u7A0B\u5E8F
 
 # NodeTransformer
 msg.dup.label =\
-    标签 {0} 已存在
+    \u6807\u7B7E {0} \u5DF2\u5B58\u5728
 
 msg.undef.label =\
-    标签 {0} 未定义
+    \u6807\u7B7E {0} \u672A\u5B9A\u4E49
 
 msg.bad.break =\
-    未标记的 break 必须在 loop 或 switch 内
+    \u672A\u6807\u8BB0\u7684 break \u5FC5\u987B\u5728 loop \u6216 switch \u5185
 
 msg.continue.outside =\
-    只能在循环语句中使用 continue
+    \u53EA\u80FD\u5728\u5FAA\u73AF\u8BED\u53E5\u4E2D\u4F7F\u7528 continue
 
 msg.continue.nonloop =\
-    只能在迭代语句中使用 continue
+    \u53EA\u80FD\u5728\u8FED\u4EE3\u8BED\u53E5\u4E2D\u4F7F\u7528 continue
 
 msg.bad.throw.eol =\
-    在关键字 throw 与 throw 表达式之间不允许使用换行符表示。
+    \u5728\u5173\u952E\u5B57 throw \u4E0E throw \u8868\u8FBE\u5F0F\u4E4B\u95F4\u4E0D\u5141\u8BB8\u4F7F\u7528\u6362\u884C\u7B26\u8868\u793A\u3002
 
 msg.no.paren.parms =\
-    在函数参数前面缺少 “(”。
+    \u5728\u51FD\u6570\u53C2\u6570\u524D\u9762\u7F3A\u5C11 \u201C(\u201D\u3002
 
 msg.no.parm =\
-    缺少形式参数
+    \u7F3A\u5C11\u5F62\u5F0F\u53C2\u6570
 
 msg.no.paren.after.parms =\
-    在形式参数后面缺少 “)”
+    \u5728\u5F62\u5F0F\u53C2\u6570\u540E\u9762\u7F3A\u5C11 \u201C)\u201D
 
 msg.no.brace.body =\
-    在函数体前面缺少 “{”
+    \u5728\u51FD\u6570\u4F53\u524D\u9762\u7F3A\u5C11 \u201C{\u201D
 
 msg.no.brace.after.body =\
-    在函数体后面缺少 “}”
+    \u5728\u51FD\u6570\u4F53\u540E\u9762\u7F3A\u5C11 \u201C}\u201D
 
 msg.no.paren.cond =\
-    在条件前面缺少 “(”
+    \u5728\u6761\u4EF6\u524D\u9762\u7F3A\u5C11 \u201C(\u201D
 
 msg.no.paren.after.cond =\
-    在字符 “)” 后面缺少条件
+    \u5728\u5B57\u7B26 \u201C)\u201D \u540E\u9762\u7F3A\u5C11\u6761\u4EF6
 
 msg.no.semi.stmt =\
-    在语句前面缺少 “;”
+    \u5728\u8BED\u53E5\u524D\u9762\u7F3A\u5C11 \u201C;\u201D
 
 msg.missing.semi =\
-    在语句后面缺少 “;”
+    \u5728\u8BED\u53E5\u540E\u9762\u7F3A\u5C11 \u201C;\u201D
 
 msg.no.name.after.dot =\
-    在运算符 “.” 后面缺少名称
+    \u5728\u8FD0\u7B97\u7B26 \u201C.\u201D \u540E\u9762\u7F3A\u5C11\u540D\u79F0
 
 msg.no.name.after.coloncolon =\
-    在运算符 “::” 后面缺少名称
+    \u5728\u8FD0\u7B97\u7B26 \u201C::\u201D \u540E\u9762\u7F3A\u5C11\u540D\u79F0
 
 msg.no.name.after.dotdot =\
-    在运算符 “..” 后面缺少名称
+    \u5728\u8FD0\u7B97\u7B26 \u201C..\u201D \u540E\u9762\u7F3A\u5C11\u540D\u79F0
 
 msg.no.name.after.xmlAttr =\
-    在 “.@” 后面缺少名称
+    \u5728 \u201C.@\u201D \u540E\u9762\u7F3A\u5C11\u540D\u79F0
 
 msg.no.bracket.index =\
-    在索引表达式中缺少 “]”
+    \u5728\u7D22\u5F15\u8868\u8FBE\u5F0F\u4E2D\u7F3A\u5C11 \u201C]\u201D
 
 msg.no.paren.switch =\
-    在 switch 表达式的前面缺少 “(”
+    \u5728 switch \u8868\u8FBE\u5F0F\u7684\u524D\u9762\u7F3A\u5C11 \u201C(\u201D
 
 msg.no.paren.after.switch =\
-    在 switch 表达式的后面缺少 “)”
+    \u5728 switch \u8868\u8FBE\u5F0F\u7684\u540E\u9762\u7F3A\u5C11 \u201C)\u201D
 
 msg.no.brace.switch =\
-    在 switch 正文的前面缺少 “{”
+    \u5728 switch \u6B63\u6587\u7684\u524D\u9762\u7F3A\u5C11 \u201C{\u201D
 
 msg.bad.switch =\
-    switch 语句不正确
+    switch \u8BED\u53E5\u4E0D\u6B63\u786E
 
 msg.no.colon.case =\
-    在 case 表达式的后面缺少 “:”
+    \u5728 case \u8868\u8FBE\u5F0F\u7684\u540E\u9762\u7F3A\u5C11 \u201C:\u201D
 
 msg.double.switch.default =\
-    default 标签在 switch 语句中重复出现
+    default \u6807\u7B7E\u5728 switch \u8BED\u53E5\u4E2D\u91CD\u590D\u51FA\u73B0
 
 msg.no.while.do =\
-    在 do-loop 的后面缺少 while
+    \u5728 do-loop \u7684\u540E\u9762\u7F3A\u5C11 while
 
 msg.no.paren.for =\
-    在 for 之后缺少 “(”
+    \u5728 for \u4E4B\u540E\u7F3A\u5C11 \u201C(\u201D
 
 msg.no.semi.for =\
-    在 for-loop 初始化程序的后面缺少 “;”
+    \u5728 for-loop \u521D\u59CB\u5316\u7A0B\u5E8F\u7684\u540E\u9762\u7F3A\u5C11 \u201C;\u201D
 
 msg.no.semi.for.cond =\
-    在 for-loop 条件的后面缺少 “;”
+    \u5728 for-loop \u6761\u4EF6\u7684\u540E\u9762\u7F3A\u5C11 \u201C;\u201D
 
 msg.in.after.for.name =\
-    在 for 的后面缺少 “in”
+    \u5728 for \u7684\u540E\u9762\u7F3A\u5C11 \u201Cin\u201D
 
 msg.no.paren.for.ctrl =\
-    在 for-loop 控件的后面缺少 “)”
+    \u5728 for-loop \u63A7\u4EF6\u7684\u540E\u9762\u7F3A\u5C11 \u201C)\u201D
 
 msg.no.paren.with =\
-    在 With-Statement 对象的前面缺少 “(”
+    \u5728 With-Statement \u5BF9\u8C61\u7684\u524D\u9762\u7F3A\u5C11 \u201C(\u201D
 
 msg.no.paren.after.with =\
-    在 With-Statement 对象的后面面缺少 “(”
+    \u5728 With-Statement \u5BF9\u8C61\u7684\u540E\u9762\u9762\u7F3A\u5C11 \u201C(\u201D
 
 msg.no.with.strict =\
-    严格模式下不允许使用 with 语句
+    \u4E25\u683C\u6A21\u5F0F\u4E0B\u4E0D\u5141\u8BB8\u4F7F\u7528 with \u8BED\u53E5
 
 msg.no.paren.after.let =\
-    在 let 的后面缺少 “(”
+    \u5728 let \u7684\u540E\u9762\u7F3A\u5C11 \u201C(\u201D
 
 msg.no.paren.let =\
-    在变量列表后面缺少 “)”
+    \u5728\u53D8\u91CF\u5217\u8868\u540E\u9762\u7F3A\u5C11 \u201C)\u201D
 
 msg.no.curly.let =\
-    在 let 语句的后面缺少 “}”
+    \u5728 let \u8BED\u53E5\u7684\u540E\u9762\u7F3A\u5C11 \u201C}\u201D
 
 msg.bad.return =\
-    返回的值无效
+    \u8FD4\u56DE\u7684\u503C\u65E0\u6548
 
 msg.no.brace.block =\
-    复合语句中缺少 “}”
+    \u590D\u5408\u8BED\u53E5\u4E2D\u7F3A\u5C11 \u201C}\u201D
 
 msg.bad.label =\
-    无效标签
+    \u65E0\u6548\u6807\u7B7E
 
 msg.bad.var =\
-    缺少变量名
+    \u7F3A\u5C11\u53D8\u91CF\u540D
 
 msg.bad.var.init =\
-    变量初始化不正确
+    \u53D8\u91CF\u521D\u59CB\u5316\u4E0D\u6B63\u786E
 
 msg.no.colon.cond =\
-    在条件表达式中缺少 “:”
+    \u5728\u6761\u4EF6\u8868\u8FBE\u5F0F\u4E2D\u7F3A\u5C11 \u201C:\u201D
 
 msg.no.paren.arg =\
-    在参数列表的后面缺少 “)”
+    \u5728\u53C2\u6570\u5217\u8868\u7684\u540E\u9762\u7F3A\u5C11 \u201C)\u201D
 
 msg.no.bracket.arg =\
-    在元素列表的后面缺少 “]”
+    \u5728\u5143\u7D20\u5217\u8868\u7684\u540E\u9762\u7F3A\u5C11 \u201C]\u201D
 
 msg.bad.prop =\
-    属性 ID 不正确
+    \u5C5E\u6027 ID \u4E0D\u6B63\u786E
 
 msg.no.colon.prop =\
-    在属性 ID 的后面缺少 “:”
+    \u5728\u5C5E\u6027 ID \u7684\u540E\u9762\u7F3A\u5C11 \u201C:\u201D
 
 msg.no.brace.prop =\
-    在属性列表的后面缺少 “}”
+    \u5728\u5C5E\u6027\u5217\u8868\u7684\u540E\u9762\u7F3A\u5C11 \u201C}\u201D
 
 msg.no.paren =\
-    在括号中缺少 “)”
+    \u5728\u62EC\u53F7\u4E2D\u7F3A\u5C11 \u201C)\u201D
 
 msg.reserved.id =\
-    标识符是保留字: {0}
+    \u6807\u8BC6\u7B26\u662F\u4FDD\u7559\u5B57: {0}
 
 msg.no.paren.catch =\
-    在 catch-block 条件的前面缺少 “(”
+    \u5728 catch-block \u6761\u4EF6\u7684\u524D\u9762\u7F3A\u5C11 \u201C(\u201D
 
 msg.bad.catchcond =\
-    无效的 catch-block 条件
+    \u65E0\u6548\u7684 catch-block \u6761\u4EF6
 
 msg.catch.unreachable =\
-    不合格的 catch 后面的任何 catch 子句都是到达不了的
+    \u4E0D\u5408\u683C\u7684 catch \u540E\u9762\u7684\u4EFB\u4F55 catch \u5B50\u53E5\u90FD\u662F\u5230\u8FBE\u4E0D\u4E86\u7684
 
 msg.no.brace.try =\
-    在 try 的前面缺少 “{”
+    \u5728 try \u7684\u524D\u9762\u7F3A\u5C11 \u201C{\u201D
 
 msg.no.brace.catchblock =\
-    在 catch-block 主体的前面缺少 “{”
+    \u5728 catch-block \u4E3B\u4F53\u7684\u524D\u9762\u7F3A\u5C11 \u201C{\u201D
 
 msg.try.no.catchfinally =\
-    try 被检测到没有 catch 或 finally
+    try \u88AB\u68C0\u6D4B\u5230\u6CA1\u6709 catch \u6216 finally
 
 msg.no.return.value =\
-    函数 {0} 并不总是返回值
+    \u51FD\u6570 {0} \u5E76\u4E0D\u603B\u662F\u8FD4\u56DE\u503C
 
 msg.anon.no.return.value =\
-    匿名函数并不总是返回值
+    \u533F\u540D\u51FD\u6570\u5E76\u4E0D\u603B\u662F\u8FD4\u56DE\u503C
 
 msg.return.inconsistent =\
-    return 语句与之前的用法不一致
+    return \u8BED\u53E5\u4E0E\u4E4B\u524D\u7684\u7528\u6CD5\u4E0D\u4E00\u81F4
 
 msg.generator.returns =\
-    类型错误：生成器函数 {0} 返回一个值
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u751F\u6210\u5668\u51FD\u6570 {0} \u8FD4\u56DE\u4E00\u4E2A\u503C
 
 msg.anon.generator.returns =\
-    类型错误：匿名生成器函数返回一个值
+    \u7C7B\u578B\u9519\u8BEF\uFF1A\u533F\u540D\u751F\u6210\u5668\u51FD\u6570\u8FD4\u56DE\u4E00\u4E2A\u503C
 
 msg.syntax =\
-    语法错误
+    \u8BED\u6CD5\u9519\u8BEF
 
 msg.unexpected.eof =\
-    文件意外结束
+    \u6587\u4EF6\u610F\u5916\u7ED3\u675F
 
 msg.XML.bad.form =\
-    XML 语法格式错误
+    XML \u8BED\u6CD5\u683C\u5F0F\u9519\u8BEF
 
 msg.XML.not.available =\
-    XML 解析不可用
+    XML \u89E3\u6790\u4E0D\u53EF\u7528
 
 msg.too.deep.parser.recursion =\
-    解析期间递归太深
+    \u89E3\u6790\u671F\u95F4\u9012\u5F52\u592A\u6DF1
 
 msg.too.many.constructor.args =\
-    构造函数的参数太多
+    \u6784\u9020\u51FD\u6570\u7684\u53C2\u6570\u592A\u591A
 
 msg.too.many.function.args =\
-    函数的参数太多
+    \u51FD\u6570\u7684\u53C2\u6570\u592A\u591A
 
 msg.no.side.effects =\
-    代码没有返回值
+    \u4EE3\u7801\u6CA1\u6709\u8FD4\u56DE\u503C
 
 msg.extra.trailing.semi =\
-    末尾有多余的分号
+    \u672B\u5C3E\u6709\u591A\u4F59\u7684\u5206\u53F7
 
 msg.extra.trailing.comma =\
-    按照 ECMA-262 的标准不允许对象初始值设定项末尾的逗号
+    \u6309\u7167 ECMA-262 \u7684\u6807\u51C6\u4E0D\u5141\u8BB8\u5BF9\u8C61\u521D\u59CB\u503C\u8BBE\u5B9A\u9879\u672B\u5C3E\u7684\u9017\u53F7
 
 msg.trailing.array.comma =\
-    数组文字末尾的逗号根据所使用的浏览器表现不同
+    \u6570\u7EC4\u6587\u5B57\u672B\u5C3E\u7684\u9017\u53F7\u6839\u636E\u6240\u4F7F\u7528\u7684\u6D4F\u89C8\u5668\u8868\u73B0\u4E0D\u540C
 
 msg.equal.as.assign =\
-    判断相等性 “==” 错误地输入成为赋值 “=” ？
+    \u5224\u65AD\u76F8\u7B49\u6027 \u201C==\u201D \u9519\u8BEF\u5730\u8F93\u5165\u6210\u4E3A\u8D4B\u503C \u201C=\u201D \uFF1F
 
 msg.var.hides.arg =\
-    变量 {0} 隐藏了一个参数
+    \u53D8\u91CF {0} \u9690\u85CF\u4E86\u4E00\u4E2A\u53C2\u6570
 
 msg.destruct.assign.no.init =\
-    解构赋值中缺少 “=”
+    \u89E3\u6784\u8D4B\u503C\u4E2D\u7F3A\u5C11 \u201C=\u201D
 
 msg.destruct.default.vals =\
-    解构声明中的默认值不支持
+    \u89E3\u6784\u58F0\u660E\u4E2D\u7684\u9ED8\u8BA4\u503C\u4E0D\u652F\u6301
 
 msg.no.old.octal.strict =\
-    严格模式下不允许使用旧的八进制数。
+    \u4E25\u683C\u6A21\u5F0F\u4E0B\u4E0D\u5141\u8BB8\u4F7F\u7528\u65E7\u7684\u516B\u8FDB\u5236\u6570\u3002
 
 msg.no.old.octal.bigint =\
-    BigInt 中不允许使用旧的八进制数。
+    BigInt \u4E2D\u4E0D\u5141\u8BB8\u4F7F\u7528\u65E7\u7684\u516B\u8FDB\u5236\u6570\u3002
 
 msg.dup.obj.lit.prop.strict =\
-    此对象文字中已定义属性 “{0}”。
+    \u6B64\u5BF9\u8C61\u6587\u5B57\u4E2D\u5DF2\u5B9A\u4E49\u5C5E\u6027 \u201C{0}\u201D\u3002
 
 msg.dup.param.strict =\
-    此函数中已声明参数 “{0}”。
+    \u6B64\u51FD\u6570\u4E2D\u5DF2\u58F0\u660E\u53C2\u6570 \u201C{0}\u201D\u3002
 
 msg.bad.id.strict =\
-    “{0}” 不是严格模式下此用途的有效标识符。
+    \u201C{0}\u201D \u4E0D\u662F\u4E25\u683C\u6A21\u5F0F\u4E0B\u6B64\u7528\u9014\u7684\u6709\u6548\u6807\u8BC6\u7B26\u3002
 
 msg.no.unary.expr.on.left.exp =\
-    “{0}” 不允许出现在 “**” 的左侧。
+    \u201C{0}\u201D \u4E0D\u5141\u8BB8\u51FA\u73B0\u5728 \u201C**\u201D \u7684\u5DE6\u4FA7\u3002
 
-# 脚本运行时(ScriptRuntime)
+# \u811A\u672C\u8FD0\u884C\u65F6(ScriptRuntime)
 
 # is there a better message for this?
 # it's currently only used as a poison pill for caller, caller and arguments properties
 msg.op.not.allowed =\
-    不允许此操作。
+    \u4E0D\u5141\u8BB8\u6B64\u64CD\u4F5C\u3002
 
 msg.no.properties =\
-    {0} 没有属性。
+    {0} \u6CA1\u6709\u5C5E\u6027\u3002
 
 msg.invalid.iterator =\
-    值不是有效的迭代器
+    \u503C\u4E0D\u662F\u6709\u6548\u7684\u8FED\u4EE3\u5668
 
 msg.iterator.primitive =\
-    __iterator__ 返回一个原始值
+    __iterator__ \u8FD4\u56DE\u4E00\u4E2A\u539F\u59CB\u503C
 
 msg.not.iterable = \
-    {0} 不可迭代
+    {0} \u4E0D\u53EF\u8FED\u4EE3
 
 msg.invalid.for.each = \
-    对每个循环无效
+    \u5BF9\u6BCF\u4E2A\u5FAA\u73AF\u65E0\u6548
 
 msg.assn.create.strict =\
-    未声明变量的赋值 {0}
+    \u672A\u58F0\u660E\u53D8\u91CF\u7684\u8D4B\u503C {0}
 
 msg.ref.undefined.prop =\
-    对未定义属性 “{0}” 的引用
+    \u5BF9\u672A\u5B9A\u4E49\u5C5E\u6027 \u201C{0}\u201D \u7684\u5F15\u7528
 
 msg.prop.not.found =\
-    未找到属性 {0}。
+    \u672A\u627E\u5230\u5C5E\u6027 {0}\u3002
 
 msg.set.prop.no.setter =\
-    无法将只有 getter 的属性 {0} 的值设置为 “{1}”。
+    \u65E0\u6CD5\u5C06\u53EA\u6709 getter \u7684\u5C5E\u6027 {0} \u7684\u503C\u8BBE\u7F6E\u4E3A \u201C{1}\u201D\u3002
 
 msg.invalid.type =\
-    {0} 类型的 JavaScript 值无效
+    {0} \u7C7B\u578B\u7684 JavaScript \u503C\u65E0\u6548
 
 msg.primitive.expected =\
-    需要使用原始类型，而不是使用 {0}
+    \u9700\u8981\u4F7F\u7528\u539F\u59CB\u7C7B\u578B\uFF0C\u800C\u4E0D\u662F\u4F7F\u7528 {0}
 
 msg.namespace.expected =\
-    命名空间对象应该位于 “::” 左侧（找到 {0} 代替）
+    \u547D\u540D\u7A7A\u95F4\u5BF9\u8C61\u5E94\u8BE5\u4F4D\u4E8E \u201C::\u201D \u5DE6\u4FA7\uFF08\u627E\u5230 {0} \u4EE3\u66FF\uFF09
 
 msg.null.to.object =\
-    无法将 null 转换为对象。
+    \u65E0\u6CD5\u5C06 null \u8F6C\u6362\u4E3A\u5BF9\u8C61\u3002
 
 msg.undef.to.object =\
-    无法将未定义的值转换为对象。
+    \u65E0\u6CD5\u5C06\u672A\u5B9A\u4E49\u7684\u503C\u8F6C\u6362\u4E3A\u5BF9\u8C61\u3002
 
 msg.cant.convert.to.bigint =\
-    无法将 {0} 转换为 BigInt。
+    \u65E0\u6CD5\u5C06 {0} \u8F6C\u6362\u4E3A BigInt\u3002
 
 msg.cant.convert.to.bigint.isnt.integer =\
-    无法将 {0} 转换为 BigInt，它不是整数。
+    \u65E0\u6CD5\u5C06 {0} \u8F6C\u6362\u4E3A BigInt\uFF0C\u5B83\u4E0D\u662F\u6574\u6570\u3002
 
 msg.bigint.bad.form =\
-    不允许形成的 BigInt 语法
+    \u4E0D\u5141\u8BB8\u5F62\u6210\u7684 BigInt \u8BED\u6CD5
 
 msg.cyclic.value =\
-    不允许使用循环 “{0}” 值。
+    \u4E0D\u5141\u8BB8\u4F7F\u7528\u5FAA\u73AF \u201C{0}\u201D \u503C\u3002
 
 msg.is.not.defined =\
-    “{0}” 未定义。
+    \u201C{0}\u201D \u672A\u5B9A\u4E49\u3002
 
 msg.undef.prop.read =\
-    无法读取 {0} 的属性 “{1}”
+    \u65E0\u6CD5\u8BFB\u53D6 {0} \u7684\u5C5E\u6027 \u201C{1}\u201D
 
 msg.undef.prop.write =\
-    无法将 {0} 的属性 “{1}” 设置为 “{2}”
+    \u65E0\u6CD5\u5C06 {0} \u7684\u5C5E\u6027 \u201C{1}\u201D \u8BBE\u7F6E\u4E3A \u201C{2}\u201D
 
 msg.undef.prop.delete =\
-    无法删除 {0} 的属性 “{1}”
+    \u65E0\u6CD5\u5220\u9664 {0} \u7684\u5C5E\u6027 \u201C{1}\u201D
 
 msg.undef.method.call =\
-    无法调用 {0} 的方法 “{1}”
+    \u65E0\u6CD5\u8C03\u7528 {0} \u7684\u65B9\u6CD5 \u201C{1}\u201D
 
 msg.undef.with =\
-    无法将 “with” 应用于 {0}
+    \u65E0\u6CD5\u5C06 \u201Cwith\u201D \u5E94\u7528\u4E8E {0}
 
 msg.isnt.function =\
-    {0} 不是函数，它是 {1}。
+    {0} \u4E0D\u662F\u51FD\u6570\uFF0C\u5B83\u662F {1}\u3002
 
 msg.isnt.function.in =\
-    无法调用对象 {1} 中的属性 {0}。它不是一个函数，而是 “{2}”。
+    \u65E0\u6CD5\u8C03\u7528\u5BF9\u8C61 {1} \u4E2D\u7684\u5C5E\u6027 {0}\u3002\u5B83\u4E0D\u662F\u4E00\u4E2A\u51FD\u6570\uFF0C\u800C\u662F \u201C{2}\u201D\u3002
 
 msg.function.not.found =\
-    找不到函数 {0}。
+    \u627E\u4E0D\u5230\u51FD\u6570 {0}\u3002
 
 msg.function.not.found.in =\
-    在对象 {1} 中找不到函数 {0} 。
+    \u5728\u5BF9\u8C61 {1} \u4E2D\u627E\u4E0D\u5230\u51FD\u6570 {0} \u3002
 
 msg.isnt.xml.object =\
-    {0} 不是 XML 对象。
+    {0} \u4E0D\u662F XML \u5BF9\u8C61\u3002
 
 msg.no.ref.to.get =\
-    {0} 不是对读取参考值的引用。
+    {0} \u4E0D\u662F\u5BF9\u8BFB\u53D6\u53C2\u8003\u503C\u7684\u5F15\u7528\u3002
 
 msg.no.ref.to.set =\
-    {0} 不是将引用值设置为 {1} 的引用。
+    {0} \u4E0D\u662F\u5C06\u5F15\u7528\u503C\u8BBE\u7F6E\u4E3A {1} \u7684\u5F15\u7528\u3002
 
 msg.no.ref.from.function =\
-    函数 {0} 不能用作赋值的左侧部分，也不能用作 “++” 或 “--” 运算符的操作数。
+    \u51FD\u6570 {0} \u4E0D\u80FD\u7528\u4F5C\u8D4B\u503C\u7684\u5DE6\u4FA7\u90E8\u5206\uFF0C\u4E5F\u4E0D\u80FD\u7528\u4F5C \u201C++\u201D \u6216 \u201C--\u201D \u8FD0\u7B97\u7B26\u7684\u64CD\u4F5C\u6570\u3002
 
 msg.bad.default.value =\
-    Object 的 getDefaultValue() 方法返回了一个对象。
+    Object \u7684 getDefaultValue() \u65B9\u6CD5\u8FD4\u56DE\u4E86\u4E00\u4E2A\u5BF9\u8C61\u3002
 
 msg.instanceof.not.object = \
-    不能在非对象上使用 “instanceof”。
+    \u4E0D\u80FD\u5728\u975E\u5BF9\u8C61\u4E0A\u4F7F\u7528 \u201Cinstanceof\u201D\u3002
 
 msg.instanceof.bad.prototype = \
-    {0} 的 “prototype” 属性不是对象。
+    {0} \u7684 \u201Cprototype\u201D \u5C5E\u6027\u4E0D\u662F\u5BF9\u8C61\u3002
 
 msg.in.not.object = \
-    不能在非对象上使用 “in”。
+    \u4E0D\u80FD\u5728\u975E\u5BF9\u8C61\u4E0A\u4F7F\u7528 \u201Cin\u201D\u3002
 
 msg.bad.radix = \
-    不允许的基数 {0}。
+    \u4E0D\u5141\u8BB8\u7684\u57FA\u6570 {0}\u3002
 
 msg.division.zero = \
-    除以零。
+    \u9664\u4EE5\u96F6\u3002
 
 msg.bigint.negative.exponent = \
-    BigInt 负指数。
+    BigInt \u8D1F\u6307\u6570\u3002
 
 msg.bigint.out.of.range.arithmetic = \
-    BigInt 的数过大。
+    BigInt \u7684\u6570\u8FC7\u5927\u3002
 
 # ScriptableObject
 msg.default.value =\
-    未找到对象默认值。
+    \u672A\u627E\u5230\u5BF9\u8C61\u9ED8\u8BA4\u503C\u3002
 
 msg.zero.arg.ctor =\
-    无法加载没有零参数构造函数的类 “{0}”。
+    \u65E0\u6CD5\u52A0\u8F7D\u6CA1\u6709\u96F6\u53C2\u6570\u6784\u9020\u51FD\u6570\u7684\u7C7B \u201C{0}\u201D\u3002
 
 duplicate.defineClass.name =\
-    方法 “{0}” 无效：名称 “{1}” 已在使用中。
+    \u65B9\u6CD5 \u201C{0}\u201D \u65E0\u6548\uFF1A\u540D\u79F0 \u201C{1}\u201D \u5DF2\u5728\u4F7F\u7528\u4E2D\u3002
 
 msg.ctor.multiple.parms =\
-    无法定义构造函数或类 {0}，因为多个构造函数具有多个参数。
+    \u65E0\u6CD5\u5B9A\u4E49\u6784\u9020\u51FD\u6570\u6216\u7C7B {0}\uFF0C\u56E0\u4E3A\u591A\u4E2A\u6784\u9020\u51FD\u6570\u5177\u6709\u591A\u4E2A\u53C2\u6570\u3002
 
 msg.extend.scriptable =\
-    {0} 必须扩展 ScriptableObject 才能定义属性 {1}。
+    {0} \u5FC5\u987B\u6269\u5C55 ScriptableObject \u624D\u80FD\u5B9A\u4E49\u5C5E\u6027 {1}\u3002
 
 msg.bad.getter.parms =\
-    为了定义一个属性，getter {0} 必须有零个参数或一个 ScriptableObject 参数。
+    \u4E3A\u4E86\u5B9A\u4E49\u4E00\u4E2A\u5C5E\u6027\uFF0Cgetter {0} \u5FC5\u987B\u6709\u96F6\u4E2A\u53C2\u6570\u6216\u4E00\u4E2A ScriptableObject \u53C2\u6570\u3002
 
 msg.obj.getter.parms =\
-    静态或委托 getter 方法 {0} 必须使用 ScriptableObject 参数。
+    \u9759\u6001\u6216\u59D4\u6258 getter \u65B9\u6CD5 {0} \u5FC5\u987B\u4F7F\u7528 ScriptableObject \u53C2\u6570\u3002
 
 msg.getter.static =\
-    getter 方法和 setter 方法必须具有相同的状态（静态或非静态）。
+    getter \u65B9\u6CD5\u548C setter \u65B9\u6CD5\u5FC5\u987B\u5177\u6709\u76F8\u540C\u7684\u72B6\u6001\uFF08\u9759\u6001\u6216\u975E\u9759\u6001\uFF09\u3002
 
 msg.setter.return =\
-    setter 方法的返回类型必须为空：{0}
+    setter \u65B9\u6CD5\u7684\u8FD4\u56DE\u7C7B\u578B\u5FC5\u987B\u4E3A\u7A7A\uFF1A{0}
 
 msg.setter2.parms =\
-    双参数 setter 方法必须使用 ScriptableObject 参数作为第一个参数。
+    \u53CC\u53C2\u6570 setter \u65B9\u6CD5\u5FC5\u987B\u4F7F\u7528 ScriptableObject \u53C2\u6570\u4F5C\u4E3A\u7B2C\u4E00\u4E2A\u53C2\u6570\u3002
 
 msg.setter1.parms =\
-    {0} 需要一个参数 getter 方法
+    {0} \u9700\u8981\u4E00\u4E2A\u53C2\u6570 getter \u65B9\u6CD5
 
 msg.setter2.expected =\
-    静态或委托设置方法 {0} 必须采用两个参数。
+    \u9759\u6001\u6216\u59D4\u6258\u8BBE\u7F6E\u65B9\u6CD5 {0} \u5FC5\u987B\u91C7\u7528\u4E24\u4E2A\u53C2\u6570\u3002
 
 msg.setter.parms =\
-    setter 方法需要一个或两个参数。
+    setter \u65B9\u6CD5\u9700\u8981\u4E00\u4E2A\u6216\u4E24\u4E2A\u53C2\u6570\u3002
 
 msg.setter.bad.type =\
-    setter 方法 “{1}” 中的参数类型 “{0}” 不正确。
+    setter \u65B9\u6CD5 \u201C{1}\u201D \u4E2D\u7684\u53C2\u6570\u7C7B\u578B \u201C{0}\u201D \u4E0D\u6B63\u786E\u3002
 
 msg.add.sealed =\
-    无法将属性添加到密封对象: {0}。
+    \u65E0\u6CD5\u5C06\u5C5E\u6027\u6DFB\u52A0\u5230\u5BC6\u5C01\u5BF9\u8C61: {0}\u3002
 
 msg.remove.sealed =\
-    无法从密封对象中删除属性: {0}。
+    \u65E0\u6CD5\u4ECE\u5BC6\u5C01\u5BF9\u8C61\u4E2D\u5220\u9664\u5C5E\u6027: {0}\u3002
 
 msg.modify.sealed =\
-    无法修改密封对象的属性: {0}。
+    \u65E0\u6CD5\u4FEE\u6539\u5BC6\u5C01\u5BF9\u8C61\u7684\u5C5E\u6027: {0}\u3002
 
 msg.modify.readonly =\
-    无法修改只读属性: {0}。
+    \u65E0\u6CD5\u4FEE\u6539\u53EA\u8BFB\u5C5E\u6027: {0}\u3002
 
 msg.both.data.and.accessor.desc =\
-    描述符不能同时定义访问器和数据。
+    \u63CF\u8FF0\u7B26\u4E0D\u80FD\u540C\u65F6\u5B9A\u4E49\u8BBF\u95EE\u5668\u548C\u6570\u636E\u3002
 
 msg.change.configurable.false.to.true =\
-    无法将 “{0}” 的可配置属性从 false 更改为 true。
+    \u65E0\u6CD5\u5C06 \u201C{0}\u201D \u7684\u53EF\u914D\u7F6E\u5C5E\u6027\u4ECE false \u66F4\u6539\u4E3A true\u3002
 
 msg.change.enumerable.with.configurable.false =\
-    无法更改 “{0}” 的可枚举属性，因为 configurable 为 false。
+    \u65E0\u6CD5\u66F4\u6539 \u201C{0}\u201D \u7684\u53EF\u679A\u4E3E\u5C5E\u6027\uFF0C\u56E0\u4E3A configurable \u4E3A false\u3002
 
 msg.change.writable.false.to.true.with.configurable.false =\
-    无法将 “{0}” 的可写属性从 false 更改为 true，因为 configurable 为 false。
+    \u65E0\u6CD5\u5C06 \u201C{0}\u201D \u7684\u53EF\u5199\u5C5E\u6027\u4ECE false \u66F4\u6539\u4E3A true\uFF0C\u56E0\u4E3A configurable \u4E3A false\u3002
 
 msg.change.value.with.writable.false =\
-    无法更改属性 “{0}” 的值，因为 writable 为 false。
+    \u65E0\u6CD5\u66F4\u6539\u5C5E\u6027 \u201C{0}\u201D \u7684\u503C\uFF0C\u56E0\u4E3A writable \u4E3A false\u3002
 
 msg.change.getter.with.configurable.false =\
-    无法更改 “{0}” 的获取属性，因为 configurable 为 false。
+    \u65E0\u6CD5\u66F4\u6539 \u201C{0}\u201D \u7684\u83B7\u53D6\u5C5E\u6027\uFF0C\u56E0\u4E3A configurable \u4E3A false\u3002
 
 msg.change.setter.with.configurable.false =\
-    无法更改 “{0}” 的设置属性，因为 configurable 为 false。
+    \u65E0\u6CD5\u66F4\u6539 \u201C{0}\u201D \u7684\u8BBE\u7F6E\u5C5E\u6027\uFF0C\u56E0\u4E3A configurable \u4E3A false\u3002
 
 msg.change.property.data.to.accessor.with.configurable.false =\
-    无法将数据 “{0}” 的属性更改为访问者的属性，因为 configurable 为 false。
+    \u65E0\u6CD5\u5C06\u6570\u636E \u201C{0}\u201D \u7684\u5C5E\u6027\u66F4\u6539\u4E3A\u8BBF\u95EE\u8005\u7684\u5C5E\u6027\uFF0C\u56E0\u4E3A configurable \u4E3A false\u3002
 
 msg.change.property.accessor.to.data.with.configurable.false =\
-    无法将访问器 “{0}” 的属性更改为数据的属性，因为 configurable 为 false。
+    \u65E0\u6CD5\u5C06\u8BBF\u95EE\u5668 \u201C{0}\u201D \u7684\u5C5E\u6027\u66F4\u6539\u4E3A\u6570\u636E\u7684\u5C5E\u6027\uFF0C\u56E0\u4E3A configurable \u4E3A false\u3002
 
 msg.not.extensible =\
-    无法向此对象添加属性，因为 extensible 为 false。
+    \u65E0\u6CD5\u5411\u6B64\u5BF9\u8C61\u6DFB\u52A0\u5C5E\u6027\uFF0C\u56E0\u4E3A extensible \u4E3A false\u3002
 
 msg.delete.property.with.configurable.false =\
-    无法删除 “{0}” 属性，因为可配置为 false。
+    \u65E0\u6CD5\u5220\u9664 \u201C{0}\u201D \u5C5E\u6027\uFF0C\u56E0\u4E3A\u53EF\u914D\u7F6E\u4E3A false\u3002
 
 # TokenStream
 msg.missing.exponent =\
-    缺少一个指数
+    \u7F3A\u5C11\u4E00\u4E2A\u6307\u6570
 
 msg.caught.nfe =\
-    数字格式错误 {0}
+    \u6570\u5B57\u683C\u5F0F\u9519\u8BEF {0}
 
 msg.unterminated.string.lit =\
-    字符串文字没有限制
+    \u5B57\u7B26\u4E32\u6587\u5B57\u6CA1\u6709\u9650\u5236
 
 msg.unterminated.comment =\
-    注释没有限制
+    \u6CE8\u91CA\u6CA1\u6709\u9650\u5236
 
 msg.unterminated.re.lit =\
-    正则表达式文字没有限制
+    \u6B63\u5219\u8868\u8FBE\u5F0F\u6587\u5B57\u6CA1\u6709\u9650\u5236
 
 msg.invalid.re.flag =\
-    正则表达式后的标志 “{0}” 无效
+    \u6B63\u5219\u8868\u8FBE\u5F0F\u540E\u7684\u6807\u5FD7 \u201C{0}\u201D \u65E0\u6548
 
 msg.no.re.input.for =\
-    {0} 没有输入
+    {0} \u6CA1\u6709\u8F93\u5165
 
 msg.illegal.character =\
-    不允许的字符：“{0}”
+    \u4E0D\u5141\u8BB8\u7684\u5B57\u7B26\uFF1A\u201C{0}\u201D
 
 msg.invalid.escape =\
-    Unicode 转义序列不正确
+    Unicode \u8F6C\u4E49\u5E8F\u5217\u4E0D\u6B63\u786E
 
 msg.bad.namespace =\
-    不是有效的默认命名空间语句。 \
-    语法是：默认 xml 命名空间 = EXPRESSION;
+    \u4E0D\u662F\u6709\u6548\u7684\u9ED8\u8BA4\u547D\u540D\u7A7A\u95F4\u8BED\u53E5\u3002 \
+    \u8BED\u6CD5\u662F\uFF1A\u9ED8\u8BA4 xml \u547D\u540D\u7A7A\u95F4 = EXPRESSION;
 
 # TokensStream warnings
 msg.bad.octal.literal =\
-    字面量 {0} 的八进制数字是不允许的，将被解释为十进制数字
+    \u5B57\u9762\u91CF {0} \u7684\u516B\u8FDB\u5236\u6570\u5B57\u662F\u4E0D\u5141\u8BB8\u7684\uFF0C\u5C06\u88AB\u89E3\u91CA\u4E3A\u5341\u8FDB\u5236\u6570\u5B57
 
 msg.reserved.keyword =\
-    不允许使用将来的保留关键字 {0}，这将被解释为普通标识符
+    \u4E0D\u5141\u8BB8\u4F7F\u7528\u5C06\u6765\u7684\u4FDD\u7559\u5173\u952E\u5B57 {0}\uFF0C\u8FD9\u5C06\u88AB\u89E3\u91CA\u4E3A\u666E\u901A\u6807\u8BC6\u7B26
 
 # LiveConnect errors
 msg.java.internal.field.type =\
-    内部错误：将 {1} 分配给 {2} 的 {0} 类型转换失败。
+    \u5185\u90E8\u9519\u8BEF\uFF1A\u5C06 {1} \u5206\u914D\u7ED9 {2} \u7684 {0} \u7C7B\u578B\u8F6C\u6362\u5931\u8D25\u3002
 
 msg.java.conversion.implicit_method =\
-    在类 {1} 中找不到转换方法 “{0}”。
+    \u5728\u7C7B {1} \u4E2D\u627E\u4E0D\u5230\u8F6C\u6362\u65B9\u6CD5 \u201C{0}\u201D\u3002
 
 msg.java.method.assign =\
-    无法分配 Java 方法 “{0}”。
+    \u65E0\u6CD5\u5206\u914D Java \u65B9\u6CD5 \u201C{0}\u201D\u3002
 
 msg.java.internal.private =\
-    内部错误：检测到尝试访问受保护的私有字段 “{0}”。
+    \u5185\u90E8\u9519\u8BEF\uFF1A\u68C0\u6D4B\u5230\u5C1D\u8BD5\u8BBF\u95EE\u53D7\u4FDD\u62A4\u7684\u79C1\u6709\u5B57\u6BB5 \u201C{0}\u201D\u3002
 
 msg.java.no_such_method =\
-    找不到方法 “{0}”。
+    \u627E\u4E0D\u5230\u65B9\u6CD5 \u201C{0}\u201D\u3002
 
 msg.script.is.not.constructor =\
-    脚本对象不是构造函数。
+    \u811A\u672C\u5BF9\u8C61\u4E0D\u662F\u6784\u9020\u51FD\u6570\u3002
 
 msg.nonjava.method =\
-    Java 方法 “{0}” 被调用，{1} 作为“this”值，无法转换为 Java 类型 {2}。
+    Java \u65B9\u6CD5 \u201C{0}\u201D \u88AB\u8C03\u7528\uFF0C{1} \u4F5C\u4E3A\u201Cthis\u201D\u503C\uFF0C\u65E0\u6CD5\u8F6C\u6362\u4E3A Java \u7C7B\u578B {2}\u3002
 
 msg.java.member.not.found =\
-    Java 类 “{0}” 没有名为 “{1}” 的公共实例字段或方法。
+    Java \u7C7B \u201C{0}\u201D \u6CA1\u6709\u540D\u4E3A \u201C{1}\u201D \u7684\u516C\u5171\u5B9E\u4F8B\u5B57\u6BB5\u6216\u65B9\u6CD5\u3002
 
 msg.java.array.index.out.of.bounds =\
-    数组索引 {0} 超出范围 [0..{1}]。
+    \u6570\u7EC4\u7D22\u5F15 {0} \u8D85\u51FA\u8303\u56F4 [0..{1}]\u3002
 
 msg.java.array.member.not.found =\
-    Java 数组没有名为 “{0}” 的公共实例字段或方法。
+    Java \u6570\u7EC4\u6CA1\u6709\u540D\u4E3A \u201C{0}\u201D \u7684\u516C\u5171\u5B9E\u4F8B\u5B57\u6BB5\u6216\u65B9\u6CD5\u3002
 
 msg.pkg.int =\
-    Java 中的包名不能以数字开头。
+    Java \u4E2D\u7684\u5305\u540D\u4E0D\u80FD\u4EE5\u6570\u5B57\u5F00\u5934\u3002
 
 msg.access.prohibited =\
-    禁止访问 Java 类 “{0}”。
+    \u7981\u6B62\u8BBF\u95EE Java \u7C7B \u201C{0}\u201D\u3002
 
 # ImporterTopLevel
 msg.ambig.import =\
-    不明确的导入：“{0}” 和 “{1}”。
+    \u4E0D\u660E\u786E\u7684\u5BFC\u5165\uFF1A\u201C{0}\u201D \u548C \u201C{1}\u201D\u3002
 
 msg.not.pkg =\
-    调用 importPackage 函数必须使用包而不是 “{0}”。
+    \u8C03\u7528 importPackage \u51FD\u6570\u5FC5\u987B\u4F7F\u7528\u5305\u800C\u4E0D\u662F \u201C{0}\u201D\u3002
 
 msg.not.class =\
-    调用 importClass 函数必须使用类而不是 “{0}”。
+    \u8C03\u7528 importClass \u51FD\u6570\u5FC5\u987B\u4F7F\u7528\u7C7B\u800C\u4E0D\u662F \u201C{0}\u201D\u3002
 
 msg.not.class.not.pkg =\
-    “{0}” 既不是类也不是包。
+    \u201C{0}\u201D \u65E2\u4E0D\u662F\u7C7B\u4E5F\u4E0D\u662F\u5305\u3002
 
 msg.prop.defined =\
-    无法导入 “{0}”，因为该名称的属性已定义。
+    \u65E0\u6CD5\u5BFC\u5165 \u201C{0}\u201D\uFF0C\u56E0\u4E3A\u8BE5\u540D\u79F0\u7684\u5C5E\u6027\u5DF2\u5B9A\u4E49\u3002
 
 #JavaAdapter
 msg.adapter.zero.args =\
-    JavaAdapter 至少需要一个参数。
+    JavaAdapter \u81F3\u5C11\u9700\u8981\u4E00\u4E2A\u53C2\u6570\u3002
 
 msg.not.java.class.arg = \
-    参数 {0} 不是 Java 类：{1}。
+    \u53C2\u6570 {0} \u4E0D\u662F Java \u7C7B\uFF1A{1}\u3002
 
 #JavaAdapter
 msg.only.one.super = \
-    JavaAdapter 只能扩展一个类。已给出类 {0} 和 {1}。
+    JavaAdapter \u53EA\u80FD\u6269\u5C55\u4E00\u4E2A\u7C7B\u3002\u5DF2\u7ED9\u51FA\u7C7B {0} \u548C {1}\u3002
 
 # Arrays
 msg.arraylength.bad =\
-    数组长度不合适。
+    \u6570\u7EC4\u957F\u5EA6\u4E0D\u5408\u9002\u3002
 
 # Arrays
 msg.arraylength.too.big =\
-    数组 {0} 的长度超出了支持的容量限制。
+    \u6570\u7EC4 {0} \u7684\u957F\u5EA6\u8D85\u51FA\u4E86\u652F\u6301\u7684\u5BB9\u91CF\u9650\u5236\u3002
 
 msg.empty.array.reduce =\
-    “reduce” 方法在空数组上没有初始值时不起作用
+    \u201Creduce\u201D \u65B9\u6CD5\u5728\u7A7A\u6570\u7EC4\u4E0A\u6CA1\u6709\u521D\u59CB\u503C\u65F6\u4E0D\u8D77\u4F5C\u7528
 
 # URI
 msg.bad.uri =\
-    URI 序列的格式不正确。
+    URI \u5E8F\u5217\u7684\u683C\u5F0F\u4E0D\u6B63\u786E\u3002
 
 # Number
 msg.bad.precision =\
-    精度 {0} 超出范围。
+    \u7CBE\u5EA6 {0} \u8D85\u51FA\u8303\u56F4\u3002
 
 # NativeGenerator
 msg.send.newborn =\
-    在第一次调用 next() 之前不能调用生成器的 send() 方法
+    \u5728\u7B2C\u4E00\u6B21\u8C03\u7528 next() \u4E4B\u524D\u4E0D\u80FD\u8C03\u7528\u751F\u6210\u5668\u7684 send() \u65B9\u6CD5
 
 msg.already.exec.gen =\
-    生成器已经在运行
+    \u751F\u6210\u5668\u5DF2\u7ECF\u5728\u8FD0\u884C
 
 msg.StopIteration.invalid =\
-    StopIteration 异常不能更改为任意对象。
+    StopIteration \u5F02\u5E38\u4E0D\u80FD\u66F4\u6539\u4E3A\u4EFB\u610F\u5BF9\u8C61\u3002
 
 msg.generator.executing =\
-    生成器仍在执行先前的调用。
+    \u751F\u6210\u5668\u4ECD\u5728\u6267\u884C\u5148\u524D\u7684\u8C03\u7528\u3002


### PR DESCRIPTION
Converted all Chinese characters in Messages_zh_CN.properties into \uXXXX Unicode escape sequences.

ResourceBundle does not support reading UTF-8 encoded .properties files, resulting in incorrect character rendering in Chinese environments. Using Unicode escapes ensures proper loading of localized messages and resolves the garbled text issue.