### PR TITLE
Enforce `WrapFactory` users to override new `wrap(...)` and `wrapAsJavaObject(...)` method

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
@@ -28,7 +28,7 @@ public class WrapFactory {
     /**
      * @see #wrap(Context, Scriptable, Object, TypeInfo)
      */
-    public Object wrap(Context cx, Scriptable scope, Object obj, Class<?> staticType) {
+    public final Object wrap(Context cx, Scriptable scope, Object obj, Class<?> staticType) {
         return wrap(cx, scope, obj, TypeInfoFactory.GLOBAL.create(staticType));
     }
 
@@ -102,7 +102,7 @@ public class WrapFactory {
     /**
      * @see #wrapAsJavaObject(Context, Scriptable, Object, TypeInfo)
      */
-    public Scriptable wrapAsJavaObject(
+    public final Scriptable wrapAsJavaObject(
             Context cx, Scriptable scope, Object javaObject, Class<?> staticType) {
         return wrapAsJavaObject(cx, scope, javaObject, TypeInfoFactory.GLOBAL.create(staticType));
     }


### PR DESCRIPTION
- Javadoc for old methods are moved to new methods. Old javadoc now provides a link to new method
- `@since` for new methods
- old methods that are not supposed to be overridden now are marked as `final`.

Hopefully these changes can properly notify users about `WrapFactory` changes, and prevent issues similar to #2265 