### PR TITLE
Change APIs and use sites to use the new `VarScope` type.

### DIFF
--- a/examples/src/main/java/DynamicScopes.java
+++ b/examples/src/main/java/DynamicScopes.java
@@ -88,7 +88,7 @@ public class DynamicScopes {
 
         // Now we can execute the precompiled script against the scope
         // to define x variable and f function in the shared scope.
-        script.exec(cx, sharedScope, sharedScope);
+        script.exec(cx, sharedScope, sharedScope.getGlobalThis());
 
         // Now we spawn some threads that execute a script that calls the
         // function 'f'. The scope chain looks like this:

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
@@ -167,7 +167,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
     Object eval(Script script, ScriptContext sc) throws ScriptException {
         try (Context cx = ctxFactory.enterContext()) {
             TopLevel scope = initScope(cx, sc);
-            Object ret = script.exec(cx, scope, scope);
+            Object ret = script.exec(cx, scope, scope.getGlobalThis());
             return Context.jsToJava(ret, Object.class);
         } catch (RhinoException re) {
             throw new ScriptException(
@@ -190,11 +190,11 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
     Object invokeMethodRaw(Object thiz, String name, Class<?> returnType, Object... args)
             throws ScriptException, NoSuchMethodException {
         try (Context cx = ctxFactory.enterContext()) {
-            VarScope scope = initScope(cx, context);
+            TopLevel scope = initScope(cx, context);
 
             Scriptable localThis;
             if (thiz == null) {
-                localThis = scope;
+                localThis = scope.getGlobalThis();
             } else {
                 localThis = Context.toObject(thiz, scope);
             }
@@ -233,8 +233,8 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
             throw new IllegalArgumentException("Not an interface");
         }
         try (Context cx = ctxFactory.enterContext()) {
-            Scriptable scope = initScope(cx, context);
-            if (methodsMissing(scope, clasz)) {
+            TopLevel scope = initScope(cx, context);
+            if (methodsMissing(scope.getGlobalThis(), clasz)) {
                 return null;
             }
         } catch (ScriptException se) {

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Dim.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Dim.java
@@ -579,7 +579,7 @@ public class Dim {
         }
 
         Scriptable proto = scriptable.getPrototype();
-        Scriptable parent = scriptable.getParentScope();
+        VarScope parent = scriptable.getParentScope();
         int extra = 0;
         if (proto != null) {
             ++extra;

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java
@@ -16,7 +16,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.ScopeObject;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.commonjs.module.ModuleScope;
 import org.mozilla.javascript.tools.shell.Global;
@@ -211,7 +210,7 @@ public class Main {
      * ContextFactory} with the given scope. No I/O redirection is performed as with {@link
      * #main(String[])}.
      */
-    public static Main mainEmbedded(ContextFactory factory, Scriptable scope, String title) {
+    public static Main mainEmbedded(ContextFactory factory, VarScope scope, String title) {
         return mainEmbeddedImpl(factory, scope, title);
     }
 

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Environment.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Environment.java
@@ -35,7 +35,7 @@ public class Environment extends ScriptableObject {
         try {
             ScriptableObject.defineClass(scope, Environment.class);
         } catch (Exception e) {
-            throw new Error(e.getMessage());
+            throw new Error(e);
         }
     }
 

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
@@ -46,6 +46,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Synchronizer;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.Wrapper;
@@ -367,7 +368,7 @@ public class Global extends ImporterTopLevel {
         Object obj = args[0];
         String filename = Context.toString(args[1]);
         FileOutputStream fos = new FileOutputStream(filename);
-        Scriptable scope = ScriptableObject.getTopLevelScope(funObj.getDeclarationScope());
+        TopLevel scope = ScriptableObject.getTopLevelScope(funObj.getDeclarationScope());
         try (ScriptableOutputStream out = new ScriptableOutputStream(fos, scope)) {
             out.writeObject(obj);
         }
@@ -564,16 +565,17 @@ public class Global extends ImporterTopLevel {
 
     private static ContextAction<Object> getAsyncAction(Context cx, Object[] args, VarScope scope) {
         ContextAction<Object> action;
+        Scriptable thisObj = ScriptableObject.getTopLevelScope(scope).getGlobalThis();
         if (args.length != 0 && args[0] instanceof Function) {
             Function f = (Function) args[0];
             Object[] newArgs =
                     args.length > 1 && args[1] instanceof Scriptable
                             ? cx.getElements((Scriptable) args[1])
                             : ScriptRuntime.emptyArgs;
-            action = cx2 -> f.call(cx2, scope, scope, newArgs);
+            action = cx2 -> f.call(cx2, scope, thisObj, newArgs);
         } else if (args.length != 0 && args[0] instanceof Script) {
             Script s = (Script) args[0];
-            action = cx2 -> s.exec(cx2, scope, scope);
+            action = cx2 -> s.exec(cx2, scope, thisObj);
         } else {
             throw reportRuntimeError("msg.spawn.args");
         }
@@ -800,7 +802,7 @@ public class Global extends ImporterTopLevel {
     }
 
     private static Global getInstance(Function function) {
-        Scriptable scope = function.getParentScope();
+        VarScope scope = function.getParentScope();
         if (!(scope instanceof Global))
             throw reportRuntimeError("msg.bad.shell.function.scope", String.valueOf(scope));
         return (Global) scope;

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Main.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Main.java
@@ -209,7 +209,7 @@ public class Main {
             Script script = cx.compileString(scriptText, "<command>", 1, null);
             if (script != null) {
                 VarScope scope = getShellScope();
-                script.exec(cx, scope, scope);
+                script.exec(cx, scope, ScriptableObject.getTopLevelScope(scope).getGlobalThis());
             }
         } catch (RhinoException rex) {
             ToolErrorReporter.reportException(cx.getErrorReporter(), rex);
@@ -490,7 +490,11 @@ public class Main {
                     String finalSource = source.toString();
                     Script script = cx.compileString(finalSource, "<stdin>", lineno, null);
                     if (script != null) {
-                        Object result = script.exec(cx, scope, scope);
+                        Object result =
+                                script.exec(
+                                        cx,
+                                        scope,
+                                        ScriptableObject.getTopLevelScope(scope).getGlobalThis());
                         // Avoid printing out undefined or function definitions.
                         if (result != Context.getUndefinedValue()
                                 && !(result instanceof Function

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
@@ -83,7 +83,13 @@ public class Timers {
         }
         timerQueue.remove();
         timers.remove(t.id);
-        cx.enqueueMicrotask(() -> t.func.call(cx, scope, scope, t.funcArgs));
+        cx.enqueueMicrotask(
+                () ->
+                        t.func.call(
+                                cx,
+                                scope,
+                                ScriptableObject.getTopLevelScope(scope).getGlobalThis(),
+                                t.funcArgs));
         return true;
     }
 

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java
@@ -37,8 +37,8 @@ class Namespace extends ScriptableObject {
                         .build();
     }
 
-    public static void init(Context cx, Scriptable scope, ScriptableObject proto, boolean sealed) {
-        DESCRIPTOR.buildConstructor(cx, (VarScope) scope, proto, sealed);
+    public static void init(Context cx, VarScope scope, ScriptableObject proto, boolean sealed) {
+        DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
     }
 
     private Namespace prototype;
@@ -73,24 +73,24 @@ class Namespace extends ScriptableObject {
     }
 
     private static Object js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(f.getPrototypeProperty(), f);
         return realThis.jsConstructor(cx, true, args);
     }
 
     private static Object js_constructorCall(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(f.getPrototypeProperty(), f);
         return realThis.jsConstructor(cx, false, args);
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).toString();
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).js_toSource();
     }
 

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/QName.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/QName.java
@@ -34,29 +34,29 @@ final class QName extends ScriptableObject {
                         .build();
     }
 
-    static void init(Context cx, Scriptable scope, ScriptableObject proto, boolean sealed) {
-        DESCRIPTOR.buildConstructor(cx, (VarScope) scope, proto, sealed);
+    static void init(Context cx, VarScope scope, ScriptableObject proto, boolean sealed) {
+        DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
     }
 
     private static Object js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(f.getPrototypeProperty(), f);
         return realThis.jsConstructor(cx, true, args);
     }
 
     private static Object js_constructorCall(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(f.getPrototypeProperty(), f);
         return realThis.jsConstructor(cx, false, args);
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).toString();
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).js_toSource();
     }
 

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XML.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XML.java
@@ -50,7 +50,7 @@ class XML extends XMLObjectImpl {
     }
 
     private static Object js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLLibImpl lib = (XMLLibImpl) f.get(LIB_KEY, f);
         if (args.length == 0 || args[0] == null || args[0] == Undefined.instance) {
             args = new Object[] {""};
@@ -61,7 +61,7 @@ class XML extends XMLObjectImpl {
     }
 
     private static Object js_constructorCall(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLLibImpl lib = (XMLLibImpl) f.get(LIB_KEY, f);
         if (args.length == 0 || args[0] == null || args[0] == Undefined.instance) {
             args = new Object[] {""};
@@ -72,7 +72,7 @@ class XML extends XMLObjectImpl {
     }
 
     static Object js_hasInstance(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length == 0 || !(args[0] instanceof Scriptable)) {
             Object v = args.length == 0 ? null : args[0];
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(v));

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java
@@ -12,7 +12,6 @@ import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.Ref;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.Wrapper;
@@ -122,7 +121,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
      * @deprecated
      */
     @Deprecated
-    Scriptable globalScope() {
+    VarScope globalScope() {
         return globalScope;
     }
 
@@ -311,7 +310,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
         return listToAdd;
     }
 
-    private Ref xmlPrimaryReference(Context cx, XMLName xmlName, Scriptable scope) {
+    private Ref xmlPrimaryReference(Context cx, XMLName xmlName, VarScope scope) {
         XMLObjectImpl xmlObj;
         XMLObjectImpl firstXml = null;
         for (; ; ) {
@@ -626,18 +625,18 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
     }
 
     @Override
-    public Ref nameRef(Context cx, Object name, Scriptable scope, int memberTypeFlags) {
+    public Ref nameRef(Context cx, Object name, VarScope scope, int memberTypeFlags) {
         if ((memberTypeFlags & Node.ATTRIBUTE_FLAG) == 0) {
             // should only be called for cases like @name or @[expr]
             throw Kit.codeBug();
         }
         XMLName xmlName = toAttributeName(cx, name);
-        return xmlPrimaryReference(cx, xmlName, scope);
+        return xmlPrimaryReference(cx, xmlName, (VarScope) scope);
     }
 
     @Override
     public Ref nameRef(
-            Context cx, Object namespace, Object name, Scriptable scope, int memberTypeFlags) {
+            Context cx, Object namespace, Object name, VarScope scope, int memberTypeFlags) {
         XMLName xmlName = XMLName.create(toNodeQName(cx, namespace, name), false, false);
 
         //    No idea what is coming in from the parser in this case; is it detecting the "@"?
@@ -647,6 +646,6 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
             }
         }
 
-        return xmlPrimaryReference(cx, xmlName, scope);
+        return xmlPrimaryReference(cx, xmlName, (VarScope) scope);
     }
 }

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -56,7 +56,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     private static Object js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLLibImpl lib = (XMLLibImpl) f.get(LIB_KEY, f);
         if (args.length == 0) {
             return lib.newXMLList();
@@ -66,7 +66,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     private static Object js_constructorCall(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLLibImpl lib = (XMLLibImpl) f.get(LIB_KEY, f);
         if (args.length == 0) {
             return lib.newXMLList();

--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -45,12 +45,11 @@ class Arguments extends ScriptableObject {
         JSFunction f = activation.function;
         calleeObj = f;
 
-        defineProperty(
-                SymbolKey.ITERATOR,
+        var iter =
                 TopLevel.getBuiltinPrototype(
-                                ScriptableObject.getTopLevelScope(parent), TopLevel.Builtins.Array)
-                        .get("values", parent),
-                ScriptableObject.DONTENUM);
+                        ScriptableObject.getTopLevelScope(parent), TopLevel.Builtins.Array);
+
+        defineProperty(SymbolKey.ITERATOR, iter.get("values", iter), ScriptableObject.DONTENUM);
         defineProperty("length", lengthObj, ScriptableObject.DONTENUM);
 
         if (f.isStrict()) {

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -563,9 +563,7 @@ public class BaseFunction extends ScriptableObject implements Function {
             }
             if (result.getParentScope() == null) {
                 VarScope parent = getParentScope();
-                if (result != parent) {
-                    result.setParentScope(parent);
-                }
+                result.setParentScope(parent);
             }
         } else {
             Object val = call(cx, scope, result, args);
@@ -583,7 +581,7 @@ public class BaseFunction extends ScriptableObject implements Function {
      * itself. In this case {@link #construct} will set scope and prototype on the result {@link
      * #call} unless they are already set.
      */
-    public Scriptable createObject(Context cx, Scriptable scope) {
+    public Scriptable createObject(Context cx, VarScope scope) {
         Scriptable newInstance = new NativeObject();
         newInstance.setPrototype(getClassPrototype());
         newInstance.setParentScope(getParentScope());

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -554,10 +554,10 @@ public class Context implements Closeable {
      */
     public static Object call(
             ContextFactory factory,
-            final Callable callable,
-            final Scriptable scope,
-            final Scriptable thisObj,
-            final Object[] args) {
+            Callable callable,
+            VarScope scope,
+            Scriptable thisObj,
+            Object[] args) {
         if (factory == null) {
             factory = ContextFactory.getGlobal();
         }
@@ -1306,7 +1306,8 @@ public class Context implements Closeable {
         // Annotate so we can check later to ensure no java code in
         // intervening frames
         isContinuationsTopCall = true;
-        return ScriptRuntime.doTopCall(script, this, scope, scope, isStrict);
+        return ScriptRuntime.doTopCall(
+                script, this, scope, Undefined.SCRIPTABLE_UNDEFINED, isStrict);
     }
 
     public Object callFunctionWithContinuations(Callable callable, VarScope scope, Object[] args)

--- a/rhino/src/main/java/org/mozilla/javascript/ContextFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ContextFactory.java
@@ -87,7 +87,7 @@ import org.mozilla.javascript.config.RhinoConfig;
  *     }
  *
  *     // Override {@link #doTopCall(Callable,
- * Context, Scriptable,
+ * Context, VarScope,
  * Scriptable, Object[])}
  *     protected Object doTopCall(Callable callable,
  *                                Context cx, Scriptable scope,
@@ -323,7 +323,7 @@ public class ContextFactory {
      * perform the real call. In this way execution of any script happens inside this function.
      */
     protected Object doTopCall(
-            Callable callable, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         Object result = callable.call(cx, (VarScope) scope, thisObj, args);
         return result instanceof ConsString ? result.toString() : result;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -153,6 +153,7 @@ public class FunctionObject extends BaseFunction {
         if (type == ScriptRuntime.BooleanClass || type == Boolean.TYPE) return JAVA_BOOLEAN_TYPE;
         if (type == ScriptRuntime.DoubleClass || type == Double.TYPE) return JAVA_DOUBLE_TYPE;
         if (ScriptRuntime.ScriptableClass.isAssignableFrom(type)) return JAVA_SCRIPTABLE_TYPE;
+        if (ScriptRuntime.VarScopeClass.isAssignableFrom(type)) return JAVA_VARSCOPE_TYPE;
         if (type == ScriptRuntime.ObjectClass) return JAVA_OBJECT_TYPE;
 
         // Note that the long type is not supported; see the javadoc for
@@ -473,7 +474,7 @@ public class FunctionObject extends BaseFunction {
      * new objects.
      */
     @Override
-    public Scriptable createObject(Context cx, Scriptable scope) {
+    public Scriptable createObject(Context cx, VarScope scope) {
         if (member.isCtor() || parmsLength == VARARGS_CTOR) {
             return null;
         }
@@ -528,7 +529,8 @@ public class FunctionObject extends BaseFunction {
     public static final int JAVA_BOOLEAN_TYPE = 3;
     public static final int JAVA_DOUBLE_TYPE = 4;
     public static final int JAVA_SCRIPTABLE_TYPE = 5;
-    public static final int JAVA_OBJECT_TYPE = 6;
+    public static final int JAVA_VARSCOPE_TYPE = 6;
+    public static final int JAVA_OBJECT_TYPE = 7;
 
     MemberBox member;
     private String functionName;

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -529,8 +529,8 @@ public class FunctionObject extends BaseFunction {
     public static final int JAVA_BOOLEAN_TYPE = 3;
     public static final int JAVA_DOUBLE_TYPE = 4;
     public static final int JAVA_SCRIPTABLE_TYPE = 5;
-    public static final int JAVA_VARSCOPE_TYPE = 6;
-    public static final int JAVA_OBJECT_TYPE = 7;
+    public static final int JAVA_OBJECT_TYPE = 6;
+    public static final int JAVA_VARSCOPE_TYPE = 7;
 
     MemberBox member;
     private String functionName;

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -2096,8 +2096,6 @@ public final class IRFactory {
             String name = child.getString();
             if ("eval".equals(name)) {
                 type = Node.SPECIALCALL_EVAL;
-            } else if ("With".equals(name)) {
-                type = Node.SPECIALCALL_WITH;
             }
         }
         Node node = new Node(nodeType, child);

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -60,7 +60,7 @@ public class IdFunctionObject extends BaseFunction {
         setImmunePrototypeProperty(prototypeProperty);
     }
 
-    public final void addAsProperty(Scriptable target) {
+    public final <T extends PropHolder<T>> void addAsProperty(T target) {
         ScriptableObject.defineProperty(target, functionName, this, ScriptableObject.DONTENUM);
     }
 
@@ -123,9 +123,7 @@ public class IdFunctionObject extends BaseFunction {
             }
             if (result.getParentScope() == null) {
                 VarScope parent = getParentScope();
-                if (result != parent) {
-                    result.setParentScope(parent);
-                }
+                result.setParentScope(parent);
             }
         } else {
             Object val = call(cx, scope, result, args);
@@ -137,7 +135,7 @@ public class IdFunctionObject extends BaseFunction {
     }
 
     @Override
-    public Scriptable createObject(Context cx, Scriptable scope) {
+    public Scriptable createObject(Context cx, VarScope scope) {
         if (useCallAsConstructor) {
             return null;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -722,7 +722,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     public final IdFunctionObject exportAsJSClass(
             int maxPrototypeId, VarScope scope, boolean sealed) {
         // Set scope and prototype unless this is top level scope itself
-        if (scope != this && scope != null) {
+        if (scope != null) {
             setParentScope(scope);
             setPrototype(getObjectPrototype(scope));
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
@@ -138,11 +138,6 @@ public class ImporterTopLevel extends TopLevel {
         topScopeFlag = true;
     }
 
-    @Override
-    public String getClassName() {
-        return topScopeFlag ? "global" : "JavaImporter";
-    }
-
     public static void init(Context cx, VarScope scope, boolean sealed) {
         init(cx, scope, sealed, false);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -79,7 +79,7 @@ public final class JavaAdapter {
     }
 
     public static Scriptable createAdapterWrapper(Scriptable obj, Object adapter) {
-        Scriptable scope = ScriptableObject.getTopLevelScope(obj.getParentScope());
+        VarScope scope = ScriptableObject.getTopLevelScope(obj.getParentScope());
         NativeJavaObject res = new NativeJavaObject(scope, adapter, TypeInfo.NONE, true);
         res.setPrototype(obj);
         return res;
@@ -576,9 +576,9 @@ public final class JavaAdapter {
         return ContextFactory.getGlobal()
                 .call(
                         cx -> {
-                            ScopeObject global = ScriptRuntime.getGlobal(cx);
-                            script.exec(cx, global, global);
-                            return global;
+                            TopLevel global = ScriptRuntime.getGlobal(cx);
+                            script.exec(cx, global, global.getGlobalThis());
+                            return global.getGlobalThis();
                         });
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -137,11 +137,6 @@ class JavaMembers {
             throw Context.throwAsScriptRuntimeEx(ex);
         }
         var type = field.type();
-        if (scope instanceof NativeJavaObject) {
-            type =
-                    TypeInfoFactory.GLOBAL.consolidateType(
-                            type, ((NativeJavaObject) scope).staticType);
-        }
         // Need to wrap the object before we return it.
         return cx.getWrapFactory().wrap(cx, ScriptableObject.getTopLevelScope(scope), got, type);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -74,7 +74,7 @@ final class NativeBigInt extends ScriptableObject {
         return (args.length >= 1) ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
     }
 
-    private static Scriptable js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
         throw ScriptRuntime.typeErrorById("msg.no.new", CLASS_NAME);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -101,7 +101,7 @@ public class NativeGlobal implements Serializable {
                             // built-ins/NativeErrors/AggregateError/newtarget-proto-custom.js work
                             // correctly
                             @Override
-                            public Scriptable createObject(Context cx, Scriptable scope) {
+                            public Scriptable createObject(Context cx, VarScope scope) {
                                 return null;
                             }
                         };
@@ -148,7 +148,7 @@ public class NativeGlobal implements Serializable {
     }
 
     private static void registerGlobalFunction(
-            Scriptable scope, boolean sealed, String name, LambdaFunction fun) {
+            VarScope scope, boolean sealed, String name, LambdaFunction fun) {
         ScriptableObject.defineProperty(scope, name, fun, DONTENUM);
         if (sealed) {
             fun.sealObject();
@@ -487,8 +487,8 @@ public class NativeGlobal implements Serializable {
      * executed via ScriptRuntime.callSpecial().
      */
     private static Object js_eval(Context cx, VarScope scope, Object[] args) {
-        VarScope global = ScriptableObject.getTopLevelScope(scope);
-        return ScriptRuntime.evalSpecial(cx, global, global, args, "eval code", 1);
+        TopLevel global = ScriptableObject.getTopLevelScope(scope);
+        return ScriptRuntime.evalSpecial(cx, global, global.getGlobalThis(), args, "eval code", 1);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaArray.java
@@ -28,7 +28,7 @@ public class NativeJavaArray extends NativeJavaObject implements SymbolScriptabl
     }
 
     @Deprecated
-    public static NativeJavaArray wrap(Scriptable scope, Object array) {
+    public static NativeJavaArray wrap(VarScope scope, Object array) {
         return new NativeJavaArray(scope, array);
     }
 
@@ -37,11 +37,11 @@ public class NativeJavaArray extends NativeJavaObject implements SymbolScriptabl
         return array;
     }
 
-    public NativeJavaArray(Scriptable scope, Object array) {
+    public NativeJavaArray(VarScope scope, Object array) {
         this(scope, array, TypeInfoFactory.GLOBAL.create(array.getClass()));
     }
 
-    public NativeJavaArray(Scriptable scope, Object array, TypeInfo staticType) {
+    public NativeJavaArray(VarScope scope, Object array, TypeInfo staticType) {
         super(scope, null, staticType);
         if (!staticType.isArray() || !array.getClass().isArray()) {
             throw new RuntimeException("Array expected");

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -31,11 +31,11 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
 
     public NativeJavaClass() {}
 
-    public NativeJavaClass(Scriptable scope, Class<?> cl) {
+    public NativeJavaClass(VarScope scope, Class<?> cl) {
         this(scope, cl, false);
     }
 
-    public NativeJavaClass(Scriptable scope, Class<?> cl, boolean isAdapter) {
+    public NativeJavaClass(VarScope scope, Class<?> cl, boolean isAdapter) {
         super(scope, cl, TypeInfo.NONE, isAdapter);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -41,12 +41,12 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     public NativeJavaObject() {}
 
-    public NativeJavaObject(Scriptable scope, Object javaObject, TypeInfo staticType) {
+    public NativeJavaObject(VarScope scope, Object javaObject, TypeInfo staticType) {
         this(scope, javaObject, staticType, false);
     }
 
     public NativeJavaObject(
-            Scriptable scope, Object javaObject, TypeInfo staticType, boolean isAdapter) {
+            VarScope scope, Object javaObject, TypeInfo staticType, boolean isAdapter) {
         this.parent = (VarScope) scope;
         this.javaObject = javaObject;
         this.staticType = staticType;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaTopPackage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaTopPackage.java
@@ -114,7 +114,7 @@ public class NativeJavaTopPackage extends NativeJavaPackage implements Function,
         throw f.unknown();
     }
 
-    private Scriptable js_getClass(Context cx, Scriptable scope, Object[] args) {
+    private Scriptable js_getClass(Context cx, VarScope scope, Object[] args) {
         if (args.length > 0 && args[0] instanceof Wrapper) {
             Scriptable result = this;
             Class<?> cl = ((Wrapper) args[0]).unwrap().getClass();

--- a/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
@@ -126,7 +126,7 @@ final class NativeNumber extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
         double val = (args.length > 0) ? ScriptRuntime.toNumeric(args[0]).doubleValue() : 0.0;
         return new NativeNumber(val);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -280,7 +280,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_defineGetterOrSetter(
-            Context cx, Scriptable scope, boolean isSetter, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, boolean isSetter, Object thisObj, Object[] args) {
         if (args.length < 2 || !(args[1] instanceof Callable)) {
             Object badArg = (args.length >= 2 ? args[1] : Undefined.instance);
             throw ScriptRuntime.notFunctionError(badArg);
@@ -312,7 +312,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_lookupGetterOrSetter(
-            Context cx, Scriptable scope, boolean isSetter, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, boolean isSetter, Object thisObj, Object[] args) {
         if (args.length < 1 || !(thisObj instanceof ScriptableObject)) return Undefined.instance;
 
         ScriptableObject so = (ScriptableObject) thisObj;
@@ -320,7 +320,7 @@ public class NativeObject extends ScriptableObject implements Map {
         int index = s.stringId != null ? 0 : s.index;
         Object gs;
         for (; ; ) {
-            gs = so.getGetterOrSetter(s.stringId, index, scope, isSetter);
+            gs = so.getGetterOrSetter(s.stringId, index, so, isSetter);
             if (gs != null) {
                 break;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -210,7 +210,7 @@ final class NativeString extends ScriptableObject {
         };
     }
 
-    private static Scriptable js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
         CharSequence s;
         if (args.length == 0) {
             s = "";

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -80,7 +80,7 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
     }
 
     private static void createStandardSymbol(
-            Scriptable scope, LambdaConstructor ctor, String name, SymbolKey key) {
+            VarScope scope, LambdaConstructor ctor, String name, SymbolKey key) {
         ctor.defineProperty(name, key, DONTENUM | READONLY | PERMANENT);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/PolicySecurityController.java
+++ b/rhino/src/main/java/org/mozilla/javascript/PolicySecurityController.java
@@ -145,7 +145,7 @@ public class PolicySecurityController extends SecurityController {
 
     public abstract static class SecureCaller {
         public abstract Object call(
-                Callable callable, Context cx, Scriptable scope, Scriptable thisObj, Object[] args);
+                Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args);
     }
 
     private static byte[] loadBytecode() {

--- a/rhino/src/main/java/org/mozilla/javascript/Ref.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Ref.java
@@ -23,12 +23,12 @@ public abstract class Ref implements Serializable {
     public abstract Object get(Context cx);
 
     /**
-     * @deprecated Use {@link #set(Context, Scriptable, Object)} instead
+     * @deprecated Use {@link #set(Context, VarScope, Object)} instead
      */
     @Deprecated
     public abstract Object set(Context cx, Object value);
 
-    public Object set(Context cx, Scriptable scope, Object value) {
+    public Object set(Context cx, VarScope scope, Object value) {
         return set(cx, value);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/SpecialRef.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SpecialRef.java
@@ -62,7 +62,7 @@ class SpecialRef extends Ref {
         }
     }
 
-    private static Scriptable getScriptableForScope(Scriptable scope) {
+    private static Scriptable getScriptableForScope(VarScope scope) {
         if (scope instanceof WithScope) {
             return ((WithScope) scope).getObject();
         } else if (scope != null) {
@@ -80,7 +80,7 @@ class SpecialRef extends Ref {
     }
 
     @Override
-    public Object set(Context cx, Scriptable owner, Object value) {
+    public Object set(Context cx, VarScope owner, Object value) {
         switch (type) {
             case SPECIAL_NONE:
                 return ScriptRuntime.setObjectProp(target, name, value, cx);
@@ -95,50 +95,43 @@ class SpecialRef extends Ref {
                             if (search == target) {
                                 throw Context.reportRuntimeErrorById("msg.cyclic.value", name);
                             }
-                            if (type == SPECIAL_PROTO) {
-                                search = search.getPrototype();
-                            } else {
-                                search = search.getParentScope();
-                            }
+                            search = search.getPrototype();
                         } while (search != null);
                     }
-                    if (type == SPECIAL_PROTO) {
-                        if (target instanceof ScriptableObject
-                                && !((ScriptableObject) target).isExtensible()
-                                && cx.getLanguageVersion() >= Context.VERSION_1_8) {
-                            throw ScriptRuntime.typeErrorById("msg.not.extensible");
-                        }
+                    if (target instanceof ScriptableObject
+                            && !((ScriptableObject) target).isExtensible()
+                            && cx.getLanguageVersion() >= Context.VERSION_1_8) {
+                        throw ScriptRuntime.typeErrorById("msg.not.extensible");
+                    }
 
-                        if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
-                            final String typeOfTarget = ScriptRuntime.typeof(target);
-                            if ("function".equals(typeOfTarget)) {
-                                if (value == null) {
-                                    target.setPrototype(Undefined.SCRIPTABLE_UNDEFINED);
-                                    return value;
-                                }
-
-                                final String typeOfValue = ScriptRuntime.typeof(value);
-                                if ("object".equals(typeOfValue)
-                                        || "function".equals(typeOfValue)) {
-                                    target.setPrototype(obj);
-                                }
+                    if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
+                        final String typeOfTarget = ScriptRuntime.typeof(target);
+                        if ("function".equals(typeOfTarget)) {
+                            if (value == null) {
+                                target.setPrototype(Undefined.SCRIPTABLE_UNDEFINED);
                                 return value;
                             }
 
                             final String typeOfValue = ScriptRuntime.typeof(value);
-                            if (NativeSymbol.TYPE_NAME.equals(typeOfTarget)) {
-                                return value;
+                            if ("object".equals(typeOfValue) || "function".equals(typeOfValue)) {
+                                target.setPrototype(obj);
                             }
-
-                            if ((value != null && !"object".equals(typeOfValue))
-                                    || !"object".equals(typeOfTarget)) {
-                                return Undefined.instance;
-                            }
-
-                            target.setPrototype(obj);
-                        } else {
-                            target.setPrototype(obj);
+                            return value;
                         }
+
+                        final String typeOfValue = ScriptRuntime.typeof(value);
+                        if (NativeSymbol.TYPE_NAME.equals(typeOfTarget)) {
+                            return value;
+                        }
+
+                        if ((value != null && !"object".equals(typeOfValue))
+                                || !"object".equals(typeOfTarget)) {
+                            return Undefined.instance;
+                        }
+
+                        target.setPrototype(obj);
+                    } else {
+                        target.setPrototype(obj);
                     }
                     return obj;
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/Undefined.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Undefined.java
@@ -100,7 +100,7 @@ public class Undefined implements Serializable {
         }
 
         @Override
-        public VarScope getPrototype() {
+        public Scriptable getPrototype() {
             return null;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
@@ -154,7 +154,7 @@ public class WrapFactory {
      * @return the wrapped value which shall not be null
      * @since 1.7R3
      */
-    public Scriptable wrapJavaClass(Context cx, Scriptable scope, Class<?> javaClass) {
+    public Scriptable wrapJavaClass(Context cx, VarScope scope, Class<?> javaClass) {
         return new NativeJavaClass(scope, javaClass);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -7,8 +7,8 @@ package org.mozilla.javascript.commonjs.module;
 import java.net.URI;
 import org.mozilla.javascript.DeclarationScope;
 import org.mozilla.javascript.ScopeObject;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 
 /**
  * A top-level module scope. This class provides methods to retrieve the module's source and base
@@ -38,14 +38,9 @@ public class ModuleScope extends DeclarationScope {
         return base;
     }
 
-    @Override
-    public String getClassName() {
-        return "module";
-    }
-
     /** Search up the chain of scopes to find a module scope. */
-    public static ModuleScope findModuleScope(Scriptable scope) {
-        Scriptable current = scope;
+    public static ModuleScope findModuleScope(VarScope scope) {
+        VarScope current = scope;
         while (current != null) {
             if (current instanceof ModuleScope) {
                 return (ModuleScope) current;

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
@@ -39,7 +39,7 @@ import org.mozilla.javascript.VarScope;
  * <p>&lt;h1&gt;Making it available&lt;/h1&gt;
  *
  * <p>In order to make the require() function available to your JavaScript program, you need to
- * invoke either {@link #install(Scriptable)} or {@link #requireMain(Context, String)}.
+ * invoke either {@link #install(VarScope)} or {@link #requireMain(Context, String)}.
  *
  * @author Attila Szegedi
  * @version $Id: Require.java,v 1.4 2011/04/07 20:26:11 hannes%helma.at Exp $
@@ -65,7 +65,7 @@ public class Require extends BaseFunction {
 
     /**
      * Creates a new instance of the require() function. Upon constructing it, you will either want
-     * to install it in the global (or some other) scope using {@link #install(Scriptable)}, or
+     * to install it in the global (or some other) scope using {@link #install(VarScope)}, or
      * alternatively, you can load the program's main module using {@link #requireMain(Context,
      * String)} and then act on the main module's exports.
      *
@@ -169,7 +169,7 @@ public class Require extends BaseFunction {
      *
      * @param scope the scope where the require() function is to be installed.
      */
-    public void install(Scriptable scope) {
+    public void install(VarScope scope) {
         ScriptableObject.putProperty(scope, "require", this);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -518,7 +518,7 @@ public class Codegen implements Evaluator {
                 "org/mozilla/javascript/BaseFunction",
                 "createObject",
                 "(Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + ")Lorg/mozilla/javascript/Scriptable;");
         cfw.addAStore(firstLocal);
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -14,11 +14,11 @@ import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.NativeGenerator;
 import org.mozilla.javascript.NativeIterator;
 import org.mozilla.javascript.NewLiteralStorage;
-import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -247,7 +247,7 @@ public final class OptRuntime extends ScriptRuntime {
         ContextFactory.getGlobal()
                 .call(
                         cx -> {
-                            ScopeObject global = getGlobal(cx);
+                            TopLevel global = getGlobal(cx);
 
                             // get the command line arguments and define "arguments"
                             // array in the top-level object
@@ -255,7 +255,7 @@ public final class OptRuntime extends ScriptRuntime {
                             System.arraycopy(args, 0, argsCopy, 0, args.length);
                             Scriptable argsObj = cx.newArray(global, argsCopy);
                             global.defineProperty("arguments", argsObj, ScriptableObject.DONTENUM);
-                            script.exec(cx, global, global);
+                            script.exec(cx, global, global.getGlobalThis());
                             return null;
                         });
     }
@@ -333,10 +333,10 @@ public final class OptRuntime extends ScriptRuntime {
         public final Scriptable thisObj;
 
         @SuppressWarnings("unused")
-        public final Scriptable activationFrame;
+        public final VarScope activationFrame;
 
         static final String activationFrame_NAME = "activationFrame";
-        static final String activationFrame_TYPE = "Lorg/mozilla/javascript/Scriptable;";
+        static final String activationFrame_TYPE = "Lorg/mozilla/javascript/VarScope;";
         static final String thisObj_NAME = "thisObj";
         static final String thisObj_TYPE = "Lorg/mozilla/javascript/Scriptable;";
 
@@ -346,8 +346,7 @@ public final class OptRuntime extends ScriptRuntime {
         int maxStack;
         Object returnValue;
 
-        GeneratorState(
-                Scriptable activationFrame, Scriptable thisObj, int maxLocals, int maxStack) {
+        GeneratorState(VarScope activationFrame, Scriptable thisObj, int maxLocals, int maxStack) {
             this.activationFrame = activationFrame;
             this.thisObj = thisObj;
             this.maxLocals = maxLocals;

--- a/rhino/src/main/java/org/mozilla/javascript/serialize/ScriptableInputStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/serialize/ScriptableInputStream.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.UniqueTag;
+import org.mozilla.javascript.VarScope;
 
 /**
  * Class ScriptableInputStream is used to read in a JavaScript object or function previously
@@ -32,7 +33,7 @@ public class ScriptableInputStream extends ObjectInputStream {
      * @param in the InputStream to read from.
      * @param scope the top-level scope to create the object in.
      */
-    public ScriptableInputStream(InputStream in, Scriptable scope) throws IOException {
+    public ScriptableInputStream(InputStream in, VarScope scope) throws IOException {
         super(in);
         this.scope = scope;
         enableResolveObject(true);
@@ -72,6 +73,6 @@ public class ScriptableInputStream extends ObjectInputStream {
         return obj;
     }
 
-    private Scriptable scope;
+    private VarScope scope;
     private ClassLoader classLoader;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/serialize/ScriptableOutputStream.java
+++ b/rhino/src/main/java/org/mozilla/javascript/serialize/ScriptableOutputStream.java
@@ -13,9 +13,11 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
+import org.mozilla.javascript.PropHolder;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.UniqueTag;
+import org.mozilla.javascript.VarScope;
 
 /**
  * Class ScriptableOutputStream is an ObjectOutputStream used to serialize JavaScript objects and
@@ -40,7 +42,7 @@ public class ScriptableOutputStream extends ObjectOutputStream {
      * @param out the OutputStream to write to.
      * @param scope the scope containing the object.
      */
-    public ScriptableOutputStream(OutputStream out, Scriptable scope) throws IOException {
+    public ScriptableOutputStream(OutputStream out, VarScope scope) throws IOException {
         super(out);
         this.scope = scope;
         table = new HashMap<>();
@@ -145,13 +147,17 @@ public class ScriptableOutputStream extends ObjectOutputStream {
         }
     }
 
-    static Object lookupQualifiedName(Scriptable scope, String qualifiedName) {
+    static Object lookupQualifiedName(VarScope scope, String qualifiedName) {
         StringTokenizer st = new StringTokenizer(qualifiedName, ".");
         Object result = scope;
         while (st.hasMoreTokens()) {
             String s = st.nextToken();
-            result = ScriptableObject.getProperty((Scriptable) result, s);
-            if (result == null || !(result instanceof Scriptable)) break;
+            if (result instanceof VarScope) {
+                result = ScriptableObject.getProperty((VarScope) result, s);
+            } else {
+                result = ScriptableObject.getProperty((Scriptable) result, s);
+            }
+            if (result == null || !(result instanceof PropHolder)) break;
         }
         return result;
     }
@@ -178,6 +184,6 @@ public class ScriptableOutputStream extends ObjectOutputStream {
         return new PendingLookup(name);
     }
 
-    private Scriptable scope;
+    private VarScope scope;
     private Map<Object, String> table;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -141,7 +141,7 @@ public class NativeArrayBuffer extends ScriptableObject {
         return LambdaConstructor.convertThisObject(thisObj, NativeArrayBuffer.class);
     }
 
-    private static NativeArrayBuffer js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static NativeArrayBuffer js_constructor(Context cx, VarScope scope, Object[] args) {
         double length = isArg(args, 0) ? ScriptRuntime.toIndex(args[0]) : 0;
 
         // ES2024: Check for options parameter with maxByteLength
@@ -168,7 +168,7 @@ public class NativeArrayBuffer extends ScriptableObject {
     }
 
     private static Boolean js_isView(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         return Boolean.valueOf((isArg(args, 0) && (args[0] instanceof NativeArrayBufferView)));
     }
 
@@ -289,8 +289,7 @@ public class NativeArrayBuffer extends ScriptableObject {
     }
 
     // ES2024 ArrayBuffer.prototype.resize
-    private static Object js_resize(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_resize(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeArrayBuffer self = getSelf(thisObj);
         if (!self.isResizable()) {
             throw ScriptRuntime.typeErrorById("msg.arraybuf.notresizeable");

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -97,7 +97,7 @@ public class NativeDataView extends NativeArrayBufferView {
         return LambdaConstructor.convertThisObject(thisObj, NativeDataView.class);
     }
 
-    private static NativeDataView js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static NativeDataView js_constructor(Context cx, VarScope scope, Object[] args) {
         if (!isArg(args, 0) || !(args[0] instanceof NativeArrayBuffer)) {
             throw ScriptRuntime.constructError("TypeError", "Missing parameters");
         }
@@ -158,43 +158,42 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_getInt8(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getInt(cx, scope, 1, true, args);
     }
 
     private static Object js_getInt16(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getInt(cx, scope, 2, true, args);
     }
 
     private static Object js_getInt32(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getInt(cx, scope, 4, true, args);
     }
 
     private static Object js_getUint8(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getInt(cx, scope, 1, false, args);
     }
 
     private static Object js_getUint16(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getInt(cx, scope, 2, false, args);
     }
 
     private static Object js_getUint32(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getInt(cx, scope, 4, false, args);
     }
 
-    private Object js_getInt(
-            Context cx, Scriptable scope, int bytes, boolean signed, Object[] args) {
+    private Object js_getInt(Context cx, VarScope scope, int bytes, boolean signed, Object[] args) {
         int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
 
         boolean littleEndian = isArg(args, 1) && (bytes > 1) && ScriptRuntime.toBoolean(args[1]);
@@ -231,24 +230,24 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_getFloat32(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getFloat(cx, scope, 4, args);
     }
 
     private static Object js_getFloat64(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getFloat(cx, scope, 8, args);
     }
 
     private static Object js_getFloat16(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getFloat(cx, scope, 2, args);
     }
 
-    private Object js_getFloat(Context cx, Scriptable scope, int bytes, Object[] args) {
+    private Object js_getFloat(Context cx, VarScope scope, int bytes, Object[] args) {
         int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
 
         boolean littleEndian = isArg(args, 1) && (bytes > 1) && ScriptRuntime.toBoolean(args[1]);
@@ -275,48 +274,48 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_setInt8(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setInt(cx, scope, 1, true, args);
         return Undefined.instance;
     }
 
     private static Object js_setInt16(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setInt(cx, scope, 2, true, args);
         return Undefined.instance;
     }
 
     private static Object js_setInt32(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setInt(cx, scope, 4, true, args);
         return Undefined.instance;
     }
 
     private static Object js_setUint8(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setInt(cx, scope, 1, false, args);
         return Undefined.instance;
     }
 
     private static Object js_setUint16(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setInt(cx, scope, 2, false, args);
         return Undefined.instance;
     }
 
     private static Object js_setUint32(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setInt(cx, scope, 4, false, args);
         return Undefined.instance;
     }
 
-    private void js_setInt(Context cx, Scriptable scope, int bytes, boolean signed, Object[] args) {
+    private void js_setInt(Context cx, VarScope scope, int bytes, boolean signed, Object[] args) {
         int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
 
         Object val = isArg(args, 1) ? ScriptRuntime.toNumber(args[1]) : ScriptRuntime.zeroObj;
@@ -384,27 +383,27 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_setFloat32(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setFloat(cx, scope, 4, args);
         return Undefined.instance;
     }
 
     private static Object js_setFloat64(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setFloat(cx, scope, 8, args);
         return Undefined.instance;
     }
 
     private static Object js_setFloat16(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setFloat(cx, scope, 2, args);
         return Undefined.instance;
     }
 
-    private void js_setFloat(Context cx, Scriptable scope, int bytes, Object[] args) {
+    private void js_setFloat(Context cx, VarScope scope, int bytes, Object[] args) {
         int pos = ScriptRuntime.toIndex(isArg(args, 0) ? args[0] : Undefined.instance);
 
         double val = isArg(args, 1) ? ScriptRuntime.toNumber(args[1]) : Double.NaN;
@@ -436,13 +435,13 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_getBigInt64(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getBigInt(true, args);
     }
 
     private static Object js_getBigUint64(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getBigInt(false, args);
     }
@@ -483,14 +482,14 @@ public class NativeDataView extends NativeArrayBufferView {
     // but end up having precisely the same effect, with only the interpretation of the 64 bits in
     // an intermediate state differing.
     private static Object js_setBigInt64(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setBigInt(args);
         return Undefined.instance;
     }
 
     private static Object js_setBigUint64(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setBigInt(args);
         return Undefined.instance;

--- a/rhino/src/main/java/org/mozilla/javascript/xml/XMLLib.java
+++ b/rhino/src/main/java/org/mozilla/javascript/xml/XMLLib.java
@@ -10,7 +10,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Ref;
 import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.VarScope;
 
@@ -73,10 +72,10 @@ public abstract class XMLLib {
 
     public abstract boolean isXMLName(Context cx, Object name);
 
-    public abstract Ref nameRef(Context cx, Object name, Scriptable scope, int memberTypeFlags);
+    public abstract Ref nameRef(Context cx, Object name, VarScope scope, int memberTypeFlags);
 
     public abstract Ref nameRef(
-            Context cx, Object namespace, Object name, Scriptable scope, int memberTypeFlags);
+            Context cx, Object namespace, Object name, VarScope scope, int memberTypeFlags);
 
     /**
      * Escapes the reserved characters in a value of an attribute.

--- a/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
@@ -87,7 +87,7 @@ public class DebuggerTest {
             cx.setGeneratingDebug(true);
             cx.setInterpretedMode(true);
             Script script = cx.compileString(TEST_SCRIPT, "this-klass", 0, null);
-            Object res = script.exec(cx, scope, scope);
+            Object res = script.exec(cx, scope, scope.getGlobalThis());
             Assertions.assertNotNull(res);
             System.err.println(res.toString());
             Assertions.assertEquals(

--- a/rhino/src/test/java/org/mozilla/javascript/EqualObjectGraphsTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/EqualObjectGraphsTest.java
@@ -98,7 +98,7 @@ public class EqualObjectGraphsTest {
                             },
                     cx,
                     top,
-                    top,
+                    top.getGlobalThis(),
                     null,
                     false);
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug421071Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug421071Test.java
@@ -16,7 +16,6 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.TopLevel;
-import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 
 public class Bug421071Test {
@@ -100,8 +99,8 @@ public class Bug421071Test {
             try (Context context = factory.enterContext()) {
                 // Run each script in its own scope, to keep global variables
                 // defined in each script separate
-                VarScope threadScope = TopLevel.createIsolate(globalScope);
-                script.exec(context, threadScope, threadScope);
+                TopLevel threadScope = TopLevel.createIsolate(globalScope);
+                script.exec(context, threadScope, threadScope.getGlobalThis());
             } catch (Exception ee) {
                 ee.printStackTrace();
             }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug482203Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug482203Test.java
@@ -24,7 +24,7 @@ public class Bug482203Test {
                     new InputStreamReader(Bug482203Test.class.getResourceAsStream("Bug482203.js"));
             Script script = cx.compileReader(in, "", 1, null);
             TopLevel scope = cx.initStandardObjects();
-            script.exec(cx, scope, scope);
+            script.exec(cx, scope, scope.getGlobalThis());
             int counter = 0;
             for (; ; ) {
                 Object cont = ScriptableObject.getProperty(scope, "c");
@@ -32,7 +32,7 @@ public class Bug482203Test {
                     break;
                 }
                 counter++;
-                ((Callable) cont).call(cx, scope, scope, new Object[] {null});
+                ((Callable) cont).call(cx, scope, scope.getGlobalThis(), new Object[] {null});
             }
             assertEquals(5, counter);
             assertEquals(Double.valueOf(3), ScriptableObject.getProperty(scope, "result"));

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug714204Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug714204Test.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
-import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.Script;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * @author André Bargull
@@ -22,7 +22,7 @@ import org.mozilla.javascript.Script;
 public class Bug714204Test {
 
     private Context cx;
-    private ScopeObject scope;
+    private TopLevel scope;
 
     @BeforeEach
     public void setUp() {
@@ -45,7 +45,7 @@ public class Bug714204Test {
         sb.append("var f = new F('a');\n");
         sb.append("(f.x == 'a')\n");
         Script script = cx.compileString(sb.toString(), "<eval>", 1, null);
-        Object result = script.exec(cx, scope, scope);
+        Object result = script.exec(cx, scope, scope.getGlobalThis());
         assertEquals(Boolean.TRUE, result);
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
@@ -100,7 +100,7 @@ public class GeneratedMethodNameTest {
             TopLevel topScope = cx.initStandardObjects();
             topScope.put("javaNameGetter", topScope, new JavaNameGetter());
             Script script = cx.compileString(scriptCode, "myScript", 1, null);
-            script.exec(cx, topScope, topScope);
+            script.exec(cx, topScope, topScope.getGlobalThis());
         }
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Issue176Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Issue176Test.java
@@ -25,7 +25,7 @@ public class Issue176Test {
             Script script = cx.compileReader(in, "Issue176.js", 1, null);
             scope = cx.initStandardObjects();
             scope.put("host", scope, this);
-            script.exec(cx, scope, scope); // calls our methods
+            script.exec(cx, scope, scope.getGlobalThis()); // calls our methods
         } finally {
             Context.exit();
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -149,10 +149,5 @@ public class LookupSetterTest {
         }
     }
 
-    public static class TopScope extends TopLevel {
-        @Override
-        public String getClassName() {
-            return "TopScope";
-        }
-    }
+    public static class TopScope extends TopLevel {}
 }

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -21,7 +21,7 @@ import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.Main;
@@ -63,10 +63,10 @@ public class ShellTest {
         return bytes.toString();
     }
 
-    private static void runFileIfExists(Context cx, VarScope global, File f) {
+    private static void runFileIfExists(Context cx, TopLevel global, File f) {
         if (frameworkFile.equals(f)) {
             try {
-                frameworkScript.exec(cx, global, global);
+                frameworkScript.exec(cx, global, global.getGlobalThis());
             } catch (RhinoException re) {
                 // Error in test framework means that the whole world is broken.
                 throw new AssertionError(re);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ContinuationComparisonTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ContinuationComparisonTest.java
@@ -53,7 +53,7 @@ public class ContinuationComparisonTest {
                         cx.compileReader(r, "ContinuationComparisonTest.js", 1, null), global);
             }
             // Make the global standard again
-            ScriptableObject.deleteProperty(global, "capture");
+            global.delete("capture");
 
             return captured.get();
         }

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorsYieldStarReturnTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorsYieldStarReturnTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.PropHolder;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
@@ -239,7 +240,7 @@ public class GeneratorsYieldStarReturnTest {
                 });
     }
 
-    private double getNumberProperty(Scriptable obj, String property) {
+    private <T extends PropHolder<T>> double getNumberProperty(T obj, String property) {
         Object value = obj.get(property, obj);
         if (value instanceof Number) {
             return ((Number) value).doubleValue();

--- a/tests/src/test/java/org/mozilla/javascript/tests/ImportClassTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ImportClassTest.java
@@ -101,7 +101,7 @@ public class ImportClassTest {
         return contextFactory.call(
                 context -> {
                     Script script = context.compileString(scriptSourceText, "", 1, null);
-                    Object exec = script.exec(context, global, global);
+                    Object exec = script.exec(context, global, global.getGlobalThis());
                     return exec;
                 });
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/InitStandardObjectsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/InitStandardObjectsTest.java
@@ -61,6 +61,6 @@ public class InitStandardObjectsTest {
 
     private Object exec(String source) {
         Script script = context.compileString(source, "", 1, null);
-        return script.exec(context, global, global);
+        return script.exec(context, global, global.getGlobalThis());
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -64,11 +65,7 @@ public class ObserveInstructionCountTest {
 
         @Override
         protected Object doTopCall(
-                Callable callable,
-                Context cx,
-                Scriptable scope,
-                Scriptable thisObj,
-                Object[] args) {
+                Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
             MyContext mcx = (MyContext) cx;
             mcx.quota = 2000;
             return super.doTopCall(callable, cx, scope, thisObj, args);

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -252,7 +252,7 @@ public class Test262SuiteTest {
             return instance;
         }
 
-        private static Object gc(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        private static Object gc(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
             System.gc();
             return Undefined.instance;
         }
@@ -271,7 +271,7 @@ public class Test262SuiteTest {
         }
 
         public static $262 createRealm(
-                Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
             TopLevel realm = cx.initSafeStandardObjects(new TopLevel());
             return install(realm, thisObj.getPrototype());
         }

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireJarTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireJarTest.java
@@ -12,9 +12,9 @@ import java.nio.file.Path;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
@@ -122,7 +122,7 @@ public class RequireJarTest extends RequireTest {
         return getSandboxedRequire(cx, cx.initStandardObjects(), true);
     }
 
-    private Require getSandboxedRequire(Context cx, Scriptable scope, boolean sandboxed)
+    private Require getSandboxedRequire(Context cx, VarScope scope, boolean sandboxed)
             throws URISyntaxException {
         return new Require(
                 cx,

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.ScriptStackElement;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
@@ -202,7 +202,7 @@ public class RequireTest {
         return getSandboxedRequire(cx, cx.initStandardObjects(), true);
     }
 
-    private Require getSandboxedRequire(Context cx, Scriptable scope, boolean sandboxed)
+    private Require getSandboxedRequire(Context cx, VarScope scope, boolean sandboxed)
             throws URISyntaxException {
         return new Require(
                 cx,

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/GenericAccessTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/GenericAccessTest.java
@@ -221,7 +221,7 @@ public class GenericAccessTest {
             Utils.contextFactoryWithFeatures(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS);
 
     private static Object readClassAndValue(
-            Context cx, Scriptable scope, Scriptable thiz, Object[] args) {
+            Context cx, VarScope scope, Scriptable thiz, Object[] args) {
         return Arrays.stream(args)
                 .map(arg -> Context.jsToJava(arg, TypeInfo.OBJECT))
                 .map(arg -> arg.getClass().getSimpleName() + ' ' + arg)


### PR DESCRIPTION
This PR stacks on top of #2329 and is the next stage in resolving #2163.

This PR changes the `call` and `construct` signatures to make the scopes `VarScope`s, then changes the `JSCode` APIs, and then adds a series of commits that change all the places these are implemented to make them obey the new type. We can do this gradually because `VarScope` is a subtype of `Scriptable` and so method references can be adapted.

This change also has to include @ZZZank's change #2298 to ensure that serialisation of native methods can still be done, without it there are too many ordering issues with deserialisation and the continuations tests will fail.

Like the previous PR in this series each commit involved in this change can be taken separately, and the PR can be split for purposes of review if desired.