### PR TITLE
Handle rest parameters in destructuring gracefully

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -4920,7 +4920,10 @@ public class Parser {
         boolean defaultValuesSetup = false;
 
         for (AbstractObjectProperty abstractProp : node.getElements()) {
-            if (abstractProp instanceof SpreadObjectProperty) throw Kit.codeBug();
+            if (abstractProp instanceof SpreadObjectProperty) {
+                reportError("msg.no.object.rest");
+                return false;
+            }
             ObjectProperty prop = (ObjectProperty) abstractProp;
 
             int lineno = 0, column = 0;

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -348,6 +348,9 @@ msg.no.paren.after.parms =\
 msg.parm.after.rest =\
     parameter after rest parameter
 
+msg.no.object.rest =\
+    object rest properties in destructuring are not supported
+
 msg.no.brace.body =\
     missing '{' before function body
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/ObjectRestErrorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ObjectRestErrorTest.java
@@ -1,0 +1,29 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/** Object rest in destructuring throws SyntaxError */
+public class ObjectRestErrorTest {
+
+    @Test
+    public void objectRestThrowsSyntaxError() {
+        Utils.assertEvaluatorExceptionES6(
+                "object rest properties in destructuring are not supported",
+                "function f() { var { a, ...rest } = { a: 1, b: 2, c: 3 }; }");
+    }
+
+    @Test
+    public void objectRestInFunctionParamThrowsSyntaxError() {
+        Utils.assertEvaluatorExceptionES6(
+                "object rest properties in destructuring are not supported",
+                "function f({ a, ...rest }) { return rest; }");
+    }
+
+    @Test
+    public void objectRestInVariableDeclarationThrowsSyntaxError() {
+        Utils.assertEvaluatorExceptionES6(
+                "object rest properties in destructuring are not supported",
+                "var { a, ...rest } = { a: 1, b: 2, c: 3 };");
+    }
+}


### PR DESCRIPTION
Fixes #2220. Throws a syntax error as expected instead of throwing a `Kit.codeBug()`.

Related: https://github.com/mozilla/rhino/pull/2207 implements support for rest parameters in destructuring.