### PR TITLE
Fix uint8 overflow in array literal skipIndexesId and sourcePositions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:  
 
 permissions: read-all
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The current release is <a href="https://github.com/mozilla/rhino/releases/tag/Rh
 
 <details><summary>Releases</summary>
 <table>
+<tr><td><a href="https://github.com/mozilla/rhino/releases/tag/Rhino1_9_1_Release">Rhino 1.9.1</a></td><td>February 15, 2026</td></tr>
 <tr><td><a href="https://github.com/mozilla/rhino/releases/tag/Rhino1_9_0_Release">Rhino 1.9.0</a></td><td>December 22, 2025</td></tr>
 <tr><td><a href="https://github.com/mozilla/rhino/releases/tag/Rhino1_8_1_Release">Rhino 1.8.1</a></td><td>December 2, 2025</td></tr>
 <tr><td><a href="https://github.com/mozilla/rhino/releases/tag/Rhino1_8_0_Release">Rhino 1.8.0</a></td><td>January 2, 2025</td></tr>

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ this using the command:
     ./gradlew -q javaToolchains
 
 Not all installers seem to put JDKs in the places where Gradle can find them. When in doubt,
-installatioons from [Adoptium](https://adoptium.net) seem to work on most platforms.
+installations from [Adoptium](https://adoptium.net) seem to work on most platforms.
 
 ### Testing on Android
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,5 @@
 # Rhino 1.9.1
-## February 10, 2026
+## February 15, 2026
 
 This release fixes a few small regressions introduced in Rhino 1.9.0.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,15 @@
+# Rhino 1.9.1
+## February 10, 2026
+
+This release fixes a few small regressions introduced in Rhino 1.9.0.
+
+* Ensure that the "global" object is present, necessary for core-js to run
+* Prevent compiled methods from introducing illegal characters in their names
+* Support reserved words like "class" as names of XML attributes
+* Fix a performance regression in the RegExp engine.
+
+Thanks to all who contributed!
+
 # Rhino 1.9.0
 ## December 22, 2025
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=rhino-root
 group=org.mozilla
-version=1.9.0
+version=1.9.1-SNAPSHOT
 mavenReleaseRepo=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 mavenSnapshotRepo=https://oss.sonatype.org/content/repositories/snapshots
 githubPackagesRepo=https://maven.pkg.github.com/mozilla/rhino

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=rhino-root
 group=org.mozilla
-version=1.9.1-SNAPSHOT
+version=1.9.1
 mavenReleaseRepo=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 mavenSnapshotRepo=https://oss.sonatype.org/content/repositories/snapshots
 githubPackagesRepo=https://maven.pkg.github.com/mozilla/rhino

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=rhino-root
 group=org.mozilla
-version=1.9.1
+version=1.9.1-PATCHED
 mavenReleaseRepo=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 mavenSnapshotRepo=https://oss.sonatype.org/content/repositories/snapshots
 githubPackagesRepo=https://maven.pkg.github.com/mozilla/rhino

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
@@ -1,57 +1,46 @@
 package org.mozilla.javascript;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /** Abstract operations for string manipulation as defined by EcmaScript */
 public class AbstractEcmaStringOperations {
-    /**
-     * GetSubstitution(matched, str, position, captures, namedCaptures, replacementTemplate)
-     *
-     * <p><a
-     * href="https://tc39.es/ecma262/multipage/text-processing.html#sec-getsubstitution">22.1.3.19.1
-     * GetSubstitution (matched, str, position, captures, namedCaptures, replacementTemplate)</a>
-     */
-    public static String getSubstitution(
-            Context cx,
-            Scriptable scope,
-            String matched,
-            String str,
-            int position,
-            NativeArray capturesArray,
-            Object namedCaptures,
-            String replacementTemplate) {
-        // See ECMAScript spec 22.1.3.19.1
-        int stringLength = str.length();
-        if (position > stringLength) Kit.codeBug();
-        StringBuilder result = new StringBuilder();
-        String templateRemainder = replacementTemplate;
-        while (!templateRemainder.isEmpty()) {
-            String ref = templateRemainder.substring(0, 1);
-            String refReplacement = ref;
 
-            if (templateRemainder.charAt(0) == '$') {
-                if (templateRemainder.length() > 1) {
-                    char c = templateRemainder.charAt(1);
+    public static List<ReplacementOperation> buildReplacementList(String replacementTemplate) {
+        List<ReplacementOperation> ops = new ArrayList<>();
+        int position = 0;
+        int start = 0;
+
+        while (position < replacementTemplate.length()) {
+            if (replacementTemplate.charAt(position) == '$') {
+                if (position < (replacementTemplate.length() - 1)) {
+                    if (start != position) {
+                        ops.add(
+                                new LiteralReplacement(
+                                        replacementTemplate.substring(start, position)));
+                    }
+                    String ref = replacementTemplate.substring(position, position + 1);
+                    char c = replacementTemplate.charAt(position + 1);
                     switch (c) {
                         case '$':
                             ref = "$$";
-                            refReplacement = "$";
+                            ops.add(new LiteralReplacement("$"));
                             break;
 
                         case '`':
                             ref = "$`";
-                            refReplacement = str.substring(0, position);
+                            ops.add(new FromStartToMatchReplacement());
                             break;
 
                         case '&':
                             ref = "$&";
-                            refReplacement = matched;
+                            ops.add(new MatchedReplacement());
                             break;
 
                         case '\'':
                             {
                                 ref = "$'";
-                                int matchLength = matched.length();
-                                int tailPos = position + matchLength;
-                                refReplacement = str.substring(Math.min(tailPos, stringLength));
+                                ops.add(new FromMatchToEndReplacement());
                                 break;
                             }
 
@@ -67,66 +56,78 @@ public class AbstractEcmaStringOperations {
                         case '9':
                             {
                                 int digitCount = 1;
-                                if (templateRemainder.length() > 2) {
-                                    char c2 = templateRemainder.charAt(2);
+                                if (replacementTemplate.length() > position + 2) {
+                                    char c2 = replacementTemplate.charAt(position + 2);
                                     if (isAsciiDigit(c2)) {
                                         digitCount = 2;
                                     }
                                 }
-                                String digits = templateRemainder.substring(1, 1 + digitCount);
+                                String digits =
+                                        replacementTemplate.substring(
+                                                position + 1, position + 1 + digitCount);
+                                ref =
+                                        replacementTemplate.substring(
+                                                position, position + 1 + digitCount);
 
                                 // No need for ScriptRuntime version; we know the string is one or
                                 // two characters and
                                 // contains only [0-9]
                                 int index = Integer.parseInt(digits);
-                                long captureLen = capturesArray.getLength();
-                                if (index > captureLen && digitCount == 2) {
-                                    digitCount = 1;
-                                    digits = digits.substring(0, 1);
-                                    index = Integer.parseInt(digits);
-                                }
-                                ref = templateRemainder.substring(0, 1 + digitCount);
-                                if (1 <= index && index <= captureLen) {
-                                    Object capture = capturesArray.get(index - 1);
-                                    if (capture
-                                            == null) { // Undefined or missing are returned as null
-                                        refReplacement = "";
-                                    } else {
-                                        refReplacement = ScriptRuntime.toString(capture);
-                                    }
+                                if (digits.length() == 1) {
+                                    ops.add(new OneDigitCaptureReplacement(index));
                                 } else {
-                                    refReplacement = ref;
+                                    ops.add(new TwoDigitCaptureReplacement(index));
                                 }
                                 break;
                             }
 
                         case '<':
                             {
-                                int gtPos = templateRemainder.indexOf('>');
-                                if (gtPos == -1 || Undefined.isUndefined(namedCaptures)) {
+                                int gtPos = replacementTemplate.indexOf('>', position + 2);
+                                if (gtPos == -1) {
                                     ref = "$<";
-                                    refReplacement = ref;
+                                    ops.add(new LiteralReplacement(ref));
                                 } else {
-                                    ref = templateRemainder.substring(0, gtPos + 1);
-                                    String groupName = templateRemainder.substring(2, gtPos);
-                                    Object capture =
-                                            ScriptRuntime.getObjectProp(
-                                                    namedCaptures, groupName, cx, scope);
-                                    if (Undefined.isUndefined(capture)) {
-                                        refReplacement = "";
-                                    } else {
-                                        refReplacement = ScriptRuntime.toString(capture);
-                                    }
+                                    ref = replacementTemplate.substring(position, gtPos + 1);
+                                    String groupName =
+                                            replacementTemplate.substring(position + 2, gtPos);
+                                    ops.add(new NamedCaptureReplacement(groupName));
                                 }
                             }
                             break;
+                        default:
+                            ops.add(new LiteralReplacement(ref));
+                            break;
                     }
+                    position += ref.length();
+                    start = position;
+                } else {
+                    position++;
                 }
+            } else {
+                position++;
             }
+        }
+        if (start != position) {
+            ops.add(new LiteralReplacement(replacementTemplate.substring(start, position)));
+        }
+        return ops;
+    }
 
-            int refLength = ref.length();
-            templateRemainder = templateRemainder.substring(refLength);
-            result.append(refReplacement);
+    public static <T> String getSubstitution(
+            Context cx,
+            Scriptable scope,
+            String matched,
+            String str,
+            int position,
+            List<T> capturesList,
+            Object namedCaptures,
+            List<ReplacementOperation> replacementTemplate) {
+        if (position > str.length()) Kit.codeBug();
+        StringBuilder result = new StringBuilder();
+        for (var op : replacementTemplate) {
+            result.append(
+                    op.replacement(cx, scope, matched, str, position, capturesList, namedCaptures));
         }
         return result.toString();
     }
@@ -147,6 +148,183 @@ public class AbstractEcmaStringOperations {
 
             default:
                 return false;
+        }
+    }
+
+    public abstract static class ReplacementOperation {
+
+        abstract <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures);
+    }
+
+    private static class LiteralReplacement extends ReplacementOperation {
+
+        private final String replacement;
+
+        LiteralReplacement(String replacement) {
+            this.replacement = replacement;
+        }
+
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            return replacement;
+        }
+    }
+
+    private static class OneDigitCaptureReplacement extends ReplacementOperation {
+        private final int capture;
+
+        OneDigitCaptureReplacement(int capture) {
+            this.capture = capture;
+        }
+
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            if (capture >= 1 && capture <= captures.size()) {
+                var v = captures.get(capture - 1);
+                if (v == null || v == Undefined.instance) {
+                    return "";
+                } else {
+                    return v.toString();
+                }
+            } else {
+                return "$" + Integer.toString(capture);
+            }
+        }
+    }
+
+    private static class TwoDigitCaptureReplacement extends ReplacementOperation {
+        private final int capture;
+
+        TwoDigitCaptureReplacement(int capture) {
+            this.capture = capture;
+        }
+
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            int i = capture;
+            if (i > 9 && i > captures.size() && i / 10 <= captures.size()) {
+                i = i / 10; // Just take the first digit.
+                var v = captures.get(i - 1);
+                if (v == null || v == Undefined.instance) {
+                    return "" + Integer.toString(capture % 10);
+                } else {
+                    return v.toString() + Integer.toString(capture % 10);
+                }
+            } else if (i >= 1 && i <= captures.size()) {
+                var v = captures.get(i - 1);
+                if (v == null || v == Undefined.instance) {
+                    return "";
+                } else {
+                    return v.toString();
+                }
+            } else {
+                return (capture >= 10 ? "$" : "$0") + Integer.toString(capture);
+            }
+        }
+    }
+
+    private static class FromStartToMatchReplacement extends ReplacementOperation {
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            return str.substring(0, position);
+        }
+    }
+
+    private static class MatchedReplacement extends ReplacementOperation {
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            return matched;
+        }
+    }
+
+    private static class FromMatchToEndReplacement extends ReplacementOperation {
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            int matchLength = matched.length();
+            int tailPos = position + matchLength;
+            return str.substring(Math.min(str.length(), tailPos));
+        }
+    }
+
+    private static class NamedCaptureReplacement extends ReplacementOperation {
+        final String groupName;
+
+        NamedCaptureReplacement(String groupName) {
+            this.groupName = groupName;
+        }
+
+        @Override
+        <T> String replacement(
+                Context cx,
+                Scriptable scope,
+                String matched,
+                String str,
+                int position,
+                List<T> captures,
+                Object namedCaptures) {
+            if (Undefined.isUndefined(namedCaptures)) {
+                List<ReplacementOperation> ops = buildReplacementList(groupName);
+                return "$<"
+                        + getSubstitution(
+                                cx, scope, matched, str, position, captures, namedCaptures, ops)
+                        + ">";
+            }
+
+            Object capture = ScriptRuntime.getObjectProp(namedCaptures, groupName, cx, scope);
+            if (Undefined.isUndefined(capture)) {
+                return "";
+            } else {
+                return ScriptRuntime.toString(capture);
+            }
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1552,7 +1552,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         }
 
         addIndexOp(Icode_LITERAL_NEW_ARRAY, count - numberOfSpread);
-        addUint8(skipIndexesId + 1);
+        addUint16(skipIndexesId + 1);
         stackChange(1);
 
         int childIdx = 0;
@@ -1561,7 +1561,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child.getFirstChild(), 0);
                 addIcode(Icode_SPREAD);
                 if (skipIndexes != null) {
-                    addUint8(sourcePositions[childIdx]);
+                    addUint16(sourcePositions[childIdx]);
                 }
                 stackChange(-1);
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -1191,6 +1191,10 @@ public final class Interpreter extends Icode implements Evaluator {
                 // make a copy or not flag
                 return 1 + 1;
 
+            case Icode_LITERAL_NEW_ARRAY:
+                // skip indexes ID (uint16)
+                return 1 + 2;
+
             case Icode_REG_BIGINT1:
                 // ubyte bigint index
                 return 1 + 1;
@@ -4400,8 +4404,8 @@ public final class Interpreter extends Icode implements Evaluator {
             // indexReg: number of values in the literal
             NewLiteralStorage storage = NewLiteralStorage.create(cx, state.indexReg, false);
 
-            int skipIdx = 0xFF & frame.idata.itsICode[frame.pc];
-            ++frame.pc;
+            int skipIdx = getIndex(frame.idata.itsICode, frame.pc);
+            frame.pc += 2;
 
             // fill in skip indexes in array literal storage
             if (skipIdx > 0) { // 0 - no skip index, otherwise subtract 1 from idx
@@ -4468,8 +4472,8 @@ public final class Interpreter extends Icode implements Evaluator {
             NewLiteralStorage store = (NewLiteralStorage) frame.stack[state.stackTop];
 
             if (store.hasSkipIndexes()) {
-                int sourcePos = 0xFF & frame.idata.itsICode[frame.pc];
-                ++frame.pc;
+                int sourcePos = getIndex(frame.idata.itsICode, frame.pc);
+                frame.pc += 2;
                 store.spread(cx, frame.scope, source, sourcePos);
             } else {
                 store.spread(cx, frame.scope, source, 0);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -739,18 +739,33 @@ public class NativeObject extends ScriptableObject implements Map {
             } else {
                 ids = sourceObj.getIds();
             }
+            // Patch for mozilla/rhino#2126: when the target is a NativeArray,
+            // AbstractEcmaObjectOperations.put() routes through
+            // ScriptableObject.putOwnProperty()/putImpl(), which bypasses
+            // NativeArray.put(int) and thus fails to update the array length.
+            // The slots get written but stay invisible (length stays 0).
+            // We short-circuit to the array's own put() so length is maintained.
+            boolean targetIsArray = targetObj instanceof NativeArray;
             for (Object key : ids) {
                 if (key instanceof Integer) {
                     int intId = (Integer) key;
                     if (sourceObj.has(intId, sourceObj) && isEnumerable(intId, sourceObj)) {
                         Object val = sourceObj.get(intId, sourceObj);
-                        AbstractEcmaObjectOperations.put(cx, targetObj, intId, val, true);
+                        if (targetIsArray) {
+                            targetObj.put(intId, targetObj, val);
+                        } else {
+                            AbstractEcmaObjectOperations.put(cx, targetObj, intId, val, true);
+                        }
                     }
                 } else if (key instanceof String) {
                     String stringId = ScriptRuntime.toString(key);
                     if (sourceObj.has(stringId, sourceObj) && isEnumerable(stringId, sourceObj)) {
                         Object val = sourceObj.get(stringId, sourceObj);
-                        AbstractEcmaObjectOperations.put(cx, targetObj, stringId, val, true);
+                        if (targetIsArray) {
+                            targetObj.put(stringId, targetObj, val);
+                        } else {
+                            AbstractEcmaObjectOperations.put(cx, targetObj, stringId, val, true);
+                        }
                     }
                 }
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.mozilla.javascript.AbstractEcmaStringOperations.ReplacementOperation;
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
 
 /**
@@ -910,8 +911,14 @@ final class NativeString extends ScriptableObject {
         String string = ScriptRuntime.toString(o);
         String searchString = ScriptRuntime.toString(searchValue);
         boolean functionalReplace = replaceValue instanceof Callable;
+        List<ReplacementOperation> replaceOps;
+
         if (!functionalReplace) {
-            replaceValue = ScriptRuntime.toString(replaceValue);
+            replaceOps =
+                    AbstractEcmaStringOperations.buildReplacementList(
+                            ScriptRuntime.toString(replaceValue));
+        } else {
+            replaceOps = List.of();
         }
         int searchLength = searchString.length();
         int position = string.indexOf(searchString);
@@ -937,7 +944,7 @@ final class NativeString extends ScriptableObject {
                                     });
             replacement = ScriptRuntime.toString(replacementObj);
         } else {
-            NativeArray captures = (NativeArray) cx.newArray(scope, 0);
+            List<Object> captures = List.of();
             replacement =
                     AbstractEcmaStringOperations.getSubstitution(
                             cx,
@@ -947,7 +954,7 @@ final class NativeString extends ScriptableObject {
                             position,
                             captures,
                             Undefined.SCRIPTABLE_UNDEFINED,
-                            (String) replaceValue);
+                            replaceOps);
         }
         return preceding + replacement + following;
     }
@@ -992,8 +999,13 @@ final class NativeString extends ScriptableObject {
         String string = ScriptRuntime.toString(o);
         String searchString = ScriptRuntime.toString(searchValue);
         boolean functionalReplace = replaceValue instanceof Callable;
+        List<ReplacementOperation> replaceOps;
         if (!functionalReplace) {
-            replaceValue = ScriptRuntime.toString(replaceValue);
+            replaceOps =
+                    AbstractEcmaStringOperations.buildReplacementList(
+                            ScriptRuntime.toString(replaceValue));
+        } else {
+            replaceOps = List.of();
         }
         int searchLength = searchString.length();
         int advanceBy = Math.max(1, searchLength);
@@ -1029,7 +1041,7 @@ final class NativeString extends ScriptableObject {
                                         });
                 replacement = ScriptRuntime.toString(replacementObj);
             } else {
-                NativeArray captures = (NativeArray) cx.newArray(scope, 0);
+                List<Object> captures = List.of();
                 replacement =
                         AbstractEcmaStringOperations.getSubstitution(
                                 cx,
@@ -1039,7 +1051,7 @@ final class NativeString extends ScriptableObject {
                                 p,
                                 captures,
                                 Undefined.SCRIPTABLE_UNDEFINED,
-                                (String) replaceValue);
+                                replaceOps);
             }
             result.append(preserved);
             result.append(replacement);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -190,6 +190,8 @@ public class ScriptRuntime {
             ((TopLevel) scope).clearCache();
         }
 
+        scope.put("global", scope, scope);
+
         scope.associateValue(LIBRARY_SCOPE_KEY, scope);
         new ClassCache().associate(scope);
         new ConcurrentFactory().associate(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.CodeGenUtils;
@@ -860,6 +861,12 @@ public class Codegen implements Evaluator {
         return "_c_" + cleanName(n) + "_" + index;
     }
 
+    /**
+     * List of illegal characters in unqualified names as specified in
+     * https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.2.2
+     */
+    private static Pattern illegalChars = Pattern.compile("[.;\\[/<>]");
+
     /** Gets a Java-compatible "informative" name for the ScriptOrFnNode */
     String cleanName(final ScriptNode n) {
         String result = "";
@@ -873,7 +880,7 @@ public class Codegen implements Evaluator {
         } else {
             result = "script";
         }
-        return result;
+        return illegalChars.matcher(result).replaceAll("_");
     }
 
     String getNonDirectBodyMethodSIgnature(ScriptNode n) {

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -3843,7 +3843,7 @@ public class NativeRegExp extends IdScriptableObject {
         setLastIndex((Scriptable) thisObj, value);
     }
 
-    private void setLastIndex(Scriptable thisObj, Object value) {
+    private static void setLastIndex(Scriptable thisObj, Object value) {
         ScriptableObject.putProperty(thisObj, "lastIndex", value);
     }
 
@@ -4404,12 +4404,9 @@ public class NativeRegExp extends IdScriptableObject {
 
         String flags = ScriptRuntime.toString(ScriptRuntime.getObjectProp(rx, "flags", cx));
         boolean unicodeMatching = flags.indexOf('u') != -1 || flags.indexOf('v') != -1;
-        String newFlags = flags.indexOf('y') != -1 ? flags : (flags + "y");
-
-        Scriptable splitter = c.construct(cx, scope, new Object[] {rx, newFlags});
-
         NativeArray a = (NativeArray) cx.newArray(scope, 0);
-        int lengthA = 0;
+        String newFlags = flags.indexOf('y') != -1 ? flags : (flags + "y");
+        Scriptable splitter = c.construct(cx, scope, new Object[] {rx, newFlags});
 
         Object limit = args.length > 1 ? args[1] : Undefined.instance;
         long lim;
@@ -4421,6 +4418,30 @@ public class NativeRegExp extends IdScriptableObject {
         if (lim == 0) {
             return a;
         }
+
+        if (splitter instanceof NativeRegExp) {
+            var regexp = (NativeRegExp) splitter;
+            var exec = ScriptableObject.getProperty(regexp, "exec");
+            if ((regexp.lastIndexAttr & READONLY) == 0
+                    && exec instanceof IdFunctionObject
+                    && ((IdFunctionObject) exec).methodId() == Id_exec
+                    && ((IdFunctionObject) exec).getTag() == REGEXP_TAG)
+                return js_SymbolSplitFast(
+                        cx, scope, (NativeRegExp) splitter, s, lim, unicodeMatching, a);
+        }
+
+        return js_SymbolSplitSlow(cx, scope, splitter, s, lim, unicodeMatching, a);
+    }
+
+    private static Object js_SymbolSplitSlow(
+            Context cx,
+            Scriptable scope,
+            Scriptable splitter,
+            String s,
+            long lim,
+            boolean unicodeMatching,
+            NativeArray a) {
+        int lengthA = 0;
 
         if (s.isEmpty()) {
             Object z = regExpExec(splitter, s, cx, scope);
@@ -4461,6 +4482,72 @@ public class NativeRegExp extends IdScriptableObject {
                     while (i <= numberOfCaptures) {
                         Object nextCapture = ScriptRuntime.getObjectIndex(z, i, cx, scope);
                         a.put((int) a.getLength(), a, nextCapture);
+                        i = i + 1;
+                        lengthA++;
+                        if (lengthA == lim) {
+                            return a;
+                        }
+                    }
+                    q = p;
+                }
+            }
+        }
+        String t = s.substring((int) p, size);
+        a.put((int) a.getLength(), a, t);
+        return a;
+    }
+
+    private static Object js_SymbolSplitFast(
+            Context cx,
+            Scriptable scope,
+            NativeRegExp splitter,
+            String s,
+            long lim,
+            boolean unicodeMatching,
+            NativeArray a) {
+        int lengthA = 0;
+
+        int[] indexp = {0};
+        RegExpImpl reImpl = getImpl(cx);
+        if (s.isEmpty()) {
+            ExecResult result = splitter.executeRegExpInternal(cx, scope, reImpl, s, indexp, MATCH);
+            if (result != null) {
+                return a;
+            }
+            a.put(0, a, s);
+            return a;
+        }
+
+        int size = s.length();
+        long p = 0;
+        long q = p;
+        while (q < size) {
+            indexp[0] = (int) q;
+            ExecResult result = splitter.executeRegExpInternal(cx, scope, reImpl, s, indexp, MATCH);
+
+            if (result == null) {
+                q = ScriptRuntime.advanceStringIndex(s, q, unicodeMatching);
+            } else {
+                long e = indexp[0];
+                e = Math.min(e, size);
+                if (e == p) {
+                    q = ScriptRuntime.advanceStringIndex(s, q, unicodeMatching);
+                } else {
+                    String t = s.substring((int) p, (int) q);
+                    a.put((int) a.getLength(), a, t);
+                    lengthA++;
+                    if (a.getLength() == lim) {
+                        return a;
+                    }
+
+                    p = e;
+                    int i = 0;
+                    while (i < result.captures.size()) {
+                        Object nextCapture = result.captures.get(i);
+                        a.put(
+                                (int) a.getLength(),
+                                a,
+                                nextCapture == null ? Undefined.instance : nextCapture);
                         i = i + 1;
                         lengthA++;
                         if (lengthA == lim) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
@@ -1,0 +1,90 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Regression test for addUint8 overflow in CodeGenerator.visitArrayLiteral.
+ * When a script contains more than 255 object/array literals, the literalIds
+ * table grows beyond 255, and skipIndexesId (encoded as uint8) overflows.
+ */
+public class ArrayLiteralOverflowTest {
+
+    @Test
+    public void testLiteralIdsOverflowWithSparseArrayInterpreted() {
+        runLiteralIdsOverflow(-1);
+    }
+
+    @Test
+    public void testLiteralIdsOverflowWithSparseArrayCompiled() {
+        runLiteralIdsOverflow(9);
+    }
+
+    @Test
+    public void testManySpreadArrayLiteralsInterpreted() {
+        runManySpreadArrayLiterals(-1);
+    }
+
+    @Test
+    public void testManySpreadArrayLiteralsCompiled() {
+        runManySpreadArrayLiterals(9);
+    }
+
+    /**
+     * Each object literal {k:v} adds one entry to literalIds.
+     * After 256 object literals, the next sparse array literal (with elisions)
+     * gets a skipIndexesId > 255, which overflows the uint8 encoding.
+     */
+    private void runLiteralIdsOverflow(int optimizationLevel) {
+        StringBuilder sb = new StringBuilder();
+        // Create 260 object literals to push literalIds past 255
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k: ").append(i).append("};\n");
+        }
+        // Now create a sparse array (with elision) that needs skipIndexes
+        // [1, , 3] has a "hole" at index 1 which triggers skipIndexes
+        sb.append("var sparse = [1, , 3];\n");
+        sb.append("sparse[0] + sparse[2];\n");
+        String script = sb.toString();
+
+        ContextFactory factory = new ContextFactory();
+        factory.call(cx -> {
+            cx.setOptimizationLevel(optimizationLevel);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            Scriptable scope = cx.initStandardObjects();
+            Object result = cx.evaluateString(scope, script, "test.js", 1, null);
+            assertEquals(4.0, ((Number) result).doubleValue(), 0.0);
+            return null;
+        });
+    }
+
+    /**
+     * Tests spread with sparse arrays when literalIds has grown past 255.
+     */
+    private void runManySpreadArrayLiterals(int optimizationLevel) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("var base = [0];\n");
+        // 260 object literals to fill literalIds
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k: ").append(i).append("};\n");
+        }
+        // Sparse array with spread: triggers both skipIndexesId and sourcePositions overflow
+        sb.append("var result = [...base, , 42];\n");
+        sb.append("result[2];\n");
+        String script = sb.toString();
+
+        ContextFactory factory = new ContextFactory();
+        factory.call(cx -> {
+            cx.setOptimizationLevel(optimizationLevel);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            Scriptable scope = cx.initStandardObjects();
+            Object result = cx.evaluateString(scope, script, "test.js", 1, null);
+            assertEquals(42.0, ((Number) result).doubleValue(), 0.0);
+            return null;
+        });
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ObjectAssignArrayTargetTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ObjectAssignArrayTargetTest.java
@@ -1,0 +1,391 @@
+package org.mozilla.javascript.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.Scriptable;
+
+/**
+ * Regression test for Object.assign with array target.
+ *
+ * <p>Bug: In Rhino 1.7.15+ (including 1.9.1), {@code Object.assign([], src)} returns an empty
+ * array instead of a copy of src's enumerable own properties. The integer-keyed property writes
+ * go through {@code AbstractEcmaObjectOperations.put} → {@code ScriptableObject.putOwnProperty} →
+ * {@code putImpl}, which bypasses {@code NativeArray.put(int)} and so the array's length is never
+ * updated. The slots are stored but invisible to iteration and serialization.
+ *
+ * <p>Upstream issue: mozilla/rhino#2126
+ *
+ * <p>The patch special-cases array targets in {@code NativeObject.js_assign} to route writes
+ * through {@code targetObj.put(int, ...)} so length is maintained.
+ */
+public class ObjectAssignArrayTargetTest {
+
+    /** Helper: run a script in interpreter mode (rhinoOptimizationLevel=-1, as used in AppServer). */
+    private static Object eval(final String script) {
+        ContextFactory factory = new ContextFactory();
+        return factory.call(cx -> {
+            cx.setOptimizationLevel(-1);
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            Scriptable scope = cx.initStandardObjects();
+            return cx.evaluateString(scope, script, "test.js", 1, null);
+        });
+    }
+
+    // ---------------------------------------------------------------------
+    // The original bug report (QUAL-3295 Major Bug 4)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void emptyArrayTarget_stringSource_jsonStringify() {
+        // The exact reproducer from QUAL-3295:
+        //   const arr = ["bla","blubb"]; const clone = Object.assign([], arr);
+        //   JSON.stringify(clone) -> "["bla","blubb"]"  (was: "[]")
+        Object result = eval(
+                "const arr = ['bla','blubb'];"
+                + "const clone = Object.assign([], arr);"
+                + "JSON.stringify(clone);");
+        assertEquals("[\"bla\",\"blubb\"]", result);
+    }
+
+    @Test
+    public void emptyArrayTarget_lengthIsUpdated() {
+        Object result = eval(
+                "const clone = Object.assign([], ['a','b','c']);"
+                + "clone.length;");
+        assertEquals(3.0, ((Number) result).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void emptyArrayTarget_valuesAreAccessibleByIndex() {
+        Object result = eval(
+                "const clone = Object.assign([], ['a','b','c']);"
+                + "clone[0] + ',' + clone[1] + ',' + clone[2];");
+        assertEquals("a,b,c", result);
+    }
+
+    // ---------------------------------------------------------------------
+    // Variants
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void preFilledArrayTarget_overwriteByIndex() {
+        // Target ["x","y","z"], source ["a","b"] -> ["a","b","z"]
+        Object result = eval(
+                "const t = ['x','y','z'];"
+                + "Object.assign(t, ['a','b']);"
+                + "JSON.stringify(t);");
+        assertEquals("[\"a\",\"b\",\"z\"]", result);
+    }
+
+    @Test
+    public void preFilledArrayTarget_lengthGrowsWhenSourceLonger() {
+        Object result = eval(
+                "const t = ['x'];"
+                + "Object.assign(t, ['a','b','c']);"
+                + "t.length;");
+        assertEquals(3.0, ((Number) result).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void arrayTarget_objectSourceWithStringIndices() {
+        // {0:"a", 1:"b"} -> array indices via String key path
+        Object result = eval(
+                "const t = [];"
+                + "Object.assign(t, {0:'a', 1:'b'});"
+                + "JSON.stringify(t);");
+        assertEquals("[\"a\",\"b\"]", result);
+    }
+
+    @Test
+    public void arrayTarget_multipleSources() {
+        Object result = eval(
+                "const t = [];"
+                + "Object.assign(t, ['a','b'], ['x','y','z']);"
+                + "JSON.stringify(t);");
+        // Second source overwrites the first by index
+        assertEquals("[\"x\",\"y\",\"z\"]", result);
+    }
+
+    @Test
+    public void arrayTarget_sparseSourceSkipsHoles() {
+        // ["a", <hole>, "c"] - hole is NOT enumerable, should be skipped
+        Object result = eval(
+                "const src = ['a',,'c'];"
+                + "const t = ['x','y','z','w'];"
+                + "Object.assign(t, src);"
+                + "JSON.stringify(t);");
+        // src[1] is a hole -> t[1] stays 'y'
+        assertEquals("[\"a\",\"y\",\"c\",\"w\"]", result);
+    }
+
+    @Test
+    public void arrayTarget_nestedValuesAreShallowCopied() {
+        Object result = eval(
+                "const inner = {x:1};"
+                + "const src = [inner];"
+                + "const clone = Object.assign([], src);"
+                + "clone[0] === inner;"); // same reference (shallow)
+        assertEquals(Boolean.TRUE, result);
+    }
+
+    @Test
+    public void arrayTarget_arrayJoinWorksAfterAssign() {
+        // join() walks 0..length-1 - direct regression test for length update
+        Object result = eval(
+                "const clone = Object.assign([], ['a','b','c']);"
+                + "clone.join('|');");
+        assertEquals("a|b|c", result);
+    }
+
+    @Test
+    public void arrayTarget_forEachCallbackInvokedForEachElement() {
+        // Array.prototype.forEach uses length - regression test
+        Object result = eval(
+                "const clone = Object.assign([], ['a','b','c']);"
+                + "let count = 0;"
+                + "clone.forEach(() => count++);"
+                + "count;");
+        assertEquals(3.0, ((Number) result).doubleValue(), 0.0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Object target (NOT array) - must remain unchanged by patch
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void objectTarget_arraySource_keepsExistingBehavior() {
+        // {} <- ["a","b"]  => {0:"a", 1:"b"}, no length
+        Object result = eval(
+                "const o = Object.assign({}, ['a','b']);"
+                + "o[0] + ',' + o[1] + ',' + (o.length === undefined);");
+        assertEquals("a,b,true", result);
+    }
+
+    @Test
+    public void objectTarget_objectSource_keepsExistingBehavior() {
+        Object result = eval(
+                "const o = Object.assign({}, {a:1, b:2});"
+                + "o.a + o.b;");
+        assertEquals(3.0, ((Number) result).doubleValue(), 0.0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Deeper / compound scenarios
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void arrayOfArrays_sourceContainsNestedArrays_outerLengthCorrect() {
+        // Source has arrays as values - inner arrays are just refs, but
+        // we want to verify the outer container is correctly built.
+        Object result = eval(
+                "const src = [[1,2],[3,4],[5,6]];"
+                + "const clone = Object.assign([], src);"
+                + "JSON.stringify(clone);");
+        assertEquals("[[1,2],[3,4],[5,6]]", result);
+    }
+
+    @Test
+    public void recursiveDeepClone_viaMapAndAssign() {
+        // A common pattern: shallow-clone every nested array via map+assign.
+        // Doubly exercises the patch path (one assign per nested array).
+        Object result = eval(
+                "const src = [[1,2],[3,4]];"
+                + "const deepish = src.map(a => Object.assign([], a));"
+                + "JSON.stringify(deepish) + '|' + (deepish[0] !== src[0]);");
+        assertEquals("[[1,2],[3,4]]|true", result);
+    }
+
+    @Test
+    public void sequentialAssigns_lengthAccumulates() {
+        // Each assign on the same target should leave length consistent.
+        Object result = eval(
+                "const t = [];"
+                + "Object.assign(t, ['a','b']);"
+                + "Object.assign(t, [, , 'c', 'd']);" // holes preserve a,b
+                + "JSON.stringify(t) + '|' + t.length;");
+        assertEquals("[\"a\",\"b\",\"c\",\"d\"]|4", result);
+    }
+
+    @Test
+    public void assignThenPushThenAssign_arrayProtocolIntact() {
+        // Mix Object.assign with normal Array.prototype.push to ensure
+        // length is not just "set" but really maintained as a writable property.
+        Object result = eval(
+                "const t = Object.assign([], ['a','b']);"
+                + "t.push('c');"
+                + "Object.assign(t, [, , , 'd']);"
+                + "JSON.stringify(t) + '|' + t.length;");
+        assertEquals("[\"a\",\"b\",\"c\",\"d\"]|4", result);
+    }
+
+    @Test
+    public void chainedAssignReturnsTarget_usableAsArray() {
+        // Object.assign returns the target. Chain it through array methods.
+        Object result = eval(
+                "Object.assign([], ['a','b','c'])"
+                + "  .map(s => s.toUpperCase())"
+                + "  .filter(s => s !== 'B')"
+                + "  .join('-');");
+        assertEquals("A-C", result);
+    }
+
+    @Test
+    public void preSizedArrayViaConstructor_overwriteAndExtend() {
+        // new Array(n) sets length without filling slots. Assign should
+        // overwrite the placeholder length and report real new length.
+        Object result = eval(
+                "const t = new Array(5);"
+                + "Object.assign(t, ['a','b']);"
+                + "JSON.stringify(t) + '|' + t.length;");
+        // Original length was 5 (with holes); assign writes indices 0,1.
+        // length must stay 5 (assign never shrinks).
+        assertEquals("[\"a\",\"b\",null,null,null]|5", result);
+    }
+
+    @Test
+    public void hundredEntriesViaAssign_lengthStaysAccurate() {
+        // Volume test: many indices in one assign call. Catches off-by-one
+        // and intermediate-state bugs that small arrays would hide.
+        Object result = eval(
+                "const big = [];"
+                + "for (let i = 0; i < 100; i++) big.push(i);"
+                + "const clone = Object.assign([], big);"
+                + "clone.length + '|' + clone[0] + '|' + clone[99] + '|' + clone.reduce((a,b)=>a+b, 0);");
+        // sum 0..99 = 4950
+        assertEquals("100|0|99|4950", result);
+    }
+
+    @Test
+    public void assignFromArrayIntoSpliceResult_chainedArrayOperations() {
+        // splice returns an array - feed it as source. Compound test:
+        // source itself is dynamically produced by an array op.
+        Object result = eval(
+                "const src = ['x','a','b','c','y'];"
+                + "const removed = src.splice(1, 3);" // ['a','b','c']
+                + "const clone = Object.assign([], removed);"
+                + "JSON.stringify(clone) + '|' + clone.length;");
+        assertEquals("[\"a\",\"b\",\"c\"]|3", result);
+    }
+
+    @Test
+    public void nestedObjectAssign_arraysAtMultipleLevels() {
+        // Build an object whose properties are arrays-via-Object.assign,
+        // then JSON-stringify the whole thing. If any layer's length is
+        // wrong, the JSON output goes sideways.
+        Object result = eval(
+                "const obj = {"
+                + "  a: Object.assign([], ['1','2']),"
+                + "  b: Object.assign([], [Object.assign([], ['x','y']), 'z'])"
+                + "};"
+                + "JSON.stringify(obj);");
+        assertEquals("{\"a\":[\"1\",\"2\"],\"b\":[[\"x\",\"y\"],\"z\"]}", result);
+    }
+
+    // ---------------------------------------------------------------------
+    // Destructuring & spread — formally not Object.assign, but they share
+    // the indexed-property write path in Rhino's internals. If the same
+    // length-update bug applies there, these tests will catch it.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void arraySpread_intoArrayLiteral_lengthCorrect() {
+        Object result = eval(
+                "const src = ['a','b','c'];"
+                + "const out = [...src];"
+                + "JSON.stringify(out) + '|' + out.length;");
+        assertEquals("[\"a\",\"b\",\"c\"]|3", result);
+    }
+
+    @Test
+    public void arraySpread_withPrefixAndSuffix() {
+        Object result = eval(
+                "const src = ['b','c'];"
+                + "const out = ['a', ...src, 'd'];"
+                + "JSON.stringify(out) + '|' + out.length;");
+        assertEquals("[\"a\",\"b\",\"c\",\"d\"]|4", result);
+    }
+
+    @Test
+    public void arrayDestructuring_basicPositional() {
+        // Plain positional destructuring - no rest. Should work and not
+        // share the buggy assign-path.
+        Object result = eval(
+                "const [a, b, c] = ['x','y','z'];"
+                + "a + '|' + b + '|' + c;");
+        assertEquals("x|y|z", result);
+    }
+
+    @Test
+    public void arrayDestructuring_withSkipsAndDefaults() {
+        Object result = eval(
+                "const [, b, , d = 'def'] = ['a','b','c'];"
+                + "b + '|' + d;");
+        assertEquals("b|def", result);
+    }
+
+    // NOTE: Array rest pattern (const [a, ...rest] = ...) and
+    // object rest pattern (const {a, ...rest} = ...) are not supported
+    // by the Rhino 1.9.1 parser - "Invalid assignment left-hand side"
+    // resp. "object rest properties in destructuring are not supported".
+    // Since they can't be written in user code, they can't trigger any
+    // bug either. No test needed.
+
+    @Test
+    public void objectSpread_intoObjectLiteral_keepsExistingBehavior() {
+        // {...src} uses CopyDataProperties — target is Object, not Array,
+        // so our patch path is not triggered. Should still work.
+        Object result = eval(
+                "const src = {a:1, b:2};"
+                + "const out = {...src, c:3};"
+                + "out.a + out.b + out.c;");
+        assertEquals(6.0, ((Number) result).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void objectSpread_arraySourceAsObject() {
+        // {...arr} — array as source, object as target. Indices become keys.
+        Object result = eval(
+                "const out = {...['a','b']};"
+                + "out[0] + ',' + out[1];");
+        assertEquals("a,b", result);
+    }
+
+    @Test
+    public void objectDestructuring_basicNoRest() {
+        Object result = eval(
+                "const {a, b} = {a:1, b:2, c:3};"
+                + "a + '|' + b;");
+        assertEquals("1|2", result);
+    }
+
+    @Test
+    public void arrayFrom_iterableSource() {
+        // Array.from also relies on integer-indexed property writes
+        Object result = eval(
+                "const out = Array.from(['a','b','c']);"
+                + "JSON.stringify(out) + '|' + out.length;");
+        assertEquals("[\"a\",\"b\",\"c\"]|3", result);
+    }
+
+    @Test
+    public void arrayOf_variadicArgs() {
+        Object result = eval(
+                "const out = Array.of('a','b','c');"
+                + "JSON.stringify(out) + '|' + out.length;");
+        assertEquals("[\"a\",\"b\",\"c\"]|3", result);
+    }
+
+    @Test
+    public void spreadOfAssignedArray_intoAnotherArray() {
+        // The assigned array must behave like a normal array when spread.
+        // Length-bug would cause [...clone] to be empty.
+        Object result = eval(
+                "const clone = Object.assign([], ['a','b','c']);"
+                + "const spread = [0, ...clone, 4];"
+                + "JSON.stringify(spread);");
+        assertEquals("[0,\"a\",\"b\",\"c\",4]", result);
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/TopLevelTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/TopLevelTest.java
@@ -1,0 +1,7 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest(value = "testsrc/jstests/top-level.js")
+public class TopLevelTest extends ScriptTestsBase {}

--- a/tests/src/test/java/org/mozilla/javascript/tests/XMLReservedWordsAttributesTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/XMLReservedWordsAttributesTest.java
@@ -1,0 +1,10 @@
+package org.mozilla.javascript.tests;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.drivers.LanguageVersion;
+import org.mozilla.javascript.drivers.RhinoTest;
+import org.mozilla.javascript.drivers.ScriptTestsBase;
+
+@RhinoTest("testsrc/jstests/xml-reserved-words-as-attributes.js")
+@LanguageVersion(Context.VERSION_ES6)
+public class XMLReservedWordsAttributesTest extends ScriptTestsBase {}

--- a/tests/testsrc/jstests/top-level.js
+++ b/tests/testsrc/jstests/top-level.js
@@ -1,0 +1,7 @@
+'use strict';
+
+load("testsrc/assert.js");
+
+assertSame(global, globalThis);
+
+"success";

--- a/tests/testsrc/jstests/xml-reserved-words-as-attributes.js
+++ b/tests/testsrc/jstests/xml-reserved-words-as-attributes.js
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Test that reserved words can be used as both XML attribute names
+// and as part of a name space qualified name.
+
+load('testsrc/assert.js');
+
+x =
+<alpha>
+    <bravo for="value1" ns:for="value3" xmlns:ns="http://someuri">
+        <charlie class="value2" ns:class="value4"/>
+    </bravo>
+</alpha>
+
+assertEquals("value1", x.bravo.@for.toXMLString());
+assertEquals("value2", x.bravo.charlie.@class.toXMLString());
+n = new Namespace("http://someuri");
+assertEquals("value3", x.bravo.@n::for.toXMLString());
+assertEquals("value4", x.bravo.charlie.@n::class.toXMLString());
+
+"success"


### PR DESCRIPTION
## Summary
- `CodeGenerator.visitArrayLiteral` encodes `skipIndexesId` and `sourcePositions` as uint8 via `addUint8`, which overflows when a script contains more than 255 object/array literals (causing `literalIds` to exceed 255 entries)
- Changed `addUint8` to `addUint16` for these values in `CodeGenerator` and updated corresponding reads in `Interpreter` (`DoLiteralNewArray`, `DoSpread`) to use `getIndex` (uint16)
- Added `bytecodeSpan` entry for `Icode_LITERAL_NEW_ARRAY` to account for the new 2-byte encoding
- Only affects interpreter mode (`optimizationLevel = -1`)

## Reproduction
A script with 260+ object literals followed by a sparse array literal (e.g. `[1, , 3]`) triggers `IllegalStateException` (from `Kit.codeBug()` in `addUint8`) during compilation in interpreter mode.

## Test plan
- Added `ArrayLiteralOverflowTest` with 4 tests covering both interpreted and compiled modes, with and without spread operators
- Full existing test suite passes without regressions