### PR TITLE
Convert pretty much all built ins to use `ClassDescriptor`s

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -6,7 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
 import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
 
 import java.io.Serial;
 import java.util.EnumSet;
@@ -26,7 +28,8 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static final Object FUNCTION_TAG = "Function";
     private static final String FUNCTION_CLASS = "Function";
-    static final String GENERATOR_FUNCTION_CLASS = "__GeneratorFunction";
+    static final SymbolKey GENERATOR_FUNCTION_CLASS =
+            new SymbolKey("GeneratorFunctionPrototype", REGULAR);
 
     private static final String APPLY_TAG = "APPLY_TAG";
     private static final String CALL_TAG = "CALL_TAG";
@@ -34,6 +37,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static final ClassDescriptor DESCRIPTOR;
     private static final ClassDescriptor ES6_DESCRIPTOR;
+    private static final ClassDescriptor GENERATOR_DESCRIPTOR;
     private static final JSDescriptor<JSFunction> APPLY_DESCRIPTOR;
     private static final JSDescriptor<JSFunction> CALL_DESCRIPTOR;
 
@@ -69,6 +73,19 @@ public class BaseFunction extends ScriptableObject implements Function {
 
         APPLY_DESCRIPTOR = DESCRIPTOR.findProtoDesc("apply");
         CALL_DESCRIPTOR = DESCRIPTOR.findProtoDesc("call");
+
+        GENERATOR_DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                GENERATOR_FUNCTION_CLASS,
+                                "GeneratorFunction",
+                                1,
+                                BaseFunction::js_gen_constructor,
+                                BaseFunction::js_gen_constructor)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value("GeneratorFunction", READONLY | DONTENUM))
+                        .build();
     }
 
     static JSFunction init(Context cx, VarScope scope, boolean sealed) {
@@ -91,41 +108,29 @@ public class BaseFunction extends ScriptableObject implements Function {
         init(Context.getContext(), scope, sealed);
     }
 
-    static Object initAsGeneratorFunction(VarScope scope, boolean sealed) {
+    static Object initAsGeneratorFunction(Context cx, VarScope scope, boolean sealed) {
         var proto = new NativeObject();
-        VarScope top = ScriptableObject.getTopLevelScope(scope);
 
-        var function = (Scriptable) ScriptableObject.getProperty(scope, FUNCTION_CLASS);
-        var functionProto =
-                (Scriptable) ScriptableObject.getProperty(function, PROTOTYPE_PROPERTY_NAME);
-        proto.setPrototype(functionProto);
-
-        var iterator = (Scriptable) ScriptableObject.getProperty(scope, "Iterator");
-        ScriptableObject.putProperty(
+        return GENERATOR_DESCRIPTOR.buildConstructor(
+                cx,
+                scope,
                 proto,
-                PROTOTYPE_PROPERTY_NAME,
-                ScriptableObject.getTopScopeValue(top, ES6Generator.GENERATOR_TAG));
+                sealed,
+                (c, ctor) -> {
+                    VarScope top = ScriptableObject.getTopLevelScope(scope);
 
-        LambdaConstructor ctor =
-                new LambdaConstructor(
-                        scope,
-                        GENERATOR_FUNCTION_CLASS,
-                        1,
-                        proto,
-                        BaseFunction::js_gen_constructorCall,
-                        BaseFunction::js_gen_constructor);
+                    var function = (Scriptable) ScriptableObject.getProperty(scope, FUNCTION_CLASS);
+                    var functionProto =
+                            (Scriptable)
+                                    ScriptableObject.getProperty(function, PROTOTYPE_PROPERTY_NAME);
+                    proto.setPrototype(functionProto);
 
-        proto.defineProperty("constructor", ctor, READONLY | DONTENUM);
+                    var generatorProto =
+                            ScriptableObject.getTopScopeValue(top, ES6Generator.GENERATOR_TAG);
 
-        // Function.prototype attributes: see ECMA 15.3.3.1
-        ctor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        proto.defineProperty(SymbolKey.TO_STRING_TAG, "GeneratorFunction", READONLY | DONTENUM);
-        ScriptableObject.putProperty(scope, GENERATOR_FUNCTION_CLASS, ctor);
-        // Function.prototype attributes: see ECMA 15.3.3.1
-        // The "GeneratorFunction" name actually never appears in the global scope.
-        // Return it here so it can be cached as a "builtin"
-        return ctor;
+                    proto.setAttributes("constructor", DONTENUM | READONLY);
+                    proto.defineProperty("prototype", generatorProto, READONLY | DONTENUM);
+                });
     }
 
     public BaseFunction() {
@@ -283,6 +288,11 @@ public class BaseFunction extends ScriptableObject implements Function {
         }
     }
 
+    static DescriptorInfo createThrowingProp(Context cx, VarScope scope, ScriptableObject obj) {
+        var thrower = ScriptRuntime.typeErrorThrower(scope);
+        return new DescriptorInfo(false, NOT_FOUND, true, thrower, thrower, null);
+    }
+
     protected final boolean defaultHas(String name) {
         return super.has(name, this);
     }
@@ -297,7 +307,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     @Override
     public String getClassName() {
-        return isGeneratorFunction() ? GENERATOR_FUNCTION_CLASS : FUNCTION_CLASS;
+        return isGeneratorFunction() ? "GeneratorFunction" : FUNCTION_CLASS;
     }
 
     // Generated code will override this
@@ -468,18 +478,14 @@ public class BaseFunction extends ScriptableObject implements Function {
         return realf.decompile(indent, EnumSet.noneOf(DecompilerFlag.class));
     }
 
-    private static Scriptable js_gen_constructorCall(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return js_gen_constructor(cx, scope, args);
-    }
-
     private static Scriptable js_constructor(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return jsConstructor(cx, f.getDeclarationScope(), args, false);
     }
 
-    private static Scriptable js_gen_constructor(Context cx, VarScope scope, Object[] args) {
-        return jsConstructor(cx, scope, args, true);
+    private static Scriptable js_gen_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return jsConstructor(cx, f.getDeclarationScope(), args, true);
     }
 
     private static BaseFunction realFunction(Object thisObj, String functionName) {

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -6,12 +6,32 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+
 import java.io.Serial;
 
 public final class ES6Generator extends ScriptableObject {
     @Serial private static final long serialVersionUID = -1617667918827493330L;
 
-    static final Object GENERATOR_TAG = "Generator";
+    static final SymbolKey GENERATOR_TAG = new SymbolKey("GeneratorPrototype", REGULAR);
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(GENERATOR_TAG)
+                        .withMethod(CTOR, "next", 1, ES6Generator::js_next)
+                        .withMethod(CTOR, "return", 1, ES6Generator::js_return)
+                        .withMethod(CTOR, "throw", 1, ES6Generator::js_throw)
+                        .withMethod(CTOR, SymbolKey.ITERATOR, 0, ES6Generator::js_iterator)
+                        .withProp(
+                                CTOR,
+                                SymbolKey.TO_STRING_TAG,
+                                value("Generator", DONTENUM | READONLY))
+                        .build();
+    }
 
     private JSFunction function;
     private Object savedState;
@@ -20,33 +40,13 @@ public final class ES6Generator extends ScriptableObject {
     private State state = State.SUSPENDED_START;
     private Object delegee;
 
-    static ES6Generator init(TopLevel scope, boolean sealed) {
+    static ScriptableObject init(Context cx, TopLevel scope, boolean sealed) {
 
-        ES6Generator prototype = new ES6Generator();
-        if (scope != null) {
-            prototype.setParentScope(scope);
-            prototype.setPrototype(getObjectPrototype(scope));
-        }
+        NativeObject prototype = new NativeObject();
+        DESCRIPTOR.populateGlobal(cx, scope, prototype, sealed);
 
-        // Define prototype methods using LambdaFunction
-        LambdaFunction next = new LambdaFunction(scope, "next", 1, ES6Generator::js_next);
-        ScriptableObject.defineProperty(prototype, "next", next, DONTENUM);
-
-        LambdaFunction returnFunc = new LambdaFunction(scope, "return", 1, ES6Generator::js_return);
-        ScriptableObject.defineProperty(prototype, "return", returnFunc, DONTENUM);
-
-        LambdaFunction throwFunc = new LambdaFunction(scope, "throw", 1, ES6Generator::js_throw);
-        ScriptableObject.defineProperty(prototype, "throw", throwFunc, DONTENUM);
-
-        LambdaFunction iterator =
-                new LambdaFunction(scope, "[Symbol.iterator]", 0, ES6Generator::js_iterator);
-        prototype.defineProperty(SymbolKey.ITERATOR, iterator, DONTENUM);
-
-        prototype.defineProperty(SymbolKey.TO_STRING_TAG, "Generator", DONTENUM | READONLY);
-
-        if (sealed) {
-            prototype.sealObject();
-        }
+        var iterCtor = (JSFunction) scope.get("Iterator", scope);
+        prototype.setPrototype((Scriptable) iterCtor.getPrototypeProperty());
 
         // Need to access Generator prototype when constructing
         // Generator instances, but don't have a generator constructor
@@ -77,8 +77,8 @@ public final class ES6Generator extends ScriptableObject {
             // If function.prototype is not an Object, use the intrinsic default prototype
             // Ref: Ecma 2026, 10.1.14 GetPrototypeFromConstructor step 4.
             // See test262: language/statements/generators/default-proto.js
-            ES6Generator prototype =
-                    (ES6Generator) ScriptableObject.getTopScopeValue(top, GENERATOR_TAG);
+            ScriptableObject prototype =
+                    (ScriptableObject) ScriptableObject.getTopScopeValue(top, GENERATOR_TAG);
             this.setPrototype(prototype);
         }
     }
@@ -92,34 +92,38 @@ public final class ES6Generator extends ScriptableObject {
         return LambdaConstructor.convertThisObject(thisObj, ES6Generator.class);
     }
 
-    private static Object js_return(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_return(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
-            return generator.resumeAbruptLocal(cx, scope, NativeGenerator.GENERATOR_CLOSE, value);
+            return generator.resumeAbruptLocal(cx, s, NativeGenerator.GENERATOR_CLOSE, value);
         }
-        return generator.resumeDelegeeReturn(cx, scope, value);
+        return generator.resumeDelegeeReturn(cx, s, value);
     }
 
-    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_next(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
-            return generator.resumeLocal(cx, scope, value);
+            return generator.resumeLocal(cx, s, value);
         }
-        return generator.resumeDelegee(cx, scope, value);
+        return generator.resumeDelegee(cx, s, value);
     }
 
-    private static Object js_throw(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_throw(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
-            return generator.resumeAbruptLocal(cx, scope, NativeGenerator.GENERATOR_THROW, value);
+            return generator.resumeAbruptLocal(cx, s, NativeGenerator.GENERATOR_THROW, value);
         }
-        return generator.resumeDelegeeThrow(cx, scope, value);
+        return generator.resumeDelegeeThrow(cx, s, value);
     }
 
-    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_iterator(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return thisObj;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -4181,7 +4181,9 @@ public final class Interpreter extends Icode implements Evaluator {
             state.indexReg += frame.idata.itsMaxVars;
             int enumType =
                     op == Token.ENUM_INIT_KEYS
-                            ? ScriptRuntime.ENUMERATE_KEYS
+                            ? cx.getLanguageVersion() <= Context.VERSION_1_8
+                                    ? ScriptRuntime.ENUMERATE_KEYS
+                                    : ScriptRuntime.ENUMERATE_KEYS_NO_ITERATOR
                             : op == Token.ENUM_INIT_VALUES
                                     ? ScriptRuntime.ENUMERATE_VALUES
                                     : op == Token.ENUM_INIT_VALUES_IN_ORDER

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -3549,8 +3549,9 @@ public final class Interpreter extends Icode implements Evaluator {
             if (fun instanceof JSFunction
                     && ((JSFunction) fun).getDescriptor().getCode() instanceof InterpreterData) {
                 JSFunction ifun = (JSFunction) fun;
-                JSDescriptor desc = ifun.getDescriptor();
-                InterpreterData idata = (InterpreterData) desc.getCode();
+
+                JSDescriptor<JSFunction> desc = ifun.getDescriptor();
+                var idata = (InterpreterData<JSFunction>) desc.getCode();
                 if (frame.fnOrScript.getDescriptor().getSecurityDomain()
                         == desc.getSecurityDomain()) {
                     CallFrame callParentFrame = frame;
@@ -3620,8 +3621,9 @@ public final class Interpreter extends Icode implements Evaluator {
                 return BREAK_WITHOUT_EXTENSION;
             }
 
-            if (fun instanceof IdFunctionObject) {
-                IdFunctionObject ifun = (IdFunctionObject) fun;
+            if (fun instanceof JSFunction) {
+                var ifun = (JSFunction) fun;
+
                 if (NativeContinuation.isContinuationConstructor(ifun)) {
                     frame.stack[state.stackTop] = captureContinuation(cx, frame.parentFrame, false);
                     return null;
@@ -3666,8 +3668,9 @@ public final class Interpreter extends Icode implements Evaluator {
             if (lhs instanceof JSFunction
                     && ((JSFunction) lhs).getConstructor() instanceof InterpreterData) {
                 JSFunction f = (JSFunction) lhs;
-                JSDescriptor desc = f.getDescriptor();
-                InterpreterData idata = (InterpreterData) desc.getConstructor();
+
+                JSDescriptor<JSFunction> desc = f.getDescriptor();
+                var idata = (InterpreterData<JSFunction>) desc.getConstructor();
                 if (frame.fnOrScript.getDescriptor().getSecurityDomain()
                         == desc.getSecurityDomain()) {
                     if (cx.getLanguageVersion() >= Context.VERSION_ES6
@@ -3700,19 +3703,20 @@ public final class Interpreter extends Icode implements Evaluator {
                     return new StateContinueResult(calleeFrame, state.indexReg);
                 }
             }
+            if (lhs instanceof JSFunction) {
+                var f = (JSFunction) lhs;
+
+                if (NativeContinuation.isContinuationConstructor(f)) {
+                    frame.stack[state.stackTop] = captureContinuation(cx, frame.parentFrame, false);
+                    return null;
+                }
+            }
+
             if (!(lhs instanceof Constructable)) {
                 if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop]);
                 throw ScriptRuntime.notFunctionError(lhs);
             }
             Constructable ctor = (Constructable) lhs;
-
-            if (ctor instanceof IdFunctionObject) {
-                IdFunctionObject ifun = (IdFunctionObject) ctor;
-                if (NativeContinuation.isContinuationConstructor(ifun)) {
-                    frame.stack[state.stackTop] = captureContinuation(cx, frame.parentFrame, false);
-                    return null;
-                }
-            }
 
             Object[] outArgs =
                     getArgsArray(frame.stack, frame.sDbl, state.stackTop + 1, state.indexReg);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeContinuation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeContinuation.java
@@ -9,16 +9,34 @@ package org.mozilla.javascript;
 import java.io.Serial;
 import java.util.Objects;
 
-public final class NativeContinuation extends IdScriptableObject implements Function {
+public final class NativeContinuation extends ScriptableObject implements Function {
     @Serial private static final long serialVersionUID = 1794167133757605367L;
 
-    private static final Object FTAG = "Continuation";
+    private static final String CLASS_NAME = "Continuation";
+
+    private static final ClassDescriptor DESCRIPTOR;
+    private static final JSDescriptor<JSFunction> CTOR_DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                0,
+                                NativeContinuation::js_constructor,
+                                NativeContinuation::js_constructor)
+                        .build();
+        CTOR_DESCRIPTOR = DESCRIPTOR.ctorDesc();
+    }
 
     private Object implementation;
 
     public static void init(Context cx, VarScope scope, boolean sealed) {
-        NativeContinuation obj = new NativeContinuation();
-        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+        DESCRIPTOR.buildConstructor(cx, scope, new NativeContinuation(), sealed);
+    }
+
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        throw Context.reportRuntimeError("Direct call is not supported");
     }
 
     public Object getImplementation() {
@@ -44,11 +62,8 @@ public final class NativeContinuation extends IdScriptableObject implements Func
         return Interpreter.restartContinuation(this, cx, scope, args);
     }
 
-    public static boolean isContinuationConstructor(IdFunctionObject f) {
-        if (f.hasTag(FTAG) && f.methodId() == Id_constructor) {
-            return true;
-        }
-        return false;
+    public static boolean isContinuationConstructor(JSFunction f) {
+        return f.getDescriptor() == CTOR_DESCRIPTOR;
     }
 
     /**
@@ -62,49 +77,4 @@ public final class NativeContinuation extends IdScriptableObject implements Func
     public static boolean equalImplementations(NativeContinuation c1, NativeContinuation c2) {
         return Objects.equals(c1.implementation, c2.implementation);
     }
-
-    @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        switch (id) {
-            case Id_constructor:
-                arity = 0;
-                s = "constructor";
-                break;
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
-        initPrototypeMethod(FTAG, id, s, arity);
-    }
-
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(FTAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
-        }
-        int id = f.methodId();
-        switch (id) {
-            case Id_constructor:
-                throw Context.reportRuntimeError("Direct call is not supported");
-        }
-        throw new IllegalArgumentException(String.valueOf(id));
-    }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        int id;
-        switch (s) {
-            case "constructor":
-                id = Id_constructor;
-                break;
-            default:
-                id = 0;
-                break;
-        }
-        return id;
-    }
-
-    private static final int Id_constructor = 1, MAX_PROTOTYPE_ID = 1;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+
 import java.io.Serial;
 
 /**
@@ -14,34 +17,27 @@ import java.io.Serial;
  *
  * @author Norris Boyd
  */
-public final class NativeGenerator extends IdScriptableObject {
+public final class NativeGenerator extends ScriptableObject {
     @Serial private static final long serialVersionUID = -1383456283657974338L;
 
-    private static final Object GENERATOR_TAG = "Generator";
+    private static final SymbolKey GENERATOR_TAG = new SymbolKey("GeneratorPrototype", REGULAR);
+    private static final ClassDescriptor DESCRIPTOR;
 
-    static NativeGenerator init(TopLevel scope, boolean sealed) {
-        // Generator
-        // Can't use "NativeGenerator().exportAsJSClass" since we don't want
-        // to define "Generator" as a constructor in the top-level scope.
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(GENERATOR_TAG)
+                        .withMethod(CTOR, "close", 1, NativeGenerator::js_close)
+                        .withMethod(CTOR, "next", 1, NativeGenerator::js_next)
+                        .withMethod(CTOR, "send", 0, NativeGenerator::js_send)
+                        .withMethod(CTOR, "throw", 0, NativeGenerator::js_throw)
+                        .withMethod(CTOR, "__iterator__", 1, NativeGenerator::js_iterator)
+                        .build();
+    }
 
-        NativeGenerator prototype = new NativeGenerator();
-        if (scope != null) {
-            prototype.setParentScope(scope);
-            prototype.setPrototype(getObjectPrototype(scope));
-        }
-        prototype.activatePrototypeMap(MAX_PROTOTYPE_ID);
-        if (sealed) {
-            prototype.sealObject();
-        }
-
-        // Need to access Generator prototype when constructing
-        // Generator instances, but don't have a generator constructor
-        // to use to find the prototype. Use the "associateValue"
-        // approach instead.
-        if (scope != null) {
-            scope.associateValue(GENERATOR_TAG, prototype);
-        }
-
+    static NativeGenerator init(Context cx, TopLevel scope, boolean sealed) {
+        var prototype = new NativeGenerator();
+        DESCRIPTOR.populateGlobal(cx, scope, prototype, sealed);
+        scope.associateValue(GENERATOR_TAG, prototype);
         return prototype;
     }
 
@@ -68,76 +64,47 @@ public final class NativeGenerator extends IdScriptableObject {
         return "Generator";
     }
 
-    @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        switch (id) {
-            case Id_close:
-                arity = 1;
-                s = "close";
-                break;
-            case Id_next:
-                arity = 1;
-                s = "next";
-                break;
-            case Id_send:
-                arity = 0;
-                s = "send";
-                break;
-            case Id_throw:
-                arity = 0;
-                s = "throw";
-                break;
-            case Id___iterator__:
-                arity = 1;
-                s = "__iterator__";
-                break;
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
-        initPrototypeMethod(GENERATOR_TAG, id, s, arity);
+    private static Object js_close(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        // need to run any pending finally clauses
+        var generator = realThis(thisObj);
+        return generator.resume(cx, s, GENERATOR_CLOSE, new GeneratorClosedException());
     }
 
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(GENERATOR_TAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
+    private static Object js_next(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        // arguments to next() are ignored
+        var generator = realThis(thisObj);
+        generator.firstTime = false;
+        return generator.resume(cx, s, GENERATOR_SEND, Undefined.instance);
+    }
+
+    private static Object js_send(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        {
+            var generator = realThis(thisObj);
+            Object arg = args.length > 0 ? args[0] : Undefined.instance;
+            if (generator.firstTime && !arg.equals(Undefined.instance)) {
+                throw ScriptRuntime.typeErrorById("msg.send.newborn");
+            }
+            return generator.resume(cx, s, GENERATOR_SEND, arg);
         }
-        int id = f.methodId();
+    }
 
-        NativeGenerator generator = ensureType(thisObj, NativeGenerator.class, f);
+    private static Object js_throw(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var generator = realThis(thisObj);
+        return generator.resume(
+                cx, s, GENERATOR_THROW, args.length > 0 ? args[0] : Undefined.instance);
+    }
 
-        switch (id) {
-            case Id_close:
-                // need to run any pending finally clauses
-                return generator.resume(cx, scope, GENERATOR_CLOSE, new GeneratorClosedException());
+    private static Object js_iterator(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return thisObj;
+    }
 
-            case Id_next:
-                // arguments to next() are ignored
-                generator.firstTime = false;
-                return generator.resume(cx, scope, GENERATOR_SEND, Undefined.instance);
-
-            case Id_send:
-                {
-                    Object arg = args.length > 0 ? args[0] : Undefined.instance;
-                    if (generator.firstTime && !arg.equals(Undefined.instance)) {
-                        throw ScriptRuntime.typeErrorById("msg.send.newborn");
-                    }
-                    return generator.resume(cx, scope, GENERATOR_SEND, arg);
-                }
-
-            case Id_throw:
-                return generator.resume(
-                        cx, scope, GENERATOR_THROW, args.length > 0 ? args[0] : Undefined.instance);
-
-            case Id___iterator__:
-                return thisObj;
-
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
+    private static NativeGenerator realThis(Object thisObj) {
+        return LambdaConstructor.convertThisObject(thisObj, NativeGenerator.class);
     }
 
     private Object resume(Context cx, VarScope scope, int operation, Object value) {
@@ -177,39 +144,6 @@ public final class NativeGenerator extends IdScriptableObject {
             if (operation == GENERATOR_CLOSE) savedState = null;
         }
     }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        int id;
-        switch (s) {
-            case "close":
-                id = Id_close;
-                break;
-            case "next":
-                id = Id_next;
-                break;
-            case "send":
-                id = Id_send;
-                break;
-            case "throw":
-                id = Id_throw;
-                break;
-            case "__iterator__":
-                id = Id___iterator__;
-                break;
-            default:
-                id = 0;
-                break;
-        }
-        return id;
-    }
-
-    private static final int Id_close = 1,
-            Id_next = 2,
-            Id_send = 3,
-            Id_throw = 4,
-            Id___iterator__ = 5,
-            MAX_PROTOTYPE_ID = 5;
 
     private JSFunction function;
     private Object savedState;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -53,7 +53,7 @@ public final class NativeIterator extends ScriptableObject {
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             ES6Generator.init(scope, sealed);
         } else {
-            NativeGenerator.init(scope, sealed);
+            NativeGenerator.init(cx, scope, sealed);
         }
 
         // StopIteration

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -46,12 +46,12 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     static void init(Context cx, TopLevel scope, boolean sealed) {
-        NativeIterator proto = new NativeIterator();
+        NativeObject proto = new NativeObject();
         var ctor = DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
 
         // Generator
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
-            ES6Generator.init(scope, sealed);
+            ES6Generator.init(cx, scope, sealed);
         } else {
             NativeGenerator.init(cx, scope, sealed);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -4,6 +4,10 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.util.ArrayList;
 import org.mozilla.javascript.TopLevel.NativeErrors;
 
@@ -20,6 +24,34 @@ public class NativePromise extends ScriptableObject {
         REJECT
     }
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                "Promise",
+                                1,
+                                ClassDescriptor.typeError(),
+                                NativePromise::constructor)
+                        .withMethod(CTOR, "resolve", 1, NativePromise::resolve)
+                        .withMethod(CTOR, "reject", 1, NativePromise::reject)
+                        .withMethod(CTOR, "all", 1, NativePromise::all)
+                        .withMethod(CTOR, "allSettled", 1, NativePromise::allSettled)
+                        .withMethod(CTOR, "race", 1, NativePromise::race)
+                        .withMethod(CTOR, "any", 1, NativePromise::any)
+                        .withMethod(CTOR, "withResolvers", 0, NativePromise::withResolvers)
+                        .withMethod(CTOR, "try", 1, NativePromise::promiseTry)
+                        .withMethod(PROTO, "then", 2, NativePromise::doThen)
+                        .withMethod(PROTO, "catch", 1, NativePromise::doCatch)
+                        .withMethod(PROTO, "finally", 1, NativePromise::doFinally)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value("Promise", DONTENUM | READONLY))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
+
     private State state = State.PENDING;
     private Object result = null;
     private boolean handled = false;
@@ -28,49 +60,19 @@ public class NativePromise extends ScriptableObject {
     private ArrayList<Reaction> rejectReactions = new ArrayList<>();
 
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        "Promise",
-                        1,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativePromise::constructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.defineConstructorMethod(scope, "resolve", 1, NativePromise::resolve);
-        constructor.defineConstructorMethod(scope, "reject", 1, NativePromise::reject);
-        constructor.defineConstructorMethod(scope, "all", 1, NativePromise::all);
-        constructor.defineConstructorMethod(scope, "allSettled", 1, NativePromise::allSettled);
-        constructor.defineConstructorMethod(scope, "race", 1, NativePromise::race);
-        constructor.defineConstructorMethod(scope, "any", 1, NativePromise::any);
-        constructor.defineConstructorMethod(
-                scope, "withResolvers", 0, NativePromise::withResolvers);
-        constructor.defineConstructorMethod(scope, "try", 1, NativePromise::promiseTry);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        constructor.definePrototypeMethod(scope, "then", 2, NativePromise::doThen);
-        constructor.definePrototypeMethod(scope, "catch", 1, NativePromise::doCatch);
-        constructor.definePrototypeMethod(scope, "finally", 1, NativePromise::doFinally);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, "Promise", DONTENUM | READONLY);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
-    private static Scriptable constructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 1 || !(args[0] instanceof Callable)) {
             throw ScriptRuntime.typeErrorById("msg.function.expected");
         }
         Callable executor = (Callable) args[0];
         NativePromise promise = new NativePromise();
-        ResolvingFunctions resolving = new ResolvingFunctions(scope, promise);
+        ResolvingFunctions resolving = new ResolvingFunctions(f.getDeclarationScope(), promise);
 
-        Scriptable thisObj = Undefined.SCRIPTABLE_UNDEFINED;
+        thisObj = Undefined.SCRIPTABLE_UNDEFINED;
         if (!cx.isStrictMode()) {
             TopLevel tcs = cx.topCallScope;
             if (tcs != null) {
@@ -78,12 +80,17 @@ public class NativePromise extends ScriptableObject {
             }
         }
 
+        var thisArg = (Scriptable) thisObj;
+
         try {
-            executor.call(cx, scope, thisObj, new Object[] {resolving.resolve, resolving.reject});
+            executor.call(cx, s, thisArg, new Object[] {resolving.resolve, resolving.reject});
         } catch (RhinoException re) {
-            resolving.reject.call(cx, scope, thisObj, new Object[] {getErrorObject(cx, scope, re)});
+            resolving.reject.call(
+                    cx, s, thisArg, new Object[] {getErrorObject(cx, f.getDeclarationScope(), re)});
         }
 
+        promise.setParentScope(f.getDeclarationScope());
+        promise.setPrototype((Scriptable) f.getPrototypeProperty());
         return promise;
     }
 
@@ -97,12 +104,13 @@ public class NativePromise extends ScriptableObject {
     }
 
     // Promise.resolve
-    private static Object resolve(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object resolve(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
-        return resolveInternal(cx, scope, thisObj, arg);
+        return resolveInternal(cx, s, thisObj, arg);
     }
 
     // PromiseResolve abstract operation
@@ -120,18 +128,20 @@ public class NativePromise extends ScriptableObject {
     }
 
     // Promise.reject
-    private static Object reject(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object reject(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
-        Capability cap = new Capability(cx, scope, thisObj);
-        cap.reject.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
+        Capability cap = new Capability(cx, f.getDeclarationScope(), thisObj);
+        cap.reject.call(
+                cx, f.getDeclarationScope(), Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
         return cap.promise;
     }
 
     private static Object doAll(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args, boolean failFast) {
+            Context cx, VarScope scope, Object thisObj, Object[] args, boolean failFast) {
         Capability cap = new Capability(cx, scope, thisObj);
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
 
@@ -150,7 +160,8 @@ public class NativePromise extends ScriptableObject {
 
         IteratorLikeIterable.Itr iterator = iterable.iterator();
         try {
-            PromiseAllResolver resolver = new PromiseAllResolver(iterator, thisObj, cap, failFast);
+            PromiseAllResolver resolver =
+                    new PromiseAllResolver(iterator, (Scriptable) thisObj, cap, failFast);
             try {
                 return resolver.resolve(cx, scope);
             } finally {
@@ -169,38 +180,41 @@ public class NativePromise extends ScriptableObject {
     }
 
     // Promise.all
-    private static Object all(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        return doAll(cx, scope, thisObj, args, true);
+    private static Object all(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return doAll(cx, f.getDeclarationScope(), thisObj, args, true);
     }
 
     // Promise.allSettled
     private static Object allSettled(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        return doAll(cx, scope, thisObj, args, false);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return doAll(cx, f.getDeclarationScope(), thisObj, args, false);
     }
 
     // Promise.race
-    private static Object race(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        Capability cap = new Capability(cx, scope, thisObj);
+    private static Object race(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
+        Capability cap = new Capability(cx, fscope, thisObj);
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
 
         IteratorLikeIterable iterable;
         try {
-            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, scope);
-            iterable = new IteratorLikeIterable(cx, scope, maybeIterable);
+            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, f.getDeclarationScope());
+            iterable = new IteratorLikeIterable(cx, fscope, maybeIterable);
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
 
         IteratorLikeIterable.Itr iterator = iterable.iterator();
         try {
             try {
-                return performRace(cx, scope, iterator, thisObj, cap);
+                return performRace(cx, fscope, iterator, thisObj, cap);
             } finally {
                 if (!iterator.isDone()) {
                     iterable.close();
@@ -209,9 +223,9 @@ public class NativePromise extends ScriptableObject {
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
     }
@@ -220,7 +234,7 @@ public class NativePromise extends ScriptableObject {
             Context cx,
             VarScope scope,
             IteratorLikeIterable.Itr iterator,
-            Scriptable thisObj,
+            Object thisObj,
             Capability cap) {
         var resolve = ScriptRuntime.getPropAndThis(thisObj, "resolve", cx, scope);
 
@@ -255,28 +269,31 @@ public class NativePromise extends ScriptableObject {
         }
     }
 
-    private static Object any(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        Capability cap = new Capability(cx, scope, thisObj);
+    private static Object any(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
+        Capability cap = new Capability(cx, fscope, thisObj);
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
 
         IteratorLikeIterable iterable;
         try {
-            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, scope);
-            iterable = new IteratorLikeIterable(cx, scope, maybeIterable);
+            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, fscope);
+            iterable = new IteratorLikeIterable(cx, fscope, maybeIterable);
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
 
         IteratorLikeIterable.Itr iterator = iterable.iterator();
         try {
-            PromiseAnyRejector rejector = new PromiseAnyRejector(iterator, thisObj, cap);
+            PromiseAnyRejector rejector =
+                    new PromiseAnyRejector(iterator, (Scriptable) thisObj, cap);
             try {
-                return rejector.reject(cx, scope);
+                return rejector.reject(cx, fscope);
             } finally {
                 if (!iterator.isDone()) {
                     iterable.close();
@@ -285,25 +302,26 @@ public class NativePromise extends ScriptableObject {
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
     }
 
     // Promise.withResolvers
     private static Object withResolvers(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
 
         // Create a capability which properly constructs a promise with resolve/reject functions
-        Capability cap = new Capability(cx, scope, thisObj);
+        Capability cap = new Capability(cx, fscope, thisObj);
 
         // Create the result object with promise, resolve, and reject properties
-        Scriptable result = cx.newObject(scope);
+        Scriptable result = cx.newObject(fscope);
         result.put("promise", result, cap.promise);
         result.put("resolve", result, cap.resolve);
         result.put("reject", result, cap.reject);
@@ -313,7 +331,8 @@ public class NativePromise extends ScriptableObject {
 
     // Promise.try
     private static Object promiseTry(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
@@ -325,7 +344,7 @@ public class NativePromise extends ScriptableObject {
         Callable func = (Callable) args[0];
 
         // Create a new promise capability using the constructor
-        Capability cap = new Capability(cx, scope, thisObj);
+        Capability cap = new Capability(cx, fscope, thisObj);
 
         // Prepare the arguments to pass to the function (all args after the function)
         Object[] funcArgs = new Object[args.length - 1];
@@ -333,17 +352,17 @@ public class NativePromise extends ScriptableObject {
 
         try {
             // Call the function synchronously
-            Object result = func.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, funcArgs);
+            Object result = func.call(cx, fscope, Undefined.SCRIPTABLE_UNDEFINED, funcArgs);
 
             // Resolve the promise with the result
-            cap.resolve.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {result});
+            cap.resolve.call(cx, fscope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {result});
         } catch (RhinoException re) {
             // If the function throws, reject the promise with the error
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
         }
 
         return cap.promise;
@@ -393,22 +412,27 @@ public class NativePromise extends ScriptableObject {
         }
     }
 
-    private static Object doThen(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object doThen(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativePromise self = LambdaConstructor.convertThisObject(thisObj, NativePromise.class);
-        return self.then(cx, scope, args);
+        return self.then(cx, f.getDeclarationScope(), args);
     }
 
     // Promise.prototype.catch
-    private static Object doCatch(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object doCatch(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
-        Scriptable coercedThis = ScriptRuntime.toObject(cx, scope, thisObj);
+        Scriptable coercedThis = ScriptRuntime.toObject(cx, fscope, thisObj);
         // No guarantee that the caller didn't change the prototype of "then"!
-        var thenFunc = ScriptRuntime.getPropAndThis(coercedThis, "then", cx, scope);
-        return thenFunc.call(cx, scope, new Object[] {Undefined.instance, arg});
+        var thenFunc = ScriptRuntime.getPropAndThis(coercedThis, "then", cx, fscope);
+        return thenFunc.call(cx, fscope, new Object[] {Undefined.instance, arg});
     }
 
     // Promise.prototype.finally
-    private static Object doFinally(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object doFinally(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
@@ -417,16 +441,16 @@ public class NativePromise extends ScriptableObject {
         Object catchFinally = onFinally;
         var ctor =
                 TopLevel.getBuiltinCtor(
-                        cx, ScriptableObject.getTopLevelScope(scope), TopLevel.Builtins.Promise);
+                        cx, ScriptableObject.getTopLevelScope(fscope), TopLevel.Builtins.Promise);
         Constructable constructor =
-                AbstractEcmaObjectOperations.speciesConstructor(cx, thisObj, ctor);
+                AbstractEcmaObjectOperations.speciesConstructor(cx, (Scriptable) thisObj, ctor);
         if (onFinally instanceof Callable) {
             Callable callableOnFinally = (Callable) thenFinally;
-            thenFinally = makeThenFinally(scope, constructor, callableOnFinally);
-            catchFinally = makeCatchFinally(scope, constructor, callableOnFinally);
+            thenFinally = makeThenFinally(fscope, constructor, callableOnFinally);
+            catchFinally = makeCatchFinally(fscope, constructor, callableOnFinally);
         }
-        var thenFunc = ScriptRuntime.getPropAndThis(thisObj, "then", cx, scope);
-        return thenFunc.call(cx, scope, new Object[] {thenFinally, catchFinally});
+        var thenFunc = ScriptRuntime.getPropAndThis(thisObj, "then", cx, fscope);
+        return thenFunc.call(cx, fscope, new Object[] {thenFinally, catchFinally});
     }
 
     // Abstract "Then Finally Function"

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,6 +38,19 @@ class NativeProxy extends ScriptableObject {
     private static final String TRAP_APPLY = "apply";
     private static final String TRAP_CONSTRUCT = "construct";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                PROXY_TAG,
+                                2,
+                                ClassDescriptor.typeError(),
+                                NativeProxy::js_constructor)
+                        .withMethod(CTOR, "revocable", 2, NativeProxy::revocable)
+                        .build();
+    }
+
     private ScriptableObject targetObj;
     private Scriptable handlerObj;
     private final String typeOf;
@@ -59,31 +74,7 @@ class NativeProxy extends ScriptableObject {
     }
 
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        PROXY_TAG,
-                        2,
-                        null, // Proxy constructor has *no* prototype
-                        null, // Proxy constructor may not be called as a function.
-                        NativeProxy::constructor) {
-
-                    @Override
-                    public Scriptable construct(Context cx, VarScope scope, Object[] args) {
-                        NativeProxy obj =
-                                (NativeProxy) getTargetConstructor().construct(cx, scope, args);
-                        // avoid getting trapped
-                        obj.setPrototypeDirect(getClassPrototype());
-                        obj.setParentScope(scope);
-                        return obj;
-                    }
-                };
-
-        constructor.defineConstructorMethod(scope, "revocable", 2, NativeProxy::revocable);
-        if (sealed) {
-            constructor.sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, null, sealed);
     }
 
     private NativeProxy(ScriptableObject target, Scriptable handler) {
@@ -1225,7 +1216,8 @@ class NativeProxy extends ScriptableObject {
         target.setPrototype(prototype);
     }
 
-    private static NativeProxy constructor(Context cx, VarScope scope, Object[] args) {
+    private static NativeProxy js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -1243,22 +1235,23 @@ class NativeProxy extends ScriptableObject {
             proxy = new NativeProxy(target, handler);
         }
 
-        proxy.setPrototypeDirect(ScriptableObject.getClassPrototype(scope, PROXY_TAG));
-        proxy.setParentScope(scope);
+        proxy.setPrototypeDirect(ScriptableObject.getClassPrototype(s, PROXY_TAG));
+        proxy.setParentScope(s);
         return proxy;
     }
 
     // Proxy.revocable
-    private static Object revocable(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object revocable(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
-        NativeProxy proxy = constructor(cx, scope, args);
+        NativeProxy proxy = js_constructor(cx, f, nt, s, thisObj, args);
 
-        NativeObject revocable = (NativeObject) cx.newObject(scope);
+        NativeObject revocable = (NativeObject) cx.newObject(s);
 
         revocable.put("proxy", revocable, proxy);
-        revocable.put("revoke", revocable, new LambdaFunction(scope, "", 0, new Revoker(proxy)));
+        revocable.put("revoke", revocable, new LambdaFunction(s, "", 0, new Revoker(proxy)));
         return revocable;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,32 +24,37 @@ final class NativeReflect extends ScriptableObject {
 
     private static final String REFLECT_TAG = "Reflect";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(REFLECT_TAG)
+                        .withMethod(CTOR, "apply", 3, NativeReflect::apply)
+                        .withMethod(CTOR, "construct", 2, NativeReflect::construct)
+                        .withMethod(CTOR, "defineProperty", 3, NativeReflect::defineProperty)
+                        .withMethod(CTOR, "deleteProperty", 2, NativeReflect::deleteProperty)
+                        .withMethod(CTOR, "get", 2, NativeReflect::get)
+                        .withMethod(
+                                CTOR,
+                                "getOwnPropertyDescriptor",
+                                2,
+                                NativeReflect::getOwnPropertyDescriptor)
+                        .withMethod(CTOR, "getPrototypeOf", 1, NativeReflect::getPrototypeOf)
+                        .withMethod(CTOR, "has", 2, NativeReflect::has)
+                        .withMethod(CTOR, "isExtensible", 1, NativeReflect::isExtensible)
+                        .withMethod(CTOR, "ownKeys", 1, NativeReflect::ownKeys)
+                        .withMethod(CTOR, "preventExtensions", 1, NativeReflect::preventExtensions)
+                        .withMethod(CTOR, "set", 3, NativeReflect::set)
+                        .withMethod(CTOR, "setPrototypeOf", 2, NativeReflect::setPrototypeOf)
+                        .withProp(
+                                CTOR,
+                                SymbolKey.TO_STRING_TAG,
+                                value(REFLECT_TAG, DONTENUM | READONLY))
+                        .build();
+    }
+
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        NativeReflect reflect = new NativeReflect();
-        reflect.setPrototype(getObjectPrototype(scope));
-        reflect.setParentScope(scope);
-
-        reflect.defineBuiltinProperty(scope, "apply", 3, NativeReflect::apply);
-        reflect.defineBuiltinProperty(scope, "construct", 2, NativeReflect::construct);
-        reflect.defineBuiltinProperty(scope, "defineProperty", 3, NativeReflect::defineProperty);
-        reflect.defineBuiltinProperty(scope, "deleteProperty", 2, NativeReflect::deleteProperty);
-        reflect.defineBuiltinProperty(scope, "get", 2, NativeReflect::get);
-        reflect.defineBuiltinProperty(
-                scope, "getOwnPropertyDescriptor", 2, NativeReflect::getOwnPropertyDescriptor);
-        reflect.defineBuiltinProperty(scope, "getPrototypeOf", 1, NativeReflect::getPrototypeOf);
-        reflect.defineBuiltinProperty(scope, "has", 2, NativeReflect::has);
-        reflect.defineBuiltinProperty(scope, "isExtensible", 1, NativeReflect::isExtensible);
-        reflect.defineBuiltinProperty(scope, "ownKeys", 1, NativeReflect::ownKeys);
-        reflect.defineBuiltinProperty(
-                scope, "preventExtensions", 1, NativeReflect::preventExtensions);
-        reflect.defineBuiltinProperty(scope, "set", 3, NativeReflect::set);
-        reflect.defineBuiltinProperty(scope, "setPrototypeOf", 2, NativeReflect::setPrototypeOf);
-
-        reflect.defineProperty(SymbolKey.TO_STRING_TAG, REFLECT_TAG, DONTENUM | READONLY);
-        if (sealed) {
-            reflect.sealObject();
-        }
-        return reflect;
+        return DESCRIPTOR.populateGlobal(cx, scope, new NativeObject(), sealed);
     }
 
     private NativeReflect() {}
@@ -56,7 +64,8 @@ final class NativeReflect extends ScriptableObject {
         return "Reflect";
     }
 
-    private static Object apply(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object apply(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -70,7 +79,7 @@ final class NativeReflect extends ScriptableObject {
         if (args[1] instanceof Scriptable) {
             thisObj = (Scriptable) args[1];
         } else if (ScriptRuntime.isPrimitive(args[1])) {
-            thisObj = cx.newObject(scope, "Object", new Object[] {args[1]});
+            thisObj = cx.newObject(s, "Object", new Object[] {args[1]});
         }
 
         if (ScriptRuntime.isSymbol(args[2])) {
@@ -79,7 +88,7 @@ final class NativeReflect extends ScriptableObject {
         ScriptableObject argumentsList = ScriptableObject.ensureScriptableObject(args[2]);
 
         return ScriptRuntime.applyOrCall(
-                true, cx, scope, callable, new Object[] {thisObj, argumentsList});
+                true, cx, s, callable, new Object[] {thisObj, argumentsList});
     }
 
     /**
@@ -87,7 +96,7 @@ final class NativeReflect extends ScriptableObject {
      * Reflect.construct (target, argumentsList[, newTarget])</a>
      */
     private static Scriptable construct(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         /*
          * 1. If IsConstructor(target) is false, throw a TypeError exception.
          * 2. If newTarget is not present, set newTarget to target.
@@ -109,7 +118,7 @@ final class NativeReflect extends ScriptableObject {
 
         Constructable ctor = (Constructable) args[0];
         if (args.length < 2) {
-            return ctor.construct(cx, scope, ScriptRuntime.emptyArgs);
+            return ctor.construct(cx, s, ScriptRuntime.emptyArgs);
         }
 
         if (args.length > 2 && !AbstractEcmaObjectOperations.isConstructor(cx, args[2])) {
@@ -140,11 +149,11 @@ final class NativeReflect extends ScriptableObject {
         // the prototype before executing call(..).
         if (ctor instanceof BaseFunction && newTargetPrototype != null) {
             BaseFunction ctorBaseFunction = (BaseFunction) ctor;
-            Scriptable result = ctorBaseFunction.createObject(cx, scope);
+            Scriptable result = ctorBaseFunction.createObject(cx, s);
             if (result != null) {
                 result.setPrototype((Scriptable) newTargetPrototype);
 
-                Object val = ctorBaseFunction.call(cx, scope, result, callArgs);
+                Object val = ctorBaseFunction.call(cx, s, result, callArgs);
                 if (val instanceof Scriptable) {
                     return (Scriptable) val;
                 }
@@ -153,7 +162,7 @@ final class NativeReflect extends ScriptableObject {
             }
         }
 
-        Scriptable newScriptable = ctor.construct(cx, scope, callArgs);
+        Scriptable newScriptable = ctor.construct(cx, s, callArgs);
         if (newTargetPrototype != null) {
             newScriptable.setPrototype((Scriptable) newTargetPrototype);
         }
@@ -162,7 +171,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object defineProperty(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -192,7 +201,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object deleteProperty(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -205,7 +214,8 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
-    private static Object get(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object get(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -225,29 +235,30 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Scriptable getOwnPropertyDescriptor(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
             if (ScriptRuntime.isSymbol(args[1])) {
                 var desc = target.getOwnPropertyDescriptor(cx, args[1]);
-                return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(scope);
+                return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(s);
             }
 
             var desc = target.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(args[1]));
-            return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(scope);
+            return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(s);
         }
         return Undefined.SCRIPTABLE_UNDEFINED;
     }
 
     private static Scriptable getPrototypeOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         return target.getPrototype();
     }
 
-    private static Object has(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object has(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -260,12 +271,14 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
-    private static Object isExtensible(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object isExtensible(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
         return target.isExtensible();
     }
 
-    private static Scriptable ownKeys(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Scriptable ownKeys(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         final List<Object> strings = new ArrayList<>();
@@ -287,17 +300,18 @@ final class NativeReflect extends ScriptableObject {
         System.arraycopy(strings.toArray(), 0, keys, 0, strings.size());
         System.arraycopy(symbols.toArray(), 0, keys, strings.size(), symbols.size());
 
-        return cx.newArray(scope, keys);
+        return cx.newArray(s, keys);
     }
 
     private static Object preventExtensions(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         return target.preventExtensions();
     }
 
-    private static Object set(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object set(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
         if (args.length < 2) {
             return true;
@@ -310,7 +324,7 @@ final class NativeReflect extends ScriptableObject {
             if (descriptor != null) {
                 Object setter = descriptor.setter;
                 if (setter != null && setter != NOT_FOUND) {
-                    ((Function) setter).call(cx, scope, receiver, new Object[] {args[2]});
+                    ((Function) setter).call(cx, s, receiver, new Object[] {args[2]});
                     return true;
                 }
 
@@ -323,11 +337,11 @@ final class NativeReflect extends ScriptableObject {
         if (ScriptRuntime.isSymbol(args[1])) {
             receiver.put((Symbol) args[1], receiver, args[2]);
         } else {
-            StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(args[1]);
-            if (s.stringId == null) {
-                receiver.put(s.index, receiver, args[2]);
+            StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(args[1]);
+            if (soi.stringId == null) {
+                receiver.put(soi.index, receiver, args[2]);
             } else {
-                receiver.put(s.stringId, receiver, args[2]);
+                receiver.put(soi.stringId, receiver, args[2]);
             }
         }
 
@@ -335,7 +349,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object setPrototypeOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -6,6 +6,12 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ScriptableObject.DONTENUM;
+import static org.mozilla.javascript.ScriptableObject.PERMANENT;
+import static org.mozilla.javascript.ScriptableObject.READONLY;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+import static org.mozilla.javascript.UniqueTag.NOT_FOUND;
+
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -69,11 +75,19 @@ public class ScriptRuntime {
 
     /** Returns representation of the [[ThrowTypeError]] object. See ECMA 5 spec, 13.2.3 */
     public static BaseFunction typeErrorThrower(Context cx) {
-        if (cx.typeErrorThrower == null) {
-            BaseFunction thrower = new ThrowTypeError(cx.topCallScope);
-            cx.typeErrorThrower = thrower;
+        return typeErrorThrower(cx.topCallScope);
+    }
+
+    private static final SymbolKey TYPE_ERROR_THROWER = new SymbolKey("TypeErrorThrower", REGULAR);
+
+    public static BaseFunction typeErrorThrower(VarScope scope) {
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
+        var thrower = top.get(TYPE_ERROR_THROWER, top);
+        if (thrower == NOT_FOUND) {
+            thrower = new ThrowTypeError(top);
+            top.defineProperty(TYPE_ERROR_THROWER, thrower, DONTENUM | READONLY | PERMANENT);
         }
-        return cx.typeErrorThrower;
+        return (BaseFunction) thrower;
     }
 
     static final class ThrowTypeError extends BaseFunction {
@@ -1629,6 +1643,17 @@ public class ScriptRuntime {
     }
 
     public static Function getExistingCtor(Context cx, VarScope scope, String constructorName) {
+        Object ctorVal = ScriptableObject.getProperty(scope, constructorName);
+        if (ctorVal instanceof Function) {
+            return (Function) ctorVal;
+        }
+        if (ctorVal == Scriptable.NOT_FOUND) {
+            throw Context.reportRuntimeErrorById("msg.ctor.not.found", constructorName);
+        }
+        throw Context.reportRuntimeErrorById("msg.not.ctor", constructorName);
+    }
+
+    public static Function getExistingCtor(Context cx, VarScope scope, SymbolKey constructorName) {
         Object ctorVal = ScriptableObject.getProperty(scope, constructorName);
         if (ctorVal instanceof Function) {
             return (Function) ctorVal;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2215,6 +2215,24 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         return null;
     }
 
+    public static Scriptable getClassPrototype(VarScope scope, Symbol className) {
+        scope = getTopLevelScope(scope);
+        Object ctor = getProperty(scope, className);
+        Object proto;
+        if (ctor instanceof BaseFunction) {
+            proto = ((BaseFunction) ctor).getPrototypeProperty();
+        } else if (ctor instanceof Scriptable) {
+            Scriptable ctorObj = (Scriptable) ctor;
+            proto = ctorObj.get("prototype", ctorObj);
+        } else {
+            return null;
+        }
+        if (proto instanceof Scriptable) {
+            return (Scriptable) proto;
+        }
+        return null;
+    }
+
     /**
      * Get the global scope.
      *
@@ -2314,6 +2332,10 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     }
 
     public static Object getProperty(VarScope obj, String name) {
+        return obj.get(name, obj);
+    }
+
+    public static Object getProperty(VarScope obj, Symbol name) {
         return obj.get(name, obj);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -200,7 +200,10 @@ public class TopLevel extends ScopeObject {
                 // Handle weird situation of "GeneratorFunction" being a real constructor
                 // which is never registered in the top-level scope
                 ctors.put(
-                        builtin, (BaseFunction) BaseFunction.initAsGeneratorFunction(this, sealed));
+                        builtin,
+                        (BaseFunction)
+                                BaseFunction.initAsGeneratorFunction(
+                                        Context.getCurrentContext(), this, sealed));
             }
         }
         errors = new EnumMap<>(NativeErrors.class);
@@ -243,7 +246,7 @@ public class TopLevel extends ScopeObject {
             }
         }
         // fall back to normal constructor lookup
-        String typeName;
+        Object typeName;
         if (type == Builtins.GeneratorFunction) {
             // GeneratorFunction isn't stored in scope with that name, but in case
             // we end up falling back to this value then we have to
@@ -252,7 +255,11 @@ public class TopLevel extends ScopeObject {
         } else {
             typeName = type.name();
         }
-        return ScriptRuntime.getExistingCtor(cx, scope, typeName);
+        if (typeName instanceof String) {
+            return ScriptRuntime.getExistingCtor(cx, scope, (String) typeName);
+        } else {
+            return ScriptRuntime.getExistingCtor(cx, scope, (SymbolKey) typeName);
+        }
     }
 
     /**
@@ -294,8 +301,7 @@ public class TopLevel extends ScopeObject {
             return result;
         }
 
-        // fall back to normal prototype lookup
-        String typeName;
+        Object typeName;
         if (type == Builtins.GeneratorFunction) {
             // GeneratorFunction isn't stored in scope with that name, but in case
             // we end up falling back to this value then we have to
@@ -304,7 +310,11 @@ public class TopLevel extends ScopeObject {
         } else {
             typeName = type.name();
         }
-        return ScriptableObject.getClassPrototype(scope, typeName);
+        if (typeName instanceof String) {
+            return ScriptableObject.getClassPrototype(scope, (String) typeName);
+        } else {
+            return ScriptableObject.getClassPrototype(scope, (SymbolKey) typeName);
+        }
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -834,7 +834,10 @@ class BodyCodegen {
                 cfw.addALoad(variableObjectLocal);
                 int enumType =
                         type == Token.ENUM_INIT_KEYS
-                                ? ScriptRuntime.ENUMERATE_KEYS
+                                ? Context.getCurrentContext().getLanguageVersion()
+                                                <= Context.VERSION_1_8
+                                        ? ScriptRuntime.ENUMERATE_KEYS
+                                        : ScriptRuntime.ENUMERATE_KEYS_NO_ITERATOR
                                 : type == Token.ENUM_INIT_VALUES
                                         ? ScriptRuntime.ENUMERATE_VALUES
                                         : type == Token.ENUM_INIT_VALUES_IN_ORDER

--- a/tests/src/test/java/org/mozilla/javascript/tests/DoctestFeature18EnabledTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DoctestFeature18EnabledTest.java
@@ -36,6 +36,7 @@ public class DoctestFeature18EnabledTest extends DoctestsTest {
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTEGER_WITHOUT_DECIMAL_PLACE);
 
         try (Context context = contextFactory.enterContext()) {
+            context.setLanguageVersion(Context.VERSION_1_8);
             context.setInterpretedMode(interpretedMode);
             Global global = new Global(context);
             int testsPassed = global.runDoctest(context, global, source, name, 1);

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -7,8 +7,7 @@ public class NativeProxyTest {
 
     @Test
     public void testToString() {
-        Utils.assertWithAllModes_ES6(
-                "function Proxy() {\n\t[native code]\n}\n", "Proxy.toString()");
+        Utils.assertWithAllModes_ES6("function Proxy() {\n\t[native code]\n}", "Proxy.toString()");
 
         Utils.assertWithAllModes_ES6(
                 "[object Object]", "Object.prototype.toString.call(new Proxy({}, {}))");
@@ -76,7 +75,7 @@ public class NativeProxyTest {
     @Test
     public void ctorAsFunction() {
         Utils.assertWithAllModes_ES6(
-                "TypeError: The constructor for Proxy may not be invoked as a function",
+                "TypeError: \"Constructor Proxy\" may only be invoked from a \"new\" expression.",
                 "try { Proxy() } catch(e) { '' + e }");
     }
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -876,10 +876,8 @@ built-ins/Function 125/509 (24.56%)
     proto-from-ctor-realm-prototype.js
     StrictFunction_restricted-properties.js strict
 
-built-ins/GeneratorFunction 5/23 (21.74%)
-    prototype/prototype.js
+built-ins/GeneratorFunction 3/23 (13.04%)
     instance-restricted-properties.js
-    name.js
     proto-from-ctor-realm.js
     proto-from-ctor-realm-prototype.js
 


### PR DESCRIPTION
This PR stacks on top of #2331 and converts almost all built ins from `LambdaConstructor` to  `ClassDescriptor`. I think the only ones left are `NativeSymbol`, `JavaAdapter`, and some test cases. I'll add those before moving this from draft.