### PR TITLE
prevent Field/Method/Constructor to be directly accessible in JS code

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
@@ -8,6 +8,7 @@
 
 package org.mozilla.javascript;
 
+import java.lang.reflect.AccessibleObject;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,11 @@ public class WrapFactory {
 
     public Scriptable wrapAsJavaObject(
             Context cx, Scriptable scope, Object javaObject, TypeInfo staticType) {
+        if (javaObject instanceof AccessibleObject) {
+            // Field, Method, Constructor
+            return Undefined.SCRIPTABLE_UNDEFINED;
+        }
+
         if (staticType.shouldReplace() && javaObject != null) {
             staticType =
                     TypeInfoFactory.getOrElse(scope, TypeInfoFactory.GLOBAL)


### PR DESCRIPTION
```javascript
/** @type {java.lang.Class} */
let c = ...;

// these operations below will now always return `undefined`
c.getMethod("name", argTypes)
c.getField("name", type)
c.getConstructor(types)
c.getMethods()[i]
```

`Class` itself is not denied, because I believe after this PR, `Class` is more or less a safe type.
`ClassLoader` also not denied, because it seems that the only potentially dangerous usage is `classLoader.loadClass("some.forbidden.clazz.Here")`, which just gives a `Class`.

I believe directly using reflection in JS code is an incredibly rare use case, but technically this is still a breaking change.