### PR TITLE
Make `this` an `Object` not a `Scriptable`, and handle `toObject` for non-strict functions.

### DIFF
--- a/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/BuiltinBenchmark.java
+++ b/benchmarks/src/jmh/java/org/mozilla/javascript/benchmarks/BuiltinBenchmark.java
@@ -334,12 +334,11 @@ public class BuiltinBenchmark {
 
     private static class DumbLambdaClass extends ScriptableObject {
 
-        private static Object noop(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        private static Object noop(Context cx, VarScope scope, Object thisObj, Object[] args) {
             return Undefined.instance;
         }
 
-        private static Object setValue(
-                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        private static Object setValue(Context cx, VarScope scope, Object thisObj, Object[] args) {
             if (args.length < 1) {
                 throw ScriptRuntime.throwError(cx, scope, "Not enough args");
             }
@@ -349,8 +348,7 @@ public class BuiltinBenchmark {
             return Undefined.instance;
         }
 
-        private static Object getValue(
-                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        private static Object getValue(Context cx, VarScope scope, Object thisObj, Object[] args) {
             DumbLambdaClass self =
                     LambdaConstructor.convertThisObject(thisObj, DumbLambdaClass.class);
             return self.value;

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
@@ -11,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import javax.script.ScriptContext;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
@@ -48,7 +47,7 @@ public class Builtins {
                         ScriptableObject.DONTENUM | ScriptableObject.READONLY);
     }
 
-    private static Object print(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object print(Context cx, VarScope scope, Object thisObj, Object[] args) {
         try {
             Builtins self = getSelf(scope);
             for (Object arg : args) {

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Dim.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Dim.java
@@ -980,7 +980,7 @@ public class Dim {
         private VarScope scope;
 
         /** The 'this' object. */
-        private Scriptable thisObj;
+        private Object thisObj;
 
         /** Whether this frame represents a function (vs a top-level script). */
         private boolean isFunction;
@@ -1006,7 +1006,7 @@ public class Dim {
 
         /** Called when the stack frame is entered. */
         @Override
-        public void onEnter(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public void onEnter(Context cx, VarScope scope, Object thisObj, Object[] args) {
             contextData.pushFrame(this);
             this.scope = scope;
             this.thisObj = thisObj;

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/JavaPolicySecurity.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/JavaPolicySecurity.java
@@ -23,7 +23,6 @@ import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.GeneratedClassLoader;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.VarScope;
 
 public class JavaPolicySecurity extends SecurityProxy {
@@ -205,7 +204,7 @@ public class JavaPolicySecurity extends SecurityProxy {
             Context cx,
             Callable callable,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args) {
         return doAction(securityDomain, () -> callable.call(cx, scope, thisObj, args));
     }
@@ -216,7 +215,7 @@ public class JavaPolicySecurity extends SecurityProxy {
             Context cx,
             Script script,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args) {
         return doAction(securityDomain, () -> script.exec(cx, scope, thisObj));
     }

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
@@ -6,7 +6,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.LambdaFunction;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
@@ -29,19 +28,14 @@ public class Timers {
     public void install(VarScope scope) {
         LambdaFunction setTimeout =
                 new LambdaFunction(
-                        scope,
-                        "setTimeout",
-                        1,
-                        (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                                setTimeout(args));
+                        scope, "setTimeout", 1, (lcx, lscope, thisObj, args) -> setTimeout(args));
         ScriptableObject.defineProperty(scope, "setTimeout", setTimeout, ScriptableObject.DONTENUM);
         LambdaFunction clearTimeout =
                 new LambdaFunction(
                         scope,
                         "clearTimeout",
                         1,
-                        (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                                clearTimeout(args));
+                        (lcx, lscope, thisObj, args) -> clearTimeout(args));
         ScriptableObject.defineProperty(
                 scope, "clearTimeout", clearTimeout, ScriptableObject.DONTENUM);
     }

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLLibImpl.java
@@ -25,7 +25,7 @@ public final class XMLLibImpl extends XMLLib implements Serializable {
     //    EXPERIMENTAL Java interface
     //
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -6301237868232033480L;
 
     /** This experimental interface is undocumented. */
     public static org.w3c.dom.Node toDomNode(Object xmlObject) {

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -765,7 +765,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     private Object applyOrCall(
-            boolean isApply, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            boolean isApply, Context cx, VarScope scope, Object thisObj, Object[] args) {
         String methodName = isApply ? "apply" : "call";
         if (!(thisObj instanceof XMLList) || ((XMLList) thisObj).targetProperty == null)
             throw ScriptRuntime.typeErrorById("msg.isnt.function", methodName);
@@ -797,7 +797,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // This XMLList is being called as a Function.
         // Let's find the real Function object.
         if (targetProperty == null) throw ScriptRuntime.notFunctionError(this);
@@ -812,7 +812,7 @@ class XMLList extends XMLObjectImpl implements Function {
             throw ScriptRuntime.typeErrorById("msg.incompat.call", methodName);
         }
         Object func = null;
-        Scriptable sobj = thisObj;
+        Scriptable sobj = ScriptRuntime.toObject(getDeclarationScope(), thisObj);
 
         while (sobj instanceof XMLObject) {
             XMLObject xmlObject = (XMLObject) sobj;

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XmlNode.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XmlNode.java
@@ -20,7 +20,7 @@ import org.w3c.dom.ProcessingInstruction;
 import org.w3c.dom.UserDataHandler;
 
 class XmlNode implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 7498300745525888082L;
 
     private static final String XML_NAMESPACES_NAMESPACE_URI = "http://www.w3.org/2000/xmlns/";
 

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -31,59 +31,6 @@ public class ArrayLikeAbstractOperations {
         public long getLength(Context cx, Scriptable o);
     }
 
-    /**
-     * Implements the methods "every", "filter", "forEach", "map", and "some" without using an
-     * IdFunctionObject.
-     */
-    public static Object iterativeMethod(
-            Context cx,
-            IterativeOperation operation,
-            VarScope scope,
-            Object thisObj,
-            Object[] args,
-            LengthAccessor lengthAccessor) {
-        return iterativeMethod(cx, null, operation, scope, thisObj, args, lengthAccessor, true);
-    }
-
-    /**
-     * Implements the methods "every", "filter", "forEach", "map", and "some" using an
-     * IdFunctionObject.
-     */
-    public static Object iterativeMethod(
-            Context cx,
-            IdFunctionObject fun,
-            IterativeOperation operation,
-            VarScope scope,
-            Object thisObj,
-            Object[] args,
-            LengthAccessor lengthAccessor) {
-        return iterativeMethod(cx, fun, operation, scope, thisObj, args, lengthAccessor, false);
-    }
-
-    private static Object iterativeMethod(
-            Context cx,
-            IdFunctionObject fun,
-            IterativeOperation operation,
-            VarScope scope,
-            Object thisObj,
-            Object[] args,
-            LengthAccessor lengthAccessor,
-            boolean skipCoercibleCheck) {
-        Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
-
-        if (!skipCoercibleCheck) {
-            if (IterativeOperation.FIND == operation
-                    || IterativeOperation.FIND_INDEX == operation
-                    || IterativeOperation.FIND_LAST == operation
-                    || IterativeOperation.FIND_LAST_INDEX == operation) {
-                requireObjectCoercible(cx, o, fun);
-            }
-        }
-
-        long length = lengthAccessor.getLength(cx, o);
-        return coercibleIterativeMethod(cx, operation, scope, o, args, length);
-    }
-
     public static Object iterativeMethod(
             Context cx,
             Object tag,

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -446,8 +446,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static Object js_apply(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
-        var thisArg = ScriptRuntime.toObject(f.getDeclarationScope(), thisObj);
-        return ScriptRuntime.applyOrCall(true, cx, f.getDeclarationScope(), thisArg, args);
+        return ScriptRuntime.applyOrCall(true, cx, f.getDeclarationScope(), thisObj, args);
     }
 
     private static Object js_call(
@@ -523,7 +522,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     /** Should be overridden. */
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return Undefined.instance;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.util.EnumSet;
 import org.mozilla.javascript.xml.XMLObject;
 
@@ -29,94 +31,56 @@ public class BaseFunction extends ScriptableObject implements Function {
     private static final String CALL_TAG = "CALL_TAG";
     private static final String PROTOTYPE_PROPERTY_NAME = "prototype";
 
-    static LambdaConstructor init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor ctor =
-                new LambdaConstructor(
-                        scope,
-                        FUNCTION_CLASS,
-                        1,
-                        BaseFunction::js_constructorCall,
-                        BaseFunction::js_constructor);
+    private static final ClassDescriptor DESCRIPTOR;
+    private static final ClassDescriptor ES6_DESCRIPTOR;
+    //    private static final ClassDescriptor GENERATOR_DESCRIPTOR;
+    private static final JSDescriptor<JSFunction> APPLY_DESCRIPTOR;
+    private static final JSDescriptor<JSFunction> CALL_DESCRIPTOR;
 
+    static {
+        var builder =
+                new ClassDescriptor.Builder(
+                                FUNCTION_CLASS,
+                                1,
+                                BaseFunction::js_constructor,
+                                BaseFunction::js_constructor)
+                        .withMethod(PROTO, "call", 1, BaseFunction::js_call)
+                        .withMethod(PROTO, "apply", 2, BaseFunction::js_apply)
+                        .withMethod(PROTO, "bind", 1, BaseFunction::js_bind)
+                        .withMethod(PROTO, "toSource", 1, BaseFunction::js_toSource)
+                        .withMethod(PROTO, "toString", 0, BaseFunction::js_toString)
+                        .withMethod(
+                                PROTO,
+                                SymbolKey.HAS_INSTANCE,
+                                1,
+                                BaseFunction::js_hasInstance,
+                                DONTENUM | READONLY | PERMANENT,
+                                DONTENUM | READONLY);
+
+        DESCRIPTOR = builder.build();
+        ES6_DESCRIPTOR =
+                builder.withProp(
+                                PROTO,
+                                "arguments",
+                                BaseFunction::js_protoArgumentsGetter,
+                                BaseFunction::js_protoArgumentsSetter,
+                                DONTENUM | READONLY)
+                        .build();
+
+        APPLY_DESCRIPTOR = DESCRIPTOR.findProtoDesc("apply");
+        CALL_DESCRIPTOR = DESCRIPTOR.findProtoDesc("call");
+    }
+
+    static JSFunction init(Context cx, VarScope scope, boolean sealed) {
         var proto =
                 new LambdaFunction(
                         scope, "", 0, null, (lcx, lscope, lthisObj, largs) -> Undefined.instance);
 
-        proto.defineProperty("constructor", ctor, DONTENUM);
-        // Set the constructor correctly here. i.e. ctor.prototype.constructor == ctor
-        // Redo the stuff about setupDefaultPrototype.
-
-        ctor.setPrototypeProperty(proto);
-        // Do this early, so that the functions on the prototype get
-        // the right prototype...
-        ScriptableObject.defineProperty(scope, FUNCTION_CLASS, ctor, DONTENUM);
-        ctor.setPrototype((Scriptable) ctor.getPrototypeProperty());
-
-        defKnownBuiltInOnProto(ctor, APPLY_TAG, scope, "apply", 2, BaseFunction::js_apply);
-        defOnProto(ctor, scope, "bind", 1, BaseFunction::js_bind);
-        defKnownBuiltInOnProto(ctor, CALL_TAG, scope, "call", 1, BaseFunction::js_call);
-        defOnProto(ctor, scope, "toSource", 1, BaseFunction::js_toSource);
-        defOnProto(ctor, scope, "toString", 0, BaseFunction::js_toString);
-        defOnProto(
-                ctor,
-                scope,
-                SymbolKey.HAS_INSTANCE,
-                1,
-                BaseFunction::js_hasInstance,
-                DONTENUM | READONLY | PERMANENT);
-
-        // Function.prototype attributes: see ECMA 15.3.3.1
-        ctor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
-            ctor.setStandardPropertyAttributes(READONLY | DONTENUM);
+        if (cx.getLanguageVersion() < Context.VERSION_ES6) {
+            return DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
+        } else {
+            return ES6_DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
         }
-
-        if (!cx.isStrictMode() && cx.getLanguageVersion() >= Context.VERSION_ES6) {
-            ctor.definePrototypeProperty(
-                    cx,
-                    "arguments",
-                    BaseFunction::js_protoArgumentsGetter,
-                    BaseFunction::js_protoArgumentsSetter,
-                    DONTENUM | READONLY);
-        }
-
-        ScriptableObject.defineProperty(scope, FUNCTION_CLASS, ctor, DONTENUM);
-        if (sealed) {
-            ctor.sealObject();
-            ((ScriptableObject) ctor.getPrototypeProperty()).sealObject();
-        }
-        return ctor;
-    }
-
-    private static void defOnProto(
-            LambdaConstructor constructor,
-            VarScope scope,
-            String name,
-            int length,
-            SerializableCallable target) {
-        constructor.definePrototypeMethod(scope, name, length, target);
-    }
-
-    private static void defKnownBuiltInOnProto(
-            LambdaConstructor constructor,
-            Object tag,
-            VarScope scope,
-            String name,
-            int length,
-            SerializableCallable target) {
-        constructor.defineKnownBuiltInPrototypeMethod(
-                tag, scope, name, length, null, target, DONTENUM, DONTENUM | READONLY);
-    }
-
-    private static void defOnProto(
-            LambdaConstructor constructor,
-            VarScope scope,
-            SymbolKey name,
-            int length,
-            SerializableCallable target,
-            int attributes) {
-        constructor.definePrototypeMethod(
-                scope, name, length, null, target, attributes, DONTENUM | READONLY);
     }
 
     /**
@@ -395,18 +359,34 @@ public class BaseFunction extends ScriptableObject implements Function {
             Id_arguments = 5,
             MAX_INSTANCE_ID = 5;
 
-    static boolean isApply(KnownBuiltInFunction f) {
-        return f.getTag() == APPLY_TAG;
+    static boolean isApply(Callable f) {
+        if (f instanceof KnownBuiltInFunction) {
+            var kf = (KnownBuiltInFunction) f;
+            var tag = kf.getTag();
+            return tag == APPLY_TAG;
+        }
+        if (f instanceof JSFunction) {
+            return ((JSFunction) f).getDescriptor() == APPLY_DESCRIPTOR;
+        }
+        return false;
     }
 
-    static boolean isApplyOrCall(KnownBuiltInFunction f) {
-        var tag = f.getTag();
-        return tag == APPLY_TAG || tag == CALL_TAG;
+    static boolean isApplyOrCall(Callable f) {
+        if (f instanceof KnownBuiltInFunction) {
+            var kf = (KnownBuiltInFunction) f;
+            var tag = kf.getTag();
+            return tag == APPLY_TAG || tag == CALL_TAG;
+        }
+        if (f instanceof JSFunction) {
+            var desc = ((JSFunction) f).getDescriptor();
+            return desc == APPLY_DESCRIPTOR || desc == CALL_DESCRIPTOR;
+        }
+        return false;
     }
 
     private static Object js_hasInstance(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        if (!(thisObj instanceof Callable)) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        if (!(thisObj instanceof Callable && thisObj instanceof Scriptable)) {
             return false;
         }
         Object protoProp = null;
@@ -434,7 +414,8 @@ public class BaseFunction extends ScriptableObject implements Function {
                         : "unknown");
     }
 
-    private static Object js_bind(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_bind(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!(thisObj instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(thisObj);
         }
@@ -443,25 +424,30 @@ public class BaseFunction extends ScriptableObject implements Function {
         final Scriptable boundThis;
         final Object[] boundArgs;
         if (argc > 0) {
-            boundThis = ScriptRuntime.toObjectOrNull(cx, args[0], scope);
+            boundThis = ScriptRuntime.toObjectOrNull(cx, args[0], s);
             boundArgs = new Object[argc - 1];
             System.arraycopy(args, 1, boundArgs, 0, argc - 1);
         } else {
             boundThis = null;
             boundArgs = ScriptRuntime.emptyArgs;
         }
-        return new BoundFunction(cx, scope, targetFunction, boundThis, boundArgs);
+        return new BoundFunction(cx, s, targetFunction, boundThis, boundArgs);
     }
 
-    private static Object js_apply(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return ScriptRuntime.applyOrCall(true, cx, scope, (Scriptable) thisObj, args);
+    private static Object js_apply(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var thisArg = ScriptRuntime.toObject(f.getDeclarationScope(), thisObj);
+        return ScriptRuntime.applyOrCall(true, cx, f.getDeclarationScope(), thisArg, args);
     }
 
-    private static Object js_call(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return ScriptRuntime.applyOrCall(false, cx, scope, (Scriptable) thisObj, args);
+    private static Object js_call(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var thisArg = ScriptRuntime.toObject(f.getDeclarationScope(), thisObj);
+        return ScriptRuntime.applyOrCall(false, cx, f.getDeclarationScope(), thisArg, args);
     }
 
-    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toSource(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         BaseFunction realf = realFunction(thisObj, "toSource");
         int indent = 0;
         EnumSet<DecompilerFlag> flags = EnumSet.of(DecompilerFlag.TO_SOURCE);
@@ -476,7 +462,8 @@ public class BaseFunction extends ScriptableObject implements Function {
         return realf.decompile(indent, flags);
     }
 
-    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toString(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         BaseFunction realf = realFunction(thisObj, "toString");
         int indent = ScriptRuntime.toInt32(args, 0);
         return realf.decompile(indent, EnumSet.noneOf(DecompilerFlag.class));
@@ -487,13 +474,9 @@ public class BaseFunction extends ScriptableObject implements Function {
         return js_gen_constructor(cx, scope, args);
     }
 
-    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
-        return jsConstructor(cx, scope, args, false);
-    }
-
-    private static Scriptable js_constructorCall(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return js_constructor(cx, scope, args);
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return jsConstructor(cx, f.getDeclarationScope(), args, false);
     }
 
     private static Scriptable js_gen_constructor(Context cx, VarScope scope, Object[] args) {
@@ -504,11 +487,14 @@ public class BaseFunction extends ScriptableObject implements Function {
         if (thisObj == null) {
             throw ScriptRuntime.notFunctionError(null);
         }
-        Object x = ((Scriptable) thisObj).getDefaultValue(ScriptRuntime.FunctionClass);
-        if (x instanceof Delegator) {
-            x = ((Delegator) x).getDelegee();
+        if (thisObj instanceof Scriptable) {
+            Object x = ((Scriptable) thisObj).getDefaultValue(ScriptRuntime.FunctionClass);
+            if (x instanceof Delegator) {
+                x = ((Delegator) x).getDelegee();
+            }
+            return ensureType(x, BaseFunction.class, functionName);
         }
-        return ensureType(x, BaseFunction.class, functionName);
+        return ensureType(thisObj, BaseFunction.class, functionName);
     }
 
     /** Make value as DontEnum, DontDelete, ReadOnly prototype property of this Function object */

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -6,7 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
 import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
 
 import java.util.EnumSet;
 import org.mozilla.javascript.xml.XMLObject;
@@ -25,7 +27,8 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static final Object FUNCTION_TAG = "Function";
     private static final String FUNCTION_CLASS = "Function";
-    static final String GENERATOR_FUNCTION_CLASS = "__GeneratorFunction";
+    static final SymbolKey GENERATOR_FUNCTION_CLASS =
+            new SymbolKey("GeneratorFunctionPrototype", REGULAR);
 
     private static final String APPLY_TAG = "APPLY_TAG";
     private static final String CALL_TAG = "CALL_TAG";
@@ -33,6 +36,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static final ClassDescriptor DESCRIPTOR;
     private static final ClassDescriptor ES6_DESCRIPTOR;
+    private static final ClassDescriptor GENERATOR_DESCRIPTOR;
     //    private static final ClassDescriptor GENERATOR_DESCRIPTOR;
     private static final JSDescriptor<JSFunction> APPLY_DESCRIPTOR;
     private static final JSDescriptor<JSFunction> CALL_DESCRIPTOR;
@@ -69,6 +73,19 @@ public class BaseFunction extends ScriptableObject implements Function {
 
         APPLY_DESCRIPTOR = DESCRIPTOR.findProtoDesc("apply");
         CALL_DESCRIPTOR = DESCRIPTOR.findProtoDesc("call");
+
+        GENERATOR_DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                GENERATOR_FUNCTION_CLASS,
+                                "GeneratorFunction",
+                                1,
+                                BaseFunction::js_gen_constructor,
+                                BaseFunction::js_gen_constructor)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value("GeneratorFunction", READONLY | DONTENUM))
+                        .build();
     }
 
     static JSFunction init(Context cx, VarScope scope, boolean sealed) {
@@ -91,41 +108,29 @@ public class BaseFunction extends ScriptableObject implements Function {
         init(Context.getContext(), scope, sealed);
     }
 
-    static Object initAsGeneratorFunction(VarScope scope, boolean sealed) {
+    static Object initAsGeneratorFunction(Context cx, VarScope scope, boolean sealed) {
         var proto = new NativeObject();
-        VarScope top = ScriptableObject.getTopLevelScope(scope);
 
-        var function = (Scriptable) ScriptableObject.getProperty(scope, FUNCTION_CLASS);
-        var functionProto =
-                (Scriptable) ScriptableObject.getProperty(function, PROTOTYPE_PROPERTY_NAME);
-        proto.setPrototype(functionProto);
-
-        var iterator = (Scriptable) ScriptableObject.getProperty(scope, "Iterator");
-        ScriptableObject.putProperty(
+        return GENERATOR_DESCRIPTOR.buildConstructor(
+                cx,
+                scope,
                 proto,
-                PROTOTYPE_PROPERTY_NAME,
-                ScriptableObject.getTopScopeValue(top, ES6Generator.GENERATOR_TAG));
+                sealed,
+                (c, ctor) -> {
+                    VarScope top = ScriptableObject.getTopLevelScope(scope);
 
-        LambdaConstructor ctor =
-                new LambdaConstructor(
-                        scope,
-                        GENERATOR_FUNCTION_CLASS,
-                        1,
-                        proto,
-                        BaseFunction::js_gen_constructorCall,
-                        BaseFunction::js_gen_constructor);
+                    var function = (Scriptable) ScriptableObject.getProperty(scope, FUNCTION_CLASS);
+                    var functionProto =
+                            (Scriptable)
+                                    ScriptableObject.getProperty(function, PROTOTYPE_PROPERTY_NAME);
+                    proto.setPrototype(functionProto);
 
-        proto.defineProperty("constructor", ctor, READONLY | DONTENUM);
+                    var generatorProto =
+                            ScriptableObject.getTopScopeValue(top, ES6Generator.GENERATOR_TAG);
 
-        // Function.prototype attributes: see ECMA 15.3.3.1
-        ctor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        proto.defineProperty(SymbolKey.TO_STRING_TAG, "GeneratorFunction", READONLY | DONTENUM);
-        ScriptableObject.putProperty(scope, GENERATOR_FUNCTION_CLASS, ctor);
-        // Function.prototype attributes: see ECMA 15.3.3.1
-        // The "GeneratorFunction" name actually never appears in the global scope.
-        // Return it here so it can be cached as a "builtin"
-        return ctor;
+                    proto.setAttributes("constructor", DONTENUM | READONLY);
+                    proto.defineProperty("prototype", generatorProto, READONLY | DONTENUM);
+                });
     }
 
     public BaseFunction() {
@@ -283,6 +288,11 @@ public class BaseFunction extends ScriptableObject implements Function {
         }
     }
 
+    static DescriptorInfo createThrowingProp(Context cx, VarScope scope, ScriptableObject obj) {
+        var thrower = ScriptRuntime.typeErrorThrower(scope);
+        return new DescriptorInfo(false, NOT_FOUND, true, thrower, thrower, null);
+    }
+
     protected final boolean defaultHas(String name) {
         return super.has(name, this);
     }
@@ -297,7 +307,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     @Override
     public String getClassName() {
-        return isGeneratorFunction() ? GENERATOR_FUNCTION_CLASS : FUNCTION_CLASS;
+        return isGeneratorFunction() ? "GeneratorFunction" : FUNCTION_CLASS;
     }
 
     // Generated code will override this
@@ -469,18 +479,14 @@ public class BaseFunction extends ScriptableObject implements Function {
         return realf.decompile(indent, EnumSet.noneOf(DecompilerFlag.class));
     }
 
-    private static Scriptable js_gen_constructorCall(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return js_gen_constructor(cx, scope, args);
-    }
-
     private static Scriptable js_constructor(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return jsConstructor(cx, f.getDeclarationScope(), args, false);
     }
 
-    private static Scriptable js_gen_constructor(Context cx, VarScope scope, Object[] args) {
-        return jsConstructor(cx, scope, args, true);
+    private static Scriptable js_gen_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return jsConstructor(cx, f.getDeclarationScope(), args, true);
     }
 
     private static BaseFunction realFunction(Object thisObj, String functionName) {

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -58,7 +58,7 @@ public class BoundFunction extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] extraArgs) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] extraArgs) {
         return targetFunction.call(cx, scope, getCallThis(), concat(boundArgs, extraArgs));
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Callable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Callable.java
@@ -20,5 +20,5 @@ public interface Callable {
      * @param args the array of arguments
      * @return the result of the call
      */
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args);
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
@@ -782,7 +782,7 @@ public class ClassDescriptor {
 
     private static class BuiltInJSCode extends JSCode<JSFunction> implements Serializable {
 
-        private static final long serialVersionUID = 2691205302914111400L;
+        private static final long serialVersionUID = -346984669839537590L;
 
         private final JSCodeExec<JSFunction> exec;
         private final JSCodeResume<JSFunction> resume;

--- a/rhino/src/main/java/org/mozilla/javascript/ContextFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ContextFactory.java
@@ -323,7 +323,7 @@ public class ContextFactory {
      * perform the real call. In this way execution of any script happens inside this function.
      */
     protected Object doTopCall(
-            Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Callable callable, Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object result = callable.call(cx, scope, thisObj, args);
         return result instanceof ConsString ? result.toString() : result;
     }
@@ -333,7 +333,7 @@ public class ContextFactory {
      * will create the first stack frame with scriptable code, it calls this method to perform the
      * real call. In this way execution of any script happens inside this function.
      */
-    protected Object doTopCall(Script script, Context cx, VarScope scope, Scriptable thisObj) {
+    protected Object doTopCall(Script script, Context cx, VarScope scope, Object thisObj) {
         Object result = script.exec(cx, scope, thisObj);
         return result instanceof ConsString ? result.toString() : result;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/DeclarationScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/DeclarationScope.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript;
 
 public class DeclarationScope extends ScopeObject {
-    private static final long serialVersionUID = -7471457301304454454L;
+    private static final long serialVersionUID = -7992031023451233550L;
 
     public DeclarationScope(VarScope parentScope) {
         super(parentScope);

--- a/rhino/src/main/java/org/mozilla/javascript/Delegator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Delegator.java
@@ -253,7 +253,7 @@ public class Delegator implements Function, SymbolScriptable {
      * @see org.mozilla.javascript.Function#call
      */
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return ((Function) getDelegee()).call(cx, scope, thisObj, args);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -7,7 +7,7 @@
 package org.mozilla.javascript;
 
 public final class ES6Generator extends ScriptableObject {
-    private static final long serialVersionUID = 1645892441041347273L;
+    private static final long serialVersionUID = -1617667918827493330L;
 
     static final Object GENERATOR_TAG = "Generator";
 

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -6,10 +6,30 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+
 public final class ES6Generator extends ScriptableObject {
     private static final long serialVersionUID = -1617667918827493330L;
 
-    static final Object GENERATOR_TAG = "Generator";
+    static final SymbolKey GENERATOR_TAG = new SymbolKey("GeneratorPrototype", REGULAR);
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(GENERATOR_TAG)
+                        .withMethod(CTOR, "next", 1, ES6Generator::js_next)
+                        .withMethod(CTOR, "return", 1, ES6Generator::js_return)
+                        .withMethod(CTOR, "throw", 1, ES6Generator::js_throw)
+                        .withMethod(CTOR, SymbolKey.ITERATOR, 0, ES6Generator::js_iterator)
+                        .withProp(
+                                CTOR,
+                                SymbolKey.TO_STRING_TAG,
+                                value("Generator", DONTENUM | READONLY))
+                        .build();
+    }
 
     private JSFunction function;
     private Object savedState;
@@ -18,33 +38,13 @@ public final class ES6Generator extends ScriptableObject {
     private State state = State.SUSPENDED_START;
     private Object delegee;
 
-    static ES6Generator init(TopLevel scope, boolean sealed) {
+    static ScriptableObject init(Context cx, TopLevel scope, boolean sealed) {
 
-        ES6Generator prototype = new ES6Generator();
-        if (scope != null) {
-            prototype.setParentScope(scope);
-            prototype.setPrototype(getObjectPrototype(scope));
-        }
+        NativeObject prototype = new NativeObject();
+        DESCRIPTOR.populateGlobal(cx, scope, prototype, sealed);
 
-        // Define prototype methods using LambdaFunction
-        LambdaFunction next = new LambdaFunction(scope, "next", 1, ES6Generator::js_next);
-        ScriptableObject.defineProperty(prototype, "next", next, DONTENUM);
-
-        LambdaFunction returnFunc = new LambdaFunction(scope, "return", 1, ES6Generator::js_return);
-        ScriptableObject.defineProperty(prototype, "return", returnFunc, DONTENUM);
-
-        LambdaFunction throwFunc = new LambdaFunction(scope, "throw", 1, ES6Generator::js_throw);
-        ScriptableObject.defineProperty(prototype, "throw", throwFunc, DONTENUM);
-
-        LambdaFunction iterator =
-                new LambdaFunction(scope, "[Symbol.iterator]", 0, ES6Generator::js_iterator);
-        prototype.defineProperty(SymbolKey.ITERATOR, iterator, DONTENUM);
-
-        prototype.defineProperty(SymbolKey.TO_STRING_TAG, "Generator", DONTENUM | READONLY);
-
-        if (sealed) {
-            prototype.sealObject();
-        }
+        var iterCtor = (JSFunction) scope.get("Iterator", scope);
+        prototype.setPrototype((Scriptable) iterCtor.getPrototypeProperty());
 
         // Need to access Generator prototype when constructing
         // Generator instances, but don't have a generator constructor
@@ -75,8 +75,8 @@ public final class ES6Generator extends ScriptableObject {
             // If function.prototype is not an Object, use the intrinsic default prototype
             // Ref: Ecma 2026, 10.1.14 GetPrototypeFromConstructor step 4.
             // See test262: language/statements/generators/default-proto.js
-            ES6Generator prototype =
-                    (ES6Generator) ScriptableObject.getTopScopeValue(top, GENERATOR_TAG);
+            ScriptableObject prototype =
+                    (ScriptableObject) ScriptableObject.getTopScopeValue(top, GENERATOR_TAG);
             this.setPrototype(prototype);
         }
     }
@@ -90,34 +90,38 @@ public final class ES6Generator extends ScriptableObject {
         return LambdaConstructor.convertThisObject(thisObj, ES6Generator.class);
     }
 
-    private static Object js_return(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_return(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
-            return generator.resumeAbruptLocal(cx, scope, NativeGenerator.GENERATOR_CLOSE, value);
+            return generator.resumeAbruptLocal(cx, s, NativeGenerator.GENERATOR_CLOSE, value);
         }
-        return generator.resumeDelegeeReturn(cx, scope, value);
+        return generator.resumeDelegeeReturn(cx, s, value);
     }
 
-    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_next(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
-            return generator.resumeLocal(cx, scope, value);
+            return generator.resumeLocal(cx, s, value);
         }
-        return generator.resumeDelegee(cx, scope, value);
+        return generator.resumeDelegee(cx, s, value);
     }
 
-    private static Object js_throw(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_throw(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
-            return generator.resumeAbruptLocal(cx, scope, NativeGenerator.GENERATOR_THROW, value);
+            return generator.resumeAbruptLocal(cx, s, NativeGenerator.GENERATOR_THROW, value);
         }
-        return generator.resumeDelegeeThrow(cx, scope, value);
+        return generator.resumeDelegeeThrow(cx, s, value);
     }
 
-    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_iterator(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return thisObj;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 public abstract class ES6Iterator extends ScriptableObject {
 
     private static final long serialVersionUID = 2438373029140003950L;
@@ -16,35 +19,26 @@ public abstract class ES6Iterator extends ScriptableObject {
     public static final String VALUE_PROPERTY = "value";
     public static final String RETURN_METHOD = "return";
 
-    protected static void init(
-            TopLevel scope, boolean sealed, ScriptableObject prototype, String tag) {
-        if (scope != null) {
-            prototype.setParentScope(scope);
-            prototype.setPrototype(getObjectPrototype(scope));
-        }
+    public static ClassDescriptor makeDescriptor(String name, String tag) {
+        // Need a way to associate the built object with the tag. We
+        // kind of need this in general, and at the top level, but we
+        // can bodge it for now.
+        return new ClassDescriptor.Builder(name)
+                .withMethod(CTOR, "next", 0, ES6Iterator::js_next)
+                .withMethod(CTOR, SymbolKey.ITERATOR, 1, ES6Iterator::js_iterator)
+                .withProp(CTOR, SymbolKey.TO_STRING_TAG, value(tag, DONTENUM | READONLY))
+                .build();
+    }
 
-        // Define prototype methods using LambdaFunction
-        LambdaFunction next = new LambdaFunction(scope, NEXT_METHOD, 0, ES6Iterator::js_next);
-        ScriptableObject.defineProperty(prototype, NEXT_METHOD, next, DONTENUM);
-
-        LambdaFunction iterator =
-                new LambdaFunction(scope, "[Symbol.iterator]", 1, ES6Iterator::js_iterator);
-        prototype.defineProperty(SymbolKey.ITERATOR, iterator, DONTENUM);
-
-        prototype.defineProperty(
-                SymbolKey.TO_STRING_TAG, prototype.getClassName(), DONTENUM | READONLY);
-
-        if (sealed) {
-            prototype.sealObject();
-        }
-
-        // Need to access Iterator prototype when constructing
-        // Iterator instances, but don't have a iterator constructor
-        // to use to find the prototype. Use the "associateValue"
-        // approach instead.
-        if (scope != null) {
-            scope.associateValue(tag, prototype);
-        }
+    public static void initialize(
+            ClassDescriptor desc,
+            Context cx,
+            TopLevel scope,
+            ScriptableObject obj,
+            boolean sealed,
+            String name) {
+        var global = desc.populateGlobal(cx, scope, obj, sealed);
+        scope.associateValue(name, global);
     }
 
     protected boolean exhausted = false;
@@ -67,12 +61,14 @@ public abstract class ES6Iterator extends ScriptableObject {
         return LambdaConstructor.convertThisObject(thisObj, ES6Iterator.class);
     }
 
-    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_next(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ES6Iterator iterator = realThis(thisObj);
-        return iterator.next(cx, scope);
+        return iterator.next(cx, s);
     }
 
-    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_iterator(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return thisObj;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Function.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Function.java
@@ -29,7 +29,7 @@ public interface Function extends Scriptable, Callable, Constructable {
      * @return the result of the call
      */
     @Override
-    Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args);
+    Object call(Context cx, VarScope scope, Object thisObj, Object[] args);
 
     /**
      * Call the function as a constructor.

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -353,7 +353,7 @@ public class FunctionObject extends BaseFunction {
      * @see org.mozilla.javascript.Function#call( Context, VarScope, Scriptable, Object[])
      */
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisArg, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisArg, Object[] args) {
         Object result;
         boolean checkMethodResult = false;
         int argsLength = args.length;

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -16,7 +16,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 public class FunctionObject extends BaseFunction {
-    private static final long serialVersionUID = -5332312783643935019L;
+    private static final long serialVersionUID = 8880062939740158370L;
 
     /**
      * Create a JavaScript function object from a Java method.

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionScope.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript;
 
 public class FunctionScope extends DeclarationScope {
-    private static final long serialVersionUID = -7471457301304454454L;
+    private static final long serialVersionUID = 4760825497832652202L;
 
     public FunctionScope(ScopeObject parentScope) {
         super(parentScope);

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -81,17 +81,17 @@ public class IdFunctionObject extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // We need to do some sneakiness here for constructors...
         return idcall.execIdCall(this, cx, scope, getThisObj(thisObj), args);
     }
 
-    public final Scriptable getThisObj(Scriptable thisObj) {
+    public final Scriptable getThisObj(Object thisObj) {
         if (useCallAsConstructor && (thisObj == null || Undefined.isUndefined(thisObj))) {
             var res = ScriptableObject.getTopLevelScope(getDeclarationScope()).getGlobalThis();
             return res;
         } else {
-            return thisObj;
+            return ScriptRuntime.toObject(getDeclarationScope(), thisObj);
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -11,7 +11,7 @@ package org.mozilla.javascript;
 import java.util.Objects;
 
 public class IdFunctionObject extends BaseFunction {
-    private static final long serialVersionUID = -5332312783643935019L;
+    private static final long serialVersionUID = 4323463961654640261L;
 
     public IdFunctionObject(IdFunctionCall idcall, Object tag, int id, int arity) {
         if (arity < 0) throw new IllegalArgumentException();

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -4177,7 +4177,9 @@ public final class Interpreter extends Icode implements Evaluator {
             state.indexReg += frame.idata.itsMaxVars;
             int enumType =
                     op == Token.ENUM_INIT_KEYS
-                            ? ScriptRuntime.ENUMERATE_KEYS
+                            ? cx.getLanguageVersion() <= Context.VERSION_1_8
+                                    ? ScriptRuntime.ENUMERATE_KEYS
+                                    : ScriptRuntime.ENUMERATE_KEYS_NO_ITERATOR
                             : op == Token.ENUM_INIT_VALUES
                                     ? ScriptRuntime.ENUMERATE_VALUES
                                     : op == Token.ENUM_INIT_VALUES_IN_ORDER

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -3545,8 +3545,9 @@ public final class Interpreter extends Icode implements Evaluator {
             if (fun instanceof JSFunction
                     && ((JSFunction) fun).getDescriptor().getCode() instanceof InterpreterData) {
                 JSFunction ifun = (JSFunction) fun;
-                JSDescriptor desc = ifun.getDescriptor();
-                InterpreterData idata = (InterpreterData) desc.getCode();
+
+                JSDescriptor<JSFunction> desc = ifun.getDescriptor();
+                var idata = (InterpreterData<JSFunction>) desc.getCode();
                 if (frame.fnOrScript.getDescriptor().getSecurityDomain()
                         == desc.getSecurityDomain()) {
                     CallFrame callParentFrame = frame;
@@ -3616,8 +3617,9 @@ public final class Interpreter extends Icode implements Evaluator {
                 return BREAK_WITHOUT_EXTENSION;
             }
 
-            if (fun instanceof IdFunctionObject) {
-                IdFunctionObject ifun = (IdFunctionObject) fun;
+            if (fun instanceof JSFunction) {
+                var ifun = (JSFunction) fun;
+
                 if (NativeContinuation.isContinuationConstructor(ifun)) {
                     frame.stack[state.stackTop] = captureContinuation(cx, frame.parentFrame, false);
                     return null;
@@ -3662,8 +3664,9 @@ public final class Interpreter extends Icode implements Evaluator {
             if (lhs instanceof JSFunction
                     && ((JSFunction) lhs).getConstructor() instanceof InterpreterData) {
                 JSFunction f = (JSFunction) lhs;
-                JSDescriptor desc = f.getDescriptor();
-                InterpreterData idata = (InterpreterData) desc.getConstructor();
+
+                JSDescriptor<JSFunction> desc = f.getDescriptor();
+                var idata = (InterpreterData<JSFunction>) desc.getConstructor();
                 if (frame.fnOrScript.getDescriptor().getSecurityDomain()
                         == desc.getSecurityDomain()) {
                     if (cx.getLanguageVersion() >= Context.VERSION_ES6
@@ -3696,19 +3699,20 @@ public final class Interpreter extends Icode implements Evaluator {
                     return new StateContinueResult(calleeFrame, state.indexReg);
                 }
             }
+            if (lhs instanceof JSFunction) {
+                var f = (JSFunction) lhs;
+
+                if (NativeContinuation.isContinuationConstructor(f)) {
+                    frame.stack[state.stackTop] = captureContinuation(cx, frame.parentFrame, false);
+                    return null;
+                }
+            }
+
             if (!(lhs instanceof Constructable)) {
                 if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop]);
                 throw ScriptRuntime.notFunctionError(lhs);
             }
             Constructable ctor = (Constructable) lhs;
-
-            if (ctor instanceof IdFunctionObject) {
-                IdFunctionObject ifun = (IdFunctionObject) ctor;
-                if (NativeContinuation.isContinuationConstructor(ifun)) {
-                    frame.stack[state.stackTop] = captureContinuation(cx, frame.parentFrame, false);
-                    return null;
-                }
-            }
 
             Object[] outArgs =
                     getArgsArray(frame.stack, frame.sDbl, state.stackTop + 1, state.indexReg);

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -75,7 +75,7 @@ public final class Interpreter extends Icode implements Evaluator {
         final boolean useActivation;
         boolean isContinuationsTopFrame;
 
-        final Scriptable thisObj;
+        final Object thisObj;
 
         // The values that change during interpretation
 
@@ -93,7 +93,7 @@ public final class Interpreter extends Icode implements Evaluator {
 
         CallFrame(
                 Context cx,
-                Scriptable thisObj,
+                Object thisObj,
                 ScriptOrFn fnOrScript,
                 InterpreterData code,
                 CallFrame parentFrame,
@@ -1166,7 +1166,7 @@ public final class Interpreter extends Icode implements Evaluator {
             InterpreterData idata,
             Context cx,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args) {
         if (!ScriptRuntime.hasTopCall(cx)) Kit.codeBug();
 
@@ -3407,7 +3407,7 @@ public final class Interpreter extends Icode implements Evaluator {
             // Check if the lookup result is a function and throw if it's not
             // must not be done sooner according to the spec
             Callable fun = result.getCallable();
-            Scriptable funThisObj = result.getThis();
+            Object funThisObj = result.getThis();
             Scriptable funHomeObj =
                     (fun instanceof BaseFunction) ? ((BaseFunction) fun).getHomeObject() : null;
             if (op == Icode_CALL_ON_SUPER) {
@@ -5015,7 +5015,7 @@ public final class Interpreter extends Icode implements Evaluator {
     private static CallFrame initFrame(
             Context cx,
             VarScope callerScope,
-            Scriptable thisObj,
+            Object thisObj,
             Scriptable homeObj,
             Object[] args,
             double[] argsDbl,

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -3435,82 +3435,72 @@ public final class Interpreter extends Icode implements Evaluator {
             // if the function is already an interpreted function, which
             // should be the majority of cases.
             for (; ; ) {
-                if (fun instanceof KnownBuiltInFunction) {
-                    KnownBuiltInFunction kfun = (KnownBuiltInFunction) fun;
-                    // Bug 405654 -- make the best effort to keep
-                    // Function.apply and Function.call within this
-                    // interpreter loop invocation
-                    if (BaseFunction.isApplyOrCall(kfun)) {
-                        // funThisObj becomes fun
-                        fun = ScriptRuntime.getCallable(funThisObj);
-                        // first arg becomes thisObj
-                        funThisObj =
-                                getApplyThis(
-                                        cx,
-                                        stack,
-                                        sDbl,
-                                        boundArgs,
-                                        state.stackTop + 1,
-                                        state.indexReg,
-                                        (Function) fun,
-                                        frame);
-                        if (BaseFunction.isApply(kfun)) {
-                            // Apply: second argument after new "this"
-                            // should be array-like
-                            // and we'll spread its elements on the stack
-                            final Object[] callArgs;
-                            if (blen > 1) {
-                                callArgs = ScriptRuntime.getApplyArguments(cx, boundArgs[1]);
-                            } else if (state.indexReg < 2) {
-                                callArgs = ScriptRuntime.emptyArgs;
-                            } else {
-                                callArgs =
-                                        ScriptRuntime.getApplyArguments(
-                                                cx, stack[state.stackTop - blen + 2]);
-                            }
-
-                            int alen = callArgs.length;
-                            // We're coming from the outside, so this
-                            // is replacing any bound args we might
-                            // have had already.
-                            boundArgs = callArgs;
-                            blen = alen;
-                            state.indexReg = alen;
+                if (BaseFunction.isApplyOrCall(fun)) {
+                    // funThisObj becomes fun
+                    var target = ScriptRuntime.getCallable(funThisObj);
+                    // first arg becomes thisObj
+                    funThisObj =
+                            getApplyThis(
+                                    cx,
+                                    stack,
+                                    sDbl,
+                                    boundArgs,
+                                    state.stackTop + 1,
+                                    state.indexReg,
+                                    (Function) target,
+                                    frame);
+                    if (BaseFunction.isApply(fun)) {
+                        // Apply: second argument after new "this"
+                        // should be array-like
+                        // and we'll spread its elements on the stack
+                        final Object[] callArgs;
+                        if (blen > 1) {
+                            callArgs = ScriptRuntime.getApplyArguments(cx, boundArgs[1]);
+                        } else if (state.indexReg < 2) {
+                            callArgs = ScriptRuntime.emptyArgs;
                         } else {
-                            // Call: shift args left, starting from 2nd
-                            if (state.indexReg > 0) {
-                                if (state.indexReg > 1 && blen == 0) {
-                                    System.arraycopy(
-                                            stack,
-                                            state.stackTop + 2,
-                                            stack,
-                                            state.stackTop + 1,
-                                            state.indexReg - 1);
-                                    System.arraycopy(
-                                            sDbl,
-                                            state.stackTop + 2,
-                                            sDbl,
-                                            state.stackTop + 1,
-                                            state.indexReg - 1);
-                                } else if (state.indexReg > 1) {
-                                    Object[] newBArgs = new Object[boundArgs.length - 1];
-                                    System.arraycopy(
-                                            boundArgs, 1, newBArgs, 0, boundArgs.length - 1);
-                                    boundArgs = newBArgs;
-                                    blen = newBArgs.length;
-                                } else {
-                                    // Bound args is 1 long.
-                                    boundArgs = new Object[0];
-                                    blen = 0;
-                                }
-                                state.indexReg--;
-                            }
+                            callArgs =
+                                    ScriptRuntime.getApplyArguments(
+                                            cx, stack[state.stackTop - blen + 2]);
                         }
+
+                        int alen = callArgs.length;
+                        // We're coming from the outside, so this
+                        // is replacing any bound args we might
+                        // have had already.
+                        boundArgs = callArgs;
+                        blen = alen;
+                        state.indexReg = alen;
                     } else {
-                        // Some other IdFunctionObject we don't know how to
-                        // reduce.
-                        break;
+                        // Call: shift args left, starting from 2nd
+                        if (state.indexReg > 0) {
+                            if (state.indexReg > 1 && blen == 0) {
+                                System.arraycopy(
+                                        stack,
+                                        state.stackTop + 2,
+                                        stack,
+                                        state.stackTop + 1,
+                                        state.indexReg - 1);
+                                System.arraycopy(
+                                        sDbl,
+                                        state.stackTop + 2,
+                                        sDbl,
+                                        state.stackTop + 1,
+                                        state.indexReg - 1);
+                            } else if (state.indexReg > 1) {
+                                Object[] newBArgs = new Object[boundArgs.length - 1];
+                                System.arraycopy(boundArgs, 1, newBArgs, 0, boundArgs.length - 1);
+                                boundArgs = newBArgs;
+                                blen = newBArgs.length;
+                            } else {
+                                // Bound args is 1 long.
+                                boundArgs = new Object[0];
+                                blen = 0;
+                            }
+                            state.indexReg--;
+                        }
                     }
+                    fun = target;
                 } else if (fun instanceof LambdaConstructor) {
                     break;
                 } else if (fun instanceof LambdaFunction) {

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -101,7 +101,7 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
             VarScope scope,
             Object thisObj,
             Object[] args) {
-        return Interpreter.interpret(executableObject, this, cx, scope, (Scriptable) thisObj, args);
+        return Interpreter.interpret(executableObject, this, cx, scope, thisObj, args);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/JSCode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSCode.java
@@ -35,7 +35,7 @@ public abstract class JSCode<T extends ScriptOrFn<T>> implements JSCodeExec<T>, 
 
     private static class NotCallable extends JSCode<JSFunction> implements Serializable {
 
-        private static final long serialVersionUID = 2691205302914111400L;
+        private static final long serialVersionUID = -31340315773728063L;
 
         @Override
         public Object execute(

--- a/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
@@ -10,14 +10,14 @@ import org.mozilla.javascript.debug.DebuggableScript;
  */
 public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
     private final JSDescriptor<JSFunction> descriptor;
-    private final Scriptable lexicalThis;
+    private final Object lexicalThis;
     private final Scriptable homeObject;
 
     public JSFunction(
             Context cx,
             VarScope scope,
             JSDescriptor<JSFunction> descriptor,
-            Scriptable lexicalThis,
+            Object lexicalThis,
             Scriptable homeObject) {
         this.descriptor = descriptor;
         this.lexicalThis = lexicalThis;
@@ -136,7 +136,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (!ScriptRuntime.hasTopCall(cx)) {
             return ScriptRuntime.doTopCall(this, cx, scope, thisObj, args, isStrict());
         }
@@ -144,12 +144,15 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
         return descriptor.getCode().execute(cx, this, Undefined.instance, scope, realThis, args);
     }
 
-    public final Scriptable getThisObj(Scriptable thisObj) {
+    public final Object getThisObj(Object thisObj) {
         if (descriptor.hasLexicalThis()) {
             return lexicalThis;
-        } else if (!descriptor.isStrict() && (thisObj == null || Undefined.isUndefined(thisObj))) {
-            var res = ScriptableObject.getTopLevelScope(getDeclarationScope()).getGlobalThis();
-            return res;
+        } else if (!descriptor.isStrict()) {
+            if (thisObj == null || Undefined.isUndefined(thisObj)) {
+                return ScriptableObject.getTopLevelScope(getDeclarationScope()).getGlobalThis();
+            } else {
+                return ScriptRuntime.toObject(getDeclarationScope(), thisObj);
+            }
         } else {
             return thisObj;
         }
@@ -213,7 +216,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
         throw new UnsupportedOperationException("Cannot set home object on JS function.");
     }
 
-    public Scriptable getFunctionThis(Scriptable functionThis) {
+    public Object getFunctionThis(Scriptable functionThis) {
         if (descriptor.hasLexicalThis()) {
             return this.lexicalThis;
         } else {

--- a/rhino/src/main/java/org/mozilla/javascript/JSScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSScript.java
@@ -29,7 +29,7 @@ public class JSScript implements Script, ScriptOrFn<JSScript> {
     }
 
     @Override
-    public Object exec(Context cx, VarScope scope, Scriptable thisObj) {
+    public Object exec(Context cx, VarScope scope, Object thisObj) {
         Object ret;
         if (!ScriptRuntime.hasTopCall(cx)) {
             // It will go through "call" path. but they are equivalent

--- a/rhino/src/main/java/org/mozilla/javascript/KnownBuiltInFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/KnownBuiltInFunction.java
@@ -12,7 +12,7 @@ package org.mozilla.javascript;
  */
 public class KnownBuiltInFunction extends LambdaFunction {
 
-    private static final long serialVersionUID = -8388132362854748293L;
+    private static final long serialVersionUID = 4527445659952834584L;
 
     private final Object tag;
 

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -124,7 +124,7 @@ public class LambdaConstructor extends LambdaFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if ((flags & CONSTRUCTOR_FUNCTION) == 0) {
             throw ScriptRuntime.typeErrorById("msg.constructor.no.function", getFunctionName());
         }

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
@@ -94,7 +94,7 @@ public class LambdaFunction extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return target.call(cx, getDeclarationScope(), thisObj, args);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
@@ -13,7 +13,7 @@ package org.mozilla.javascript;
  */
 public class LambdaFunction extends BaseFunction {
 
-    private static final long serialVersionUID = -8388132362854748293L;
+    private static final long serialVersionUID = 6594410813947157220L;
 
     // The target is expected to be a lambda. Lambdas may be serialized, which
     // requires this special interface.

--- a/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
@@ -17,7 +17,7 @@ import java.security.PrivilegedAction;
  * <p>This improves startup time and average memory usage.
  */
 public final class LazilyLoadedCtor<T extends PropHolder<T>> implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -1531091529063000542L;
     private static final int STATE_BEFORE_INIT = 0;
     private static final int STATE_INITIALIZING = 1;
     private static final int STATE_WITH_VALUE = 2;

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -171,7 +171,7 @@ final class MemberBox implements Serializable {
                         public Object call(
                                 Context cx,
                                 VarScope callScope,
-                                Scriptable thisObj,
+                                Object thisObj,
                                 Object[] originalArgs) {
                             MemberBox nativeGetter = MemberBox.this;
                             if (nativeGetter.delegateTo == null) {
@@ -204,7 +204,7 @@ final class MemberBox implements Serializable {
                         public Object call(
                                 Context cx,
                                 VarScope callScope,
-                                Scriptable thisObj,
+                                Object thisObj,
                                 Object[] originalArgs) {
                             MemberBox nativeSetter = MemberBox.this;
                             Object value =

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -645,7 +645,7 @@ public class NativeArray extends ScriptableObject implements List {
         final Scriptable items =
                 ScriptRuntime.toObject(s, (args.length >= 1) ? args[0] : Undefined.instance);
         Object mapArg = (args.length >= 2) ? args[1] : Undefined.instance;
-        Scriptable thisArg = null;
+        Object thisArg = null;
         final boolean mapping = !Undefined.isUndefined(mapArg);
         Function mapFn = null;
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
@@ -15,7 +15,7 @@ public final class NativeArrayIterator extends ES6Iterator {
         VALUES
     }
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 3370645355934941865L;
     private static final String ITERATOR_TAG = "ArrayIterator";
 
     private ARRAY_ITERATOR_TYPE type;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
@@ -18,10 +18,14 @@ public final class NativeArrayIterator extends ES6Iterator {
     private static final long serialVersionUID = 3370645355934941865L;
     private static final String ITERATOR_TAG = "ArrayIterator";
 
+    private static final ClassDescriptor DESCRIPTOR =
+            ES6Iterator.makeDescriptor(ITERATOR_TAG, "Array Iterator");
+
     private ARRAY_ITERATOR_TYPE type;
 
-    static void init(TopLevel scope, boolean sealed) {
-        ES6Iterator.init(scope, sealed, new NativeArrayIterator(), ITERATOR_TAG);
+    static void init(Context cx, VarScope scope, boolean sealed) {
+        ES6Iterator.initialize(
+                DESCRIPTOR, cx, (TopLevel) scope, new NativeArrayIterator(), sealed, ITERATOR_TAG);
     }
 
     /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -6,6 +6,10 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.math.BigInteger;
 
 /** This class implements the BigInt native object. */
@@ -14,46 +18,33 @@ final class NativeBigInt extends ScriptableObject {
 
     private static final String CLASS_NAME = "BigInt";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                1,
+                                NativeBigInt::js_constructorFunc,
+                                NativeBigInt::js_constructor)
+                        .withMethod(CTOR, "asIntN", 2, NativeBigInt::js_asIntN)
+                        .withMethod(CTOR, "asUintN", 2, NativeBigInt::js_asUintN)
+                        .withMethod(PROTO, "toString", 0, NativeBigInt::js_toString)
+                        // Alias toLocaleString to toString
+                        .withMethod(PROTO, "toLocaleString", 0, NativeBigInt::js_toString)
+                        .withMethod(PROTO, "toSource", 0, NativeBigInt::js_toSource)
+                        .withMethod(PROTO, "valueOf", 0, NativeBigInt::js_valueOf)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
+                        .build();
+    }
+
     private final BigInteger bigIntValue;
 
     static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        1,
-                        NativeBigInt::js_constructorFunc,
-                        NativeBigInt::js_constructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        constructor.defineConstructorMethod(
-                scope,
-                "asIntN",
-                2,
-                (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                        js_asIntOrUintN(true, args));
-        constructor.defineConstructorMethod(
-                scope,
-                "asUintN",
-                2,
-                (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                        js_asIntOrUintN(false, args));
-        constructor.definePrototypeMethod(scope, "toString", 0, NativeBigInt::js_toString);
-        // Alias toLocaleString to toString
-        constructor.definePrototypeMethod(scope, "toLocaleString", 0, NativeBigInt::js_toString);
-        constructor.definePrototypeMethod(scope, "toSource", 0, NativeBigInt::js_toSource);
-        constructor.definePrototypeMethod(
-                scope,
-                "valueOf",
-                0,
-                (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                        toSelf(thisObj).bigIntValue);
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
     NativeBigInt(BigInteger bigInt) {
@@ -70,15 +61,17 @@ final class NativeBigInt extends ScriptableObject {
     }
 
     private static Object js_constructorFunc(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return (args.length >= 1) ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
     }
 
-    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         throw ScriptRuntime.typeErrorById("msg.no.new", CLASS_NAME);
     }
 
-    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toString(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         int base =
                 (args.length == 0 || args[0] == Undefined.instance)
                         ? 10
@@ -87,8 +80,24 @@ final class NativeBigInt extends ScriptableObject {
         return ScriptRuntime.bigIntToString(value, base);
     }
 
-    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toSource(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return "(new BigInt(" + ScriptRuntime.toString(toSelf(thisObj).bigIntValue) + "))";
+    }
+
+    private static Object js_asIntN(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_asIntOrUintN(true, args);
+    }
+
+    private static Object js_asUintN(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_asIntOrUintN(false, args);
+    }
+
+    private static Object js_valueOf(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return toSelf(thisObj).bigIntValue;
     }
 
     private static Object js_asIntOrUintN(boolean isSigned, Object[] args) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCallSite.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCallSite.java
@@ -6,26 +6,45 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 /**
  * This class is used by the V8 extension "Error.prepareStackTrace." It is passed to that function,
  * which may then use it to format the stack as it sees fit.
  */
-public class NativeCallSite extends IdScriptableObject {
+public class NativeCallSite extends ScriptableObject {
     private static final long serialVersionUID = 2688372752566593594L;
-    private static final String CALLSITE_TAG = "CallSite";
+
     private ScriptStackElement element;
 
-    static void init(VarScope scope, boolean sealed) {
-        NativeCallSite cs = new NativeCallSite();
-        cs.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                "CallSite",
+                                0,
+                                NativeCallSite::js_constructor,
+                                NativeCallSite::js_constructor)
+                        .withMethod(PROTO, "getThis", 0, NativeCallSite::js_getThis)
+                        .withMethod(PROTO, "getTypeName", 0, NativeCallSite::js_getTypeName)
+                        .withMethod(PROTO, "getFunction", 0, NativeCallSite::js_getFunction)
+                        .withMethod(PROTO, "getFunctionName", 0, NativeCallSite::js_getFunctionName)
+                        .withMethod(PROTO, "getMethodName", 0, NativeCallSite::js_getMethodName)
+                        .withMethod(PROTO, "getFileName", 0, NativeCallSite::js_getFileName)
+                        .withMethod(PROTO, "getLineNumber", 0, NativeCallSite::js_getLineNumber)
+                        .withMethod(PROTO, "getColumnNumber", 0, NativeCallSite::js_getColumnNumber)
+                        .withMethod(PROTO, "getEvalOrigin", 0, NativeCallSite::js_getEvalOrigin)
+                        .withMethod(PROTO, "isToplevel", 0, NativeCallSite::js_isToplevel)
+                        .withMethod(PROTO, "isEval", 0, NativeCallSite::js_isEval)
+                        .withMethod(PROTO, "isNative", 0, NativeCallSite::js_isNative)
+                        .withMethod(PROTO, "isConstructor", 0, NativeCallSite::js_isConstructor)
+                        .withMethod(PROTO, "toString", 0, NativeCallSite::js_toString)
+                        .build();
     }
 
-    static NativeCallSite make(VarScope scope, Scriptable ctorObj) {
-        NativeCallSite cs = new NativeCallSite();
-        Scriptable proto = (Scriptable) ctorObj.get("prototype", ctorObj);
-        cs.setParentScope(scope);
-        cs.setPrototype(proto);
-        return cs;
+    static void init(Context cx, VarScope scope, boolean sealed) {
+        DESCRIPTOR.buildConstructor(cx, scope, new NativeCallSite(), sealed);
     }
 
     private NativeCallSite() {}
@@ -40,118 +59,89 @@ public class NativeCallSite extends IdScriptableObject {
     }
 
     @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        switch (id) {
-            case Id_constructor:
-                arity = 0;
-                s = "constructor";
-                break;
-            case Id_getThis:
-                arity = 0;
-                s = "getThis";
-                break;
-            case Id_getTypeName:
-                arity = 0;
-                s = "getTypeName";
-                break;
-            case Id_getFunction:
-                arity = 0;
-                s = "getFunction";
-                break;
-            case Id_getFunctionName:
-                arity = 0;
-                s = "getFunctionName";
-                break;
-            case Id_getMethodName:
-                arity = 0;
-                s = "getMethodName";
-                break;
-            case Id_getFileName:
-                arity = 0;
-                s = "getFileName";
-                break;
-            case Id_getLineNumber:
-                arity = 0;
-                s = "getLineNumber";
-                break;
-            case Id_getColumnNumber:
-                arity = 0;
-                s = "getColumnNumber";
-                break;
-            case Id_getEvalOrigin:
-                arity = 0;
-                s = "getEvalOrigin";
-                break;
-            case Id_isToplevel:
-                arity = 0;
-                s = "isToplevel";
-                break;
-            case Id_isEval:
-                arity = 0;
-                s = "isEval";
-                break;
-            case Id_isNative:
-                arity = 0;
-                s = "isNative";
-                break;
-            case Id_isConstructor:
-                arity = 0;
-                s = "isConstructor";
-                break;
-            case Id_toString:
-                arity = 0;
-                s = "toString";
-                break;
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
-        initPrototypeMethod(CALLSITE_TAG, id, s, arity);
-    }
-
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(CALLSITE_TAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
-        }
-        int id = f.methodId();
-        switch (id) {
-            case Id_constructor:
-                return make(scope, f);
-            case Id_getFunctionName:
-                return getFunctionName(thisObj);
-            case Id_getFileName:
-                return getFileName(thisObj);
-            case Id_getLineNumber:
-                return getLineNumber(thisObj);
-            case Id_getThis:
-            case Id_getTypeName:
-            case Id_getFunction:
-            case Id_getColumnNumber:
-                return Undefined.instance;
-            case Id_getMethodName:
-                return null;
-            case Id_getEvalOrigin:
-            case Id_isEval:
-            case Id_isConstructor:
-            case Id_isNative:
-            case Id_isToplevel:
-                return Boolean.FALSE;
-            case Id_toString:
-                return js_toString(thisObj);
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
-    }
-
-    @Override
     public String toString() {
         if (element == null) {
             return "";
         }
         return element.toString();
+    }
+
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var res = new NativeCallSite();
+        res.setPrototype((Scriptable) f.getPrototypeProperty());
+        res.setParentScope(s);
+        return res;
+    }
+
+    private static Object js_getThis(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Undefined.instance;
+    }
+
+    private static Object js_getTypeName(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Undefined.instance;
+    }
+
+    private static Object js_getFunction(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Undefined.instance;
+    }
+
+    private static Object js_getFunctionName(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return getFunctionName((Scriptable) thisObj);
+    }
+
+    private static Object js_getMethodName(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return null;
+    }
+
+    private static Object js_getFileName(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return getFileName((Scriptable) thisObj);
+    }
+
+    private static Object js_getLineNumber(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return getLineNumber((Scriptable) thisObj);
+    }
+
+    private static Object js_getColumnNumber(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Undefined.instance;
+    }
+
+    private static Object js_getEvalOrigin(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Boolean.FALSE;
+    }
+
+    private static Object js_isToplevel(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Boolean.FALSE;
+    }
+
+    private static Object js_isEval(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Boolean.FALSE;
+    }
+
+    private static Object js_isNative(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Boolean.FALSE;
+    }
+
+    private static Object js_isConstructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return Boolean.FALSE;
+    }
+
+    private static Object js_toString(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_toString((Scriptable) thisObj);
     }
 
     private static Object js_toString(Scriptable obj) {
@@ -202,77 +192,4 @@ public class NativeCallSite extends IdScriptableObject {
         }
         return Integer.valueOf(cs.element.lineNumber);
     }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        int id;
-        switch (s) {
-            case "constructor":
-                id = Id_constructor;
-                break;
-            case "getThis":
-                id = Id_getThis;
-                break;
-            case "getTypeName":
-                id = Id_getTypeName;
-                break;
-            case "getFunction":
-                id = Id_getFunction;
-                break;
-            case "getFunctionName":
-                id = Id_getFunctionName;
-                break;
-            case "getMethodName":
-                id = Id_getMethodName;
-                break;
-            case "getFileName":
-                id = Id_getFileName;
-                break;
-            case "getLineNumber":
-                id = Id_getLineNumber;
-                break;
-            case "getColumnNumber":
-                id = Id_getColumnNumber;
-                break;
-            case "getEvalOrigin":
-                id = Id_getEvalOrigin;
-                break;
-            case "isToplevel":
-                id = Id_isToplevel;
-                break;
-            case "isEval":
-                id = Id_isEval;
-                break;
-            case "isNative":
-                id = Id_isNative;
-                break;
-            case "isConstructor":
-                id = Id_isConstructor;
-                break;
-            case "toString":
-                id = Id_toString;
-                break;
-            default:
-                id = 0;
-                break;
-        }
-        return id;
-    }
-
-    private static final int Id_constructor = 1,
-            Id_getThis = 2,
-            Id_getTypeName = 3,
-            Id_getFunction = 4,
-            Id_getFunctionName = 5,
-            Id_getMethodName = 6,
-            Id_getFileName = 7,
-            Id_getLineNumber = 8,
-            Id_getColumnNumber = 9,
-            Id_getEvalOrigin = 10,
-            Id_isToplevel = 11,
-            Id_isEval = 12,
-            Id_isNative = 13,
-            Id_isConstructor = 14,
-            Id_toString = 15,
-            MAX_PROTOTYPE_ID = 15;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
@@ -18,10 +18,6 @@ public class NativeCollectionIterator extends ES6Iterator {
         BOTH
     }
 
-    static void init(TopLevel scope, String tag, boolean sealed) {
-        ES6Iterator.init(scope, sealed, new NativeCollectionIterator(tag), tag);
-    }
-
     public NativeCollectionIterator(String tag) {
         this.className = tag;
         this.iterator = Collections.emptyIterator();

--- a/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
@@ -255,7 +255,7 @@ public class NativeConsole extends ScriptableObject {
                         public Object call(
                                 Context callCx,
                                 VarScope callScope,
-                                Scriptable callThisObj,
+                                Object callThisObj,
                                 Object[] callArgs) {
                             Object value = callArgs[1];
                             while (value instanceof Delegator) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeContinuation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeContinuation.java
@@ -57,7 +57,7 @@ public final class NativeContinuation extends ScriptableObject implements Functi
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return Interpreter.restartContinuation(this, cx, scope, args);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeContinuation.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeContinuation.java
@@ -8,16 +8,34 @@ package org.mozilla.javascript;
 
 import java.util.Objects;
 
-public final class NativeContinuation extends IdScriptableObject implements Function {
+public final class NativeContinuation extends ScriptableObject implements Function {
     private static final long serialVersionUID = 1794167133757605367L;
 
-    private static final Object FTAG = "Continuation";
+    private static final String CLASS_NAME = "Continuation";
+
+    private static final ClassDescriptor DESCRIPTOR;
+    private static final JSDescriptor<JSFunction> CTOR_DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                0,
+                                NativeContinuation::js_constructor,
+                                NativeContinuation::js_constructor)
+                        .build();
+        CTOR_DESCRIPTOR = DESCRIPTOR.ctorDesc();
+    }
 
     private Object implementation;
 
     public static void init(Context cx, VarScope scope, boolean sealed) {
-        NativeContinuation obj = new NativeContinuation();
-        obj.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
+        DESCRIPTOR.buildConstructor(cx, scope, new NativeContinuation(), sealed);
+    }
+
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        throw Context.reportRuntimeError("Direct call is not supported");
     }
 
     public Object getImplementation() {
@@ -43,11 +61,8 @@ public final class NativeContinuation extends IdScriptableObject implements Func
         return Interpreter.restartContinuation(this, cx, scope, args);
     }
 
-    public static boolean isContinuationConstructor(IdFunctionObject f) {
-        if (f.hasTag(FTAG) && f.methodId() == Id_constructor) {
-            return true;
-        }
-        return false;
+    public static boolean isContinuationConstructor(JSFunction f) {
+        return f.getDescriptor() == CTOR_DESCRIPTOR;
     }
 
     /**
@@ -61,49 +76,4 @@ public final class NativeContinuation extends IdScriptableObject implements Func
     public static boolean equalImplementations(NativeContinuation c1, NativeContinuation c2) {
         return Objects.equals(c1.implementation, c2.implementation);
     }
-
-    @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        switch (id) {
-            case Id_constructor:
-                arity = 0;
-                s = "constructor";
-                break;
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
-        initPrototypeMethod(FTAG, id, s, arity);
-    }
-
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(FTAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
-        }
-        int id = f.methodId();
-        switch (id) {
-            case Id_constructor:
-                throw Context.reportRuntimeError("Direct call is not supported");
-        }
-        throw new IllegalArgumentException(String.valueOf(id));
-    }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        int id;
-        switch (s) {
-            case "constructor":
-                id = Id_constructor;
-                break;
-            default:
-                id = 0;
-                break;
-        }
-        return id;
-    }
-
-    private static final int Id_constructor = 1, MAX_PROTOTYPE_ID = 1;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -82,7 +82,7 @@ final class NativeError extends ScriptableObject {
 
     static void init(Context cx, VarScope scope, boolean sealed) {
         var ctor = DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
-        NativeCallSite.init(scope, sealed);
+        NativeCallSite.init(cx, scope, sealed);
 
         ProtoProps protoProps = new ProtoProps();
         ((ScriptableObject) ctor.getPrototypeProperty()).associateValue(ProtoProps.KEY, protoProps);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
@@ -6,40 +6,36 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+
 /**
  * This class implements generator objects. See <a
  * href="http://developer.mozilla.org/en/docs/New_in_JavaScript_1.7#Generators">Generators</a>
  *
  * @author Norris Boyd
  */
-public final class NativeGenerator extends IdScriptableObject {
+public final class NativeGenerator extends ScriptableObject {
     private static final long serialVersionUID = -1383456283657974338L;
 
-    private static final Object GENERATOR_TAG = "Generator";
+    private static final SymbolKey GENERATOR_TAG = new SymbolKey("GeneratorPrototype", REGULAR);
+    private static final ClassDescriptor DESCRIPTOR;
 
-    static NativeGenerator init(TopLevel scope, boolean sealed) {
-        // Generator
-        // Can't use "NativeGenerator().exportAsJSClass" since we don't want
-        // to define "Generator" as a constructor in the top-level scope.
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(GENERATOR_TAG)
+                        .withMethod(CTOR, "close", 1, NativeGenerator::js_close)
+                        .withMethod(CTOR, "next", 1, NativeGenerator::js_next)
+                        .withMethod(CTOR, "send", 0, NativeGenerator::js_send)
+                        .withMethod(CTOR, "throw", 0, NativeGenerator::js_throw)
+                        .withMethod(CTOR, "__iterator__", 1, NativeGenerator::js_iterator)
+                        .build();
+    }
 
-        NativeGenerator prototype = new NativeGenerator();
-        if (scope != null) {
-            prototype.setParentScope(scope);
-            prototype.setPrototype(getObjectPrototype(scope));
-        }
-        prototype.activatePrototypeMap(MAX_PROTOTYPE_ID);
-        if (sealed) {
-            prototype.sealObject();
-        }
-
-        // Need to access Generator prototype when constructing
-        // Generator instances, but don't have a generator constructor
-        // to use to find the prototype. Use the "associateValue"
-        // approach instead.
-        if (scope != null) {
-            scope.associateValue(GENERATOR_TAG, prototype);
-        }
-
+    static NativeGenerator init(Context cx, TopLevel scope, boolean sealed) {
+        var prototype = new NativeGenerator();
+        DESCRIPTOR.populateGlobal(cx, scope, prototype, sealed);
+        scope.associateValue(GENERATOR_TAG, prototype);
         return prototype;
     }
 
@@ -66,76 +62,47 @@ public final class NativeGenerator extends IdScriptableObject {
         return "Generator";
     }
 
-    @Override
-    protected void initPrototypeId(int id) {
-        String s;
-        int arity;
-        switch (id) {
-            case Id_close:
-                arity = 1;
-                s = "close";
-                break;
-            case Id_next:
-                arity = 1;
-                s = "next";
-                break;
-            case Id_send:
-                arity = 0;
-                s = "send";
-                break;
-            case Id_throw:
-                arity = 0;
-                s = "throw";
-                break;
-            case Id___iterator__:
-                arity = 1;
-                s = "__iterator__";
-                break;
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
-        initPrototypeMethod(GENERATOR_TAG, id, s, arity);
+    private static Object js_close(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        // need to run any pending finally clauses
+        var generator = realThis(thisObj);
+        return generator.resume(cx, s, GENERATOR_CLOSE, new GeneratorClosedException());
     }
 
-    @Override
-    public Object execIdCall(
-            IdFunctionObject f, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        if (!f.hasTag(GENERATOR_TAG)) {
-            return super.execIdCall(f, cx, scope, thisObj, args);
+    private static Object js_next(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        // arguments to next() are ignored
+        var generator = realThis(thisObj);
+        generator.firstTime = false;
+        return generator.resume(cx, s, GENERATOR_SEND, Undefined.instance);
+    }
+
+    private static Object js_send(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        {
+            var generator = realThis(thisObj);
+            Object arg = args.length > 0 ? args[0] : Undefined.instance;
+            if (generator.firstTime && !arg.equals(Undefined.instance)) {
+                throw ScriptRuntime.typeErrorById("msg.send.newborn");
+            }
+            return generator.resume(cx, s, GENERATOR_SEND, arg);
         }
-        int id = f.methodId();
+    }
 
-        NativeGenerator generator = ensureType(thisObj, NativeGenerator.class, f);
+    private static Object js_throw(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var generator = realThis(thisObj);
+        return generator.resume(
+                cx, s, GENERATOR_THROW, args.length > 0 ? args[0] : Undefined.instance);
+    }
 
-        switch (id) {
-            case Id_close:
-                // need to run any pending finally clauses
-                return generator.resume(cx, scope, GENERATOR_CLOSE, new GeneratorClosedException());
+    private static Object js_iterator(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return thisObj;
+    }
 
-            case Id_next:
-                // arguments to next() are ignored
-                generator.firstTime = false;
-                return generator.resume(cx, scope, GENERATOR_SEND, Undefined.instance);
-
-            case Id_send:
-                {
-                    Object arg = args.length > 0 ? args[0] : Undefined.instance;
-                    if (generator.firstTime && !arg.equals(Undefined.instance)) {
-                        throw ScriptRuntime.typeErrorById("msg.send.newborn");
-                    }
-                    return generator.resume(cx, scope, GENERATOR_SEND, arg);
-                }
-
-            case Id_throw:
-                return generator.resume(
-                        cx, scope, GENERATOR_THROW, args.length > 0 ? args[0] : Undefined.instance);
-
-            case Id___iterator__:
-                return thisObj;
-
-            default:
-                throw new IllegalArgumentException(String.valueOf(id));
-        }
+    private static NativeGenerator realThis(Object thisObj) {
+        return LambdaConstructor.convertThisObject(thisObj, NativeGenerator.class);
     }
 
     private Object resume(Context cx, VarScope scope, int operation, Object value) {
@@ -175,39 +142,6 @@ public final class NativeGenerator extends IdScriptableObject {
             if (operation == GENERATOR_CLOSE) savedState = null;
         }
     }
-
-    @Override
-    protected int findPrototypeId(String s) {
-        int id;
-        switch (s) {
-            case "close":
-                id = Id_close;
-                break;
-            case "next":
-                id = Id_next;
-                break;
-            case "send":
-                id = Id_send;
-                break;
-            case "throw":
-                id = Id_throw;
-                break;
-            case "__iterator__":
-                id = Id___iterator__;
-                break;
-            default:
-                id = 0;
-                break;
-        }
-        return id;
-    }
-
-    private static final int Id_close = 1,
-            Id_next = 2,
-            Id_send = 3,
-            Id_throw = 4,
-            Id___iterator__ = 5,
-            MAX_PROTOTYPE_ID = 5;
 
     private JSFunction function;
     private Object savedState;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
@@ -13,7 +13,7 @@ package org.mozilla.javascript;
  * @author Norris Boyd
  */
 public final class NativeGenerator extends IdScriptableObject {
-    private static final long serialVersionUID = 1645892441041347273L;
+    private static final long serialVersionUID = -1383456283657974338L;
 
     private static final Object GENERATOR_TAG = "Generator";
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -12,6 +12,8 @@ import static org.mozilla.javascript.ScriptableObject.DONTENUM;
 import static org.mozilla.javascript.ScriptableObject.READONLY;
 
 import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.Map;
 import org.mozilla.javascript.xml.XMLLib;
 
 /**
@@ -26,6 +28,7 @@ public class NativeGlobal implements Serializable {
 
     private static final ClassDescriptor DESCRIPTOR;
     private static final JSDescriptor<JSFunction> EVAL_DESCRIPTOR;
+    private static final Map<TopLevel.NativeErrors, ClassDescriptor> ERROR_DESCRIPTORS;
 
     static {
         DESCRIPTOR =
@@ -50,6 +53,36 @@ public class NativeGlobal implements Serializable {
                         .withProp(CTOR, "undefined", value(Undefined.instance))
                         .build();
         EVAL_DESCRIPTOR = DESCRIPTOR.findCtorDesc("eval");
+
+        var errorDescs =
+                new EnumMap<TopLevel.NativeErrors, ClassDescriptor>(TopLevel.NativeErrors.class);
+        for (var e : TopLevel.NativeErrors.values()) {
+            if (e == TopLevel.NativeErrors.Error) continue;
+            ClassDescriptor.Builder builder;
+            if (e != TopLevel.NativeErrors.AggregateError) {
+                builder =
+                        new ClassDescriptor.Builder(
+                                e.name(),
+                                1,
+                                (c, f, nt, s, thisObj, args) -> NativeError.make(c, s, f, args),
+                                (c, f, nt, s, thisObj, args) -> NativeError.make(c, s, f, args));
+            } else {
+                builder =
+                        new ClassDescriptor.Builder(
+                                e.name(),
+                                2,
+                                (c, f, nt, s, thisObj, args) ->
+                                        NativeError.makeAggregate(c, s, f, args),
+                                (c, f, nt, s, thisObj, args) ->
+                                        NativeError.makeAggregate(c, s, f, args));
+            }
+            errorDescs.put(
+                    e,
+                    builder.withProtoValue("name", e.name(), DONTENUM)
+                            .withProtoValue("message", "", DONTENUM)
+                            .build());
+        }
+        ERROR_DESCRIPTORS = Map.copyOf(errorDescs);
     }
 
     public static void init(Context cx, TopLevel scope, boolean sealed) {
@@ -70,76 +103,20 @@ public class NativeGlobal implements Serializable {
                 ScriptableObject.ensureScriptable(
                         ScriptableObject.getProperty(nativeError, "prototype"));
 
-        for (TopLevel.NativeErrors error : TopLevel.NativeErrors.values()) {
-            if (error == TopLevel.NativeErrors.Error) {
-                // Error is initialized elsewhere and we should not overwrite it.
-                continue;
-            }
-            String name = error.name();
-            TopLevel topLevelScope = ScriptableObject.getTopLevelScope(scope);
-            Function builtinErrorCtor =
-                    TopLevel.getBuiltinCtor(cx, topLevelScope, TopLevel.Builtins.Error);
-            ScriptableObject errorProto = NativeError.makeProto(topLevelScope, builtinErrorCtor);
-            errorProto.defineProperty("name", name, DONTENUM);
-            errorProto.defineProperty("message", "", DONTENUM);
-
-            BaseFunction ctor;
-
-            // Building errors is complex because of the prototype chain requirements. This is a bit
-            // arcane, but it's a combination that makes test262 happy.
-            if (error == TopLevel.NativeErrors.AggregateError) {
-                var target =
-                        new SerializableConstructable() {
-                            // We need a reference to the LambdaFunction, so we use this "lateBound"
-                            // trick. It ain't great, but it's the only idea I have.
-                            private Function lateBoundCtor;
-
-                            @Override
-                            public Scriptable construct(
-                                    Context callCx, VarScope callScope, Object[] args) {
-                                return NativeError.makeAggregate(
-                                        callCx, callScope, lateBoundCtor, args);
-                            }
-                        };
-                ctor =
-                        new LambdaConstructor(scope, name, 2, target) {
-                            // Necessary to make the test262 case
-                            // built-ins/NativeErrors/AggregateError/newtarget-proto-custom.js work
-                            // correctly
-                            @Override
-                            public Scriptable createObject(Context cx, VarScope scope) {
-                                return null;
-                            }
-                        };
-                target.lateBoundCtor = ctor;
-            } else {
-                var target =
-                        new SerializableConstructable() {
-                            private Function lateBoundCtor;
-
-                            @Override
-                            public Scriptable construct(
-                                    Context callCx, VarScope callScope, Object[] args) {
-                                return NativeError.make(callCx, callScope, lateBoundCtor, args);
-                            }
-                        };
-                ctor = new LambdaConstructor(scope, name, 1, target);
-                target.lateBoundCtor = ctor;
-            }
-
-            ctor.setImmunePrototypeProperty(errorProto);
-            ctor.setPrototype(nativeError);
-            errorProto.put("constructor", errorProto, ctor);
-            errorProto.setAttributes("constructor", DONTENUM);
-            errorProto.setPrototype(nativeErrorProto);
-            ctor.setAttributes("name", DONTENUM | READONLY);
-            ctor.setAttributes("length", DONTENUM | READONLY);
-            if (sealed) {
-                errorProto.sealObject();
-                ctor.sealObject();
-            }
-
-            ScriptableObject.defineProperty(scope, name, ctor, DONTENUM);
+        Function builtinErrorCtor = TopLevel.getBuiltinCtor(cx, scope, TopLevel.Builtins.Error);
+        for (var e : ERROR_DESCRIPTORS.entrySet()) {
+            var name = e.getKey().name();
+            var desc = e.getValue();
+            var errorProto = NativeError.makeProto(scope, builtinErrorCtor);
+            desc.buildConstructor(
+                    cx,
+                    scope,
+                    errorProto,
+                    sealed,
+                    (c, ctor) -> {
+                        ctor.setPrototype(nativeError);
+                        errorProto.setPrototype(nativeErrorProto);
+                    });
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -8,8 +8,8 @@ package org.mozilla.javascript;
 
 import static org.mozilla.javascript.ClassDescriptor.Builder.value;
 import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
 import static org.mozilla.javascript.ScriptableObject.DONTENUM;
-import static org.mozilla.javascript.ScriptableObject.READONLY;
 
 import java.io.Serializable;
 import java.util.EnumMap;
@@ -78,8 +78,8 @@ public class NativeGlobal implements Serializable {
             }
             errorDescs.put(
                     e,
-                    builder.withProtoValue("name", e.name(), DONTENUM)
-                            .withProtoValue("message", "", DONTENUM)
+                    builder.withProp(PROTO, "name", value(e.name(), DONTENUM))
+                            .withProp(PROTO, "message", value("", DONTENUM))
                             .build());
         }
         ERROR_DESCRIPTORS = Map.copyOf(errorDescs);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -6,8 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
 import static org.mozilla.javascript.ScriptableObject.DONTENUM;
-import static org.mozilla.javascript.ScriptableObject.PERMANENT;
 import static org.mozilla.javascript.ScriptableObject.READONLY;
 
 import java.io.Serializable;
@@ -23,36 +24,41 @@ import org.mozilla.javascript.xml.XMLLib;
 public class NativeGlobal implements Serializable {
     static final long serialVersionUID = 6080442165748707530L;
 
-    public static void init(Context cx, TopLevel scope, boolean sealed) {
-        defineGlobalFunction(scope, sealed, "decodeURI", 1, NativeGlobal::js_decodeURI);
-        defineGlobalFunction(
-                scope, sealed, "decodeURIComponent", 1, NativeGlobal::js_decodeURIComponent);
-        defineGlobalFunction(scope, sealed, "encodeURI", 1, NativeGlobal::js_encodeURI);
-        defineGlobalFunction(
-                scope, sealed, "encodeURIComponent", 1, NativeGlobal::js_encodeURIComponent);
-        defineGlobalFunction(scope, sealed, "escape", 1, NativeGlobal::js_escape);
-        defineGlobalFunction(scope, sealed, "isFinite", 1, NativeGlobal::js_isFinite);
-        defineGlobalFunction(scope, sealed, "isNaN", 1, NativeGlobal::js_isNaN);
-        defineGlobalFunction(scope, sealed, "isXMLName", 1, NativeGlobal::js_isXMLName);
-        defineGlobalFunction(scope, sealed, "parseFloat", 1, NativeGlobal::js_parseFloat);
-        defineGlobalFunction(scope, sealed, "parseInt", 2, NativeGlobal::js_parseInt);
-        defineGlobalFunction(scope, sealed, "unescape", 1, NativeGlobal::js_unescape);
-        defineGlobalFunction(scope, sealed, "uneval", 1, NativeGlobal::js_uneval);
-        defineGlobalFunctionEval(scope, sealed);
+    private static final ClassDescriptor DESCRIPTOR;
+    private static final JSDescriptor<JSFunction> EVAL_DESCRIPTOR;
 
-        ScriptableObject.defineProperty(
-                scope, "NaN", ScriptRuntime.NaNobj, READONLY | DONTENUM | PERMANENT);
-        ScriptableObject.defineProperty(
-                scope, "Infinity", Double.POSITIVE_INFINITY, READONLY | DONTENUM | PERMANENT);
-        ScriptableObject.defineProperty(
-                scope, "undefined", Undefined.instance, READONLY | DONTENUM | PERMANENT);
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder("globalThis")
+                        .withMethod(CTOR, "decodeURI", 1, NativeGlobal::js_decodeURI)
+                        .withMethod(
+                                CTOR, "decodeURIComponent", 1, NativeGlobal::js_decodeURIComponent)
+                        .withMethod(CTOR, "encodeURI", 1, NativeGlobal::js_encodeURI)
+                        .withMethod(
+                                CTOR, "encodeURIComponent", 1, NativeGlobal::js_encodeURIComponent)
+                        .withMethod(CTOR, "escape", 1, NativeGlobal::js_escape)
+                        .withMethod(CTOR, "isFinite", 1, NativeGlobal::js_isFinite)
+                        .withMethod(CTOR, "isNaN", 1, NativeGlobal::js_isNaN)
+                        .withMethod(CTOR, "isXMLName", 1, NativeGlobal::js_isXMLName)
+                        .withMethod(CTOR, "parseFloat", 1, NativeGlobal::js_parseFloat)
+                        .withMethod(CTOR, "parseInt", 2, NativeGlobal::js_parseInt)
+                        .withMethod(CTOR, "unescape", 1, NativeGlobal::js_unescape)
+                        .withMethod(CTOR, "uneval", 1, NativeGlobal::js_uneval)
+                        .withMethod(CTOR, "eval", 1, NativeGlobal::js_eval)
+                        .withProp(CTOR, "NaN", value(ScriptRuntime.NaNobj))
+                        .withProp(CTOR, "Infinity", value(Double.POSITIVE_INFINITY))
+                        .withProp(CTOR, "undefined", value(Undefined.instance))
+                        .build();
+        EVAL_DESCRIPTOR = DESCRIPTOR.findCtorDesc("eval");
+    }
+
+    public static void init(Context cx, TopLevel scope, boolean sealed) {
         var globalThis = scope.getGlobalThis();
+        DESCRIPTOR.populateGlobal(cx, scope, globalThis, false);
 
         var obj = (Scriptable) scope.get("Object", scope);
         var objProto = (Scriptable) obj.get("prototype", obj);
         globalThis.setPrototype(objProto);
-
-        ScriptableObject.defineProperty(scope, "globalThis", globalThis, DONTENUM);
 
         /*
             Each error constructor gets its own Error object as a prototype,
@@ -124,7 +130,7 @@ public class NativeGlobal implements Serializable {
             ctor.setImmunePrototypeProperty(errorProto);
             ctor.setPrototype(nativeError);
             errorProto.put("constructor", errorProto, ctor);
-            errorProto.setAttributes("constructor", ScriptableObject.DONTENUM);
+            errorProto.setAttributes("constructor", DONTENUM);
             errorProto.setPrototype(nativeErrorProto);
             ctor.setAttributes("name", DONTENUM | READONLY);
             ctor.setAttributes("length", DONTENUM | READONLY);
@@ -137,46 +143,26 @@ public class NativeGlobal implements Serializable {
         }
     }
 
-    private static void defineGlobalFunction(
-            VarScope scope,
-            boolean sealed,
-            String name,
-            int length,
-            SerializableCallable callable) {
-        LambdaFunction fun = new LambdaFunction(scope, name, length, null, callable);
-        registerGlobalFunction(scope, sealed, name, fun);
-    }
-
-    private static void registerGlobalFunction(
-            VarScope scope, boolean sealed, String name, LambdaFunction fun) {
-        ScriptableObject.defineProperty(scope, name, fun, DONTENUM);
-        if (sealed) {
-            fun.sealObject();
-        }
-    }
-
-    // Eval is special because we need to "recognize" it in isEvalFunction
-    private static void defineGlobalFunctionEval(VarScope scope, boolean sealed) {
-        LambdaFunction evalFun = new EvalLambdaFunction(scope);
-        registerGlobalFunction(scope, sealed, "eval", evalFun);
-    }
-
     static boolean isEvalFunction(Object functionObj) {
-        return functionObj instanceof EvalLambdaFunction;
+        return functionObj instanceof JSFunction
+                && ((JSFunction) functionObj).getDescriptor() == EVAL_DESCRIPTOR;
     }
 
-    private static String js_uneval(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static String js_uneval(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object value = (args.length != 0) ? args[0] : Undefined.instance;
-        return ScriptRuntime.uneval(cx, scope, value);
+        return ScriptRuntime.uneval(cx, s, value);
     }
 
-    private static Boolean js_isXMLName(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Boolean js_isXMLName(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object name = (args.length == 0) ? Undefined.instance : args[0];
-        XMLLib xmlLib = XMLLib.extractFromScope(scope);
+        XMLLib xmlLib = XMLLib.extractFromScope(s);
         return xmlLib.isXMLName(cx, name);
     }
 
-    private static Boolean js_isNaN(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Boolean js_isNaN(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // The global method isNaN, as per ECMA-262 15.1.2.6.
         if (args.length < 1) {
             return true;
@@ -186,48 +172,52 @@ public class NativeGlobal implements Serializable {
         }
     }
 
-    private static Object js_isFinite(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_isFinite(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 1) {
             return Boolean.FALSE;
         }
         return NativeNumber.isFinite(args[0]);
     }
 
-    private static String js_decodeURI(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static String js_decodeURI(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return decode(str, true);
     }
 
     private static String js_decodeURIComponent(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return decode(str, false);
     }
 
-    private static String js_encodeURI(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static String js_encodeURI(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return encode(str, true);
     }
 
     private static String js_encodeURIComponent(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return encode(str, false);
     }
 
     /** The global method parseInt, as per ECMA-262 15.1.2.2. */
-    static Object js_parseInt(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        String s = ScriptRuntime.toString(args, 0);
+    static Object js_parseInt(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        String str = ScriptRuntime.toString(args, 0);
         int radix = ScriptRuntime.toInt32(args, 1);
 
-        int len = s.length();
+        int len = str.length();
         if (len == 0) return ScriptRuntime.NaNobj;
 
         boolean negative = false;
         int start = 0;
         char c;
         do {
-            c = s.charAt(start);
+            c = str.charAt(start);
             if (!ScriptRuntime.isStrWhiteSpaceChar(c)) break;
             start++;
         } while (start < len);
@@ -239,15 +229,15 @@ public class NativeGlobal implements Serializable {
             radix = NO_RADIX;
         } else if (radix < 2 || radix > 36) {
             return ScriptRuntime.NaNobj;
-        } else if (radix == 16 && len - start > 1 && s.charAt(start) == '0') {
-            c = s.charAt(start + 1);
+        } else if (radix == 16 && len - start > 1 && str.charAt(start) == '0') {
+            c = str.charAt(start + 1);
             if (c == 'x' || c == 'X') start += 2;
         }
 
         if (radix == NO_RADIX) {
             radix = 10;
-            if (len - start > 1 && s.charAt(start) == '0') {
-                c = s.charAt(start + 1);
+            if (len - start > 1 && str.charAt(start) == '0') {
+                c = str.charAt(start + 1);
                 if (c == 'x' || c == 'X') {
                     radix = 16;
                     start += 2;
@@ -260,7 +250,7 @@ public class NativeGlobal implements Serializable {
             }
         }
 
-        double d = ScriptRuntime.stringPrefixToNumber(s, start, radix);
+        double d = ScriptRuntime.stringPrefixToNumber(str, start, radix);
         return negative ? -d : d;
     }
 
@@ -269,11 +259,12 @@ public class NativeGlobal implements Serializable {
      *
      * @param args the arguments to parseFloat, ignoring args[>=1]
      */
-    static Object js_parseFloat(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    static Object js_parseFloat(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 1) return ScriptRuntime.NaNobj;
 
-        String s = ScriptRuntime.toString(args[0]);
-        int len = s.length();
+        String str = ScriptRuntime.toString(args[0]);
+        int len = str.length();
         int start = 0;
         // Scan forward to skip whitespace
         char c;
@@ -281,7 +272,7 @@ public class NativeGlobal implements Serializable {
             if (start == len) {
                 return ScriptRuntime.NaNobj;
             }
-            c = s.charAt(start);
+            c = str.charAt(start);
             if (!ScriptRuntime.isStrWhiteSpaceChar(c)) {
                 break;
             }
@@ -294,13 +285,13 @@ public class NativeGlobal implements Serializable {
             if (i == len) {
                 return ScriptRuntime.NaNobj;
             }
-            c = s.charAt(i);
+            c = str.charAt(i);
         }
 
         if (c == 'I') {
             // check for "Infinity"
-            if (i + 8 <= len && s.regionMatches(i, "Infinity", 0, 8)) {
-                if (s.charAt(start) == '-') {
+            if (i + 8 <= len && str.regionMatches(i, "Infinity", 0, 8)) {
+                if (str.charAt(start) == '-') {
                     return Double.NEGATIVE_INFINITY;
                 } else {
                     return Double.POSITIVE_INFINITY;
@@ -314,7 +305,7 @@ public class NativeGlobal implements Serializable {
         int exponent = -1;
         boolean exponentValid = false;
         for (; i < len; i++) {
-            switch (s.charAt(i)) {
+            switch (str.charAt(i)) {
                 case '.':
                     if (decimal != -1) // Only allow a single decimal point.
                     break;
@@ -365,9 +356,9 @@ public class NativeGlobal implements Serializable {
         if (exponent != -1 && !exponentValid) {
             i = exponent;
         }
-        s = s.substring(start, i);
+        str = str.substring(start, i);
         try {
-            return Double.valueOf(s);
+            return Double.valueOf(str);
         } catch (NumberFormatException ex) {
             return ScriptRuntime.NaNobj;
         }
@@ -379,10 +370,11 @@ public class NativeGlobal implements Serializable {
      * <p>Includes code for the 'mask' argument supported by the C escape method, which used to be
      * part of the browser embedding. Blame for the strange constant names should be directed there.
      */
-    private static Object js_escape(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_escape(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         final int URL_XALPHAS = 1, URL_XPALPHAS = 2, URL_PATH = 4;
 
-        String s = ScriptRuntime.toString(args, 0);
+        String str = ScriptRuntime.toString(args, 0);
 
         int mask = URL_XALPHAS | URL_XPALPHAS | URL_PATH;
         if (args.length > 1) { // the 'mask' argument.  Non-ECMA.
@@ -395,8 +387,8 @@ public class NativeGlobal implements Serializable {
         }
 
         StringBuilder sb = null;
-        for (int k = 0, L = s.length(); k != L; ++k) {
-            int c = s.charAt(k);
+        for (int k = 0, L = str.length(); k != L; ++k) {
+            int c = str.charAt(k);
             if (mask != 0
                     && ((c >= '0' && c <= '9')
                             || (c >= 'A' && c <= 'Z')
@@ -440,16 +432,17 @@ public class NativeGlobal implements Serializable {
             }
         }
 
-        return (sb == null) ? s : sb.toString();
+        return (sb == null) ? str : sb.toString();
     }
 
     /** The global unescape method, as per ECMA-262 15.1.2.5. */
-    private static Object js_unescape(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        String s = ScriptRuntime.toString(args, 0);
-        int firstEscapePos = s.indexOf('%');
+    private static Object js_unescape(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        String str = ScriptRuntime.toString(args, 0);
+        int firstEscapePos = str.indexOf('%');
         if (firstEscapePos >= 0) {
-            int L = s.length();
-            char[] buf = s.toCharArray();
+            int L = str.length();
+            char[] buf = str.toCharArray();
             int destination = firstEscapePos;
             for (int k = firstEscapePos; k != L; ) {
                 char c = buf[k];
@@ -477,17 +470,18 @@ public class NativeGlobal implements Serializable {
                 buf[destination] = c;
                 ++destination;
             }
-            s = new String(buf, 0, destination);
+            str = new String(buf, 0, destination);
         }
-        return s;
+        return str;
     }
 
     /**
      * This is an indirect call to eval, and thus uses the global environment. Direct calls are
      * executed via ScriptRuntime.callSpecial().
      */
-    private static Object js_eval(Context cx, VarScope scope, Object[] args) {
-        TopLevel top = ScriptableObject.getTopLevelScope(scope);
+    private static Object js_eval(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        TopLevel top = ScriptableObject.getTopLevelScope(f.getDeclarationScope());
         return ScriptRuntime.evalSpecial(cx, top, top.getGlobalThis(), args, "eval code", 1);
     }
 
@@ -739,21 +733,5 @@ public class NativeGlobal implements Serializable {
             utf8Buffer[0] = (byte) (0x100 - (1 << (8 - utf8Length)) + ucs4Char);
         }
         return utf8Length;
-    }
-
-    /**
-     * A simple subclass of {@link LambdaFunction} used to "tag" eval, so that we can recognize it
-     * in {@link NativeGlobal#isEvalFunction}
-     */
-    private static class EvalLambdaFunction extends LambdaFunction {
-        public EvalLambdaFunction(VarScope scope) {
-            super(
-                    scope,
-                    "eval",
-                    1,
-                    null,
-                    (callCx, callScope, thisObj, args) ->
-                            NativeGlobal.js_eval(callCx, callScope, args));
-        }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.util.Iterator;
 
 /**
@@ -21,28 +23,30 @@ public final class NativeIterator extends ScriptableObject {
 
     private Object objectIterator;
 
+    private static final String STOP_ITERATION = "StopIteration";
+    public static final String ITERATOR_PROPERTY_NAME = "__iterator__";
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    private static final ClassDescriptor STOP_ITER_DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                2,
+                                NativeIterator::jsConstructorCall,
+                                NativeIterator::jsConstructor)
+                        .withMethod(PROTO, "next", 0, NativeIterator::js_next)
+                        .withMethod(
+                                PROTO, ITERATOR_PROPERTY_NAME, 1, NativeIterator::js_iteratorMethod)
+                        .build();
+        STOP_ITER_DESCRIPTOR = new ClassDescriptor.Builder(STOP_ITERATION, 0, null, null).build();
+    }
+
     static void init(Context cx, TopLevel scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        2,
-                        NativeIterator::jsConstructorCall,
-                        NativeIterator::jsConstructor);
-        constructor.setPrototypePropertyAttributes(PERMANENT | READONLY | DONTENUM);
-
         NativeIterator proto = new NativeIterator();
-        constructor.setPrototypeScriptable(proto);
-
-        constructor.definePrototypeMethod(scope, "next", 0, NativeIterator::js_next);
-        constructor.definePrototypeMethod(
-                scope, ITERATOR_PROPERTY_NAME, 1, NativeIterator::js_iteratorMethod);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, ScriptableObject.DONTENUM);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
+        var ctor = DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
 
         // Generator
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
@@ -52,17 +56,11 @@ public final class NativeIterator extends ScriptableObject {
         }
 
         // StopIteration
-        NativeObject obj = new StopIteration();
-        obj.setPrototype(getObjectPrototype(scope));
-        obj.setParentScope(scope);
-        if (sealed) {
-            obj.sealObject();
-        }
-        ScriptableObject.defineProperty(scope, STOP_ITERATION, obj, ScriptableObject.DONTENUM);
+        var stopCtor = STOP_ITER_DESCRIPTOR.populateGlobal(cx, scope, new StopIteration(), sealed);
         // Use "associateValue" so that generators can continue to
         // throw StopIteration even if the property of the global
         // scope is replaced or deleted.
-        scope.associateValue(ITERATOR_TAG, obj);
+        scope.associateValue(ITERATOR_TAG, stopCtor);
     }
 
     /** Only for constructing the prototype object. */
@@ -84,9 +82,6 @@ public final class NativeIterator extends ScriptableObject {
         TopLevel top = ScriptableObject.getTopLevelScope(scope);
         return ScriptableObject.getTopScopeValue(top, ITERATOR_TAG);
     }
-
-    private static final String STOP_ITERATION = "StopIteration";
-    public static final String ITERATOR_PROPERTY_NAME = "__iterator__";
 
     public static class StopIteration extends NativeObject {
         private static final long serialVersionUID = 2485151085722377663L;
@@ -123,13 +118,13 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     private static Object jsConstructorCall(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        Scriptable target = requireIteratorTarget(cx, scope, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        Scriptable target = requireIteratorTarget(cx, s, args);
         boolean keyOnly = isKeyOnly(args);
 
         Iterator<?> iterator = getJavaIterator(target);
         if (iterator != null) {
-            VarScope topScope = ScriptableObject.getTopLevelScope(scope);
+            VarScope topScope = ScriptableObject.getTopLevelScope(s);
             return cx.getWrapFactory()
                     .wrap(
                             cx,
@@ -143,13 +138,14 @@ public final class NativeIterator extends ScriptableObject {
             return jsIterator;
         }
 
-        return createNativeIterator(cx, scope, target, keyOnly);
+        return createNativeIterator(cx, s, target, keyOnly);
     }
 
-    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
-        Scriptable target = requireIteratorTarget(cx, scope, args);
+    private static Scriptable jsConstructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        Scriptable target = requireIteratorTarget(cx, s, args);
         boolean keyOnly = isKeyOnly(args);
-        return createNativeIterator(cx, scope, target, keyOnly);
+        return createNativeIterator(cx, s, target, keyOnly);
     }
 
     private static Scriptable requireIteratorTarget(Context cx, VarScope scope, Object[] args) {
@@ -165,9 +161,10 @@ public final class NativeIterator extends ScriptableObject {
         return args.length > 1 && ScriptRuntime.toBoolean(args[1]);
     }
 
-    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_next(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeIterator iterator = realThis(thisObj);
-        return iterator.next(cx, scope);
+        return iterator.next(cx, s);
     }
 
     private static NativeIterator createNativeIterator(
@@ -188,7 +185,7 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     private static Object js_iteratorMethod(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -45,12 +45,12 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     static void init(Context cx, TopLevel scope, boolean sealed) {
-        NativeIterator proto = new NativeIterator();
+        NativeObject proto = new NativeObject();
         var ctor = DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
 
         // Generator
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
-            ES6Generator.init(scope, sealed);
+            ES6Generator.init(cx, scope, sealed);
         } else {
             NativeGenerator.init(cx, scope, sealed);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -52,7 +52,7 @@ public final class NativeIterator extends ScriptableObject {
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             ES6Generator.init(scope, sealed);
         } else {
-            NativeGenerator.init(scope, sealed);
+            NativeGenerator.init(cx, scope, sealed);
         }
 
         // StopIteration

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 import java.lang.reflect.Array;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
@@ -30,21 +33,21 @@ public final class NativeJSON extends ScriptableObject {
 
     private static final int MAX_STRINGIFY_GAP_LENGTH = 10;
 
+    private static final ClassDescriptor DESCRIPTION;
+
+    static {
+        DESCRIPTION =
+                new ClassDescriptor.Builder(JSON_TAG)
+                        .withMethod(CTOR, "parse", 2, NativeJSON::parse)
+                        .withMethod(CTOR, "stringify", 3, NativeJSON::stringify)
+                        .withProp(CTOR, "toSource", value("JSON"))
+                        .withProp(
+                                CTOR, SymbolKey.TO_STRING_TAG, value(JSON_TAG, DONTENUM | READONLY))
+                        .build();
+    }
+
     static Object init(Context cx, VarScope scope, boolean sealed) {
-        NativeJSON json = new NativeJSON();
-        json.setPrototype(getObjectPrototype(scope));
-        json.setParentScope(scope);
-
-        json.defineBuiltinProperty(scope, "parse", 2, NativeJSON::parse);
-        json.defineBuiltinProperty(scope, "stringify", 3, NativeJSON::stringify);
-
-        json.defineProperty("toSource", "JSON", DONTENUM | READONLY | PERMANENT);
-
-        json.defineProperty(SymbolKey.TO_STRING_TAG, JSON_TAG, DONTENUM | READONLY);
-        if (sealed) {
-            json.sealObject();
-        }
-        return json;
+        return DESCRIPTION.populateGlobal(cx, scope, new NativeJSON(), sealed);
     }
 
     private NativeJSON() {}
@@ -54,19 +57,21 @@ public final class NativeJSON extends ScriptableObject {
         return "JSON";
     }
 
-    private static Object parse(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object parse(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String jtext = ScriptRuntime.toString(args, 0);
         Object reviver = null;
         if (args.length > 1) {
             reviver = args[1];
         }
         if (reviver instanceof Callable) {
-            return parse(cx, scope, jtext, (Callable) reviver);
+            return parse(cx, f.getDeclarationScope(), jtext, (Callable) reviver);
         }
-        return parse(cx, scope, jtext);
+        return parse(cx, f.getDeclarationScope(), jtext);
     }
 
-    private static Object stringify(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object stringify(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object value = Undefined.instance, replacer = null, space = null;
 
         if (args.length > 0) {
@@ -78,7 +83,7 @@ public final class NativeJSON extends ScriptableObject {
                 }
             }
         }
-        return stringify(cx, scope, value, replacer, space);
+        return stringify(cx, s, value, replacer, space);
     }
 
     private static Object parse(Context cx, VarScope scope, String jtext) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -116,7 +116,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // If it looks like a "cast" of an object to this class type,
         // walk the prototype chain to see if there's a wrapper of a
         // object that's an instanceof this class.

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaConstructor.java
@@ -30,7 +30,7 @@ public class NativeJavaConstructor extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return NativeJavaClass.constructSpecific(cx, scope, args, ctor);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -160,7 +160,7 @@ public class NativeJavaMap extends NativeJavaObject {
     }
 
     private static Callable symbol_iterator =
-            (Context cx, VarScope scope, Scriptable thisObj, Object[] args) -> {
+            (cx, scope, thisObj, args) -> {
                 if (!(thisObj instanceof NativeJavaMap)) {
                     throw ScriptRuntime.typeErrorById("msg.incompat.call", SymbolKey.ITERATOR);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -30,8 +30,8 @@ public class NativeJavaMap extends NativeJavaObject {
     private final TypeInfo keyType;
     private final TypeInfo valueType;
 
-    static void init(TopLevel scope, boolean sealed) {
-        NativeJavaMapIterator.init(scope, sealed);
+    static void init(Context cx, TopLevel scope, boolean sealed) {
+        NativeJavaMapIterator.init(cx, scope, sealed);
     }
 
     @SuppressWarnings("unchecked")
@@ -171,8 +171,17 @@ public class NativeJavaMap extends NativeJavaObject {
         private static final long serialVersionUID = -6354388021424261488L;
         private static final String ITERATOR_TAG = "JavaMapIterator";
 
-        static void init(TopLevel scope, boolean sealed) {
-            ES6Iterator.init(scope, sealed, new NativeJavaMapIterator(), ITERATOR_TAG);
+        private static final ClassDescriptor DESCRIPTOR =
+                ES6Iterator.makeDescriptor(ITERATOR_TAG, "Java Map Iterator");
+
+        static void init(Context cx, VarScope scope, boolean sealed) {
+            ES6Iterator.initialize(
+                    DESCRIPTOR,
+                    cx,
+                    (TopLevel) scope,
+                    new NativeJavaMapIterator(),
+                    sealed,
+                    ITERATOR_TAG);
         }
 
         /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -168,7 +168,7 @@ public class NativeJavaMap extends NativeJavaObject {
             };
 
     private static final class NativeJavaMapIterator extends ES6Iterator {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = -6354388021424261488L;
         private static final String ITERATOR_TAG = "JavaMapIterator";
 
         static void init(TopLevel scope, boolean sealed) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -129,7 +129,7 @@ public class NativeJavaMethod extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // Find a method that matches the types given.
         if (methods.length == 0) {
             throw new RuntimeException("No methods defined for call");
@@ -159,7 +159,7 @@ public class NativeJavaMethod extends BaseFunction {
         if (meth.isStatic()) {
             javaObject = null; // don't need an object
         } else {
-            Scriptable o = thisObj;
+            Scriptable o = ScriptRuntime.toObject(getDeclarationScope(), thisObj);
             Class<?> c = meth.getDeclaringClass();
             for (; ; ) {
                 if (o == null) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -904,7 +904,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
     }
 
     private static Callable symbol_iterator =
-            (Context cx, VarScope scope, Scriptable thisObj, Object[] args) -> {
+            (cx, scope, thisObj, args) -> {
                 if (!(thisObj instanceof NativeJavaObject)) {
                     throw ScriptRuntime.typeErrorById("msg.incompat.call", SymbolKey.ITERATOR);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -35,8 +35,8 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     private static final long serialVersionUID = -6948590651130498591L;
 
-    static void init(TopLevel scope, boolean sealed) {
-        JavaIterableIterator.init(scope, sealed);
+    static void init(Context cx, TopLevel scope, boolean sealed) {
+        JavaIterableIterator.init(cx, scope, sealed);
     }
 
     public NativeJavaObject() {}
@@ -919,8 +919,12 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         private static final long serialVersionUID = -2636492890037940863L;
         private static final String ITERATOR_TAG = "JavaIterableIterator";
 
-        static void init(TopLevel scope, boolean sealed) {
-            ES6Iterator.init(scope, sealed, new JavaIterableIterator(), ITERATOR_TAG);
+        private static final ClassDescriptor DESCRIPTOR =
+                ES6Iterator.makeDescriptor(ITERATOR_TAG, "Java Iterable Iterator");
+
+        static void init(Context cx, TopLevel scope, boolean sealed) {
+            ES6Iterator.initialize(
+                    DESCRIPTOR, cx, scope, new JavaIterableIterator(), sealed, ITERATOR_TAG);
         }
 
         /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -916,7 +916,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
             };
 
     private static final class JavaIterableIterator extends ES6Iterator {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = -2636492890037940863L;
         private static final String ITERATOR_TAG = "JavaIterableIterator";
 
         static void init(TopLevel scope, boolean sealed) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaTopPackage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaTopPackage.java
@@ -38,7 +38,7 @@ public class NativeJavaTopPackage extends NativeJavaPackage implements Function,
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return construct(cx, scope, args);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -14,11 +14,20 @@ public class NativeMap extends ScriptableObject {
     private static final String CLASS_NAME = "Map";
     static final String ITERATOR_TAG = "Map Iterator";
 
+    private static final ClassDescriptor ITER_DESCRIPTOR =
+            ES6Iterator.makeDescriptor(ITERATOR_TAG, ITERATOR_TAG);
     private final Hashtable entries = new Hashtable();
 
     private boolean instanceOfMap = false;
 
     static Object init(Context cx, VarScope scope, boolean sealed) {
+        ES6Iterator.initialize(
+                ITER_DESCRIPTOR,
+                cx,
+                (TopLevel) scope,
+                new NativeCollectionIterator(ITERATOR_TAG),
+                sealed,
+                ITERATOR_TAG);
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -6,6 +6,11 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.alias;
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.util.List;
 import java.util.Map;
 
@@ -14,8 +19,48 @@ public class NativeMap extends ScriptableObject {
     private static final String CLASS_NAME = "Map";
     static final String ITERATOR_TAG = "Map Iterator";
 
+    private static final ClassDescriptor DESCRIPTOR;
     private static final ClassDescriptor ITER_DESCRIPTOR =
             ES6Iterator.makeDescriptor(ITERATOR_TAG, ITERATOR_TAG);
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                0,
+                                ClassDescriptor.typeError(),
+                                NativeMap::js_constructor)
+                        .withMethod(CTOR, "groupBy", 2, NativeMap::jsGroupBy)
+                        .withMethod(PROTO, "set", 2, NativeMap::js_set)
+                        .withMethod(PROTO, "delete", 1, NativeMap::js_delete)
+                        .withMethod(PROTO, "get", 1, NativeMap::js_get)
+                        .withMethod(PROTO, "has", 1, NativeMap::js_has)
+                        .withMethod(PROTO, "clear", 0, NativeMap::js_clear)
+                        .withMethod(PROTO, "keys", 0, NativeMap::js_keys)
+                        .withMethod(PROTO, "values", 0, NativeMap::js_values)
+                        .withMethod(PROTO, "forEach", 1, NativeMap::js_forEach)
+                        .withMethod(PROTO, "entries", 0, NativeMap::js_entries)
+                        .withProp(PROTO, SymbolKey.ITERATOR, alias("entries", DONTENUM))
+                        .withProp(
+                                PROTO,
+                                "size",
+                                (thisObj) -> realThis(thisObj, "size").js_getSize(),
+                                null,
+                                DONTENUM)
+                        .withProp(
+                                PROTO,
+                                NativeSet.GETSIZE,
+                                (thisObj) -> realThis(thisObj, "size").js_getSize(),
+                                null,
+                                DONTENUM | PERMANENT)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
+
     private final Hashtable entries = new Hashtable();
 
     private boolean instanceOfMap = false;
@@ -28,55 +73,7 @@ public class NativeMap extends ScriptableObject {
                 new NativeCollectionIterator(ITERATOR_TAG),
                 sealed,
                 ITERATOR_TAG);
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        0,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeMap::jsConstructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.defineConstructorMethod(scope, "groupBy", 2, NativeMap::jsGroupBy);
-
-        constructor.definePrototypeMethod(scope, "set", 2, NativeMap::js_set);
-        constructor.definePrototypeMethod(scope, "delete", 1, NativeMap::js_delete);
-        constructor.definePrototypeMethod(scope, "get", 1, NativeMap::js_get);
-        constructor.definePrototypeMethod(scope, "has", 1, NativeMap::js_has);
-        constructor.definePrototypeMethod(scope, "clear", 0, NativeMap::js_clear);
-        constructor.definePrototypeMethod(scope, "keys", 0, NativeMap::js_keys);
-        constructor.definePrototypeMethod(scope, "values", 0, NativeMap::js_values);
-        constructor.definePrototypeMethod(scope, "forEach", 1, NativeMap::js_forEach);
-
-        constructor.definePrototypeMethod(scope, "entries", 0, NativeMap::js_entries);
-        constructor.definePrototypeAlias("entries", SymbolKey.ITERATOR, DONTENUM);
-
-        // The spec requires very specific handling of the "size" prototype
-        // property that's not like other things that we already do.
-        ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
-        desc.put("enumerable", desc, Boolean.FALSE);
-        desc.put("configurable", desc, Boolean.TRUE);
-        LambdaFunction sizeFunc =
-                new LambdaFunction(
-                        scope,
-                        "get size",
-                        0,
-                        (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                                realThis(thisObj, "size").js_getSize(),
-                        false);
-        desc.put("get", desc, sizeFunc);
-        constructor.definePrototypeProperty(cx, "size", desc);
-        constructor.definePrototypeProperty(cx, NativeSet.GETSIZE, desc);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
     @Override
@@ -84,40 +81,45 @@ public class NativeMap extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeMap nm = new NativeMap();
         nm.instanceOfMap = true;
         if (args.length > 0) {
-            loadFromIterable(cx, scope, nm, key(args));
+            loadFromIterable(cx, s, nm, key(args));
         }
+        nm.setParentScope(s);
+        nm.setPrototype((Scriptable) f.getPrototypeProperty());
         return nm;
     }
 
-    private static Object jsGroupBy(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object jsGroupBy(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object items = args.length < 1 ? Undefined.instance : args[0];
         Object callback = args.length < 2 ? Undefined.instance : args[1];
 
         Map<Object, List<Object>> groups =
                 AbstractEcmaObjectOperations.groupBy(
                         cx,
-                        scope,
+                        s,
                         CLASS_NAME,
                         "groupBy",
                         items,
                         callback,
                         AbstractEcmaObjectOperations.KEY_COERCION.COLLECTION);
 
-        NativeMap map = (NativeMap) cx.newObject(scope, "Map");
+        NativeMap map = (NativeMap) cx.newObject(s, "Map");
 
         for (Map.Entry<Object, List<Object>> entry : groups.entrySet()) {
-            Scriptable elements = cx.newArray(scope, entry.getValue().toArray());
+            Scriptable elements = cx.newArray(s, entry.getValue().toArray());
             map.entries.put(entry.getKey(), elements);
         }
 
         return map;
     }
 
-    private static Object js_set(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_set(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "set")
                 .js_set(key(args), args.length > 1 ? args[1] : Undefined.instance);
     }
@@ -132,7 +134,8 @@ public class NativeMap extends ScriptableObject {
         return this;
     }
 
-    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_delete(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "delete").js_delete(key(args));
     }
 
@@ -140,7 +143,8 @@ public class NativeMap extends ScriptableObject {
         return entries.deleteEntry(arg);
     }
 
-    private static Object js_get(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_get(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "get").js_get(key(args));
     }
 
@@ -152,7 +156,8 @@ public class NativeMap extends ScriptableObject {
         return entry.value;
     }
 
-    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_has(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "has").js_has(key(args));
     }
 
@@ -164,23 +169,30 @@ public class NativeMap extends ScriptableObject {
         return entries.size();
     }
 
-    private static Object js_keys(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "keys").js_iterator(scope, NativeCollectionIterator.Type.KEYS);
+    private static Object js_keys(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "keys")
+                .js_iterator(f.getDeclarationScope(), NativeCollectionIterator.Type.KEYS);
     }
 
-    private static Object js_values(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.VALUES);
+    private static Object js_values(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "values")
+                .js_iterator(f.getDeclarationScope(), NativeCollectionIterator.Type.VALUES);
     }
 
-    private static Object js_entries(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "entries").js_iterator(scope, NativeCollectionIterator.Type.BOTH);
+    private static Object js_entries(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "entries")
+                .js_iterator(f.getDeclarationScope(), NativeCollectionIterator.Type.BOTH);
     }
 
     private Object js_iterator(VarScope scope, NativeCollectionIterator.Type type) {
         return new NativeCollectionIterator(scope, ITERATOR_TAG, type, entries.iterator());
     }
 
-    private static Object js_clear(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_clear(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "clear").js_clear();
     }
 
@@ -190,11 +202,11 @@ public class NativeMap extends ScriptableObject {
     }
 
     private static Object js_forEach(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "forEach")
                 .js_forEach(
                         cx,
-                        scope,
+                        s,
                         args.length > 0 ? args[0] : Undefined.instance,
                         args.length > 1 ? args[1] : Undefined.instance);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 /**
  * This class implements the Math native object. See ECMA 15.8.
  *
@@ -18,64 +21,62 @@ final class NativeMath extends ScriptableObject {
     private static final double LOG2E = 1.4426950408889634;
     private static final Double Double32 = Double.valueOf(32d);
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(MATH_TAG)
+                        .withProp(CTOR, "toSource", value("Math"))
+                        .withMethod(CTOR, "abs", 1, NativeMath::abs)
+                        .withMethod(CTOR, "acos", 1, NativeMath::acos)
+                        .withMethod(CTOR, "acosh", 1, NativeMath::acosh)
+                        .withMethod(CTOR, "asin", 1, NativeMath::asin)
+                        .withMethod(CTOR, "asinh", 1, NativeMath::asinh)
+                        .withMethod(CTOR, "atan", 1, NativeMath::atan)
+                        .withMethod(CTOR, "atanh", 1, NativeMath::atanh)
+                        .withMethod(CTOR, "atan2", 2, NativeMath::atan2)
+                        .withMethod(CTOR, "cbrt", 1, NativeMath::cbrt)
+                        .withMethod(CTOR, "ceil", 1, NativeMath::ceil)
+                        .withMethod(CTOR, "clz32", 1, NativeMath::clz32)
+                        .withMethod(CTOR, "cos", 1, NativeMath::cos)
+                        .withMethod(CTOR, "cosh", 1, NativeMath::cosh)
+                        .withMethod(CTOR, "exp", 1, NativeMath::exp)
+                        .withMethod(CTOR, "expm1", 1, NativeMath::expm1)
+                        .withMethod(CTOR, "f16round", 1, NativeMath::f16round)
+                        .withMethod(CTOR, "floor", 1, NativeMath::floor)
+                        .withMethod(CTOR, "fround", 1, NativeMath::fround)
+                        .withMethod(CTOR, "hypot", 2, NativeMath::hypot)
+                        .withMethod(CTOR, "imul", 2, NativeMath::imul)
+                        .withMethod(CTOR, "log", 1, NativeMath::log)
+                        .withMethod(CTOR, "log1p", 1, NativeMath::log1p)
+                        .withMethod(CTOR, "log10", 1, NativeMath::log10)
+                        .withMethod(CTOR, "log2", 1, NativeMath::log2)
+                        .withMethod(CTOR, "max", 2, NativeMath::max)
+                        .withMethod(CTOR, "min", 2, NativeMath::min)
+                        .withMethod(CTOR, "pow", 2, NativeMath::pow)
+                        .withMethod(CTOR, "random", 0, NativeMath::random)
+                        .withMethod(CTOR, "round", 1, NativeMath::round)
+                        .withMethod(CTOR, "sign", 1, NativeMath::sign)
+                        .withMethod(CTOR, "sin", 1, NativeMath::sin)
+                        .withMethod(CTOR, "sinh", 1, NativeMath::sinh)
+                        .withMethod(CTOR, "sqrt", 1, NativeMath::sqrt)
+                        .withMethod(CTOR, "tan", 1, NativeMath::tan)
+                        .withMethod(CTOR, "tanh", 1, NativeMath::tanh)
+                        .withMethod(CTOR, "trunc", 1, NativeMath::trunc)
+                        .withProp(CTOR, "E", value(Math.E))
+                        .withProp(CTOR, "PI", value(Math.PI))
+                        .withProp(CTOR, "LN10", value(2.302585092994046))
+                        .withProp(CTOR, "LN2", value(0.6931471805599453))
+                        .withProp(CTOR, "LOG2E", value(LOG2E))
+                        .withProp(CTOR, "LOG10E", value(0.4342944819032518))
+                        .withProp(CTOR, "SQRT1_2", value(0.7071067811865476))
+                        .withProp(CTOR, "SQRT2", value(1.4142135623730951))
+                        .withProp(CTOR, SymbolKey.TO_STRING_TAG, value("Math", DONTENUM | READONLY))
+                        .build();
+    }
+
     static Object init(Context cx, VarScope scope, boolean sealed) {
-        NativeMath math = new NativeMath();
-        math.setPrototype(getObjectPrototype(scope));
-        math.setParentScope(scope);
-
-        math.defineProperty("toSource", "Math", DONTENUM | READONLY | PERMANENT);
-
-        math.defineBuiltinProperty(scope, "abs", 1, NativeMath::abs);
-        math.defineBuiltinProperty(scope, "acos", 1, NativeMath::acos);
-        math.defineBuiltinProperty(scope, "acosh", 1, NativeMath::acosh);
-        math.defineBuiltinProperty(scope, "asin", 1, NativeMath::asin);
-        math.defineBuiltinProperty(scope, "asinh", 1, NativeMath::asinh);
-        math.defineBuiltinProperty(scope, "atan", 1, NativeMath::atan);
-        math.defineBuiltinProperty(scope, "atanh", 1, NativeMath::atanh);
-        math.defineBuiltinProperty(scope, "atan2", 2, NativeMath::atan2);
-        math.defineBuiltinProperty(scope, "cbrt", 1, NativeMath::cbrt);
-        math.defineBuiltinProperty(scope, "ceil", 1, NativeMath::ceil);
-        math.defineBuiltinProperty(scope, "clz32", 1, NativeMath::clz32);
-        math.defineBuiltinProperty(scope, "cos", 1, NativeMath::cos);
-        math.defineBuiltinProperty(scope, "cosh", 1, NativeMath::cosh);
-        math.defineBuiltinProperty(scope, "exp", 1, NativeMath::exp);
-        math.defineBuiltinProperty(scope, "expm1", 1, NativeMath::expm1);
-        math.defineBuiltinProperty(scope, "f16round", 1, NativeMath::f16round);
-        math.defineBuiltinProperty(scope, "floor", 1, NativeMath::floor);
-        math.defineBuiltinProperty(scope, "fround", 1, NativeMath::fround);
-        math.defineBuiltinProperty(scope, "hypot", 2, NativeMath::hypot);
-        math.defineBuiltinProperty(scope, "imul", 2, NativeMath::imul);
-        math.defineBuiltinProperty(scope, "log", 1, NativeMath::log);
-        math.defineBuiltinProperty(scope, "log1p", 1, NativeMath::log1p);
-        math.defineBuiltinProperty(scope, "log10", 1, NativeMath::log10);
-        math.defineBuiltinProperty(scope, "log2", 1, NativeMath::log2);
-        math.defineBuiltinProperty(scope, "max", 2, NativeMath::max);
-        math.defineBuiltinProperty(scope, "min", 2, NativeMath::min);
-        math.defineBuiltinProperty(scope, "pow", 2, NativeMath::pow);
-        math.defineBuiltinProperty(scope, "random", 0, NativeMath::random);
-        math.defineBuiltinProperty(scope, "round", 1, NativeMath::round);
-        math.defineBuiltinProperty(scope, "sign", 1, NativeMath::sign);
-        math.defineBuiltinProperty(scope, "sin", 1, NativeMath::sin);
-        math.defineBuiltinProperty(scope, "sinh", 1, NativeMath::sinh);
-        math.defineBuiltinProperty(scope, "sqrt", 1, NativeMath::sqrt);
-        math.defineBuiltinProperty(scope, "tan", 1, NativeMath::tan);
-        math.defineBuiltinProperty(scope, "tanh", 1, NativeMath::tanh);
-        math.defineBuiltinProperty(scope, "trunc", 1, NativeMath::trunc);
-
-        math.defineProperty("E", Math.E, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("PI", Math.PI, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("LN10", 2.302585092994046, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("LN2", 0.6931471805599453, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("LOG2E", LOG2E, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("LOG10E", 0.4342944819032518, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("SQRT1_2", 0.7071067811865476, DONTENUM | READONLY | PERMANENT);
-        math.defineProperty("SQRT2", 1.4142135623730951, DONTENUM | READONLY | PERMANENT);
-
-        math.defineProperty(SymbolKey.TO_STRING_TAG, MATH_TAG, DONTENUM | READONLY);
-        if (sealed) {
-            math.sealObject();
-        }
-        return math;
+        return DESCRIPTOR.populateGlobal(cx, scope, new NativeMath(), sealed);
     }
 
     private NativeMath() {}
@@ -85,7 +86,8 @@ final class NativeMath extends ScriptableObject {
         return "Math";
     }
 
-    private static Object abs(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object abs(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // abs(-0.0) should be 0.0, but -0.0 < 0.0 == false
         x = (x == 0.0) ? 0.0 : (x < 0.0) ? -x : x;
@@ -93,7 +95,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object acos(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object acos(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
             x = Math.acos(x);
@@ -103,7 +106,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object acosh(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object acosh(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x)) {
             return Double.valueOf(Math.log(x + Math.sqrt(x * x - 1.0)));
@@ -111,7 +115,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object asin(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object asin(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
             x = Math.asin(x);
@@ -121,7 +126,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object asinh(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object asinh(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (Double.isInfinite(x)) {
             return Double.valueOf(x);
@@ -138,13 +144,15 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object atan(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object atan(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.atan(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object atanh(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object atanh(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
             if (x == 0) {
@@ -158,25 +166,29 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object atan2(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object atan2(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.atan2(x, ScriptRuntime.toNumber(args, 1));
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object cbrt(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object cbrt(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.cbrt(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object ceil(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object ceil(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.ceil(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object clz32(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object clz32(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (x == 0 || Double.isNaN(x) || Double.isInfinite(x)) {
             return Double32;
@@ -214,19 +226,22 @@ final class NativeMath extends ScriptableObject {
         return Double.valueOf(32 - place);
     }
 
-    private static Object cos(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object cos(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Double.isInfinite(x) ? Double.NaN : Math.cos(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object cosh(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object cosh(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.cosh(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object exp(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object exp(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x =
                 (x == Double.POSITIVE_INFINITY)
@@ -235,19 +250,22 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object expm1(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object expm1(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.expm1(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object floor(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object floor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.floor(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object f16round(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object f16round(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // Handle missing arguments
         if (args.length == 0) {
             return ScriptRuntime.NaNobj;
@@ -392,7 +410,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(Double.longBitsToDouble(resultBits));
     }
 
-    private static Object fround(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object fround(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // Rely on Java to truncate down to a "float" here"
         float fx = (float) x;
@@ -401,7 +420,8 @@ final class NativeMath extends ScriptableObject {
 
     // Based on code from
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
-    private static Object hypot(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object hypot(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args == null) {
             return 0.0;
         }
@@ -431,7 +451,8 @@ final class NativeMath extends ScriptableObject {
         return Math.sqrt(y);
     }
 
-    private static Object imul(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object imul(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args == null) {
             return 0;
         }
@@ -442,33 +463,38 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x * y);
     }
 
-    private static Object log(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object log(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // Java's log(<0) = -Infinity; we need NaN
         x = (x < 0) ? Double.NaN : Math.log(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object log1p(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object log1p(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.log1p(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object log10(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object log10(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.log10(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object log2(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object log2(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // Java's log(<0) = -Infinity; we need NaN
         x = (x < 0) ? Double.NaN : Math.log(x) * LOG2E;
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object max(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object max(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = Double.NEGATIVE_INFINITY;
         for (int i = 0; i != args.length; ++i) {
             double d = ScriptRuntime.toNumber(args[i]);
@@ -478,7 +504,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object min(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object min(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = Double.POSITIVE_INFINITY;
         for (int i = 0; i != args.length; ++i) {
             double d = ScriptRuntime.toNumber(args[i]);
@@ -489,7 +516,8 @@ final class NativeMath extends ScriptableObject {
     }
 
     // See Ecma 15.8.2.13
-    private static Object pow(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object pow(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         double y = ScriptRuntime.toNumber(args, 1);
         double result;
@@ -545,11 +573,13 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(result);
     }
 
-    private static Object random(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object random(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ScriptRuntime.wrapNumber(Math.random());
     }
 
-    private static Object round(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object round(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && !Double.isInfinite(x)) {
             // Round only finite x
@@ -568,7 +598,8 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object sign(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object sign(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x)) {
             if (x == 0) {
@@ -582,37 +613,43 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object sin(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object sin(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Double.isInfinite(x) ? Double.NaN : Math.sin(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object sinh(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object sinh(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.sinh(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object sqrt(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object sqrt(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.sqrt(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object tan(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object tan(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.tan(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object tanh(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object tanh(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.tanh(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object trunc(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object trunc(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = ((x < 0.0) ? Math.ceil(x) : Math.floor(x));
         return ScriptRuntime.wrapNumber(x);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
@@ -6,6 +6,11 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+import static org.mozilla.javascript.ScriptRuntime.wrapNumber;
+
 import java.text.NumberFormat;
 import java.util.IllformedLocaleException;
 import java.util.Locale;
@@ -34,87 +39,57 @@ final class NativeNumber extends ScriptableObject {
     private static final double MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
     private static final double EPSILON = 2.220446049250313e-16;
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                1,
+                                NativeNumber::js_constructorFunc,
+                                NativeNumber::js_constructor)
+                        .withProp(CTOR, "NaN", value(ScriptRuntime.NaNobj))
+                        .withProp(
+                                CTOR,
+                                "POSITIVE_INFINITY",
+                                value(wrapNumber(Double.POSITIVE_INFINITY)))
+                        .withProp(
+                                CTOR,
+                                "NEGATIVE_INFINITY",
+                                value(wrapNumber(Double.NEGATIVE_INFINITY)))
+                        .withProp(CTOR, "MAX_VALUE", value(wrapNumber(Double.MAX_VALUE)))
+                        .withProp(CTOR, "MIN_VALUE", value(wrapNumber(Double.MIN_VALUE)))
+                        .withProp(CTOR, "MAX_SAFE_INTEGER", value(wrapNumber(MAX_SAFE_INTEGER)))
+                        .withProp(CTOR, "MIN_SAFE_INTEGER", value(wrapNumber(MIN_SAFE_INTEGER)))
+                        .withProp(CTOR, "EPSILON", value(wrapNumber(EPSILON)))
+                        .withMethod(CTOR, "isFinite", 1, NativeNumber::js_isFinite)
+                        .withMethod(CTOR, "isNaN", 1, NativeNumber::js_isNaN)
+                        .withMethod(CTOR, "isInteger", 1, NativeNumber::js_isInteger)
+                        .withMethod(CTOR, "isSafeInteger", 1, NativeNumber::js_isSafeInteger)
+                        .withProp(
+                                CTOR,
+                                "parseFloat",
+                                (c, s, o) ->
+                                        new DescriptorInfo(s.get("parseFloat", s), DONTENUM, true))
+                        .withProp(
+                                CTOR,
+                                "parseInt",
+                                (c, s, o) ->
+                                        new DescriptorInfo(s.get("parseInt", s), DONTENUM, true))
+                        .withMethod(PROTO, "toString", 1, NativeNumber::js_toString)
+                        .withMethod(PROTO, "toLocaleString", 0, NativeNumber::js_toLocaleString)
+                        .withMethod(PROTO, "toSource", 0, NativeNumber::js_toSource)
+                        .withMethod(PROTO, "valueOf", 0, NativeNumber::js_valueOf)
+                        .withMethod(PROTO, "toFixed", 1, NativeNumber::js_toFixed)
+                        .withMethod(PROTO, "toExponential", 1, NativeNumber::js_toExponential)
+                        .withMethod(PROTO, "toPrecision", 1, NativeNumber::js_toPrecision)
+                        .build();
+    }
+
     private final double doubleValue;
 
-    static void init(VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        1,
-                        NativeNumber::js_constructorFunc,
-                        NativeNumber::js_constructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        constructor.setPrototypeScriptable(new NativeNumber(0.0));
-
-        final int propAttr = DONTENUM | PERMANENT | READONLY;
-
-        constructor.defineProperty("NaN", ScriptRuntime.NaNobj, propAttr);
-        constructor.defineProperty(
-                "POSITIVE_INFINITY", ScriptRuntime.wrapNumber(Double.POSITIVE_INFINITY), propAttr);
-        constructor.defineProperty(
-                "NEGATIVE_INFINITY", ScriptRuntime.wrapNumber(Double.NEGATIVE_INFINITY), propAttr);
-        constructor.defineProperty(
-                "MAX_VALUE", ScriptRuntime.wrapNumber(Double.MAX_VALUE), propAttr);
-        constructor.defineProperty(
-                "MIN_VALUE", ScriptRuntime.wrapNumber(Double.MIN_VALUE), propAttr);
-        constructor.defineProperty(
-                "MAX_SAFE_INTEGER", ScriptRuntime.wrapNumber(MAX_SAFE_INTEGER), propAttr);
-        constructor.defineProperty(
-                "MIN_SAFE_INTEGER", ScriptRuntime.wrapNumber(MIN_SAFE_INTEGER), propAttr);
-        constructor.defineProperty("EPSILON", ScriptRuntime.wrapNumber(EPSILON), propAttr);
-
-        constructor.defineConstructorMethod(
-                scope,
-                "isFinite",
-                1,
-                null,
-                NativeNumber::js_isFinite,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope, "isNaN", 1, null, NativeNumber::js_isNaN, DONTENUM, DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "isInteger",
-                1,
-                null,
-                NativeNumber::js_isInteger,
-                DONTENUM,
-                DONTENUM | READONLY);
-        constructor.defineConstructorMethod(
-                scope,
-                "isSafeInteger",
-                1,
-                null,
-                NativeNumber::js_isSafeInteger,
-                DONTENUM,
-                DONTENUM | READONLY);
-
-        Object parseFloat = ScriptRuntime.getTopLevelProp(scope, "parseFloat");
-        if (parseFloat instanceof Function) {
-            constructor.defineProperty("parseFloat", parseFloat, DONTENUM);
-        }
-        Object parseInt = ScriptRuntime.getTopLevelProp(scope, "parseInt");
-        if (parseInt instanceof Function) {
-            constructor.defineProperty("parseInt", parseInt, DONTENUM);
-        }
-
-        constructor.definePrototypeMethod(scope, "toString", 1, NativeNumber::js_toString);
-        constructor.definePrototypeMethod(
-                scope, "toLocaleString", 0, NativeNumber::js_toLocaleString);
-        constructor.definePrototypeMethod(scope, "toSource", 0, NativeNumber::js_toSource);
-        constructor.definePrototypeMethod(scope, "valueOf", 0, NativeNumber::js_valueOf);
-        constructor.definePrototypeMethod(scope, "toFixed", 1, NativeNumber::js_toFixed);
-        constructor.definePrototypeMethod(
-                scope, "toExponential", 1, NativeNumber::js_toExponential);
-        constructor.definePrototypeMethod(scope, "toPrecision", 1, NativeNumber::js_toPrecision);
-
-        ScriptableObject.defineProperty(scope, CLASS_NAME, constructor, DONTENUM);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
+    static void init(Context cx, VarScope scope, boolean sealed) {
+        DESCRIPTOR.buildConstructor(cx, scope, new NativeNumber(0.0), sealed);
     }
 
     NativeNumber(double number) {
@@ -126,21 +101,27 @@ final class NativeNumber extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double val = (args.length > 0) ? ScriptRuntime.toNumeric(args[0]).doubleValue() : 0.0;
-        return new NativeNumber(val);
+        var res = new NativeNumber(val);
+        res.setPrototype((Scriptable) f.getPrototypeProperty());
+        res.setParentScope(f.getDeclarationScope());
+        return res;
     }
 
     private static Object js_constructorFunc(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return (args.length > 0) ? ScriptRuntime.toNumeric(args[0]).doubleValue() : 0.0;
     }
 
-    private static Object js_valueOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_valueOf(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return toSelf(thisObj).doubleValue;
     }
 
-    private static Object js_toFixed(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toFixed(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double value = toSelf(thisObj).doubleValue;
 
         int fractionDigits;
@@ -162,7 +143,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toExponential(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double value = toSelf(thisObj).doubleValue;
 
         double p;
@@ -188,7 +169,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toPrecision(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double value = toSelf(thisObj).doubleValue;
         // Undefined precision, fall back to ToString()
         if (args.length == 0 || Undefined.isUndefined(args[0])) {
@@ -217,7 +198,8 @@ final class NativeNumber extends ScriptableObject {
         return LambdaConstructor.convertThisObject(thisObj, NativeNumber.class);
     }
 
-    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toString(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         int base =
                 (args.length == 0 || Undefined.isUndefined(args[0]))
                         ? 10
@@ -226,9 +208,9 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toLocaleString(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!cx.hasFeature(Context.FEATURE_INTL_402)) {
-            return js_toString(cx, scope, thisObj, ScriptRuntime.emptyArgs);
+            return js_toString(cx, f, nt, s, thisObj, ScriptRuntime.emptyArgs);
         }
 
         if (args.length != 0 && args[0] instanceof String) {
@@ -245,7 +227,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toSource(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return "(new Number(" + ScriptRuntime.toString(toSelf(thisObj).doubleValue) + "))";
     }
 
@@ -263,7 +245,8 @@ final class NativeNumber extends ScriptableObject {
         return ScriptRuntime.numberToString(doubleValue, 10);
     }
 
-    private static Object js_isFinite(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_isFinite(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Number n = argToNumber(args);
         return n == null ? Boolean.FALSE : isFinite(n);
     }
@@ -273,7 +256,8 @@ final class NativeNumber extends ScriptableObject {
         return Double.isFinite(nd);
     }
 
-    private static Object js_isNaN(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_isNaN(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Number val = argToNumber(args);
         if (val == null) {
             return false;
@@ -285,7 +269,8 @@ final class NativeNumber extends ScriptableObject {
         return Double.isNaN(d);
     }
 
-    private static Object js_isInteger(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_isInteger(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Number val = argToNumber(args);
         if (val == null) {
             return false;
@@ -297,7 +282,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_isSafeInteger(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Number val = argToNumber(args);
         if (val == null) {
             return false;

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -459,13 +459,13 @@ public class NativePromise extends ScriptableObject {
         return new LambdaFunction(
                 scope,
                 1,
-                (Context cx, VarScope ls, Scriptable thisObj, Object[] args) -> {
+                (Context cx, VarScope ls, Object thisObj, Object[] args) -> {
                     Object value = args.length > 0 ? args[0] : Undefined.instance;
                     LambdaFunction valueThunk =
                             new LambdaFunction(
                                     scope,
                                     0,
-                                    (Context vc, VarScope vs, Scriptable vt, Object[] va) -> value);
+                                    (Context vc, VarScope vs, Object vt, Object[] va) -> value);
                     Object result =
                             onFinally.call(
                                     cx,
@@ -484,13 +484,13 @@ public class NativePromise extends ScriptableObject {
         return new LambdaFunction(
                 scope,
                 1,
-                (Context cx, VarScope ls, Scriptable thisObj, Object[] args) -> {
+                (Context cx, VarScope ls, Object thisObj, Object[] args) -> {
                     Object reason = args.length > 0 ? args[0] : Undefined.instance;
                     LambdaFunction reasonThrower =
                             new LambdaFunction(
                                     scope,
                                     0,
-                                    (Context vc, VarScope vs, Scriptable vt, Object[] va) -> {
+                                    (Context vc, VarScope vs, Object vt, Object[] va) -> {
                                         throw new JavaScriptException(reason, null, 0);
                                     });
                     Object result =
@@ -614,7 +614,7 @@ public class NativePromise extends ScriptableObject {
                     new LambdaFunction(
                             topScope,
                             1,
-                            (Context cx, VarScope scope, Scriptable thisObj, Object[] args) ->
+                            (Context cx, VarScope scope, Object thisObj, Object[] args) ->
                                     resolve(
                                             cx,
                                             scope,
@@ -624,7 +624,7 @@ public class NativePromise extends ScriptableObject {
                     new LambdaFunction(
                             topScope,
                             1,
-                            (Context cx, VarScope scope, Scriptable thisObj, Object[] args) ->
+                            (Context cx, VarScope scope, Object thisObj, Object[] args) ->
                                     reject(
                                             cx,
                                             scope,
@@ -738,7 +738,7 @@ public class NativePromise extends ScriptableObject {
                     new LambdaFunction(
                             topScope,
                             2,
-                            (Context cx, VarScope scope, Scriptable thisObj, Object[] args) ->
+                            (Context cx, VarScope scope, Object thisObj, Object[] args) ->
                                     executor(args));
 
             promise = ((Constructable) pc).construct(topCx, topScope, new Object[] {executorFunc});
@@ -777,15 +777,12 @@ public class NativePromise extends ScriptableObject {
         int remainingElements = 1;
 
         IteratorLikeIterable.Itr iterator;
-        Scriptable thisObj;
+        Object thisObj;
         Capability capability;
         boolean failFast;
 
         PromiseAllResolver(
-                IteratorLikeIterable.Itr iter,
-                Scriptable thisObj,
-                Capability cap,
-                boolean failFast) {
+                IteratorLikeIterable.Itr iter, Object thisObj, Capability cap, boolean failFast) {
             this.iterator = iter;
             this.thisObj = thisObj;
             this.capability = cap;
@@ -836,7 +833,7 @@ public class NativePromise extends ScriptableObject {
                         new LambdaFunction(
                                 topScope,
                                 1,
-                                (Context cx, VarScope scope, Scriptable thisObj, Object[] args) -> {
+                                (cx, scope, thisObj, args) -> {
                                     Object value = (args.length > 0 ? args[0] : Undefined.instance);
                                     if (!failFast) {
                                         Scriptable elementResult = cx.newObject(scope);
@@ -853,10 +850,7 @@ public class NativePromise extends ScriptableObject {
                             new LambdaFunction(
                                     topScope,
                                     1,
-                                    (Context cx,
-                                            VarScope scope,
-                                            Scriptable thisObj,
-                                            Object[] args) -> {
+                                    (cx, scope, thisObj, args) -> {
                                         Scriptable result = cx.newObject(scope);
                                         result.put("status", result, " rejected");
                                         result.put(
@@ -953,7 +947,7 @@ public class NativePromise extends ScriptableObject {
                         new LambdaFunction(
                                 topScope,
                                 1,
-                                (Context cx, VarScope scope, Scriptable thisObj, Object[] args) -> {
+                                (cx, scope, thisObj, args) -> {
                                     Object value = (args.length > 0 ? args[0] : Undefined.instance);
                                     return eltResolver.reject(cx, scope, value, this);
                                 });

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -4,6 +4,10 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.util.ArrayList;
 import org.mozilla.javascript.TopLevel.NativeErrors;
 
@@ -20,6 +24,34 @@ public class NativePromise extends ScriptableObject {
         REJECT
     }
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                "Promise",
+                                1,
+                                ClassDescriptor.typeError(),
+                                NativePromise::constructor)
+                        .withMethod(CTOR, "resolve", 1, NativePromise::resolve)
+                        .withMethod(CTOR, "reject", 1, NativePromise::reject)
+                        .withMethod(CTOR, "all", 1, NativePromise::all)
+                        .withMethod(CTOR, "allSettled", 1, NativePromise::allSettled)
+                        .withMethod(CTOR, "race", 1, NativePromise::race)
+                        .withMethod(CTOR, "any", 1, NativePromise::any)
+                        .withMethod(CTOR, "withResolvers", 0, NativePromise::withResolvers)
+                        .withMethod(CTOR, "try", 1, NativePromise::promiseTry)
+                        .withMethod(PROTO, "then", 2, NativePromise::doThen)
+                        .withMethod(PROTO, "catch", 1, NativePromise::doCatch)
+                        .withMethod(PROTO, "finally", 1, NativePromise::doFinally)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value("Promise", DONTENUM | READONLY))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
+
     private State state = State.PENDING;
     private Object result = null;
     private boolean handled = false;
@@ -28,49 +60,19 @@ public class NativePromise extends ScriptableObject {
     private ArrayList<Reaction> rejectReactions = new ArrayList<>();
 
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        "Promise",
-                        1,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativePromise::constructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.defineConstructorMethod(scope, "resolve", 1, NativePromise::resolve);
-        constructor.defineConstructorMethod(scope, "reject", 1, NativePromise::reject);
-        constructor.defineConstructorMethod(scope, "all", 1, NativePromise::all);
-        constructor.defineConstructorMethod(scope, "allSettled", 1, NativePromise::allSettled);
-        constructor.defineConstructorMethod(scope, "race", 1, NativePromise::race);
-        constructor.defineConstructorMethod(scope, "any", 1, NativePromise::any);
-        constructor.defineConstructorMethod(
-                scope, "withResolvers", 0, NativePromise::withResolvers);
-        constructor.defineConstructorMethod(scope, "try", 1, NativePromise::promiseTry);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-
-        constructor.definePrototypeMethod(scope, "then", 2, NativePromise::doThen);
-        constructor.definePrototypeMethod(scope, "catch", 1, NativePromise::doCatch);
-        constructor.definePrototypeMethod(scope, "finally", 1, NativePromise::doFinally);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, "Promise", DONTENUM | READONLY);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
-    private static Scriptable constructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 1 || !(args[0] instanceof Callable)) {
             throw ScriptRuntime.typeErrorById("msg.function.expected");
         }
         Callable executor = (Callable) args[0];
         NativePromise promise = new NativePromise();
-        ResolvingFunctions resolving = new ResolvingFunctions(scope, promise);
+        ResolvingFunctions resolving = new ResolvingFunctions(f.getDeclarationScope(), promise);
 
-        Scriptable thisObj = Undefined.SCRIPTABLE_UNDEFINED;
+        thisObj = Undefined.SCRIPTABLE_UNDEFINED;
         if (!cx.isStrictMode()) {
             TopLevel tcs = cx.topCallScope;
             if (tcs != null) {
@@ -78,12 +80,17 @@ public class NativePromise extends ScriptableObject {
             }
         }
 
+        var thisArg = (Scriptable) thisObj;
+
         try {
-            executor.call(cx, scope, thisObj, new Object[] {resolving.resolve, resolving.reject});
+            executor.call(cx, s, thisArg, new Object[] {resolving.resolve, resolving.reject});
         } catch (RhinoException re) {
-            resolving.reject.call(cx, scope, thisObj, new Object[] {getErrorObject(cx, scope, re)});
+            resolving.reject.call(
+                    cx, s, thisArg, new Object[] {getErrorObject(cx, f.getDeclarationScope(), re)});
         }
 
+        promise.setParentScope(f.getDeclarationScope());
+        promise.setPrototype((Scriptable) f.getPrototypeProperty());
         return promise;
     }
 
@@ -97,12 +104,13 @@ public class NativePromise extends ScriptableObject {
     }
 
     // Promise.resolve
-    private static Object resolve(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object resolve(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
-        return resolveInternal(cx, scope, thisObj, arg);
+        return resolveInternal(cx, s, thisObj, arg);
     }
 
     // PromiseResolve abstract operation
@@ -120,18 +128,20 @@ public class NativePromise extends ScriptableObject {
     }
 
     // Promise.reject
-    private static Object reject(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object reject(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
-        Capability cap = new Capability(cx, scope, thisObj);
-        cap.reject.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
+        Capability cap = new Capability(cx, f.getDeclarationScope(), thisObj);
+        cap.reject.call(
+                cx, f.getDeclarationScope(), Undefined.SCRIPTABLE_UNDEFINED, new Object[] {arg});
         return cap.promise;
     }
 
     private static Object doAll(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args, boolean failFast) {
+            Context cx, VarScope scope, Object thisObj, Object[] args, boolean failFast) {
         Capability cap = new Capability(cx, scope, thisObj);
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
 
@@ -150,7 +160,8 @@ public class NativePromise extends ScriptableObject {
 
         IteratorLikeIterable.Itr iterator = iterable.iterator();
         try {
-            PromiseAllResolver resolver = new PromiseAllResolver(iterator, thisObj, cap, failFast);
+            PromiseAllResolver resolver =
+                    new PromiseAllResolver(iterator, (Scriptable) thisObj, cap, failFast);
             try {
                 return resolver.resolve(cx, scope);
             } finally {
@@ -169,38 +180,41 @@ public class NativePromise extends ScriptableObject {
     }
 
     // Promise.all
-    private static Object all(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        return doAll(cx, scope, thisObj, args, true);
+    private static Object all(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return doAll(cx, f.getDeclarationScope(), thisObj, args, true);
     }
 
     // Promise.allSettled
     private static Object allSettled(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        return doAll(cx, scope, thisObj, args, false);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return doAll(cx, f.getDeclarationScope(), thisObj, args, false);
     }
 
     // Promise.race
-    private static Object race(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        Capability cap = new Capability(cx, scope, thisObj);
+    private static Object race(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
+        Capability cap = new Capability(cx, fscope, thisObj);
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
 
         IteratorLikeIterable iterable;
         try {
-            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, scope);
-            iterable = new IteratorLikeIterable(cx, scope, maybeIterable);
+            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, f.getDeclarationScope());
+            iterable = new IteratorLikeIterable(cx, fscope, maybeIterable);
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
 
         IteratorLikeIterable.Itr iterator = iterable.iterator();
         try {
             try {
-                return performRace(cx, scope, iterator, thisObj, cap);
+                return performRace(cx, fscope, iterator, thisObj, cap);
             } finally {
                 if (!iterator.isDone()) {
                     iterable.close();
@@ -209,9 +223,9 @@ public class NativePromise extends ScriptableObject {
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
     }
@@ -220,7 +234,7 @@ public class NativePromise extends ScriptableObject {
             Context cx,
             VarScope scope,
             IteratorLikeIterable.Itr iterator,
-            Scriptable thisObj,
+            Object thisObj,
             Capability cap) {
         var resolve = ScriptRuntime.getPropAndThis(thisObj, "resolve", cx, scope);
 
@@ -255,28 +269,31 @@ public class NativePromise extends ScriptableObject {
         }
     }
 
-    private static Object any(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        Capability cap = new Capability(cx, scope, thisObj);
+    private static Object any(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
+        Capability cap = new Capability(cx, fscope, thisObj);
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
 
         IteratorLikeIterable iterable;
         try {
-            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, scope);
-            iterable = new IteratorLikeIterable(cx, scope, maybeIterable);
+            Object maybeIterable = ScriptRuntime.callIterator(arg, cx, fscope);
+            iterable = new IteratorLikeIterable(cx, fscope, maybeIterable);
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
 
         IteratorLikeIterable.Itr iterator = iterable.iterator();
         try {
-            PromiseAnyRejector rejector = new PromiseAnyRejector(iterator, thisObj, cap);
+            PromiseAnyRejector rejector =
+                    new PromiseAnyRejector(iterator, (Scriptable) thisObj, cap);
             try {
-                return rejector.reject(cx, scope);
+                return rejector.reject(cx, fscope);
             } finally {
                 if (!iterator.isDone()) {
                     iterable.close();
@@ -285,25 +302,26 @@ public class NativePromise extends ScriptableObject {
         } catch (RhinoException re) {
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
             return cap.promise;
         }
     }
 
     // Promise.withResolvers
     private static Object withResolvers(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
 
         // Create a capability which properly constructs a promise with resolve/reject functions
-        Capability cap = new Capability(cx, scope, thisObj);
+        Capability cap = new Capability(cx, fscope, thisObj);
 
         // Create the result object with promise, resolve, and reject properties
-        Scriptable result = cx.newObject(scope);
+        Scriptable result = cx.newObject(fscope);
         result.put("promise", result, cap.promise);
         result.put("resolve", result, cap.resolve);
         result.put("reject", result, cap.reject);
@@ -313,7 +331,8 @@ public class NativePromise extends ScriptableObject {
 
     // Promise.try
     private static Object promiseTry(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
@@ -325,7 +344,7 @@ public class NativePromise extends ScriptableObject {
         Callable func = (Callable) args[0];
 
         // Create a new promise capability using the constructor
-        Capability cap = new Capability(cx, scope, thisObj);
+        Capability cap = new Capability(cx, fscope, thisObj);
 
         // Prepare the arguments to pass to the function (all args after the function)
         Object[] funcArgs = new Object[args.length - 1];
@@ -333,17 +352,17 @@ public class NativePromise extends ScriptableObject {
 
         try {
             // Call the function synchronously
-            Object result = func.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, funcArgs);
+            Object result = func.call(cx, fscope, Undefined.SCRIPTABLE_UNDEFINED, funcArgs);
 
             // Resolve the promise with the result
-            cap.resolve.call(cx, scope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {result});
+            cap.resolve.call(cx, fscope, Undefined.SCRIPTABLE_UNDEFINED, new Object[] {result});
         } catch (RhinoException re) {
             // If the function throws, reject the promise with the error
             cap.reject.call(
                     cx,
-                    scope,
+                    fscope,
                     Undefined.SCRIPTABLE_UNDEFINED,
-                    new Object[] {getErrorObject(cx, scope, re)});
+                    new Object[] {getErrorObject(cx, fscope, re)});
         }
 
         return cap.promise;
@@ -393,22 +412,27 @@ public class NativePromise extends ScriptableObject {
         }
     }
 
-    private static Object doThen(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object doThen(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativePromise self = LambdaConstructor.convertThisObject(thisObj, NativePromise.class);
-        return self.then(cx, scope, args);
+        return self.then(cx, f.getDeclarationScope(), args);
     }
 
     // Promise.prototype.catch
-    private static Object doCatch(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object doCatch(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         Object arg = (args.length > 0 ? args[0] : Undefined.instance);
-        Scriptable coercedThis = ScriptRuntime.toObject(cx, scope, thisObj);
+        Scriptable coercedThis = ScriptRuntime.toObject(cx, fscope, thisObj);
         // No guarantee that the caller didn't change the prototype of "then"!
-        var thenFunc = ScriptRuntime.getPropAndThis(coercedThis, "then", cx, scope);
-        return thenFunc.call(cx, scope, new Object[] {Undefined.instance, arg});
+        var thenFunc = ScriptRuntime.getPropAndThis(coercedThis, "then", cx, fscope);
+        return thenFunc.call(cx, fscope, new Object[] {Undefined.instance, arg});
     }
 
     // Promise.prototype.finally
-    private static Object doFinally(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object doFinally(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        var fscope = f.getDeclarationScope();
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
@@ -417,16 +441,16 @@ public class NativePromise extends ScriptableObject {
         Object catchFinally = onFinally;
         var ctor =
                 TopLevel.getBuiltinCtor(
-                        cx, ScriptableObject.getTopLevelScope(scope), TopLevel.Builtins.Promise);
+                        cx, ScriptableObject.getTopLevelScope(fscope), TopLevel.Builtins.Promise);
         Constructable constructor =
-                AbstractEcmaObjectOperations.speciesConstructor(cx, thisObj, ctor);
+                AbstractEcmaObjectOperations.speciesConstructor(cx, (Scriptable) thisObj, ctor);
         if (onFinally instanceof Callable) {
             Callable callableOnFinally = (Callable) thenFinally;
-            thenFinally = makeThenFinally(scope, constructor, callableOnFinally);
-            catchFinally = makeCatchFinally(scope, constructor, callableOnFinally);
+            thenFinally = makeThenFinally(fscope, constructor, callableOnFinally);
+            catchFinally = makeCatchFinally(fscope, constructor, callableOnFinally);
         }
-        var thenFunc = ScriptRuntime.getPropAndThis(thisObj, "then", cx, scope);
-        return thenFunc.call(cx, scope, new Object[] {thenFinally, catchFinally});
+        var thenFunc = ScriptRuntime.getPropAndThis(thisObj, "then", cx, fscope);
+        return thenFunc.call(cx, fscope, new Object[] {thenFinally, catchFinally});
     }
 
     // Abstract "Then Finally Function"

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -62,7 +62,7 @@ class NativeProxy extends ScriptableObject {
         }
 
         @Override
-        public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
             if (revocableProxy != null) {
                 revocableProxy.handlerObj = null;
                 revocableProxy.targetObj = null;
@@ -1327,7 +1327,7 @@ class NativeProxy extends ScriptableObject {
          * [[Call]] (thisArgument, argumentsList)</a>
          */
         @Override
-        public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
             /*
              * 1. Let handler be O.[[ProxyHandler]].
              * 2. If handler is null, throw a TypeError exception.

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +37,19 @@ class NativeProxy extends ScriptableObject {
     private static final String TRAP_APPLY = "apply";
     private static final String TRAP_CONSTRUCT = "construct";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                PROXY_TAG,
+                                2,
+                                ClassDescriptor.typeError(),
+                                NativeProxy::js_constructor)
+                        .withMethod(CTOR, "revocable", 2, NativeProxy::revocable)
+                        .build();
+    }
+
     private ScriptableObject targetObj;
     private Scriptable handlerObj;
     private final String typeOf;
@@ -58,31 +73,7 @@ class NativeProxy extends ScriptableObject {
     }
 
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        PROXY_TAG,
-                        2,
-                        null, // Proxy constructor has *no* prototype
-                        null, // Proxy constructor may not be called as a function.
-                        NativeProxy::constructor) {
-
-                    @Override
-                    public Scriptable construct(Context cx, VarScope scope, Object[] args) {
-                        NativeProxy obj =
-                                (NativeProxy) getTargetConstructor().construct(cx, scope, args);
-                        // avoid getting trapped
-                        obj.setPrototypeDirect(getClassPrototype());
-                        obj.setParentScope(scope);
-                        return obj;
-                    }
-                };
-
-        constructor.defineConstructorMethod(scope, "revocable", 2, NativeProxy::revocable);
-        if (sealed) {
-            constructor.sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, null, sealed);
     }
 
     private NativeProxy(ScriptableObject target, Scriptable handler) {
@@ -1224,7 +1215,8 @@ class NativeProxy extends ScriptableObject {
         target.setPrototype(prototype);
     }
 
-    private static NativeProxy constructor(Context cx, VarScope scope, Object[] args) {
+    private static NativeProxy js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -1242,22 +1234,23 @@ class NativeProxy extends ScriptableObject {
             proxy = new NativeProxy(target, handler);
         }
 
-        proxy.setPrototypeDirect(ScriptableObject.getClassPrototype(scope, PROXY_TAG));
-        proxy.setParentScope(scope);
+        proxy.setPrototypeDirect(ScriptableObject.getClassPrototype(s, PROXY_TAG));
+        proxy.setParentScope(s);
         return proxy;
     }
 
     // Proxy.revocable
-    private static Object revocable(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object revocable(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }
-        NativeProxy proxy = constructor(cx, scope, args);
+        NativeProxy proxy = js_constructor(cx, f, nt, s, thisObj, args);
 
-        NativeObject revocable = (NativeObject) cx.newObject(scope);
+        NativeObject revocable = (NativeObject) cx.newObject(s);
 
         revocable.put("proxy", revocable, proxy);
-        revocable.put("revoke", revocable, new LambdaFunction(scope, "", 0, new Revoker(proxy)));
+        revocable.put("revoke", revocable, new LambdaFunction(s, "", 0, new Revoker(proxy)));
         return revocable;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
@@ -20,32 +23,37 @@ final class NativeReflect extends ScriptableObject {
 
     private static final String REFLECT_TAG = "Reflect";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(REFLECT_TAG)
+                        .withMethod(CTOR, "apply", 3, NativeReflect::apply)
+                        .withMethod(CTOR, "construct", 2, NativeReflect::construct)
+                        .withMethod(CTOR, "defineProperty", 3, NativeReflect::defineProperty)
+                        .withMethod(CTOR, "deleteProperty", 2, NativeReflect::deleteProperty)
+                        .withMethod(CTOR, "get", 2, NativeReflect::get)
+                        .withMethod(
+                                CTOR,
+                                "getOwnPropertyDescriptor",
+                                2,
+                                NativeReflect::getOwnPropertyDescriptor)
+                        .withMethod(CTOR, "getPrototypeOf", 1, NativeReflect::getPrototypeOf)
+                        .withMethod(CTOR, "has", 2, NativeReflect::has)
+                        .withMethod(CTOR, "isExtensible", 1, NativeReflect::isExtensible)
+                        .withMethod(CTOR, "ownKeys", 1, NativeReflect::ownKeys)
+                        .withMethod(CTOR, "preventExtensions", 1, NativeReflect::preventExtensions)
+                        .withMethod(CTOR, "set", 3, NativeReflect::set)
+                        .withMethod(CTOR, "setPrototypeOf", 2, NativeReflect::setPrototypeOf)
+                        .withProp(
+                                CTOR,
+                                SymbolKey.TO_STRING_TAG,
+                                value(REFLECT_TAG, DONTENUM | READONLY))
+                        .build();
+    }
+
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        NativeReflect reflect = new NativeReflect();
-        reflect.setPrototype(getObjectPrototype(scope));
-        reflect.setParentScope(scope);
-
-        reflect.defineBuiltinProperty(scope, "apply", 3, NativeReflect::apply);
-        reflect.defineBuiltinProperty(scope, "construct", 2, NativeReflect::construct);
-        reflect.defineBuiltinProperty(scope, "defineProperty", 3, NativeReflect::defineProperty);
-        reflect.defineBuiltinProperty(scope, "deleteProperty", 2, NativeReflect::deleteProperty);
-        reflect.defineBuiltinProperty(scope, "get", 2, NativeReflect::get);
-        reflect.defineBuiltinProperty(
-                scope, "getOwnPropertyDescriptor", 2, NativeReflect::getOwnPropertyDescriptor);
-        reflect.defineBuiltinProperty(scope, "getPrototypeOf", 1, NativeReflect::getPrototypeOf);
-        reflect.defineBuiltinProperty(scope, "has", 2, NativeReflect::has);
-        reflect.defineBuiltinProperty(scope, "isExtensible", 1, NativeReflect::isExtensible);
-        reflect.defineBuiltinProperty(scope, "ownKeys", 1, NativeReflect::ownKeys);
-        reflect.defineBuiltinProperty(
-                scope, "preventExtensions", 1, NativeReflect::preventExtensions);
-        reflect.defineBuiltinProperty(scope, "set", 3, NativeReflect::set);
-        reflect.defineBuiltinProperty(scope, "setPrototypeOf", 2, NativeReflect::setPrototypeOf);
-
-        reflect.defineProperty(SymbolKey.TO_STRING_TAG, REFLECT_TAG, DONTENUM | READONLY);
-        if (sealed) {
-            reflect.sealObject();
-        }
-        return reflect;
+        return DESCRIPTOR.populateGlobal(cx, scope, new NativeObject(), sealed);
     }
 
     private NativeReflect() {}
@@ -55,7 +63,8 @@ final class NativeReflect extends ScriptableObject {
         return "Reflect";
     }
 
-    private static Object apply(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object apply(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -69,7 +78,7 @@ final class NativeReflect extends ScriptableObject {
         if (args[1] instanceof Scriptable) {
             thisObj = (Scriptable) args[1];
         } else if (ScriptRuntime.isPrimitive(args[1])) {
-            thisObj = cx.newObject(scope, "Object", new Object[] {args[1]});
+            thisObj = cx.newObject(s, "Object", new Object[] {args[1]});
         }
 
         if (ScriptRuntime.isSymbol(args[2])) {
@@ -78,7 +87,7 @@ final class NativeReflect extends ScriptableObject {
         ScriptableObject argumentsList = ScriptableObject.ensureScriptableObject(args[2]);
 
         return ScriptRuntime.applyOrCall(
-                true, cx, scope, callable, new Object[] {thisObj, argumentsList});
+                true, cx, s, callable, new Object[] {thisObj, argumentsList});
     }
 
     /**
@@ -86,7 +95,7 @@ final class NativeReflect extends ScriptableObject {
      * Reflect.construct (target, argumentsList[, newTarget])</a>
      */
     private static Scriptable construct(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         /*
          * 1. If IsConstructor(target) is false, throw a TypeError exception.
          * 2. If newTarget is not present, set newTarget to target.
@@ -108,7 +117,7 @@ final class NativeReflect extends ScriptableObject {
 
         Constructable ctor = (Constructable) args[0];
         if (args.length < 2) {
-            return ctor.construct(cx, scope, ScriptRuntime.emptyArgs);
+            return ctor.construct(cx, s, ScriptRuntime.emptyArgs);
         }
 
         if (args.length > 2 && !AbstractEcmaObjectOperations.isConstructor(cx, args[2])) {
@@ -139,11 +148,11 @@ final class NativeReflect extends ScriptableObject {
         // the prototype before executing call(..).
         if (ctor instanceof BaseFunction && newTargetPrototype != null) {
             BaseFunction ctorBaseFunction = (BaseFunction) ctor;
-            Scriptable result = ctorBaseFunction.createObject(cx, scope);
+            Scriptable result = ctorBaseFunction.createObject(cx, s);
             if (result != null) {
                 result.setPrototype((Scriptable) newTargetPrototype);
 
-                Object val = ctorBaseFunction.call(cx, scope, result, callArgs);
+                Object val = ctorBaseFunction.call(cx, s, result, callArgs);
                 if (val instanceof Scriptable) {
                     return (Scriptable) val;
                 }
@@ -152,7 +161,7 @@ final class NativeReflect extends ScriptableObject {
             }
         }
 
-        Scriptable newScriptable = ctor.construct(cx, scope, callArgs);
+        Scriptable newScriptable = ctor.construct(cx, s, callArgs);
         if (newTargetPrototype != null) {
             newScriptable.setPrototype((Scriptable) newTargetPrototype);
         }
@@ -161,7 +170,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object defineProperty(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -191,7 +200,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object deleteProperty(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -204,7 +213,8 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
-    private static Object get(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object get(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -224,29 +234,30 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Scriptable getOwnPropertyDescriptor(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
             if (ScriptRuntime.isSymbol(args[1])) {
                 var desc = target.getOwnPropertyDescriptor(cx, args[1]);
-                return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(scope);
+                return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(s);
             }
 
             var desc = target.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(args[1]));
-            return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(scope);
+            return desc == null ? Undefined.SCRIPTABLE_UNDEFINED : desc.toObject(s);
         }
         return Undefined.SCRIPTABLE_UNDEFINED;
     }
 
     private static Scriptable getPrototypeOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         return target.getPrototype();
     }
 
-    private static Object has(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object has(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -259,12 +270,14 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
-    private static Object isExtensible(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object isExtensible(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
         return target.isExtensible();
     }
 
-    private static Scriptable ownKeys(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Scriptable ownKeys(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         final List<Object> strings = new ArrayList<>();
@@ -286,17 +299,18 @@ final class NativeReflect extends ScriptableObject {
         System.arraycopy(strings.toArray(), 0, keys, 0, strings.size());
         System.arraycopy(symbols.toArray(), 0, keys, strings.size(), symbols.size());
 
-        return cx.newArray(scope, keys);
+        return cx.newArray(s, keys);
     }
 
     private static Object preventExtensions(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         return target.preventExtensions();
     }
 
-    private static Object set(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object set(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
         if (args.length < 2) {
             return true;
@@ -309,7 +323,7 @@ final class NativeReflect extends ScriptableObject {
             if (descriptor != null) {
                 Object setter = descriptor.setter;
                 if (setter != null && setter != NOT_FOUND) {
-                    ((Function) setter).call(cx, scope, receiver, new Object[] {args[2]});
+                    ((Function) setter).call(cx, s, receiver, new Object[] {args[2]});
                     return true;
                 }
 
@@ -322,11 +336,11 @@ final class NativeReflect extends ScriptableObject {
         if (ScriptRuntime.isSymbol(args[1])) {
             receiver.put((Symbol) args[1], receiver, args[2]);
         } else {
-            StringIdOrIndex s = ScriptRuntime.toStringIdOrIndex(args[1]);
-            if (s.stringId == null) {
-                receiver.put(s.index, receiver, args[2]);
+            StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(args[1]);
+            if (soi.stringId == null) {
+                receiver.put(soi.index, receiver, args[2]);
             } else {
-                receiver.put(s.stringId, receiver, args[2]);
+                receiver.put(soi.stringId, receiver, args[2]);
             }
         }
 
@@ -334,7 +348,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object setPrototypeOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",

--- a/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
@@ -66,7 +66,7 @@ class NativeScript extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (script != null) {
             return script.exec(cx, scope, thisObj);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
@@ -25,7 +25,7 @@ class NativeScript extends BaseFunction {
 
     private static final Object SCRIPT_TAG = "Script";
 
-    static LambdaConstructor init(Context cx, VarScope scope, boolean sealed) {
+    static LambdaConstructor init2(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor obj =
                 new LambdaConstructor(
                         scope,
@@ -70,7 +70,7 @@ class NativeScript extends BaseFunction {
      */
     @Deprecated
     static void init(VarScope scope, boolean sealed) {
-        init(Context.getContext(), scope, sealed);
+        init2(Context.getContext(), scope, sealed);
     }
 
     private NativeScript(Script script) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.util.EnumSet;
 
 /**
@@ -23,46 +25,26 @@ import java.util.EnumSet;
 class NativeScript extends BaseFunction {
     private static final long serialVersionUID = -6795101161980121700L;
 
-    private static final Object SCRIPT_TAG = "Script";
+    private static final String SCRIPT_TAG = "Script";
 
-    static LambdaConstructor init2(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor obj =
-                new LambdaConstructor(
-                        scope,
-                        "Script",
-                        1,
-                        NativeScript::js_constructorCall,
-                        NativeScript::js_constructor);
+    private static final ClassDescriptor DESCRIPTOR;
 
-        var proto = new NativeScript(null);
-        proto.setPrototypeProperty(null);
-        obj.setPrototypeProperty(proto);
-
-        var function = (Scriptable) ScriptableObject.getProperty(scope, "Function");
-        var functionProto = (Scriptable) ScriptableObject.getProperty(function, "prototype");
-        proto.setPrototype(functionProto);
-
-        defineMethod(obj, scope, "toString", 0, NativeScript::js_toString);
-        defineMethod(obj, scope, "exec", 0, NativeScript::js_exec);
-        defineMethod(obj, scope, "compile", 0, NativeScript::js_compile);
-
-        ScriptableObject.defineProperty(scope, "Script", obj, DONTENUM);
-        if (sealed) {
-            obj.sealObject();
-            ((ScriptableObject) obj.getPrototypeProperty()).sealObject();
-        }
-
-        return obj;
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                SCRIPT_TAG,
+                                1,
+                                NativeScript::js_constructorCall,
+                                NativeScript::js_constructor)
+                        .withMethod(PROTO, "toString", 0, NativeScript::js_toString)
+                        .withMethod(PROTO, "exec", 0, NativeScript::js_exec)
+                        .withMethod(PROTO, "compile", 0, NativeScript::js_compile)
+                        .build();
     }
 
-    private static void defineMethod(
-            LambdaConstructor typedArray,
-            VarScope scope,
-            String name,
-            int length,
-            SerializableCallable target) {
-        typedArray.definePrototypeMethod(
-                scope, name, length, target, DONTENUM, DONTENUM | READONLY);
+    static JSFunction init2(Context cx, VarScope scope, boolean sealed) {
+        var proto = new NativeScript(null);
+        return DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
     }
 
     /**
@@ -114,18 +96,21 @@ class NativeScript extends BaseFunction {
         return super.decompile(indent, flags);
     }
 
-    private static Object js_compile(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_compile(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeScript real = realThis(thisObj, "compile");
         String source = ScriptRuntime.toString(args, 0);
         real.script = compile(cx, source);
         return real;
     }
 
-    private static Object js_exec(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_exec(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         throw Context.reportRuntimeErrorById("msg.cant.call.indirect", "exec");
     }
 
-    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toString(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeScript real = realThis(thisObj, "toString");
         Script realScript = real.script;
         if (realScript == null) {
@@ -135,15 +120,16 @@ class NativeScript extends BaseFunction {
     }
 
     private static Scriptable js_constructorCall(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return js_constructor(cx, scope, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_constructor(cx, f, nt, s, thisObj, args);
     }
 
-    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String source = (args.length == 0) ? "" : ScriptRuntime.toString(args[0]);
         Script script = compile(cx, source);
         NativeScript nscript = new NativeScript(script);
-        ScriptRuntime.setObjectProtoAndParent(nscript, scope);
+        ScriptRuntime.setObjectProtoAndParent(nscript, f.getDeclarationScope());
         return nscript;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -193,9 +193,8 @@ public class NativeSet extends ScriptableObject {
         final Function f = (Function) arg1;
 
         for (Hashtable.Entry entry : entries) {
-            Scriptable thisObj = ScriptRuntime.getThisForScope(f.getDeclarationScope(), arg2);
             final Hashtable.Entry e = entry;
-            f.call(cx, scope, thisObj, new Object[] {e.value, e.value, this});
+            f.call(cx, scope, arg2, new Object[] {e.value, e.value, this});
         }
         return Undefined.instance;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -6,6 +6,11 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.alias;
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 public class NativeSet extends ScriptableObject {
     private static final long serialVersionUID = -8442212766987072986L;
     private static final String CLASS_NAME = "Set";
@@ -13,8 +18,55 @@ public class NativeSet extends ScriptableObject {
 
     static final SymbolKey GETSIZE = new SymbolKey("[Symbol.getSize]", Symbol.Kind.REGULAR);
 
+    private static final ClassDescriptor DESCRIPTOR;
     private static final ClassDescriptor ITER_DESCRIPTOR =
             ES6Iterator.makeDescriptor(ITERATOR_TAG, ITERATOR_TAG);
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                0,
+                                ClassDescriptor.typeError(),
+                                NativeSet::js_constructor)
+                        .withMethod(PROTO, "add", 1, NativeSet::js_add)
+                        .withMethod(PROTO, "delete", 1, NativeSet::js_delete)
+                        .withMethod(PROTO, "has", 1, NativeSet::js_has)
+                        .withMethod(PROTO, "clear", 0, NativeSet::js_clear)
+                        .withMethod(PROTO, "values", 0, NativeSet::js_values)
+                        .withProp(PROTO, "keys", alias("values", DONTENUM | READONLY))
+                        .withProp(PROTO, SymbolKey.ITERATOR, alias("values", DONTENUM))
+                        .withMethod(PROTO, "forEach", 1, NativeSet::js_forEach)
+                        .withMethod(PROTO, "entries", 0, NativeSet::js_entries)
+
+                        // ES2025 Set methods
+                        .withMethod(PROTO, "intersection", 1, NativeSet::js_intersection)
+                        .withMethod(PROTO, "union", 1, NativeSet::js_union)
+                        .withMethod(PROTO, "difference", 1, NativeSet::js_difference)
+                        .withMethod(
+                                PROTO, "symmetricDifference", 1, NativeSet::js_symmetricDifference)
+                        .withMethod(PROTO, "isSubsetOf", 1, NativeSet::js_isSubsetOf)
+                        .withMethod(PROTO, "isSupersetOf", 1, NativeSet::js_isSupersetOf)
+                        .withMethod(PROTO, "isDisjointFrom", 1, NativeSet::js_isDisjointFrom)
+                        .withProp(
+                                PROTO,
+                                "size",
+                                (thisObj) -> realThis(thisObj, "size").js_getSize(),
+                                null,
+                                DONTENUM)
+                        .withProp(
+                                PROTO,
+                                NativeSet.GETSIZE,
+                                (thisObj) -> realThis(thisObj, "size").js_getSize(),
+                                null,
+                                DONTENUM | PERMANENT)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     private final Hashtable entries = new Hashtable();
 
@@ -28,74 +80,7 @@ public class NativeSet extends ScriptableObject {
                 new NativeCollectionIterator(ITERATOR_TAG),
                 sealed,
                 ITERATOR_TAG);
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        0,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeSet::jsConstructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        var propAttrs = DONTENUM | READONLY;
-        constructor.definePrototypeMethod(scope, "add", 1, NativeSet::js_add, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "delete", 1, NativeSet::js_delete, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(scope, "has", 1, NativeSet::js_has, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "clear", 0, NativeSet::js_clear, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "values", 0, NativeSet::js_values, DONTENUM, propAttrs);
-        constructor.definePrototypeAlias("values", "keys", propAttrs);
-        constructor.definePrototypeAlias("values", SymbolKey.ITERATOR, DONTENUM);
-
-        constructor.definePrototypeMethod(
-                scope, "forEach", 1, NativeSet::js_forEach, DONTENUM, propAttrs);
-
-        constructor.definePrototypeMethod(
-                scope, "entries", 0, NativeSet::js_entries, DONTENUM, propAttrs);
-
-        // ES2025 Set methods
-        constructor.definePrototypeMethod(
-                scope, "intersection", 1, NativeSet::js_intersection, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "union", 1, NativeSet::js_union, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "difference", 1, NativeSet::js_difference, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope,
-                "symmetricDifference",
-                1,
-                NativeSet::js_symmetricDifference,
-                DONTENUM,
-                propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "isSubsetOf", 1, NativeSet::js_isSubsetOf, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "isSupersetOf", 1, NativeSet::js_isSupersetOf, DONTENUM, propAttrs);
-        constructor.definePrototypeMethod(
-                scope, "isDisjointFrom", 1, NativeSet::js_isDisjointFrom, DONTENUM, propAttrs);
-
-        // The spec requires very specific handling of the "size" prototype
-        // property that's not like other things that we already do.
-        ScriptableObject desc = (ScriptableObject) cx.newObject(scope);
-        desc.put("enumerable", desc, Boolean.FALSE);
-        desc.put("configurable", desc, Boolean.TRUE);
-        LambdaFunction sizeFunc = new LambdaFunction(scope, "get size", 0, NativeSet::js_getSize);
-        sizeFunc.setPrototypeProperty(Undefined.instance);
-        desc.put("get", desc, sizeFunc);
-        constructor.definePrototypeProperty(cx, "size", desc);
-        constructor.definePrototypeProperty(cx, NativeSet.GETSIZE, desc);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
     @Override
@@ -103,16 +88,20 @@ public class NativeSet extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet ns = new NativeSet();
         ns.instanceOfSet = true;
         if (args.length > 0) {
-            loadFromIterable(cx, scope, ns, NativeMap.key(args));
+            loadFromIterable(cx, s, ns, NativeMap.key(args));
         }
+        ns.setParentScope(f.getDeclarationScope());
+        ns.setPrototype((Scriptable) f.getPrototypeProperty());
         return ns;
     }
 
-    private static Object js_add(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_add(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         var k = NativeMap.key(args);
         return realThis.js_add(k);
@@ -128,7 +117,8 @@ public class NativeSet extends ScriptableObject {
         return this;
     }
 
-    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_delete(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_delete(arg);
@@ -138,7 +128,8 @@ public class NativeSet extends ScriptableObject {
         return entries.deleteEntry(arg);
     }
 
-    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_has(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_has(arg);
@@ -152,7 +143,8 @@ public class NativeSet extends ScriptableObject {
         return entries.has(arg);
     }
 
-    private static Object js_clear(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_clear(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         return realThis.js_clear();
     }
@@ -162,34 +154,34 @@ public class NativeSet extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private static Object js_getSize(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        NativeSet realThis = realThis(thisObj, "add");
-        return realThis.js_getSize();
-    }
-
     private Object js_getSize() {
         return entries.size();
     }
 
-    private static Object js_values(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_values(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
-        return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.VALUES);
+        return realThis(thisObj, "values")
+                .js_iterator(f.getDeclarationScope(), NativeCollectionIterator.Type.VALUES);
     }
 
-    private static Object js_entries(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_entries(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
-        return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.BOTH);
+        return realThis(thisObj, "values")
+                .js_iterator(f.getDeclarationScope(), NativeCollectionIterator.Type.BOTH);
     }
 
     private Object js_iterator(VarScope scope, NativeCollectionIterator.Type type) {
         return new NativeCollectionIterator(scope, ITERATOR_TAG, type, entries.iterator());
     }
 
-    private static Object js_forEach(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_forEach(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "forEach")
                 .js_forEach(
                         cx,
-                        scope,
+                        f.getDeclarationScope(),
                         NativeMap.key(args),
                         args.length > 1 ? args[1] : Undefined.SCRIPTABLE_UNDEFINED);
     }
@@ -252,8 +244,8 @@ public class NativeSet extends ScriptableObject {
     // ES2025 Set Methods Implementation
 
     private static Object js_intersection(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "intersection").js_intersection(cx, scope, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "intersection").js_intersection(cx, s, args);
     }
 
     private Object js_intersection(Context cx, VarScope scope, Object[] args) {
@@ -338,8 +330,9 @@ public class NativeSet extends ScriptableObject {
         return result;
     }
 
-    private static Object js_union(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "union").js_union(cx, scope, args);
+    private static Object js_union(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "union").js_union(cx, s, args);
     }
 
     private Object js_union(Context cx, VarScope scope, Object[] args) {
@@ -393,8 +386,9 @@ public class NativeSet extends ScriptableObject {
         return result;
     }
 
-    private static Object js_difference(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "difference").js_difference(cx, scope, args);
+    private static Object js_difference(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "difference").js_difference(cx, s, args);
     }
 
     private Object js_difference(Context cx, VarScope scope, Object[] args) {
@@ -493,8 +487,8 @@ public class NativeSet extends ScriptableObject {
     }
 
     private static Object js_symmetricDifference(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "symmetricDifference").js_symmetricDifference(cx, scope, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "symmetricDifference").js_symmetricDifference(cx, s, args);
     }
 
     private Object js_symmetricDifference(Context cx, VarScope scope, Object[] args) {
@@ -556,8 +550,9 @@ public class NativeSet extends ScriptableObject {
         return result;
     }
 
-    private static Object js_isSubsetOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "isSubsetOf").js_isSubsetOf(cx, scope, args);
+    private static Object js_isSubsetOf(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "isSubsetOf").js_isSubsetOf(cx, s, args);
     }
 
     private Object js_isSubsetOf(Context cx, VarScope scope, Object[] args) {
@@ -614,8 +609,8 @@ public class NativeSet extends ScriptableObject {
     }
 
     private static Object js_isSupersetOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "isSupersetOf").js_isSupersetOf(cx, scope, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "isSupersetOf").js_isSupersetOf(cx, s, args);
     }
 
     private Object js_isSupersetOf(Context cx, VarScope scope, Object[] args) {
@@ -663,8 +658,8 @@ public class NativeSet extends ScriptableObject {
     }
 
     private static Object js_isDisjointFrom(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        return realThis(thisObj, "isDisjointFrom").js_isDisjointFrom(cx, scope, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return realThis(thisObj, "isDisjointFrom").js_isDisjointFrom(cx, s, args);
     }
 
     private Object js_isDisjointFrom(Context cx, VarScope scope, Object[] args) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -13,12 +13,21 @@ public class NativeSet extends ScriptableObject {
 
     static final SymbolKey GETSIZE = new SymbolKey("[Symbol.getSize]", Symbol.Kind.REGULAR);
 
+    private static final ClassDescriptor ITER_DESCRIPTOR =
+            ES6Iterator.makeDescriptor(ITERATOR_TAG, ITERATOR_TAG);
+
     private final Hashtable entries = new Hashtable();
 
     private boolean instanceOfSet = false;
 
-    static Object init(Context cx, VarScope s, boolean sealed) {
-        TopLevel scope = (TopLevel) s;
+    static Object init(Context cx, VarScope scope, boolean sealed) {
+        ES6Iterator.initialize(
+                ITER_DESCRIPTOR,
+                cx,
+                (TopLevel) scope,
+                new NativeCollectionIterator(ITERATOR_TAG),
+                sealed,
+                ITERATOR_TAG);
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
 import static org.mozilla.javascript.ScriptRuntime.rangeError;
 import static org.mozilla.javascript.ScriptRuntimeES6.requireObjectCoercible;
 
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.mozilla.javascript.AbstractEcmaStringOperations.ReplacementOperation;
+import org.mozilla.javascript.ClassDescriptor.BuiltInJSCodeExec;
 import org.mozilla.javascript.ScriptRuntime.StringIdOrIndex;
 
 /**
@@ -39,145 +42,132 @@ final class NativeString extends ScriptableObject {
 
     private final CharSequence string;
 
-    static void init(VarScope scope, boolean sealed) {
-        LambdaConstructor c =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        1,
-                        NativeString::js_constructorFunc,
-                        NativeString::js_constructor);
-        c.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        c.setPrototypeScriptable(new NativeString(""));
+    private static final ClassDescriptor DESCRIPTOR;
 
-        defConsMethod(c, scope, "fromCharCode", 1, NativeString::js_fromCharCode);
-        defConsMethod(c, scope, "fromCodePoint", 1, NativeString::js_fromCodePoint);
-        defConsMethod(c, scope, "raw", 1, NativeString::js_raw);
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                1,
+                                NativeString::js_constructorFunc,
+                                NativeString::js_constructor)
+                        .withMethod(CTOR, "fromCharCode", 1, NativeString::js_fromCharCode)
+                        .withMethod(CTOR, "fromCodePoint", 1, NativeString::js_fromCodePoint)
+                        .withMethod(CTOR, "raw", 1, NativeString::js_raw)
 
-        /*
-         * All of the methods below are on the constructor for compatibility with ancient Rhino
-         * versions. They are no longer part of ECMAScript. The "wrapConstructor" method is a
-         * technique used in the past in Rhino to adapt the instance functions so that they
-         * may be called on the constructor directly.
-         */
-        defConsMethod(c, scope, "charAt", 1, wrapConstructor(NativeString::js_charAt));
-        defConsMethod(c, scope, "charCodeAt", 1, wrapConstructor(NativeString::js_charCodeAt));
-        defConsMethod(c, scope, "indexOf", 2, wrapConstructor(NativeString::js_indexOf));
-        defConsMethod(c, scope, "lastIndexOf", 2, wrapConstructor(NativeString::js_lastIndexOf));
-        defConsMethod(c, scope, "split", 3, wrapConstructor(NativeString::js_split));
-        defConsMethod(c, scope, "substring", 3, wrapConstructor(NativeString::js_substring));
-        defConsMethod(c, scope, "toLowerCase", 1, wrapConstructor(NativeString::js_toLowerCase));
-        defConsMethod(c, scope, "toUpperCase", 1, wrapConstructor(NativeString::js_toUpperCase));
-        defConsMethod(c, scope, "substr", 3, wrapConstructor(NativeString::js_substr));
-        defConsMethod(c, scope, "concat", 2, wrapConstructor(NativeString::js_concat));
-        defConsMethod(c, scope, "slice", 3, wrapConstructor(NativeString::js_slice));
-        defConsMethod(
-                c,
-                scope,
-                "equalsIgnoreCase",
-                2,
-                wrapConstructor(NativeString::js_equalsIgnoreCase));
-        defConsMethod(c, scope, "match", 2, wrapConstructor(NativeString::js_match));
-        defConsMethod(c, scope, "search", 2, wrapConstructor(NativeString::js_search));
-        defConsMethod(c, scope, "replace", 2, wrapConstructor(NativeString::js_replace));
-        defConsMethod(c, scope, "replaceAll", 2, wrapConstructor(NativeString::js_replaceAll));
-        defConsMethod(
-                c, scope, "localeCompare", 2, wrapConstructor(NativeString::js_localeCompare));
-        defConsMethod(
-                c,
-                scope,
-                "toLocaleLowerCase",
-                1,
-                wrapConstructor(NativeString::js_toLocaleLowerCase));
+                        /*
+                         * All of the methods below are on the constructor for compatibility with ancient Rhino
+                         * versions. They are no longer part of ECMAScript. The "wrapConstructor" method is a
+                         * technique used in the past in Rhino to adapt the instance functions so that they
+                         * may be called on the constructor directly.
+                         */
+                        .withMethod(CTOR, "charAt", 1, forCtor(NativeString::js_charAt))
+                        .withMethod(CTOR, "charCodeAt", 1, forCtor(NativeString::js_charCodeAt))
+                        .withMethod(CTOR, "indexOf", 2, forCtor(NativeString::js_indexOf))
+                        .withMethod(CTOR, "lastIndexOf", 2, forCtor(NativeString::js_lastIndexOf))
+                        .withMethod(CTOR, "split", 3, forCtor(NativeString::js_split))
+                        .withMethod(CTOR, "substring", 3, forCtor(NativeString::js_substring))
+                        .withMethod(CTOR, "toLowerCase", 1, forCtor(NativeString::js_toLowerCase))
+                        .withMethod(CTOR, "toUpperCase", 1, forCtor(NativeString::js_toUpperCase))
+                        .withMethod(CTOR, "substr", 3, forCtor(NativeString::js_substr))
+                        .withMethod(CTOR, "concat", 2, forCtor(NativeString::js_concat))
+                        .withMethod(CTOR, "slice", 3, forCtor(NativeString::js_slice))
+                        .withMethod(
+                                CTOR,
+                                "equalsIgnoreCase",
+                                2,
+                                forCtor(NativeString::js_equalsIgnoreCase))
+                        .withMethod(CTOR, "match", 2, forCtor(NativeString::js_match))
+                        .withMethod(CTOR, "search", 2, forCtor(NativeString::js_search))
+                        .withMethod(CTOR, "replace", 2, forCtor(NativeString::js_replace))
+                        .withMethod(CTOR, "replaceAll", 2, forCtor(NativeString::js_replaceAll))
+                        .withMethod(
+                                CTOR, "localeCompare", 2, forCtor(NativeString::js_localeCompare))
+                        .withMethod(
+                                CTOR,
+                                "toLocaleLowerCase",
+                                1,
+                                forCtor(NativeString::js_toLocaleLowerCase))
 
-        /* Back to prototype methods -- these are all part of ECMAScript */
-        defProtoMethod(c, scope, SymbolKey.ITERATOR, 0, NativeString::js_iterator);
-        defProtoMethod(c, scope, "toString", 0, NativeString::js_toString);
-        defProtoMethod(c, scope, "toSource", 0, NativeString::js_toSource);
-        defProtoMethod(c, scope, "valueOf", 0, NativeString::js_toString);
-        defProtoMethod(c, scope, "charAt", 1, NativeString::js_charAt);
-        defProtoMethod(c, scope, "charCodeAt", 1, NativeString::js_charCodeAt);
-        defProtoMethod(c, scope, "indexOf", 1, NativeString::js_indexOf);
-        defProtoMethod(c, scope, "lastIndexOf", 1, NativeString::js_lastIndexOf);
-        defProtoMethod(c, scope, "split", 2, NativeString::js_split);
-        defProtoMethod(c, scope, "substring", 2, NativeString::js_substring);
-        defProtoMethod(c, scope, "toLowerCase", 0, NativeString::js_toLowerCase);
-        defProtoMethod(c, scope, "toUpperCase", 0, NativeString::js_toUpperCase);
-        defProtoMethod(c, scope, "substr", 2, NativeString::js_substr);
-        defProtoMethod(c, scope, "concat", 1, NativeString::js_concat);
-        defProtoMethod(c, scope, "slice", 2, NativeString::js_slice);
-        defProtoMethod(c, scope, "bold", 0, NativeString::js_bold);
-        defProtoMethod(c, scope, "italics", 0, NativeString::js_italics);
-        defProtoMethod(c, scope, "fixed", 0, NativeString::js_fixed);
-        defProtoMethod(c, scope, "strike", 0, NativeString::js_strike);
-        defProtoMethod(c, scope, "small", 0, NativeString::js_small);
-        defProtoMethod(c, scope, "big", 0, NativeString::js_big);
-        defProtoMethod(c, scope, "blink", 0, NativeString::js_blink);
-        defProtoMethod(c, scope, "sup", 0, NativeString::js_sup);
-        defProtoMethod(c, scope, "sub", 0, NativeString::js_sub);
-        defProtoMethod(c, scope, "fontsize", 0, NativeString::js_fontsize);
-        defProtoMethod(c, scope, "fontcolor", 0, NativeString::js_fontcolor);
-        defProtoMethod(c, scope, "link", 0, NativeString::js_link);
-        defProtoMethod(c, scope, "anchor", 0, NativeString::js_anchor);
-        defProtoMethod(c, scope, "equals", 1, NativeString::js_equals);
-        defProtoMethod(c, scope, "equalsIgnoreCase", 1, NativeString::js_equalsIgnoreCase);
-        defProtoMethod(c, scope, "match", 1, NativeString::js_match);
-        defProtoMethod(c, scope, "matchAll", 1, NativeString::js_matchAll);
-        defProtoMethod(c, scope, "search", 1, NativeString::js_search);
-        defProtoMethod(c, scope, "replace", 2, NativeString::js_replace);
-        defProtoMethod(c, scope, "replaceAll", 2, NativeString::js_replaceAll);
-        defProtoMethod(c, scope, "at", 1, NativeString::js_at);
-        defProtoMethod(c, scope, "localeCompare", 1, NativeString::js_localeCompare);
-        defProtoMethod(c, scope, "toLocaleLowerCase", 0, NativeString::js_toLocaleLowerCase);
-        defProtoMethod(c, scope, "toLocaleUpperCase", 0, NativeString::js_toLocaleUpperCase);
-        defProtoMethod(c, scope, "trim", 0, NativeString::js_trim);
-        defProtoMethod(c, scope, "trimLeft", 0, NativeString::js_trimLeft);
-        defProtoMethod(c, scope, "trimStart", 0, NativeString::js_trimLeft);
-        defProtoMethod(c, scope, "trimRight", 0, NativeString::js_trimRight);
-        defProtoMethod(c, scope, "trimEnd", 0, NativeString::js_trimRight);
-        defProtoMethod(c, scope, "includes", 1, NativeString::js_includes);
-        defProtoMethod(c, scope, "startsWith", 1, NativeString::js_startsWith);
-        defProtoMethod(c, scope, "endsWith", 1, NativeString::js_endsWith);
-        defProtoMethod(c, scope, "normalize", 0, NativeString::js_normalize);
-        defProtoMethod(c, scope, "repeat", 1, NativeString::js_repeat);
-        defProtoMethod(c, scope, "codePointAt", 1, NativeString::js_codePointAt);
-        defProtoMethod(c, scope, "padStart", 1, NativeString::js_padStart);
-        defProtoMethod(c, scope, "padEnd", 1, NativeString::js_padEnd);
-        defProtoMethod(c, scope, "isWellFormed", 0, NativeString::js_isWellFormed);
-        defProtoMethod(c, scope, "toWellFormed", 0, NativeString::js_toWellFormed);
+                        /* Back to prototype methods -- these are all part of ECMAScript */
 
-        if (sealed) {
-            c.sealObject();
-            ((NativeString) c.getPrototypeProperty()).sealObject();
-        }
-        ScriptableObject.defineProperty(scope, CLASS_NAME, c, DONTENUM);
+                        .withMethod(PROTO, SymbolKey.ITERATOR, 0, NativeString::js_iterator)
+                        .withMethod(PROTO, "toString", 0, NativeString::js_toString)
+                        .withMethod(PROTO, "toSource", 0, NativeString::js_toSource)
+                        .withMethod(PROTO, "valueOf", 0, NativeString::js_toString)
+                        .withMethod(PROTO, "charAt", 1, NativeString::js_charAt)
+                        .withMethod(PROTO, "charCodeAt", 1, NativeString::js_charCodeAt)
+                        .withMethod(PROTO, "indexOf", 1, NativeString::js_indexOf)
+                        .withMethod(PROTO, "lastIndexOf", 1, NativeString::js_lastIndexOf)
+                        .withMethod(PROTO, "split", 2, NativeString::js_split)
+                        .withMethod(PROTO, "substring", 2, NativeString::js_substring)
+                        .withMethod(PROTO, "toLowerCase", 0, NativeString::js_toLowerCase)
+                        .withMethod(PROTO, "toUpperCase", 0, NativeString::js_toUpperCase)
+                        .withMethod(PROTO, "substr", 2, NativeString::js_substr)
+                        .withMethod(PROTO, "concat", 1, NativeString::js_concat)
+                        .withMethod(PROTO, "slice", 2, NativeString::js_slice)
+                        .withMethod(PROTO, "bold", 0, NativeString::js_bold)
+                        .withMethod(PROTO, "italics", 0, NativeString::js_italics)
+                        .withMethod(PROTO, "fixed", 0, NativeString::js_fixed)
+                        .withMethod(PROTO, "strike", 0, NativeString::js_strike)
+                        .withMethod(PROTO, "small", 0, NativeString::js_small)
+                        .withMethod(PROTO, "big", 0, NativeString::js_big)
+                        .withMethod(PROTO, "blink", 0, NativeString::js_blink)
+                        .withMethod(PROTO, "sup", 0, NativeString::js_sup)
+                        .withMethod(PROTO, "sub", 0, NativeString::js_sub)
+                        .withMethod(PROTO, "fontsize", 0, NativeString::js_fontsize)
+                        .withMethod(PROTO, "fontcolor", 0, NativeString::js_fontcolor)
+                        .withMethod(PROTO, "link", 0, NativeString::js_link)
+                        .withMethod(PROTO, "anchor", 0, NativeString::js_anchor)
+                        .withMethod(PROTO, "equals", 1, NativeString::js_equals)
+                        .withMethod(PROTO, "equalsIgnoreCase", 1, NativeString::js_equalsIgnoreCase)
+                        .withMethod(PROTO, "match", 1, NativeString::js_match)
+                        .withMethod(PROTO, "matchAll", 1, NativeString::js_matchAll)
+                        .withMethod(PROTO, "search", 1, NativeString::js_search)
+                        .withMethod(PROTO, "replace", 2, NativeString::js_replace)
+                        .withMethod(PROTO, "replaceAll", 2, NativeString::js_replaceAll)
+                        .withMethod(PROTO, "at", 1, NativeString::js_at)
+                        .withMethod(PROTO, "localeCompare", 1, NativeString::js_localeCompare)
+                        .withMethod(
+                                PROTO, "toLocaleLowerCase", 0, NativeString::js_toLocaleLowerCase)
+                        .withMethod(
+                                PROTO, "toLocaleUpperCase", 0, NativeString::js_toLocaleUpperCase)
+                        .withMethod(PROTO, "trim", 0, NativeString::js_trim)
+                        .withMethod(PROTO, "trimLeft", 0, NativeString::js_trimLeft)
+                        .withMethod(PROTO, "trimStart", 0, NativeString::js_trimLeft)
+                        .withMethod(PROTO, "trimRight", 0, NativeString::js_trimRight)
+                        .withMethod(PROTO, "trimEnd", 0, NativeString::js_trimRight)
+                        .withMethod(PROTO, "includes", 1, NativeString::js_includes)
+                        .withMethod(PROTO, "startsWith", 1, NativeString::js_startsWith)
+                        .withMethod(PROTO, "endsWith", 1, NativeString::js_endsWith)
+                        .withMethod(PROTO, "normalize", 0, NativeString::js_normalize)
+                        .withMethod(PROTO, "repeat", 1, NativeString::js_repeat)
+                        .withMethod(PROTO, "codePointAt", 1, NativeString::js_codePointAt)
+                        .withMethod(PROTO, "padStart", 1, NativeString::js_padStart)
+                        .withMethod(PROTO, "padEnd", 1, NativeString::js_padEnd)
+                        .withMethod(PROTO, "isWellFormed", 0, NativeString::js_isWellFormed)
+                        .withMethod(PROTO, "toWellFormed", 0, NativeString::js_toWellFormed)
+                        .build();
     }
 
-    private static void defConsMethod(
-            LambdaConstructor c,
-            VarScope scope,
-            String name,
-            int length,
-            SerializableCallable target) {
-        c.defineConstructorMethod(scope, name, length, target);
+    private static BuiltInJSCodeExec<JSFunction> forCtor(BuiltInJSCodeExec<JSFunction> code) {
+        return (cx, f, nt, s, thisObj, args) -> {
+            Object[] realArgs;
+            Object realThis;
+            if (args.length > 0) {
+                realThis = ScriptRuntime.toObject(cx, s, ScriptRuntime.toCharSequence(args[0]));
+                realArgs = new Object[args.length - 1];
+                System.arraycopy(args, 1, realArgs, 0, realArgs.length);
+            } else {
+                realThis = ScriptRuntime.toObject(cx, s, ScriptRuntime.toCharSequence(thisObj));
+                realArgs = args;
+            }
+            return code.execute(cx, f, nt, s, realThis, realArgs);
+        };
     }
 
-    private static void defProtoMethod(
-            LambdaConstructor c,
-            VarScope scope,
-            SymbolKey key,
-            int length,
-            SerializableCallable target) {
-        c.definePrototypeMethod(scope, key, length, target);
-    }
-
-    private static void defProtoMethod(
-            LambdaConstructor c,
-            VarScope scope,
-            String name,
-            int length,
-            SerializableCallable target) {
-        c.definePrototypeMethod(scope, name, length, target);
+    static void init(Context cx, VarScope scope, boolean sealed) {
+        DESCRIPTOR.buildConstructor(cx, scope, new NativeString(""), sealed);
     }
 
     NativeString(CharSequence s) {
@@ -192,52 +182,38 @@ final class NativeString extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static SerializableCallable wrapConstructor(SerializableCallable target) {
-        return (Context cx, VarScope scope, Scriptable origThis, Object[] origArgs) -> {
-            Scriptable thisObj;
-            Object[] newArgs;
-            if (origArgs.length > 0) {
-                thisObj =
-                        ScriptRuntime.toObject(
-                                cx, scope, ScriptRuntime.toCharSequence(origArgs[0]));
-                newArgs = new Object[origArgs.length - 1];
-                System.arraycopy(origArgs, 1, newArgs, 0, newArgs.length);
-            } else {
-                thisObj = ScriptRuntime.toObject(cx, scope, ScriptRuntime.toCharSequence(origThis));
-                newArgs = origArgs;
-            }
-            return target.call(cx, scope, thisObj, newArgs);
-        };
-    }
-
-    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
-        CharSequence s;
+    private static Scriptable js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        CharSequence str;
         if (args.length == 0) {
-            s = "";
+            str = "";
         } else {
-            s = ScriptRuntime.toCharSequence(args[0]);
+            str = ScriptRuntime.toCharSequence(args[0]);
         }
-        return new NativeString(s);
+        var res = new NativeString(str);
+        res.setPrototype((Scriptable) f.getPrototypeProperty());
+        res.setParentScope(f.getDeclarationScope());
+        return res;
     }
 
     private static Object js_constructorFunc(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
-        CharSequence s;
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        CharSequence str;
         if (args.length == 0) {
-            s = "";
+            str = "";
         } else if (ScriptRuntime.isSymbol(args[0])) {
             // 19.4.3.2 et.al. Convert a symbol to a string with String() but not
             // new String()
-            s = args[0].toString();
+            str = args[0].toString();
         } else {
-            s = ScriptRuntime.toCharSequence(args[0]);
+            str = ScriptRuntime.toCharSequence(args[0]);
         }
         // String(val) converts val to a string value.
-        return s instanceof String ? s : s.toString();
+        return str instanceof String ? str : str.toString();
     }
 
     private static Object js_fromCharCode(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         int n = args.length;
         if (n < 1) {
             return "";
@@ -250,7 +226,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_fromCodePoint(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         int n = args.length;
         if (n < 1) {
             return "";
@@ -268,11 +244,13 @@ final class NativeString extends ScriptableObject {
         return new String(codePoints, 0, n);
     }
 
-    private static Object js_charAt(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_charAt(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return charAt(cx, thisObj, args, false);
     }
 
-    private static Object js_charCodeAt(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_charCodeAt(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return charAt(cx, thisObj, args, true);
     }
 
@@ -291,7 +269,8 @@ final class NativeString extends ScriptableObject {
         return ScriptRuntime.wrapInt(c);
     }
 
-    private static Object js_indexOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_indexOf(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "indexOf"));
         String searchStr = ScriptRuntime.toString(args, 0);
@@ -307,7 +286,8 @@ final class NativeString extends ScriptableObject {
         return target.indexOf(searchStr, (int) position);
     }
 
-    private static Object js_startsWith(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_startsWith(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "startsWith"));
@@ -319,7 +299,8 @@ final class NativeString extends ScriptableObject {
         return target.startsWith(searchStr, (int) position);
     }
 
-    private static Object js_endsWith(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_endsWith(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "endsWith"));
         checkValidRegex(cx, args, 0, "endsWith");
@@ -333,7 +314,8 @@ final class NativeString extends ScriptableObject {
         return target.substring(0, (int) position).endsWith(searchStr);
     }
 
-    private static Object js_includes(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_includes(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "includes"));
         String searchStr = ScriptRuntime.toString(args, 0);
@@ -358,20 +340,21 @@ final class NativeString extends ScriptableObject {
         }
     }
 
-    private static Object js_split(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_split(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.23
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "split");
 
         if (cx.getLanguageVersion() <= Context.VERSION_1_8) {
             // Use old algorithm for backward compatibility
             return ScriptRuntime.checkRegExpProxy(cx)
-                    .js_split(cx, scope, ScriptRuntime.toString(o), args);
+                    .js_split(cx, s, ScriptRuntime.toString(o), args);
         }
 
         Object separator = args.length > 0 ? args[0] : Undefined.instance;
         Object limit = args.length > 1 ? args[1] : Undefined.instance;
         if (!Undefined.isUndefined(separator) && separator != null) {
-            Object splitter = ScriptRuntime.getObjectElem(separator, SymbolKey.SPLIT, cx, scope);
+            Object splitter = ScriptRuntime.getObjectElem(separator, SymbolKey.SPLIT, cx, s);
             // If method is not undefined, it should be a Callable
             if (splitter != null && !Undefined.isUndefined(splitter)) {
                 if (!(splitter instanceof Callable)) {
@@ -381,8 +364,8 @@ final class NativeString extends ScriptableObject {
                 return ((Callable) splitter)
                         .call(
                                 cx,
-                                scope,
-                                ScriptRuntime.toObject(scope, separator),
+                                s,
+                                ScriptRuntime.toObject(s, separator),
                                 new Object[] {
                                     o instanceof NativeString ? ((NativeString) o).string : o,
                                     limit,
@@ -390,7 +373,7 @@ final class NativeString extends ScriptableObject {
             }
         }
 
-        String s = ScriptRuntime.toString(o);
+        String str = ScriptRuntime.toString(o);
         long lim;
         if (Undefined.isUndefined(limit)) {
             lim = Integer.MAX_VALUE;
@@ -399,17 +382,17 @@ final class NativeString extends ScriptableObject {
         }
         String r = ScriptRuntime.toString(separator);
         if (lim == 0) {
-            return cx.newArray(scope, 0);
+            return cx.newArray(s, 0);
         }
         if (Undefined.isUndefined(separator)) {
-            return cx.newArray(scope, new Object[] {s});
+            return cx.newArray(s, new Object[] {str});
         }
 
         int separatorLength = r.length();
         if (separatorLength == 0) {
-            int strLen = s.length();
+            int strLen = str.length();
             int outLen = ScriptRuntime.clamp((int) lim, 0, strLen);
-            String head = s.substring(0, outLen);
+            String head = str.substring(0, outLen);
 
             List<Object> codeUnits = new ArrayList<>();
             for (int i = 0; i < head.length(); ) {
@@ -417,49 +400,53 @@ final class NativeString extends ScriptableObject {
                 codeUnits.add(Character.toString(c));
                 i += Character.charCount(c);
             }
-            return cx.newArray(scope, codeUnits.toArray());
+            return cx.newArray(s, codeUnits.toArray());
         }
 
-        if (s.isEmpty()) {
-            return cx.newArray(scope, new Object[] {s});
+        if (str.isEmpty()) {
+            return cx.newArray(s, new Object[] {str});
         }
 
         List<String> substrings = new ArrayList<>();
         int i = 0;
-        int j = s.indexOf(r);
+        int j = str.indexOf(r);
         while (j != -1) {
-            String t = s.substring(i, j);
+            String t = str.substring(i, j);
             substrings.add(t);
             if (substrings.size() >= lim) {
-                return cx.newArray(scope, substrings.toArray());
+                return cx.newArray(s, substrings.toArray());
             }
             i = j + separatorLength;
-            j = s.indexOf(r, i);
+            j = str.indexOf(r, i);
         }
-        String t = s.substring(i);
+        String t = str.substring(i);
         substrings.add(t);
 
-        return cx.newArray(scope, substrings.toArray());
+        return cx.newArray(s, substrings.toArray());
     }
 
     private static NativeString realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeString.class);
     }
 
-    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_iterator(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return new NativeStringIterator(
-                scope, requireObjectCoercible(cx, thisObj, CLASS_NAME, "[Symbol.iterator]"));
+                f.getDeclarationScope(),
+                requireObjectCoercible(cx, thisObj, CLASS_NAME, "[Symbol.iterator]"));
     }
 
-    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toString(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // ECMA 15.5.4.2: the toString function is not generic.
         CharSequence cs = realThis(thisObj).string;
         return cs instanceof String ? cs : cs.toString();
     }
 
-    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
-        CharSequence s = realThis(thisObj).string;
-        return "(new String(\"" + ScriptRuntime.escapeString(s.toString()) + "\"))";
+    private static Object js_toSource(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        CharSequence str = realThis(thisObj).string;
+        return "(new String(\"" + ScriptRuntime.escapeString(str.toString()) + "\"))";
     }
 
     /*
@@ -576,12 +563,13 @@ final class NativeString extends ScriptableObject {
      * See ECMA 22.1.3.13
      *
      */
-    private static Object js_match(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_match(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "match");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
         RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
         if (regexp != null && !Undefined.isUndefined(regexp)) {
-            Object matcher = ScriptRuntime.getObjectElem(regexp, SymbolKey.MATCH, cx, scope);
+            Object matcher = ScriptRuntime.getObjectElem(regexp, SymbolKey.MATCH, cx, s);
             // If method is not undefined, it should be a Callable
             if (matcher != null && !Undefined.isUndefined(matcher)) {
                 if (!(matcher instanceof Callable)) {
@@ -589,11 +577,11 @@ final class NativeString extends ScriptableObject {
                             regexp, matcher, SymbolKey.MATCH.getName());
                 }
                 return ((Callable) matcher)
-                        .call(cx, scope, ScriptRuntime.toObject(scope, regexp), new Object[] {o});
+                        .call(cx, s, ScriptRuntime.toObject(s, regexp), new Object[] {o});
             }
         }
 
-        String s = ScriptRuntime.toString(o);
+        String str = ScriptRuntime.toString(o);
         String regexpToString = Undefined.isUndefined(regexp) ? "" : ScriptRuntime.toString(regexp);
 
         String flags = null;
@@ -604,13 +592,13 @@ final class NativeString extends ScriptableObject {
         }
 
         Object compiledRegExp = regExpProxy.compileRegExp(cx, regexpToString, flags);
-        Scriptable rx = regExpProxy.wrapRegExp(cx, scope, compiledRegExp);
+        Scriptable rx = regExpProxy.wrapRegExp(cx, s, compiledRegExp);
 
-        Object method = ScriptRuntime.getObjectElem(rx, SymbolKey.MATCH, cx, scope);
+        Object method = ScriptRuntime.getObjectElem(rx, SymbolKey.MATCH, cx, s);
         if (!(method instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(rx, method, SymbolKey.MATCH.getName());
         }
-        return ((Callable) method).call(cx, scope, rx, new Object[] {s});
+        return ((Callable) method).call(cx, s, rx, new Object[] {str});
     }
 
     /*
@@ -619,7 +607,7 @@ final class NativeString extends ScriptableObject {
      *
      */
     private static Object js_lastIndexOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "lastIndexOf"));
@@ -635,7 +623,8 @@ final class NativeString extends ScriptableObject {
     /*
      * See ECMA 15.5.4.15
      */
-    private static Object js_substring(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_substring(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         CharSequence target =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "substring"));
@@ -664,7 +653,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toLowerCase(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // See ECMA 15.5.4.11
         String thisStr =
                 ScriptRuntime.toString(
@@ -673,7 +662,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toUpperCase(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // See ECMA 15.5.4.12
         String thisStr =
                 ScriptRuntime.toString(
@@ -689,7 +678,7 @@ final class NativeString extends ScriptableObject {
      * Non-ECMA methods.
      */
     private static CharSequence js_substr(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         CharSequence target =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "substr"));
@@ -730,7 +719,8 @@ final class NativeString extends ScriptableObject {
     /*
      * Python-esque sequence operations.
      */
-    private static String js_concat(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static String js_concat(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "concat"));
         int N = args.length;
@@ -746,9 +736,9 @@ final class NativeString extends ScriptableObject {
         int size = target.length();
         String[] argsAsStrings = new String[N];
         for (int i = 0; i != N; ++i) {
-            String s = ScriptRuntime.toString(args[i]);
-            argsAsStrings[i] = s;
-            size += s.length();
+            String str = ScriptRuntime.toString(args[i]);
+            argsAsStrings[i] = str;
+            size += str.length();
         }
 
         StringBuilder result = new StringBuilder(size);
@@ -759,7 +749,8 @@ final class NativeString extends ScriptableObject {
         return result.toString();
     }
 
-    private static Object js_slice(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_slice(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         CharSequence target =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "slice"));
@@ -788,7 +779,8 @@ final class NativeString extends ScriptableObject {
         return target.subSequence((int) begin, (int) end);
     }
 
-    private static Object js_at(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_at(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "at"));
         Object targetArg = (args.length >= 1) ? args[0] : Undefined.instance;
         int len = str.length();
@@ -803,25 +795,27 @@ final class NativeString extends ScriptableObject {
         return str.substring(k, k + 1);
     }
 
-    private static Object js_equals(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_equals(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String s1 = ScriptRuntime.toString(thisObj);
         String s2 = ScriptRuntime.toString(args, 0);
         return s1.equals(s2);
     }
 
     private static Object js_equalsIgnoreCase(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String s1 = ScriptRuntime.toString(thisObj);
         String s2 = ScriptRuntime.toString(args, 0);
         return s1.equalsIgnoreCase(s2);
     }
 
-    private static Object js_search(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_search(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "search");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
         RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
         if (regexp != null && !Undefined.isUndefined(regexp)) {
-            Object matcher = ScriptRuntime.getObjectElem(regexp, SymbolKey.SEARCH, cx, scope);
+            Object matcher = ScriptRuntime.getObjectElem(regexp, SymbolKey.SEARCH, cx, s);
             // If method is not undefined, it should be a Callable
             if (matcher != null && !Undefined.isUndefined(matcher)) {
                 if (!(matcher instanceof Callable)) {
@@ -829,11 +823,11 @@ final class NativeString extends ScriptableObject {
                             regexp, matcher, SymbolKey.SEARCH.getName());
                 }
                 return ((Callable) matcher)
-                        .call(cx, scope, ScriptRuntime.toObject(scope, regexp), new Object[] {o});
+                        .call(cx, s, ScriptRuntime.toObject(s, regexp), new Object[] {o});
             }
         }
 
-        String s = ScriptRuntime.toString(o);
+        String str = ScriptRuntime.toString(o);
         String regexpToString = Undefined.isUndefined(regexp) ? "" : ScriptRuntime.toString(regexp);
 
         String flags = null;
@@ -843,23 +837,24 @@ final class NativeString extends ScriptableObject {
         }
 
         Object compiledRegExp = regExpProxy.compileRegExp(cx, regexpToString, flags);
-        Scriptable rx = regExpProxy.wrapRegExp(cx, scope, compiledRegExp);
+        Scriptable rx = regExpProxy.wrapRegExp(cx, s, compiledRegExp);
 
-        Object method = ScriptRuntime.getObjectElem(rx, SymbolKey.SEARCH, cx, scope);
+        Object method = ScriptRuntime.getObjectElem(rx, SymbolKey.SEARCH, cx, s);
         if (!(method instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(rx, method, SymbolKey.SEARCH.getName());
         }
-        return ((Callable) method).call(cx, scope, rx, new Object[] {s});
+        return ((Callable) method).call(cx, s, rx, new Object[] {str});
     }
 
-    private static Object js_replace(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_replace(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.19
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "replace");
 
         if (cx.getLanguageVersion() <= Context.VERSION_1_8) {
             // Use old algorithm for backward compatibility
             return ScriptRuntime.checkRegExpProxy(cx)
-                    .action(cx, scope, thisObj, args, RegExpProxy.RA_REPLACE);
+                    .action(cx, s, thisObj, args, RegExpProxy.RA_REPLACE);
         }
 
         // Spec-compliant algorithm
@@ -868,8 +863,7 @@ final class NativeString extends ScriptableObject {
         Object replaceValue = args.length > 1 ? args[1] : Undefined.instance;
 
         if (!Undefined.isUndefined(searchValue) && searchValue != null) {
-            Object replacer =
-                    ScriptRuntime.getObjectElem(searchValue, SymbolKey.REPLACE, cx, scope);
+            Object replacer = ScriptRuntime.getObjectElem(searchValue, SymbolKey.REPLACE, cx, s);
             // If method is not undefined, it should be a Callable
             if (replacer != null && !Undefined.isUndefined(replacer)) {
                 if (!(replacer instanceof Callable)) {
@@ -879,8 +873,8 @@ final class NativeString extends ScriptableObject {
                 return ((Callable) replacer)
                         .call(
                                 cx,
-                                scope,
-                                ScriptRuntime.toObject(scope, searchValue),
+                                s,
+                                ScriptRuntime.toObject(s, searchValue),
                                 new Object[] {
                                     o instanceof NativeString ? ((NativeString) o).string : o,
                                     replaceValue
@@ -911,13 +905,13 @@ final class NativeString extends ScriptableObject {
         String replacement;
         if (functionalReplace) {
             Scriptable callThis =
-                    ScriptRuntime.getApplyOrCallThis(cx, scope, null, 0, (Function) replaceValue);
+                    ScriptRuntime.getApplyOrCallThis(cx, s, null, 0, (Function) replaceValue);
 
             Object replacementObj =
                     ((Callable) replaceValue)
                             .call(
                                     cx,
-                                    scope,
+                                    s,
                                     callThis,
                                     new Object[] {
                                         searchString, position, string,
@@ -928,7 +922,7 @@ final class NativeString extends ScriptableObject {
             replacement =
                     AbstractEcmaStringOperations.getSubstitution(
                             cx,
-                            scope,
+                            s,
                             searchString,
                             string,
                             position,
@@ -939,7 +933,8 @@ final class NativeString extends ScriptableObject {
         return preceding + replacement + following;
     }
 
-    private static Object js_replaceAll(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_replaceAll(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.20
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "replaceAll");
 
@@ -949,9 +944,9 @@ final class NativeString extends ScriptableObject {
         if (searchValue != null && !Undefined.isUndefined(searchValue)) {
             boolean isRegExp =
                     searchValue instanceof Scriptable
-                            && AbstractEcmaObjectOperations.isRegExp(cx, scope, searchValue);
+                            && AbstractEcmaObjectOperations.isRegExp(cx, s, searchValue);
             if (isRegExp) {
-                Object flags = ScriptRuntime.getObjectProp(searchValue, "flags", cx, scope);
+                Object flags = ScriptRuntime.getObjectProp(searchValue, "flags", cx, s);
                 requireObjectCoercible(cx, flags, CLASS_NAME, "replaceAll");
                 String flagsStr = ScriptRuntime.toString(flags);
                 if (!flagsStr.contains("g")) {
@@ -959,7 +954,7 @@ final class NativeString extends ScriptableObject {
                 }
             }
 
-            Object matcher = ScriptRuntime.getObjectElem(searchValue, SymbolKey.REPLACE, cx, scope);
+            Object matcher = ScriptRuntime.getObjectElem(searchValue, SymbolKey.REPLACE, cx, s);
             // If method is not undefined, it should be a Callable
             if (matcher != null && !Undefined.isUndefined(matcher)) {
                 if (!(matcher instanceof Callable)) {
@@ -969,8 +964,8 @@ final class NativeString extends ScriptableObject {
                 return ((Callable) matcher)
                         .call(
                                 cx,
-                                scope,
-                                ScriptRuntime.toObject(scope, searchValue),
+                                s,
+                                ScriptRuntime.toObject(s, searchValue),
                                 new Object[] {o, replaceValue});
             }
         }
@@ -1006,14 +1001,13 @@ final class NativeString extends ScriptableObject {
             String replacement;
             if (functionalReplace) {
                 Scriptable callThis =
-                        ScriptRuntime.getApplyOrCallThis(
-                                cx, scope, null, 0, (Function) replaceValue);
+                        ScriptRuntime.getApplyOrCallThis(cx, s, null, 0, (Function) replaceValue);
 
                 Object replacementObj =
                         ((Callable) replaceValue)
                                 .call(
                                         cx,
-                                        scope,
+                                        s,
                                         callThis,
                                         new Object[] {
                                             searchString, p, string,
@@ -1024,7 +1018,7 @@ final class NativeString extends ScriptableObject {
                 replacement =
                         AbstractEcmaStringOperations.getSubstitution(
                                 cx,
-                                scope,
+                                s,
                                 searchString,
                                 string,
                                 p,
@@ -1042,14 +1036,15 @@ final class NativeString extends ScriptableObject {
         return result.toString();
     }
 
-    private static Object js_matchAll(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_matchAll(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.14
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "matchAll");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
         if (regexp != null && !Undefined.isUndefined(regexp)) {
-            boolean isRegExp = AbstractEcmaObjectOperations.isRegExp(cx, scope, regexp);
+            boolean isRegExp = AbstractEcmaObjectOperations.isRegExp(cx, s, regexp);
             if (isRegExp) {
-                Object flags = ScriptRuntime.getObjectProp(regexp, "flags", cx, scope);
+                Object flags = ScriptRuntime.getObjectProp(regexp, "flags", cx, s);
                 requireObjectCoercible(cx, flags, CLASS_NAME, "matchAll");
                 String flagsStr = ScriptRuntime.toString(flags);
                 if (!flagsStr.contains("g")) {
@@ -1057,7 +1052,7 @@ final class NativeString extends ScriptableObject {
                 }
             }
 
-            Object matcher = ScriptRuntime.getObjectElem(regexp, SymbolKey.MATCH_ALL, cx, scope);
+            Object matcher = ScriptRuntime.getObjectElem(regexp, SymbolKey.MATCH_ALL, cx, s);
             // If method is not undefined, it should be a Callable
             if (matcher != null && !Undefined.isUndefined(matcher)) {
                 if (!(matcher instanceof Callable)) {
@@ -1065,25 +1060,25 @@ final class NativeString extends ScriptableObject {
                             regexp, matcher, SymbolKey.MATCH_ALL.getName());
                 }
                 return ((Callable) matcher)
-                        .call(cx, scope, ScriptRuntime.toObject(scope, regexp), new Object[] {o});
+                        .call(cx, s, ScriptRuntime.toObject(s, regexp), new Object[] {o});
             }
         }
 
-        String s = ScriptRuntime.toString(o);
+        String str = ScriptRuntime.toString(o);
         String regexpToString = Undefined.isUndefined(regexp) ? "" : ScriptRuntime.toString(regexp);
         RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
         Object compiledRegExp = regExpProxy.compileRegExp(cx, regexpToString, "g");
-        Scriptable rx = regExpProxy.wrapRegExp(cx, scope, compiledRegExp);
+        Scriptable rx = regExpProxy.wrapRegExp(cx, s, compiledRegExp);
 
-        Object method = ScriptRuntime.getObjectElem(rx, SymbolKey.MATCH_ALL, cx, scope);
+        Object method = ScriptRuntime.getObjectElem(rx, SymbolKey.MATCH_ALL, cx, s);
         if (!(method instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(rx, method, SymbolKey.MATCH_ALL.getName());
         }
-        return ((Callable) method).call(cx, scope, rx, new Object[] {s});
+        return ((Callable) method).call(cx, s, rx, new Object[] {str});
     }
 
     private static Object js_localeCompare(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // For now, create and configure a collator instance. I can't
         // actually imagine that this'd be slower than caching them
         // a la ClassCache, so we aren't trying to outsmart ourselves
@@ -1098,7 +1093,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toLocaleLowerCase(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String thisStr =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "toLocaleLowerCase"));
@@ -1115,7 +1110,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toLocaleUpperCase(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String thisStr =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "toLocaleUpperCase"));
@@ -1131,7 +1126,8 @@ final class NativeString extends ScriptableObject {
         return thisStr.toUpperCase(locale);
     }
 
-    private static Object js_trim(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_trim(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "trim"));
         char[] chars = str.toCharArray();
@@ -1148,7 +1144,8 @@ final class NativeString extends ScriptableObject {
         return str.substring(start, end);
     }
 
-    private static Object js_trimLeft(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_trimLeft(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "trimLeft"));
         char[] chars = str.toCharArray();
@@ -1162,7 +1159,8 @@ final class NativeString extends ScriptableObject {
         return str.substring(start, end);
     }
 
-    private static Object js_trimRight(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_trimRight(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "trimRight"));
@@ -1178,7 +1176,8 @@ final class NativeString extends ScriptableObject {
         return str.substring(start, end);
     }
 
-    private static Object js_normalize(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_normalize(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length == 0 || Undefined.isUndefined(args[0])) {
             return Normalizer.normalize(
                     ScriptRuntime.toString(
@@ -1203,7 +1202,8 @@ final class NativeString extends ScriptableObject {
                 form);
     }
 
-    private static String js_repeat(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static String js_repeat(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "repeat"));
         double cnt = ScriptRuntime.toInteger(args, 0);
@@ -1239,7 +1239,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_codePointAt(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "codePointAt"));
@@ -1288,11 +1288,13 @@ final class NativeString extends ScriptableObject {
         return concat.insert(0, pad).toString();
     }
 
-    private static Object js_padStart(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_padStart(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return pad(cx, thisObj, "padStart", args, true);
     }
 
-    private static Object js_padEnd(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_padEnd(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return pad(cx, thisObj, "padEnd", args, false);
     }
 
@@ -1303,13 +1305,14 @@ final class NativeString extends ScriptableObject {
      *
      * <p>22.1.2.4 String.raw [Draft ECMA-262 / April 28, 2021]
      */
-    private static Object js_raw(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_raw(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         /* step 1-2 */
         Object arg0 = args.length > 0 ? args[0] : Undefined.instance;
-        Scriptable cooked = ScriptRuntime.toObject(cx, scope, arg0);
+        Scriptable cooked = ScriptRuntime.toObject(cx, s, arg0);
         /* step 3 */
         Object rawValue = ScriptRuntime.getObjectProp(cooked, "raw", cx);
-        Scriptable raw = ScriptRuntime.toObject(cx, scope, rawValue);
+        Scriptable raw = ScriptRuntime.toObject(cx, s, rawValue);
         /* step 4-5 */
         long rawLength = NativeArray.getLengthProperty(cx, raw);
         if (rawLength > Integer.MAX_VALUE) {
@@ -1341,7 +1344,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_isWellFormed(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         CharSequence str =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "isWellFormed"));
@@ -1367,7 +1370,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toWellFormed(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         CharSequence str =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "toWellFormed"));
@@ -1413,55 +1416,68 @@ final class NativeString extends ScriptableObject {
         return sb.toString();
     }
 
-    private static Object js_bold(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_bold(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "bold", "b", null, args);
     }
 
-    private static Object js_italics(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_italics(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "italics", "i", null, args);
     }
 
-    private static Object js_fixed(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_fixed(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "fixed", "tt", null, args);
     }
 
-    private static Object js_strike(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_strike(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "strike", "strike", null, args);
     }
 
-    private static Object js_small(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_small(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "small", "small", null, args);
     }
 
-    private static Object js_big(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_big(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "big", "big", null, args);
     }
 
-    private static Object js_blink(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_blink(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "blink", "blink", null, args);
     }
 
-    private static Object js_sup(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_sup(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "sup", "sup", null, args);
     }
 
-    private static Object js_sub(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_sub(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "sub", "sub", null, args);
     }
 
-    private static Object js_fontsize(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_fontsize(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "fontsize", "font", "size", args);
     }
 
-    private static Object js_fontcolor(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_fontcolor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "fontcolor", "font", "color", args);
     }
 
-    private static Object js_link(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_link(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "link", "a", "href", args);
     }
 
-    private static Object js_anchor(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_anchor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "anchor", "a", "name", args);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
@@ -7,7 +7,7 @@
 package org.mozilla.javascript;
 
 public final class NativeStringIterator extends ES6Iterator {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 6709689999500242078L;
     private static final String ITERATOR_TAG = "StringIterator";
 
     static void init(TopLevel scope, boolean sealed) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
@@ -10,8 +10,12 @@ public final class NativeStringIterator extends ES6Iterator {
     private static final long serialVersionUID = 6709689999500242078L;
     private static final String ITERATOR_TAG = "StringIterator";
 
-    static void init(TopLevel scope, boolean sealed) {
-        ES6Iterator.init(scope, sealed, new NativeStringIterator(), ITERATOR_TAG);
+    private static final ClassDescriptor DESCRIPTOR =
+            ES6Iterator.makeDescriptor(ITERATOR_TAG, "String Iterator");
+
+    static void init(Context cx, VarScope scope, boolean sealed) {
+        ES6Iterator.initialize(
+                DESCRIPTOR, cx, (TopLevel) scope, new NativeStringIterator(), sealed, ITERATOR_TAG);
     }
 
     /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
@@ -6,6 +6,10 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.WeakHashMap;
@@ -23,6 +27,27 @@ public class NativeWeakMap extends ScriptableObject {
 
     private static final String CLASS_NAME = "WeakMap";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                0,
+                                ClassDescriptor.typeError(),
+                                NativeWeakMap::jsConstructor)
+                        .withMethod(PROTO, "set", 2, NativeWeakMap::js_set)
+                        .withMethod(PROTO, "delete", 1, NativeWeakMap::js_delete)
+                        .withMethod(PROTO, "get", 1, NativeWeakMap::js_get)
+                        .withMethod(PROTO, "has", 1, NativeWeakMap::js_has)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
+
     private boolean instanceOfWeakMap = false;
 
     private transient WeakHashMap<Object, Object> map = new WeakHashMap<>();
@@ -30,29 +55,7 @@ public class NativeWeakMap extends ScriptableObject {
     private static final Object NULL_VALUE = new Object();
 
     static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        0,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeWeakMap::jsConstructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.definePrototypeMethod(scope, "set", 2, NativeWeakMap::js_set);
-        constructor.definePrototypeMethod(scope, "delete", 1, NativeWeakMap::js_delete);
-        constructor.definePrototypeMethod(scope, "get", 1, NativeWeakMap::js_get);
-        constructor.definePrototypeMethod(scope, "has", 1, NativeWeakMap::js_has);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
     @Override
@@ -60,16 +63,20 @@ public class NativeWeakMap extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable jsConstructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeWeakMap nm = new NativeWeakMap();
         nm.instanceOfWeakMap = true;
         if (args.length > 0) {
-            NativeMap.loadFromIterable(cx, scope, nm, NativeMap.key(args));
+            NativeMap.loadFromIterable(cx, f.getDeclarationScope(), nm, NativeMap.key(args));
         }
+        nm.setParentScope(f.getDeclarationScope());
+        nm.setPrototype((Scriptable) f.getPrototypeProperty());
         return nm;
     }
 
-    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_delete(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "delete").js_delete(NativeMap.key(args));
     }
 
@@ -80,7 +87,8 @@ public class NativeWeakMap extends ScriptableObject {
         return map.remove(key) != null;
     }
 
-    private static Object js_get(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_get(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "get").js_get(NativeMap.key(args));
     }
 
@@ -97,7 +105,8 @@ public class NativeWeakMap extends ScriptableObject {
         return result;
     }
 
-    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_has(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "has").js_has(NativeMap.key(args));
     }
 
@@ -108,7 +117,8 @@ public class NativeWeakMap extends ScriptableObject {
         return map.containsKey(key);
     }
 
-    private static Object js_set(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_set(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, "set")
                 .js_set(NativeMap.key(args), args.length > 1 ? args[1] : Undefined.instance);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
@@ -6,6 +6,10 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.WeakHashMap;
@@ -21,33 +25,32 @@ public class NativeWeakSet extends ScriptableObject {
 
     private static final String CLASS_NAME = "WeakSet";
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                0,
+                                ClassDescriptor.typeError(),
+                                NativeWeakSet::jsConstructor)
+                        .withMethod(PROTO, "add", 1, NativeWeakSet::js_add)
+                        .withMethod(PROTO, "delete", 1, NativeWeakSet::js_delete)
+                        .withMethod(PROTO, "has", 1, NativeWeakSet::js_has)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
+
     private boolean instanceOfWeakSet = false;
 
     private transient WeakHashMap<Object, Boolean> map = new WeakHashMap<>();
 
     static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        0,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeWeakSet::jsConstructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.definePrototypeMethod(scope, "add", 1, NativeWeakSet::js_add);
-        constructor.definePrototypeMethod(scope, "delete", 1, NativeWeakSet::js_delete);
-        constructor.definePrototypeMethod(scope, "has", 1, NativeWeakSet::js_has);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
     @Override
@@ -55,16 +58,20 @@ public class NativeWeakSet extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
+    private static Scriptable jsConstructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeWeakSet ns = new NativeWeakSet();
         ns.instanceOfWeakSet = true;
         if (args.length > 0) {
-            NativeSet.loadFromIterable(cx, scope, ns, NativeMap.key(args));
+            NativeSet.loadFromIterable(cx, f.getDeclarationScope(), ns, NativeMap.key(args));
         }
+        ns.setParentScope(f.getDeclarationScope());
+        ns.setPrototype((Scriptable) f.getPrototypeProperty());
         return ns;
     }
 
-    private static Object js_add(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_add(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeWeakSet realThis = realThis(thisObj, "add");
         var k = NativeMap.key(args);
         return realThis.js_add(k);
@@ -84,7 +91,8 @@ public class NativeWeakSet extends ScriptableObject {
         return this;
     }
 
-    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_delete(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeWeakSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_delete(arg);
@@ -97,7 +105,8 @@ public class NativeWeakSet extends ScriptableObject {
         return map.remove(key) != null;
     }
 
-    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_has(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeWeakSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_has(arg);

--- a/rhino/src/main/java/org/mozilla/javascript/PolicySecurityController.java
+++ b/rhino/src/main/java/org/mozilla/javascript/PolicySecurityController.java
@@ -88,7 +88,7 @@ public class PolicySecurityController extends SecurityController {
             Context cx,
             Callable callable,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args) {
         // Run in doPrivileged as we might be checked for "getClassLoader"
         // runtime permission
@@ -145,7 +145,7 @@ public class PolicySecurityController extends SecurityController {
 
     public abstract static class SecureCaller {
         public abstract Object call(
-                Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args);
+                Callable callable, Context cx, VarScope scope, Object thisObj, Object[] args);
     }
 
     private static byte[] loadBytecode() {

--- a/rhino/src/main/java/org/mozilla/javascript/RefCallable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RefCallable.java
@@ -17,5 +17,5 @@ public interface RefCallable extends Callable {
      * @param thisObj the JavaScript {@code this} object
      * @param args the array of arguments
      */
-    public Ref refCall(Context cx, Scriptable thisObj, Object[] args);
+    public Ref refCall(Context cx, Object thisObj, Object[] args);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
@@ -18,7 +18,7 @@ public interface RegExpProxy {
     public static final int RA_REPLACE_ALL = 3;
     public static final int RA_SEARCH = 4;
 
-    public void register(TopLevel scope, boolean sealed);
+    public void register(Context cx, TopLevel scope, boolean sealed);
 
     public boolean isRegExp(Scriptable obj);
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScopeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScopeObject.java
@@ -10,7 +10,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 public class ScopeObject extends SlotMapOwner<VarScope> implements VarScope, Serializable {
-    private static final long serialVersionUID = -7471457301304454454L;
+    private static final long serialVersionUID = 2283542168979106620L;
 
     private final VarScope parentScope;
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScopeWrapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScopeWrapper.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript;
 
 public class ScopeWrapper extends ScriptableObject {
-    private static final long serialVersionUID = -7471457301304454454L;
+    private static final long serialVersionUID = -3481312197060837332L;
 
     private final VarScope scope;
 

--- a/rhino/src/main/java/org/mozilla/javascript/Script.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Script.java
@@ -42,7 +42,7 @@ public interface Script {
      * @return the result of executing the script
      * @see org.mozilla.javascript.Context#initStandardObjects()
      */
-    Object exec(Context cx, VarScope scope, Scriptable thisObj);
+    Object exec(Context cx, VarScope scope, Object thisObj);
 
     default JSDescriptor<JSScript> getDescriptor() {
         return null;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -6,6 +6,12 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ScriptableObject.DONTENUM;
+import static org.mozilla.javascript.ScriptableObject.PERMANENT;
+import static org.mozilla.javascript.ScriptableObject.READONLY;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+import static org.mozilla.javascript.UniqueTag.NOT_FOUND;
+
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -69,11 +75,19 @@ public class ScriptRuntime {
 
     /** Returns representation of the [[ThrowTypeError]] object. See ECMA 5 spec, 13.2.3 */
     public static BaseFunction typeErrorThrower(Context cx) {
-        if (cx.typeErrorThrower == null) {
-            BaseFunction thrower = new ThrowTypeError(cx.topCallScope);
-            cx.typeErrorThrower = thrower;
+        return typeErrorThrower(cx.topCallScope);
+    }
+
+    private static final SymbolKey TYPE_ERROR_THROWER = new SymbolKey("TypeErrorThrower", REGULAR);
+
+    public static BaseFunction typeErrorThrower(VarScope scope) {
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
+        var thrower = top.get(TYPE_ERROR_THROWER, top);
+        if (thrower == NOT_FOUND) {
+            thrower = new ThrowTypeError(top);
+            top.defineProperty(TYPE_ERROR_THROWER, thrower, DONTENUM | READONLY | PERMANENT);
         }
-        return cx.typeErrorThrower;
+        return (BaseFunction) thrower;
     }
 
     static final class ThrowTypeError extends BaseFunction {
@@ -1629,6 +1643,17 @@ public class ScriptRuntime {
     }
 
     public static Function getExistingCtor(Context cx, VarScope scope, String constructorName) {
+        Object ctorVal = ScriptableObject.getProperty(scope, constructorName);
+        if (ctorVal instanceof Function) {
+            return (Function) ctorVal;
+        }
+        if (ctorVal == Scriptable.NOT_FOUND) {
+            throw Context.reportRuntimeErrorById("msg.ctor.not.found", constructorName);
+        }
+        throw Context.reportRuntimeErrorById("msg.not.ctor", constructorName);
+    }
+
+    public static Function getExistingCtor(Context cx, VarScope scope, SymbolKey constructorName) {
         Object ctorVal = ScriptableObject.getProperty(scope, constructorName);
         if (ctorVal instanceof Function) {
             return (Function) ctorVal;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -231,7 +231,7 @@ public class ScriptRuntime {
         }
         NativeString.init(cx, scope, sealed);
         NativeBoolean.init(cx, scope, sealed);
-        NativeNumber.init(scope, sealed);
+        NativeNumber.init(cx, scope, sealed);
         NativeDate.init(cx, scope, sealed);
         new LazilyLoadedCtor<>(scope, "Math", sealed, true, NativeMath::init);
         new LazilyLoadedCtor<>(scope, "JSON", sealed, true, NativeJSON::init);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -229,7 +229,7 @@ public class ScriptRuntime {
             // representation
             NativeArray.setMaximumInitialCapacity(200000);
         }
-        NativeString.init(scope, sealed);
+        NativeString.init(cx, scope, sealed);
         NativeBoolean.init(cx, scope, sealed);
         NativeNumber.init(scope, sealed);
         NativeDate.init(cx, scope, sealed);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -207,7 +207,7 @@ public class ScriptRuntime {
                         : new LegacyCacheFactory.Concurrent();
         typeFactory.associate(scope);
 
-        LambdaConstructor function = BaseFunction.init(cx, scope, sealed);
+        JSFunction function = BaseFunction.init(cx, scope, sealed);
         JSFunction obj = NativeObject.init(cx, scope, sealed);
 
         ScriptableObject objectPrototype = (ScriptableObject) obj.getPrototypeProperty();
@@ -236,7 +236,7 @@ public class ScriptRuntime {
         new LazilyLoadedCtor<>(scope, "Math", sealed, true, NativeMath::init);
         new LazilyLoadedCtor<>(scope, "JSON", sealed, true, NativeJSON::init);
 
-        NativeScript.init(cx, scope, sealed);
+        NativeScript.init2(cx, scope, sealed);
 
         NativeIterator.init(cx, scope, sealed); // Also initializes NativeGenerator & ES6Generator
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -240,12 +240,12 @@ public class ScriptRuntime {
 
         NativeIterator.init(cx, scope, sealed); // Also initializes NativeGenerator & ES6Generator
 
-        NativeArrayIterator.init(scope, sealed);
-        NativeStringIterator.init(scope, sealed);
+        NativeArrayIterator.init(cx, scope, sealed);
+        NativeStringIterator.init(cx, scope, sealed);
         registerRegExp(cx, scope, sealed);
 
-        NativeJavaObject.init(scope, sealed);
-        NativeJavaMap.init(scope, sealed);
+        NativeJavaObject.init(cx, scope, sealed);
+        NativeJavaMap.init(cx, scope, sealed);
 
         // define lazy-loaded properties using their class name
         // Depends on the old reflection-based lazy loading mechanism
@@ -282,8 +282,6 @@ public class ScriptRuntime {
 
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             NativeSymbol.init(cx, scope, sealed);
-            NativeCollectionIterator.init(scope, NativeSet.ITERATOR_TAG, sealed);
-            NativeCollectionIterator.init(scope, NativeMap.ITERATOR_TAG, sealed);
             new LazilyLoadedCtor<>(scope, "Map", sealed, true, NativeMap::init);
             new LazilyLoadedCtor<>(scope, "Promise", sealed, true, NativePromise::init);
             new LazilyLoadedCtor<>(scope, "Set", sealed, true, NativeSet::init);
@@ -302,7 +300,7 @@ public class ScriptRuntime {
     private static void registerRegExp(Context cx, TopLevel scope, boolean sealed) {
         RegExpProxy regExpProxy = getRegExpProxy(cx);
         if (regExpProxy != null) {
-            regExpProxy.register(scope, sealed);
+            regExpProxy.register(cx, scope, sealed);
         }
     }
 
@@ -2817,6 +2815,7 @@ public class ScriptRuntime {
     private static Boolean enumNextInOrder(IdEnumeration enumObj, Context cx) {
         Object v = ScriptableObject.getProperty(enumObj.iterator, ES6Iterator.NEXT_METHOD);
         if (!(v instanceof Callable)) {
+            new Error(String.format("%s", v)).printStackTrace();
             throw notFunctionError(enumObj.iterator, ES6Iterator.NEXT_METHOD);
         }
         Callable f = (Callable) v;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -2635,7 +2635,7 @@ public class ScriptRuntime {
      * if a given property has already been enumerated.
      */
     private static class IdEnumeration implements Serializable {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = -8685189816346084720L;
         Scriptable obj;
         Object[] ids;
         HashSet<Object> used;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -116,7 +116,7 @@ public class ScriptRuntime {
         }
 
         @Override
-        public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
             throwNotAllowed();
             return null;
         }
@@ -152,7 +152,7 @@ public class ScriptRuntime {
          * @return the result of the call
          */
         @Override
-        public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
             Object[] nestedArgs = new Object[2];
 
             nestedArgs[0] = methodName;
@@ -3426,7 +3426,7 @@ public class ScriptRuntime {
      * times. The args array reference should not be stored in any object that can be GC-reachable
      * after this method returns. If this is necessary, store args.clone(), not args array itself.
      */
-    public static Ref callRef(Callable function, Scriptable thisObj, Object[] args, Context cx) {
+    public static Ref callRef(Callable function, Object thisObj, Object[] args, Context cx) {
         if (function instanceof RefCallable) {
             RefCallable rfunction = (RefCallable) function;
             Ref ref = rfunction.refCall(cx, thisObj, args);
@@ -3459,7 +3459,7 @@ public class ScriptRuntime {
             Scriptable thisObj,
             Object[] args,
             VarScope scope,
-            Scriptable callerThis,
+            Object callerThis,
             int callType,
             String filename,
             int lineNumber,
@@ -3498,7 +3498,7 @@ public class ScriptRuntime {
      * <p>See Ecma 15.3.4.[34]
      */
     public static Object applyOrCall(
-            boolean isApply, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            boolean isApply, Context cx, VarScope scope, Object thisObj, Object[] args) {
         int L = args.length;
         Callable function = getCallable(thisObj);
 
@@ -3574,14 +3574,16 @@ public class ScriptRuntime {
         }
     }
 
-    static Callable getCallable(Scriptable thisObj) {
+    static Callable getCallable(Object thisObj) {
         Callable function;
         if (thisObj instanceof Callable) {
             function = (Callable) thisObj;
         } else if (thisObj == null) {
             throw ScriptRuntime.notFunctionError(null, null);
+        } else if (!(thisObj instanceof Scriptable)) {
+            throw ScriptRuntime.notFunctionError(thisObj, null);
         } else {
-            Object value = thisObj.getDefaultValue(ScriptRuntime.FunctionClass);
+            Object value = ((Scriptable) thisObj).getDefaultValue(ScriptRuntime.FunctionClass);
             if (!(value instanceof Callable)) {
                 throw ScriptRuntime.notFunctionError(value, thisObj);
             }
@@ -4901,12 +4903,12 @@ public class ScriptRuntime {
      */
     @Deprecated
     public static Object doTopCall(
-            Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Callable callable, Context cx, VarScope scope, Object thisObj, Object[] args) {
         return doTopCall(callable, cx, scope, thisObj, args, cx.isStrictMode());
     }
 
     @Deprecated
-    public static Object doTopCall(Script script, Context cx, VarScope scope, Scriptable thisObj) {
+    public static Object doTopCall(Script script, Context cx, VarScope scope, Object thisObj) {
         return doTopCall(script, cx, scope, thisObj, cx.isStrictMode());
     }
 
@@ -4914,7 +4916,7 @@ public class ScriptRuntime {
             Callable callable,
             Context cx,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args,
             boolean isTopLevelStrict) {
         if (scope == null) throw new IllegalArgumentException();
@@ -4941,11 +4943,7 @@ public class ScriptRuntime {
     }
 
     public static Object doTopCall(
-            Script script,
-            Context cx,
-            VarScope scope,
-            Scriptable thisObj,
-            boolean isTopLevelStrict) {
+            Script script, Context cx, VarScope scope, Object thisObj, boolean isTopLevelStrict) {
         if (scope == null) throw new IllegalArgumentException();
         if (cx.topCallScope != null) throw new IllegalStateException();
 
@@ -5010,11 +5008,7 @@ public class ScriptRuntime {
     }
 
     public static void initScript(
-            ScriptOrFn execObj,
-            Scriptable thisObj,
-            Context cx,
-            VarScope scope,
-            boolean evalScript) {
+            ScriptOrFn execObj, Object thisObj, Context cx, VarScope scope, boolean evalScript) {
         if (cx.topCallScope == null) throw new IllegalStateException();
 
         var desc = execObj.getDescriptor();

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -45,8 +45,7 @@ public class ScriptRuntimeES6 {
                         scope,
                         "get [Symbol.species]",
                         0,
-                        (Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) ->
-                                thisObj,
+                        (Context lcx, VarScope lscope, Object thisObj, Object[] args) -> thisObj,
                         false),
                 ScriptableObject.NOT_FOUND,
                 ScriptableObject.NOT_FOUND);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -2214,6 +2214,24 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         return null;
     }
 
+    public static Scriptable getClassPrototype(VarScope scope, Symbol className) {
+        scope = getTopLevelScope(scope);
+        Object ctor = getProperty(scope, className);
+        Object proto;
+        if (ctor instanceof BaseFunction) {
+            proto = ((BaseFunction) ctor).getPrototypeProperty();
+        } else if (ctor instanceof Scriptable) {
+            Scriptable ctorObj = (Scriptable) ctor;
+            proto = ctorObj.get("prototype", ctorObj);
+        } else {
+            return null;
+        }
+        if (proto instanceof Scriptable) {
+            return (Scriptable) proto;
+        }
+        return null;
+    }
+
     /**
      * Get the global scope.
      *
@@ -2313,6 +2331,10 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     }
 
     public static Object getProperty(VarScope obj, String name) {
+        return obj.get(name, obj);
+    }
+
+    public static Object getProperty(VarScope obj, Symbol name) {
         return obj.get(name, obj);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/SecurityController.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SecurityController.java
@@ -135,14 +135,14 @@ public abstract class SecurityController {
             Context cx,
             Callable callable,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args) {
         return execWithDomain(
                 cx,
                 scope,
                 new Script() {
                     @Override
-                    public Object exec(Context cx, VarScope scope, Scriptable thisObjIgnored) {
+                    public Object exec(Context cx, VarScope scope, Object thisObjIgnored) {
                         return callable.call(cx, scope, thisObj, args);
                     }
                 },
@@ -154,7 +154,7 @@ public abstract class SecurityController {
             Context cx,
             Script script,
             VarScope scope,
-            Scriptable thisObj,
+            Object thisObj,
             Object[] args) {
         return execWithDomain(cx, scope, script, securityDomain);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -16,7 +16,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 public abstract class SlotMapOwner<T extends PropHolder<T>> implements PropHolder<T> {
-    private static final long serialVersionUID = 1L;
 
     /**
      * Maximum size of an {@link EmbeddedSlotMap} before it is promoted to a {@link HashSlotMap}.

--- a/rhino/src/main/java/org/mozilla/javascript/Synchronizer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Synchronizer.java
@@ -51,7 +51,7 @@ public class Synchronizer extends Delegator {
      * @see org.mozilla.javascript.Function#call
      */
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object sync = syncObject != null ? syncObject : thisObj;
         synchronized (sync instanceof Wrapper ? ((Wrapper) sync).unwrap() : sync) {
             return ((Function) obj).call(cx, scope, thisObj, args);

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -197,7 +197,10 @@ public class TopLevel extends ScopeObject {
                 // Handle weird situation of "GeneratorFunction" being a real constructor
                 // which is never registered in the top-level scope
                 ctors.put(
-                        builtin, (BaseFunction) BaseFunction.initAsGeneratorFunction(this, sealed));
+                        builtin,
+                        (BaseFunction)
+                                BaseFunction.initAsGeneratorFunction(
+                                        Context.getCurrentContext(), this, sealed));
             }
         }
         errors = new EnumMap<>(NativeErrors.class);
@@ -240,7 +243,7 @@ public class TopLevel extends ScopeObject {
             }
         }
         // fall back to normal constructor lookup
-        String typeName;
+        Object typeName;
         if (type == Builtins.GeneratorFunction) {
             // GeneratorFunction isn't stored in scope with that name, but in case
             // we end up falling back to this value then we have to
@@ -249,7 +252,11 @@ public class TopLevel extends ScopeObject {
         } else {
             typeName = type.name();
         }
-        return ScriptRuntime.getExistingCtor(cx, scope, typeName);
+        if (typeName instanceof String) {
+            return ScriptRuntime.getExistingCtor(cx, scope, (String) typeName);
+        } else {
+            return ScriptRuntime.getExistingCtor(cx, scope, (SymbolKey) typeName);
+        }
     }
 
     /**
@@ -291,8 +298,7 @@ public class TopLevel extends ScopeObject {
             return result;
         }
 
-        // fall back to normal prototype lookup
-        String typeName;
+        Object typeName;
         if (type == Builtins.GeneratorFunction) {
             // GeneratorFunction isn't stored in scope with that name, but in case
             // we end up falling back to this value then we have to
@@ -301,7 +307,11 @@ public class TopLevel extends ScopeObject {
         } else {
             typeName = type.name();
         }
-        return ScriptableObject.getClassPrototype(scope, typeName);
+        if (typeName instanceof String) {
+            return ScriptableObject.getClassPrototype(scope, (String) typeName);
+        } else {
+            return ScriptableObject.getClassPrototype(scope, (SymbolKey) typeName);
+        }
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/WithScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WithScope.java
@@ -3,8 +3,6 @@ package org.mozilla.javascript;
 import static org.mozilla.javascript.Scriptable.NOT_FOUND;
 
 public class WithScope implements VarScope {
-    private static final long serialVersionUID = -7471457301304454454L;
-
     // This cannot be final because XML dot queries mutate it!
     private Scriptable obj;
     private final VarScope parent;

--- a/rhino/src/main/java/org/mozilla/javascript/ast/AstNode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/AstNode.java
@@ -138,7 +138,7 @@ public abstract class AstNode extends Node implements Comparable<AstNode> {
     }
 
     public static class PositionComparator implements Comparator<AstNode>, Serializable {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1551233591343412911L;
 
         /**
          * Sorts nodes by (relative) start position. The start positions are relative to their

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScope.java
@@ -15,7 +15,7 @@ import org.mozilla.javascript.VarScope;
  * URIs in order to resolve relative module IDs and check sandbox constraints.
  */
 public class ModuleScope extends DeclarationScope {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -877901398709024429L;
     private final URI uri;
     private final URI base;
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/ModuleScript.java
@@ -16,7 +16,7 @@ import org.mozilla.javascript.Script;
  * @version $Id: ModuleScript.java,v 1.3 2011/04/07 20:26:11 hannes%helma.at Exp $
  */
 public class ModuleScript implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -8287890021565388770L;
     private final Script script;
     private final URI uri;
     private final URI base;

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
@@ -174,7 +174,7 @@ public class Require extends BaseFunction {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args == null || args.length < 1) {
             throw ScriptRuntime.throwError(cx, scope, "require() needs one argument");
         }

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/Require.java
@@ -45,7 +45,7 @@ import org.mozilla.javascript.VarScope;
  * @version $Id: Require.java,v 1.4 2011/04/07 20:26:11 hannes%helma.at Exp $
  */
 public class Require extends BaseFunction {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 5682218649242405574L;
     private final ModuleScriptProvider moduleScriptProvider;
     private final TopLevel nativeScope;
     private final Scriptable paths;

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/RequireBuilder.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/RequireBuilder.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.TopLevel;
  * @version $Id: RequireBuilder.java,v 1.4 2011/04/07 20:26:11 hannes%helma.at Exp $
  */
 public class RequireBuilder implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 5244169608278369242L;
     private boolean sandboxed = true;
     private ModuleScriptProvider moduleScriptProvider;
     private Script preExec;

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/DefaultUrlConnectionExpiryCalculator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/DefaultUrlConnectionExpiryCalculator.java
@@ -19,7 +19,7 @@ import java.net.URLConnection;
  */
 public class DefaultUrlConnectionExpiryCalculator
         implements UrlConnectionExpiryCalculator, Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 6649125723317726741L;
     private final long relativeExpiry;
 
     /** Creates a new default expiry calculator with one minute relative expiry. */

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/ModuleSource.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/ModuleSource.java
@@ -31,7 +31,7 @@ import java.net.URI;
  * @version $Id: ModuleSource.java,v 1.3 2011/04/07 20:26:12 hannes%helma.at Exp $
  */
 public class ModuleSource implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 7183957145984428890L;
     private final Reader reader;
     private final Object securityDomain;
     private final URI uri;

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/ModuleSourceProviderBase.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/ModuleSourceProviderBase.java
@@ -26,7 +26,7 @@ import org.mozilla.javascript.ScriptableObject;
  * @version $Id: ModuleSourceProviderBase.java,v 1.3 2011/04/07 20:26:12 hannes%helma.at Exp $
  */
 public abstract class ModuleSourceProviderBase implements ModuleSourceProvider, Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -5687971989835149396L;
 
     @Override
     public ModuleSource loadSource(String moduleId, Scriptable paths, Object validator)

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/ParsedContentType.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/ParsedContentType.java
@@ -14,7 +14,7 @@ import java.util.StringTokenizer;
  * @version $Id: ParsedContentType.java,v 1.3 2011/04/07 20:26:12 hannes%helma.at Exp $
  */
 public final class ParsedContentType implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2660291075921848672L;
     private final String contentType;
     private final String encoding;
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/SoftCachingModuleScriptProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/SoftCachingModuleScriptProvider.java
@@ -30,7 +30,7 @@ import org.mozilla.javascript.commonjs.module.ModuleScript;
  *     $
  */
 public class SoftCachingModuleScriptProvider extends CachingModuleScriptProviderBase {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 523398435792363456L;
     private transient ReferenceQueue<Script> scriptRefQueue = new ReferenceQueue<>();
     private transient ConcurrentMap<String, ScriptReference> scripts =
             new ConcurrentHashMap<>(16, .75f, getConcurrencyLevel());

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/StrongCachingModuleScriptProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/StrongCachingModuleScriptProvider.java
@@ -19,7 +19,7 @@ import org.mozilla.javascript.commonjs.module.ModuleScript;
  */
 public class StrongCachingModuleScriptProvider extends CachingModuleScriptProviderBase {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -8435427841788350515L;
     private final Map<String, CachedModuleScript> modules =
             new ConcurrentHashMap<>(16, .75f, getConcurrencyLevel());
 

--- a/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/commonjs/module/provider/UrlModuleSourceProvider.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @version $Id: UrlModuleSourceProvider.java,v 1.4 2011/04/07 20:26:12 hannes%helma.at Exp $
  */
 public class UrlModuleSourceProvider extends ModuleSourceProviderBase {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 6253848745572187376L;
     private final Iterable<URI> privilegedUris;
     private final Iterable<URI> fallbackUris;
     private final UrlConnectionSecurityDomainProvider urlConnectionSecurityDomainProvider;
@@ -213,7 +213,7 @@ public class UrlModuleSourceProvider extends ModuleSourceProviderBase {
     }
 
     private static class URLValidator implements Serializable {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = -832296617758674059L;
         private final URI uri;
         private final long lastModified;
         private final String entityTags;

--- a/rhino/src/main/java/org/mozilla/javascript/debug/DebugFrame.java
+++ b/rhino/src/main/java/org/mozilla/javascript/debug/DebugFrame.java
@@ -9,7 +9,6 @@
 package org.mozilla.javascript.debug;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.VarScope;
 
 /**
@@ -27,7 +26,7 @@ public interface DebugFrame {
      * @param thisObj value of the JavaScript {@code this} object
      * @param args the array of arguments
      */
-    default void onEnter(Context cx, VarScope activation, Scriptable thisObj, Object[] args) {}
+    default void onEnter(Context cx, VarScope activation, Object thisObj, Object[] args) {}
 
     /**
      * Called when executed code reaches new line in the source.

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -832,7 +832,10 @@ class BodyCodegen {
                 cfw.addALoad(variableObjectLocal);
                 int enumType =
                         type == Token.ENUM_INIT_KEYS
-                                ? ScriptRuntime.ENUMERATE_KEYS
+                                ? Context.getCurrentContext().getLanguageVersion()
+                                                <= Context.VERSION_1_8
+                                        ? ScriptRuntime.ENUMERATE_KEYS
+                                        : ScriptRuntime.ENUMERATE_KEYS_NO_ITERATOR
                                 : type == Token.ENUM_INIT_VALUES
                                         ? ScriptRuntime.ENUMERATE_VALUES
                                         : type == Token.ENUM_INIT_VALUES_IN_ORDER

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -456,7 +456,7 @@ class BodyCodegen {
             addScriptRuntimeInvoke(
                     "initScript",
                     "(Lorg/mozilla/javascript/ScriptOrFn;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
+                            + "Ljava/lang/Object;"
                             + "Lorg/mozilla/javascript/Context;"
                             + "Lorg/mozilla/javascript/VarScope;"
                             + "Z"
@@ -1083,7 +1083,7 @@ class BodyCodegen {
                 addScriptRuntimeInvoke(
                         "callRef",
                         "(Lorg/mozilla/javascript/Callable;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
+                                + "Ljava/lang/Object;"
                                 + "[Ljava/lang/Object;"
                                 + "Lorg/mozilla/javascript/Context;"
                                 + ")Lorg/mozilla/javascript/Ref;");
@@ -2690,7 +2690,7 @@ class BodyCodegen {
                         + "Lorg/mozilla/javascript/Scriptable;"
                         + "[Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/VarScope;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Ljava/lang/Object;"
                         + "I"
                         + "Ljava/lang/String;IZ"
                         + ")Ljava/lang/Object;");
@@ -2734,7 +2734,7 @@ class BodyCodegen {
                         + "Lorg/mozilla/javascript/Scriptable;"
                         + "[Ljava/lang/Object;"
                         + "Lorg/mozilla/javascript/VarScope;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Ljava/lang/Object;"
                         + "I"
                         + "Ljava/lang/String;IZ"
                         + ")Ljava/lang/Object;");
@@ -2801,7 +2801,7 @@ class BodyCodegen {
                 "call",
                 "(Lorg/mozilla/javascript/Context;"
                         + "Lorg/mozilla/javascript/VarScope;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Ljava/lang/Object;"
                         + "[Ljava/lang/Object;"
                         + ")Ljava/lang/Object;");
 
@@ -2889,7 +2889,7 @@ class BodyCodegen {
                     ByteCode.INVOKEVIRTUAL,
                     "org/mozilla/javascript/JSFunction",
                     "getThisObj",
-                    "(Lorg/mozilla/javascript/Scriptable;)Lorg/mozilla/javascript/Scriptable;");
+                    "(Ljava/lang/Object;)Ljava/lang/Object;");
             cfw.addAStore(thisObjLocal);
         }
         cfw.addALoad(contextLocal);
@@ -2971,7 +2971,7 @@ class BodyCodegen {
                     "call",
                     "(Lorg/mozilla/javascript/Context;"
                             + "Lorg/mozilla/javascript/VarScope;"
-                            + "Lorg/mozilla/javascript/Scriptable;"
+                            + "Ljava/lang/Object;"
                             + "[Ljava/lang/Object;"
                             + ")Ljava/lang/Object;");
         }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -985,7 +985,7 @@ public class Codegen implements Evaluator {
                     + "Lorg/mozilla/javascript/Context;"
                     + "Lorg/mozilla/javascript/VarScope;"
                     + "Lorg/mozilla/javascript/JSDescriptor;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Scriptable;"
                     + ")V";
 

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpCallable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpCallable.java
@@ -19,7 +19,7 @@ class NativeRegExpCallable extends NativeRegExp implements Function {
     }
 
     @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return execSub(cx, scope, args, MATCH);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -6,6 +6,7 @@
 
 package org.mozilla.javascript.regexp;
 
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ES6Iterator;
 import org.mozilla.javascript.ScriptRuntime;
@@ -19,6 +20,9 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     private static final long serialVersionUID = -1622794465605583044L;
     private static final String ITERATOR_TAG = "RegExpStringIterator";
 
+    private static final ClassDescriptor DESCRIPTOR =
+            ES6Iterator.makeDescriptor(ITERATOR_TAG, "RegExp String Iterator");
+
     private Scriptable regexp;
     private String string;
     private boolean global;
@@ -26,8 +30,14 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     private boolean nextDone;
     private Object next = null;
 
-    public static void init(TopLevel scope, boolean sealed) {
-        ES6Iterator.init(scope, sealed, new NativeRegExpStringIterator(), ITERATOR_TAG);
+    public static void init(Context cx, VarScope scope, boolean sealed) {
+        ES6Iterator.initialize(
+                DESCRIPTOR,
+                cx,
+                (TopLevel) scope,
+                new NativeRegExpStringIterator(),
+                sealed,
+                ITERATOR_TAG);
     }
 
     /** Only for constructing the prototype object. */

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -16,7 +16,7 @@ import org.mozilla.javascript.VarScope;
 
 // See ECMAScript spec 22.2.9.1
 public final class NativeRegExpStringIterator extends ES6Iterator {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -1622794465605583044L;
     private static final String ITERATOR_TAG = "RegExpStringIterator";
 
     private Scriptable regexp;

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -22,8 +22,8 @@ import org.mozilla.javascript.VarScope;
 public class RegExpImpl implements RegExpProxy {
 
     @Override
-    public void register(TopLevel scope, boolean sealed) {
-        NativeRegExpStringIterator.init(scope, sealed);
+    public void register(Context cx, TopLevel scope, boolean sealed) {
+        NativeRegExpStringIterator.init(cx, scope, sealed);
         new LazilyLoadedCtor<>(scope, "RegExp", sealed, true, NativeRegExp::init);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeArrayBuffer.java
@@ -6,10 +6,17 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import org.mozilla.javascript.AbstractEcmaObjectOperations;
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Constructable;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
@@ -29,6 +36,42 @@ public class NativeArrayBuffer extends ScriptableObject {
 
     private static final byte[] EMPTY_BUF = new byte[0];
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder("ArrayBuffer", 1, NativeArrayBuffer::js_constructor)
+                        .withMethod(CTOR, "isView", 1, NativeArrayBuffer::js_isView)
+                        .withMethod(PROTO, "slice", 2, NativeArrayBuffer::js_slice)
+                        .withMethod(PROTO, "transfer", 0, NativeArrayBuffer::js_transfer)
+                        .withMethod(PROTO, "resize", 1, NativeArrayBuffer::js_resize)
+                        .withMethod(
+                                PROTO,
+                                "transferToFixedLength",
+                                0,
+                                NativeArrayBuffer::js_transferToFixedLength)
+                        .withProp(
+                                PROTO,
+                                "byteLength",
+                                NativeArrayBuffer::js_byteLength,
+                                null,
+                                DONTENUM)
+                        .withProp(PROTO, "detached", NativeArrayBuffer::js_detached, null, DONTENUM)
+                        .withProp(
+                                PROTO, "resizable", NativeArrayBuffer::js_resizable, null, DONTENUM)
+                        .withProp(
+                                PROTO,
+                                "maxByteLength",
+                                NativeArrayBuffer::js_maxByteLength,
+                                null,
+                                DONTENUM)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value("ArrayBuffer", DONTENUM | READONLY))
+                        .build();
+    }
+
     byte[] buffer;
     // ES2024: maxByteLength for resizable buffers (-1 = fixed-length)
     private int maxByteLength = -1;
@@ -39,34 +82,7 @@ public class NativeArrayBuffer extends ScriptableObject {
     }
 
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        "ArrayBuffer",
-                        1,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeArrayBuffer::js_constructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.defineConstructorMethod(scope, "isView", 1, NativeArrayBuffer::js_isView);
-        constructor.definePrototypeMethod(scope, "slice", 2, NativeArrayBuffer::js_slice);
-        constructor.definePrototypeMethod(scope, "transfer", 0, NativeArrayBuffer::js_transfer);
-        constructor.definePrototypeMethod(
-                scope, "transferToFixedLength", 0, NativeArrayBuffer::js_transferToFixedLength);
-        constructor.definePrototypeMethod(scope, "resize", 1, NativeArrayBuffer::js_resize);
-        constructor.definePrototypeProperty(cx, "byteLength", NativeArrayBuffer::js_byteLength);
-        constructor.definePrototypeProperty(cx, "detached", NativeArrayBuffer::js_detached);
-        constructor.definePrototypeProperty(cx, "resizable", NativeArrayBuffer::js_resizable);
-        constructor.definePrototypeProperty(
-                cx, "maxByteLength", NativeArrayBuffer::js_maxByteLength);
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, "ArrayBuffer", DONTENUM | READONLY);
-
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
     /** Create an empty buffer. */
@@ -137,11 +153,12 @@ public class NativeArrayBuffer extends ScriptableObject {
         return newBuf;
     }
 
-    private static NativeArrayBuffer getSelf(Scriptable thisObj) {
+    private static NativeArrayBuffer getSelf(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeArrayBuffer.class);
     }
 
-    private static NativeArrayBuffer js_constructor(Context cx, VarScope scope, Object[] args) {
+    private static NativeArrayBuffer js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         double length = isArg(args, 0) ? ScriptRuntime.toIndex(args[0]) : 0;
 
         // ES2024: Check for options parameter with maxByteLength
@@ -163,17 +180,19 @@ public class NativeArrayBuffer extends ScriptableObject {
         }
 
         NativeArrayBuffer buffer = new NativeArrayBuffer(length);
+        buffer.setParentScope(f.getDeclarationScope());
+        buffer.setPrototype((Scriptable) f.getPrototypeProperty());
         buffer.maxByteLength = maxByteLength;
         return buffer;
     }
 
     private static Boolean js_isView(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return Boolean.valueOf((isArg(args, 0) && (args[0] instanceof NativeArrayBufferView)));
     }
 
     private static NativeArrayBuffer js_slice(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeArrayBuffer self = getSelf(thisObj);
 
         if (self.isDetached()) {
@@ -198,12 +217,12 @@ public class NativeArrayBuffer extends ScriptableObject {
         Constructable constructor =
                 AbstractEcmaObjectOperations.speciesConstructor(
                         cx,
-                        thisObj,
+                        self,
                         TopLevel.getBuiltinCtor(
                                 cx,
-                                ScriptableObject.getTopLevelScope(scope),
+                                ScriptableObject.getTopLevelScope(s),
                                 TopLevel.Builtins.ArrayBuffer));
-        Scriptable newBuf = constructor.construct(cx, scope, new Object[] {len});
+        Scriptable newBuf = constructor.construct(cx, s, new Object[] {len});
         if (!(newBuf instanceof NativeArrayBuffer)) {
             throw ScriptRuntime.typeErrorById("msg.species.invalid.ctor");
         }
@@ -270,18 +289,18 @@ public class NativeArrayBuffer extends ScriptableObject {
 
     // ES2025 ArrayBuffer.prototype.transfer
     private static Scriptable js_transfer(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var self = getSelf(thisObj);
         var arg1 = args.length > 0 ? args[0] : Undefined.instance;
-        return self.copyAndDetach(cx, scope, arg1, true);
+        return self.copyAndDetach(cx, s, arg1, true);
     }
 
     // ES2025 ArrayBuffer.prototype.transferToFixedLength
     private static Scriptable js_transferToFixedLength(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var self = getSelf(thisObj);
         var arg1 = args.length > 0 ? args[0] : Undefined.instance;
-        return self.copyAndDetach(cx, scope, arg1, false);
+        return self.copyAndDetach(cx, s, arg1, false);
     }
 
     private static boolean isArg(Object[] args, int i) {
@@ -289,7 +308,8 @@ public class NativeArrayBuffer extends ScriptableObject {
     }
 
     // ES2024 ArrayBuffer.prototype.resize
-    private static Object js_resize(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object js_resize(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeArrayBuffer self = getSelf(thisObj);
         if (!self.isResizable()) {
             throw ScriptRuntime.typeErrorById("msg.arraybuf.notresizeable");

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
@@ -6,13 +6,17 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.math.BigInteger;
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -25,6 +29,21 @@ public class NativeBigInt64Array extends NativeBigIntArrayView {
 
     private static final String CLASS_NAME = "BigInt64Array";
     private static final int BYTES_PER_ELEMENT = 8;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeBigInt64Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(8))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(8))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeBigInt64Array() {}
 
@@ -41,33 +60,8 @@ public class NativeBigInt64Array extends NativeBigIntArrayView {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeBigInt64Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeBigInt64Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -75,8 +69,10 @@ public class NativeBigInt64Array extends NativeBigIntArrayView {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeFloat64Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeFloat64Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeBigInt64Array::new, 8);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
@@ -21,7 +21,7 @@ import org.mozilla.javascript.VarScope;
  * interface. It also implements List&lt;Double&gt; for direct manipulation in Java.
  */
 public class NativeBigInt64Array extends NativeBigIntArrayView {
-    private static final long serialVersionUID = -1255405650050639335L;
+    private static final long serialVersionUID = 3291575517061505304L;
 
     private static final String CLASS_NAME = "BigInt64Array";
     private static final int BYTES_PER_ELEMENT = 8;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
@@ -6,13 +6,17 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.math.BigInteger;
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -25,6 +29,21 @@ public class NativeBigUint64Array extends NativeBigIntArrayView {
 
     private static final String CLASS_NAME = "BigUint64Array";
     private static final int BYTES_PER_ELEMENT = 8;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeBigUint64Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(8))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(8))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeBigUint64Array() {}
 
@@ -41,33 +60,8 @@ public class NativeBigUint64Array extends NativeBigIntArrayView {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeBigUint64Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeBigUint64Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -75,8 +69,10 @@ public class NativeBigUint64Array extends NativeBigIntArrayView {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeFloat64Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeFloat64Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeBigUint64Array::new, 8);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
@@ -21,7 +21,7 @@ import org.mozilla.javascript.VarScope;
  * interface. It also implements List&lt;Double&gt; for direct manipulation in Java.
  */
 public class NativeBigUint64Array extends NativeBigIntArrayView {
-    private static final long serialVersionUID = -1255405650050639335L;
+    private static final long serialVersionUID = 6278562787625694949L;
 
     private static final String CLASS_NAME = "BigUint64Array";
     private static final int BYTES_PER_ELEMENT = 8;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -1,4 +1,4 @@
-/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+/* -*- Mode: java; tab-width: 8g; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -6,12 +6,17 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.math.BigInteger;
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
@@ -26,6 +31,46 @@ public class NativeDataView extends NativeArrayBufferView {
     private static final long serialVersionUID = 1427967607557438968L;
 
     public static final String CLASS_NAME = "DataView";
+
+    public static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                1,
+                                NativeTypedArrayView::typeError,
+                                NativeDataView::js_constructor)
+                        .withProp(PROTO, "buffer", NativeDataView::js_buffer, null, DONTENUM)
+                        .withProp(
+                                PROTO, "byteLength", NativeDataView::js_byteLength, null, DONTENUM)
+                        .withProp(
+                                PROTO, "byteOffset", NativeDataView::js_byteOffset, null, DONTENUM)
+                        .withProp(PROTO, SymbolKey.TO_STRING_TAG, value(CLASS_NAME, DONTENUM | READONLY))
+                        .withMethod(PROTO, "getFloat16", 1, NativeDataView::js_getFloat16)
+                        .withMethod(PROTO, "getFloat32", 1, NativeDataView::js_getFloat32)
+                        .withMethod(PROTO, "getFloat64", 1, NativeDataView::js_getFloat64)
+                        .withMethod(PROTO, "getInt8", 1, NativeDataView::js_getInt8)
+                        .withMethod(PROTO, "getInt16", 1, NativeDataView::js_getInt16)
+                        .withMethod(PROTO, "getInt32", 1, NativeDataView::js_getInt32)
+                        .withMethod(PROTO, "getUint8", 1, NativeDataView::js_getUint8)
+                        .withMethod(PROTO, "getUint16", 1, NativeDataView::js_getUint16)
+                        .withMethod(PROTO, "getUint32", 1, NativeDataView::js_getUint32)
+                        .withMethod(PROTO, "getBigInt64", 1, NativeDataView::js_getBigInt64)
+                        .withMethod(PROTO, "getBigUint64", 1, NativeDataView::js_getBigUint64)
+                        .withMethod(PROTO, "setFloat16", 2, NativeDataView::js_setFloat16)
+                        .withMethod(PROTO, "setFloat32", 2, NativeDataView::js_setFloat32)
+                        .withMethod(PROTO, "setFloat64", 2, NativeDataView::js_setFloat64)
+                        .withMethod(PROTO, "setInt8", 2, NativeDataView::js_setInt8)
+                        .withMethod(PROTO, "setInt16", 2, NativeDataView::js_setInt16)
+                        .withMethod(PROTO, "setInt32", 2, NativeDataView::js_setInt32)
+                        .withMethod(PROTO, "setUint8", 2, NativeDataView::js_setUint8)
+                        .withMethod(PROTO, "setUint16", 2, NativeDataView::js_setUint16)
+                        .withMethod(PROTO, "setUint32", 2, NativeDataView::js_setUint32)
+                        .withMethod(PROTO, "setBigInt64", 2, NativeDataView::js_setBigInt64)
+                        .withMethod(PROTO, "setBigUint64", 2, NativeDataView::js_setBigUint64)
+                        .build();
+    }
 
     private final boolean autoLength;
 
@@ -45,59 +90,35 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        1,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeDataView::js_constructor);
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-
-        constructor.definePrototypeProperty(
-                cx, "buffer", (Scriptable thisObj) -> realThis(thisObj).arrayBuffer);
-        constructor.definePrototypeProperty(cx, "byteLength", NativeDataView::js_getByteLength);
-        constructor.definePrototypeProperty(cx, "byteOffset", NativeDataView::js_getByteOffset);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-        constructor.definePrototypeMethod(scope, "getFloat16", 1, NativeDataView::js_getFloat16);
-        constructor.definePrototypeMethod(scope, "getFloat32", 1, NativeDataView::js_getFloat32);
-        constructor.definePrototypeMethod(scope, "getFloat64", 1, NativeDataView::js_getFloat64);
-        constructor.definePrototypeMethod(scope, "getInt8", 1, NativeDataView::js_getInt8);
-        constructor.definePrototypeMethod(scope, "getInt16", 1, NativeDataView::js_getInt16);
-        constructor.definePrototypeMethod(scope, "getInt32", 1, NativeDataView::js_getInt32);
-        constructor.definePrototypeMethod(scope, "getUint8", 1, NativeDataView::js_getUint8);
-        constructor.definePrototypeMethod(scope, "getUint16", 1, NativeDataView::js_getUint16);
-        constructor.definePrototypeMethod(scope, "getUint32", 1, NativeDataView::js_getUint32);
-        constructor.definePrototypeMethod(scope, "getBigInt64", 1, NativeDataView::js_getBigInt64);
-        constructor.definePrototypeMethod(
-                scope, "getBigUint64", 1, NativeDataView::js_getBigUint64);
-        constructor.definePrototypeMethod(scope, "setFloat16", 2, NativeDataView::js_setFloat16);
-        constructor.definePrototypeMethod(scope, "setFloat32", 2, NativeDataView::js_setFloat32);
-        constructor.definePrototypeMethod(scope, "setFloat64", 2, NativeDataView::js_setFloat64);
-        constructor.definePrototypeMethod(scope, "setInt8", 2, NativeDataView::js_setInt8);
-        constructor.definePrototypeMethod(scope, "setInt16", 2, NativeDataView::js_setInt16);
-        constructor.definePrototypeMethod(scope, "setInt32", 2, NativeDataView::js_setInt32);
-        constructor.definePrototypeMethod(scope, "setUint8", 2, NativeDataView::js_setUint8);
-        constructor.definePrototypeMethod(scope, "setUint16", 2, NativeDataView::js_setUint16);
-        constructor.definePrototypeMethod(scope, "setUint32", 2, NativeDataView::js_setUint32);
-        constructor.definePrototypeMethod(scope, "setBigInt64", 2, NativeDataView::js_setBigInt64);
-        constructor.definePrototypeMethod(
-                scope, "setBigUint64", 2, NativeDataView::js_setBigUint64);
-
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+        return DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
     }
 
-    private static NativeDataView realThis(Scriptable thisObj) {
+    private static NativeDataView realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeDataView.class);
     }
 
-    private static NativeDataView js_constructor(Context cx, VarScope scope, Object[] args) {
+    private static Object js_buffer(Scriptable thisObj) {
+        return realThis(thisObj).arrayBuffer;
+    }
+
+    private static Object js_byteLength(Scriptable thisObj) {
+        NativeDataView self = realThis(thisObj);
+        if (self.isDataViewOutOfBounds()) {
+            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
+        }
+        return self.getByteLength();
+    }
+
+    private static Object js_byteOffset(Scriptable thisObj) {
+        NativeDataView self = realThis(thisObj);
+        if (self.isDataViewOutOfBounds()) {
+            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
+        }
+        return self.offset;
+    }
+
+    private static NativeDataView js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!isArg(args, 0) || !(args[0] instanceof NativeArrayBuffer)) {
             throw ScriptRuntime.constructError("TypeError", "Missing parameters");
         }
@@ -130,7 +151,10 @@ public class NativeDataView extends NativeArrayBufferView {
             }
         }
 
-        return new NativeDataView(ab, pos, len, autoLength);
+        var res = new NativeDataView(ab, pos, len, autoLength);
+        res.setParentScope(f.getDeclarationScope());
+        res.setPrototype((Scriptable) f.getPrototypeProperty());
+        return res;
     }
 
     @Override
@@ -158,39 +182,39 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_getInt8(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getInt(cx, scope, 1, true, args);
+        return realThis.js_getInt(cx, s, 1, true, args);
     }
 
     private static Object js_getInt16(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getInt(cx, scope, 2, true, args);
+        return realThis.js_getInt(cx, s, 2, true, args);
     }
 
     private static Object js_getInt32(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getInt(cx, scope, 4, true, args);
+        return realThis.js_getInt(cx, s, 4, true, args);
     }
 
     private static Object js_getUint8(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getInt(cx, scope, 1, false, args);
+        return realThis.js_getInt(cx, s, 1, false, args);
     }
 
     private static Object js_getUint16(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getInt(cx, scope, 2, false, args);
+        return realThis.js_getInt(cx, s, 2, false, args);
     }
 
     private static Object js_getUint32(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getInt(cx, scope, 4, false, args);
+        return realThis.js_getInt(cx, s, 4, false, args);
     }
 
     private Object js_getInt(Context cx, VarScope scope, int bytes, boolean signed, Object[] args) {
@@ -230,21 +254,21 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_getFloat32(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getFloat(cx, scope, 4, args);
+        return realThis.js_getFloat(cx, s, 4, args);
     }
 
     private static Object js_getFloat64(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getFloat(cx, scope, 8, args);
+        return realThis.js_getFloat(cx, s, 8, args);
     }
 
     private static Object js_getFloat16(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        return realThis.js_getFloat(cx, scope, 2, args);
+        return realThis.js_getFloat(cx, s, 2, args);
     }
 
     private Object js_getFloat(Context cx, VarScope scope, int bytes, Object[] args) {
@@ -274,44 +298,44 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_setInt8(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setInt(cx, scope, 1, true, args);
+        realThis.js_setInt(cx, s, 1, true, args);
         return Undefined.instance;
     }
 
     private static Object js_setInt16(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setInt(cx, scope, 2, true, args);
+        realThis.js_setInt(cx, s, 2, true, args);
         return Undefined.instance;
     }
 
     private static Object js_setInt32(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setInt(cx, scope, 4, true, args);
+        realThis.js_setInt(cx, s, 4, true, args);
         return Undefined.instance;
     }
 
     private static Object js_setUint8(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setInt(cx, scope, 1, false, args);
+        realThis.js_setInt(cx, s, 1, false, args);
         return Undefined.instance;
     }
 
     private static Object js_setUint16(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setInt(cx, scope, 2, false, args);
+        realThis.js_setInt(cx, s, 2, false, args);
         return Undefined.instance;
     }
 
     private static Object js_setUint32(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setInt(cx, scope, 4, false, args);
+        realThis.js_setInt(cx, s, 4, false, args);
         return Undefined.instance;
     }
 
@@ -383,23 +407,23 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_setFloat32(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setFloat(cx, scope, 4, args);
+        realThis.js_setFloat(cx, s, 4, args);
         return Undefined.instance;
     }
 
     private static Object js_setFloat64(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setFloat(cx, scope, 8, args);
+        realThis.js_setFloat(cx, s, 8, args);
         return Undefined.instance;
     }
 
     private static Object js_setFloat16(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
-        realThis.js_setFloat(cx, scope, 2, args);
+        realThis.js_setFloat(cx, s, 2, args);
         return Undefined.instance;
     }
 
@@ -435,13 +459,13 @@ public class NativeDataView extends NativeArrayBufferView {
     }
 
     private static Object js_getBigInt64(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getBigInt(true, args);
     }
 
     private static Object js_getBigUint64(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         return realThis.js_getBigInt(false, args);
     }
@@ -482,14 +506,14 @@ public class NativeDataView extends NativeArrayBufferView {
     // but end up having precisely the same effect, with only the interpretation of the 64 bits in
     // an intermediate state differing.
     private static Object js_setBigInt64(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setBigInt(args);
         return Undefined.instance;
     }
 
     private static Object js_setBigUint64(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);
         realThis.js_setBigInt(args);
         return Undefined.instance;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -46,7 +46,10 @@ public class NativeDataView extends NativeArrayBufferView {
                                 PROTO, "byteLength", NativeDataView::js_byteLength, null, DONTENUM)
                         .withProp(
                                 PROTO, "byteOffset", NativeDataView::js_byteOffset, null, DONTENUM)
-                        .withProp(PROTO, SymbolKey.TO_STRING_TAG, value(CLASS_NAME, DONTENUM | READONLY))
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
                         .withMethod(PROTO, "getFloat16", 1, NativeDataView::js_getFloat16)
                         .withMethod(PROTO, "getFloat32", 1, NativeDataView::js_getFloat32)
                         .withMethod(PROTO, "getFloat64", 1, NativeDataView::js_getFloat64)

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
@@ -6,12 +6,18 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -25,10 +31,31 @@ public class NativeFloat16Array extends NativeTypedArrayView<Float> {
     private static final String CLASS_NAME = "Float16Array";
     private static final int BYTES_PER_ELEMENT = 2;
 
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeFloat16Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(2))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(2))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
+
     public NativeFloat16Array() {}
 
     public NativeFloat16Array(NativeArrayBuffer ab, int off, int len) {
         super(ab, off, len, len * BYTES_PER_ELEMENT);
+    }
+
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeFloat16Array::new, 2);
     }
 
     public NativeFloat16Array(int len) {
@@ -40,33 +67,8 @@ public class NativeFloat16Array extends NativeTypedArrayView<Float> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeFloat16Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeFloat16Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.VarScope;
  * interface. It also implements List&lt;Float&gt; for direct manipulation in Java.
  */
 public class NativeFloat16Array extends NativeTypedArrayView<Float> {
-    private static final long serialVersionUID = -8963461831950499340L;
+    private static final long serialVersionUID = -6624401421392903192L;
 
     private static final String CLASS_NAME = "Float16Array";
     private static final int BYTES_PER_ELEMENT = 2;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
@@ -6,12 +6,16 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -24,6 +28,21 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
 
     private static final String CLASS_NAME = "Float32Array";
     private static final int BYTES_PER_ELEMENT = 4;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeFloat32Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(4))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(4))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeFloat32Array() {}
 
@@ -40,33 +59,8 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeFloat32Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeFloat32Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -74,8 +68,10 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeFloat32Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeFloat32Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeFloat32Array::new, 4);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.VarScope;
  * interface. It also implements List&lt;Float&gt; for direct manipulation in Java.
  */
 public class NativeFloat32Array extends NativeTypedArrayView<Float> {
-    private static final long serialVersionUID = -8963461831950499340L;
+    private static final long serialVersionUID = -1986336631829489295L;
 
     private static final String CLASS_NAME = "Float32Array";
     private static final int BYTES_PER_ELEMENT = 4;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
@@ -6,12 +6,16 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -24,6 +28,21 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
 
     private static final String CLASS_NAME = "Float64Array";
     private static final int BYTES_PER_ELEMENT = 8;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeFloat64Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(8))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(8))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeFloat64Array() {}
 
@@ -40,33 +59,8 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeFloat64Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeFloat64Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -74,8 +68,10 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeFloat64Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeFloat64Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeFloat64Array::new, 8);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.VarScope;
  * interface. It also implements List&lt;Double&gt; for direct manipulation in Java.
  */
 public class NativeFloat64Array extends NativeTypedArrayView<Double> {
-    private static final long serialVersionUID = -1255405650050639335L;
+    private static final long serialVersionUID = -2289070055226752021L;
 
     private static final String CLASS_NAME = "Float64Array";
     private static final int BYTES_PER_ELEMENT = 8;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
@@ -6,11 +6,15 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -23,6 +27,21 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
 
     private static final String CLASS_NAME = "Int16Array";
     private static final int BYTES_PER_ELEMENT = 2;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeInt16Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(2))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(2))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeInt16Array() {}
 
@@ -39,33 +58,8 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeInt16Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeInt16Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -73,8 +67,10 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeInt16Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeInt16Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeInt16Array::new, 2);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
@@ -6,12 +6,16 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -24,6 +28,21 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
 
     private static final String CLASS_NAME = "Int32Array";
     private static final int BYTES_PER_ELEMENT = 4;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeInt32Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(4))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(4))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeInt32Array() {}
 
@@ -40,33 +59,8 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeInt32Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeInt32Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -74,8 +68,10 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeInt32Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeInt32Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeInt32Array::new, 4);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.VarScope;
  * It also implements List&lt;Integer&gt; for direct manipulation in Java.
  */
 public class NativeInt32Array extends NativeTypedArrayView<Integer> {
-    private static final long serialVersionUID = -8963461831950499340L;
+    private static final long serialVersionUID = 2090724894289667699L;
 
     private static final String CLASS_NAME = "Int32Array";
     private static final int BYTES_PER_ELEMENT = 4;

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
@@ -6,11 +6,15 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -22,6 +26,21 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
     private static final long serialVersionUID = 6655250857400433124L;
 
     private static final String CLASS_NAME = "Int8Array";
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeInt8Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(1))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(1))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeInt8Array() {}
 
@@ -38,28 +57,8 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx, lscope, args, NativeInt8Array::new, 1));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeInt8Array::realThis);
-        constructor.defineProperty("BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -67,8 +66,10 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
         return 1;
     }
 
-    private static NativeInt8Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeInt8Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeInt8Array::new, 1);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
@@ -19,7 +19,7 @@ import org.mozilla.javascript.VarScope;
  * It also implements List&lt;Byte&gt; for direct manipulation in Java.
  */
 public class NativeInt8Array extends NativeTypedArrayView<Byte> {
-    private static final long serialVersionUID = -3349419704390398895L;
+    private static final long serialVersionUID = 6655250857400433124L;
 
     private static final String CLASS_NAME = "Int8Array";
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -6,7 +6,9 @@
 
 package org.mozilla.javascript.typedarrays;
 
-import static org.mozilla.javascript.SymbolKey.TO_STRING_TAG;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -23,20 +25,21 @@ import org.mozilla.javascript.ArrayLikeAbstractOperations;
 import org.mozilla.javascript.ArrayLikeAbstractOperations.IterativeOperation;
 import org.mozilla.javascript.ArrayLikeAbstractOperations.ReduceOperation;
 import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Constructable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ExternalArrayData;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.IteratorLikeIterable;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeArrayIterator;
 import org.mozilla.javascript.NativeArrayIterator.ARRAY_ITERATOR_TYPE;
-import org.mozilla.javascript.ScopeObject;
+import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.SerializableCallable;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
@@ -50,6 +53,82 @@ import org.mozilla.javascript.Wrapper;
 public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         implements List<T>, RandomAccess, ExternalArrayData {
     private static final long serialVersionUID = -4963053773152251274L;
+
+    private static final ClassDescriptor DESCRIPTOR;
+    private static final String TYPED_ARRAY_TAG = "%TypedArray%";
+    private static final SymbolKey TYPED_ARRAY = new SymbolKey(TYPED_ARRAY_TAG, REGULAR);
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                TYPED_ARRAY,
+                                "TypedArray",
+                                0,
+                                NativeTypedArrayView::typeError,
+                                NativeTypedArrayView::typeError)
+                        .withProp(PROTO, "buffer", NativeTypedArrayView::js_buffer, null, DONTENUM)
+                        .withProp(
+                                PROTO,
+                                "byteLength",
+                                NativeTypedArrayView::js_byteLength,
+                                null,
+                                DONTENUM)
+                        .withProp(
+                                PROTO,
+                                "byteOffset",
+                                NativeTypedArrayView::js_byteOffset,
+                                null,
+                                DONTENUM)
+                        .withProp(PROTO, "length", NativeTypedArrayView::js_length, null, DONTENUM)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                NativeTypedArrayView::js_toStringTag,
+                                null,
+                                DONTENUM)
+                        .withMethod(PROTO, "at", 1, NativeTypedArrayView::js_at)
+                        .withMethod(PROTO, "copyWithin", 2, NativeTypedArrayView::js_copyWithin)
+                        .withMethod(PROTO, "entries", 0, NativeTypedArrayView::js_entries)
+                        .withMethod(PROTO, "every", 1, NativeTypedArrayView::js_every)
+                        .withMethod(PROTO, "fill", 1, NativeTypedArrayView::js_fill)
+                        .withMethod(PROTO, "filter", 1, NativeTypedArrayView::js_filter)
+                        .withMethod(PROTO, "find", 1, NativeTypedArrayView::js_find)
+                        .withMethod(PROTO, "findIndex", 1, NativeTypedArrayView::js_findIndex)
+                        .withMethod(PROTO, "findLast", 1, NativeTypedArrayView::js_findLast)
+                        .withMethod(
+                                PROTO, "findLastIndex", 1, NativeTypedArrayView::js_findLastIndex)
+                        .withMethod(PROTO, "forEach", 1, NativeTypedArrayView::js_forEach)
+                        .withMethod(PROTO, "includes", 1, NativeTypedArrayView::js_includes)
+                        .withMethod(PROTO, "indexOf", 1, NativeTypedArrayView::js_indexOf)
+                        .withMethod(PROTO, "join", 1, NativeTypedArrayView::js_join)
+                        .withMethod(PROTO, "keys", 0, NativeTypedArrayView::js_keys)
+                        .withMethod(PROTO, "lastIndexOf", 1, NativeTypedArrayView::js_lastIndexOf)
+                        .withMethod(PROTO, "map", 1, NativeTypedArrayView::js_map)
+                        .withMethod(PROTO, "reduce", 1, NativeTypedArrayView::js_reduce)
+                        .withMethod(PROTO, "reduceRight", 1, NativeTypedArrayView::js_reduceRight)
+                        .withMethod(PROTO, "reverse", 0, NativeTypedArrayView::js_reverse)
+                        .withMethod(PROTO, "set", 1, NativeTypedArrayView::js_set)
+                        .withMethod(PROTO, "slice", 2, NativeTypedArrayView::js_slice)
+                        .withMethod(PROTO, "some", 1, NativeTypedArrayView::js_some)
+                        .withMethod(PROTO, "sort", 1, NativeTypedArrayView::js_sort)
+                        .withMethod(PROTO, "subarray", 2, NativeTypedArrayView::js_subarray)
+                        .withMethod(
+                                PROTO, "toLocaleString", 0, NativeTypedArrayView::js_toLocaleString)
+                        .withMethod(PROTO, "toReversed", 0, NativeTypedArrayView::js_toReversed)
+                        .withMethod(PROTO, "toSorted", 1, NativeTypedArrayView::js_toSorted)
+                        .withMethod(PROTO, "toString", 0, NativeTypedArrayView::js_toString)
+                        .withMethod(PROTO, "values", 0, NativeTypedArrayView::js_values)
+                        .withMethod(PROTO, "with", 2, NativeTypedArrayView::js_with)
+                        .withMethod(PROTO, SymbolKey.ITERATOR, 0, NativeTypedArrayView::js_iterator)
+                        .withMethod(CTOR, "from", 1, NativeTypedArrayView::js_from)
+                        .withMethod(CTOR, "of", 0, NativeTypedArrayView::js_of)
+                        .build();
+    }
+
+    static Object typeError(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        throw ScriptRuntime.typeError("Not callable as function");
+    }
 
     /**
      * The length in elements of the array. For auto-length views (ES2025), this is not used but is
@@ -235,112 +314,25 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return -1;
     }
 
-    private static final Object TYPED_ARRAY_TAG = "%TypedArray.prototype%";
-
     // Actual functions
 
-    static void init(Context cx, VarScope scope, LambdaConstructor constructor, RealThis realThis) {
-        ScopeObject s = (ScopeObject) scope;
-        // Where do we store this prototype? Top level scope for now?
-
-        LambdaConstructor ta = (LambdaConstructor) s.getAssociatedValue(TYPED_ARRAY_TAG);
-        if (ta == null) {
-            var proto = (ScriptableObject) cx.newObject(s);
-            ta =
-                    new LambdaConstructor(
-                            s,
-                            "TypedArray",
-                            0,
-                            proto,
-                            null,
-                            (lcx, ls, largs) -> {
-                                throw ScriptRuntime.typeError(
-                                        "TypedArray constructor cannot be invoked directly");
-                            });
-            proto.defineProperty("constructor", ta, DONTENUM);
-            defineProtoProperty(ta, cx, "buffer", NativeTypedArrayView::js_buffer, null);
-            defineProtoProperty(ta, cx, "byteLength", NativeTypedArrayView::js_byteLength, null);
-            defineProtoProperty(ta, cx, "byteOffset", NativeTypedArrayView::js_byteOffset, null);
-            defineProtoProperty(ta, cx, "length", NativeTypedArrayView::js_length, null);
-            defineProtoProperty(ta, cx, TO_STRING_TAG, NativeTypedArrayView::js_toStringTag, null);
-
-            defineMethod(ta, s, "at", 1, NativeTypedArrayView::js_at);
-            defineMethod(ta, s, "copyWithin", 2, NativeTypedArrayView::js_copyWithin);
-            defineMethod(ta, s, "entries", 0, NativeTypedArrayView::js_entries);
-            defineMethod(ta, s, "every", 1, NativeTypedArrayView::js_every);
-            defineMethod(ta, s, "fill", 1, NativeTypedArrayView::js_fill);
-            defineMethod(ta, s, "filter", 1, NativeTypedArrayView::js_filter);
-            defineMethod(ta, s, "find", 1, NativeTypedArrayView::js_find);
-            defineMethod(ta, s, "findIndex", 1, NativeTypedArrayView::js_findIndex);
-            defineMethod(ta, s, "findLast", 1, NativeTypedArrayView::js_findLast);
-            defineMethod(ta, s, "findLastIndex", 1, NativeTypedArrayView::js_findLastIndex);
-            defineMethod(ta, s, "forEach", 1, NativeTypedArrayView::js_forEach);
-            defineMethod(ta, s, "includes", 1, NativeTypedArrayView::js_includes);
-            defineMethod(ta, s, "indexOf", 1, NativeTypedArrayView::js_indexOf);
-            defineMethod(ta, s, "join", 1, NativeTypedArrayView::js_join);
-            defineMethod(ta, s, "keys", 0, NativeTypedArrayView::js_keys);
-            defineMethod(ta, s, "lastIndexOf", 1, NativeTypedArrayView::js_lastIndexOf);
-            defineMethod(ta, s, "map", 1, NativeTypedArrayView::js_map);
-            defineMethod(ta, s, "reduce", 1, NativeTypedArrayView::js_reduce);
-            defineMethod(ta, s, "reduceRight", 1, NativeTypedArrayView::js_reduceRight);
-            defineMethod(ta, s, "reverse", 0, NativeTypedArrayView::js_reverse);
-            defineMethod(ta, s, "set", 1, NativeTypedArrayView::js_set);
-            defineMethod(ta, s, "slice", 2, NativeTypedArrayView::js_slice);
-            defineMethod(ta, s, "some", 1, NativeTypedArrayView::js_some);
-            defineMethod(ta, s, "sort", 1, NativeTypedArrayView::js_sort);
-            defineMethod(ta, s, "subarray", 2, NativeTypedArrayView::js_subarray);
-            defineMethod(ta, s, "toLocaleString", 0, NativeTypedArrayView::js_toLocaleString);
-            defineMethod(ta, s, "toReversed", 0, NativeTypedArrayView::js_toReversed);
-            defineMethod(ta, s, "toSorted", 1, NativeTypedArrayView::js_toSorted);
-            defineMethod(ta, s, "toString", 0, NativeTypedArrayView::js_toString);
-            defineMethod(ta, s, "values", 0, NativeTypedArrayView::js_values);
-            defineMethod(ta, s, "with", 2, NativeTypedArrayView::js_with);
-            defineMethod(ta, s, SymbolKey.ITERATOR, 0, NativeTypedArrayView::js_iterator);
-
-            ta.defineConstructorMethod(scope, "from", 1, NativeTypedArrayView::js_from);
-            ta.defineConstructorMethod(scope, "of", 0, NativeTypedArrayView::js_of);
-
-            ta = (LambdaConstructor) s.associateValue(TYPED_ARRAY_TAG, ta);
+    static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        var res = scope.get(TYPED_ARRAY, scope);
+        if (res == NOT_FOUND) {
+            res = DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), false);
         }
-        constructor.setPrototype(ta);
-        ((ScriptableObject) constructor.getPrototypeProperty())
-                .setPrototype((Scriptable) ta.getPrototypeProperty());
+        return (JSFunction) res;
     }
 
-    private static void defineProtoProperty(
-            LambdaConstructor typedArray,
-            Context cx,
-            String name,
-            LambdaGetterFunction getter,
-            LambdaSetterFunction setter) {
-        typedArray.definePrototypeProperty(cx, name, getter, setter, DONTENUM | READONLY);
-    }
-
-    private static void defineProtoProperty(
-            LambdaConstructor typedArray,
-            Context cx,
-            SymbolKey name,
-            LambdaGetterFunction getter,
-            LambdaSetterFunction setter) {
-        typedArray.definePrototypeProperty(cx, name, getter, setter);
-    }
-
-    private static void defineMethod(
-            LambdaConstructor typedArray,
-            VarScope scope,
-            String name,
-            int length,
-            SerializableCallable target) {
-        typedArray.definePrototypeMethod(scope, name, length, target);
-    }
-
-    private static void defineMethod(
-            LambdaConstructor typedArray,
-            VarScope scope,
-            SymbolKey key,
-            int length,
-            SerializableCallable target) {
-        typedArray.definePrototypeMethod(scope, key, length, target);
+    static JSFunction initSubClass(
+            Context cx, VarScope scope, ClassDescriptor desc, boolean sealed) {
+        var ta = init(cx, scope, sealed);
+        var proto = new NativeObject();
+        var ctor = desc.buildConstructor(cx, scope, proto, sealed);
+        proto.setPrototype((Scriptable) ta.getPrototypeProperty());
+        proto.setParentScope(scope);
+        ctor.setPrototype(ta);
+        return ctor;
     }
 
     // Detect incompatibility between BigInt and non-BigInt classes
@@ -397,6 +389,21 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     protected interface RealThis {
         NativeTypedArrayView<?> realThis(Scriptable thisObj);
+    }
+
+    protected static NativeTypedArrayView<?> js_constructor(
+            Context cx,
+            JSFunction f,
+            Object nt,
+            VarScope s,
+            Object thisObj,
+            Object[] args,
+            TypedArrayConstructable constructable,
+            int bytesPerElement) {
+        var array = js_constructor(cx, s, args, constructable, bytesPerElement);
+        array.setParentScope(f.getDeclarationScope());
+        array.setPrototype((Scriptable) f.getPrototypeProperty());
+        return array;
     }
 
     protected static NativeTypedArrayView<?> js_constructor(
@@ -673,17 +680,17 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static String js_toString(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        return js_toStringInternal(cx, scope, thisObj, args, false);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_toStringInternal(cx, s, thisObj, args, false);
     }
 
     private static String js_toLocaleString(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        return js_toStringInternal(cx, scope, thisObj, args, true);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_toStringInternal(cx, s, thisObj, args, true);
     }
 
     private static String js_toStringInternal(
-            Context cx, VarScope scope, Scriptable thisObj, Object[] args, boolean useLocale) {
+            Context cx, VarScope scope, Object thisObj, Object[] args, boolean useLocale) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
@@ -713,83 +720,80 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         }
     }
 
-    private static Object js_entries(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_entries(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
-        return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.ENTRIES);
+        return new NativeArrayIterator(s, self, ARRAY_ITERATOR_TYPE.ENTRIES);
     }
 
-    private static Object js_every(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_every(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx, IterativeOperation.EVERY, lscope, self, args, self.validateAndGetLength());
+                cx, IterativeOperation.EVERY, s, self, args, self.validateAndGetLength());
     }
 
-    private static Object js_filter(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_filter(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         Scriptable array =
                 (Scriptable)
                         ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                                lcx,
+                                cx,
                                 IterativeOperation.FILTER,
-                                lscope,
+                                s,
                                 self,
                                 args,
                                 self.validateAndGetLength());
-        long newLen = NativeArray.getLengthProperty(lcx, array);
+        long newLen = NativeArray.getLengthProperty(cx, array);
         NativeTypedArrayView<?> newArray =
-                self.typedArraySpeciesCreate(lcx, lscope, new Object[] {newLen}, "filter");
+                self.typedArraySpeciesCreate(cx, s, new Object[] {newLen}, "filter");
         for (int i = 0; i < newLen; i++) {
             newArray.js_set(i, array.get(i, array));
         }
         return newArray;
     }
 
-    private static Object js_find(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_find(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx, IterativeOperation.FIND, lscope, self, args, self.validateAndGetLength());
+                cx, IterativeOperation.FIND, s, self, args, self.validateAndGetLength());
     }
 
     private static Object js_findIndex(
-            Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx,
-                IterativeOperation.FIND_INDEX,
-                lscope,
-                self,
-                args,
-                self.validateAndGetLength());
+                cx, IterativeOperation.FIND_INDEX, s, self, args, self.validateAndGetLength());
     }
 
-    private static Object js_findLast(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_findLast(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx, IterativeOperation.FIND_LAST, lscope, self, args, self.validateAndGetLength());
+                cx, IterativeOperation.FIND_LAST, s, self, args, self.validateAndGetLength());
     }
 
     private static Object js_findLastIndex(
-            Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx,
-                IterativeOperation.FIND_LAST_INDEX,
-                lscope,
-                self,
-                args,
-                self.validateAndGetLength());
+                cx, IterativeOperation.FIND_LAST_INDEX, s, self, args, self.validateAndGetLength());
     }
 
-    private static Object js_forEach(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_forEach(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx, IterativeOperation.FOR_EACH, lscope, self, args, self.validateAndGetLength());
+                cx, IterativeOperation.FOR_EACH, s, self, args, self.validateAndGetLength());
     }
 
-    private static Boolean js_includes(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Boolean js_includes(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -817,7 +821,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return Boolean.FALSE;
     }
 
-    private static Object js_indexOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_indexOf(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -849,20 +854,21 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static Object js_iterator(
-            Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) {
-        return js_values(lcx, lscope, thisObj, args);
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return js_values(cx, f, nt, s, thisObj, args);
     }
 
-    private static Object js_keys(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_keys(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
-        return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.KEYS);
+        return new NativeArrayIterator(s, self, ARRAY_ITERATOR_TYPE.KEYS);
     }
 
     private static Object js_lastIndexOf(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -891,35 +897,38 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return -1;
     }
 
-    private static Object js_map(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_map(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
         NativeTypedArrayView<?> newArray =
-                self.typedArraySpeciesCreate(lcx, lscope, new Object[] {len}, "map");
+                self.typedArraySpeciesCreate(cx, s, new Object[] {len}, "map");
         Scriptable array =
                 (Scriptable)
                         ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                                lcx, IterativeOperation.MAP, lscope, thisObj, args, len);
+                                cx, IterativeOperation.MAP, s, thisObj, args, len);
         for (int i = 0; i < len; i++) {
             newArray.js_set(i, array.get(i, array));
         }
         return newArray;
     }
 
-    private static Object js_reduce(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_reduce(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.reduceMethodWithLength(
-                lcx, ReduceOperation.REDUCE, lscope, self, args, self.validateAndGetLength());
+                cx, ReduceOperation.REDUCE, s, self, args, self.validateAndGetLength());
     }
 
     private static Object js_reduceRight(
-            Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.reduceMethodWithLength(
-                lcx, ReduceOperation.REDUCE_RIGHT, lscope, self, args, self.validateAndGetLength());
+                cx, ReduceOperation.REDUCE_RIGHT, s, self, args, self.validateAndGetLength());
     }
 
-    private static Scriptable js_slice(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Scriptable js_slice(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long srcLength = self.validateAndGetLength();
 
@@ -947,7 +956,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
         long count = Math.max(end - begin, 0);
 
-        var a = self.typedArraySpeciesCreate(cx, scope, new Object[] {count}, "slice");
+        var a = self.typedArraySpeciesCreate(cx, s, new Object[] {count}, "slice");
 
         if (count > 0) {
             if (self.isTypedArrayOutOfBounds()) {
@@ -967,21 +976,24 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return a;
     }
 
-    private static Object js_some(Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_some(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
-                lcx, IterativeOperation.SOME, lscope, self, args, self.validateAndGetLength());
+                cx, IterativeOperation.SOME, s, self, args, self.validateAndGetLength());
     }
 
-    private static Object js_values(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
+    private static Object js_values(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
-        return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.VALUES);
+        return new NativeArrayIterator(s, self, ARRAY_ITERATOR_TYPE.VALUES);
     }
 
-    private static String js_join(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static String js_join(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1019,7 +1031,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static NativeTypedArrayView<?> js_reverse(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1032,7 +1044,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static NativeTypedArrayView<?> js_fill(
-            Context cx, VarScope scope, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1071,7 +1083,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return self;
     }
 
-    private static Scriptable js_sort(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Scriptable js_sort(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (isArg(args, 0) && !(args[0] instanceof Callable)) {
             throw ScriptRuntime.typeErrorById("msg.function.expected");
         }
@@ -1079,7 +1092,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
-        Object[] working = self.sortTemporaryArray(cx, scope, args);
+        Object[] working = self.sortTemporaryArray(cx, s, args);
         for (int i = 0; i < len; ++i) {
             self.js_set(i, working[i]);
         }
@@ -1101,7 +1114,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return working;
     }
 
-    private static Object js_copyWithin(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_copyWithin(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1162,7 +1176,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return self;
     }
 
-    private static Object js_set(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_set(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         double offset = isArg(args, 1) ? ScriptRuntime.toIntegerOrInfinity(args[1]) : 0;
         if (offset < 0) {
@@ -1172,13 +1187,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             NativeTypedArrayView<?> nativeView = (NativeTypedArrayView<?>) args[0];
             self.setRange(nativeView, offset);
         } else {
-            self.setRange(cx, scope, ScriptableObject.ensureScriptable(args[0]), offset);
+            self.setRange(cx, s, ScriptableObject.ensureScriptable(args[0]), offset);
         }
 
         return Undefined.instance;
     }
 
-    private static Object js_subarray(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_subarray(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length == 0 && cx.getLanguageVersion() < Context.VERSION_ES6) {
             throw ScriptRuntime.constructError("Error", "invalid arguments");
         }
@@ -1207,10 +1223,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             constructorArgs = new Object[] {self.arrayBuffer, beginOffset, newLen};
         }
 
-        return self.typedArraySpeciesCreate(cx, scope, constructorArgs, "subarray");
+        return self.typedArraySpeciesCreate(cx, s, constructorArgs, "subarray");
     }
 
-    private static Object js_at(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_at(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1252,14 +1269,15 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return (NativeTypedArrayView<?>) newArray;
     }
 
-    private static Object js_toReversed(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toReversed(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         int len = self.getLength();
 
         NativeArrayBuffer newBuffer = new NativeArrayBuffer(len * self.getBytesPerElement());
         Scriptable result =
                 cx.newObject(
-                        scope,
+                        s,
                         self.getClassName(),
                         new Object[] {newBuffer, 0, len, self.getBytesPerElement()});
 
@@ -1272,17 +1290,18 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_toSorted(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_toSorted(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         int len = self.getLength();
 
-        Object[] working = self.sortTemporaryArray(cx, scope, args);
+        Object[] working = self.sortTemporaryArray(cx, s, args);
 
         // Move value in a new typed array of the same type
         NativeArrayBuffer newBuffer = new NativeArrayBuffer(len * self.getBytesPerElement());
         Scriptable result =
                 cx.newObject(
-                        scope,
+                        s,
                         self.getClassName(),
                         new Object[] {newBuffer, 0, len, self.getBytesPerElement()});
         for (int k = 0; k < len; ++k) {
@@ -1292,7 +1311,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_with(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_with(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
 
         long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(args[0]) : 0;
@@ -1314,7 +1334,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         NativeArrayBuffer newBuffer = new NativeArrayBuffer(len * self.getBytesPerElement());
         Scriptable result =
                 cx.newObject(
-                        scope,
+                        s,
                         self.getClassName(),
                         new Object[] {newBuffer, 0, len, self.getBytesPerElement()});
 
@@ -1326,11 +1346,12 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_from(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_from(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 1) {
             throw ScriptRuntime.typeErrorById("msg.missing.argument");
         }
-        final Scriptable items = ScriptRuntime.toObject(scope, args[0]);
+        final Scriptable items = ScriptRuntime.toObject(s, args[0]);
         if (!AbstractEcmaObjectOperations.isConstructor(cx, thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.constructor.expected");
         }
@@ -1367,9 +1388,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         if (!(iteratorProp == Scriptable.NOT_FOUND)
                 && !(items instanceof List) // NativeArray and NativeTypedArrayView
                 && !Undefined.isUndefined(iteratorProp)) {
-            final Object iterator = ScriptRuntime.callIterator(items, cx, scope);
+            final Object iterator = ScriptRuntime.callIterator(items, cx, s);
             if (!Undefined.isUndefined(iterator)) {
-                try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
+                try (IteratorLikeIterable it = new IteratorLikeIterable(cx, s, iterator)) {
                     listFromIterator = new ArrayList<>();
                     for (Object temp : it) {
                         listFromIterator.add(temp);
@@ -1390,7 +1411,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             size = (int) AbstractEcmaObjectOperations.lengthOfArrayLike(cx, items);
         }
 
-        Scriptable result = constructable.construct(cx, scope, new Object[] {size});
+        Scriptable result = constructable.construct(cx, s, new Object[] {size});
         if (!(result instanceof NativeTypedArrayView)) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.receiver.incompatible", "from");
         }
@@ -1415,11 +1436,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                     temp = Undefined.instance;
                 }
             } else {
-                temp = ScriptRuntime.getObjectIndex(items, k, cx, scope);
+                temp = ScriptRuntime.getObjectIndex(items, k, cx, s);
             }
 
             if (mapFn != null) {
-                temp = mapFn.call(cx, scope, mapFnThisArg, new Object[] {temp, k});
+                temp = mapFn.call(cx, s, mapFnThisArg, new Object[] {temp, k});
             }
 
             typedArray.setArrayElement(k, temp);
@@ -1428,13 +1449,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_of(Context cx, VarScope scope, Object thisObj, Object[] args) {
+    private static Object js_of(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (!AbstractEcmaObjectOperations.isConstructor(cx, thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.constructor.expected");
         }
         Constructable constructable = (Constructable) thisObj;
 
-        Scriptable result = constructable.construct(cx, scope, new Object[] {args.length});
+        Scriptable result = constructable.construct(cx, s, new Object[] {args.length});
 
         if (!(result instanceof NativeTypedArrayView)) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.receiver.incompatible", "of");

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
@@ -6,11 +6,15 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -23,6 +27,21 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
 
     private static final String CLASS_NAME = "Uint16Array";
     private static final int BYTES_PER_ELEMENT = 2;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeUint16Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(2))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(2))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeUint16Array() {}
 
@@ -39,33 +58,8 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeUint16Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeUint16Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -73,8 +67,10 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeUint16Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeUint16Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeUint16Array::new, 2);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
@@ -6,11 +6,15 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -23,6 +27,21 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
 
     private static final String CLASS_NAME = "Uint32Array";
     private static final int BYTES_PER_ELEMENT = 4;
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeUint32Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(4))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(4))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeUint32Array() {}
 
@@ -39,33 +58,8 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx,
-                                        lscope,
-                                        args,
-                                        NativeUint32Array::new,
-                                        BYTES_PER_ELEMENT));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeUint32Array::realThis);
-        constructor.defineProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", BYTES_PER_ELEMENT, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -73,8 +67,10 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
         return BYTES_PER_ELEMENT;
     }
 
-    private static NativeUint32Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeUint32Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeUint32Array::new, 4);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
@@ -19,7 +19,7 @@ import org.mozilla.javascript.VarScope;
  * It also implements List&lt;Integer&gt; for direct manipulation in Java.
  */
 public class NativeUint8Array extends NativeTypedArrayView<Integer> {
-    private static final long serialVersionUID = -3349419704390398895L;
+    private static final long serialVersionUID = 4309679036296927829L;
 
     private static final String CLASS_NAME = "Uint8Array";
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
@@ -6,11 +6,15 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -22,6 +26,21 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
     private static final long serialVersionUID = 4309679036296927829L;
 
     private static final String CLASS_NAME = "Uint8Array";
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeUint8Array::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(1))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(1))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeUint8Array() {}
 
@@ -38,28 +57,8 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx, lscope, args, NativeUint8Array::new, 1));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeUint8Array::realThis);
-        constructor.defineProperty("BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -67,8 +66,10 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
         return 1;
     }
 
-    private static NativeUint8Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeUint8Array.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeUint8Array::new, 1);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
@@ -21,7 +21,7 @@ import org.mozilla.javascript.VarScope;
  * insertion.
  */
 public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
-    private static final long serialVersionUID = -3349419704390398895L;
+    private static final long serialVersionUID = -1383405116607004281L;
 
     private static final String CLASS_NAME = "Uint8ClampedArray";
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
@@ -6,11 +6,15 @@
 
 package org.mozilla.javascript.typedarrays;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.CTOR;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
+import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.LambdaConstructor;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 
@@ -24,6 +28,21 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
     private static final long serialVersionUID = -1383405116607004281L;
 
     private static final String CLASS_NAME = "Uint8ClampedArray";
+
+    private static final ClassDescriptor DESCRIPTOR;
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME,
+                                3,
+                                NativeTypedArrayView::typeError,
+                                NativeUint8ClampedArray::js_constructor)
+                        .withProp(CTOR, "BYTES_PER_ELEMENT", value(1))
+                        .withProp(PROTO, "BYTES_PER_ELEMENT", value(1))
+                        .withProp(CTOR, SymbolKey.SPECIES, ScriptRuntimeES6::symbolSpecies)
+                        .build();
+    }
 
     public NativeUint8ClampedArray() {}
 
@@ -40,28 +59,8 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, VarScope scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        3,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        (Context lcx, VarScope lscope, Object[] args) ->
-                                NativeTypedArrayView.js_constructor(
-                                        lcx, lscope, args, NativeUint8ClampedArray::new, 1));
-        constructor.setPrototypePropertyAttributes(DONTENUM | READONLY | PERMANENT);
-        NativeTypedArrayView.init(cx, scope, constructor, NativeUint8ClampedArray::realThis);
-        constructor.defineProperty("BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
-        constructor.definePrototypeProperty(
-                "BYTES_PER_ELEMENT", 1, DONTENUM | READONLY | PERMANENT);
-
-        ScriptRuntimeES6.addSymbolSpecies(cx, scope, constructor);
-        if (sealed) {
-            constructor.sealObject();
-            ((ScriptableObject) constructor.getPrototypeProperty()).sealObject();
-        }
-        return constructor;
+    public static JSFunction init(Context cx, VarScope scope, boolean sealed) {
+        return NativeTypedArrayView.initSubClass(cx, scope, DESCRIPTOR, sealed);
     }
 
     @Override
@@ -69,8 +68,10 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
         return 1;
     }
 
-    private static NativeUint8ClampedArray realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeUint8ClampedArray.class);
+    private static Object js_constructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        return NativeTypedArrayView.js_constructor(
+                cx, f, nt, s, thisObj, args, NativeUint8ClampedArray::new, 1);
     }
 
     @Override

--- a/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
@@ -66,7 +66,7 @@ public class DebuggerTest {
         }
 
         @Override
-        public void onEnter(Context cx, VarScope activation, Scriptable thisObj, Object[] args) {
+        public void onEnter(Context cx, VarScope activation, Object thisObj, Object[] args) {
             var names = new HashSet<String>();
             for (var id : activation.getIds()) {
                 names.add(id.toString());

--- a/rhino/src/test/java/org/mozilla/javascript/tests/TypeOfTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/TypeOfTest.java
@@ -58,7 +58,7 @@ public class TypeOfTest {
                 new BaseFunction() {
                     @Override
                     public Object call(
-                            Context _cx, VarScope _scope, Scriptable _thisObj, Object[] _args) {
+                            Context _cx, VarScope _scope, Object _thisObj, Object[] _args) {
                         return _args[0].getClass().getName();
                     }
                 };

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -20,7 +20,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.LambdaFunction;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
@@ -112,7 +111,7 @@ public abstract class ScriptTestsBase {
                         scope,
                         "AbortJS",
                         1,
-                        (Context lcx, VarScope lscope, Scriptable localThis, Object[] args) -> {
+                        (lcx, lscope, localThis, args) -> {
                             assert (args.length > 0);
                             throw new TestFailureException(ScriptRuntime.toString(args[0]));
                         }));
@@ -124,7 +123,7 @@ public abstract class ScriptTestsBase {
                         scope,
                         "EnqueueMicrotask",
                         1,
-                        (Context lcx, VarScope lscope, Scriptable localThis, Object[] args) -> {
+                        (lcx, lscope, localThis, args) -> {
                             assert (args.length > 0);
                             assert (args[0] instanceof Callable);
                             lcx.enqueueMicrotask(
@@ -139,7 +138,7 @@ public abstract class ScriptTestsBase {
                         scope,
                         "PerformMicrotaskCheckpoint",
                         0,
-                        (Context lcx, VarScope lscope, Scriptable localThis, Object[] args) -> {
+                        (lcx, lscope, localThis, args) -> {
                             lcx.processMicrotasks();
                             return Undefined.instance;
                         }));

--- a/tests/src/test/java/org/mozilla/javascript/tests/DoctestFeature18EnabledTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DoctestFeature18EnabledTest.java
@@ -36,6 +36,7 @@ public class DoctestFeature18EnabledTest extends DoctestsTest {
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTEGER_WITHOUT_DECIMAL_PLACE);
 
         try (Context context = contextFactory.enterContext()) {
+            context.setLanguageVersion(Context.VERSION_1_8);
             context.setInterpretedMode(interpretedMode);
             Global global = new Global(context);
             int testsPassed = global.runDoctest(context, global, source, name, 1);

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
@@ -137,10 +137,7 @@ public class GeneratorStackTraceTest {
                                     scope,
                                     "javaHelper",
                                     0,
-                                    (Context ctx,
-                                            VarScope scope2,
-                                            Scriptable thisObj,
-                                            Object[] args) -> {
+                                    (ctx, scope2, thisObj, args) -> {
                                         throw new RuntimeException("Java-side failure!");
                                     });
                     ScriptableObject.putProperty(scope, "javaHelper", f);

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
@@ -59,12 +59,7 @@ public class LambdaFunctionTest {
     @Test
     public void noArgLambdaFunction() {
         LambdaFunction f =
-                new LambdaFunction(
-                        root,
-                        "foo",
-                        0,
-                        (Context ctx, VarScope scope, Scriptable thisObj, Object[] args) ->
-                                "Hello");
+                new LambdaFunction(root, "foo", 0, (ctx, scope, thisObj, args) -> "Hello");
         ScriptableObject.putProperty(root, "foo", f);
         eval(
                 "assertEquals(foo.name, 'foo');\n"
@@ -205,11 +200,7 @@ public class LambdaFunctionTest {
 
     @Test
     public void lambdaFunctionNoNew() {
-        LambdaFunction func =
-                new LambdaFunction(
-                        root,
-                        0,
-                        (Context ctx, VarScope scope, Scriptable thisObj, Object[] args) -> true);
+        LambdaFunction func = new LambdaFunction(root, 0, (ctx, scope, thisObj, args) -> true);
         ScriptableObject.defineProperty(root, "noNewFunc", func, 0);
         eval(
                 "let o = noNewFunc();\n"
@@ -254,15 +245,14 @@ public class LambdaFunctionTest {
                     scope,
                     "sayHello",
                     1,
-                    (Context cx, VarScope s, Scriptable thisObj, Object[] args) ->
-                            TestClass.sayHello(args),
+                    (cx, s, thisObj, args) -> TestClass.sayHello(args),
                     0,
                     DONTENUM | READONLY);
             constructor.definePrototypeMethod(
                     scope,
                     "appendToValue",
                     1,
-                    (Context cx, VarScope s, Scriptable thisObj, Object[] args) -> {
+                    (cx, s, thisObj, args) -> {
                         TestClass self =
                                 LambdaConstructor.convertThisObject(thisObj, TestClass.class);
                         return self.appendToValue(args);
@@ -327,14 +317,14 @@ public class LambdaFunctionTest {
                             scope,
                             "SpecialConstructorClass",
                             1,
-                            (Context lcx, VarScope s, Scriptable thisObj, Object[] args) -> {
+                            (lcx, s, thisObj, args) -> {
                                 String arg = "";
                                 if (args.length > 0) {
                                     arg = ScriptRuntime.toString(args[0]);
                                 }
                                 return "You passed " + arg;
                             },
-                            (Context lcx, VarScope s, Object[] args) -> {
+                            (lcx, s, args) -> {
                                 SpecialConstructorClass tc = new SpecialConstructorClass();
                                 if (args.length > 0) {
                                     tc.value = ScriptRuntime.toString(args[0]);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
@@ -65,7 +64,7 @@ public class ObserveInstructionCountTest {
 
         @Override
         protected Object doTopCall(
-                Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+                Callable callable, Context cx, VarScope scope, Object thisObj, Object[] args) {
             MyContext mcx = (MyContext) cx;
             mcx.quota = 2000;
             return super.doTopCall(callable, cx, scope, thisObj, args);

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -252,13 +252,12 @@ public class Test262SuiteTest {
             return instance;
         }
 
-        private static Object gc(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        private static Object gc(Context cx, VarScope scope, Object thisObj, Object[] args) {
             System.gc();
             return Undefined.instance;
         }
 
-        public static Object evalScript(
-                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public static Object evalScript(Context cx, VarScope scope, Object thisObj, Object[] args) {
             if (args.length == 0) {
                 throw ScriptRuntime.throwError(cx, scope, "not enough args");
             }
@@ -270,14 +269,13 @@ public class Test262SuiteTest {
             return ((TopLevel) scriptable.getParentScope()).getGlobalThis();
         }
 
-        public static $262 createRealm(
-                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public static $262 createRealm(Context cx, VarScope scope, Object thisObj, Object[] args) {
             TopLevel realm = cx.initSafeStandardObjects(new TopLevel());
-            return install(realm, thisObj.getPrototype());
+            return install(realm, ScriptRuntime.toObject(realm, thisObj).getPrototype());
         }
 
         public static Object detachArrayBuffer(
-                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+                Context cx, VarScope scope, Object thisObj, Object[] args) {
             Scriptable buf = ScriptRuntime.toObject(scope, args[0]);
             if (buf instanceof NativeArrayBuffer) {
                 ((NativeArrayBuffer) buf).detach();

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
@@ -88,7 +88,7 @@ public class ComplianceTest {
         }
 
         @Override
-        public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        public Object call(Context cx, VarScope scope, Object thisObj, Object[] args) {
             if (args.length > 1 && "fail".equals(args[1])) {
                 throw new AssertionFailedError(String.valueOf(args[0]));
             }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -7,8 +7,7 @@ public class NativeProxyTest {
 
     @Test
     public void testToString() {
-        Utils.assertWithAllModes_ES6(
-                "function Proxy() {\n\t[native code]\n}\n", "Proxy.toString()");
+        Utils.assertWithAllModes_ES6("function Proxy() {\n\t[native code]\n}", "Proxy.toString()");
 
         Utils.assertWithAllModes_ES6(
                 "[object Object]", "Object.prototype.toString.call(new Proxy({}, {}))");
@@ -76,7 +75,7 @@ public class NativeProxyTest {
     @Test
     public void ctorAsFunction() {
         Utils.assertWithAllModes_ES6(
-                "TypeError: The constructor for Proxy may not be invoked as a function",
+                "TypeError: \"Constructor Proxy\" may only be invoked from a \"new\" expression.",
                 "try { Proxy() } catch(e) { '' + e }");
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/GenericAccessTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/GenericAccessTest.java
@@ -221,7 +221,7 @@ public class GenericAccessTest {
             Utils.contextFactoryWithFeatures(Context.FEATURE_ENABLE_JAVA_MAP_ACCESS);
 
     private static Object readClassAndValue(
-            Context cx, VarScope scope, Scriptable thiz, Object[] args) {
+            Context cx, VarScope scope, Object thiz, Object[] args) {
         return Arrays.stream(args)
                 .map(arg -> Context.jsToJava(arg, TypeInfo.OBJECT))
                 .map(arg -> arg.getClass().getSimpleName() + ' ' + arg)

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -867,10 +867,8 @@ built-ins/Function 125/509 (24.56%)
     proto-from-ctor-realm-prototype.js
     StrictFunction_restricted-properties.js strict
 
-built-ins/GeneratorFunction 5/23 (21.74%)
-    prototype/prototype.js
+built-ins/GeneratorFunction 3/23 (13.04%)
     instance-restricted-properties.js
-    name.js
     proto-from-ctor-realm.js
     proto-from-ctor-realm-prototype.js
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -444,7 +444,8 @@ harness 22/116 (18.97%)
     compare-array-arguments.js
     nativeFunctionMatcher.js
 
-built-ins/AggregateError 2/25 (8.0%)
+built-ins/AggregateError 3/25 (12.0%)
+    newtarget-proto-custom.js
     newtarget-proto-fallback.js
     proto-from-ctor-realm.js
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -449,7 +449,7 @@ built-ins/AggregateError 3/25 (12.0%)
     newtarget-proto-fallback.js
     proto-from-ctor-realm.js
 
-built-ins/Array 244/3077 (7.93%)
+built-ins/Array 240/3077 (7.8%)
     fromAsync 95/95 (100.0%)
     length/define-own-prop-length-coercion-order-set.js
     prototype/at/coerced-index-resize.js
@@ -476,19 +476,15 @@ built-ins/Array 244/3077 (7.93%)
     prototype/filter/resizable-buffer.js
     prototype/filter/resizable-buffer-grow-mid-iteration.js
     prototype/filter/resizable-buffer-shrink-mid-iteration.js
-    prototype/findIndex/callbackfn-resize-arraybuffer.js
     prototype/findIndex/resizable-buffer.js
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/callbackfn-resize-arraybuffer.js
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/callbackfn-resize-arraybuffer.js
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/find/callbackfn-resize-arraybuffer.js
     prototype/find/resizable-buffer.js
     prototype/find/resizable-buffer-grow-mid-iteration.js
     prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -2407,116 +2403,75 @@ built-ins/ThrowTypeError 2/14 (14.29%)
     unique-per-realm-function-proto.js
     unique-per-realm-non-simple.js non-strict
 
-built-ins/TypedArray 198/1434 (13.81%)
+built-ins/TypedArray 128/1434 (8.93%)
     from/iterated-array-changed-by-tonumber.js
     prototype/at/coerced-index-resize.js
     prototype/at/resizable-buffer.js
-    prototype/at/return-abrupt-from-this-out-of-bounds.js
-    prototype/byteLength/resizable-array-buffer-auto.js
-    prototype/byteLength/resizable-array-buffer-fixed.js
     prototype/byteLength/resizable-buffer-assorted.js
     prototype/byteLength/resized-out-of-bounds-1.js
     prototype/byteLength/resized-out-of-bounds-2.js
-    prototype/byteLength/return-bytelength.js
-    prototype/byteOffset/resizable-array-buffer-fixed.js
     prototype/byteOffset/resized-out-of-bounds.js
-    prototype/copyWithin/bit-precision.js
-    prototype/copyWithin/byteoffset.js
     prototype/copyWithin/coerced-target-start-end-shrink.js
     prototype/copyWithin/coerced-target-start-grow.js
     prototype/copyWithin/resizable-buffer.js
-    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
     prototype/entries/resizable-buffer.js
     prototype/entries/resizable-buffer-grow-mid-iteration.js
     prototype/entries/resizable-buffer-shrink-mid-iteration.js
-    prototype/entries/return-abrupt-from-this-out-of-bounds.js
-    prototype/every/callbackfn-resize.js
     prototype/every/resizable-buffer.js
     prototype/every/resizable-buffer-grow-mid-iteration.js
     prototype/every/resizable-buffer-shrink-mid-iteration.js
-    prototype/every/return-abrupt-from-this-out-of-bounds.js
     prototype/fill/coerced-value-start-end-resize.js
     prototype/fill/resizable-buffer.js
-    prototype/fill/return-abrupt-from-this-out-of-bounds.js
-    prototype/filter/callbackfn-resize.js
     prototype/filter/resizable-buffer.js
     prototype/filter/resizable-buffer-grow-mid-iteration.js
     prototype/filter/resizable-buffer-shrink-mid-iteration.js
-    prototype/filter/return-abrupt-from-this-out-of-bounds.js
-    prototype/find/callbackfn-resize.js
     prototype/find/resizable-buffer.js
     prototype/find/resizable-buffer-grow-mid-iteration.js
     prototype/find/resizable-buffer-shrink-mid-iteration.js
-    prototype/find/return-abrupt-from-this-out-of-bounds.js
-    prototype/findIndex/callbackfn-resize.js
     prototype/findIndex/resizable-buffer.js
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js
-    prototype/findLast/callbackfn-resize.js
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/return-abrupt-from-this-out-of-bounds.js
-    prototype/findLastIndex/callbackfn-resize.js
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
-    prototype/forEach/callbackfn-resize.js
     prototype/forEach/resizable-buffer.js
     prototype/forEach/resizable-buffer-grow-mid-iteration.js
     prototype/forEach/resizable-buffer-shrink-mid-iteration.js
-    prototype/forEach/return-abrupt-from-this-out-of-bounds.js
     prototype/includes/coerced-searchelement-fromindex-resize.js
     prototype/includes/resizable-buffer.js
     prototype/includes/resizable-buffer-special-float-values.js
-    prototype/includes/return-abrupt-from-this-out-of-bounds.js
-    prototype/includes/search-undefined-after-shrinking-buffer.js
-    prototype/includes/search-undefined-after-shrinking-buffer-index-is-oob.js
     prototype/indexOf/coerced-searchelement-fromindex-grow.js
     prototype/indexOf/coerced-searchelement-fromindex-shrink.js
     prototype/indexOf/resizable-buffer.js
     prototype/indexOf/resizable-buffer-special-float-values.js
-    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js
     prototype/join/coerced-separator-grow.js
     prototype/join/coerced-separator-shrink.js
     prototype/join/resizable-buffer.js
-    prototype/join/return-abrupt-from-this-out-of-bounds.js
     prototype/keys/resizable-buffer.js
     prototype/keys/resizable-buffer-grow-mid-iteration.js
     prototype/keys/resizable-buffer-shrink-mid-iteration.js
-    prototype/keys/return-abrupt-from-this-out-of-bounds.js
     prototype/lastIndexOf/coerced-position-grow.js
     prototype/lastIndexOf/coerced-position-shrink.js
-    prototype/lastIndexOf/negative-index-and-resize-to-smaller.js
     prototype/lastIndexOf/resizable-buffer.js
     prototype/lastIndexOf/resizable-buffer-special-float-values.js
-    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js
-    prototype/length/resizable-array-buffer-auto.js
-    prototype/length/resizable-array-buffer-fixed.js
     prototype/length/resizable-buffer-assorted.js
     prototype/length/resized-out-of-bounds-1.js
     prototype/length/resized-out-of-bounds-2.js
-    prototype/map/callbackfn-resize.js
     prototype/map/resizable-buffer.js
     prototype/map/resizable-buffer-grow-mid-iteration.js
     prototype/map/resizable-buffer-shrink-mid-iteration.js
-    prototype/map/return-abrupt-from-this-out-of-bounds.js
     prototype/map/speciesctor-resizable-buffer-grow.js
     prototype/map/speciesctor-resizable-buffer-shrink.js
-    prototype/reduce/callbackfn-resize.js
     prototype/reduce/resizable-buffer.js
     prototype/reduce/resizable-buffer-grow-mid-iteration.js
     prototype/reduce/resizable-buffer-shrink-mid-iteration.js
-    prototype/reduce/return-abrupt-from-this-out-of-bounds.js
-    prototype/reduceRight/callbackfn-resize.js
     prototype/reduceRight/resizable-buffer.js
     prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
     prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
-    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js
     prototype/reverse/resizable-buffer.js
-    prototype/reverse/return-abrupt-from-this-out-of-bounds.js
     prototype/set/BigInt/array-arg-primitive-toobject.js
     prototype/set/BigInt/bigint-tobiguint64.js
     prototype/set/BigInt/number-tobigint.js
@@ -2533,66 +2488,37 @@ built-ins/TypedArray 198/1434 (13.81%)
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
-    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js
-    prototype/set/typedarray-arg-target-out-of-bounds.js
     prototype/slice/coerced-start-end-grow.js
     prototype/slice/coerced-start-end-shrink.js
     prototype/slice/resizable-buffer.js
-    prototype/slice/return-abrupt-from-this-out-of-bounds.js
     prototype/slice/speciesctor-resize.js
-    prototype/slice/speciesctor-return-same-buffer-with-offset.js
-    prototype/some/callbackfn-resize.js
     prototype/some/resizable-buffer.js
     prototype/some/resizable-buffer-grow-mid-iteration.js
     prototype/some/resizable-buffer-shrink-mid-iteration.js
-    prototype/some/return-abrupt-from-this-out-of-bounds.js
     prototype/sort/comparefn-grow.js
     prototype/sort/comparefn-resizable-buffer.js
     prototype/sort/comparefn-shrink.js
     prototype/sort/resizable-buffer-default-comparator.js
-    prototype/sort/return-abrupt-from-this-out-of-bounds.js
     prototype/subarray/BigInt/infinity.js
-    prototype/subarray/byteoffset-with-detached-buffer.js
     prototype/subarray/coerced-begin-end-grow.js
     prototype/subarray/coerced-begin-end-shrink.js
     prototype/subarray/infinity.js
     prototype/subarray/resizable-buffer.js
-    prototype/subarray/result-is-new-instance-from-same-ctor.js
-    prototype/subarray/result-is-new-instance-with-shared-buffer.js
-    prototype/subarray/results-with-different-length.js
-    prototype/subarray/results-with-empty-length.js
-    prototype/subarray/speciesctor-get-species-custom-ctor.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/subarray/tointeger-begin.js
     prototype/Symbol.toStringTag/BigInt/name.js
     prototype/Symbol.toStringTag/name.js
     prototype/toLocaleString/resizable-buffer.js
-    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js
     prototype/toLocaleString/user-provided-tolocalestring-grow.js
     prototype/toLocaleString/user-provided-tolocalestring-shrink.js
-    prototype/toReversed/immutable.js
-    prototype/toReversed/length-property-ignored.js
     prototype/toReversed/this-value-invalid.js
-    prototype/toSorted/immutable.js
-    prototype/toSorted/length-property-ignored.js
     prototype/toSorted/this-value-invalid.js
     prototype/values/make-out-of-bounds-after-exhausted.js
     prototype/values/resizable-buffer.js
     prototype/values/resizable-buffer-grow-mid-iteration.js
     prototype/values/resizable-buffer-shrink-mid-iteration.js
-    prototype/values/return-abrupt-from-this-out-of-bounds.js
     prototype/with/BigInt/early-type-coercion-bigint.js
-    prototype/with/early-type-coercion.js
-    prototype/with/ignores-species.js
-    prototype/with/immutable.js
-    prototype/with/index-casted-to-number.js
-    prototype/with/index-negative.js
     prototype/with/index-validated-against-current-length.js
-    prototype/with/length-property-ignored.js
-    prototype/with/negative-fractional-index-truncated-to-zero.js
-    prototype/with/order-of-evaluation.js
     prototype/with/valid-typedarray-index-checked-after-coercions.js
     prototype/resizable-and-fixed-have-same-prototype.js
     prototype/Symbol.iterator.js
@@ -2604,7 +2530,7 @@ built-ins/TypedArray 198/1434 (13.81%)
     resizable-buffer-length-tracking-1.js
     resizable-buffer-length-tracking-2.js
 
-built-ins/TypedArrayConstructors 193/736 (26.22%)
+built-ins/TypedArrayConstructors 191/736 (25.95%)
     ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2769,8 +2695,6 @@ built-ins/TypedArrayConstructors 193/736 (26.22%)
     internals/HasProperty/key-is-lower-than-zero.js
     internals/HasProperty/key-is-minus-zero.js
     internals/HasProperty/key-is-not-integer.js
-    internals/HasProperty/resizable-array-buffer-auto.js
-    internals/HasProperty/resizable-array-buffer-fixed.js
     internals/OwnPropertyKeys/BigInt/integer-indexes.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-keys.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -449,7 +449,7 @@ built-ins/AggregateError 3/25 (12.0%)
     newtarget-proto-fallback.js
     proto-from-ctor-realm.js
 
-built-ins/Array 240/3077 (7.8%)
+built-ins/Array 244/3077 (7.93%)
     fromAsync 95/95 (100.0%)
     length/define-own-prop-length-coercion-order-set.js
     prototype/at/coerced-index-resize.js
@@ -476,15 +476,19 @@ built-ins/Array 240/3077 (7.8%)
     prototype/filter/resizable-buffer.js
     prototype/filter/resizable-buffer-grow-mid-iteration.js
     prototype/filter/resizable-buffer-shrink-mid-iteration.js
+    prototype/findIndex/callbackfn-resize-arraybuffer.js
     prototype/findIndex/resizable-buffer.js
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLastIndex/callbackfn-resize-arraybuffer.js
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLast/callbackfn-resize-arraybuffer.js
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
+    prototype/find/callbackfn-resize-arraybuffer.js
     prototype/find/resizable-buffer.js
     prototype/find/resizable-buffer-grow-mid-iteration.js
     prototype/find/resizable-buffer-shrink-mid-iteration.js
@@ -2405,75 +2409,116 @@ built-ins/ThrowTypeError 2/14 (14.29%)
     unique-per-realm-function-proto.js
     unique-per-realm-non-simple.js non-strict
 
-built-ins/TypedArray 129/1434 (9.0%)
+built-ins/TypedArray 198/1434 (13.81%)
     from/iterated-array-changed-by-tonumber.js
     prototype/at/coerced-index-resize.js
     prototype/at/resizable-buffer.js
+    prototype/at/return-abrupt-from-this-out-of-bounds.js
+    prototype/byteLength/resizable-array-buffer-auto.js
+    prototype/byteLength/resizable-array-buffer-fixed.js
     prototype/byteLength/resizable-buffer-assorted.js
     prototype/byteLength/resized-out-of-bounds-1.js
     prototype/byteLength/resized-out-of-bounds-2.js
+    prototype/byteLength/return-bytelength.js
+    prototype/byteOffset/resizable-array-buffer-fixed.js
     prototype/byteOffset/resized-out-of-bounds.js
+    prototype/copyWithin/bit-precision.js
+    prototype/copyWithin/byteoffset.js
     prototype/copyWithin/coerced-target-start-end-shrink.js
     prototype/copyWithin/coerced-target-start-grow.js
     prototype/copyWithin/resizable-buffer.js
+    prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js
     prototype/entries/resizable-buffer.js
     prototype/entries/resizable-buffer-grow-mid-iteration.js
     prototype/entries/resizable-buffer-shrink-mid-iteration.js
+    prototype/entries/return-abrupt-from-this-out-of-bounds.js
+    prototype/every/callbackfn-resize.js
     prototype/every/resizable-buffer.js
     prototype/every/resizable-buffer-grow-mid-iteration.js
     prototype/every/resizable-buffer-shrink-mid-iteration.js
+    prototype/every/return-abrupt-from-this-out-of-bounds.js
     prototype/fill/coerced-value-start-end-resize.js
     prototype/fill/resizable-buffer.js
+    prototype/fill/return-abrupt-from-this-out-of-bounds.js
+    prototype/filter/callbackfn-resize.js
     prototype/filter/resizable-buffer.js
     prototype/filter/resizable-buffer-grow-mid-iteration.js
     prototype/filter/resizable-buffer-shrink-mid-iteration.js
+    prototype/filter/return-abrupt-from-this-out-of-bounds.js
+    prototype/find/callbackfn-resize.js
     prototype/find/resizable-buffer.js
     prototype/find/resizable-buffer-grow-mid-iteration.js
     prototype/find/resizable-buffer-shrink-mid-iteration.js
+    prototype/find/return-abrupt-from-this-out-of-bounds.js
+    prototype/findIndex/callbackfn-resize.js
     prototype/findIndex/resizable-buffer.js
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findIndex/return-abrupt-from-this-out-of-bounds.js
+    prototype/findLast/callbackfn-resize.js
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLast/return-abrupt-from-this-out-of-bounds.js
+    prototype/findLastIndex/callbackfn-resize.js
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
+    prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js
+    prototype/forEach/callbackfn-resize.js
     prototype/forEach/resizable-buffer.js
     prototype/forEach/resizable-buffer-grow-mid-iteration.js
     prototype/forEach/resizable-buffer-shrink-mid-iteration.js
+    prototype/forEach/return-abrupt-from-this-out-of-bounds.js
     prototype/includes/coerced-searchelement-fromindex-resize.js
     prototype/includes/resizable-buffer.js
     prototype/includes/resizable-buffer-special-float-values.js
+    prototype/includes/return-abrupt-from-this-out-of-bounds.js
+    prototype/includes/search-undefined-after-shrinking-buffer.js
+    prototype/includes/search-undefined-after-shrinking-buffer-index-is-oob.js
     prototype/indexOf/coerced-searchelement-fromindex-grow.js
     prototype/indexOf/coerced-searchelement-fromindex-shrink.js
     prototype/indexOf/resizable-buffer.js
     prototype/indexOf/resizable-buffer-special-float-values.js
+    prototype/indexOf/return-abrupt-from-this-out-of-bounds.js
     prototype/join/coerced-separator-grow.js
     prototype/join/coerced-separator-shrink.js
     prototype/join/resizable-buffer.js
+    prototype/join/return-abrupt-from-this-out-of-bounds.js
     prototype/keys/resizable-buffer.js
     prototype/keys/resizable-buffer-grow-mid-iteration.js
     prototype/keys/resizable-buffer-shrink-mid-iteration.js
+    prototype/keys/return-abrupt-from-this-out-of-bounds.js
     prototype/lastIndexOf/coerced-position-grow.js
     prototype/lastIndexOf/coerced-position-shrink.js
+    prototype/lastIndexOf/negative-index-and-resize-to-smaller.js
     prototype/lastIndexOf/resizable-buffer.js
     prototype/lastIndexOf/resizable-buffer-special-float-values.js
+    prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js
+    prototype/length/resizable-array-buffer-auto.js
+    prototype/length/resizable-array-buffer-fixed.js
     prototype/length/resizable-buffer-assorted.js
     prototype/length/resized-out-of-bounds-1.js
     prototype/length/resized-out-of-bounds-2.js
+    prototype/map/callbackfn-resize.js
     prototype/map/resizable-buffer.js
     prototype/map/resizable-buffer-grow-mid-iteration.js
     prototype/map/resizable-buffer-shrink-mid-iteration.js
+    prototype/map/return-abrupt-from-this-out-of-bounds.js
     prototype/map/speciesctor-resizable-buffer-grow.js
     prototype/map/speciesctor-resizable-buffer-shrink.js
+    prototype/reduce/callbackfn-resize.js
     prototype/reduce/resizable-buffer.js
     prototype/reduce/resizable-buffer-grow-mid-iteration.js
     prototype/reduce/resizable-buffer-shrink-mid-iteration.js
+    prototype/reduce/return-abrupt-from-this-out-of-bounds.js
+    prototype/reduceRight/callbackfn-resize.js
     prototype/reduceRight/resizable-buffer.js
     prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
     prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
+    prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js
     prototype/reverse/resizable-buffer.js
+    prototype/reverse/return-abrupt-from-this-out-of-bounds.js
     prototype/set/BigInt/array-arg-primitive-toobject.js
     prototype/set/BigInt/bigint-tobiguint64.js
     prototype/set/BigInt/number-tobigint.js
@@ -2490,37 +2535,66 @@ built-ins/TypedArray 129/1434 (9.0%)
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
+    prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js
+    prototype/set/typedarray-arg-target-out-of-bounds.js
     prototype/slice/coerced-start-end-grow.js
     prototype/slice/coerced-start-end-shrink.js
     prototype/slice/resizable-buffer.js
+    prototype/slice/return-abrupt-from-this-out-of-bounds.js
     prototype/slice/speciesctor-resize.js
+    prototype/slice/speciesctor-return-same-buffer-with-offset.js
+    prototype/some/callbackfn-resize.js
     prototype/some/resizable-buffer.js
     prototype/some/resizable-buffer-grow-mid-iteration.js
     prototype/some/resizable-buffer-shrink-mid-iteration.js
+    prototype/some/return-abrupt-from-this-out-of-bounds.js
     prototype/sort/comparefn-grow.js
     prototype/sort/comparefn-resizable-buffer.js
     prototype/sort/comparefn-shrink.js
     prototype/sort/resizable-buffer-default-comparator.js
+    prototype/sort/return-abrupt-from-this-out-of-bounds.js
     prototype/subarray/BigInt/infinity.js
+    prototype/subarray/byteoffset-with-detached-buffer.js
     prototype/subarray/coerced-begin-end-grow.js
     prototype/subarray/coerced-begin-end-shrink.js
     prototype/subarray/infinity.js
     prototype/subarray/resizable-buffer.js
+    prototype/subarray/result-is-new-instance-from-same-ctor.js
+    prototype/subarray/result-is-new-instance-with-shared-buffer.js
+    prototype/subarray/results-with-different-length.js
+    prototype/subarray/results-with-empty-length.js
+    prototype/subarray/speciesctor-get-species-custom-ctor.js
+    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
+    prototype/subarray/tointeger-begin.js
     prototype/Symbol.toStringTag/BigInt/name.js
     prototype/Symbol.toStringTag/name.js
     prototype/toLocaleString/resizable-buffer.js
+    prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js
     prototype/toLocaleString/user-provided-tolocalestring-grow.js
     prototype/toLocaleString/user-provided-tolocalestring-shrink.js
+    prototype/toReversed/immutable.js
+    prototype/toReversed/length-property-ignored.js
     prototype/toReversed/this-value-invalid.js
+    prototype/toSorted/immutable.js
+    prototype/toSorted/length-property-ignored.js
     prototype/toSorted/this-value-invalid.js
     prototype/values/make-out-of-bounds-after-exhausted.js
     prototype/values/resizable-buffer.js
     prototype/values/resizable-buffer-grow-mid-iteration.js
     prototype/values/resizable-buffer-shrink-mid-iteration.js
+    prototype/values/return-abrupt-from-this-out-of-bounds.js
     prototype/with/BigInt/early-type-coercion-bigint.js
+    prototype/with/early-type-coercion.js
+    prototype/with/ignores-species.js
+    prototype/with/immutable.js
+    prototype/with/index-casted-to-number.js
+    prototype/with/index-negative.js
     prototype/with/index-validated-against-current-length.js
+    prototype/with/length-property-ignored.js
+    prototype/with/negative-fractional-index-truncated-to-zero.js
+    prototype/with/order-of-evaluation.js
     prototype/with/valid-typedarray-index-checked-after-coercions.js
     prototype/resizable-and-fixed-have-same-prototype.js
     prototype/Symbol.iterator.js
@@ -2529,11 +2603,10 @@ built-ins/TypedArray 129/1434 (9.0%)
     out-of-bounds-behaves-like-detached.js
     out-of-bounds-get-and-set.js
     out-of-bounds-has.js
-    prototype.js
     resizable-buffer-length-tracking-1.js
     resizable-buffer-length-tracking-2.js
 
-built-ins/TypedArrayConstructors 191/736 (25.95%)
+built-ins/TypedArrayConstructors 193/736 (26.22%)
     ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2698,6 +2771,8 @@ built-ins/TypedArrayConstructors 191/736 (25.95%)
     internals/HasProperty/key-is-lower-than-zero.js
     internals/HasProperty/key-is-minus-zero.js
     internals/HasProperty/key-is-not-integer.js
+    internals/HasProperty/resizable-array-buffer-auto.js
+    internals/HasProperty/resizable-array-buffer-fixed.js
     internals/OwnPropertyKeys/BigInt/integer-indexes.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-and-symbol-keys-.js
     internals/OwnPropertyKeys/BigInt/integer-indexes-and-string-keys.js


### PR DESCRIPTION
This PR stacks on top of #2332, adding two commits
[Convert thisObj to be Object not Scriptable.](https://github.com/mozilla/rhino/commit/c6c7fc8cf03216af796b681dadf6387c7b19550e)
[Update test 262 properties.](https://github.com/mozilla/rhino/commit/f45037e918d989a261b2adde8450f6c52393fb7c)

This PR converts `this` to be an `Object` rather than a `Scriptable`. We then handle the `toObject` conversion in functions.