### PR TITLE
Downgrade spotless to a working version.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.2.1'
+    implementation 'com.diffplug.spotless:spotless-plugin-gradle:8.2.0'
     implementation 'net.ltgt.gradle:gradle-errorprone-plugin:4.3.0'
     implementation 'de.obqo.decycle:de.obqo.decycle.gradle.plugin:1.2.3'
 }


### PR DESCRIPTION
The latest version of spotless appears to have broken. At 2.8.0 I get the expected output (for formatting warnings etc.) but at 2.8.1 I just get things like

```
> There were 18 lint error(s), they must be fixed or suppressed.
  src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/QName.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XML.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLCtor.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLLoaderImpl.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLName.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XMLWithScope.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XmlNode.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/main/java/org/mozilla/javascript/xmlimpl/XmlProcessor.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/test/java/org/mozilla/javascript/tests/CustomTestDBF.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/test/java/org/mozilla/javascript/tests/XMLSecureParserTest.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/test/java/org/mozilla/javascript/xmlimpl/tests/E4XBasicTest.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/test/java/org/mozilla/javascript/xmlimpl/tests/NonResettableDocumentBuilder.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/test/java/org/mozilla/javascript/xmlimpl/tests/NonResettableDocumentBuilderFactory.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  src/test/java/org/mozilla/javascript/xmlimpl/tests/XmlNonResettableDocumentBuilderTest.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/base/Throwables (...)
  Resolve these lints or suppress with `suppressLintsFor`
```

I'll try and debug why that is occurring, but I think it's worth downgrading until this is sorted out.