### PR TITLE
reorganize LiveConnect related decycle rules

### DIFF
--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -85,22 +85,38 @@ decycle {
     // TODO: easy to remove: See #1890
     ignoring from: "org.mozilla.classfile.ClassFileWriter\$StackMapTable", to: "org.mozilla.javascript.Kit"
 
-    // TODO: Long-term-plan: LiveConnect should be moved to a separate module
-    // TODO: Move all "Native*" classes to o.m.j.lc
-    ignoring from: "org.mozilla.javascript.Native*", to: "org.mozilla.javascript.lc.type.TypeInfo*"
-    // CHECKME: Can we move JavaMembers + MemberBox also to o.m.j.lc
-    ignoring from: "org.mozilla.javascript.JavaMembers", to: "org.mozilla.javascript.lc.type.TypeInfo*"
-    ignoring from: "org.mozilla.javascript.MemberBox", to: "org.mozilla.javascript.lc.type.*"
-    ignoring from: "org.mozilla.javascript.AccessorSlot\$MemberBoxSetter", to: "org.mozilla.javascript.lc.type.TypeInfo"
-    // CHECKME: Can we remove dependency to typeinfo from these objects?
+    /// --- LiveConnect start ---
+
+    // references from LiveConnect to LiveConnect
+    ignoring(from: "org.mozilla.javascript.lc.**", to: "org.mozilla.javascript.lc.**")
+
+    // LiveConnect classes in root package
+    // TODO: Move them to LiveConnect module
+    ignoring(
+        from: "org.mozilla.javascript.(Native*|JavaMembers|MemberBox|AccessorSlot\$MemberBoxSetter|FieldAndMethods|InterfaceAdapter|WrapFactory)",
+        to: "org.mozilla.javascript.lc.**"
+    )
+
+    // In theory, this is also LiveConnect classes in root package, but Rhino is using one of
+    // its methods to create instance from compiled script
+    ignoring from: "org.mozilla.javascript.JavaAdapter", to: "org.mozilla.javascript.lc.**"
+
+    // `ScriptableObject#defineProperty(...)` allows using methods to build getter/setter
+    // Given that its reflection usage is rather simple, we should be able to replace it with a small helper class
     ignoring from: "org.mozilla.javascript.ScriptableObject", to: "org.mozilla.javascript.lc.type.TypeInfoFactory"
+
+    // `new FunctionObject(String, Member, Scriptable)` allows using method/constructor to build function
+    // similar to ScriptableObject, its reflection usage is rather basic
     ignoring from: "org.mozilla.javascript.FunctionObject", to: "org.mozilla.javascript.lc.type.TypeInfo*"
+
+    // `Context#jsToJava(...)` used TypeInfo and TypeInfoFactory
+    // removing this is absolutely a breaking change, wait until 2.0.0
     ignoring from: "org.mozilla.javascript.Context", to: "org.mozilla.javascript.lc.type.TypeInfo*"
-    ignoring from: "org.mozilla.javascript.ScriptRuntime", to: "org.mozilla.javascript.lc.type.TypeInfoFactory"
+
+    // `ScriptRuntime.initSafeStandardObjects(...)` called `new ConcurrentFactory().associate(scope)`
+    // can be resolved by moving this to future `LiveConnectBridge`
+    ignoring from: "org.mozilla.javascript.ScriptRuntime", to: "org.mozilla.javascript.lc.type.*"
     ignoring from: "org.mozilla.javascript.ScriptRuntime", to: "org.mozilla.javascript.lc.type.impl.factory.ConcurrentFactory"
 
-    // currently accepted cycles (may be resolved, when it is clear, how to separate the liveconnect stuff)
-    ignoring from: "org.mozilla.javascript.lc.type.*", to: "org.mozilla.javascript.(Scriptable|ScriptableObject)"
-    ignoring from: "org.mozilla.javascript.lc.type.TypeInfoFactory", to: "org.mozilla.javascript.lc.type.impl.factory.*"
-    ignoring from: "org.mozilla.javascript.lc.type.*", to: "org.mozilla.javascript.lc.type.impl.*"
+    /// --- LiveConnect end ---
 }


### PR DESCRIPTION
In https://github.com/mozilla/rhino/pull/2201#discussion_r2599401122 @aardvark179 mentioned that we keep having to fix the decycle rules, especially LiveConnect related ones, during development. This PR reorganized LiveConnect related decycle rules, so that they are more lenient and concise.

Changes in this PR:
- added a wildcard rule to ignore all references within `lc` package
- rules for LiveConnect classes in root package are handled via a single "A or B or C" style rule
- explanation and possible solution for each package cycle