### PR TITLE
Fix IdFunctionObject.isConstructor() to return useCallAsConstructor

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -108,6 +108,11 @@ public class IdFunctionObject extends BaseFunction {
     }
 
     @Override
+    public boolean isConstructor() {
+        return useCallAsConstructor;
+    }
+
+    @Override
     public String getFunctionName() {
         return (functionName == null) ? "" : functionName;
     }

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -804,10 +804,8 @@ built-ins/Date 35/594 (5.89%)
 
 ~built-ins/DisposableStack 91/91 (100.0%)
 
-built-ins/Error 7/53 (13.21%)
+built-ins/Error 5/53 (9.43%)
     isError/error-subclass.js {unsupported: [class]}
-    isError/is-a-constructor.js
-    prototype/toString/not-a-constructor.js
     prototype/no-error-data.js
     prototype/S15.11.4_A2.js
     cause_abrupt.js
@@ -1966,7 +1964,7 @@ built-ins/Reflect 11/153 (7.19%)
     set/return-false-if-receiver-is-not-writable.js
     set/return-false-if-target-is-not-writable.js
 
-built-ins/RegExp 701/1868 (37.53%)
+built-ins/RegExp 691/1868 (36.99%)
     CharacterClassEscapes 12/12 (100.0%)
     dotall 4/4 (100.0%)
     escape 20/20 (100.0%)
@@ -2319,7 +2317,6 @@ built-ins/RegExp 701/1868 (37.53%)
     prototype/dotAll 8/8 (100.0%)
     prototype/exec/duplicate-named-indices-groups-properties.js
     prototype/exec/failure-lastindex-access.js
-    prototype/exec/not-a-constructor.js
     prototype/exec/regexp-builtin-exec-v-u-flag.js
     prototype/exec/S15.10.6.2_A5_T3.js
     prototype/exec/success-lastindex-access.js
@@ -2371,7 +2368,6 @@ built-ins/RegExp 701/1868 (37.53%)
     prototype/sticky/this-val-regexp-prototype.js
     prototype/Symbol.matchAll/isregexp-called-once.js
     prototype/Symbol.matchAll/isregexp-this-throws.js
-    prototype/Symbol.matchAll/not-a-constructor.js
     prototype/Symbol.matchAll/this-get-flags.js
     prototype/Symbol.matchAll/this-not-object-throws.js
     prototype/Symbol.matchAll/this-tostring-flags.js
@@ -2383,25 +2379,17 @@ built-ins/RegExp 701/1868 (37.53%)
     prototype/Symbol.match/g-get-exec-err.js
     prototype/Symbol.match/get-global-err.js
     prototype/Symbol.match/get-unicode-error.js
-    prototype/Symbol.match/not-a-constructor.js
     prototype/Symbol.replace/coerce-global.js
     prototype/Symbol.replace/coerce-unicode.js
     prototype/Symbol.replace/get-global-err.js
     prototype/Symbol.replace/get-unicode-error.js
-    prototype/Symbol.replace/not-a-constructor.js
     prototype/Symbol.search/cstm-exec-return-invalid.js
-    prototype/Symbol.search/not-a-constructor.js
     prototype/Symbol.search/set-lastindex-init-err.js
     prototype/Symbol.search/set-lastindex-init-samevalue.js
     prototype/Symbol.search/set-lastindex-restore-err.js
     prototype/Symbol.search/set-lastindex-restore-samevalue.js
-    prototype/Symbol.split/not-a-constructor.js
     prototype/Symbol.split/this-val-non-obj.js
-    prototype/test/not-a-constructor.js
     prototype/test/S15.10.6.3_A1_T22.js
-    prototype/toString/not-a-constructor.js
-    prototype/toString/S15.10.6.4_A6.js
-    prototype/toString/S15.10.6.4_A7.js
     prototype/unicodeSets/cross-realm.js
     prototype/unicodeSets/length.js
     prototype/unicodeSets/name.js


### PR DESCRIPTION
Built-in methods like Date.prototype.getDate, RegExp.prototype.exec, etc. were incorrectly reporting as constructors even though calling them with 'new' would throw TypeError. This caused 65 test262 "not-a-constructor" tests to fail.

The fix adds an isConstructor() override that returns the existing useCallAsConstructor field, which is only set to true for functions explicitly marked as constructors via markAsConstructor().