### PR TITLE
Fix double-evaluation of Date constructor arguments

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeDate.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeDate.java
@@ -925,7 +925,7 @@ final class NativeDate extends IdScriptableObject {
                 if (Double.isNaN(d) || Double.isInfinite(d)) {
                     return ScriptRuntime.NaN;
                 }
-                array[loop] = ScriptRuntime.toInteger(args[loop]);
+                array[loop] = ScriptRuntime.toInteger(d);
             } else {
                 if (loop == 2) {
                     array[loop] = 1; /* Default the date argument to 1. */

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -775,7 +775,7 @@ built-ins/DataView 86/561 (15.33%)
     toindex-bytelength-sab.js {unsupported: [SharedArrayBuffer]}
     toindex-byteoffset-sab.js {unsupported: [SharedArrayBuffer]}
 
-built-ins/Date 85/594 (14.31%)
+built-ins/Date 83/594 (13.97%)
     now/not-a-constructor.js
     parse/not-a-constructor.js
     parse/year-zero.js
@@ -846,10 +846,8 @@ built-ins/Date 85/594 (14.31%)
     prototype/valueOf/not-a-constructor.js
     prototype/valueOf/S9.4_A3_T1.js
     prototype/no-date-value.js
-    UTC/coercion-order.js
     UTC/fp-evaluation-order.js
     UTC/not-a-constructor.js
-    coercion-order.js
     proto-from-ctor-realm-one.js
     proto-from-ctor-realm-two.js
     proto-from-ctor-realm-zero.js


### PR DESCRIPTION
The date_msecFromArgs function was calling toNumber() and then toInteger() on the same argument, which caused the argument's toString/valueOf to be called twice. Fixed by using the already-computed number value when converting to integer.

Fixes 2 test262 tests:
- built-ins/Date/UTC/coercion-order.js
- built-ins/Date/coercion-order.js