### PR TITLE
Fix generator .return() to include value when in completed state

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -321,6 +321,7 @@ public final class ES6Generator extends ScriptableObject {
             if (op == NativeGenerator.GENERATOR_THROW) {
                 throw new JavaScriptException(value, lineSource, lineNumber);
             }
+            ScriptableObject.putProperty(result, ES6Iterator.VALUE_PROPERTY, value);
             ScriptableObject.putProperty(result, ES6Iterator.DONE_PROPERTY, Boolean.TRUE);
             return result;
         }

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -939,11 +939,9 @@ built-ins/GeneratorFunction 4/23 (17.39%)
     name.js
     proto-from-ctor-realm-prototype.js
 
-built-ins/GeneratorPrototype 6/61 (9.84%)
+built-ins/GeneratorPrototype 4/61 (6.56%)
     next/from-state-executing.js
-    return/from-state-completed.js
     return/from-state-executing.js
-    return/from-state-suspended-start.js
     throw/from-state-executing.js
     constructor.js
 


### PR DESCRIPTION
When .return(value) is called on a completed generator, set the value property on the result object instead of returning undefined.