### PR TITLE
Fixed an off-by-one error in the lexer when encountering EOF

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TokenStream.java
@@ -2261,8 +2261,18 @@ class TokenStream implements Parser.CurrentPositionReporter {
         // skip to end of line
         int c;
         while ((c = getChar()) != EOF_CHAR && c != '\n') {}
-        ungetChar(c);
-        tokenEnd = cursor;
+        if (c == EOF_CHAR) {
+            // If we've hit EOF, the cursor hasn't been incremented, so we need to save tokenEnd
+            // _before_ ungetChar
+            tokenEnd = cursor;
+            ungetChar(c);
+        } else {
+            // If we've hit a newline, the cursor has been incremented past it, and ungetChar will
+            // point at the newline, so saving tokenEnd after ungetChar will correctly exclude the
+            // newline
+            ungetChar(c);
+            tokenEnd = cursor;
+        }
     }
 
     /** Returns the offset into the current line. */

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -1498,6 +1498,18 @@ public class ParserTest {
                 new String[] {"Missing = in destructuring declaration", "syntax error"});
     }
 
+    @Test
+    public void commentValueIsNotTruncatedBecauseOfEof() {
+        String source = "// comment";
+
+        AstRoot root = parse(source);
+        assertNotNull(root.getComments());
+        assertEquals(1, root.getComments().size());
+        Comment comment = root.getComments().first();
+        assertEquals(source, comment.getValue());
+        assertEquals(10, comment.getLength());
+    }
+
     private void expectParseErrors(String string, String[] errors) {
         parse(string, errors, null, false);
     }


### PR DESCRIPTION
Small change in the lexer for handling correctly EOF and `ungetChar`. Hopefully the code and comments are self-explanatory.

Fixes https://github.com/mozilla/rhino/issues/2151