### PR TITLE
Support reserved words in XML attribute names.

### DIFF
--- a/tests/src/test/java/org/mozilla/javascript/tests/XMLReservedWordsAttributesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/XMLReservedWordsAttributesTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/xml-reserved-words-as-attributes.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class XMLReservedWordsAttributesTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/xml-reserved-words-as-attributes.js
+++ b/tests/testsrc/jstests/xml-reserved-words-as-attributes.js
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Test that reserved words can be used as both XML attribute names
+// and as part of a name space qualified name.
+
+load('testsrc/assert.js');
+
+x =
+<alpha>
+    <bravo for="value1" ns:for="value3" xmlns:ns="http://someuri">
+        <charlie class="value2" ns:class="value4"/>
+    </bravo>
+</alpha>
+
+assertEquals("value1", x.bravo.@for.toXMLString());
+assertEquals("value2", x.bravo.charlie.@class.toXMLString());
+n = new Namespace("http://someuri");
+assertEquals("value3", x.bravo.@n::for.toXMLString());
+assertEquals("value4", x.bravo.charlie.@n::class.toXMLString());
+
+"success"


### PR DESCRIPTION
This updates the XML attribute access parsing code to match the main property access parsing code. This has the same behaviour regarding reserved words as property names. This should hopefully fix #2258.