### PR TITLE
Implement support for destructuring in `catch`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -1821,7 +1821,7 @@ public class Parser {
                         guardPos = -1,
                         catchLine = lineNumber(),
                         catchColumn = columnNumber();
-                Name varName = null;
+                AstNode varName = null;
                 AstNode catchCond = null;
 
                 switch (peekToken()) {
@@ -1829,27 +1829,41 @@ public class Parser {
                         {
                             matchToken(Token.LP, true);
                             lp = ts.tokenBeg;
-                            if (!matchToken(Token.UNDEFINED, true)) {
-                                mustMatchToken(Token.NAME, "msg.bad.catchcond", true);
-                            }
 
-                            varName = createNameNode();
-                            Comment jsdocNodeForName = getAndResetJsDoc();
-                            if (jsdocNodeForName != null) {
-                                varName.setJsDocNode(jsdocNodeForName);
-                            }
-                            String varNameString = varName.getIdentifier();
-                            if ("undefined".equals(varNameString)) {
-                                hasUndefinedBeenRedefined = true;
-                            }
-                            if (inUseStrictDirective) {
-                                if ("eval".equals(varNameString)
-                                        || "arguments".equals(varNameString)) {
-                                    reportError("msg.bad.id.strict", varNameString);
+                            int tt = peekToken();
+                            if (tt == Token.LB || tt == Token.LC) {
+                                // Destructuring pattern
+                                if (compilerEnv.getLanguageVersion() >= Context.VERSION_ES6) {
+                                    varName = destructuringPrimaryExpr();
+                                    markDestructuring(varName);
+                                } else {
+                                    reportError("msg.catch.destructuring.requires.es6");
+                                }
+                            } else {
+                                // Simple identifier
+                                if (!matchToken(Token.UNDEFINED, true)) {
+                                    mustMatchToken(Token.NAME, "msg.bad.catchcond", true);
+                                }
+
+                                varName = createNameNode();
+                                Comment jsdocNodeForName = getAndResetJsDoc();
+                                if (jsdocNodeForName != null) {
+                                    varName.setJsDocNode(jsdocNodeForName);
+                                }
+                                String varNameString = ((Name) varName).getIdentifier();
+                                if ("undefined".equals(varNameString)) {
+                                    hasUndefinedBeenRedefined = true;
+                                }
+                                if (inUseStrictDirective) {
+                                    if ("eval".equals(varNameString)
+                                            || "arguments".equals(varNameString)) {
+                                        reportError("msg.bad.id.strict", varNameString);
+                                    }
                                 }
                             }
 
-                            if (matchToken(Token.IF, true)) {
+                            // Non-standard extension: we support "catch (e if cond)
+                            if (varName instanceof Name && matchToken(Token.IF, true)) {
                                 guardPos = ts.tokenBeg;
                                 catchCond = expr(false);
                             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/ast/CatchClause.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/CatchClause.java
@@ -12,11 +12,13 @@ import org.mozilla.javascript.Token;
  * Node representing a catch-clause of a try-statement. Node type is {@link Token#CATCH}.
  *
  * <pre><i>CatchClause</i> :
- *        <b>catch</b> ( <i><b>Identifier</b></i> [<b>if</b> Expression] ) Block</pre>
+ *        <b>catch</b> ( <i><b>Identifier</b></i> [<b>if</b> Expression] ) Block
+ *        <b>catch</b> ( <i><b>ObjectPattern</b></i> ) Block
+ *        <b>catch</b> ( <i><b>ArrayPattern</b></i> ) Block</pre>
  */
 public class CatchClause extends AstNode {
 
-    private Name varName;
+    private AstNode varName;
     private AstNode catchCondition;
     private Scope body;
     private int ifPosition = -1;
@@ -40,20 +42,23 @@ public class CatchClause extends AstNode {
     /**
      * Returns catch variable node
      *
-     * @return catch variable
+     * @return catch variable (can be Name, ArrayLiteral, or ObjectLiteral)
      */
-    public Name getVarName() {
+    public AstNode getVarName() {
         return varName;
     }
 
     /**
      * Sets catch variable node, and sets its parent to this node.
      *
-     * @param varName catch variable
+     * @param varName catch variable (can be Name, ArrayLiteral, or ObjectLiteral)
      */
-    public void setVarName(Name varName) {
+    public void setVarName(AstNode varName) {
         this.varName = varName;
         if (varName != null) {
+            assert varName instanceof Name
+                    || varName instanceof ArrayLiteral
+                    || varName instanceof ObjectLiteral;
             varName.setParent(this);
         }
     }

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -492,6 +492,9 @@ msg.bad.catchcond =\
 msg.catch.unreachable =\
     any catch clauses following an unqualified catch are unreachable
 
+msg.catch.destructuring.requires.es6 =\
+    Destructuring in catch blocks requires ES6 or later
+
 msg.no.brace.try =\
     missing '{' before try block
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CatchDestructuringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CatchDestructuringTest.java
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+class CatchDestructuringTest {
+    @Test
+    void cannotUseObjectDestructuringInEs5() {
+        Utils.assertEvaluatorException_1_8(
+                "Destructuring in catch blocks requires ES6 or later (test#3)",
+                "try {\n"
+                        + "  throw new Error('test');\n"
+                        + "} catch ({message}) {\n"
+                        + "  message;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canUseObjectDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "hey",
+                "try {\n"
+                        + "  throw new Error('hey');\n"
+                        + "} catch ({message}) {\n"
+                        + "  message;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canUseObjectDestructuringWithRenaming() {
+        Utils.assertWithAllModes_ES6(
+                "hey",
+                "try {\n"
+                        + "  throw new Error('hey');\n"
+                        + "} catch ({message: m}) {\n"
+                        + "  m;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canUseNestedObjectDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "nested",
+                "try {\n"
+                        + "  throw {error: {code: 'nested'}};\n"
+                        + "} catch ({error: {code}}) {\n"
+                        + "  code;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canUseDefaultValuesInDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "default",
+                "try {\n"
+                        + "  throw {};\n"
+                        + "} catch ({message = 'default'}) {\n"
+                        + "  message;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void cannotUseObjectDestructuringAndConditions() {
+        Utils.assertEvaluatorExceptionES6(
+                "invalid catch block condition (test#3)",
+                "try {\n"
+                        + "  throw new Error('hey');\n"
+                        + "} catch ( {e} if e.message ) {\n"
+                        + "  e.message;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void cannotUseArrayDestructuringInEs5() {
+        Utils.assertEvaluatorException_1_8(
+                "Destructuring in catch blocks requires ES6 or later (test#3)",
+                "try {\n"
+                        + "  throw ['h', 'e', 'y']\n"
+                        + "} catch ([h, e, y]) {\n"
+                        + "  h + e + y;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canUseArrayDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "hey",
+                "try {\n"
+                        + "  throw ['h', 'e', 'y']\n"
+                        + "} catch ([h, e, y]) {\n"
+                        + "  h + e + y;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canSkipArrayElements() {
+        Utils.assertWithAllModes_ES6(
+                "c",
+                "try {\n"
+                        + "  throw ['a', 'b', 'c'];\n"
+                        + "} catch ([, , third]) {\n"
+                        + "  third;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canUseNestedArrayDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "b",
+                "try {\n"
+                        + "  throw [['a', 'b'], ['c', 'd']];\n"
+                        + "} catch ([[x, y], [z, w]]) {\n"
+                        + "  y;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canCombineObjectAndArrayDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "value",
+                "try {\n"
+                        + "  throw {data: ['value', 'other']};\n"
+                        + "} catch ({data: [first]}) {\n"
+                        + "  first;\n"
+                        + "}\n");
+    }
+
+    @Test
+    void canCombineArrayAndObjectDestructuring() {
+        Utils.assertWithAllModes_ES6(
+                "test",
+                "try {\n"
+                        + "  throw [{message: 'test'}];\n"
+                        + "} catch ([{message}]) {\n"
+                        + "  message;\n"
+                        + "}\n");
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.IOException;
 import java.util.List;
@@ -555,7 +556,7 @@ public class ParserTest {
         List<CatchClause> catchBlocks = tryStmt.getCatchClauses();
         CatchClause catchClause = catchBlocks.get(0);
         Scope catchVarBlock = catchClause.getBody();
-        Name catchVar = catchClause.getVarName();
+        Name catchVar = assertInstanceOf(Name.class, catchClause.getVarName());
         AstNode finallyBlock = tryStmt.getFinallyBlock();
         AstNode finallyStmt = (AstNode) finallyBlock.getFirstChild();
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -6786,48 +6786,23 @@ language/statements/switch 60/111 (54.05%)
 
 language/statements/throw 0/14 (0.0%)
 
-language/statements/try 113/201 (56.22%)
+language/statements/try 64/201 (31.84%)
     dstr/ary-init-iter-close.js
     dstr/ary-init-iter-get-err.js
     dstr/ary-init-iter-get-err-array-prototype.js
-    dstr/ary-init-iter-no-close.js
-    dstr/ary-name-iter-val.js
-    dstr/ary-ptrn-elem-ary-elem-init.js
-    dstr/ary-ptrn-elem-ary-elem-iter.js
     dstr/ary-ptrn-elem-ary-elision-init.js
-    dstr/ary-ptrn-elem-ary-elision-iter.js
-    dstr/ary-ptrn-elem-ary-empty-init.js
-    dstr/ary-ptrn-elem-ary-empty-iter.js
     dstr/ary-ptrn-elem-ary-rest-init.js
     dstr/ary-ptrn-elem-ary-rest-iter.js
-    dstr/ary-ptrn-elem-ary-val-null.js
-    dstr/ary-ptrn-elem-id-init-exhausted.js
     dstr/ary-ptrn-elem-id-init-fn-name-arrow.js
     dstr/ary-ptrn-elem-id-init-fn-name-class.js
     dstr/ary-ptrn-elem-id-init-fn-name-cover.js
     dstr/ary-ptrn-elem-id-init-fn-name-fn.js
     dstr/ary-ptrn-elem-id-init-fn-name-gen.js
-    dstr/ary-ptrn-elem-id-init-hole.js
-    dstr/ary-ptrn-elem-id-init-skipped.js
-    dstr/ary-ptrn-elem-id-init-throws.js
-    dstr/ary-ptrn-elem-id-init-undef.js
-    dstr/ary-ptrn-elem-id-init-unresolvable.js
-    dstr/ary-ptrn-elem-id-iter-complete.js
-    dstr/ary-ptrn-elem-id-iter-done.js
     dstr/ary-ptrn-elem-id-iter-step-err.js
-    dstr/ary-ptrn-elem-id-iter-val.js
     dstr/ary-ptrn-elem-id-iter-val-array-prototype.js
     dstr/ary-ptrn-elem-id-iter-val-err.js
-    dstr/ary-ptrn-elem-obj-id.js
-    dstr/ary-ptrn-elem-obj-id-init.js
-    dstr/ary-ptrn-elem-obj-prop-id.js
-    dstr/ary-ptrn-elem-obj-prop-id-init.js
-    dstr/ary-ptrn-elem-obj-val-null.js
-    dstr/ary-ptrn-elem-obj-val-undef.js
     dstr/ary-ptrn-elision.js
-    dstr/ary-ptrn-elision-exhausted.js
     dstr/ary-ptrn-elision-step-err.js
-    dstr/ary-ptrn-empty.js
     dstr/ary-ptrn-rest-ary-elem.js
     dstr/ary-ptrn-rest-ary-elision.js
     dstr/ary-ptrn-rest-ary-empty.js
@@ -6843,34 +6818,12 @@ language/statements/try 113/201 (56.22%)
     dstr/ary-ptrn-rest-obj-prop-id.js
     dstr/obj-init-null.js
     dstr/obj-init-undefined.js
-    dstr/obj-ptrn-empty.js
-    dstr/obj-ptrn-id-get-value-err.js
     dstr/obj-ptrn-id-init-fn-name-arrow.js
     dstr/obj-ptrn-id-init-fn-name-class.js
     dstr/obj-ptrn-id-init-fn-name-cover.js
     dstr/obj-ptrn-id-init-fn-name-fn.js
     dstr/obj-ptrn-id-init-fn-name-gen.js
-    dstr/obj-ptrn-id-init-skipped.js
-    dstr/obj-ptrn-id-init-throws.js
-    dstr/obj-ptrn-id-init-unresolvable.js
-    dstr/obj-ptrn-id-trailing-comma.js
-    dstr/obj-ptrn-list-err.js
-    dstr/obj-ptrn-prop-ary.js
-    dstr/obj-ptrn-prop-ary-init.js
-    dstr/obj-ptrn-prop-ary-trailing-comma.js
-    dstr/obj-ptrn-prop-ary-value-null.js
     dstr/obj-ptrn-prop-eval-err.js
-    dstr/obj-ptrn-prop-id.js
-    dstr/obj-ptrn-prop-id-get-value-err.js
-    dstr/obj-ptrn-prop-id-init.js
-    dstr/obj-ptrn-prop-id-init-skipped.js
-    dstr/obj-ptrn-prop-id-init-throws.js
-    dstr/obj-ptrn-prop-id-init-unresolvable.js
-    dstr/obj-ptrn-prop-id-trailing-comma.js
-    dstr/obj-ptrn-prop-obj.js
-    dstr/obj-ptrn-prop-obj-init.js
-    dstr/obj-ptrn-prop-obj-value-null.js
-    dstr/obj-ptrn-prop-obj-value-undef.js
     dstr/obj-ptrn-rest-getter.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-skip-non-enumerable.js {unsupported: [object-rest]}
     dstr/obj-ptrn-rest-val-obj.js {unsupported: [object-rest]}
@@ -6894,8 +6847,6 @@ language/statements/try 113/201 (56.22%)
     early-catch-function.js
     early-catch-lex.js
     scope-catch-block-lex-open.js
-    scope-catch-param-lex-open.js
-    scope-catch-param-var-none.js non-strict
     static-init-await-binding-valid.js
     tco-catch.js {unsupported: [tail-call-optimization]}
     tco-catch-finally.js {unsupported: [tail-call-optimization]}


### PR DESCRIPTION
Extend the parser and IR to support things like `catch ({message})` or `catch ([a, b])`.

Note that, while Rhino supports a non-standard extension for conditions in catch clauses, i.e. `catch (a if b)`, I have opted to _not_ support it if we have a destructuring expression.

The implementation does this:

- at parse time, we rely on pre-existing functions
- the AST node for `CatchClause` was made more generic, and will now contain either the name or the destructuring expression
- during the IR generation, from:

```js
catch ( {message} ) { 
  body
}
```

we generate:

```js
catch ( $tempname ) { 
  let {message} = $tempname;
  body
}
```

---

Fixes https://github.com/mozilla/rhino/issues/2194