### PR TITLE
NativeProxy: fix set trap not passing receiver object

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -537,6 +537,13 @@ class NativeProxy extends ScriptableObject {
      */
     @Override
     public void put(String name, Scriptable start, Object value) {
+        putAndReturn(name, start, value);
+    }
+
+    /**
+     * Workaround for the missing return value of method {@link #put(String, Scriptable, Object)}
+     */
+    boolean putAndReturn(String name, Scriptable start, Object value) {
         /*
          * 1. Assert: IsPropertyKey(P) is true.
          * 2. Let handler be O.[[ProxyHandler]].
@@ -564,7 +571,7 @@ class NativeProxy extends ScriptableObject {
                     ScriptRuntime.toBoolean(
                             callTrap(trap, new Object[] {target, name, value, this}));
             if (!booleanTrapResult) {
-                return; // false
+                return false;
             }
 
             DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), name);
@@ -581,13 +588,14 @@ class NativeProxy extends ScriptableObject {
                     throw ScriptRuntime.typeError("proxy set has to be available");
                 }
             }
-            return; // true
+            return true;
         }
 
         if (start == this) {
             start = target;
         }
         target.put(name, start, value);
+        return true; // still no result from put
     }
 
     /**
@@ -597,6 +605,11 @@ class NativeProxy extends ScriptableObject {
      */
     @Override
     public void put(int index, Scriptable start, Object value) {
+        putAndReturn(index, start, value);
+    }
+
+    /** Workaround for the missing return value of method {@link #put(int, Scriptable, Object)} */
+    boolean putAndReturn(int index, Scriptable start, Object value) {
         /*
          * 1. Assert: IsPropertyKey(P) is true.
          * 2. Let handler be O.[[ProxyHandler]].
@@ -628,7 +641,7 @@ class NativeProxy extends ScriptableObject {
                                         target, ScriptRuntime.toString(index), value, this
                                     }));
             if (!booleanTrapResult) {
-                return; // false
+                return false;
             }
 
             DescriptorInfo targetDesc =
@@ -646,13 +659,14 @@ class NativeProxy extends ScriptableObject {
                     throw ScriptRuntime.typeError("proxy set has to be available");
                 }
             }
-            return; // true
+            return true;
         }
 
         if (start == this) {
             start = target;
         }
         target.put(index, start, value);
+        return true; // still no result from put
     }
 
     /**
@@ -662,6 +676,13 @@ class NativeProxy extends ScriptableObject {
      */
     @Override
     public void put(Symbol key, Scriptable start, Object value) {
+        putAndReturn(key, start, value);
+    }
+
+    /**
+     * Workaround for the missing return value of method {@link #put(Symbol, Scriptable, Object)}
+     */
+    boolean putAndReturn(Symbol key, Scriptable start, Object value) {
         /*
          * 1. Assert: IsPropertyKey(P) is true.
          * 2. Let handler be O.[[ProxyHandler]].
@@ -689,7 +710,7 @@ class NativeProxy extends ScriptableObject {
                     ScriptRuntime.toBoolean(
                             callTrap(trap, new Object[] {target, key, value, this}));
             if (!booleanTrapResult) {
-                return; // false
+                return false;
             }
 
             DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), key);
@@ -706,7 +727,7 @@ class NativeProxy extends ScriptableObject {
                     throw ScriptRuntime.typeError("proxy set has to be available");
                 }
             }
-            return; // true
+            return true;
         }
 
         if (start == this) {
@@ -714,6 +735,7 @@ class NativeProxy extends ScriptableObject {
         }
         SymbolScriptable symbolScriptableTarget = ensureSymbolScriptable(target);
         symbolScriptableTarget.put(key, start, value);
+        return true; // still no result from put
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -561,7 +561,8 @@ class NativeProxy extends ScriptableObject {
         Function trap = getTrap(TRAP_SET);
         if (trap != null) {
             boolean booleanTrapResult =
-                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, name, value}));
+                    ScriptRuntime.toBoolean(
+                            callTrap(trap, new Object[] {target, name, value, this}));
             if (!booleanTrapResult) {
                 return; // false
             }
@@ -623,7 +624,9 @@ class NativeProxy extends ScriptableObject {
                     ScriptRuntime.toBoolean(
                             callTrap(
                                     trap,
-                                    new Object[] {target, ScriptRuntime.toString(index), value}));
+                                    new Object[] {
+                                        target, ScriptRuntime.toString(index), value, this
+                                    }));
             if (!booleanTrapResult) {
                 return; // false
             }
@@ -683,7 +686,8 @@ class NativeProxy extends ScriptableObject {
         Function trap = getTrap(TRAP_SET);
         if (trap != null) {
             boolean booleanTrapResult =
-                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, key, value}));
+                    ScriptRuntime.toBoolean(
+                            callTrap(trap, new Object[] {target, key, value, this}));
             if (!booleanTrapResult) {
                 return; // false
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -387,7 +387,7 @@ class NativeProxy extends ScriptableObject {
 
         Function trap = getTrap(TRAP_GET);
         if (trap != null) {
-            Object trapResult = callTrap(trap, new Object[] {target, name, this});
+            Object trapResult = callTrap(trap, new Object[] {target, name, start});
 
             DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), name);
             if (targetDesc != null && targetDesc.isConfigurable(false)) {
@@ -443,7 +443,7 @@ class NativeProxy extends ScriptableObject {
         Function trap = getTrap(TRAP_GET);
         if (trap != null) {
             Object trapResult =
-                    callTrap(trap, new Object[] {target, ScriptRuntime.toString(index), this});
+                    callTrap(trap, new Object[] {target, ScriptRuntime.toString(index), start});
 
             DescriptorInfo targetDesc =
                     target.getOwnPropertyDescriptor(Context.getContext(), index);
@@ -501,7 +501,7 @@ class NativeProxy extends ScriptableObject {
 
         Function trap = getTrap(TRAP_GET);
         if (trap != null) {
-            Object trapResult = callTrap(trap, new Object[] {target, key, this});
+            Object trapResult = callTrap(trap, new Object[] {target, key, start});
 
             DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), key);
             if (targetDesc != null
@@ -569,7 +569,7 @@ class NativeProxy extends ScriptableObject {
         if (trap != null) {
             boolean booleanTrapResult =
                     ScriptRuntime.toBoolean(
-                            callTrap(trap, new Object[] {target, name, value, this}));
+                            callTrap(trap, new Object[] {target, name, value, start}));
             if (!booleanTrapResult) {
                 return false;
             }
@@ -638,7 +638,7 @@ class NativeProxy extends ScriptableObject {
                             callTrap(
                                     trap,
                                     new Object[] {
-                                        target, ScriptRuntime.toString(index), value, this
+                                        target, ScriptRuntime.toString(index), value, start
                                     }));
             if (!booleanTrapResult) {
                 return false;
@@ -708,7 +708,7 @@ class NativeProxy extends ScriptableObject {
         if (trap != null) {
             boolean booleanTrapResult =
                     ScriptRuntime.toBoolean(
-                            callTrap(trap, new Object[] {target, key, value, this}));
+                            callTrap(trap, new Object[] {target, key, value, start}));
             if (!booleanTrapResult) {
                 return false;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -433,6 +433,9 @@ final class NativeReflect extends ScriptableObject {
             return true;
         }
 
+        // A missing value must be treated as undefined
+        final Object value = args.length > 2 ? args[2] : Undefined.instance;
+
         // Step 3: default receiver to target when not supplied (args[3]).
         // Note: receiver is intentionally typed as Scriptable, not ScriptableObject,
         // because the caller may pass any object (e.g. a Proxy) as the receiver.
@@ -444,6 +447,17 @@ final class NativeReflect extends ScriptableObject {
             key = args[1]; // Symbol — used as-is
         } else {
             key = ScriptRuntime.toString(args[1]); // coerce to String
+        }
+
+        if (receiver != target && target instanceof NativeProxy proxyTarget) {
+            if (key instanceof Symbol) {
+                return proxyTarget.putAndReturn((Symbol) key, receiver, args[2]);
+            }
+            StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(key);
+            if (soi.stringId == null) {
+                return proxyTarget.putAndReturn(soi.index, receiver, args[2]);
+            }
+            return proxyTarget.putAndReturn(soi.stringId, receiver, args[2]);
         }
 
         if (receiver != target) {
@@ -473,7 +487,7 @@ final class NativeReflect extends ScriptableObject {
                 }
                 if (ownDesc != null) {
                     // Found the property somewhere in target's chain.
-                    return ordinarySetWithOwnDescriptor(cx, s, receiver, key, args[2], ownDesc);
+                    return ordinarySetWithOwnDescriptor(cx, s, receiver, key, value, ownDesc);
                 }
                 current = current.getPrototype();
             }
@@ -481,7 +495,7 @@ final class NativeReflect extends ScriptableObject {
             // Spec step 2c: no descriptor found anywhere in target's chain.
             // Treat as writable data → CreateDataProperty(receiver, key, V).
             if (receiver instanceof ScriptableObject receiverObj) {
-                DescriptorInfo newDesc = new DescriptorInfo(true, true, true, args[2]);
+                DescriptorInfo newDesc = new DescriptorInfo(true, true, true, value);
                 receiverObj.defineOwnProperty(cx, key, newDesc);
             }
             return true;
@@ -491,26 +505,26 @@ final class NativeReflect extends ScriptableObject {
         // For a NativeProxy, we use putAndReturn() to capture the result.
         if (target instanceof NativeProxy proxyTarget) {
             if (key instanceof Symbol) {
-                return proxyTarget.putAndReturn((Symbol) key, receiver, args[2]);
+                return proxyTarget.putAndReturn((Symbol) key, receiver, value);
             }
 
             StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(key);
             if (soi.stringId == null) {
-                return proxyTarget.putAndReturn(soi.index, receiver, args[2]);
+                return proxyTarget.putAndReturn(soi.index, receiver, value);
             }
-            return proxyTarget.putAndReturn(soi.stringId, receiver, args[2]);
+            return proxyTarget.putAndReturn(soi.stringId, receiver, value);
         }
 
         // For a plain ScriptableObject put() has no return value, we
         // assume true.
         if (key instanceof Symbol) {
-            receiver.put((Symbol) key, receiver, args[2]);
+            receiver.put((Symbol) key, receiver, value);
         } else {
             StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(key);
             if (soi.stringId == null) {
-                receiver.put(soi.index, receiver, args[2]);
+                receiver.put(soi.index, receiver, value);
             } else {
-                receiver.put(soi.stringId, receiver, args[2]);
+                receiver.put(soi.stringId, receiver, value);
             }
         }
         return true;
@@ -580,18 +594,27 @@ final class NativeReflect extends ScriptableObject {
                 if (existingDesc.isWritable(false)) {
                     return false;
                 }
-                // Step 1.d.iii — { [[Value]]: V } only; all other fields NOT_FOUND so that
-                // defineOwnProperty preserves the existing writable/enumerable/configurable.
+                // Step 1.d.iii
                 DescriptorInfo valueDesc =
                         new DescriptorInfo(
                                 NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, value);
-                receiverObj.defineOwnProperty(cx, key, valueDesc);
+                try {
+                    receiverObj.defineOwnProperty(cx, key, valueDesc);
+                } catch (EcmaError e) {
+                    // Rhino throws where spec says [[DefineOwnProperty]] returns false.
+                    return false;
+                }
                 return true;
             }
 
-            // Step 1.e — CreateDataProperty: {writable:true, enumerable:true, configurable:true}
+            // Step 1.e — CreateDataProperty
             DescriptorInfo newDesc = new DescriptorInfo(true, true, true, value);
-            receiverObj.defineOwnProperty(cx, key, newDesc);
+            try {
+                receiverObj.defineOwnProperty(cx, key, newDesc);
+            } catch (EcmaError e) {
+                // Rhino throws where spec says [[DefineOwnProperty]] returns false.
+                return false;
+            }
             return true;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -201,18 +201,17 @@ final class NativeReflect extends ScriptableObject {
         DescriptorInfo desc = new DescriptorInfo(ScriptableObject.ensureScriptableObject(args[2]));
 
         Object key = args[1];
-
         try {
             if (key instanceof Symbol) {
                 return target.defineOwnProperty(cx, key, desc);
-            } else {
-                String propertyKey =
-                        ScriptRuntime.toString(
-                                ScriptRuntime.toPrimitive(key, ScriptRuntime.StringClass));
-                return target.defineOwnProperty(cx, propertyKey, desc);
             }
-
+            String propertyKey =
+                    ScriptRuntime.toString(
+                            ScriptRuntime.toPrimitive(key, ScriptRuntime.StringClass));
+            return target.defineOwnProperty(cx, propertyKey, desc);
         } catch (EcmaError e) {
+            // Rhino throws where the spec says [[DefineOwnProperty]] should return false.
+            // Map those back to the spec-correct false return value.
             return false;
         }
     }
@@ -255,20 +254,30 @@ final class NativeReflect extends ScriptableObject {
          */
         ScriptableObject target = checkTarget(args);
 
-        if (args.length > 1) {
-            if (ScriptRuntime.isSymbol(args[1])) {
-                Object prop = ScriptableObject.getProperty(target, (Symbol) args[1]);
-                return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
-            }
-            if (args[1] instanceof Number) {
-                Object prop = ScriptableObject.getProperty(target, ScriptRuntime.toIndex(args[1]));
-                return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
-            }
+        if (args.length < 2) {
+            return Undefined.SCRIPTABLE_UNDEFINED;
+        }
 
-            Object prop = ScriptableObject.getProperty(target, ScriptRuntime.toString(args[1]));
+        // Step 3: default receiver to target when not supplied.
+        Scriptable receiver =
+                (args.length > 2 && args[2] instanceof Scriptable) ? (Scriptable) args[2] : target;
+
+        if (ScriptRuntime.isSymbol(args[1])) {
+            Object prop = ScriptableObject.getSuperProperty(target, receiver, (Symbol) args[1]);
             return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
         }
-        return Undefined.SCRIPTABLE_UNDEFINED;
+
+        if (args[1] instanceof Number) {
+            Object prop =
+                    ScriptableObject.getSuperProperty(
+                            target, receiver, ScriptRuntime.toIndex(args[1]));
+            return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
+        }
+
+        Object prop =
+                ScriptableObject.getSuperProperty(
+                        target, receiver, ScriptRuntime.toString(args[1]));
+        return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -446,31 +446,48 @@ final class NativeReflect extends ScriptableObject {
             key = ScriptRuntime.toString(args[1]); // coerce to String
         }
 
-        // OrdinarySetWithOwnDescriptor is only needed when receiver != target.
-        // When receiver == target we must call target.[[Set]] directly via put(),
-        // which correctly invokes any proxy set trap on target.
-        // Inlining OrdinarySetWithOwnDescriptor when receiver == target would
-        // bypass the proxy trap and apply the plain-object non-writable check
-        // incorrectly (e.g. a configurable+non-writable property where the trap
-        // returns true would wrongly return false).
         if (receiver != target) {
-            // OrdinarySet step 1:
-            //   Let ownDesc be ? O.[[GetOwnProperty]](P).
-            DescriptorInfo ownDesc =
-                    (key instanceof Symbol)
-                            ? target.getOwnPropertyDescriptor(cx, key)
-                            : target.getOwnPropertyDescriptor(cx, (String) key);
-
-            if (ownDesc != null) {
-                // Target owns the property: delegate to OrdinarySetWithOwnDescriptor.
-                return ordinarySetWithOwnDescriptor(cx, s, receiver, key, args[2], ownDesc);
+            /*
+             * OrdinarySet ( O, P, V, Receiver ):
+             *   1. Let ownDesc be ? O.[[GetOwnProperty]](P).
+             *   2. If ownDesc is undefined, then
+             *      a. Let parent be ? O.[[GetPrototypeOf]]().
+             *      b. If parent is not null, return ? parent.[[Set]](P, V, Receiver).
+             *      c. Else, let ownDesc be the PropertyDescriptor
+             *         { [[Value]]: undefined, [[Writable]]: true,
+             *           [[Enumerable]]: true, [[Configurable]]: true }.
+             *   3. Return ? OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
+             *
+             * We walk target's prototype chain ourselves, calling getOwnPropertyDescriptor
+             * at each node. getSuperProperty() cannot be reused here because it calls
+             * obj.get() (invoking getters) rather than retrieving descriptors.
+             */
+            Scriptable current = target;
+            while (current != null) {
+                DescriptorInfo ownDesc = null;
+                if (current instanceof ScriptableObject so) {
+                    ownDesc =
+                            (key instanceof Symbol)
+                                    ? so.getOwnPropertyDescriptor(cx, key)
+                                    : so.getOwnPropertyDescriptor(cx, (String) key);
+                }
+                if (ownDesc != null) {
+                    // Found the property somewhere in target's chain.
+                    return ordinarySetWithOwnDescriptor(cx, s, receiver, key, args[2], ownDesc);
+                }
+                current = current.getPrototype();
             }
+
+            // Spec step 2c: no descriptor found anywhere in target's chain.
+            // Treat as writable data → CreateDataProperty(receiver, key, V).
+            if (receiver instanceof ScriptableObject receiverObj) {
+                DescriptorInfo newDesc = new DescriptorInfo(true, true, true, args[2]);
+                receiverObj.defineOwnProperty(cx, key, newDesc);
+            }
+            return true;
         }
 
-        // receiver == target (or target has no own property P):
-        // delegate to [[Set]] on the receiver, which correctly fires any proxy
-        // set trap when receiver/target is a Proxy.
-
+        // receiver == target:
         // For a NativeProxy, we use putAndReturn() to capture the result.
         if (target instanceof NativeProxy proxyTarget) {
             if (key instanceof Symbol) {
@@ -544,10 +561,9 @@ final class NativeReflect extends ScriptableObject {
                 return false;
             }
             // Step 1.b
-            if (!(receiver instanceof ScriptableObject)) {
+            if (!(receiver instanceof ScriptableObject receiverObj)) {
                 return false;
             }
-            ScriptableObject receiverObj = (ScriptableObject) receiver;
 
             // Step 1.c
             DescriptorInfo existingDesc =

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -84,13 +84,10 @@ final class NativeReflect extends ScriptableObject {
                     Integer.toString(args.length));
         }
 
-        Scriptable callable = ScriptableObject.ensureScriptable(args[0]);
-
-        if (args[1] instanceof Scriptable) {
-            thisObj = (Scriptable) args[1];
-        } else if (ScriptRuntime.isPrimitive(args[1])) {
-            thisObj = cx.newObject(s, "Object", new Object[] {args[1]});
+        if (!(args[0] instanceof Callable)) {
+            throw ScriptRuntime.notFunctionError(args[0]);
         }
+        Scriptable callable = (Scriptable) args[0];
 
         if (ScriptRuntime.isSymbol(args[2])) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(args[2]));
@@ -98,7 +95,7 @@ final class NativeReflect extends ScriptableObject {
         ScriptableObject argumentsList = ScriptableObject.ensureScriptableObject(args[2]);
 
         return ScriptRuntime.applyOrCall(
-                true, cx, s, callable, new Object[] {thisObj, argumentsList});
+                true, cx, s, callable, new Object[] {args[1], argumentsList});
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -64,8 +64,18 @@ final class NativeReflect extends ScriptableObject {
         return "Reflect";
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.apply">28.1.1 Reflect.apply
+     * ( target, thisArgument, argumentsList )</a>
+     */
     private static Object apply(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If IsCallable(target) is false, throw a TypeError exception.
+         * 2. Let args be ? CreateListFromArrayLike(argumentsList).
+         * 3. Perform PrepareForTailCall().
+         * 4. Return ? Call(target, thisArgument, args).
+         */
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -170,8 +180,18 @@ final class NativeReflect extends ScriptableObject {
         return newScriptable;
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.defineproperty">28.1.3
+     * Reflect.defineProperty ( target, propertyKey, attributes )</a>
+     */
     private static Object defineProperty(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let key be ? ToPropertyKey(propertyKey).
+         * 3. Let desc be ? ToPropertyDescriptor(attributes).
+         * 4. Return ? target.[[DefineOwnProperty]](key, desc).
+         */
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -200,8 +220,17 @@ final class NativeReflect extends ScriptableObject {
         }
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.deleteproperty">28.1.4
+     * Reflect.deleteProperty ( target, propertyKey )</a>
+     */
     private static Object deleteProperty(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let key be ? ToPropertyKey(propertyKey).
+         * 3. Return ? target.[[Delete]](key).
+         */
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -214,8 +243,19 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.get">28.1.5 Reflect.get (
+     * target, propertyKey [ , receiver ] )</a>
+     */
     private static Object get(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let key be ? ToPropertyKey(propertyKey).
+         * 3. If receiver is not present, then
+         *    a. Set receiver to target.
+         * 4. Return ? target.[[Get]](key, receiver).
+         */
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -234,8 +274,19 @@ final class NativeReflect extends ScriptableObject {
         return Undefined.SCRIPTABLE_UNDEFINED;
     }
 
+    /**
+     * see <a
+     * href="https://262.ecma-international.org/12.0/#sec-reflect.getownpropertydescriptor">28.1.6
+     * Reflect.getOwnPropertyDescriptor ( target, propertyKey )</a>
+     */
     private static Scriptable getOwnPropertyDescriptor(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let key be ? ToPropertyKey(propertyKey).
+         * 3. Let desc be ? target.[[GetOwnProperty]](key).
+         * 4. Return FromPropertyDescriptor(desc).
+         */
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -250,15 +301,32 @@ final class NativeReflect extends ScriptableObject {
         return Undefined.SCRIPTABLE_UNDEFINED;
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.getprototypeof">28.1.7
+     * Reflect.getPrototypeOf ( target )</a>
+     */
     private static Scriptable getPrototypeOf(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Return ? target.[[GetPrototypeOf]]().
+         */
         ScriptableObject target = checkTarget(args);
 
         return target.getPrototype();
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.has">28.1.8 Reflect.has (
+     * target, propertyKey )</a>
+     */
     private static Object has(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let key be ? ToPropertyKey(propertyKey).
+         * 3. Return ? target.[[HasProperty]](key).
+         */
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -271,14 +339,31 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.isextensible">28.1.9
+     * Reflect.isExtensible ( target )</a>
+     */
     private static Object isExtensible(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Return ? IsExtensible(target).
+         */
         ScriptableObject target = checkTarget(args);
         return target.isExtensible();
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.ownkeys">28.1.10
+     * Reflect.ownKeys ( target )</a>
+     */
     private static Scriptable ownKeys(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let keys be ? target.[[OwnPropertyKeys]]().
+         * 3. Return CreateArrayFromList(keys).
+         */
         ScriptableObject target = checkTarget(args);
 
         final List<Object> strings = new ArrayList<>();
@@ -303,15 +388,34 @@ final class NativeReflect extends ScriptableObject {
         return cx.newArray(s, keys);
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.preventextensions">28.1.11
+     * Reflect.preventExtensions ( target )</a>
+     */
     private static Object preventExtensions(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Return ? target.[[PreventExtensions]]().
+         */
         ScriptableObject target = checkTarget(args);
 
         return target.preventExtensions();
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.set">28.1.12 Reflect.set (
+     * target, propertyKey, V [ , receiver ] )</a>
+     */
     private static Object set(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. Let key be ? ToPropertyKey(propertyKey).
+         * 3. If receiver is not present, then
+         *    a. Set receiver to target.
+         * 4. Return ? target.[[Set]](key, V, receiver).
+         */
         ScriptableObject target = checkTarget(args);
         if (args.length < 2) {
             return true;
@@ -348,8 +452,17 @@ final class NativeReflect extends ScriptableObject {
         return true;
     }
 
+    /**
+     * see <a href="https://262.ecma-international.org/12.0/#sec-reflect.setprototypeof">28.1.13
+     * Reflect.setPrototypeOf ( target, proto )</a>
+     */
     private static Object setPrototypeOf(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
+        /*
+         * 1. If Type(target) is not Object, throw a TypeError exception.
+         * 2. If Type(proto) is not Object and proto is not null, throw a TypeError exception.
+         * 3. Return ? target.[[SetPrototypeOf]](proto).
+         */
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -415,40 +415,172 @@ final class NativeReflect extends ScriptableObject {
          * 3. If receiver is not present, then
          *    a. Set receiver to target.
          * 4. Return ? target.[[Set]](key, V, receiver).
+         *
+         * Note: we cannot simply call target.put(key, receiver, value) to implement
+         * target.[[Set]] because Rhino's put() does not correctly propagate the receiver —
+         * it would either write to the wrong object or re-enter a proxy set trap on the
+         * receiver causing infinite recursion. Instead, we inline OrdinarySet /
+         * OrdinarySetWithOwnDescriptor below.
          */
         ScriptableObject target = checkTarget(args);
         if (args.length < 2) {
             return true;
         }
 
-        ScriptableObject receiver =
-                args.length > 3 ? ScriptableObject.ensureScriptableObject(args[3]) : target;
-        if (receiver != target) {
-            DescriptorInfo descriptor = target.getOwnPropertyDescriptor(cx, args[1]);
-            if (descriptor != null) {
-                Object setter = descriptor.setter;
-                if (setter != null && setter != NOT_FOUND) {
-                    ((Function) setter).call(cx, s, receiver, new Object[] {args[2]});
-                    return true;
-                }
+        // Step 3: default receiver to target when not supplied (args[3]).
+        // Note: receiver is intentionally typed as Scriptable, not ScriptableObject,
+        // because the caller may pass any object (e.g. a Proxy) as the receiver.
+        Scriptable receiver = args.length > 3 ? ScriptableObject.ensureScriptable(args[3]) : target;
 
-                if (descriptor.isConfigurable(false)) {
-                    return false;
-                }
+        // Normalize the property key once so we can reuse it below.
+        final Object key;
+        if (ScriptRuntime.isSymbol(args[1])) {
+            key = args[1]; // Symbol — used as-is
+        } else {
+            key = ScriptRuntime.toString(args[1]); // coerce to String
+        }
+
+        // OrdinarySetWithOwnDescriptor is only needed when receiver != target.
+        // When receiver == target we must call target.[[Set]] directly via put(),
+        // which correctly invokes any proxy set trap on target.
+        // Inlining OrdinarySetWithOwnDescriptor when receiver == target would
+        // bypass the proxy trap and apply the plain-object non-writable check
+        // incorrectly (e.g. a configurable+non-writable property where the trap
+        // returns true would wrongly return false).
+        if (receiver != target) {
+            // OrdinarySet step 1:
+            //   Let ownDesc be ? O.[[GetOwnProperty]](P).
+            DescriptorInfo ownDesc =
+                    (key instanceof Symbol)
+                            ? target.getOwnPropertyDescriptor(cx, key)
+                            : target.getOwnPropertyDescriptor(cx, (String) key);
+
+            if (ownDesc != null) {
+                // Target owns the property: delegate to OrdinarySetWithOwnDescriptor.
+                return ordinarySetWithOwnDescriptor(cx, s, receiver, key, args[2], ownDesc);
             }
         }
 
-        if (ScriptRuntime.isSymbol(args[1])) {
-            receiver.put((Symbol) args[1], receiver, args[2]);
+        // receiver == target (or target has no own property P):
+        // delegate to [[Set]] on the receiver, which correctly fires any proxy
+        // set trap when receiver/target is a Proxy.
+
+        // For a NativeProxy, we use putAndReturn() to capture the result.
+        if (target instanceof NativeProxy proxyTarget) {
+            if (key instanceof Symbol) {
+                return proxyTarget.putAndReturn((Symbol) key, receiver, args[2]);
+            }
+
+            StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(key);
+            if (soi.stringId == null) {
+                return proxyTarget.putAndReturn(soi.index, receiver, args[2]);
+            }
+            return proxyTarget.putAndReturn(soi.stringId, receiver, args[2]);
+        }
+
+        // For a plain ScriptableObject put() has no return value, we
+        // assume true.
+        if (key instanceof Symbol) {
+            receiver.put((Symbol) key, receiver, args[2]);
         } else {
-            StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(args[1]);
+            StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(key);
             if (soi.stringId == null) {
                 receiver.put(soi.index, receiver, args[2]);
             } else {
                 receiver.put(soi.stringId, receiver, args[2]);
             }
         }
+        return true;
+    }
 
+    /**
+     * Implements the OrdinarySetWithOwnDescriptor abstract operation.
+     *
+     * <p>see <a href="https://262.ecma-international.org/14.0/#sec-ordinarysetwithowndescriptor">
+     * OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )</a>
+     *
+     * <p>IMPORTANT: when the property is a writable data descriptor this method calls {@code
+     * Receiver.[[DefineOwnProperty]]} — <em>not</em> {@code Receiver.[[Set]]}. The spec mandates
+     * the former. Using {@code receiver.put()} (i.e. {@code [[Set]]}) would re-trigger any proxy
+     * set trap installed on the receiver, causing infinite recursion when the receiver is a {@code
+     * Proxy} object (e.g. {@code with (proxy) { p = 1; }}).
+     */
+    private static boolean ordinarySetWithOwnDescriptor(
+            Context cx,
+            VarScope s,
+            Scriptable receiver,
+            Object key,
+            Object value,
+            DescriptorInfo ownDesc) {
+        /*
+         * 1. If IsDataDescriptor(ownDesc) is true, then
+         *    a. If ownDesc.[[Writable]] is false, return false.
+         *    b. If Type(Receiver) is not Object, return false.
+         *    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+         *    d. If existingDescriptor is not undefined, then
+         *       i.  If IsAccessorDescriptor(existingDescriptor) is true, return false.
+         *       ii. If existingDescriptor.[[Writable]] is false, return false.
+         *       iii.Let valueDesc be the PropertyDescriptor { [[Value]]: V }.
+         *           Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
+         *    e. Else,
+         *       Return ? CreateDataProperty(Receiver, P, V).
+         * 2. Assert: IsAccessorDescriptor(ownDesc) is true.
+         * 3. Let setter be ownDesc.[[Set]].
+         * 4. If setter is undefined, return false.
+         * 5. Perform ? Call(setter, Receiver, « V »).
+         * 6. Return true.
+         */
+
+        // Step 1: data descriptor
+        if (ownDesc.isDataDescriptor()) {
+            // Step 1.a
+            if (ownDesc.isWritable(false)) {
+                return false;
+            }
+            // Step 1.b
+            if (!(receiver instanceof ScriptableObject)) {
+                return false;
+            }
+            ScriptableObject receiverObj = (ScriptableObject) receiver;
+
+            // Step 1.c
+            DescriptorInfo existingDesc =
+                    (key instanceof Symbol)
+                            ? receiverObj.getOwnPropertyDescriptor(cx, key)
+                            : receiverObj.getOwnPropertyDescriptor(cx, (String) key);
+
+            if (existingDesc != null) {
+                // Step 1.d.i
+                if (existingDesc.isAccessorDescriptor()) {
+                    return false;
+                }
+                // Step 1.d.ii
+                if (existingDesc.isWritable(false)) {
+                    return false;
+                }
+                // Step 1.d.iii — { [[Value]]: V } only; all other fields NOT_FOUND so that
+                // defineOwnProperty preserves the existing writable/enumerable/configurable.
+                DescriptorInfo valueDesc =
+                        new DescriptorInfo(
+                                NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, value);
+                receiverObj.defineOwnProperty(cx, key, valueDesc);
+                return true;
+            }
+
+            // Step 1.e — CreateDataProperty: {writable:true, enumerable:true, configurable:true}
+            DescriptorInfo newDesc = new DescriptorInfo(true, true, true, value);
+            receiverObj.defineOwnProperty(cx, key, newDesc);
+            return true;
+        }
+
+        // Steps 2–6: accessor descriptor
+        Object setter = ownDesc.setter;
+        // Step 4
+        if (setter == null || setter == NOT_FOUND || Undefined.isUndefined(setter)) {
+            return false;
+        }
+        // Step 5
+        ((Function) setter).call(cx, s, receiver, new Object[] {value});
         return true;
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -953,4 +953,56 @@ public class NativeProxyTest {
 
         Utils.assertWithAllModes_ES6(true, js);
     }
+
+    @Test
+    public void setTrapReceivesReceiver() {
+        String js =
+                "var _receiver;\n"
+                        + "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    _receiver = receiver;\n"
+                        + "    t[prop] = value;\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "proxy.x = 1;\n"
+                        + "'' + (_receiver === proxy) + ' ' + target.x";
+        Utils.assertWithAllModes_ES6("true 1", js);
+    }
+
+    @Test
+    public void setTrapReceiverWithIndexProperty() {
+        String js =
+                "var _receiver;\n"
+                        + "var target = [10, 20, 30];\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    _receiver = receiver;\n"
+                        + "    t[prop] = value;\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "proxy[1] = 99;\n"
+                        + "'' + (_receiver === proxy) + ' ' + target[1]";
+        Utils.assertWithAllModes_ES6("true 99", js);
+    }
+
+    @Test
+    public void setTrapReceiverWithSymbolProperty() {
+        String js =
+                "var _receiver;\n"
+                        + "var sym = Symbol('test');\n"
+                        + "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    _receiver = receiver;\n"
+                        + "    t[prop] = value;\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "proxy[sym] = 'hello';\n"
+                        + "'' + (_receiver === proxy) + ' ' + target[sym]";
+        Utils.assertWithAllModes_ES6("true hello", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -1128,4 +1128,150 @@ public class NativeProxyTest {
 
         Utils.assertWithAllModes_ES6("false", js);
     }
+
+    @Test
+    public void setTrapReceivesCorrectReceiverWhenDifferentFromProxy() {
+        // Reflect.set(proxy, 'p', value, otherReceiver) must forward otherReceiver
+        // as the 4th argument to the set trap — NOT the proxy itself.
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.set(proxy, 'p', 42, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void setTrapReceivesProxyAsReceiverWhenNoExplicitReceiverGiven() {
+        // When no receiver is supplied to Reflect.set, it defaults to the proxy itself.
+        // The trap must receive the proxy as the 4th argument.
+        String js =
+                "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    return receiver === proxy;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "'' + Reflect.set(proxy, 'p', 42);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void setTrapReceiverIsStartNotProxy_directAssignment() {
+        // Even for a direct assignment (proxy.p = v), the set trap's receiver
+        // must be the object where the assignment began (the proxy itself here),
+        // not the underlying target.
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    log.push(receiver === proxy ? 'proxy' : 'other');\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "proxy.p = 1;\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("proxy", js);
+    }
+
+    @Test
+    public void getTrapReceivesCorrectReceiverWhenDifferentFromProxy() {
+        // Reflect.get(proxy, 'p', otherReceiver) must forward otherReceiver
+        // as the 3rd argument to the get trap — NOT the proxy itself.
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    return 42;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.get(proxy, 'p', otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void getTrapReceivesProxyAsReceiverWhenNoExplicitReceiverGiven() {
+        // When no receiver is supplied to Reflect.get, it defaults to the proxy.
+        // The trap must receive the proxy as the 3rd argument.
+        String js =
+                "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    return receiver === proxy;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(proxy, 'p');";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getTrapReceiverIsProxyForDirectPropertyRead() {
+        // Direct read proxy.p — the trap's receiver must be the proxy,
+        // not the underlying target.
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    log.push(receiver === proxy ? 'proxy' : 'other');\n"
+                        + "    return 1;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "var _ = proxy.p;\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("proxy", js);
+    }
+
+    @Test
+    public void getTrapReceivesCorrectReceiverWithIndexKey() {
+        // Same bug exists for the int-key overload.
+        String js =
+                "var log = [];\n"
+                        + "var target = [];\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    if (prop === '0') {\n"
+                        + "      log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    }\n"
+                        + "    return undefined;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.get(proxy, 0, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void getTrapReceivesCorrectReceiverWithSymbolKey() {
+        // Same bug exists for the Symbol-key overload.
+        String js =
+                "var log = [];\n"
+                        + "var sym = Symbol('test');\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    if (prop === sym) {\n"
+                        + "      log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    }\n"
+                        + "    return undefined;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.get(proxy, sym, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -1005,4 +1005,127 @@ public class NativeProxyTest {
                         + "'' + (_receiver === proxy) + ' ' + target[sym]";
         Utils.assertWithAllModes_ES6("true hello", js);
     }
+
+    @Test
+    public void setTrapWithProxyAsReceiverViaWith() {
+        // similar to what is done in set-mutable-binding-idref-with-proxy-env.js
+        // 'with (proxy)' uses the proxy as both the
+        // scope object and the receiver. Reflect.set(env, "p", 1, proxy) must
+        // call proxy.[[DefineOwnProperty]] not proxy.[[Set]].
+        String js =
+                "var log = [];\n"
+                        + "var env = { p: 0 };\n"
+                        + "var proxy = new Proxy(env, {\n"
+                        + "  has(t, pk) {\n"
+                        + "    log.push('has:' + String(pk));\n"
+                        + "    return Reflect.has(t, pk);\n"
+                        + "  },\n"
+                        + "  get(t, pk, r) {\n"
+                        + "    log.push('get:' + String(pk));\n"
+                        + "    return Reflect.get(t, pk, r);\n"
+                        + "  },\n"
+                        + "  set(t, pk, v, r) {\n"
+                        + "    log.push('set:' + String(pk));\n"
+                        + "    return Reflect.set(t, pk, v, r);\n"
+                        + "  },\n"
+                        + "  getOwnPropertyDescriptor(t, pk) {\n"
+                        + "    log.push('getOwnPropertyDescriptor:' + String(pk));\n"
+                        + "    return Reflect.getOwnPropertyDescriptor(t, pk);\n"
+                        + "  },\n"
+                        + "  defineProperty(t, pk, d) {\n"
+                        + "    log.push('defineProperty:' + String(pk));\n"
+                        + "    return Reflect.defineProperty(t, pk, d);\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "with (proxy) {\n"
+                        + "  p = 1;\n"
+                        + "}\n"
+                        + "'' + log";
+
+        // finally should be
+        // "has:p,get:Symbol(Symbol.unscopables),has:p,set:p,getOwnPropertyDescriptor:p,defineProperty:p"
+        Utils.assertWithAllModes_ES6(
+                "has:p,has:p,set:p,getOwnPropertyDescriptor:p,defineProperty:p", js);
+    }
+
+    @Test
+    public void setTrapWithProxyAsReceiverValueWrittenToProxy() {
+        // Verify the value ends up on the proxy's target, not lost.
+        String js =
+                "var env = { p: 0 };\n"
+                        + "var proxy = new Proxy(env, {\n"
+                        + "  set(t, pk, v, r) {\n"
+                        + "    return Reflect.set(t, pk, v, r);\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "with (proxy) {\n"
+                        + "  p = 42;\n"
+                        + "}\n"
+                        + "'' + env.p;";
+
+        Utils.assertWithAllModes_ES6("42", js);
+    }
+
+    @Test
+    public void setTrapWithProxyAsReceiverAccessorOnTarget() {
+        // Accessor property on target: setter should be called with the proxy as receiver.
+        String js =
+                "var log = [];\n"
+                        + "var env = {};\n"
+                        + "Object.defineProperty(env, 'p', {\n"
+                        + "  get() { return 0; },\n"
+                        + "  set(v) { log.push('setter:' + v); },\n"
+                        + "  configurable: true\n"
+                        + "});\n"
+                        + "var proxy = new Proxy(env, {\n"
+                        + "  set(t, pk, v, r) {\n"
+                        + "    return Reflect.set(t, pk, v, r);\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "with (proxy) {\n"
+                        + "  p = 7;\n"
+                        + "}\n"
+                        + "'' + log;";
+
+        Utils.assertWithAllModes_ES6("setter:7", js);
+    }
+
+    @Test
+    public void setTrapWithProxyAsReceiverNoSetterReturnsFalse() {
+        // Accessor property with no setter: Reflect.set must return false (not throw).
+        String js =
+                "var env = {};\n"
+                        + "Object.defineProperty(env, 'p', {\n"
+                        + "  get() { return 0; },\n"
+                        + "  configurable: true\n"
+                        + "});\n"
+                        + "var proxy = new Proxy(env, {\n"
+                        + "  set(t, pk, v, r) {\n"
+                        + "    return Reflect.set(t, pk, v, r);\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "'' + Reflect.set(proxy, 'p', 7);";
+
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void setTrapWithProxyAsReceiverNonWritableReturnsFalse() {
+        // Non-writable data property on target: Reflect.set must return false.
+        String js =
+                "var env = {};\n"
+                        + "Object.defineProperty(env, 'p', {\n"
+                        + "  value: 0,\n"
+                        + "  writable: false,\n"
+                        + "  configurable: true\n"
+                        + "});\n"
+                        + "var proxy = new Proxy(env, {\n"
+                        + "  set(t, pk, v, r) {\n"
+                        + "    return Reflect.set(t, pk, v, r);\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "'' + Reflect.set(proxy, 'p', 7);";
+
+        Utils.assertWithAllModes_ES6("false", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -747,4 +747,122 @@ public class NativeReflectTest {
                         + "'' + Reflect.get(target, sym, receiver);";
         Utils.assertWithAllModes_ES6("true", js);
     }
+
+    @Test
+    public void setPlainFallbackConsultsTargetChainNotReceiverChain() {
+        // target has no own 'p'. 'p' lives on target's prototype (writable).
+        // receiver has no own 'p'. receiver's prototype has a non-writable 'p'.
+        //
+        // Spec: target.[[Set]]('p', 42, receiver)
+        //   → no own desc on target → walk target's proto chain
+        //   → finds writable 'p' on targetProto → OrdinarySetWithOwnDescriptor
+        //   → receiver has no own 'p' → CreateDataProperty(receiver, 'p', 42) ← own write
+        String js =
+                "var targetProto = { p: 1 };\n"
+                        + "var target = Object.create(targetProto);\n"
+                        + "var receiverProto = {};\n"
+                        + "Object.defineProperty(receiverProto, 'p', {\n"
+                        + "  value: 0, writable: false, configurable: true\n"
+                        + "});\n"
+                        + "var receiver = Object.create(receiverProto);\n"
+                        + "var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "'' + result + ' ' + receiver.hasOwnProperty('p') + ' ' + receiver.p;";
+        Utils.assertWithAllModes_ES6("true true 42", js);
+    }
+
+    @Test
+    public void setPlainFallbackNoOwnPropCreatesOwnOnReceiver() {
+        // Neither target nor receiver has own 'p'. No proto chain interference.
+        // Spec: target.[[Set]] → no own on target (or proto) → CreateDataProperty(receiver, 'p', 42).
+        // receiver must end up with its own 'p'; target must be untouched.
+        String js =
+                "var target = {};\n"
+                        + "var receiver = {};\n"
+                        + "var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "'' + result\n"
+                        + "+ ' ' + receiver.hasOwnProperty('p')\n"
+                        + "+ ' ' + receiver.p\n"
+                        + "+ ' ' + target.hasOwnProperty('p');";
+        Utils.assertWithAllModes_ES6("true true 42 false", js);
+    }
+
+    @Test
+    public void setPlainFallbackIndexKeyConsultsTargetChain() {
+        // Same as setPlainFallbackConsultsTargetChainNotReceiverChain but with integer key.
+        String js =
+                "var targetProto = [, , 99];\n"
+                        + "var target = Object.create(targetProto);\n"
+                        + "var receiverProto = [];\n"
+                        + "Object.defineProperty(receiverProto, '2', {\n"
+                        + "  value: 0, writable: false, configurable: true\n"
+                        + "});\n"
+                        + "var receiver = Object.create(receiverProto);\n"
+                        + "var result = Reflect.set(target, 2, 42, receiver);\n"
+                        + "'' + result + ' ' + receiver.hasOwnProperty('2') + ' ' + receiver[2];";
+        Utils.assertWithAllModes_ES6("true true 42", js);
+    }
+
+    @Test
+    public void setPlainFallbackSymbolKeyConsultsTargetChain() {
+        // Same scenario for Symbol keys.
+        String js =
+                "var sym = Symbol('p');\n"
+                        + "var targetProto = {};\n"
+                        + "targetProto[sym] = 1;\n"
+                        + "var target = Object.create(targetProto);\n"
+                        + "var receiverProto = {};\n"
+                        + "Object.defineProperty(receiverProto, sym, {\n"
+                        + "  value: 0, writable: false, configurable: true\n"
+                        + "});\n"
+                        + "var receiver = Object.create(receiverProto);\n"
+                        + "var result = Reflect.set(target, sym, 42, receiver);\n"
+                        + "'' + result + ' ' + receiver.hasOwnProperty(sym) + ' ' + receiver[sym];";
+        Utils.assertWithAllModes_ES6("true true 42", js);
+    }
+
+    @Test
+    public void setFallbackShouldCallSetterFromTargetProtoNotCreateOwnOnReceiver() {
+        // target has no own 'p'. target's prototype has an accessor (setter) for 'p'.
+        // receiver has no own 'p' and is extensible.
+        //
+        // Spec: target.[[Set]]('p', 42, receiver)
+        //   → no own desc on target → walk target's proto chain
+        //   → finds accessor on targetProto → call setter with receiver as 'this'
+        //   → return true, receiver gets NO own 'p' (setter was called instead)
+        String js =
+                "var log = [];\n"
+                        + "var targetProto = {};\n"
+                        + "Object.defineProperty(targetProto, 'p', {\n"
+                        + "  set: function(v) { log.push('setter:' + v); },\n"
+                        + "  configurable: true\n"
+                        + "});\n"
+                        + "var target = Object.create(targetProto);\n"
+                        + "var receiver = {};\n"
+                        + "var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        // setter must be called, receiver must NOT get an own 'p'
+                        + "'' + result + ' ' + log + ' ' + receiver.hasOwnProperty('p');";
+        Utils.assertWithAllModes_ES6("true setter:42 false", js);
+    }
+
+    @Test
+    public void setFallbackShouldReturnFalseForNonWritableOnTargetProto() {
+        // target has no own 'p'. target's prototype has a NON-WRITABLE 'p'.
+        // receiver has no own 'p'.
+        //
+        // Spec: target.[[Set]]('p', 42, receiver)
+        //   → no own on target → walk target's proto chain
+        //   → finds non-writable data 'p' on targetProto
+        //   → OrdinarySetWithOwnDescriptor: writable=false → return false
+        //   → receiver gets NO own 'p'
+        String js =
+                "var targetProto = {};\n"
+                        + "Object.defineProperty(targetProto, 'p', {\n"
+                        + "  value: 1, writable: false, configurable: true\n"
+                        + "});\n"
+                        + "var target = Object.create(targetProto);\n"
+                        + "var receiver = {};\n"
+                        + "var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "'' + result + ' ' + receiver.hasOwnProperty('p');";
+        Utils.assertWithAllModes_ES6("false false", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -662,4 +662,89 @@ public class NativeReflectTest {
                         + "'' + viaCall + ' ' + viaReflect;";
         Utils.assertWithAllModes_ES6("true true", js);
     }
+
+    @Test
+    public void definePropertyReturnsFalseWhenTrapReturnsFalse() {
+        // On a proxy whose defineProperty trap returns false, Reflect.defineProperty
+        // must return false — this is the legitimate false path, not an error.
+        String js =
+                "var p = new Proxy({}, {\n"
+                        + "  defineProperty() { return false; }\n"
+                        + "});\n"
+                        + "'' + Reflect.defineProperty(p, 'x', { value: 1 });";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void definePropertyReturnsTrueOnSuccess() {
+        String js =
+                "var o = {};\n"
+                        + "'' + Reflect.defineProperty(o, 'p', { value: 42, configurable: true });";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverDefaultsToTarget() {
+        // When no receiver is supplied, getter sees target as 'this'.
+        String js =
+                "var o = {};\n"
+                        + "Object.defineProperty(o, 'p', {\n"
+                        + "  get() { return this === o; }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(o, 'p');";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverPassedToGetter() {
+        // When a receiver is supplied, getter sees receiver as 'this', not target.
+        String js =
+                "var target = {};\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(target, 'p', {\n"
+                        + "  get() { return this === receiver; }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(target, 'p', receiver);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverPassedToGetterOnPrototype() {
+        // Getter is on the prototype, receiver is the leaf object — 'this' must
+        // still be the receiver, not the prototype where the getter lives.
+        String js =
+                "var receiver = {};\n"
+                        + "var proto = {};\n"
+                        + "Object.defineProperty(proto, 'p', {\n"
+                        + "  get() { return this === receiver; }\n"
+                        + "});\n"
+                        + "var target = Object.create(proto);\n"
+                        + "'' + Reflect.get(target, 'p', receiver);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverDoesNotAffectDataProperty() {
+        // Receiver has no effect on plain data property reads — value comes from
+        // the prototype chain of target, not receiver.
+        String js =
+                "var target = { p: 42 };\n"
+                        + "var receiver = { p: 99 };\n"
+                        + "'' + Reflect.get(target, 'p', receiver);";
+        Utils.assertWithAllModes_ES6("42", js);
+    }
+
+    @Test
+    public void getReceiverWithSymbolKey() {
+        // Receiver must also be forwarded for Symbol-keyed getters.
+        String js =
+                "var sym = Symbol('test');\n"
+                        + "var target = {};\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(target, sym, {\n"
+                        + "  get() { return this === receiver; }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(target, sym, receiver);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -607,4 +607,59 @@ public class NativeReflectTest {
                         + "'' + Reflect.set(p, 'attr', 'foo');";
         Utils.assertWithAllModes_ES6("true", js);
     }
+
+    @Test
+    public void applyThisArgumentMatchesCall_number() {
+        // Reflect.apply must not add extra boxing on top of what the call
+        // machinery does. Whatever typeof this fn.call(42) gives,
+        // Reflect.apply(fn, 42, []) must give the same result.
+        String js =
+                "function getThis() { 'use strict'; return typeof this; }\n"
+                        + "var viaCall    = getThis.call(42);\n"
+                        + "var viaReflect = Reflect.apply(getThis, 42, []);\n"
+                        + "'' + (viaCall === viaReflect);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void applyThisArgumentMatchesCall_string() {
+        String js =
+                "function getThis() { 'use strict'; return typeof this; }\n"
+                        + "var viaCall    = getThis.call('hello');\n"
+                        + "var viaReflect = Reflect.apply(getThis, 'hello', []);\n"
+                        + "'' + (viaCall === viaReflect);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void applyThisArgumentMatchesCall_null() {
+        String js =
+                "function getThis() { 'use strict'; return this === null; }\n"
+                        + "var viaCall    = getThis.call(null);\n"
+                        + "var viaReflect = Reflect.apply(getThis, null, []);\n"
+                        + "'' + (viaCall === viaReflect);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void applyThisArgumentMatchesCall_undefined() {
+        String js =
+                "function getThis() { 'use strict'; return this === undefined; }\n"
+                        + "var viaCall    = getThis.call(undefined);\n"
+                        + "var viaReflect = Reflect.apply(getThis, undefined, []);\n"
+                        + "'' + (viaCall === viaReflect);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void applyThisArgumentMatchesCall_object() {
+        // Object thisArg: must be the exact same reference in both cases.
+        String js =
+                "var obj = {};\n"
+                        + "function getThis() { 'use strict'; return this === obj; }\n"
+                        + "var viaCall    = getThis.call(obj);\n"
+                        + "var viaReflect = Reflect.apply(getThis, obj, []);\n"
+                        + "'' + viaCall + ' ' + viaReflect;";
+        Utils.assertWithAllModes_ES6("true true", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -865,4 +865,193 @@ public class NativeReflectTest {
                         + "'' + result + ' ' + receiver.hasOwnProperty('p');";
         Utils.assertWithAllModes_ES6("false false", js);
     }
+
+    @Test
+    public void setMissingValueArgumentTreatedAsUndefined() {
+        // Reflect.set(target, key) — value argument is omitted.
+        // Spec: missing arguments are undefined, so this is equivalent to
+        // Reflect.set(target, 'p', undefined).
+        String js =
+                "var target = {};\n"
+                        + "var result = Reflect.set(target, 'p');\n"
+                        + "'' + result + ' ' + target.p + ' ' + (target.p === undefined);";
+        Utils.assertWithAllModes_ES6("true undefined true", js);
+    }
+
+    @Test
+    public void setMissingValueWithReceiverTreatedAsUndefined() {
+        // Reflect.set(target, key, <missing>, receiver) is not reachable from JS
+        // (you cannot pass a 4th arg without a 3rd), but the missing-value case
+        // with an explicit receiver via Reflect.set(target, key) still applies.
+        // Verifies the set trap also receives undefined as the value.
+        String js =
+                "var log = [];\n"
+                        + "var proxy = new Proxy({}, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    log.push(value === undefined);\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.set(proxy, 'p');\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void setTrapCalledWhenReceiverDiffersFromProxy_stringKey() {
+        // Reflect.set(proxy, 'p', 42, otherReceiver) — receiver != proxy.
+        // The proxy's set trap MUST still be invoked, with otherReceiver as
+        // the 4th trap argument.
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    log.push('trap:' + prop + ':' + value\n"
+                        + "             + ':' + (receiver === otherReceiver));\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.set(proxy, 'p', 42, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("trap:p:42:true", js);
+    }
+
+    @Test
+    public void setTrapCalledWhenReceiverDiffersFromProxy_indexKey() {
+        // Same as above but with an integer key.
+        String js =
+                "var log = [];\n"
+                        + "var target = [];\n"
+                        + "var otherReceiver = [];\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    log.push('trap:' + prop + ':' + value\n"
+                        + "             + ':' + (receiver === otherReceiver));\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.set(proxy, 0, 99, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("trap:0:99:true", js);
+    }
+
+    @Test
+    public void setTrapCalledWhenReceiverDiffersFromProxy_symbolKey() {
+        // Same as above but with a Symbol key.
+        String js =
+                "var log = [];\n"
+                        + "var sym = Symbol('s');\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    if (prop === sym) {\n"
+                        + "      log.push('trap:' + value\n"
+                        + "               + ':' + (receiver === otherReceiver));\n"
+                        + "    }\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.set(proxy, sym, 42, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("trap:42:true", js);
+    }
+
+    @Test
+    public void setTrapReturnFalseHonouredWhenReceiverDiffers() {
+        // When the set trap returns false, Reflect.set must return false —
+        // even when receiver != proxy.
+        String js =
+                "var target = {};\n"
+                        + "var otherReceiver = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    return false;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "'' + Reflect.set(proxy, 'p', 42, otherReceiver);";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void setTrapNotCalledWhenNoTrapAndReceiverDiffers() {
+        // No set trap defined — the value must still end up written correctly.
+        String js =
+                "var target = { p: 1 };\n"
+                        + "var otherReceiver = {};\n"
+                        + "var proxy = new Proxy(target, {});\n"
+                        + "var result = Reflect.set(proxy, 'p', 42, otherReceiver);\n"
+                        + "'' + result\n"
+                        + "+ ' target=' + target.p\n"
+                        + "+ ' receiver=' + otherReceiver.p;";
+        Utils.assertWithAllModes_ES6("true target=1 receiver=42", js);
+    }
+
+    @Test
+    public void setReturnsFlaseNotThrowWhenReceiverDefinePropertyWouldThrow_nonExtensible() {
+        // target has own writable 'p'. receiver is non-extensible and does NOT
+        // have own 'p'. OrdinarySetWithOwnDescriptor step 1.e calls
+        // CreateDataProperty(receiver, 'p', 42) → Receiver.[[DefineOwnProperty]].
+        // On a non-extensible receiver that has no own 'p', [[DefineOwnProperty]]
+        // must return false per spec. Rhino throws an EcmaError instead, so
+        // Reflect.set must catch it and return false rather than propagating the throw.
+        String js =
+                "var target = { p: 1 };\n"
+                        + "var receiver = Object.preventExtensions({});\n"
+                        + "try {\n"
+                        + "  var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "  '' + result + ' ' + receiver.hasOwnProperty('p');\n"
+                        + "} catch(e) {\n"
+                        + "  'threw: ' + e;\n"
+                        + "}";
+        Utils.assertWithAllModes_ES6("false false", js);
+    }
+
+    @Test
+    public void setReturnsFalseNotThrowWhenReceiverDefinePropertyWouldThrow_nonConfigurable() {
+        // target has own writable 'p'. receiver has own non-writable non-configurable 'p'.
+        // OrdinarySetWithOwnDescriptor step 1.d.iii calls [[DefineOwnProperty]] with
+        // { [[Value]]: 42 } on receiver. The existing slot is non-configurable and
+        // non-writable so [[DefineOwnProperty]] must return false. Rhino throws instead.
+        String js =
+                "var target = { p: 1 };\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(receiver, 'p', {\n"
+                        + "  value: 0, writable: false, configurable: false\n"
+                        + "});\n"
+                        + "try {\n"
+                        + "  var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "  '' + result + ' ' + receiver.p;\n"
+                        + "} catch(e) {\n"
+                        + "  'threw: ' + e;\n"
+                        + "}";
+        Utils.assertWithAllModes_ES6("false 0", js);
+    }
+
+    @Test
+    public void setReturnsFalseNotThrowWhenCreateDataPropertyFailsOnNonExtensibleReceiver() {
+        // target has own writable 'p'. receiver is non-extensible with NO own 'p'.
+        //
+        // OrdinarySetWithOwnDescriptor flow:
+        //   - ownDesc (from target) is writable data         → step 1.a passes
+        //   - receiver is a ScriptableObject                 → step 1.b passes
+        //   - existingDesc on receiver is null (no own 'p')  → step 1.d skipped
+        //   - step 1.e: CreateDataProperty(receiver, 'p', 42)
+        //     → Receiver.[[DefineOwnProperty]] on a non-extensible object
+        //     → spec: returns false
+        //     → Rhino: throws EcmaError
+        //   → Reflect.set must return false, not propagate the throw.
+        String js =
+                "var target = { p: 1 };\n"
+                        + "var receiver = Object.preventExtensions({});\n"
+                        + "try {\n"
+                        + "  var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "  '' + result + ' ' + receiver.hasOwnProperty('p');\n"
+                        + "} catch(e) {\n"
+                        + "  'threw: ' + e;\n"
+                        + "}";
+        Utils.assertWithAllModes_ES6("false false", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -460,4 +460,151 @@ public class NativeReflectTest {
                         + "+ ' ' + Reflect.setPrototypeOf(o3, proto)";
         Utils.assertWithAllModes_ES6("true true true", js);
     }
+
+    @Test
+    public void setWithoutReceiver() {
+        // Basic sanity: no receiver argument, value lands on target.
+        String js = "var o = { p: 0 };\n" + "Reflect.set(o, 'p', 42);\n" + "'' + o.p;";
+        Utils.assertWithAllModes_ES6("42", js);
+    }
+
+    @Test
+    public void setWithReceiverSameAsTarget() {
+        // receiver === target: ordinary path, value lands on the object.
+        String js = "var o = { p: 0 };\n" + "'' + Reflect.set(o, 'p', 99, o) + ' ' + o.p;";
+        Utils.assertWithAllModes_ES6("true 99", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_writableDataProp() {
+        // OrdinarySetWithOwnDescriptor step 1.d.iii:
+        // target has writable data property, receiver is a different object.
+        // Value must be written to the receiver via [[DefineOwnProperty]], not [[Set]].
+        String js =
+                "var target = { p: 0 };\n"
+                        + "var receiver = { p: 10 };\n"
+                        + "var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "'' + result + ' ' + target.p + ' ' + receiver.p;";
+        // target unchanged, receiver updated, returns true
+        Utils.assertWithAllModes_ES6("true 0 42", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_newPropOnReceiver() {
+        // OrdinarySetWithOwnDescriptor step 1.e (CreateDataProperty):
+        // target has writable data property, receiver does NOT own that property yet.
+        String js =
+                "var target = { p: 0 };\n"
+                        + "var receiver = {};\n"
+                        + "var result = Reflect.set(target, 'p', 42, receiver);\n"
+                        + "'' + result + ' ' + target.p + ' ' + receiver.p;";
+        // target unchanged, new property created on receiver
+        Utils.assertWithAllModes_ES6("true 0 42", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_nonWritableOwnDescOnTarget() {
+        // OrdinarySetWithOwnDescriptor step 1.a: target property is non-writable → false.
+        String js =
+                "var target = {};\n"
+                        + "Object.defineProperty(target, 'p', { value: 0, writable: false, configurable: true });\n"
+                        + "var receiver = {};\n"
+                        + "'' + Reflect.set(target, 'p', 42, receiver);";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_nonWritableOwnDescOnReceiver() {
+        // OrdinarySetWithOwnDescriptor step 1.d.ii:
+        // receiver already owns the property but it is non-writable → false.
+        String js =
+                "var target = { p: 0 };\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(receiver, 'p', { value: 1, writable: false, configurable: true });\n"
+                        + "'' + Reflect.set(target, 'p', 42, receiver);";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_accessorDescOnReceiverReturnsFalse() {
+        // OrdinarySetWithOwnDescriptor step 1.d.i:
+        // receiver owns an accessor for that property → false.
+        String js =
+                "var target = { p: 0 };\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(receiver, 'p', { get() { return 1; }, configurable: true });\n"
+                        + "'' + Reflect.set(target, 'p', 42, receiver);";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_accessorWithSetter() {
+        // OrdinarySetWithOwnDescriptor step 3: target has accessor with setter,
+        // setter must be called with receiver as 'this'.
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "Object.defineProperty(target, 'p', {\n"
+                        + "  get() { return 0; },\n"
+                        + "  set(v) { log.push(this === receiver ? 'receiver' : 'other', v); },\n"
+                        + "  configurable: true\n"
+                        + "});\n"
+                        + "var receiver = {};\n"
+                        + "var result = Reflect.set(target, 'p', 7, receiver);\n"
+                        + "'' + result + ' ' + log;";
+        Utils.assertWithAllModes_ES6("true receiver,7", js);
+    }
+
+    @Test
+    public void setWithReceiverDifferentFromTarget_accessorNoSetterReturnsFalse() {
+        // OrdinarySetWithOwnDescriptor step 4: target has accessor with no setter → false.
+        String js =
+                "var target = {};\n"
+                        + "Object.defineProperty(target, 'p', { get() { return 0; }, configurable: true });\n"
+                        + "var receiver = {};\n"
+                        + "'' + Reflect.set(target, 'p', 7, receiver);";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void setWithReceiverPreservesExistingAttributesOnReceiver() {
+        // When receiver already owns the (writable) property, [[DefineOwnProperty]]
+        // with {[[Value]]: V} must preserve writable/enumerable/configurable.
+        String js =
+                "var target = { p: 0 };\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(receiver, 'p', {\n"
+                        + "  value: 1, writable: true, enumerable: false, configurable: false\n"
+                        + "});\n"
+                        + "Reflect.set(target, 'p', 42, receiver);\n"
+                        + "var d = Object.getOwnPropertyDescriptor(receiver, 'p');\n"
+                        + "'' + d.value + ' ' + d.writable + ' ' + d.enumerable + ' ' + d.configurable;";
+        // value updated, other attributes unchanged
+        Utils.assertWithAllModes_ES6("42 true false false", js);
+    }
+
+    @Test
+    public void setTrapReturnsTrueForConfigurableNonWritableProperty() {
+        // Reflect.set(proxy, "attr", "foo") must return true when the
+        // set trap returns true and the target property is configurable (even though
+        // it is non-writable). The OrdinarySetWithOwnDescriptor non-writable check
+        // must NOT run when the target itself is the proxy — the trap result is final.
+        // See: ECMAScript [[Set]] 10.5.9 step 11 — invariant only applies when
+        // targetDesc.[[Configurable]] is false.
+        String js =
+                "var target = {};\n"
+                        + "var handler = {\n"
+                        + "  set: function(t, prop, value, receiver) {\n"
+                        + "    return true;\n"
+                        + "  }\n"
+                        + "};\n"
+                        + "var p = new Proxy(target, handler);\n"
+                        + "Object.defineProperty(target, 'attr', {\n"
+                        + "  configurable: true,\n"
+                        + "  writable: false,\n"
+                        + "  value: 'foo'\n"
+                        + "});\n"
+                        + "'' + Reflect.set(p, 'attr', 'foo');";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -773,7 +773,8 @@ public class NativeReflectTest {
     @Test
     public void setPlainFallbackNoOwnPropCreatesOwnOnReceiver() {
         // Neither target nor receiver has own 'p'. No proto chain interference.
-        // Spec: target.[[Set]] → no own on target (or proto) → CreateDataProperty(receiver, 'p', 42).
+        // Spec: target.[[Set]] → no own on target (or proto)
+        // → CreateDataProperty(receiver, 'p', 42).
         // receiver must end up with its own 'p'; target must be untouched.
         String js =
                 "var target = {};\n"

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1922,7 +1922,7 @@ built-ins/Promise 416/677 (61.45%)
     resolve-thenable-deferred.js {unsupported: [async]}
     resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy 65/311 (20.9%)
+built-ins/Proxy 59/311 (18.97%)
     construct/arguments-realm.js
     construct/call-parameters.js
     construct/call-parameters-new-target.js
@@ -1971,12 +1971,6 @@ built-ins/Proxy 65/311 (20.9%)
     setPrototypeOf/toboolean-trap-result-true-target-is-extensible.js
     setPrototypeOf/trap-is-missing-target-is-proxy.js
     setPrototypeOf/trap-is-null-target-is-proxy.js
-    set/boolean-trap-result-is-false-boolean-return-false.js
-    set/boolean-trap-result-is-false-null-return-false.js
-    set/boolean-trap-result-is-false-number-return-false.js
-    set/boolean-trap-result-is-false-string-return-false.js
-    set/boolean-trap-result-is-false-undefined-return-false.js
-    set/call-parameters.js
     set/call-parameters-prototype.js
     set/call-parameters-prototype-dunder-proto.js
     set/call-parameters-prototype-index.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2665,7 +2665,7 @@ built-ins/TypedArray 130/1438 (9.04%)
     resizable-buffer-length-tracking-1.js
     resizable-buffer-length-tracking-2.js
 
-built-ins/TypedArrayConstructors 169/738 (22.9%)
+built-ins/TypedArrayConstructors 170/738 (23.04%)
     ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2830,6 +2830,7 @@ built-ins/TypedArrayConstructors 169/738 (22.9%)
     internals/Set/key-is-not-canonical-index.js
     internals/Set/key-is-not-numeric-index.js
     internals/Set/key-is-out-of-bounds-receiver-is-not-object.js
+    internals/Set/key-is-out-of-bounds-receiver-is-proto.js
     internals/Set/key-is-symbol.js
     internals/Set/key-is-valid-index-prototype-chain-set.js
     internals/Set/key-is-valid-index-reflect-set.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1983,11 +1983,10 @@ built-ins/Proxy 59/311 (18.97%)
     get-fn-realm.js
     get-fn-realm-recursive.js
 
-built-ins/Reflect 11/153 (7.19%)
+built-ins/Reflect 10/153 (6.54%)
     defineProperty/return-abrupt-from-property-key.js
     deleteProperty/return-abrupt-from-result.js
     deleteProperty/return-boolean.js strict
-    get/return-value-from-receiver.js
     ownKeys/return-on-corresponding-order-large-index.js
     set/call-prototype-property-set.js
     set/different-property-descriptors.js


### PR DESCRIPTION
Co-authored-by: Lai Quang Duong

This
* passes the receiver to the set trap
* passes the receiver to the get trap
* fixes an StackOverflow exception (became visible after the change for 'passes the receiver to the set trap')
* adds a bunch of spec hints to the implementation of the NativeReflect class
* implements a workaround for the missing put return value in class NativeProxy, this workaround is used by NativeReflect to implement a more correct behaviour
* fixes a check in NativeReflect; now checks for Callable in sync with the spec

This does not make so many more 262 test to pass, but i think is at least a small step forward.