### PR TITLE
simplify serialization of `MemberBox`

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -31,7 +31,7 @@ import org.mozilla.javascript.lc.type.VariableTypeInfo;
  * @author Igor Bukanov
  */
 final class MemberBox implements Serializable {
-    private static final long serialVersionUID = 6358550398665688245L;
+    private static final long serialVersionUID = 8260700214130563887L;
 
     private transient Member memberObject;
     private transient List<TypeInfo> argTypeInfos;


### PR DESCRIPTION
1. There's a boolean at the start of serialized data, representing whether the `member` is present. This PR removed this because `MemberBox` is an internal class and never has its `member` set to `null`
2. The writing/reading of parameter types is rewritten to read/write method descriptor string, which can be converted from/to parameter types array via `MethodType`.
3. `serialVersionUID` updated to reflect serialization logic change