### PR TITLE
Introduce `VarScope` as a subclass of `Scriptable`

### DIFF
--- a/examples/src/main/java/Matrix.java
+++ b/examples/src/main/java/Matrix.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
 
 /**
  * Matrix: An example host object class that implements the Scriptable interface.
@@ -188,14 +189,14 @@ public class Matrix implements Scriptable {
 
     /** Get parent. */
     @Override
-    public Scriptable getParentScope() {
+    public VarScope getParentScope() {
         return parent;
     }
 
     /** Set parent. */
     @Override
     public void setParentScope(Scriptable parent) {
-        this.parent = parent;
+        this.parent = (VarScope) parent;
     }
 
     /**
@@ -239,5 +240,6 @@ public class Matrix implements Scriptable {
     private int dim;
 
     private List<Object> list;
-    private Scriptable prototype, parent;
+    private Scriptable prototype;
+    private VarScope parent;
 }

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/BindingsObject.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/BindingsObject.java
@@ -8,6 +8,7 @@ import javax.script.Bindings;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
 
 /**
  * This class makes the Bindings object into a Scriptable. That way, we can query and modify the
@@ -15,12 +16,14 @@ import org.mozilla.javascript.ScriptableObject;
  */
 public class BindingsObject extends ScriptableObject {
     private final Bindings bindings;
+    private final VarScope parentScope;
 
-    BindingsObject(Bindings bindings) {
+    BindingsObject(VarScope parentScope, Bindings bindings) {
         if (bindings == null) {
             throw new IllegalArgumentException("Bindings must not be null");
         }
         this.bindings = bindings;
+        this.parentScope = parentScope;
     }
 
     @Override
@@ -38,7 +41,7 @@ public class BindingsObject extends ScriptableObject {
 
     @Override
     public void put(String name, Scriptable start, Object value) {
-        bindings.put(name, Context.javaToJS(value, start));
+        bindings.put(name, Context.javaToJS(value, parentScope));
     }
 
     @Override

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
@@ -99,12 +99,15 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
             var globalScope =
                     TopLevel.createIsolate(
                             topLevelScope,
-                            new BindingsObject(sc.getBindings(ScriptContext.GLOBAL_SCOPE)));
+                            new BindingsObject(
+                                    topLevelScope, sc.getBindings(ScriptContext.GLOBAL_SCOPE)));
             return TopLevel.createIsolate(
-                    globalScope, new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
+                    globalScope,
+                    new BindingsObject(globalScope, sc.getBindings(ScriptContext.ENGINE_SCOPE)));
         } else {
             return TopLevel.createIsolate(
-                    topLevelScope, new BindingsObject(sc.getBindings(ScriptContext.ENGINE_SCOPE)));
+                    topLevelScope,
+                    new BindingsObject(topLevelScope, sc.getBindings(ScriptContext.ENGINE_SCOPE)));
         }
     }
 

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
@@ -15,8 +15,8 @@ import javax.swing.JFrame;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Kit;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.commonjs.module.ModuleScope;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -181,7 +181,7 @@ public class Main {
             global.installRequire(cx, List.of(), false);
 
             URI uri = new File(System.getProperty("user.dir")).toURI();
-            ScriptableObject scope = ModuleScope.createModuleScope(global, uri, null);
+            ScopeObject scope = ModuleScope.createModuleScope(global, uri, null);
 
             main.setScope(scope);
 

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Environment.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Environment.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
 
 /**
  * Environment, intended to be instantiated at global scope, provides a natural way to access System
@@ -30,7 +31,7 @@ public class Environment extends ScriptableObject {
 
     private Environment thePrototypeInstance = null;
 
-    public static void defineClass(ScriptableObject scope) {
+    public static void defineClass(VarScope scope) {
         try {
             ScriptableObject.defineClass(scope, Environment.class);
         } catch (Exception e) {
@@ -47,7 +48,7 @@ public class Environment extends ScriptableObject {
         if (thePrototypeInstance == null) thePrototypeInstance = this;
     }
 
-    public Environment(ScriptableObject scope) {
+    public Environment(VarScope scope) {
         setParentScope(scope);
         Object ctor = ScriptRuntime.getTopLevelProp(scope, "Environment");
         if (ctor != null && ctor instanceof Scriptable) {

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XML.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XML.java
@@ -17,6 +17,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.xml.XMLObject;
 
 class XML extends XMLObjectImpl {
@@ -37,11 +38,7 @@ class XML extends XMLObjectImpl {
     }
 
     public static void init(
-            Context cx,
-            ScriptableObject scope,
-            XMLObjectImpl proto,
-            boolean sealed,
-            XMLLibImpl lib) {
+            Context cx, VarScope scope, XMLObjectImpl proto, boolean sealed, XMLLibImpl lib) {
         DESCRIPTOR.buildConstructor(
                 cx,
                 scope,
@@ -114,7 +111,7 @@ class XML extends XMLObjectImpl {
         return false;
     }
 
-    XML(XMLLibImpl lib, Scriptable scope, XMLObject prototype, XmlNode node) {
+    XML(XMLLibImpl lib, VarScope scope, XMLObject prototype, XmlNode node) {
         super(lib, scope, prototype);
         initialize(node);
     }

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java
@@ -13,8 +13,8 @@ import org.mozilla.javascript.Node;
 import org.mozilla.javascript.Ref;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.Wrapper;
 import org.mozilla.javascript.xml.XMLLib;
 import org.mozilla.javascript.xml.XMLObject;
@@ -39,11 +39,12 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
         }
     }
 
-    public static void init(Context cx, Scriptable scope, boolean sealed) {
+    public static void init(Context cx, Scriptable s, boolean sealed) {
+        VarScope scope = (VarScope) s;
         XMLLibImpl lib = new XMLLibImpl(scope);
         XMLLib bound = lib.bindToScope(scope);
         if (bound == lib) {
-            lib.exportToScope(cx, (ScriptableObject) scope, sealed);
+            lib.exportToScope(cx, scope, sealed);
         }
     }
 
@@ -97,7 +98,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
         return options.getPrettyIndent();
     }
 
-    private Scriptable globalScope;
+    private VarScope globalScope;
 
     private XML xmlPrototype;
     private XMLList xmlListPrototype;
@@ -106,7 +107,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
 
     private XmlProcessor options = new XmlProcessor();
 
-    private XMLLibImpl(Scriptable globalScope) {
+    private XMLLibImpl(VarScope globalScope) {
         this.globalScope = globalScope;
     }
 
@@ -130,7 +131,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
         return options;
     }
 
-    private void exportToScope(Context cx, ScriptableObject scope, boolean sealed) {
+    private void exportToScope(Context cx, VarScope scope, boolean sealed) {
         xmlPrototype = newXML(XmlNode.createText(options, ""));
         xmlListPrototype = newXMLList();
         namespacePrototype = Namespace.create(this.globalScope, null, XmlNode.Namespace.GLOBAL);
@@ -318,7 +319,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
             // XML object can only present on scope chain as a wrapper
             // of XMLWithScope
             if (scope instanceof XMLWithScope) {
-                xmlObj = (XMLObjectImpl) scope.getPrototype();
+                xmlObj = (XMLObjectImpl) ((XMLWithScope) scope).getObject();
                 if (xmlObj.hasXMLProperty(xmlName)) {
                     break;
                 }

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -19,6 +19,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.xml.XMLObject;
 
 class XMLList extends XMLObjectImpl implements Function {
@@ -79,7 +80,7 @@ class XMLList extends XMLObjectImpl implements Function {
         }
     }
 
-    XMLList(XMLLibImpl lib, Scriptable scope, XMLObject prototype) {
+    XMLList(XMLLibImpl lib, VarScope scope, XMLObject prototype) {
         super(lib, scope, prototype);
         _annos = new XmlNode.InternalList();
     }

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLoaderImpl.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLoaderImpl.java
@@ -1,18 +1,18 @@
 package org.mozilla.javascript.xmlimpl;
 
 import org.mozilla.javascript.LazilyLoadedCtor;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.xml.XMLLib;
 import org.mozilla.javascript.xml.XMLLoader;
 
 public class XMLLoaderImpl implements XMLLoader {
     @Override
-    public void load(ScriptableObject scope, boolean sealed) {
+    public void load(ScopeObject scope, boolean sealed) {
         String implClass = XMLLibImpl.class.getName();
-        new LazilyLoadedCtor(scope, "XML", implClass, sealed, true);
-        new LazilyLoadedCtor(scope, "XMLList", implClass, sealed, true);
-        new LazilyLoadedCtor(scope, "Namespace", implClass, sealed, true);
-        new LazilyLoadedCtor(scope, "QName", implClass, sealed, true);
+        new LazilyLoadedCtor<>(scope, "XML", implClass, sealed, true);
+        new LazilyLoadedCtor<>(scope, "XMLList", implClass, sealed, true);
+        new LazilyLoadedCtor<>(scope, "Namespace", implClass, sealed, true);
+        new LazilyLoadedCtor<>(scope, "QName", implClass, sealed, true);
     }
 
     @Override

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
@@ -13,7 +13,6 @@ import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.Kit;
-import org.mozilla.javascript.NativeWith;
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.Ref;
 import org.mozilla.javascript.ScriptRuntime;
@@ -21,6 +20,8 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolScriptable;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.WithScope;
 import org.mozilla.javascript.xml.XMLObject;
 
 /**
@@ -123,7 +124,7 @@ abstract class XMLObjectImpl extends XMLObject {
                         0);
     }
 
-    protected XMLObjectImpl(XMLLibImpl lib, Scriptable scope, XMLObject prototype) {
+    protected XMLObjectImpl(XMLLibImpl lib, VarScope scope, XMLObject prototype) {
         initialize(lib, scope, prototype);
     }
 
@@ -456,12 +457,12 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     @Override
-    public NativeWith enterWith(Scriptable scope) {
+    public WithScope enterWith(VarScope scope) {
         return new XMLWithScope(lib, scope, this);
     }
 
     @Override
-    public NativeWith enterDotQuery(Scriptable scope) {
+    public WithScope enterDotQuery(VarScope scope) {
         XMLWithScope xws = new XMLWithScope(lib, scope, this);
         xws.initAsDotQuery();
         return xws;

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLWithScope.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLWithScope.java
@@ -6,11 +6,12 @@
 
 package org.mozilla.javascript.xmlimpl;
 
-import org.mozilla.javascript.NativeWith;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.WithScope;
 import org.mozilla.javascript.xml.XMLObject;
 
-final class XMLWithScope extends NativeWith {
+final class XMLWithScope extends WithScope {
     private static final long serialVersionUID = -696429282095170887L;
 
     private XMLLibImpl lib;
@@ -18,13 +19,13 @@ final class XMLWithScope extends NativeWith {
     private XMLList _xmlList;
     private XMLObject _dqPrototype;
 
-    XMLWithScope(XMLLibImpl lib, Scriptable parent, XMLObject prototype) {
+    XMLWithScope(XMLLibImpl lib, VarScope parent, XMLObject prototype) {
         super(parent, prototype);
         this.lib = lib;
     }
 
     void initAsDotQuery() {
-        XMLObject prototype = (XMLObject) getPrototype();
+        XMLObject prototype = (XMLObject) getObject();
         // XMLWithScope also handles the .(xxx) DotQuery for XML
         // basically DotQuery is a for/in/with statement and in
         // the following 3 statements we setup to signal it's
@@ -37,7 +38,7 @@ final class XMLWithScope extends NativeWith {
         if (prototype instanceof XMLList) {
             XMLList xl = (XMLList) prototype;
             if (xl.length() > 0) {
-                setPrototype((Scriptable) xl.get(0, null));
+                setObject((Scriptable) xl.get(0, null));
             }
         }
         // Always return the outer-most type of XML lValue of
@@ -70,7 +71,7 @@ final class XMLWithScope extends NativeWith {
                 // reset the expression to run with this object as
                 // the WITH selector.
                 _currIndex = idx;
-                setPrototype((Scriptable) orgXmlL.get(idx, null));
+                setObject((Scriptable) orgXmlL.get(idx, null));
 
                 // continue looping
                 return null;

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -78,7 +78,7 @@ public class ClassCache implements Serializable {
             // we expect this to not happen frequently, so computing top scope twice is acceptable
             var topScope = ScriptableObject.getTopLevelScope(scope);
             cache = new ClassCache();
-            cache.associate(((ScriptableObject) topScope));
+            cache.associate(topScope);
         }
         return cache;
     }
@@ -92,7 +92,7 @@ public class ClassCache implements Serializable {
      *     ClassCache were successfully associated or false otherwise.
      * @see #get(Scriptable scope)
      */
-    public boolean associate(ScriptableObject topScope) {
+    public boolean associate(TopLevel topScope) {
         if (topScope.getParentScope() != null) {
             // Can only associate cache with top level scope
             throw new IllegalArgumentException();

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1605,6 +1605,10 @@ public class Context implements Closeable {
         return result;
     }
 
+    public VarScope newVarEnv(VarScope parent) {
+        return new DeclarationScope(parent);
+    }
+
     /**
      * Create a new JavaScript object by executing the named constructor.
      *

--- a/rhino/src/main/java/org/mozilla/javascript/DeclarationScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/DeclarationScope.java
@@ -3,7 +3,7 @@ package org.mozilla.javascript;
 public class DeclarationScope extends ScopeObject {
     private static final long serialVersionUID = -7471457301304454454L;
 
-    public DeclarationScope(ScopeObject parentScope) {
+    public DeclarationScope(VarScope parentScope) {
         super(parentScope);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Delegator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Delegator.java
@@ -203,7 +203,7 @@ public class Delegator implements Function, SymbolScriptable {
      * @see org.mozilla.javascript.Scriptable#getParentScope
      */
     @Override
-    public Scriptable getParentScope() {
+    public VarScope getParentScope() {
         return getDelegee().getParentScope();
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Function.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Function.java
@@ -53,7 +53,7 @@ public interface Function extends Scriptable, Callable, Constructable {
      * it is useful to distinguish the two concepts as parent scopes are no longer supported by the
      * spec in general and present a significant barrier to future optimisations.
      */
-    default Scriptable getDeclarationScope() {
+    default VarScope getDeclarationScope() {
         return this.getParentScope();
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -324,7 +324,7 @@ public class FunctionObject extends BaseFunction {
         ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
         setImmunePrototypeProperty(prototype);
 
-        prototype.setParentScope(this);
+        prototype.setParentScope(scope);
 
         defineProperty(prototype, "constructor", this, attributes);
         setParentScope(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -81,7 +81,7 @@ public final class Interpreter extends Icode implements Evaluator {
         int pc;
         int pcPrevBranch;
         int pcSourceLineStart;
-        Scriptable scope;
+        VarScope scope;
 
         int savedStackTop;
         int savedCallOp;
@@ -247,7 +247,7 @@ public final class Interpreter extends Icode implements Evaluator {
 
         void initializeArgs(
                 Context cx,
-                Scriptable callerScope,
+                VarScope callerScope,
                 Object[] args,
                 double[] argsDbl,
                 Object[] boundArgs,
@@ -564,7 +564,7 @@ public final class Interpreter extends Icode implements Evaluator {
         }
 
         @Override
-        public Scriptable getParentScope() {
+        public VarScope getParentScope() {
             return frame.scope;
         }
 
@@ -1154,7 +1154,7 @@ public final class Interpreter extends Icode implements Evaluator {
             ScriptOrFn ifun,
             InterpreterData idata,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Scriptable thisObj,
             Object[] args) {
         if (!ScriptRuntime.hasTopCall(cx)) Kit.codeBug();
@@ -3138,7 +3138,8 @@ public final class Interpreter extends Icode implements Evaluator {
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
             final Object[] stack = frame.stack;
             Ref ref = (Ref) stack[state.stackTop];
-            stack[state.stackTop] = ScriptRuntime.refGet(ref, cx);
+            var res = ScriptRuntime.refGet(ref, cx);
+            stack[state.stackTop] = res;
             return null;
         }
     }
@@ -4267,7 +4268,7 @@ public final class Interpreter extends Icode implements Evaluator {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
             state.indexReg += frame.idata.itsMaxVars;
-            frame.scope = (Scriptable) frame.stack[state.indexReg];
+            frame.scope = (VarScope) frame.stack[state.indexReg];
             return null;
         }
     }
@@ -4914,7 +4915,7 @@ public final class Interpreter extends Icode implements Evaluator {
             int localShift = frame.idata.itsMaxVars;
             int scopeLocal = localShift + table[indexReg + EXCEPTION_SCOPE_SLOT];
             int exLocal = localShift + table[indexReg + EXCEPTION_LOCAL_SLOT];
-            frame.scope = (Scriptable) frame.stack[scopeLocal];
+            frame.scope = (VarScope) frame.stack[scopeLocal];
             frame.stack[exLocal] = throwable;
 
             throwable = null;
@@ -5005,7 +5006,7 @@ public final class Interpreter extends Icode implements Evaluator {
 
     private static CallFrame initFrame(
             Context cx,
-            Scriptable callerScope,
+            VarScope callerScope,
             Scriptable thisObj,
             Scriptable homeObj,
             Object[] args,
@@ -5045,12 +5046,12 @@ public final class Interpreter extends Icode implements Evaluator {
                 // found. Normally, frame.scope is a NativeCall when called
                 // from initFrame() for a debugged or activatable function.
                 // However, when called from interpretLoop() as part of
-                // restarting a continuation, it can also be a NativeWith if
+                // restarting a continuation, it can also be a WIthScope if
                 // the continuation was captured within a "with" or "catch"
                 // block ("catch" implicitly uses NativeWith to create a scope
                 // to expose the exception variable).
                 for (; ; ) {
-                    if (scope instanceof NativeWith) {
+                    if (scope instanceof WithScope) {
                         scope = scope.getParentScope();
                         if (scope == null
                                 || (frame.parentFrame != null

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -101,7 +101,8 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
             Scriptable scope,
             Object thisObj,
             Object[] args) {
-        return Interpreter.interpret(executableObject, this, cx, scope, (Scriptable) thisObj, args);
+        return Interpreter.interpret(
+                executableObject, this, cx, (VarScope) scope, (Scriptable) thisObj, args);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
@@ -46,7 +46,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
     }
 
     @Override
-    public Scriptable getDeclarationScope() {
+    public VarScope getDeclarationScope() {
         return this.getParentScope();
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -576,7 +576,7 @@ public final class JavaAdapter {
         return ContextFactory.getGlobal()
                 .call(
                         cx -> {
-                            ScriptableObject global = ScriptRuntime.getGlobal(cx);
+                            ScopeObject global = ScriptRuntime.getGlobal(cx);
                             script.exec(cx, global, global);
                             return global;
                         });

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -87,7 +87,7 @@ class JavaMembers {
         return findExplicitFunction(name, isStatic) != null;
     }
 
-    Object get(Scriptable scope, String name, Object javaObject, boolean isStatic) {
+    Object get(Scriptable obj, Scriptable scope, String name, Object javaObject, boolean isStatic) {
         Map<String, Object> ht = isStatic ? staticMembers : members;
         Object member = ht.get(name);
         if (!isStatic && member == null) {
@@ -126,7 +126,7 @@ class JavaMembers {
             if (bean.getter == null) {
                 return Scriptable.NOT_FOUND;
             }
-            return bean.getter.call(cx, scope, scope, ScriptRuntime.emptyArgs);
+            return bean.getter.call(cx, scope, obj, ScriptRuntime.emptyArgs);
         }
 
         var field = (NativeJavaField) member;

--- a/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
@@ -16,13 +16,13 @@ import java.security.PrivilegedAction;
  *
  * <p>This improves startup time and average memory usage.
  */
-public final class LazilyLoadedCtor implements Serializable {
+public final class LazilyLoadedCtor<T extends PropHolder<T>> implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final int STATE_BEFORE_INIT = 0;
     private static final int STATE_INITIALIZING = 1;
     private static final int STATE_WITH_VALUE = 2;
 
-    private final Scriptable scope;
+    private final SlotMapOwner<T> scope;
     private final Initializable initializer;
     private final String propertyName;
     private final boolean sealed;
@@ -38,7 +38,7 @@ public final class LazilyLoadedCtor implements Serializable {
      * initialization function.
      */
     public LazilyLoadedCtor(
-            ScriptableObject scope,
+            SlotMapOwner<T> scope,
             String propertyName,
             boolean sealed,
             boolean privileged,
@@ -61,7 +61,7 @@ public final class LazilyLoadedCtor implements Serializable {
      * initialization function.
      */
     public LazilyLoadedCtor(
-            ScriptableObject scope,
+            SlotMapOwner<T> scope,
             String propertyName,
             boolean sealed,
             Initializable initializer,
@@ -74,7 +74,7 @@ public final class LazilyLoadedCtor implements Serializable {
      * This is a legacy mechanism.
      */
     public LazilyLoadedCtor(
-            ScriptableObject scope, String propertyName, String className, boolean sealed) {
+            SlotMapOwner<T> scope, String propertyName, String className, boolean sealed) {
         this(scope, propertyName, className, sealed, false);
     }
 
@@ -83,7 +83,7 @@ public final class LazilyLoadedCtor implements Serializable {
      * This is a legacy mechanism.
      */
     public LazilyLoadedCtor(
-            ScriptableObject scope,
+            SlotMapOwner<T> scope,
             String propertyName,
             String className,
             boolean sealed,
@@ -130,13 +130,14 @@ public final class LazilyLoadedCtor implements Serializable {
         return buildValueInternal();
     }
 
+    @SuppressWarnings("unchecked")
     private Object buildValueInternal() {
         Context cx = Context.getCurrentContext();
-        Object value = initializer.initialize(cx, scope, sealed);
+        Object value = initializer.initialize(cx, (Scriptable) scope, sealed);
         if (value != null) {
             return value;
         }
-        return scope.get(propertyName, scope);
+        return scope.get(propertyName, (T) scope);
     }
 
     private static Object buildUsingReflection(

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCall.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ScriptableObject.CONST;
+import static org.mozilla.javascript.ScriptableObject.PERMANENT;
+
 /**
  * This class implements the activation object.
  *
@@ -14,32 +17,21 @@ package org.mozilla.javascript;
  * @see org.mozilla.javascript.Arguments
  * @author Norris Boyd
  */
-public final class NativeCall extends IdScriptableObject {
+public final class NativeCall extends DeclarationScope {
     private static final long serialVersionUID = -7471457301304454454L;
 
     private static final Object CALL_TAG = "Call";
 
-    static void init(Scriptable scope, boolean sealed) {
-        NativeCall obj = new NativeCall();
-        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
-    }
-
-    NativeCall() {
-        function = null;
-        originalArgs = null;
-    }
-
     NativeCall(
             JSFunction function,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object[] args,
             boolean isArrow,
             boolean argsHasRest,
             boolean requiresArgumentObject) {
+        super(scope);
         this.function = function;
-
-        setParentScope(scope);
         // leave prototype null
 
         this.originalArgs = (args == null) ? ScriptRuntime.emptyArgs : args;
@@ -95,53 +87,9 @@ public final class NativeCall extends IdScriptableObject {
         }
     }
 
-    @Override
-    public String getClassName() {
-        return "Call";
-    }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        return "constructor".equals(s) ? Id_constructor : 0;
-    }
-
-    @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        if (id == Id_constructor) {
-            arity = 1;
-            s = "constructor";
-        } else {
-            throw new IllegalArgumentException(String.valueOf(id));
-        }
-        initPrototypeMethod(CALL_TAG, id, s, arity);
-    }
-
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(CALL_TAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
-        }
-        int id = f.methodId();
-        if (id == Id_constructor) {
-            if (thisObj != null) {
-                throw Context.reportRuntimeErrorById("msg.only.from.new", "Call");
-            }
-            ScriptRuntime.checkDeprecated(cx, "Call");
-            NativeCall result = new NativeCall();
-            result.setPrototype(getObjectPrototype(scope));
-            return result;
-        }
-        throw new IllegalArgumentException(String.valueOf(id));
-    }
-
     public Scriptable getHomeObject() {
         return function.getHomeObject();
     }
-
-    private static final int Id_constructor = 1, MAX_PROTOTYPE_ID = 1;
 
     final JSFunction function;
     final Object[] originalArgs;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -262,7 +262,7 @@ final class NativeError extends ScriptableObject {
         }
 
         Scriptable eltArray = cx.newArray(this, elts);
-        return prepare.call(cx, prepare, this, new Object[] {this, eltArray});
+        return prepare.call(cx, prepare.getDeclarationScope(), this, new Object[] {this, eltArray});
     }
 
     private static Object js_toString(Scriptable thisObj) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaArray.java
@@ -82,7 +82,7 @@ public class NativeJavaArray extends NativeJavaObject implements SymbolScriptabl
         if (0 <= index && index < length) {
             Context cx = Context.getContext();
             Object obj = Array.get(array, index);
-            return cx.getWrapFactory().wrap(cx, this, obj, componentType);
+            return cx.getWrapFactory().wrap(cx, parent, obj, componentType);
         }
         return Undefined.instance;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -70,7 +70,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         }
 
         if (members.has(name, true)) {
-            return members.get(this, name, javaObject, true);
+            return members.get(this, parent, name, javaObject, true);
         }
 
         Context cx = Context.getContext();
@@ -86,7 +86,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         Class<?> nestedClass = findNestedClass(getClassObject(), name);
         if (nestedClass != null) {
             Scriptable nestedValue = wrapFactory.wrapJavaClass(cx, scope, nestedClass);
-            nestedValue.setParentScope(this);
+            nestedValue.setParentScope(parent);
             return nestedValue;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaList.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaList.java
@@ -108,7 +108,7 @@ public class NativeJavaList extends NativeJavaObject {
             Context cx = Context.getCurrentContext();
             Object obj = list.get(index);
             if (cx != null) {
-                return cx.getWrapFactory().wrap(cx, this, obj, elementType);
+                return cx.getWrapFactory().wrap(cx, parent, obj, elementType);
             }
             return obj;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -86,7 +86,7 @@ public class NativeJavaMap extends NativeJavaObject {
         Context cx = Context.getCurrentContext();
         if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             if (map.containsKey(name)) {
-                return cx.getWrapFactory().wrap(cx, this, map.get(name), valueType);
+                return cx.getWrapFactory().wrap(cx, parent, map.get(name), valueType);
             }
         }
         return super.get(name, start);
@@ -98,7 +98,7 @@ public class NativeJavaMap extends NativeJavaObject {
         if (cx != null && cx.hasFeature(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS)) {
             var key = Integer.valueOf(index);
             if (map.containsKey(key)) {
-                return cx.getWrapFactory().wrap(cx, this, map.get(key), valueType);
+                return cx.getWrapFactory().wrap(cx, parent, map.get(key), valueType);
             }
         }
         return super.get(index, start);
@@ -206,8 +206,8 @@ public class NativeJavaMap extends NativeJavaObject {
             Object key = e.getKey();
             Object value = e.getValue();
             WrapFactory wrapFactory = cx.getWrapFactory();
-            key = wrapFactory.wrap(cx, this, key, keyType);
-            value = wrapFactory.wrap(cx, this, value, valueType);
+            key = wrapFactory.wrap(cx, scope, key, keyType);
+            value = wrapFactory.wrap(cx, scope, value, valueType);
 
             return cx.newArray(scope, new Object[] {key, value});
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -47,7 +47,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     public NativeJavaObject(
             Scriptable scope, Object javaObject, TypeInfo staticType, boolean isAdapter) {
-        this.parent = scope;
+        this.parent = (VarScope) scope;
         this.javaObject = javaObject;
         this.staticType = staticType;
         this.isAdapter = isAdapter;
@@ -62,7 +62,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
             dynamicType = staticType.asClass();
         }
         members = JavaMembers.lookupClass(parent, dynamicType, staticType.asClass(), isAdapter);
-        fieldAndMethods = members.getFieldAndMethodsObjects(this, javaObject, false);
+        fieldAndMethods = members.getFieldAndMethodsObjects(parent, javaObject, false);
     }
 
     @Override
@@ -89,9 +89,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         if (fieldAndMethod != null) {
             return fieldAndMethod;
         }
-        // TODO: passing 'this' as the scope is bogus since it has
-        //  no parent scope
-        return members.get(this, name, javaObject, false);
+        return members.get(this, parent, name, javaObject, false);
     }
 
     @Override
@@ -168,14 +166,14 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     /** Returns the parent (enclosing) scope of the object. */
     @Override
-    public Scriptable getParentScope() {
+    public VarScope getParentScope() {
         return parent;
     }
 
     /** Sets the parent (enclosing) scope of the object. */
     @Override
     public void setParentScope(Scriptable m) {
-        parent = m;
+        parent = (VarScope) m;
     }
 
     @Override
@@ -951,7 +949,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                 return Undefined.instance;
             }
             Object obj = iterator.next();
-            return cx.getWrapFactory().wrap(cx, this, obj, obj == null ? null : obj.getClass());
+            return cx.getWrapFactory().wrap(cx, scope, obj, obj == null ? null : obj.getClass());
         }
 
         @Override
@@ -966,7 +964,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
     protected Scriptable prototype;
 
     /** The parent scope of this object. */
-    protected Scriptable parent;
+    protected VarScope parent;
 
     protected transient Object javaObject;
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaTopPackage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaTopPackage.java
@@ -91,7 +91,7 @@ public class NativeJavaTopPackage extends NativeJavaPackage implements Function,
 
         // It's safe to downcast here since initStandardObjects takes
         // a ScriptableObject.
-        ScriptableObject global = (ScriptableObject) scope;
+        ScopeObject global = (ScopeObject) scope;
 
         if (sealed) {
             getClass.sealObject();

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -1361,7 +1361,7 @@ class NativeProxy extends ScriptableObject {
         }
 
         @Override
-        public Scriptable getDeclarationScope() {
+        public VarScope getDeclarationScope() {
             ScriptableObject target = getTargetThrowIfRevoked();
             if (target instanceof Function) {
                 return ((Function) target).getDeclarationScope();

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWith.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWith.java
@@ -32,7 +32,7 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
     private NativeWith() {}
 
     protected NativeWith(Scriptable parent, Scriptable prototype) {
-        this.parent = parent;
+        this.parent = (VarScope) parent;
         this.prototype = prototype;
     }
 
@@ -136,13 +136,13 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
     }
 
     @Override
-    public Scriptable getParentScope() {
+    public VarScope getParentScope() {
         return parent;
     }
 
     @Override
     public void setParentScope(Scriptable parent) {
-        this.parent = parent;
+        this.parent = (VarScope) parent;
     }
 
     @Override
@@ -187,14 +187,13 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
 
     static Object newWithSpecial(Context cx, Scriptable scope, Object[] args) {
         ScriptRuntime.checkDeprecated(cx, "With");
-        scope = ScriptableObject.getTopLevelScope(scope);
-        NativeWith thisObj = new NativeWith();
-        thisObj.setPrototype(
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
+        var obj =
                 args.length == 0
                         ? ScriptableObject.getObjectPrototype(scope)
-                        : ScriptRuntime.toObject(cx, scope, args[0]));
-        thisObj.setParentScope(scope);
-        return thisObj;
+                        : ScriptRuntime.toObject(cx, scope, args[0]);
+        var newWith = new WithScope(top, obj);
+        return newWith;
     }
 
     private static final Object FTAG = "With";
@@ -202,5 +201,5 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
     private static final int Id_constructor = 1;
 
     protected Scriptable prototype;
-    protected Scriptable parent;
+    protected VarScope parent;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScopeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScopeObject.java
@@ -12,9 +12,9 @@ import java.io.Serializable;
 public class ScopeObject extends SlotMapOwner<Scriptable> implements VarScope, Serializable {
     private static final long serialVersionUID = -7471457301304454454L;
 
-    private final ScopeObject parentScope;
+    private final VarScope parentScope;
 
-    public ScopeObject(ScopeObject parentScope) {
+    public ScopeObject(VarScope parentScope) {
         this.parentScope = parentScope;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScopeWrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScopeWrapper.java
@@ -1,0 +1,45 @@
+package org.mozilla.javascript;
+
+public class ScopeWrapper extends ScriptableObject {
+    private static final long serialVersionUID = -7471457301304454454L;
+
+    private final Scriptable scope;
+
+    public ScopeWrapper(Scriptable scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public Scriptable getPrototype() {
+        return null;
+    }
+
+    @Override
+    public Object get(String name, Scriptable start) {
+        return scope.get(name, scope);
+    }
+
+    @Override
+    public void put(String name, Scriptable start, Object value) {
+        scope.put(name, scope, value);
+    }
+
+    @Override
+    public boolean has(String name, Scriptable start) {
+        return scope.has(name, scope);
+    }
+
+    @Override
+    public VarScope getParentScope() {
+        return scope.getParentScope();
+    }
+
+    @Override
+    public String getClassName() {
+        return "scope";
+    }
+
+    public Scriptable getScope() {
+        return scope;
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptOrFn.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptOrFn.java
@@ -15,7 +15,7 @@ public interface ScriptOrFn<T extends ScriptOrFn<T>> {
         return null;
     }
 
-    public default Scriptable getDeclarationScope() {
+    public default VarScope getDeclarationScope() {
         return null;
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -217,9 +217,6 @@ public class ScriptRuntime {
         function.setPrototype(functionPrototype);
         obj.setPrototype(functionPrototype);
 
-        // Set the prototype of the object passed in if need be
-        if (scope.getPrototype() == null) scope.setPrototype(objectPrototype);
-
         // must precede NativeGlobal since it's needed therein
         NativeError.init(cx, scope, sealed);
         NativeGlobal.init(cx, scope, sealed);
@@ -235,11 +232,10 @@ public class ScriptRuntime {
         NativeBoolean.init(cx, scope, sealed);
         NativeNumber.init(scope, sealed);
         NativeDate.init(cx, scope, sealed);
-        new LazilyLoadedCtor(scope, "Math", sealed, true, NativeMath::init);
-        new LazilyLoadedCtor(scope, "JSON", sealed, true, NativeJSON::init);
+        new LazilyLoadedCtor<>(scope, "Math", sealed, true, NativeMath::init);
+        new LazilyLoadedCtor<>(scope, "JSON", sealed, true, NativeJSON::init);
 
         NativeWith.init(scope, sealed);
-        NativeCall.init(scope, sealed);
         NativeScript.init(cx, scope, sealed);
 
         NativeIterator.init(cx, scope, sealed); // Also initializes NativeGenerator & ES6Generator
@@ -254,7 +250,7 @@ public class ScriptRuntime {
         // define lazy-loaded properties using their class name
         // Depends on the old reflection-based lazy loading mechanism
         // to property initialize the prototype.
-        new LazilyLoadedCtor(
+        new LazilyLoadedCtor<>(
                 scope, "Continuation", "org.mozilla.javascript.NativeContinuation", sealed, true);
 
         if (cx.hasFeature(Context.FEATURE_E4X)) {
@@ -266,35 +262,36 @@ public class ScriptRuntime {
         if (((cx.getLanguageVersion() >= Context.VERSION_1_8)
                         && cx.hasFeature(Context.FEATURE_V8_EXTENSIONS))
                 || (cx.getLanguageVersion() >= Context.VERSION_ES6)) {
-            new LazilyLoadedCtor(scope, "ArrayBuffer", sealed, true, NativeArrayBuffer::init);
-            new LazilyLoadedCtor(scope, "Int8Array", sealed, true, NativeInt8Array::init);
-            new LazilyLoadedCtor(scope, "Uint8Array", sealed, true, NativeUint8Array::init);
-            new LazilyLoadedCtor(
+            new LazilyLoadedCtor<>(scope, "ArrayBuffer", sealed, true, NativeArrayBuffer::init);
+            new LazilyLoadedCtor<>(scope, "Int8Array", sealed, true, NativeInt8Array::init);
+            new LazilyLoadedCtor<>(scope, "Uint8Array", sealed, true, NativeUint8Array::init);
+            new LazilyLoadedCtor<>(
                     scope, "Uint8ClampedArray", sealed, true, NativeUint8ClampedArray::init);
-            new LazilyLoadedCtor(scope, "Int16Array", sealed, true, NativeInt16Array::init);
-            new LazilyLoadedCtor(scope, "Uint16Array", sealed, true, NativeUint16Array::init);
-            new LazilyLoadedCtor(scope, "Int32Array", sealed, true, NativeInt32Array::init);
-            new LazilyLoadedCtor(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
-            new LazilyLoadedCtor(scope, "BigInt64Array", sealed, true, NativeBigInt64Array::init);
-            new LazilyLoadedCtor(scope, "BigUint64Array", sealed, true, NativeBigUint64Array::init);
-            new LazilyLoadedCtor(scope, "Float16Array", sealed, true, NativeFloat16Array::init);
-            new LazilyLoadedCtor(scope, "Float32Array", sealed, true, NativeFloat32Array::init);
-            new LazilyLoadedCtor(scope, "Float64Array", sealed, true, NativeFloat64Array::init);
-            new LazilyLoadedCtor(scope, "DataView", sealed, true, NativeDataView::init);
+            new LazilyLoadedCtor<>(scope, "Int16Array", sealed, true, NativeInt16Array::init);
+            new LazilyLoadedCtor<>(scope, "Uint16Array", sealed, true, NativeUint16Array::init);
+            new LazilyLoadedCtor<>(scope, "Int32Array", sealed, true, NativeInt32Array::init);
+            new LazilyLoadedCtor<>(scope, "Uint32Array", sealed, true, NativeUint32Array::init);
+            new LazilyLoadedCtor<>(scope, "BigInt64Array", sealed, true, NativeBigInt64Array::init);
+            new LazilyLoadedCtor<>(
+                    scope, "BigUint64Array", sealed, true, NativeBigUint64Array::init);
+            new LazilyLoadedCtor<>(scope, "Float16Array", sealed, true, NativeFloat16Array::init);
+            new LazilyLoadedCtor<>(scope, "Float32Array", sealed, true, NativeFloat32Array::init);
+            new LazilyLoadedCtor<>(scope, "Float64Array", sealed, true, NativeFloat64Array::init);
+            new LazilyLoadedCtor<>(scope, "DataView", sealed, true, NativeDataView::init);
         }
 
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             NativeSymbol.init(cx, scope, sealed);
             NativeCollectionIterator.init(scope, NativeSet.ITERATOR_TAG, sealed);
             NativeCollectionIterator.init(scope, NativeMap.ITERATOR_TAG, sealed);
-            new LazilyLoadedCtor(scope, "Map", sealed, true, NativeMap::init);
-            new LazilyLoadedCtor(scope, "Promise", sealed, true, NativePromise::init);
-            new LazilyLoadedCtor(scope, "Set", sealed, true, NativeSet::init);
-            new LazilyLoadedCtor(scope, "WeakMap", sealed, true, NativeWeakMap::init);
-            new LazilyLoadedCtor(scope, "WeakSet", sealed, true, NativeWeakSet::init);
-            new LazilyLoadedCtor(scope, "BigInt", sealed, true, NativeBigInt::init);
-            new LazilyLoadedCtor(scope, "Proxy", sealed, true, NativeProxy::init);
-            new LazilyLoadedCtor(scope, "Reflect", sealed, true, NativeReflect::init);
+            new LazilyLoadedCtor<>(scope, "Map", sealed, true, NativeMap::init);
+            new LazilyLoadedCtor<>(scope, "Promise", sealed, true, NativePromise::init);
+            new LazilyLoadedCtor<>(scope, "Set", sealed, true, NativeSet::init);
+            new LazilyLoadedCtor<>(scope, "WeakMap", sealed, true, NativeWeakMap::init);
+            new LazilyLoadedCtor<>(scope, "WeakSet", sealed, true, NativeWeakSet::init);
+            new LazilyLoadedCtor<>(scope, "BigInt", sealed, true, NativeBigInt::init);
+            new LazilyLoadedCtor<>(scope, "Proxy", sealed, true, NativeProxy::init);
+            new LazilyLoadedCtor<>(scope, "Reflect", sealed, true, NativeReflect::init);
         }
 
         scope.cacheBuiltins(sealed);
@@ -313,16 +310,17 @@ public class ScriptRuntime {
         TopLevel s = initSafeStandardObjects(cx, scope, sealed);
 
         // These depend on the legacy initialization behavior of the lazy loading mechanism
-        new LazilyLoadedCtor(
+        new LazilyLoadedCtor<>(
                 s, "Packages", "org.mozilla.javascript.NativeJavaTopPackage", sealed, true);
-        new LazilyLoadedCtor(
+        new LazilyLoadedCtor<>(
                 s, "getClass", "org.mozilla.javascript.NativeJavaTopPackage", sealed, true);
-        new LazilyLoadedCtor(s, "JavaAdapter", "org.mozilla.javascript.JavaAdapter", sealed, true);
-        new LazilyLoadedCtor(
+        new LazilyLoadedCtor<>(
+                s, "JavaAdapter", "org.mozilla.javascript.JavaAdapter", sealed, true);
+        new LazilyLoadedCtor<>(
                 s, "JavaImporter", "org.mozilla.javascript.ImporterTopLevel", sealed, true);
 
         for (String packageName : getTopPackageNames()) {
-            new LazilyLoadedCtor(
+            new LazilyLoadedCtor<>(
                     s, packageName, "org.mozilla.javascript.NativeJavaTopPackage", sealed, true);
         }
 
@@ -336,10 +334,8 @@ public class ScriptRuntime {
                 : new String[] {"java", "javax", "org", "com", "edu", "net"};
     }
 
-    public static ScriptableObject getLibraryScopeOrNull(Scriptable scope) {
-        ScriptableObject libScope;
-        libScope = (ScriptableObject) ScriptableObject.getTopScopeValue(scope, LIBRARY_SCOPE_KEY);
-        return libScope;
+    public static ScopeObject getLibraryScopeOrNull(Scriptable scope) {
+        return (ScopeObject) ScriptableObject.getTopScopeValue(scope, LIBRARY_SCOPE_KEY);
     }
 
     // It is public so NativeRegExp can access it.
@@ -2354,8 +2350,8 @@ public class ScriptRuntime {
 
         XMLObject firstXMLObject = null;
         for (; ; ) {
-            if (scope instanceof NativeWith) {
-                Scriptable withObj = scope.getPrototype();
+            if (scope instanceof WithScope) {
+                Scriptable withObj = ((WithScope) scope).getObject();
                 if (withObj instanceof XMLObject) {
                     XMLObject xmlObj = (XMLObject) withObj;
                     if (xmlObj.has(name, xmlObj)) {
@@ -2444,8 +2440,8 @@ public class ScriptRuntime {
 
         XMLObject firstXMLObject = null;
         for (; ; ) {
-            if (scope instanceof NativeWith) {
-                Scriptable withObj = scope.getPrototype();
+            if (scope instanceof WithScope) {
+                Scriptable withObj = ((WithScope) scope).getObject();
                 if (withObj instanceof XMLObject) {
                     XMLObject xmlObj = (XMLObject) withObj;
                     if (xmlObj.has(name, xmlObj)) {
@@ -2528,8 +2524,8 @@ public class ScriptRuntime {
         childScopesChecks:
         if (parent != null) {
             // Check for possibly nested "with" scopes first
-            while (scope instanceof NativeWith) {
-                Scriptable withObj = scope.getPrototype();
+            while (scope instanceof WithScope) {
+                Scriptable withObj = ((WithScope) scope).getObject();
                 if (withObj instanceof XMLObject) {
                     XMLObject xmlObject = (XMLObject) withObj;
                     if (xmlObject.has(cx, id)) {
@@ -4042,15 +4038,19 @@ public class ScriptRuntime {
                 }
                 target = scopeChain;
                 do {
-                    if (target instanceof NativeWith
-                            && target.getPrototype() instanceof XMLObject) {
+                    if (target instanceof WithScope
+                            && ((WithScope) target).getObject() instanceof XMLObject) {
                         break;
                     }
                     value = target.get(id, scopeChain);
                     if (value != Scriptable.NOT_FOUND) {
                         break search;
                     }
-                    target = target.getPrototype();
+                    if (target instanceof VarScope) {
+                        target = null;
+                    } else {
+                        target = target.getPrototype();
+                    }
                 } while (target != null);
                 scopeChain = scopeChain.getParentScope();
             } while (scopeChain != null);
@@ -4827,7 +4827,7 @@ public class ScriptRuntime {
     // Statements
     // ------------------
 
-    public static ScriptableObject getGlobal(Context cx) {
+    public static TopLevel getGlobal(Context cx) {
         final String GLOBAL_CLASS = "org.mozilla.javascript.tools.shell.Global";
         Class<?> globalClass = Kit.classOrNull(GLOBAL_CLASS);
         if (globalClass != null) {
@@ -4835,7 +4835,7 @@ public class ScriptRuntime {
                 Class<?>[] parm = {ScriptRuntime.ContextClass};
                 Constructor<?> globalClassCtor = globalClass.getConstructor(parm);
                 Object[] arg = {cx};
-                return (ScriptableObject) globalClassCtor.newInstance(arg);
+                return (TopLevel) globalClassCtor.newInstance(arg);
             } catch (RuntimeException e) {
                 throw e;
             } catch (Exception e) {
@@ -4979,7 +4979,7 @@ public class ScriptRuntime {
             Scriptable varScope = scope;
             // Never define any variables from var statements inside with
             // object. See bug 38590.
-            while (varScope instanceof NativeWith) {
+            while (varScope instanceof WithScope) {
                 varScope = varScope.getParentScope();
             }
 
@@ -5008,30 +5008,30 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #createFunctionActivation(JSFunction, Context, Scriptable, Object[],
+     * @deprecated Use {@link #createFunctionActivation(JSFunction, Context, VarScope, Object[],
      *     boolean, boolean)} instead
      */
     @Deprecated
-    public static Scriptable createFunctionActivation(
+    public static VarScope createFunctionActivation(
             JSFunction funObj, Scriptable scope, Object[] args) {
         return createFunctionActivation(
-                funObj, Context.getCurrentContext(), scope, args, false, true);
+                funObj, Context.getCurrentContext(), (VarScope) scope, args, false, false);
     }
 
-    public static Scriptable createFunctionActivation(
+    public static VarScope createFunctionActivation(
             JSFunction funObj,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object[] args,
             boolean argsHasRest,
             boolean requiresArgumentObject) {
         return new NativeCall(funObj, cx, scope, args, false, argsHasRest, requiresArgumentObject);
     }
 
-    public static Scriptable createArrowFunctionActivation(
+    public static VarScope createArrowFunctionActivation(
             JSFunction funObj,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object[] args,
             boolean argsHasRest,
             boolean requiresArgumentObject) {
@@ -5282,7 +5282,7 @@ public class ScriptRuntime {
         return shutter == null || shutter.visibleToScripts(obj.getClass().getName());
     }
 
-    public static Scriptable enterWith(Object obj, Context cx, Scriptable scope) {
+    public static VarScope enterWith(Object obj, Context cx, VarScope scope) {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             throw typeErrorById("msg.undef.with", toString(obj));
@@ -5291,15 +5291,15 @@ public class ScriptRuntime {
             XMLObject xmlObject = (XMLObject) sobj;
             return xmlObject.enterWith(scope);
         }
-        return new NativeWith(scope, sobj);
+        return new WithScope((VarScope) scope, sobj);
     }
 
-    public static Scriptable leaveWith(Scriptable scope) {
-        NativeWith nw = (NativeWith) scope;
+    public static VarScope leaveWith(VarScope scope) {
+        WithScope nw = (WithScope) scope;
         return nw.getParentScope();
     }
 
-    public static Scriptable enterDotQuery(Object value, Scriptable scope) {
+    public static VarScope enterDotQuery(Object value, VarScope scope) {
         if (!(value instanceof XMLObject)) {
             throw notXmlError(value);
         }
@@ -5307,14 +5307,14 @@ public class ScriptRuntime {
         return object.enterDotQuery(scope);
     }
 
-    public static Object updateDotQuery(boolean value, Scriptable scope) {
+    public static Object updateDotQuery(boolean value, VarScope scope) {
         // Return null to continue looping
-        NativeWith nw = (NativeWith) scope;
+        WithScope nw = (WithScope) scope;
         return nw.updateDotQuery(value);
     }
 
-    public static Scriptable leaveDotQuery(Scriptable scope) {
-        NativeWith nw = (NativeWith) scope;
+    public static VarScope leaveDotQuery(VarScope scope) {
+        WithScope nw = (WithScope) scope;
         return nw.getParentScope();
     }
 
@@ -5395,7 +5395,7 @@ public class ScriptRuntime {
                 // Always put function expression statements into initial
                 // activation object ignoring the with statement to follow
                 // SpiderMonkey
-                while (scope instanceof NativeWith) {
+                while (scope instanceof WithScope) {
                     scope = scope.getParentScope();
                 }
                 scope.put(name, scope, function);

--- a/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
@@ -270,7 +270,7 @@ public interface Scriptable extends PropHolder<Scriptable> {
      *
      * @return the parent scope
      */
-    public Scriptable getParentScope();
+    public VarScope getParentScope();
 
     /**
      * Set the parent scope of the object.

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -108,7 +108,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     private Scriptable prototypeObject;
 
     /** The parent scope of this object. */
-    private Scriptable parentScopeObject;
+    private VarScope parentScopeObject;
 
     // Where external array data is stored.
     private transient ExternalArrayData externalData;
@@ -152,7 +152,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         super(0);
         if (scope == null) throw new IllegalArgumentException();
 
-        parentScopeObject = scope;
+        parentScopeObject = (VarScope) scope;
         prototypeObject = prototype;
     }
 
@@ -595,14 +595,14 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
 
     /** Returns the parent (enclosing) scope of the object. */
     @Override
-    public Scriptable getParentScope() {
+    public VarScope getParentScope() {
         return parentScopeObject;
     }
 
     /** Sets the parent (enclosing) scope of the object. */
     @Override
     public void setParentScope(Scriptable m) {
-        parentScopeObject = m;
+        parentScopeObject = (VarScope) m;
     }
 
     /**
@@ -1089,7 +1089,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
                         "jsStaticFunction must be used with static method.");
             }
 
-            FunctionObject f = new FunctionObject(name, method, proto);
+            FunctionObject f = new FunctionObject(name, method, scope);
             if (f.isVarArgsConstructor()) {
                 throw Context.reportRuntimeErrorById("msg.varargs.fun", ctorMember.getName());
             }
@@ -2737,7 +2737,11 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         Scriptable obj = start;
         do {
             if (obj.has(name, start)) break;
-            obj = obj.getPrototype();
+            if (obj instanceof VarScope) {
+                obj = null;
+            } else {
+                obj = obj.getPrototype();
+            }
         } while (obj != null);
         return obj;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/SpecialRef.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SpecialRef.java
@@ -54,9 +54,20 @@ class SpecialRef extends Ref {
             case SPECIAL_PROTO:
                 return target.getPrototype();
             case SPECIAL_PARENT:
-                return target.getParentScope();
+                return getScriptableForScope(target.getParentScope());
             default:
                 throw Kit.codeBug();
+        }
+    }
+
+    private static Scriptable getScriptableForScope(Scriptable scope) {
+        if (scope instanceof WithScope) {
+            return ((WithScope) scope).getObject();
+        } else if (scope != null) {
+            // Wrap it.
+            return new ScopeWrapper(scope);
+        } else {
+            return null;
         }
     }
 
@@ -72,7 +83,6 @@ class SpecialRef extends Ref {
             case SPECIAL_NONE:
                 return ScriptRuntime.setObjectProp(target, name, value, cx);
             case SPECIAL_PROTO:
-            case SPECIAL_PARENT:
                 {
                     Scriptable obj = ScriptRuntime.toObjectOrNull(cx, value, scope);
                     if (obj != null) {
@@ -127,10 +137,12 @@ class SpecialRef extends Ref {
                         } else {
                             target.setPrototype(obj);
                         }
-                    } else {
-                        target.setParentScope(obj);
                     }
                     return obj;
+                }
+            case SPECIAL_PARENT:
+                {
+                    throw Kit.codeBug();
                 }
             default:
                 throw Kit.codeBug();

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -32,7 +32,7 @@ import java.util.EnumMap;
  * dynamic scopes) embeddings should explicitly call {@link #cacheBuiltins(boolean)} to initialize
  * the class cache for each top-level scope.
  */
-public class TopLevel extends ScriptableObject {
+public class TopLevel extends ScopeObject {
 
     private static final long serialVersionUID = -4648046356662472260L;
 
@@ -129,6 +129,7 @@ public class TopLevel extends ScriptableObject {
     }
 
     public TopLevel(ScriptableObject customGlobal) {
+        super(null);
         globalThis = customGlobal;
     }
 
@@ -426,5 +427,10 @@ public class TopLevel extends ScriptableObject {
     @Override
     public void defineConst(String name, Scriptable start) {
         globalThis.defineConst(name, globalThis);
+    }
+
+    public void defineFunctionProperties(
+            Scriptable scope, String[] names, Class<?> clazz, int attributes) {
+        getGlobalThis().defineFunctionProperties(scope, names, clazz, attributes);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Undefined.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Undefined.java
@@ -108,7 +108,7 @@ public class Undefined implements Serializable {
         public void setPrototype(Scriptable prototype) {}
 
         @Override
-        public Scriptable getParentScope() {
+        public VarScope getParentScope() {
             return null;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/WithScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WithScope.java
@@ -3,7 +3,8 @@ package org.mozilla.javascript;
 public class WithScope implements VarScope {
     private static final long serialVersionUID = -7471457301304454454L;
 
-    private final Scriptable obj;
+    // This cannot be final because XML dot queries mutate it!
+    private Scriptable obj;
     private final VarScope parent;
 
     public WithScope(VarScope parentScope, Scriptable obj) {
@@ -14,6 +15,10 @@ public class WithScope implements VarScope {
     @Override
     public VarScope getParentScope() {
         return parent;
+    }
+
+    public void setObject(Scriptable obj) {
+        this.obj = obj;
     }
 
     @Override
@@ -90,5 +95,11 @@ public class WithScope implements VarScope {
 
     public Scriptable getObject() {
         return obj;
+    }
+
+    /** Must return null to continue looping or the final collection result. */
+    protected Object updateDotQuery(boolean value) {
+        // NativeWith itself does not support it
+        throw new IllegalStateException();
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -5,27 +5,28 @@
 package org.mozilla.javascript.commonjs.module;
 
 import java.net.URI;
+import org.mozilla.javascript.DeclarationScope;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 
 /**
  * A top-level module scope. This class provides methods to retrieve the module's source and base
  * URIs in order to resolve relative module IDs and check sandbox constraints.
  */
-public class ModuleScope extends ScriptableObject {
+public class ModuleScope extends DeclarationScope {
     private static final long serialVersionUID = 1L;
     private final URI uri;
     private final URI base;
 
-    private ModuleScope(URI uri, URI base) {
+    private ModuleScope(ScopeObject scope, URI uri, URI base) {
+        super(scope);
         this.uri = uri;
         this.base = base;
     }
 
-    public static ScriptableObject createModuleScope(TopLevel global, URI uri, URI base) {
-        var moduleScope = new ModuleScope(uri, base);
-        moduleScope.setParentScope(global);
+    public static ScopeObject createModuleScope(TopLevel global, URI uri, URI base) {
+        var moduleScope = new ModuleScope(global, uri, base);
         return moduleScope;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -103,7 +103,7 @@ class BodyCodegen {
                     ByteCode.INVOKEINTERFACE,
                     "org/mozilla/javascript/Function",
                     "getDeclarationScope",
-                    "()Lorg/mozilla/javascript/Scriptable;");
+                    "()Lorg/mozilla/javascript/VarScope;");
             cfw.addAStore(variableObjectLocal);
         }
 
@@ -111,6 +111,7 @@ class BodyCodegen {
         cfw.addALoad(funObjLocal);
         cfw.addALoad(contextLocal);
         cfw.addALoad(variableObjectLocal);
+        cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
         cfw.addALoad(argsLocal);
         cfw.addPush(scriptOrFn.hasRestParameter());
         cfw.addPush(
@@ -120,11 +121,11 @@ class BodyCodegen {
                 "createFunctionActivation",
                 "(Lorg/mozilla/javascript/JSFunction;"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + "[Ljava/lang/Object;"
                         + "Z"
                         + "Z"
-                        + ")Lorg/mozilla/javascript/Scriptable;");
+                        + ")Lorg/mozilla/javascript/VarScope;");
         cfw.addAStore(variableObjectLocal);
 
         // Evaluate default params for generators after creating activation scope
@@ -249,7 +250,7 @@ class BodyCodegen {
                     ByteCode.INVOKEINTERFACE,
                     "org/mozilla/javascript/Function",
                     "getDeclarationScope",
-                    "()Lorg/mozilla/javascript/Scriptable;");
+                    "()Lorg/mozilla/javascript/VarScope;");
             cfw.addAStore(variableObjectLocal);
         }
 
@@ -421,6 +422,7 @@ class BodyCodegen {
             cfw.addALoad(funObjLocal);
             cfw.addALoad(contextLocal);
             cfw.addALoad(variableObjectLocal);
+            cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
             cfw.addALoad(argsLocal);
             cfw.addPush(scriptOrFn.hasRestParameter());
             cfw.addPush(
@@ -433,11 +435,11 @@ class BodyCodegen {
                     methodName,
                     "(Lorg/mozilla/javascript/JSFunction;"
                             + "Lorg/mozilla/javascript/Context;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
+                            + "Lorg/mozilla/javascript/VarScope;"
                             + "[Ljava/lang/Object;"
                             + "Z"
                             + "Z"
-                            + ")Lorg/mozilla/javascript/Scriptable;");
+                            + ")Lorg/mozilla/javascript/VarScope;");
             cfw.addAStore(variableObjectLocal);
             cfw.addALoad(contextLocal);
             cfw.addALoad(variableObjectLocal);
@@ -803,22 +805,24 @@ class BodyCodegen {
                 generateExpression(child, node);
                 cfw.addALoad(contextLocal);
                 cfw.addALoad(variableObjectLocal);
+                cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
                 addScriptRuntimeInvoke(
                         "enterWith",
                         "(Ljava/lang/Object;"
                                 + "Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
-                                + ")Lorg/mozilla/javascript/Scriptable;");
+                                + "Lorg/mozilla/javascript/VarScope;"
+                                + ")Lorg/mozilla/javascript/VarScope;");
                 cfw.addAStore(variableObjectLocal);
                 incReferenceWordLocal(variableObjectLocal);
                 break;
 
             case Token.LEAVEWITH:
                 cfw.addALoad(variableObjectLocal);
+                cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
                 addScriptRuntimeInvoke(
                         "leaveWith",
-                        "(Lorg/mozilla/javascript/Scriptable;"
-                                + ")Lorg/mozilla/javascript/Scriptable;");
+                        "(Lorg/mozilla/javascript/VarScope;"
+                                + ")Lorg/mozilla/javascript/VarScope;");
                 cfw.addAStore(variableObjectLocal);
                 decReferenceWordLocal(variableObjectLocal);
                 break;
@@ -4666,11 +4670,12 @@ class BodyCodegen {
         updateLineNumber(node);
         generateExpression(child, node);
         cfw.addALoad(variableObjectLocal);
+        cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
         addScriptRuntimeInvoke(
                 "enterDotQuery",
                 "(Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
-                        + ")Lorg/mozilla/javascript/Scriptable;");
+                        + "Lorg/mozilla/javascript/VarScope;"
+                        + ")Lorg/mozilla/javascript/VarScope;");
         cfw.addAStore(variableObjectLocal);
 
         // add push null/pop with label in between to simplify code for loop
@@ -4684,16 +4689,18 @@ class BodyCodegen {
         generateExpression(child.getNext(), node);
         addDynamicInvoke("MATH:TOBOOLEAN", Signatures.MATH_TO_BOOLEAN);
         cfw.addALoad(variableObjectLocal);
+        cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
         addScriptRuntimeInvoke(
                 "updateDotQuery",
-                "(Z" + "Lorg/mozilla/javascript/Scriptable;" + ")Ljava/lang/Object;");
+                "(Z" + "Lorg/mozilla/javascript/VarScope;" + ")Ljava/lang/Object;");
         cfw.add(ByteCode.DUP);
         cfw.add(ByteCode.IFNULL, queryLoopStart);
         // stack: ... non_null_result_of_updateDotQuery
         cfw.addALoad(variableObjectLocal);
+        cfw.add(ByteCode.CHECKCAST, "org/mozilla/javascript/VarScope");
         addScriptRuntimeInvoke(
                 "leaveDotQuery",
-                "(Lorg/mozilla/javascript/Scriptable;" + ")Lorg/mozilla/javascript/Scriptable;");
+                "(Lorg/mozilla/javascript/VarScope;" + ")Lorg/mozilla/javascript/VarScope;");
         cfw.addAStore(variableObjectLocal);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -14,6 +14,7 @@ import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.NativeGenerator;
 import org.mozilla.javascript.NativeIterator;
 import org.mozilla.javascript.NewLiteralStorage;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
@@ -245,7 +246,7 @@ public final class OptRuntime extends ScriptRuntime {
         ContextFactory.getGlobal()
                 .call(
                         cx -> {
-                            ScriptableObject global = getGlobal(cx);
+                            ScopeObject global = getGlobal(cx);
 
                             // get the command line arguments and define "arguments"
                             // array in the top-level object

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -23,7 +23,7 @@ public class RegExpImpl implements RegExpProxy {
     @Override
     public void register(TopLevel scope, boolean sealed) {
         NativeRegExpStringIterator.init(scope, sealed);
-        new LazilyLoadedCtor(scope, "RegExp", sealed, true, NativeRegExp::init);
+        new LazilyLoadedCtor<>(scope, "RegExp", sealed, true, NativeRegExp::init);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -32,6 +32,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeArrayIterator;
 import org.mozilla.javascript.NativeArrayIterator.ARRAY_ITERATOR_TYPE;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
@@ -238,7 +239,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     static void init(
             Context cx, Scriptable scope, LambdaConstructor constructor, RealThis realThis) {
-        ScriptableObject s = (ScriptableObject) scope;
+        ScopeObject s = (ScopeObject) scope;
         // Where do we store this prototype? Top level scope for now?
 
         LambdaConstructor ta = (LambdaConstructor) s.getAssociatedValue(TYPED_ARRAY_TAG);

--- a/rhino/src/main/java/org/mozilla/javascript/xml/XMLLib.java
+++ b/rhino/src/main/java/org/mozilla/javascript/xml/XMLLib.java
@@ -8,6 +8,7 @@ package org.mozilla.javascript.xml;
 
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Ref;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
@@ -38,7 +39,7 @@ public abstract class XMLLib {
     }
 
     public static XMLLib extractFromScopeOrNull(Scriptable scope) {
-        ScriptableObject so = ScriptRuntime.getLibraryScopeOrNull(scope);
+        ScopeObject so = ScriptRuntime.getLibraryScopeOrNull(scope);
         if (so == null) {
             // If library is not yet initialized, return null
             return null;
@@ -61,7 +62,7 @@ public abstract class XMLLib {
     }
 
     protected final XMLLib bindToScope(Scriptable scope) {
-        ScriptableObject so = ScriptRuntime.getLibraryScopeOrNull(scope);
+        ScopeObject so = ScriptRuntime.getLibraryScopeOrNull(scope);
         if (so == null) {
             // standard library should be initialized at this point
             throw new IllegalStateException();

--- a/rhino/src/main/java/org/mozilla/javascript/xml/XMLLoader.java
+++ b/rhino/src/main/java/org/mozilla/javascript/xml/XMLLoader.java
@@ -1,10 +1,10 @@
 package org.mozilla.javascript.xml;
 
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 
 /** This interface is used to load the XML implementation using the ServiceLoader pattern. */
 public interface XMLLoader {
-    void load(ScriptableObject scope, boolean sealed);
+    void load(ScopeObject scope, boolean sealed);
 
     XMLLib.Factory getFactory();
 }

--- a/rhino/src/main/java/org/mozilla/javascript/xml/XMLObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/xml/XMLObject.java
@@ -7,10 +7,11 @@
 package org.mozilla.javascript.xml;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.NativeWith;
 import org.mozilla.javascript.Ref;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.WithScope;
 
 /** This Interface describes what all XML objects (XML, XMLList) should have in common. */
 public abstract class XMLObject extends ScriptableObject {
@@ -52,10 +53,10 @@ public abstract class XMLObject extends ScriptableObject {
     public abstract Ref memberRef(Context cx, Object namespace, Object elem, int memberTypeFlags);
 
     /** Wrap this object into NativeWith to implement the with statement. */
-    public abstract NativeWith enterWith(Scriptable scope);
+    public abstract WithScope enterWith(VarScope scope);
 
     /** Wrap this object into NativeWith to implement the .() query. */
-    public abstract NativeWith enterDotQuery(Scriptable scope);
+    public abstract WithScope enterDotQuery(VarScope scope);
 
     /**
      * Custom {@code +} operator. Should return {@link Scriptable#NOT_FOUND} if this object does not

--- a/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
@@ -50,6 +50,7 @@ public class AssignSubclassTest {
                     try {
                         ScriptableObject.defineClass(scope, MySubclass.class);
                     } catch (Exception e) {
+                        e.printStackTrace();
                         fail(e);
                     }
                     Object result =

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug687669Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug687669Test.java
@@ -14,7 +14,7 @@ import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ErrorReporter;
 import org.mozilla.javascript.Parser;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.ast.AstRoot;
 
@@ -24,7 +24,7 @@ import org.mozilla.javascript.ast.AstRoot;
 public class Bug687669Test {
 
     private Context cx;
-    private ScriptableObject scope;
+    private ScopeObject scope;
 
     @BeforeEach
     public void setUp() {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug708801Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug708801Test.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.ErrorReporter;
 import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.JSDescriptor;
 import org.mozilla.javascript.Parser;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -45,7 +45,7 @@ public class Bug708801Test {
 
     private abstract static class Action implements ContextAction<Object> {
         protected Context cx;
-        protected ScriptableObject scope;
+        protected ScopeObject scope;
 
         @SuppressWarnings("unused")
         protected Object evaluate(String s) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug714204Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug714204Test.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.ScriptableObject;
 
 /**
  * @author André Bargull
@@ -22,7 +22,7 @@ import org.mozilla.javascript.ScriptableObject;
 public class Bug714204Test {
 
     private Context cx;
-    private ScriptableObject scope;
+    private ScopeObject scope;
 
     @BeforeEach
     public void setUp() {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
@@ -11,6 +11,7 @@ import static org.mozilla.javascript.testutils.Utils.runWithAllModes;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
+import org.mozilla.javascript.ScopeWrapper;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 
@@ -477,11 +478,21 @@ public class Bug783797Test {
                         new Action() {
                             @Override
                             public void run(Context cx, TopLevel scope1, TopLevel scope2) {
-                                assertSame(scope2, eval(cx, scope2, "test.__parent__"));
-                                assertSame(scope2, eval(cx, scope1, "scope2.test.__parent__"));
-                                assertSame(
-                                        scope2,
-                                        eval(cx, scope1, "var t=scope2.test; t.__parent__"));
+                                Object parent = eval(cx, scope2, "test.__parent__");
+                                if (parent instanceof ScopeWrapper) {
+                                    parent = ((ScopeWrapper) parent).getScope();
+                                }
+                                assertSame(scope2, parent);
+                                parent = eval(cx, scope1, "scope2.test.__parent__");
+                                if (parent instanceof ScopeWrapper) {
+                                    parent = ((ScopeWrapper) parent).getScope();
+                                }
+                                assertSame(scope2, parent);
+                                parent = eval(cx, scope1, "var t=scope2.test; t.__parent__");
+                                if (parent instanceof ScopeWrapper) {
+                                    parent = ((ScopeWrapper) parent).getScope();
+                                }
+                                assertSame(scope2, parent);
                             }
                         }));
     }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/BuiltinsSealingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/BuiltinsSealingTest.java
@@ -78,7 +78,6 @@ class BuiltinsSealingTest {
     @Test
     public void rhinoNonStandard() {
         assertIsSealed("With");
-        assertIsSealed("Call");
         assertIsSealed("CallSite");
         assertIsSealed("Iterator");
         assertIsSealed("Continuation");

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DefineClassMapInheritance.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DefineClassMapInheritance.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 
 @SuppressWarnings("serial")
 public class DefineClassMapInheritance {
@@ -41,7 +42,7 @@ public class DefineClassMapInheritance {
         }
     }
 
-    private static Object evaluate(Context cx, ScriptableObject scope, String source) {
+    private static Object evaluate(Context cx, VarScope scope, String source) {
         return cx.evaluateString(scope, source, "<eval>", 1, null);
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.SymbolScriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -203,7 +204,7 @@ public class IterableTest {
         }
 
         @Override
-        public Scriptable getParentScope() {
+        public VarScope getParentScope() {
             return scope;
         }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/JavaIterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/JavaIterableTest.java
@@ -20,8 +20,8 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.NativeArray;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 
 public class JavaIterableTest {
 
@@ -146,7 +146,7 @@ public class JavaIterableTest {
                         context -> {
                             context.setLanguageVersion(Context.VERSION_ES6);
                             TopLevel global = context.initStandardObjects();
-                            Scriptable scope = context.newObject(global);
+                            VarScope scope = context.newVarEnv(global);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return context.evaluateString(scope, scriptSourceText, "", 1, null);
                         });

--- a/rhino/src/test/java/org/mozilla/javascript/tests/WrapFactoryTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/WrapFactoryTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ImporterTopLevel;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 
 /**
@@ -63,7 +62,8 @@ public class WrapFactoryTest {
             String getResult) {
         try (Context cx = Context.enter()) {
             cx.getWrapFactory().setJavaPrimitiveWrap(javaPrimitiveWrap);
-            Scriptable scope = cx.newObject(new ImporterTopLevel(cx));
+            var topLevel = new ImporterTopLevel(cx);
+            var scope = cx.newVarEnv(topLevel);
 
             // register object
             Map<String, Object> map = new LinkedHashMap<>();

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComparatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComparatorTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class ComparatorTest {
@@ -75,7 +76,7 @@ public class ComparatorTest {
     public void customComparator() throws IOException {
         try (Context cx = Context.enter()) {
             Global global = new Global(cx);
-            Scriptable root = cx.newObject(global);
+            VarScope root = cx.newVarEnv(global);
             FileReader fr = new FileReader("testsrc/jstests/extensions/custom-comparators.js");
 
             cx.evaluateReader(root, fr, "custom-comparators.js", 1, null);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ErrorReporterTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ErrorReporterTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ErrorReporter;
 import org.mozilla.javascript.EvaluatorException;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 
 public class ErrorReporterTest {
 
     private Context cx;
-    private ScriptableObject scope;
+    private ScopeObject scope;
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/tests/src/test/java/org/mozilla/javascript/tests/ExternalArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ExternalArrayTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ExternalArrayData;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.typedarrays.NativeFloat64Array;
 import org.mozilla.javascript.typedarrays.NativeInt16Array;
@@ -18,7 +19,7 @@ import org.mozilla.javascript.typedarrays.NativeInt32Array;
 
 public class ExternalArrayTest {
     private Context cx;
-    private Scriptable root;
+    private VarScope root;
 
     @BeforeEach
     public void init() {
@@ -27,7 +28,7 @@ public class ExternalArrayTest {
         cx.setGeneratingDebug(true);
 
         Global global = new Global(cx);
-        root = cx.newObject(global);
+        root = cx.newVarEnv(global);
     }
 
     @AfterEach

--- a/tests/src/test/java/org/mozilla/javascript/tests/JavaAcessibilityTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/JavaAcessibilityTest.java
@@ -163,7 +163,7 @@ public class JavaAcessibilityTest {
         return contextFactory.call(
                 context -> {
                     Script script = context.compileString(scriptSourceText, "", 1, null);
-                    return script.exec(context, global, global);
+                    return script.exec(context, global, global.getGlobalThis());
                 });
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaListTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaListTest.java
@@ -18,7 +18,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.NativeArray;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.tools.shell.Global;
 
 /** From @makusuko (Markus Sunela), imported from PR https://github.com/mozilla/rhino/pull/561 */
@@ -230,7 +230,7 @@ public class NativeJavaListTest {
         return ContextFactory.getGlobal()
                 .call(
                         context -> {
-                            Scriptable scope = context.newObject(global);
+                            VarScope scope = context.newVarEnv(global);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return convert.apply(
                                     context.evaluateString(scope, scriptSourceText, "", 1, null));

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -18,7 +18,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeJavaMethod;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -227,7 +227,7 @@ public class NativeJavaMapTest {
         return getContextFactory(enableJavaMapAccess)
                 .call(
                         context -> {
-                            Scriptable scope = context.newObject(global);
+                            VarScope scope = context.newVarEnv(global);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return convert.apply(
                                     context.evaluateString(scope, scriptSourceText, "", 1, null));
@@ -238,7 +238,7 @@ public class NativeJavaMapTest {
         return getContextFactory(false)
                 .call(
                         context -> {
-                            Scriptable scope = context.newObject(global);
+                            VarScope scope = context.newVarEnv(global);
                             context.setLanguageVersion(Context.VERSION_ES6);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return context.evaluateString(scope, scriptSourceText, "", 1, null);

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -57,7 +58,7 @@ public class NativeJavaMethodTest {
                 });
     }
 
-    private static ScriptableObject initContext(Context cx, MethodDummy methodDummy) {
+    private static ScopeObject initContext(Context cx, MethodDummy methodDummy) {
         cx.setLanguageVersion(Context.VERSION_ES6);
         final var scope = cx.initStandardObjects();
         ScriptableObject.putProperty(scope, "d", Context.javaToJS(methodDummy, scope));

--- a/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NestedContextPrototypeTest.java
@@ -100,7 +100,7 @@ public class NestedContextPrototypeTest {
                                     scope = global;
                                     break;
                                 case NESTED:
-                                    scope = context.newObject(global);
+                                    scope = context.newVarEnv(global);
                                     break;
                                 case SEALED:
                                     scope = TopLevel.createIsolate(global);

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaLfTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaLfTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.StackStyle;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -36,7 +36,7 @@ public class StackTraceExtensionMozillaLfTest {
             cx.setGeneratingDebug(true);
 
             Global global = new Global(cx);
-            Scriptable root = cx.newObject(global);
+            VarScope root = cx.newVarEnv(global);
 
             try (FileReader rdr =
                     new FileReader("testsrc/jstests/extensions/stack-traces-mozilla-lf.js")) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.StackStyle;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -36,7 +36,7 @@ public class StackTraceExtensionMozillaTest {
             cx.setGeneratingDebug(true);
 
             Global global = new Global(cx);
-            Scriptable root = cx.newObject(global);
+            VarScope root = cx.newVarEnv(global);
 
             try (FileReader rdr =
                     new FileReader("testsrc/jstests/extensions/stack-traces-mozilla.js")) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionRhinoTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionRhinoTest.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -25,7 +25,7 @@ public class StackTraceExtensionRhinoTest {
             cx.setGeneratingDebug(debug);
 
             Global global = new Global(cx);
-            Scriptable root = cx.newObject(global);
+            VarScope root = cx.newVarEnv(global);
             root.put("ExpectFileNames", global, interpretedMode || debug);
 
             try (FileReader rdr =

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionV8Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionV8Test.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.StackStyle;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -36,7 +36,7 @@ public class StackTraceExtensionV8Test {
             cx.setGeneratingDebug(true);
 
             Global global = new Global(cx);
-            Scriptable root = cx.newObject(global);
+            VarScope root = cx.newVarEnv(global);
 
             try (FileReader rdr = new FileReader("testsrc/jstests/extensions/stack-traces-v8.js")) {
                 cx.evaluateReader(root, rdr, "stack-traces-v8.js", 1, null);

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -44,6 +44,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
@@ -232,7 +233,7 @@ public class Test262SuiteTest {
             return proto;
         }
 
-        static $262 install(ScriptableObject scope, Scriptable parentScope) {
+        static $262 install(ScopeObject scope, Scriptable parentScope) {
             $262 instance = new $262(scope, parentScope);
 
             scope.put("$262", scope, instance);

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/ObjectToStringNullUndefinedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/ObjectToStringNullUndefinedTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 
 public class ObjectToStringNullUndefinedTest {
     private Context cx;
-    private ScriptableObject scope;
+    private ScopeObject scope;
 
     @BeforeEach
     public void setUp() {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/RegexpTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/RegexpTest.java
@@ -16,12 +16,12 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.EvaluatorException;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 
 public class RegexpTest {
 
     private Context cx;
-    private ScriptableObject scope;
+    private ScopeObject scope;
 
     @BeforeEach
     public void setUp() {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/Test262RegExpTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/Test262RegExpTest.java
@@ -14,14 +14,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EcmaError;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.ScopeObject;
 
 /**
  * @author André Bargull
  */
 public class Test262RegExpTest {
     private Context cx;
-    private ScriptableObject scope;
+    private ScopeObject scope;
 
     @BeforeEach
     public void setUp() {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
@@ -9,6 +9,7 @@ import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.WithScope;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -51,11 +52,12 @@ public class FunctionNullSetTest {
                             final MyHostObject jsObj = new MyHostObject();
                             jsObj.setPrototype(prototype);
                             jsObj.setParentScope(scope);
+                            var jsScope = new WithScope(scope, jsObj);
 
                             final Function realFunction_ =
-                                    cx.compileFunction(jsObj, script, "myevent", 0, null);
+                                    cx.compileFunction(jsScope, script, "myevent", 0, null);
 
-                            realFunction_.call(cx, jsObj, jsObj, new Object[0]);
+                            realFunction_.call(cx, jsScope, jsObj, new Object[0]);
 
                             assertNull(jsObj.onclick_);
                         } catch (final Exception e) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ParentPropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ParentPropertyTest.java
@@ -18,7 +18,7 @@ public class ParentPropertyTest {
         // https://whereswalden.com/2010/05/07/spidermonkey-change-du-jour-the-special-__parent__-property-has-been-removed/
         String script = "var a = {};" + "'' + a.__parent__;";
 
-        Utils.assertWithAllModes_1_8("[object topLevel]", script);
+        Utils.assertWithAllModes_1_8("[object scope]", script);
         Utils.assertWithAllModes_ES6("undefined", script);
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/CustomTypeInfoFactoryTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/CustomTypeInfoFactoryTest.java
@@ -94,7 +94,7 @@ public class CustomTypeInfoFactoryTest {
         }
     }
 
-    private static byte[] simulateSer(ScriptableObject o) throws IOException {
+    private static byte[] simulateSer(ScopeObject o) throws IOException {
         var output = new ByteArrayOutputStream();
         var objectOut = new ObjectOutputStream(output);
         objectOut.writeObject(o);
@@ -102,10 +102,10 @@ public class CustomTypeInfoFactoryTest {
         return output.toByteArray();
     }
 
-    private static ScriptableObject simulateDeser(byte[] data)
+    private static ScopeObject simulateDeser(byte[] data)
             throws IOException, ClassNotFoundException {
         var input = new ByteArrayInputStream(data);
         var objectIn = new ObjectInputStream(input);
-        return (ScriptableObject) objectIn.readObject();
+        return (ScopeObject) objectIn.readObject();
     }
 }

--- a/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
+++ b/tests/testsrc/doctests/object.getownpropertydescriptor.doctest
@@ -47,7 +47,7 @@ true
 js> desc.__proto__ === Object.prototype
 true
 js> desc.__parent__;
-[object global]
+[object scope]
 
 js> var func = function(){}
 js> func.a = 1; Object.getOwnPropertyDescriptor(func, 'a').toSource()


### PR DESCRIPTION
This PR stacks on top of #2328 and is the next step after it in resolving #2163.

This change adds `VarScope` as a subclass of `Scriptable`, hoists a number of methods up from `ScriptableObject` to `SlotMapOwner` and introduces a new `ScopeObject` class. This is the first stage of separating objects and scopes, and lays the initial ground work, follow up PRs will change the APIs within Rhino to use `VarScope`, change the use sites to accept only `VarScope`s, and then finally once all those changes are done will we split the hierarchy.

This PR has also been written so that it is possible to split it into the individual commits, let me know @gbrail and @rbri if you would like it split like that.