### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ this using the command:
     ./gradlew -q javaToolchains
 
 Not all installers seem to put JDKs in the places where Gradle can find them. When in doubt,
-installatioons from [Adoptium](https://adoptium.net) seem to work on most platforms.
+installations from [Adoptium](https://adoptium.net) seem to work on most platforms.
 
 ### Testing on Android
 


### PR DESCRIPTION
This PR fixes a minor typo in the `README.md` file under the **Testing on other Java Versions** section.

**Correction:**
 `installatioons` → `installations`