### PR TITLE
Initialise `CallSite` against top level scope.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -39,7 +39,7 @@ final class NativeError extends IdScriptableObject {
         obj.setAttributes("name", DONTENUM);
         obj.setAttributes("message", DONTENUM);
         obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
-        NativeCallSite.init(obj, sealed);
+        NativeCallSite.init(scope, sealed);
     }
 
     static NativeError makeProto(Scriptable scope, Function ctorObj) {


### PR DESCRIPTION
`NativeCallsite.init` is currently called with the scope being the `Error` constructor, but we still end up with `NativeCallSite`'s constructor in the top level scope under the name `CallSite`. This seems wrong, and fixing this doesn't appear to break anything, but I thought it was worth its own PR because it is an odd change, and deserves some scrutiny.